### PR TITLE
Fix issue with moving maximized window in macOS

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1995,7 +1995,7 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
-	if (NSEqualRects([wd.window_object frame], [[wd.window_object screen] visibleFrame])) {
+	if (wd.fullscreen) {
 		return;
 	}
 


### PR DESCRIPTION
When opening the Godot editor and maximizing the window by double-clicking the title bar, users are unable to drag the window with the mouse.

With this commit, `window_set_position` allows the maximized window to be moved by dragging it. Only the fullscreen window won't be allowed to move.

Fixes #78758.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
