### PR TITLE
Fix some uses of `float` and `real_t` in `core/math`

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -278,7 +278,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	return m;
 }
 
-float Basis::get_uniform_scale() const {
+real_t Basis::get_uniform_scale() const {
 	return (rows[0].length() + rows[1].length() + rows[2].length()) / 3.0f;
 }
 

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -99,7 +99,7 @@ struct _NO_DISCARD_ Basis {
 
 	void scale_orthogonal(const Vector3 &p_scale);
 	Basis scaled_orthogonal(const Vector3 &p_scale) const;
-	float get_uniform_scale() const;
+	real_t get_uniform_scale() const;
 
 	Vector3 get_scale() const;
 	Vector3 get_scale_abs() const;

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -258,7 +258,7 @@ struct BVH_ABB {
 	}
 
 	// Actually surface area metric.
-	float get_area() const {
+	real_t get_area() const {
 		POINT d = calculate_size();
 		return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}

--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -10,7 +10,7 @@ String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
 	POINT size = aabb.calculate_size();
 
 	String sz;
-	float vol = 0.0;
+	real_t vol = 0.0;
 
 	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		sz += "(";

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -150,7 +150,7 @@ void _split_leaf_sort_groups(int &num_a, int &num_b, uint16_t *group_a, uint16_t
 
 	BVHABB_CLASS rest_aabb;
 
-	float best_size = FLT_MAX;
+	real_t best_size = FLT_MAX;
 	int best_candidate = -1;
 
 	// find most likely from a to move into b
@@ -171,7 +171,7 @@ void _split_leaf_sort_groups(int &num_a, int &num_b, uint16_t *group_a, uint16_t
 		groupb_aabb_new.merge(temp_bounds[group_a[check]]);
 
 		// now compare the sizes
-		float size = groupb_aabb_new.get_area() + rest_aabb.get_area();
+		real_t size = groupb_aabb_new.get_area() + rest_aabb.get_area();
 		if (size < best_size) {
 			best_size = size;
 			best_candidate = check;

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -233,7 +233,7 @@ public:
 				points[i] = (points[i] - rect.position) / rect.size;
 			}
 
-			float delta_max = Math::sqrt(2.0) * 20.0;
+			const real_t delta_max = Math::sqrt(2.0) * 20.0;
 			Vector3 center = Vector3(0.5, 0.5, 0.5);
 
 			// any simplex that contains everything is good
@@ -332,8 +332,7 @@ public:
 					center.y = double(new_simplex->circum_center_y);
 					center.z = double(new_simplex->circum_center_z);
 
-					float radius2 = Math::sqrt(double(new_simplex->circum_r2));
-					radius2 += 0.0001; //
+					const real_t radius2 = Math::sqrt(double(new_simplex->circum_r2)) + 0.0001;
 					Vector3 extents = Vector3(radius2, radius2, radius2);
 					Vector3i from = Vector3i((center - extents) * ACCEL_GRID_SIZE);
 					Vector3i to = Vector3i((center + extents) * ACCEL_GRID_SIZE);

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -594,7 +594,7 @@ public:
 		max = x2;                        \
 	}
 
-	_FORCE_INLINE_ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
+	_FORCE_INLINE_ static bool planeBoxOverlap(Vector3 normal, real_t d, Vector3 maxbox) {
 		int q;
 		Vector3 vmin, vmax;
 		for (q = 0; q <= 2; q++) {
@@ -678,8 +678,7 @@ public:
 		return false;                              \
 	}
 
-	/*======================== Z-tests ========================*/
-
+/*======================== Z-tests ========================*/
 #define AXISTEST_Z12(a, b, fa, fb)                 \
 	p1 = a * v1.x - b * v1.y;                      \
 	p2 = a * v2.x - b * v2.y;                      \
@@ -718,21 +717,19 @@ public:
 		/*    2) normal of the triangle */
 		/*    3) crossproduct(edge from tri, {x,y,z}-directin) */
 		/*       this gives 3x3=9 more tests */
-		Vector3 v0, v1, v2;
-		float min, max, d, p0, p1, p2, rad, fex, fey, fez;
-		Vector3 normal, e0, e1, e2;
+		real_t min, max, p0, p1, p2, rad, fex, fey, fez;
 
 		/* This is the fastest branch on Sun */
 		/* move everything so that the boxcenter is in (0,0,0) */
 
-		v0 = triverts[0] - boxcenter;
-		v1 = triverts[1] - boxcenter;
-		v2 = triverts[2] - boxcenter;
+		const Vector3 v0 = triverts[0] - boxcenter;
+		const Vector3 v1 = triverts[1] - boxcenter;
+		const Vector3 v2 = triverts[2] - boxcenter;
 
 		/* compute triangle edges */
-		e0 = v1 - v0; /* tri edge 0 */
-		e1 = v2 - v1; /* tri edge 1 */
-		e2 = v0 - v2; /* tri edge 2 */
+		const Vector3 e0 = v1 - v0; /* tri edge 0 */
+		const Vector3 e1 = v2 - v1; /* tri edge 1 */
+		const Vector3 e2 = v0 - v2; /* tri edge 2 */
 
 		/* Bullet 3:  */
 		/*  test the 9 tests first (this was faster) */
@@ -784,8 +781,8 @@ public:
 		/* Bullet 2: */
 		/*  test if the box intersects the plane of the triangle */
 		/*  compute plane equation of triangle: normal*x+d=0 */
-		normal = e0.cross(e1);
-		d = -normal.dot(v0); /* plane eq: normal.x+d=0 */
+		const Vector3 normal = e0.cross(e1);
+		const real_t d = -normal.dot(v0); /* plane eq: normal.x+d=0 */
 		return planeBoxOverlap(normal, d, boxhalfsize); /* if true, box and triangle overlaps */
 	}
 
@@ -793,51 +790,51 @@ public:
 	static Vector<int8_t> generate_sdf8(const Vector<uint32_t> &p_positive, const Vector<uint32_t> &p_negative);
 
 	static Vector3 triangle_get_barycentric_coords(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, const Vector3 &p_pos) {
-		Vector3 v0 = p_b - p_a;
-		Vector3 v1 = p_c - p_a;
-		Vector3 v2 = p_pos - p_a;
+		const Vector3 v0 = p_b - p_a;
+		const Vector3 v1 = p_c - p_a;
+		const Vector3 v2 = p_pos - p_a;
 
-		float d00 = v0.dot(v0);
-		float d01 = v0.dot(v1);
-		float d11 = v1.dot(v1);
-		float d20 = v2.dot(v0);
-		float d21 = v2.dot(v1);
-		float denom = (d00 * d11 - d01 * d01);
+		const real_t d00 = v0.dot(v0);
+		const real_t d01 = v0.dot(v1);
+		const real_t d11 = v1.dot(v1);
+		const real_t d20 = v2.dot(v0);
+		const real_t d21 = v2.dot(v1);
+		const real_t denom = (d00 * d11 - d01 * d01);
 		if (denom == 0) {
 			return Vector3(); //invalid triangle, return empty
 		}
-		float v = (d11 * d20 - d01 * d21) / denom;
-		float w = (d00 * d21 - d01 * d20) / denom;
-		float u = 1.0f - v - w;
+		const real_t v = (d11 * d20 - d01 * d21) / denom;
+		const real_t w = (d00 * d21 - d01 * d20) / denom;
+		const real_t u = 1.0f - v - w;
 		return Vector3(u, v, w);
 	}
 
 	static Color tetrahedron_get_barycentric_coords(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, const Vector3 &p_d, const Vector3 &p_pos) {
-		Vector3 vap = p_pos - p_a;
-		Vector3 vbp = p_pos - p_b;
+		const Vector3 vap = p_pos - p_a;
+		const Vector3 vbp = p_pos - p_b;
 
-		Vector3 vab = p_b - p_a;
-		Vector3 vac = p_c - p_a;
-		Vector3 vad = p_d - p_a;
+		const Vector3 vab = p_b - p_a;
+		const Vector3 vac = p_c - p_a;
+		const Vector3 vad = p_d - p_a;
 
-		Vector3 vbc = p_c - p_b;
-		Vector3 vbd = p_d - p_b;
+		const Vector3 vbc = p_c - p_b;
+		const Vector3 vbd = p_d - p_b;
 		// ScTP computes the scalar triple product
 #define STP(m_a, m_b, m_c) ((m_a).dot((m_b).cross((m_c))))
-		float va6 = STP(vbp, vbd, vbc);
-		float vb6 = STP(vap, vac, vad);
-		float vc6 = STP(vap, vad, vab);
-		float vd6 = STP(vap, vab, vac);
-		float v6 = 1 / STP(vab, vac, vad);
+		const real_t va6 = STP(vbp, vbd, vbc);
+		const real_t vb6 = STP(vap, vac, vad);
+		const real_t vc6 = STP(vap, vad, vab);
+		const real_t vd6 = STP(vap, vab, vac);
+		const real_t v6 = 1 / STP(vab, vac, vad);
 		return Color(va6 * v6, vb6 * v6, vc6 * v6, vd6 * v6);
 #undef STP
 	}
 
 	_FORCE_INLINE_ static Vector3 octahedron_map_decode(const Vector2 &p_uv) {
 		// https://twitter.com/Stubbesaurus/status/937994790553227264
-		Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
+		const Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
 		Vector3 n = Vector3(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
-		float t = CLAMP(-n.z, 0.0f, 1.0f);
+		const real_t t = CLAMP(-n.z, 0.0f, 1.0f);
 		n.x += n.x >= 0 ? -t : t;
 		n.y += n.y >= 0 ? -t : t;
 		return n.normalized();

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -37,7 +37,7 @@
 #include "core/math/transform_3d.h"
 #include "core/string/ustring.h"
 
-float Projection::determinant() const {
+real_t Projection::determinant() const {
 	return columns[0][3] * columns[1][2] * columns[2][1] * columns[3][0] - columns[0][2] * columns[1][3] * columns[2][1] * columns[3][0] -
 			columns[0][3] * columns[1][1] * columns[2][2] * columns[3][0] + columns[0][1] * columns[1][3] * columns[2][2] * columns[3][0] +
 			columns[0][2] * columns[1][1] * columns[2][3] * columns[3][0] - columns[0][1] * columns[1][2] * columns[2][3] * columns[3][0] -
@@ -831,13 +831,13 @@ real_t Projection::get_fov() const {
 	}
 }
 
-float Projection::get_lod_multiplier() const {
+real_t Projection::get_lod_multiplier() const {
 	if (is_orthogonal()) {
 		return get_viewport_half_extents().x;
 	} else {
-		float zn = get_z_near();
-		float width = get_viewport_half_extents().x * 2.0;
-		return 1.0 / (zn / width);
+		const real_t zn = get_z_near();
+		const real_t width = get_viewport_half_extents().x * 2.0f;
+		return 1.0f / (zn / width);
 	}
 
 	// Usage is lod_size / (lod_distance * multiplier) < threshold

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -65,7 +65,7 @@ struct _NO_DISCARD_ Projection {
 		return columns[p_axis];
 	}
 
-	float determinant() const;
+	real_t determinant() const;
 	void set_identity();
 	void set_zero();
 	void set_light_bias();
@@ -148,7 +148,7 @@ struct _NO_DISCARD_ Projection {
 		return !(*this == p_cam);
 	}
 
-	float get_lod_multiplier() const;
+	real_t get_lod_multiplier() const;
 
 	Projection();
 	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -307,14 +307,14 @@ struct _NO_DISCARD_ Rect2 {
 			i_f = i;
 
 			Vector2 r = (b - a);
-			float l = r.length();
+			const real_t l = r.length();
 			if (l == 0.0f) {
 				continue;
 			}
 
 			// Check inside.
 			Vector2 tg = r.orthogonal();
-			float s = tg.dot(center) - tg.dot(a);
+			const real_t s = tg.dot(center) - tg.dot(a);
 			if (s < 0.0f) {
 				side_plus++;
 			} else {
@@ -330,8 +330,8 @@ struct _NO_DISCARD_ Rect2 {
 			Vector2 t13 = (position - a) * ir;
 			Vector2 t24 = (end - a) * ir;
 
-			float tmin = MAX(MIN(t13.x, t24.x), MIN(t13.y, t24.y));
-			float tmax = MIN(MAX(t13.x, t24.x), MAX(t13.y, t24.y));
+			const real_t tmin = MAX(MIN(t13.x, t24.x), MIN(t13.y, t24.y));
+			const real_t tmax = MIN(MAX(t13.x, t24.x), MAX(t13.y, t24.y));
 
 			// if tmax < 0, ray (line) is intersecting AABB, but the whole AABB is behind us
 			if (tmax < 0 || tmin > tmax || tmin >= l) {

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -101,14 +101,14 @@ Vector2 Vector3::octahedron_encode() const {
 Vector3 Vector3::octahedron_decode(const Vector2 &p_oct) {
 	Vector2 f(p_oct.x * 2.0f - 1.0f, p_oct.y * 2.0f - 1.0f);
 	Vector3 n(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
-	float t = CLAMP(-n.z, 0.0f, 1.0f);
+	const real_t t = CLAMP(-n.z, 0.0f, 1.0f);
 	n.x += n.x >= 0 ? -t : t;
 	n.y += n.y >= 0 ? -t : t;
 	return n.normalized();
 }
 
 Vector2 Vector3::octahedron_tangent_encode(float p_sign) const {
-	const float bias = 1.0f / 32767.0f;
+	const real_t bias = 1.0f / (real_t)32767.0f;
 	Vector2 res = octahedron_encode();
 	res.y = MAX(res.y, bias);
 	res.y = res.y * 0.5f + 0.5f;

--- a/tests/core/math/test_geometry_3d.h
+++ b/tests/core/math/test_geometry_3d.h
@@ -136,9 +136,9 @@ TEST_CASE("[Geometry3D] Get Closest Point To Segment") {
 }
 
 TEST_CASE("[Geometry3D] Plane and Box Overlap") {
-	CHECK(Geometry3D::planeBoxOverlap(Vector3(3, 4, 2), 5, Vector3(5, 5, 5)) == true);
-	CHECK(Geometry3D::planeBoxOverlap(Vector3(0, 1, 0), -10, Vector3(5, 5, 5)) == false);
-	CHECK(Geometry3D::planeBoxOverlap(Vector3(1, 0, 0), -6, Vector3(5, 5, 5)) == false);
+	CHECK(Geometry3D::planeBoxOverlap(Vector3(3, 4, 2), 5.0f, Vector3(5, 5, 5)) == true);
+	CHECK(Geometry3D::planeBoxOverlap(Vector3(0, 1, 0), -10.0f, Vector3(5, 5, 5)) == false);
+	CHECK(Geometry3D::planeBoxOverlap(Vector3(1, 0, 0), -6.0f, Vector3(5, 5, 5)) == false);
 }
 
 TEST_CASE("[Geometry3D] Is Point in Projected Triangle") {


### PR DESCRIPTION
This PR fixes a few places where `float` was used when `real_t` should've been used, such as cases where the input data was already using `real_t`, and `float` would cause an undesired truncation on double-precision builds.

Most of this PR affects precision=double builds only, but a few things affect precision=single:

* Fix 2 calculations in `Projection::get_lod_multiplier` being needlessly done with doubles (only to then be casted down to float in each step), now it uses `real_t` (singles in single-precision).
* Fix `radius2` being calculated as a mix of single and double with its added margin, now the whole calculation is double.

I also included some `const` keywords for local variables that are set and not changed, which improves readability but does not change behavior.