### PR TITLE
Fix crash when open import dialog due to renaming the external bone map

### DIFF
--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1798,6 +1798,8 @@ void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions
 }
 
 Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
+
 	if (r_err) {
 		*r_err = OK;
 	}

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -49,6 +49,8 @@ void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> *r_extension
 Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
+
 	// FIXME: Hack to work around GH-86309.
 	if (p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == EditorSceneFormatImporterUFBX::FBX_IMPORTER_UFBX) {
 		Ref<EditorSceneFormatImporterUFBX> fbx2gltf_importer;

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -48,6 +48,8 @@ void EditorSceneFormatImporterUFBX::get_extensions(List<String> *r_extensions) c
 Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
+
 	// FIXME: Hack to work around GH-86309.
 	if (p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == FBX_IMPORTER_FBX2GLTF && GLOBAL_GET("filesystem/import/fbx2gltf/enabled")) {
 		Ref<EditorSceneFormatImporterFBX2GLTF> fbx2gltf_importer;

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -113,6 +113,8 @@ void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) 
 Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
+
 	String blender_path = EDITOR_GET("filesystem/import/blender/blender_path");
 
 	if (blender_major_version == -1 || blender_minor_version == -1) {

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -47,6 +47,8 @@ void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) c
 Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
+
 	Ref<GLTFDocument> gltf;
 	gltf.instantiate();
 	Ref<GLTFState> state;


### PR DESCRIPTION
This is a quick fix for https://github.com/godotengine/godot/issues/90014 , and it can be dumped by a more deliberate solution.

The core issue is that in the *.import file, it uses name for external reference like below:

```
_subresources={
"nodes": {
"PATH:Armature/Skeleton3D": {
"retarget/bone_map": Resource("res://external_bone_map.tres")
}
}
}
```

So renaming the resource will fail to load this config file, so the following code in scene_import_settings will not be excuted:

https://github.com/godotengine/godot/blob/29b3d9e9e538f0aa8effc8ad8bf19a2915292a89/editor/import/3d/scene_import_settings.cpp#L720-L732

which leads to the `p_options` in the following functions being empty, and eventually crashed in the importer when excuteing things like `p_options["animation/fps"]`

The ultimate solution maybe to use uuid instead of resource name, but I guess that's a breaking change. 

For a temp fix this maybe not enough (other file formats should be protected like this) or maybe we should place it in `ResourceImporterScene::pre_import`. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
