### PR TITLE
Add support for flipping BoxContainer children

### DIFF
--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -22,6 +22,9 @@
 		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="BoxContainer.AlignmentMode" default="0">
 			The alignment of the container's children (must be one of [constant ALIGNMENT_BEGIN], [constant ALIGNMENT_CENTER], or [constant ALIGNMENT_END]).
 		</member>
+		<member name="reverse_fill" type="bool" setter="set_reverse_fill" getter="is_reverse_fill" default="false">
+			If [code]true[/code], the container's children are arranged in reverse order.
+		</member>
 		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" default="false">
 			If [code]true[/code], the [BoxContainer] will arrange its children vertically, rather than horizontally.
 			Can't be changed when using [HBoxContainer] and [VBoxContainer].

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -190,7 +190,7 @@ void BoxContainer::_resort() {
 	int start;
 	int end;
 	int delta;
-	if (!rtl || vertical) {
+	if ((!rtl || vertical) != reverse_fill) {
 		start = 0;
 		end = get_child_count();
 		delta = +1;
@@ -335,6 +335,15 @@ bool BoxContainer::is_vertical() const {
 	return vertical;
 }
 
+void BoxContainer::set_reverse_fill(bool p_reverse_fill) {
+	reverse_fill = p_reverse_fill;
+	_resort();
+}
+
+bool BoxContainer::is_reverse_fill() const {
+	return reverse_fill;
+}
+
 Control *BoxContainer::add_spacer(bool p_begin) {
 	Control *c = memnew(Control);
 	c->set_mouse_filter(MOUSE_FILTER_PASS); //allow spacer to pass mouse events
@@ -387,6 +396,8 @@ void BoxContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_alignment"), &BoxContainer::get_alignment);
 	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &BoxContainer::set_vertical);
 	ClassDB::bind_method(D_METHOD("is_vertical"), &BoxContainer::is_vertical);
+	ClassDB::bind_method(D_METHOD("set_reverse_fill", "reverse_fill"), &BoxContainer::set_reverse_fill);
+	ClassDB::bind_method(D_METHOD("is_reverse_fill"), &BoxContainer::is_reverse_fill);
 
 	BIND_ENUM_CONSTANT(ALIGNMENT_BEGIN);
 	BIND_ENUM_CONSTANT(ALIGNMENT_CENTER);
@@ -394,6 +405,7 @@ void BoxContainer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Begin,Center,End"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reverse_fill"), "set_reverse_fill", "is_reverse_fill");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, BoxContainer, separation);
 }

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -45,6 +45,7 @@ public:
 
 private:
 	bool vertical = false;
+	bool reverse_fill = false;
 	AlignmentMode alignment = ALIGNMENT_BEGIN;
 
 	struct ThemeCache {
@@ -68,6 +69,9 @@ public:
 
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
+
+	void set_reverse_fill(bool p_reverse_fill);
+	bool is_reverse_fill() const;
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/804

The actual flipping logic is already implemented for RTL support, so this PR just adds an extra toggle.

Yeah, the same thing can be achieved by moving newly added nodes to the top:

```gdscript
add_child(node)
move_child(node, 0)
```

But it's a hack tying logical order with physical order.