### PR TITLE
Add DebugView for Array and Dictionary, based of the DebugView from the .NET Foundation

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
+using System.Diagnostics;
 
 #nullable enable
 
@@ -16,6 +17,8 @@ namespace Godot.Collections
     /// interfacing with the engine. Otherwise prefer .NET collections
     /// such as <see cref="System.Array"/> or <see cref="List{T}"/>.
     /// </summary>
+    [DebuggerTypeProxy(typeof(ArrayDebugView<Variant>))]
+    [DebuggerDisplay("Count = {Count}")]
 #pragma warning disable CA1710 // Identifiers should have correct suffix
     public sealed class Array :
 #pragma warning restore CA1710
@@ -1040,6 +1043,8 @@ namespace Godot.Collections
     /// such as arrays or <see cref="List{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of the array.</typeparam>
+    [DebuggerTypeProxy(typeof(ArrayDebugView<>))]
+    [DebuggerDisplay("Count = {Count}")]
     [SuppressMessage("ReSharper", "RedundantExtendsListEntry")]
     [SuppressMessage("Naming", "CA1710", MessageId = "Identifiers should have correct suffix")]
     public sealed class Array<[MustBeVariant] T> :

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebugView.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebugView.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Godot.Collections
+{
+    internal sealed class ArrayDebugView<T>
+    {
+        private readonly IList<T> _array;
+
+        public ArrayDebugView(IList<T> array)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+
+            _array = array;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                var items = new T[_array.Count];
+                _array.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryDebugView<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> _dictionary;
+
+        public DictionaryDebugView(IDictionary<TKey, TValue> dictionary)
+        {
+            ArgumentNullException.ThrowIfNull(dictionary);
+
+            _dictionary = dictionary;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public DictionaryKeyItemDebugView<TKey, TValue>[] Items
+        {
+            get
+            {
+                var items = new KeyValuePair<TKey, TValue>[_dictionary.Count];
+                var views = new DictionaryKeyItemDebugView<TKey, TValue>[_dictionary.Count];
+                _dictionary.CopyTo(items, 0);
+                for (int i = 0; i < items.Length; i++)
+                {
+                    views[i] = new DictionaryKeyItemDebugView<TKey, TValue>(items[i]);
+                }
+                return views;
+            }
+        }
+    }
+
+    [DebuggerDisplay("{Value}", Name = "[{Key}]")]
+    internal readonly struct DictionaryKeyItemDebugView<TKey, TValue>
+    {
+        public DictionaryKeyItemDebugView(KeyValuePair<TKey, TValue> keyValue)
+        {
+            Key = keyValue.Key;
+            Value = keyValue.Value;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public TKey Key { get; }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public TValue Value { get; }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
+using System.Diagnostics;
 
 #nullable enable
 
@@ -14,6 +15,8 @@ namespace Godot.Collections
     /// typed elements allocated in the engine in C++. Useful when
     /// interfacing with the engine.
     /// </summary>
+    [DebuggerTypeProxy(typeof(DictionaryDebugView<Variant, Variant>))]
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class Dictionary :
         IDictionary<Variant, Variant>,
         IReadOnlyDictionary<Variant, Variant>,
@@ -480,6 +483,8 @@ namespace Godot.Collections
     /// </summary>
     /// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
     /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
+    [DebuggerTypeProxy(typeof(DictionaryDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}")]
     public class Dictionary<[MustBeVariant] TKey, [MustBeVariant] TValue> :
         IDictionary<TKey, TValue>,
         IReadOnlyDictionary<TKey, TValue>,

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Core\Color.cs" />
     <Compile Include="Core\Colors.cs" />
     <Compile Include="Core\DebuggingUtils.cs" />
+    <Compile Include="Core\DebugView.cs" />
     <Compile Include="Core\DelegateUtils.cs" />
     <Compile Include="Core\Dictionary.cs" />
     <Compile Include="Core\Dispatcher.cs" />


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/6969

I am working on reimplementing the debug view for the C# runtime. Initially, I was creating a new debug view. Then, I incorporate the debug view from the .NET Foundation. This approach ensures consistency between the C# runtime’s enumerable and the GODOT enumerable. 


This is why the comment of MIT license of the .net Foundation.
