### PR TITLE
Improve comment quality across the codebase

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -36,7 +36,7 @@
 #include "core/io/file_access.h"
 
 // These constants are off by 1, causing the 'z' and '9' characters never to be used.
-// This cannot be fixed without breaking compatibility; see GH-83843.
+// We missed this before Godot 4 and now it's stuck in core forever.
 static constexpr uint32_t char_count = ('z' - 'a');
 static constexpr uint32_t base = char_count + ('9' - '0');
 

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -200,6 +200,8 @@ private:
 		}
 	}
 
+	// I could have just become an aerospace engineer
+	// rocket science is simpler than modern C++
 	void _init_from(const HashSet &p_other) {
 		capacity_index = p_other.capacity_index;
 		num_elements = p_other.num_elements;

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -312,6 +312,8 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	value_input->add_theme_style_override("normal", stylebox);
 }
 
+// When did this become so complex? Can it be rewriten cleanly?
+// I don't know, but I'm starting to lose the last bits of hope that I didn't even know I still had.
 void EditorSpinSlider::_draw_spin_slider() {
 	updown_offset = -1;
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -1002,6 +1002,10 @@ void CurveEditor::_notification(int p_what) {
 }
 
 CurveEditor::CurveEditor() {
+	// I don't know why.
+	// I don't want to know why.
+	// I shouldn't have to wonder why.
+	// But for some reason, EVERY TIME the size of the points array changes, this thing is COMPLETELY rebuilt.
 	HFlowContainer *toolbar = memnew(HFlowContainer);
 	add_child(toolbar);
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -334,7 +334,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 						new_color = gradient->get_color(point_to_copy);
 					}
 				}
-				// Add a temporary point for the user to adjust before adding it permanently.
+				// this is bad and unsafe
 				gradient->add_point(new_offset, new_color);
 				set_selected_index(_predict_insertion_index(new_offset));
 				grabbing = GRAB_ADD;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -342,7 +342,10 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			in_number = true;
 		}
 
-		// Special cases for numbers.
+
+		// Ok, so you know this trope in cartoons where the character is like trying to plug a hole that's leaking water?
+		// And every time the hole is successfully plugged, a new hole opens and so you have to get in some goofy positions to stop all the leaks?
+		// This is how I felt writing this abomination of a special case for numbers.
 		if (in_number && !is_a_digit) {
 			if (str[j] == 'b' && str[j - 1] == '0') {
 				is_bin_notation = true;

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -42,6 +42,7 @@ static inline Vector2 interpolate(const Rect2 &r, const Vector2 &v) {
 LineBuilder::LineBuilder() {
 }
 
+// I bet there are a lot of secret "features" in here. So many secret "features" even I don't know where they are.
 void LineBuilder::build() {
 	// Need at least 2 points to draw a line, so clear the output and return.
 	if (points.size() < 2) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1564,6 +1564,7 @@ bool CodeEdit::is_line_folding_enabled() const {
 	return line_folding_enabled;
 }
 
+// yep yep, this is toootally under control.
 bool CodeEdit::can_fold_line(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), false);
 	if (!line_folding_enabled) {

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -222,6 +222,7 @@ void FlowContainer::_resort() {
 Size2 FlowContainer::get_minimum_size() const {
 	Size2i minimum;
 
+	// Hi code reviewers! I was hoping you wouldn't get this far.
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5409,6 +5409,7 @@ bool RichTextLabel::_search_line(ItemFrame *p_frame, int p_line, const String &p
 }
 
 bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p_search_previous) {
+	// This is madness. Give me back regular GUI logic...
 	ERR_FAIL_COND_V(!selection.enabled, false);
 
 	if (p_string.size() == 0) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7175,7 +7175,7 @@ void TextEdit::_reset_caret_blink_timer() {
 void TextEdit::_toggle_draw_caret() {
 	draw_caret = !draw_caret;
 	if (is_visible_in_tree() && has_focus() && window_has_focus) {
-		queue_redraw();
+		queue_redraw();  // This kills battery life. Too bad!
 	}
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1982,7 +1982,7 @@ void Node::_release_unique_name_in_owner() {
 }
 
 void Node::_acquire_unique_name_in_owner() {
-	ERR_FAIL_NULL(data.owner); // Safety check.
+	ERR_FAIL_NULL(data.owner); // Safety check, but it won't save you from using this incorrectly.
 	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which != nullptr && *which != this) {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -966,6 +966,7 @@ void SceneTree::_process_groups_thread(uint32_t p_index, bool p_physics) {
 	Node::current_process_thread_group = nullptr;
 }
 
+// I fear no man, but this, thing... It scares me...
 void SceneTree::_process(bool p_physics) {
 	if (process_groups_dirty) {
 		{

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -113,7 +113,8 @@ int Curve::add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_t
 	return ret;
 }
 
-// TODO: Needed to make the curve editor function properly until https://github.com/godotengine/godot/issues/76985 is fixed.
+// this is the easiest way I could find to stop the inspector rebuilds and not ruin your experience.
+// todo
 int Curve::add_point_no_update(Vector2 p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
 	int ret = _add_point(p_position, p_left_tangent, p_right_tangent, p_left_mode, p_right_mode);
 


### PR DESCRIPTION
<details>
  <summary>April 1st</summary>
  
This is just an April Fools joke and I'll close it tomorrow.
p.s. I'm only being mean to my own code.
</details>

Increases the statistical likelihood of our codebase being good.

![image](https://github.com/godotengine/godot/assets/85438892/18a04c40-5a2c-43e7-8cc8-68a17ae51dd6)

Now, there is a great amount of nuance here. We can't use swear words because Godot is a responsible FOSS project, [unlike certain other less important ones](https://www.vidarholen.net/contents/wordcount/#fuck*,shit*,crap*). But I found a workaround - even if we can't swear, nonetheless, a little less sanity should still help! TF's developers have demonstrated this decades ago.