### PR TITLE
Fix `INSTANCE_CUSTOM.w` not being assigned correctly in CPUParticles 2D and 3D

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -753,10 +753,10 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			p.custom[0] = 0.0; // unused
 			p.custom[1] = 0.0; // phase [0..1]
 			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand);
-			p.custom[3] = 0.0;
+			p.custom[3] = (1.0 - Math::randf() * lifetime_randomness);
 			p.transform = Transform2D();
 			p.time = 0;
-			p.lifetime = lifetime * (1.0 - Math::randf() * lifetime_randomness);
+			p.lifetime = lifetime * p.custom[3];
 			p.base_color = Color(1, 1, 1, 1);
 
 			switch (emission_shape) {

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -69,7 +69,7 @@ void CPUParticles3D::set_amount(int p_amount) {
 
 		for (int i = 0; i < p_amount; i++) {
 			w[i].active = false;
-			w[i].custom[3] = 0.0; // Make sure w component isn't garbage data
+			w[i].custom[3] = 1.0; // Make sure w component isn't garbage data and doesn't break shaders with CUSTOM.y/Custom.w
 		}
 	}
 
@@ -813,9 +813,10 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			p.custom[0] = Math::deg_to_rad(base_angle); //angle
 			p.custom[1] = 0.0; //phase
 			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand); //animation offset (0-1)
+			p.custom[3] = (1.0 - Math::randf() * lifetime_randomness);
 			p.transform = Transform3D();
 			p.time = 0;
-			p.lifetime = lifetime * (1.0 - Math::randf() * lifetime_randomness);
+			p.lifetime = lifetime * p.custom[3];
 			p.base_color = Color(1, 1, 1, 1);
 
 			switch (emission_shape) {


### PR DESCRIPTION
This PR fixes an issue with CPUParticles not assigning and using INSTANCE_CUSTOM.w in the same way as GPUParticles, causing any shader that correctly uses lifetime (`INSTANCE_CUSTOM.y/INSTANCE_CUSTOM.w`) to misbehave when assigned to CPUParticles from GPUParticles.

There's no issue coupled to this because it came out of a troubleshooting conversation on discord that turned into a bug report.

[CPU_Particles_Instance_Custom_MRP.zip](https://github.com/godotengine/godot/files/14823109/CPU_Particles_Instance_Custom_MRP.zip)
