### PR TITLE
[Doc] Improve description of `y_sort_enabled`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -606,14 +606,15 @@
 			[b]Note:[/b] For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
 		</member>
 		<member name="y_sort_enabled" type="bool" setter="set_y_sort_enabled" getter="is_y_sort_enabled" default="false">
-			If [code]true[/code], this [CanvasItem] and its [CanvasItem] child nodes are sorted according to the Y position. Nodes with a lower Y position are drawn before those with a higher Y position. If [code]false[/code], Y-sorting is disabled.
-			You can nest nodes with Y-sorting. Child Y-sorted nodes are sorted in the same space as the parent Y-sort. This feature allows you to organize a scene better or divide it into multiple ones without changing your scene tree.
+			If [code]true[/code], this and child [CanvasItem] nodes with a lower Y position are rendered in front of nodes with a higher Y position. If [code]false[/code], this and child [CanvasItem] nodes are rendered normally in scene tree order.
+			With Y-sorting enabled on a parent node ('A') but disabled on a child node ('B'), the child node ('B') is sorted but its children ('C1', 'C2', etc) render together on the same Y position as the child node 'B'. This allows you to organize the render order of a scene without changing the scene tree.
+			Nodes sort relative to each other only if they are on the same [member z_index].
 		</member>
 		<member name="z_as_relative" type="bool" setter="set_z_as_relative" getter="is_z_relative" default="true">
 			If [code]true[/code], the node's Z index is relative to its parent's Z index. If this node's Z index is 2 and its parent's effective Z index is 3, then this node's effective Z index will be 2 + 3 = 5.
 		</member>
 		<member name="z_index" type="int" setter="set_z_index" getter="get_z_index" default="0">
-			Z index. Controls the order in which the nodes render. A node with a higher Z index will display in front of others. Must be between [constant RenderingServer.CANVAS_ITEM_Z_MIN] and [constant RenderingServer.CANVAS_ITEM_Z_MAX] (inclusive).
+			Controls the order in which the nodes render. A node with a higher Z index will display in front of others. Must be between [constant RenderingServer.CANVAS_ITEM_Z_MIN] and [constant RenderingServer.CANVAS_ITEM_Z_MAX] (inclusive).
 			[b]Note:[/b] Changing the Z index of a [Control] only affects the drawing order, not the order in which input events are handled. This can be useful to implement certain UI animations, e.g. a menu where hovered items are scaled and should overlap others.
 		</member>
 	</members>


### PR DESCRIPTION
Y-sorting is an incredibly important tool in non-tile-based 2D games, and I only truly understood Godot's robust implementation of it after wasting 2 days writing complex scripts to control Sprite offsets as I did not comprehend the description for `y_sort_enabled`. This PR aims to improve that description so that I can save others the experimentation.

In short:
- I merged the two first sentences as they were saying the same thing twice.
- I attempted to _actually_ explain what disabling y-sorting does instead of stating the obvious 'if you disable this, you disable this.'
- I rewrote the second part to clarify that disabling y-sorting essentially **groups** the nodes under the y position of the parent if the outermost parent is Y-sorted. This concept is in my opinion quite complex and I think the previous description failed to describe the affordance of that complexity, namely: you can turn `y_sort_enabled` on and off on selected nodes to group and Y-sort the entire scene in a smart way.
- I added that Y-sorting only works if those nodes are on the same Z-index. I was a bit in doubt about adding this, as it makes the whole tooltip another two lines higher, but decided to add it because there is a relationship with Z-index that isn't explained anywhere else.

As a bonus, I also removed the redundant 'Z index' at the start of the description for `z_index`. If that should be a separate PR, let me know. 