### PR TITLE
Allow wrapping for begin rotate transformation to bring it in line with Blender.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1603,11 +1603,7 @@ void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> m = p_event;
 
 	if (m.is_valid()) {
-		if (_edit.mode == TRANSFORM_ROTATE) {
-			_edit.mouse_pos = m->get_position(); // rotate should not wrap
-		} else {
-			_edit.mouse_pos += _get_warped_mouse_motion(p_event);
-		}
+		_edit.mouse_pos += _get_warped_mouse_motion(p_event);
 		update_transform(_get_key_modifier(m) == Key::SHIFT);
 	}
 }


### PR DESCRIPTION
The original PR which brought the Blender style controls into Godot (Begin Rotate Transformation for rotation) specifically disallowed wrapping for rotation but Blender actually does have the rotation with wrapping so this PR removes the extra branch and brings it in line with Blender's functionality.

Also fixes these:
- Fixes https://github.com/godotengine/godot/issues/90081
- Fixes https://github.com/godotengine/godot/issues/85810

________________
As a side note, although the wrapping can seem strange to many even in Blender it does have its use. When you want more fine control over the rotation you can quickly move your mouse outside the view to wrap it around to "decrease the sensitivity" (larger radius -> smaller angle difference on input movement).