### PR TITLE
[Core] Optimize `HashMap`

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -30,23 +30,30 @@
 
 #include "node_path.h"
 
+#include "core/templates/hashfuncs.h"
 #include "core/variant/variant.h"
 
 void NodePath::_update_hash_cache() const {
 	uint32_t h = data->absolute ? 1 : 0;
 	int pc = data->path.size();
 	const StringName *sn = data->path.ptr();
+	uint32_t hash_mixed = h;
 	for (int i = 0; i < pc; i++) {
-		h = h ^ sn[i].hash();
+		uint32_t string_hash = sn[i].hash();
+		h = h ^ string_hash;
+		hash_mixed = hash_djb2_one_32(string_hash, hash_mixed); // Don't change to murmur3 because StringName uses djb2!
 	}
 	int spc = data->subpath.size();
 	const StringName *ssn = data->subpath.ptr();
 	for (int i = 0; i < spc; i++) {
-		h = h ^ ssn[i].hash();
+		uint32_t string_hash = ssn[i].hash();
+		h = h ^ string_hash;
+		hash_mixed = hash_djb2_one_32(string_hash, hash_mixed);
 	}
 
 	data->hash_cache_valid = true;
 	data->hash_cache = h;
+	data->hash_mixed_cache = hash_fmix32(hash_mixed);
 }
 
 void NodePath::prepend_period() {

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -43,6 +43,7 @@ class NodePath {
 		bool absolute;
 		mutable bool hash_cache_valid;
 		mutable uint32_t hash_cache;
+		mutable uint32_t hash_mixed_cache;
 	};
 
 	mutable Data *data = nullptr;
@@ -76,6 +77,16 @@ public:
 			_update_hash_cache();
 		}
 		return data->hash_cache;
+	}
+
+	_FORCE_INLINE_ uint32_t hash_mixed() const {
+		if (!data) {
+			return 0;
+		}
+		if (!data->hash_cache_valid) {
+			_update_hash_cache();
+		}
+		return data->hash_mixed_cache;
 	}
 
 	operator String() const;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -65,6 +65,7 @@ class StringName {
 		bool operator!=(const char *p_name) const;
 
 		int idx = 0;
+		uint32_t hash_mixed = 0;
 		uint32_t hash = 0;
 		_Data *prev = nullptr;
 		_Data *next = nullptr;
@@ -145,6 +146,16 @@ public:
 			return get_empty_hash();
 		}
 	}
+
+	// Used by HashMapHasherDefault. Don`t use it as seed to create other hash.
+	_FORCE_INLINE_ uint32_t hash_mixed() const {
+		if (unlikely(_data == nullptr)) {
+			return get_empty_hash();
+		}
+
+		return _data->hash_mixed;
+	}
+
 	_FORCE_INLINE_ const void *data_unique_pointer() const {
 		return (void *)_data;
 	}

--- a/core/templates/hash_map.cpp
+++ b/core/templates/hash_map.cpp
@@ -41,3 +41,12 @@ bool _hashmap_variant_less_than(const Variant &p_left, const Variant &p_right) {
 	}
 	return res;
 }
