### PR TITLE
Fix mouse selection exist, even if no mouse button is pressed.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1674,7 +1674,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
 					_edit.gizmo = Ref<EditorNode3DGizmo>();
 				}
-				
+
 				// cancel select
 				if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
 					selection_in_progress = false;
@@ -2377,6 +2377,15 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		if (!orthogonal && ED_IS_SHORTCUT("spatial_editor/freelook_toggle", p_event)) {
 			set_freelook_active(!is_freelook_active());
 
+			if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
+				selection_in_progress = false;
+
+				if (cursor.region_select) {
+					cursor.region_select = false;
+					_select_region();
+					surface->queue_redraw();
+				}
+			}
 		} else if (k->get_keycode() == Key::ESCAPE) {
 			set_freelook_active(false);
 		}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -683,6 +683,21 @@ float Node3DEditorViewport::get_fov() const {
 	return CLAMP(spatial_editor->get_fov() * cursor.fov_scale, MIN_FOV, MAX_FOV);
 }
 
+void Node3DEditorViewport::clear_selection() {
+	if (selection_in_progress) {
+		selection_in_progress = false;
+
+		if (cursor.region_select) {
+			Vector2 center = surface->get_global_position() + (surface->get_size() / 2);
+			cursor.region_begin = center;
+			cursor.region_end = center;
+			cursor.region_select = false;
+			_select_region();
+			surface->queue_redraw();
+		}
+	}
+}
+
 Transform3D Node3DEditorViewport::_get_camera_transform() const {
 	return camera->get_global_transform();
 }
@@ -1677,15 +1692,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				// cancel select
 				if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
-					selection_in_progress = false;
-
-					if (cursor.region_select) {
-						cursor.region_begin = b->get_position();
-						cursor.region_end = b->get_position();
-						cursor.region_select = false;
-						_select_region();
-						surface->queue_redraw();
-					}
+					clear_selection();
 				}
 
 				if (_edit.mode == TRANSFORM_NONE && b->is_pressed()) {
@@ -1913,14 +1920,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							_select_clicked(false);
 						}
 
-						if (cursor.region_select) {
-							if (selection_in_progress) {
-								_select_region();
-							}
-
-							cursor.region_select = false;
-							surface->queue_redraw();
-						}
+						clear_selection();
 					}
 
 					if (_edit.mode != TRANSFORM_NONE) {
@@ -2378,13 +2378,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			set_freelook_active(!is_freelook_active());
 
 			if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
-				selection_in_progress = false;
-
-				if (cursor.region_select) {
-					cursor.region_select = false;
-					_select_region();
-					surface->queue_redraw();
-				}
+				clear_selection();
 			}
 		} else if (k->get_keycode() == Key::ESCAPE) {
 			set_freelook_active(false);
@@ -3073,6 +3067,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 			if (freelook_active) {
 				set_freelook_active(false);
 			}
+
+			clear_selection();
 		} break;
 	}
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3068,6 +3068,12 @@ void Node3DEditorViewport::_notification(int p_what) {
 				_remove_preview_node();
 			}
 		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			if (freelook_active) {
+				set_freelook_active(false);
+			}
+		} break;
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -300,6 +300,7 @@ private:
 	Vector<_RayResult> selection_results_menu;
 	bool clicked_wants_append = false;
 	bool selection_in_progress = false;
+	void clear_selection();
 
 	PopupMenu *selection_menu = nullptr;
 


### PR DESCRIPTION
fix #24593 
Sorry, I just rename my branch.
same as #89882 

fix mouse selection exist after right click

https://github.com/godotengine/godot/assets/94742489/d17a40f4-2ba2-4f00-a7ef-a2fbec0a7ffc

fix mouse selection exist after app lose focus

https://github.com/godotengine/godot/assets/94742489/f698e341-9770-4810-a36b-545f507ffa18

for following issue i just stop free look after app lose focus to avoid this #50051
> One issue is that after you click back in the editor, using freelook or panning won't do anything when you move the mouse until you left click a second time.



