### PR TITLE
Include 'Orphan Resource Explorer' and 'Upgrade Mesh Surfaces' in Command Palette. 

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6780,8 +6780,8 @@ EditorNode::EditorNode() {
 	tool_menu = memnew(PopupMenu);
 	tool_menu->connect("index_pressed", callable_mp(this, &EditorNode::_tool_menu_option));
 	project_menu->add_submenu_node_item(TTR("Tools"), tool_menu);
-	tool_menu->add_item(TTR("Orphan Resource Explorer..."), TOOLS_ORPHAN_RESOURCES);
-	tool_menu->add_item(TTR("Upgrade Mesh Surfaces..."), TOOLS_SURFACE_UPGRADE);
+	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/orphan_resource_explorer", TTR("Orphan Resource Explorer...")), TOOLS_ORPHAN_RESOURCES);
+	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/upgrade_mesh_surfaces", TTR("Upgrade Mesh Surfaces...")), TOOLS_SURFACE_UPGRADE);
 
 	project_menu->add_separator();
 	project_menu->add_shortcut(ED_SHORTCUT("editor/reload_current_project", TTR("Reload Current Project")), RELOAD_CURRENT_PROJECT);


### PR DESCRIPTION
Updates the tools in `project->tools` so that they can be accessed from shortcut or command palette:

![image](https://github.com/godotengine/godot/assets/18729296/a1619160-595e-475e-b87e-6418cace1a03)

There is no supplied shortcut by default, but setting one in editor settings is possible:

![image](https://github.com/godotengine/godot/assets/18729296/34022a39-b380-4ae5-91bb-75132d0ed8b6)