+
+// Explicit instantiation.
+template class HashMap<int, int>;
+template class HashMap<String, int>;
+template class HashMap<StringName, bool>;
+template class HashMap<StringName, StringName>;
+template class HashMap<StringName, String>;
+template class HashMap<StringName, Variant>;
+template class HashMap<StringName, int>;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -68,21 +68,23 @@ template <typename TKey, typename TValue,
 		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
 class HashMap {
 public:
-	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
-	static constexpr float MAX_OCCUPANCY = 0.75;
+	// Must be a power of two.
+	static constexpr uint32_t INITIAL_CAPACITY = 16;
 	static constexpr uint32_t EMPTY_HASH = 0;
+	static_assert(EMPTY_HASH == 0, "EMPTY_HASH must always be 0 for the memcpy() optimization.");
 
 private:
 	Allocator element_alloc;
-	HashMapElement<TKey, TValue> **elements = nullptr;
-	uint32_t *hashes = nullptr;
 	HashMapElement<TKey, TValue> *head_element = nullptr;
 	HashMapElement<TKey, TValue> *tail_element = nullptr;
+	HashMapElement<TKey, TValue> **elements = nullptr;
+	uint32_t *hashes = nullptr;
 
-	uint32_t capacity_index = 0;
+	// Due to optimization, this is `capacity - 1`. Use + 1 to get normal capacity.
+	uint32_t capacity = 0;
 	uint32_t num_elements = 0;
 
-	_FORCE_INLINE_ uint32_t _hash(const TKey &p_key) const {
+	uint32_t _hash(const TKey &p_key) const {
 		uint32_t hash = Hasher::hash(p_key);
 
 		if (unlikely(hash == EMPTY_HASH)) {
@@ -92,163 +94,174 @@ private:
 		return hash;
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_pos, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_pos = fastmod(p_hash, p_capacity_inv, p_capacity);
-		return fastmod(p_pos - original_pos + p_capacity, p_capacity_inv, p_capacity);
+	static _FORCE_INLINE_ uint32_t _get_resize_count(uint32_t p_capacity) {
+		return p_capacity ^ (p_capacity + 1) >> 2; // = get_capacity() * 0.75 - 1; Works only if p_capacity = 2^n - 1.
+	}
+
+	static _FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_pos, uint32_t p_hash, uint32_t p_local_capacity) {
+		const uint32_t original_pos = p_hash & p_local_capacity;
+		return (p_pos - original_pos + p_local_capacity + 1) & p_local_capacity;
 	}
 
 	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
-		if (elements == nullptr || num_elements == 0) {
-			return false; // Failed lookups, no elements
+		if (unlikely(elements == nullptr)) {
+			return false;
+		}
+		return _lookup_pos_with_hash(p_key, r_pos, _hash(p_key));
+	}
+
+	bool _lookup_pos_with_hash(const TKey &p_key, uint32_t &r_pos, uint32_t p_hash) const {
+		if (unlikely(elements == nullptr)) {
+			return false;
+		}
+		const uint32_t local_capacity = capacity;
+		uint32_t pos = p_hash & local_capacity;
+
+		if (hashes[pos] == p_hash && Comparator::compare(elements[pos]->data.key, p_key)) {
+			r_pos = pos;
+			return true;
 		}
 
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t hash = _hash(p_key);
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-		uint32_t distance = 0;
+		if (hashes[pos] == EMPTY_HASH) {
+			return false;
+		}
 
+		// A collision occurred.
+		pos = (pos + 1) & local_capacity;
+		uint32_t distance = 1;
 		while (true) {
-			if (hashes[pos] == EMPTY_HASH) {
-				return false;
-			}
-
-			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
-				return false;
-			}
-
-			if (hashes[pos] == hash && Comparator::compare(elements[pos]->data.key, p_key)) {
+			if (hashes[pos] == p_hash && Comparator::compare(elements[pos]->data.key, p_key)) {
 				r_pos = pos;
 				return true;
 			}
 
-			pos = fastmod((pos + 1), capacity_inv, capacity);
+			if (hashes[pos] == EMPTY_HASH) {
+				return false;
+			}
+
+			if (distance > _get_probe_length(pos, hashes[pos], local_capacity)) {
+				return false;
+			}
+
+			pos = (pos + 1) & local_capacity;
 			distance++;
 		}
 	}
 
-	void _insert_with_hash(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+	void _insert_with_hash_and_element(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
+		const uint32_t local_capacity = capacity;
+		uint32_t pos = p_hash & local_capacity;
+
+		if (hashes[pos] == EMPTY_HASH) {
+			elements[pos] = p_value;
+			hashes[pos] = p_hash;
+			num_elements++;
+			return;
+		}
+
 		uint32_t hash = p_hash;
 		HashMapElement<TKey, TValue> *value = p_value;
-		uint32_t distance = 0;
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-
+		uint32_t distance = 1;
+		pos = (pos + 1) & local_capacity;
 		while (true) {
 			if (hashes[pos] == EMPTY_HASH) {
 				elements[pos] = value;
 				hashes[pos] = hash;
-
 				num_elements++;
-
+#ifdef DEV_ENABLED
+				if (unlikely(distance > 12)) {
+					WARN_PRINT("Excessive collision count (" +
+							itos(distance) + "), is the right hash function being used?");
+				}
+#endif
 				return;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(pos, hashes[pos], capacity, capacity_inv);
+			uint32_t existing_probe_len = _get_probe_length(pos, hashes[pos], local_capacity);
 			if (existing_probe_len < distance) {
 				SWAP(hash, hashes[pos]);
 				SWAP(value, elements[pos]);
 				distance = existing_probe_len;
 			}
 
-			pos = fastmod((pos + 1), capacity_inv, capacity);
+			pos = (pos + 1) & local_capacity;
 			distance++;
 		}
 	}
 
-	void _resize_and_rehash(uint32_t p_new_capacity_index) {
-		uint32_t old_capacity = hash_table_size_primes[capacity_index];
+	void _resize_and_rehash(uint32_t p_new_capacity) {
+		const uint32_t real_old_capacity = capacity + 1;
 
-		// Capacity can't be 0.
-		capacity_index = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_index);
-
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		// Capacity can't be 0 and must be 2^n - 1.
+		capacity = MAX(4u, p_new_capacity);
+		const uint32_t real_capacity = next_power_of_2(capacity);
+		capacity = real_capacity - 1;
 
 		HashMapElement<TKey, TValue> **old_elements = elements;
 		uint32_t *old_hashes = hashes;
 
-		num_elements = 0;
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-		elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * capacity));
+		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * real_capacity));
+		elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * real_capacity));
 
-		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = 0;
-			elements[i] = nullptr;
-		}
+		memset(hashes, EMPTY_HASH, real_capacity * sizeof(uint32_t));
 
