### PR TITLE
Fix small error in Variant doc

### DIFF
--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -11,7 +11,7 @@
 		foo = "Now foo is a string!"
 		foo = RefCounted.new() # foo is an Object
 		var bar: int = 2 # bar is a statically typed integer.
-		# bar = "Uh oh! I can't make static variables become a different type!"
+		# bar = "Uh oh! I can't make statically typed variables become a different type!"
 		[/gdscript]
 		[csharp]
 		// C# is statically typed. Once a variable has a type it cannot be changed. You can use the `var` keyword to let the compiler infer the type automatically.
@@ -36,7 +36,7 @@
 		match typeof(foo):
 		    TYPE_NIL:
 		        print("foo is null")
-		    TYPE_INTEGER:
+		    TYPE_INT:
 		        print("foo is an integer")
 		    TYPE_OBJECT:
 		        # Note that Objects are their own special category.


### PR DESCRIPTION
This comment is referring to the statically typed variable declared in the above line.

Static variables exist in GDScript and they are a different thing so this should be fixed.