-		if (old_capacity == 0) {
+		if (old_elements == nullptr) {
 			// Nothing to do.
 			return;
 		}
 
-		for (uint32_t i = 0; i < old_capacity; i++) {
-			if (old_hashes[i] == EMPTY_HASH) {
-				continue;
-			}
+		if (num_elements != 0) {
+			num_elements = 0;
 
-			_insert_with_hash(old_hashes[i], old_elements[i]);
+			for (uint32_t i = 0; i < real_old_capacity; i++) {
+				if (old_hashes[i] == EMPTY_HASH) {
+					continue;
+				}
+
+				_insert_with_hash_and_element(old_hashes[i], old_elements[i]);
+			}
 		}
 
 		Memory::free_static(old_elements);
 		Memory::free_static(old_hashes);
 	}
 
-	_FORCE_INLINE_ HashMapElement<TKey, TValue> *_insert(const TKey &p_key, const TValue &p_value, bool p_front_insert = false) {
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+	// This method does not check that the key is in the table.
+	// Use it if you know for sure that the key is new.
+	HashMapElement<TKey, TValue> *_insert_with_hash(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert = false) {
 		if (unlikely(elements == nullptr)) {
-			// Allocate on demand to save memory.
-
-			hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-			elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * capacity));
-
-			for (uint32_t i = 0; i < capacity; i++) {
-				hashes[i] = EMPTY_HASH;
-				elements[i] = nullptr;
-			}
+			_resize_and_rehash(capacity);
+		} else if (unlikely(num_elements > _get_resize_count(capacity))) {
+			_resize_and_rehash(capacity * 2);
 		}
 
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		HashMapElement<TKey, TValue> *elem = element_alloc.new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
 
-		if (exists) {
-			elements[pos]->data.value = p_value;
-			return elements[pos];
+		if (tail_element == nullptr) {
+			head_element = elem;
+			tail_element = elem;
+		} else if (p_front_insert) {
+			head_element->prev = elem;
+			elem->next = head_element;
+			head_element = elem;
 		} else {
-			if (num_elements + 1 > MAX_OCCUPANCY * capacity) {
-				ERR_FAIL_COND_V_MSG(capacity_index + 1 == HASH_TABLE_SIZE_MAX, nullptr, "Hash table maximum capacity reached, aborting insertion.");
-				_resize_and_rehash(capacity_index + 1);
-			}
-
-			HashMapElement<TKey, TValue> *elem = element_alloc.new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
-
-			if (tail_element == nullptr) {
-				head_element = elem;
-				tail_element = elem;
-			} else if (p_front_insert) {
-				head_element->prev = elem;
-				elem->next = head_element;
-				head_element = elem;
-			} else {
-				tail_element->next = elem;
-				elem->prev = tail_element;
-				tail_element = elem;
-			}
-
-			uint32_t hash = _hash(p_key);
-			_insert_with_hash(hash, elem);
-			return elem;
+			tail_element->next = elem;
+			elem->prev = tail_element;
+			tail_element = elem;
 		}
+
+		_insert_with_hash_and_element(p_hash, elem);
+		return elem;
 	}
 
 public:
-	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[capacity_index]; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return capacity + 1; }
 	_FORCE_INLINE_ uint32_t size() const { return num_elements; }
 
 	/* Standard Godot Container API */
 
-	bool is_empty() const {
+	_FORCE_INLINE_ bool is_empty() const {
 		return num_elements == 0;
 	}
 
@@ -256,16 +269,14 @@ public:
 		if (elements == nullptr || num_elements == 0) {
 			return;
 		}
-		uint32_t capacity = hash_table_size_primes[capacity_index];
-		for (uint32_t i = 0; i < capacity; i++) {
-			if (hashes[i] == EMPTY_HASH) {
-				continue;
-			}
 
-			hashes[i] = EMPTY_HASH;
-			element_alloc.delete_allocation(elements[i]);
-			elements[i] = nullptr;
+		HashMapElement<TKey, TValue> *current = tail_element;
+		while (current != nullptr) {
+			HashMapElement<TKey, TValue> *prev = current->prev;
+			element_alloc.delete_allocation(current);
+			current = prev;
 		}
+		memset(hashes, EMPTY_HASH, (capacity + 1) * sizeof(uint32_t));
 
 		tail_element = nullptr;
 		head_element = nullptr;
@@ -347,7 +358,7 @@ public:
 		return nullptr;
 	}
 
-	_FORCE_INLINE_ bool has(const TKey &p_key) const {
+	bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		return _lookup_pos(p_key, _pos);
 	}
@@ -360,14 +371,13 @@ public:
 			return false;
 		}
 
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t next_pos = fastmod((pos + 1), capacity_inv, capacity);
-		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], capacity, capacity_inv) != 0) {
+		const uint32_t local_capacity = capacity;
+		uint32_t next_pos = (pos + 1) & local_capacity;
+		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], local_capacity) != 0) {
 			SWAP(hashes[next_pos], hashes[pos]);
 			SWAP(elements[next_pos], elements[pos]);
 			pos = next_pos;
-			next_pos = fastmod((pos + 1), capacity_inv, capacity);
+			next_pos = (next_pos + 1) & local_capacity;
 		}
 
 		hashes[pos] = EMPTY_HASH;
@@ -389,7 +399,6 @@ public:
 		}
 
 		element_alloc.delete_allocation(elements[pos]);
-		elements[pos] = nullptr;
 
 		num_elements--;
 		return true;
@@ -407,24 +416,22 @@ public:
 		HashMapElement<TKey, TValue> *element = elements[pos];
 
 		// Delete the old entries in hashes and elements.
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t next_pos = fastmod((pos + 1), capacity_inv, capacity);
-		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], capacity, capacity_inv) != 0) {
+		const uint32_t local_capacity = capacity;
+		uint32_t next_pos = (pos + 1) & local_capacity;
+		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], local_capacity) != 0) {
 			SWAP(hashes[next_pos], hashes[pos]);
 			SWAP(elements[next_pos], elements[pos]);
 			pos = next_pos;
-			next_pos = fastmod((pos + 1), capacity_inv, capacity);
+			next_pos = (next_pos + 1) & local_capacity;
 		}
 		hashes[pos] = EMPTY_HASH;
-		elements[pos] = nullptr;
-		// _insert_with_hash will increment this again.
+		// _insert_with_hash_and_element will increment this again.
 		num_elements--;
 
 		// Update the HashMapElement with the new key and reinsert it.
 		const_cast<TKey &>(element->data.key) = p_new_key;
 		uint32_t hash = _hash(p_new_key);
-		_insert_with_hash(hash, element);
+		_insert_with_hash_and_element(hash, element);
 
 		return true;
 	}
@@ -432,22 +439,16 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		uint32_t new_index = capacity_index;
-
-		while (hash_table_size_primes[new_index] < p_new_capacity) {
-			ERR_FAIL_COND_MSG(new_index + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
-			new_index++;
-		}
-
-		if (new_index == capacity_index) {
+		if (p_new_capacity <= get_capacity()) {
 			return;
 		}
 
-		if (elements == nullptr) {
-			capacity_index = new_index;
-			return; // Unallocated yet.
+		if (unlikely(elements == nullptr)) {
+			capacity = MAX(4u, p_new_capacity);
+			capacity = next_power_of_2(capacity) - 1;
+			return;
 		}
-		_resize_and_rehash(new_index);
+		_resize_and_rehash(p_new_capacity);
 	}
 
 	/** Iterator API **/
@@ -538,7 +539,7 @@ public:
 		return Iterator(tail_element);
 	}
 
-	_FORCE_INLINE_ Iterator find(const TKey &p_key) {
+	Iterator find(const TKey &p_key) {
 		uint32_t pos = 0;
 		bool exists = _lookup_pos(p_key, pos);
 		if (!exists) {
@@ -563,7 +564,7 @@ public:
 		return ConstIterator(tail_element);
 	}
 
-	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const {
+	ConstIterator find(const TKey &p_key) const {
 		uint32_t pos = 0;
 		bool exists = _lookup_pos(p_key, pos);
 		if (!exists) {
@@ -583,60 +584,73 @@ public:
 
 	TValue &operator[](const TKey &p_key) {
 		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
-		if (!exists) {
-			return _insert(p_key, TValue())->data.value;
-		} else {
+		const uint32_t hash = _hash(p_key);
+		bool exists = _lookup_pos_with_hash(p_key, pos, hash);
+		if (exists) {
 			return elements[pos]->data.value;
+		} else {
+			return _insert_with_hash(p_key, TValue(), hash)->data.value;
 		}
 	}
 
 	/* Insert */
 
 	Iterator insert(const TKey &p_key, const TValue &p_value, bool p_front_insert = false) {
-		return Iterator(_insert(p_key, p_value, p_front_insert));
+		uint32_t pos = 0;
+		const uint32_t hash = _hash(p_key);
+		bool exists = _lookup_pos_with_hash(p_key, pos, hash);
+		if (!exists) {
+			return Iterator(_insert_with_hash(p_key, p_value, hash, p_front_insert));
+		} else {
+			elements[pos]->data.value = p_value;
+			return Iterator(elements[pos]);
+		}
 	}
 
 	/* Constructors */
 
 	HashMap(const HashMap &p_other) {
-		reserve(hash_table_size_primes[p_other.capacity_index]);
-
-		if (p_other.num_elements == 0) {
+		capacity = p_other.capacity;
+		if (p_other.num_elements == 0 || p_other.elements == nullptr) {
 			return;
 		}
 
+		_resize_and_rehash(p_other.capacity);
+
 		for (const KeyValue<TKey, TValue> &E : p_other) {
-			insert(E.key, E.value);
+			uint32_t hash = _hash(E.key);
+			_insert_with_hash(E.key, E.value, hash);
 		}
 	}
 
 	void operator=(const HashMap &p_other) {
 		if (this == &p_other) {
-			return; // Ignore self assignment.
+			return;
 		}
 		if (num_elements != 0) {
 			clear();
 		}
 
-		reserve(hash_table_size_primes[p_other.capacity_index]);
-
 		if (p_other.elements == nullptr) {
-			return; // Nothing to copy.
+			return;
+		}
+
+		if (p_other.capacity > capacity) {
+			_resize_and_rehash(p_other.capacity);
 		}
 
 		for (const KeyValue<TKey, TValue> &E : p_other) {
-			insert(E.key, E.value);
+			uint32_t hash = _hash(E.key);
+			_insert_with_hash(E.key, E.value, hash);
 		}
 	}
 
 	HashMap(uint32_t p_initial_capacity) {
-		// Capacity can't be 0.
-		capacity_index = 0;
-		reserve(p_initial_capacity);
+		capacity = MAX(4u, p_initial_capacity);
+		capacity = next_power_of_2(capacity) - 1;
 	}
-	HashMap() {
-		capacity_index = MIN_CAPACITY_INDEX;
+	HashMap() :
+			capacity(INITIAL_CAPACITY - 1) {
 	}
 
 	HashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
@@ -646,27 +660,31 @@ public:
 		}
 	}
 
-	uint32_t debug_get_hash(uint32_t p_index) {
-		if (num_elements == 0) {
-			return 0;
-		}
-		ERR_FAIL_INDEX_V(p_index, get_capacity(), 0);
-		return hashes[p_index];
-	}
-	Iterator debug_get_element(uint32_t p_index) {
-		if (num_elements == 0) {
-			return Iterator();
-		}
-		ERR_FAIL_INDEX_V(p_index, get_capacity(), Iterator());
-		return Iterator(elements[p_index]);
-	}
-
 	~HashMap() {
-		clear();
-
 		if (elements != nullptr) {
+			HashMapElement<TKey, TValue> *current = tail_element;
+			while (current != nullptr) {
+				HashMapElement<TKey, TValue> *prev = current->prev;
+				element_alloc.delete_allocation(current);
+				current = prev;
+			}
+
 			Memory::free_static(elements);
 			Memory::free_static(hashes);
+			elements = nullptr;
+			hashes = nullptr;
+			tail_element = nullptr;
+			head_element = nullptr;
+			num_elements = 0;
+			capacity = INITIAL_CAPACITY - 1;
 		}
 	}
 };
+
+extern template class HashMap<int, int>;
+extern template class HashMap<String, int>;
+extern template class HashMap<StringName, bool>;
+extern template class HashMap<StringName, StringName>;
+extern template class HashMap<StringName, String>;
+extern template class HashMap<StringName, Variant>;
+extern template class HashMap<StringName, int>;

--- a/core/templates/hashfuncs.cpp
+++ b/core/templates/hashfuncs.cpp
@@ -1,0 +1,250 @@
+/**************************************************************************/
+/*  hashfuncs.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "hashfuncs.h"
+
+uint32_t hash_djb2(const char *p_cstr) {
+	const unsigned char *chr = (const unsigned char *)p_cstr;
+	uint32_t hash = 5381;
+	uint32_t c = *chr++;
+
+	while (c) {
+		hash = ((hash << 5) + hash) ^ c; /* hash * 33 ^ c */
+		c = *chr++;
+	}
+
+	return hash;
+}
+
+uint32_t hash_djb2_buffer(const uint8_t *p_buff, int p_len, uint32_t p_prev) {
+	uint32_t hash = p_prev;
+
+	for (int i = 0; i < p_len; i++) {
+		hash = ((hash << 5) + hash) ^ p_buff[i]; /* hash * 33 + c */
+	}
+
+	return hash;
+}
+
+uint32_t hash_murmur3_buffer(const void *key, int length, const uint32_t seed) {
+	// Although not required, this is a random prime number.
+	const uint8_t *data = (const uint8_t *)key;
+	const int nblocks = length / 4;
+
+	uint32_t h1 = seed;
+
+	const uint32_t c1 = 0xcc9e2d51;
+	const uint32_t c2 = 0x1b873593;
+
+	const uint32_t *blocks = (const uint32_t *)(data + nblocks * 4);
+
+	for (int i = -nblocks; i; i++) {
+		uint32_t k1 = blocks[i];
+
+		k1 *= c1;
+		k1 = hash_rotl32(k1, 15);
+		k1 *= c2;
+
+		h1 ^= k1;
+		h1 = hash_rotl32(h1, 13);
+		h1 = h1 * 5 + 0xe6546b64;
+	}
+
+	const uint8_t *tail = (const uint8_t *)(data + nblocks * 4);
+
+	uint32_t k1 = 0;
+
+	switch (length & 3) {
+		case 3:
+			k1 ^= tail[2] << 16;
+			[[fallthrough]];
+		case 2:
+			k1 ^= tail[1] << 8;
+			[[fallthrough]];
+		case 1:
+			k1 ^= tail[0];
+			k1 *= c1;
+			k1 = hash_rotl32(k1, 15);
+			k1 *= c2;
+			h1 ^= k1;
+	};
+
+	// Finalize with additional bit mixing.
+	h1 ^= length;
+	return hash_fmix32(h1);
+}
+
+uint32_t HashMapHasherDefault::hash(const String &p_string) {
+	return hash_fmix32(p_string.hash());
+}
+
+uint32_t HashMapHasherDefault::hash(const char *p_cstr) {
+	return hash_fmix32(hash_djb2(p_cstr));
+}
+
+uint32_t HashMapHasherDefault::hash(const wchar_t p_wchar) {
+	return hash_fmix32(uint32_t(p_wchar));
+}
+
+uint32_t HashMapHasherDefault::hash(const char16_t p_uchar) {
+	return hash_fmix32(uint32_t(p_uchar));
+}
+
+uint32_t HashMapHasherDefault::hash(const char32_t p_uchar) {
+	return hash_fmix32(uint32_t(p_uchar));
+}
+
+uint32_t HashMapHasherDefault::hash(const RID &p_rid) {
+	return hash_one_uint64(p_rid.get_id());
+}
+
+uint32_t HashMapHasherDefault::hash(const CharString &p_char_string) {
+	return hash_murmur3_buffer(p_char_string.get_data(), sizeof(char) * p_char_string.size());
+}
+
+uint32_t HashMapHasherDefault::hash(const StringName &p_string_name) {
+	return p_string_name.hash_mixed();
+}
+
+uint32_t HashMapHasherDefault::hash(const NodePath &p_path) {
+	return p_path.hash_mixed();
+}
+
+uint32_t HashMapHasherDefault::hash(const ObjectID &p_id) {
+	return hash_one_uint64(p_id);
+}
+
+uint32_t HashMapHasherDefault::hash(const uint64_t p_int) {
+	return hash_one_uint64(p_int);
+}
+
+uint32_t HashMapHasherDefault::hash(const int64_t p_int) {
+	return hash_one_uint64(p_int);
+}
+
+uint32_t HashMapHasherDefault::hash(const float p_float) {
+	return hash_murmur3_one_float(p_float);
+}
+
+uint32_t HashMapHasherDefault::hash(const double p_double) {
+	return hash_murmur3_one_double(p_double);
+}
+
+uint32_t HashMapHasherDefault::hash(const uint32_t p_int) {
+	return hash_fmix32(p_int);
+}
+
+uint32_t HashMapHasherDefault::hash(const int32_t p_int) {
+	return hash_fmix32(uint32_t(p_int));
+}
+
+uint32_t HashMapHasherDefault::hash(const uint16_t p_int) {
+	return hash_fmix32(uint32_t(p_int));
+}
+
+uint32_t HashMapHasherDefault::hash(const int16_t p_int) {
+	return hash_fmix32(uint32_t(p_int));
+}
+
+uint32_t HashMapHasherDefault::hash(const uint8_t p_int) {
+	return hash_fmix32(uint32_t(p_int));
+}
+
+uint32_t HashMapHasherDefault::hash(const int8_t p_int) {
+	return hash_fmix32(uint32_t(p_int));
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector2i &p_vec) {
+	uint32_t h = hash_murmur3_one_32(uint32_t(p_vec.x));
+	h = hash_murmur3_one_32(uint32_t(p_vec.y), h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector3i &p_vec) {
+	uint32_t h = hash_murmur3_one_32(uint32_t(p_vec.x));
+	h = hash_murmur3_one_32(uint32_t(p_vec.y), h);
+	h = hash_murmur3_one_32(uint32_t(p_vec.z), h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector4i &p_vec) {
+	uint32_t h = hash_murmur3_one_32(uint32_t(p_vec.x));
+	h = hash_murmur3_one_32(uint32_t(p_vec.y), h);
+	h = hash_murmur3_one_32(uint32_t(p_vec.z), h);
+	h = hash_murmur3_one_32(uint32_t(p_vec.w), h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector2 &p_vec) {
+	uint32_t h = hash_murmur3_one_real(p_vec.x);
+	h = hash_murmur3_one_real(p_vec.y, h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector3 &p_vec) {
+	uint32_t h = hash_murmur3_one_real(p_vec.x);
+	h = hash_murmur3_one_real(p_vec.y, h);
+	h = hash_murmur3_one_real(p_vec.z, h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Vector4 &p_vec) {
+	uint32_t h = hash_murmur3_one_real(p_vec.x);
+	h = hash_murmur3_one_real(p_vec.y, h);
+	h = hash_murmur3_one_real(p_vec.z, h);
+	h = hash_murmur3_one_real(p_vec.w, h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Rect2i &p_rect) {
+	uint32_t h = hash_murmur3_one_32(uint32_t(p_rect.position.x));
+	h = hash_murmur3_one_32(uint32_t(p_rect.position.y), h);
+	h = hash_murmur3_one_32(uint32_t(p_rect.size.x), h);
+	h = hash_murmur3_one_32(uint32_t(p_rect.size.y), h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const Rect2 &p_rect) {
+	uint32_t h = hash_murmur3_one_real(p_rect.position.x);
+	h = hash_murmur3_one_real(p_rect.position.y, h);
+	h = hash_murmur3_one_real(p_rect.size.x, h);
+	h = hash_murmur3_one_real(p_rect.size.y, h);
+	return hash_fmix32(h);
+}
+
+uint32_t HashMapHasherDefault::hash(const AABB &p_aabb) {
+	uint32_t h = hash_murmur3_one_real(p_aabb.position.x);
+	h = hash_murmur3_one_real(p_aabb.position.y, h);
+	h = hash_murmur3_one_real(p_aabb.position.z, h);
+	h = hash_murmur3_one_real(p_aabb.size.x, h);
+	h = hash_murmur3_one_real(p_aabb.size.y, h);
+	h = hash_murmur3_one_real(p_aabb.size.z, h);
+	return hash_fmix32(h);
+}

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3547,3 +3547,12 @@ void Variant::unregister_types() {
 	_unregister_variant_destructors();
 	_unregister_variant_utility_functions();
 }
+
+uint32_t VariantHasher::hash(const Variant &p_variant) {
+	uint32_t hash = p_variant.hash();
+	Variant::Type type = p_variant.get_type();
+	if (type == Variant::STRING || type == Variant::STRING_NAME || type == Variant::NODE_PATH) {
+		return hash_fmix32(hash);
+	}
+	return hash;
+}

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -897,7 +897,7 @@ Vector<Variant> varray(VarArgs... p_args) {
 }
 
 struct VariantHasher {
-	static _FORCE_INLINE_ uint32_t hash(const Variant &p_variant) { return p_variant.hash(); }
+	static uint32_t hash(const Variant &p_variant);
 };
 
 struct VariantComparator {

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 
 #include "tests/test_macros.h"
@@ -145,4 +146,138 @@ TEST_CASE("[HashMap] Const iteration") {
 		++idx;
 	}
 }
+
+TEST_CASE("[HashMap] Replace key") {
+	HashMap<int, int> map;
+	map.insert(42, 84);
+	map.insert(0, 12934);
+	CHECK(map.replace_key(0, 1));
+	CHECK(map.has(1));
+	CHECK(map[1] == 12934);
+}
+
+TEST_CASE("[HashMap] Clear") {
+	HashMap<int, int> map;
+	map.insert(42, 84);
+	map.insert(123, 12385);
+	map.insert(0, 12934);
+
+	map.clear();
+	CHECK(!map.has(42));
+	CHECK(map.size() == 0);
+	CHECK(map.is_empty());
+}
+
+TEST_CASE("[HashMap] Get") {
+	HashMap<int, int> map;
+	map.insert(42, 84);
+	map.insert(123, 12385);
+	map.insert(0, 12934);
+
+	CHECK(map.get(123) == 12385);
+	map.get(123) = 10;
+	CHECK(map.get(123) == 10);
+
+	CHECK(*map.getptr(0) == 12934);
+	*map.getptr(0) = 1;
+	CHECK(*map.getptr(0) == 1);
+
+	CHECK(map.get(42) == 84);
+	CHECK(map.getptr(-10) == nullptr);
+}
+
+TEST_CASE("[HashMap] Insert, iterate and remove many elements") {
+	const int elem_max = 1234;
+	HashMap<int, int> map;
+	for (int i = 0; i < elem_max; i++) {
+		map.insert(i, i);
+	}
+
+	//insert order should have been kept
+	int idx = 0;
+	for (auto &K : map) {
+		CHECK(idx == K.key);
+		CHECK(idx == K.value);
+		CHECK(map.has(idx));
+		idx++;
+	}
+
+	Vector<int> elems_still_valid;
+
+	for (int i = 0; i < elem_max; i++) {
+		if ((i % 5) == 0) {
+			map.erase(i);
+		} else {
+			elems_still_valid.push_back(i);
+		}
+	}
+
+	CHECK(elems_still_valid.size() == map.size());
+
+	for (int i = 0; i < elems_still_valid.size(); i++) {
+		CHECK(map.has(elems_still_valid[i]));
+	}
+}
+
+TEST_CASE("[HashMap] Insert, iterate and remove many strings") {
+	const int elem_max = 432;
+	HashMap<String, String> map;
+	for (int i = 0; i < elem_max; i++) {
+		map.insert(itos(i), itos(i));
+	}
+
+	//insert order should have been kept
+	int idx = 0;
+	for (auto &K : map) {
+		CHECK(itos(idx) == K.key);
+		CHECK(itos(idx) == K.value);
+		CHECK(map.has(itos(idx)));
+		idx++;
+	}
+
+	Vector<String> elems_still_valid;
+
+	for (int i = 0; i < elem_max; i++) {
+		if ((i % 5) == 0) {
+			map.erase(itos(i));
+		} else {
+			elems_still_valid.push_back(itos(i));
+		}
+	}
+
+	CHECK(elems_still_valid.size() == map.size());
+
+	for (int i = 0; i < elems_still_valid.size(); i++) {
+		CHECK(map.has(elems_still_valid[i]));
+	}
+
+	elems_still_valid.clear();
+}
+
+TEST_CASE("[HashMap] Copy constructor") {
+	HashMap<int, int> map0;
+	const uint32_t count = 5;
+	for (uint32_t i = 0; i < count; i++) {
+		map0.insert(i, i);
+	}
+	HashMap<int, int> map1(map0);
+	CHECK(map0.size() == map1.size());
+	CHECK(map0.get_capacity() == map1.get_capacity());
+	CHECK(*map0.getptr(0) == *map1.getptr(0));
+}
+
+TEST_CASE("[HashMap] Operator =") {
+	HashMap<int, int> map0;
+	HashMap<int, int> map1;
+	const uint32_t count = 5;
+	map1.insert(1234, 1234);
+	for (uint32_t i = 0; i < count; i++) {
+		map0.insert(i, i);
+	}
+	map1 = map0;
+	CHECK(map0.size() == map1.size());
+	CHECK(map0.get_capacity() == map1.get_capacity());
+	CHECK(*map0.getptr(0) == *map1.getptr(0));
+}
+
 } // namespace TestHashMap


### PR DESCRIPTION
**Benchmarks**

Compile command: `scons -j11 target=template_release scu_build=true`

**HashMap<int, int>**
| Elements | Time find before (nsec) | Time find after (nsec) |
|----------|-------------------------|------------------------|
| 10       | 685                     | 453                    |
| 50       | 672                     | 707                    |
| 250      | 2542                    | 2330                   |
| 1250     | 13065                   | 8843                   |
| 6250     | 55934                   | 43017                  |
| 31250    | 373167                  | 293621                 |
| 156250   | 1905111                 | 1500588                |
| 781250   | 14192621                | 11117365               |
| 3906250  | 82247888                | 66698464               |
| 19531250 | 441888032               | 364882432              |


| Elements | Time insert before (usec) | Time insert after (usec) |
|----------|--------------------|-------------------|
| 5        | 2                  | 0                 |
| 25       | 1                  | 0                 |
| 125      | 14                 | 4                 |
| 625      | 34                 | 18                |
| 3125     | 162                | 95                |
| 15625    | 808                | 723               |
| 78125    | 3953               | 3477              |
| 390625   | 39874              | 28357             |
| 1953125  | 188333             | 154200            |
| 9765625  | 970730             | 758132            |

Notes. These benchmarks were conducted using the `reserve` method, as there were different map expansion points due to the replacement from `fastmod` to `&`. There were 5 times more elements reserved than were inserted.
In the `find benchmark`, 50% of the elements are not in the table itself, which gives 50% of the misses. Also it looks for all of these elements. Therefore, the increase in time is proportional to the increased number of elements.

**Reducing the size of the compiled binary.**
If you compare the binary generated by CI with mine and with the master, you can see that the binary is about 0.1 - 1 MB smaller.
Most likely, this is due to the `_FORCE_INLINE_` that I added for some methods.

**Replacing fastmod with &**
I completely replaced `fastmod` with `&`.  
As I checked, `&` is 5 times faster than `fastmod` and 10 times faster than `%`. Also, keep in mind that `fastmod` is not supported on 32-bit architectures.

**How `&` works?**
We can instantly calculate `141%100`, where we simply discard everything but the hundredth. The remainder of the division will be `41`. The same is true for `1267 % 10 = 7` or `4 % 10000 = 4`. For computers, this works in binary, as I did.

The necessary condition is that the number from which we want to take the remainder of the division must be `2^n`. 
Let's represent some number in binary format `00100`.
To find the remainder from, say, a hash of `11110`, we need to subtract 1 from our number and then do a bitwise AND. 
`11110 & 00011 = 00010`. And that's it.

**How `&` was implemented?**
In order to reduce the number of operations in the parts of the code that are most often used, I made `capacity` one less than used in other containers. But the `get_capacity` method will return the normal capacity. Next, we need to make sure that the condition for our number `2^n - 1` is met. In the `_resize_and_rehash` method, I use this 
``` c++
capacity = next_power_of_2(capacity) - 1;
```
 to satisfy this condition. Before that, It used a loop to fit the number from the hash table array (in `reserve` method).

**Removing unnecessary hash calculations**
`insert` method previously had 2 `_hash` calculations and the `operator []` had 3 in total. 
I removed the hash calculation from the `_insert` method and renamed this method to `_insert_with_hash`. I renamed the other method, which was `_insert_with_hash`, to `_insert_with_hash_and_element`. 
I also added the `_look_up_with_hash` method, which searches for a position with a previously calculated hash. 

**Improving hash quality for string**
Using hash_fmix32 for calculated hash for strings greatly reduced the number of collisions. This can be seen by comparing the results of this code.
GDScript implementation:
``` gdscript
var map = {}
var start = Time.get_ticks_usec()
for i in range(10000):
	map[str(i)] = 4
for i in range(10000):
	var a = map[str(i)]
print(Time.get_ticks_usec() - start)
```
C++ implementation:
```c++
HashMap<String, long> map;
uint64_t start = OS::get_singleton()->get_ticks_usec();
for (int i = 0; i < 10000; i++) {
	map[itos(i)] = 4;
}
uint64_t end = OS::get_singleton()->get_ticks_usec();
print_line(end - start);
```
There is a 30% performance improvement in gdscript and a 213% improvement in C++ If the implementation of the hashmap differs only by the hasher.

**Improving Comparator for floating point numbers**
Using a bitwise comparison instead of a normal one and checking for NAN significantly reduces the comparison time.

Closes: #98598