### PR TITLE
Show TileMap collision debug shape outlines

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -917,9 +917,15 @@ void TileMapLayer::_physics_draw_cell_debug(const RID &p_canvas_item, const Vect
 	RenderingServer *rs = RenderingServer::get_singleton();
 	PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 
-	Color debug_collision_color = get_tree()->get_debug_collisions_color();
-	Vector<Color> color;
-	color.push_back(debug_collision_color);
+	bool enabled_edge_lines = Shape2D::is_collision_outline_enabled();
+
+	Color debug_face_color = get_tree()->get_debug_collisions_color();
+	Color debug_edge_color = Color(debug_face_color, 1.0);
+
+	Vector<Color> debug_face_colors;
+	debug_face_colors.push_back(debug_face_color);
+	Vector<Color> debug_edge_colors;
+	debug_edge_colors.push_back(debug_edge_color);
 
 	Transform2D quadrant_to_local(0, p_quadrant_pos);
 	Transform2D global_to_quadrant = (get_global_transform() * quadrant_to_local).affine_inverse();
@@ -932,7 +938,14 @@ void TileMapLayer::_physics_draw_cell_debug(const RID &p_canvas_item, const Vect
 				const RID &shape = ps->body_get_shape(body, shape_index);
 				const PhysicsServer2D::ShapeType &type = ps->shape_get_type(shape);
 				if (type == PhysicsServer2D::SHAPE_CONVEX_POLYGON) {
-					rs->canvas_item_add_polygon(p_canvas_item, ps->shape_get_data(shape), color);
+					Vector<Vector2> debug_polygon_vertices = ps->shape_get_data(shape);
+
+					rs->canvas_item_add_polygon(p_canvas_item, debug_polygon_vertices, debug_face_colors);
+
+					if (enabled_edge_lines) {
+						debug_polygon_vertices.push_back(debug_polygon_vertices[0]);
+						rs->canvas_item_add_polyline(p_canvas_item, debug_polygon_vertices, debug_edge_colors);
+					}
 				} else {
 					WARN_PRINT("Wrong shape type for a tile, should be SHAPE_CONVEX_POLYGON.");
 				}

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -111,11 +111,6 @@ void Shape2D::_bind_methods() {
 }
 
 bool Shape2D::is_collision_outline_enabled() {
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		return true;
-	}
-#endif
 	return GLOBAL_GET("debug/shapes/collision/draw_2d_outlines");
 }
 


### PR DESCRIPTION
Shows TileMap collision debug shape outlines.

Fixes https://github.com/godotengine/godot/issues/90073

This makes the collision shape outlines, and therefore shape seams, visible that are responsible for many, many 2D physics problems.

I know this will be a not-so-nice visual surprise for many TileMap projects when they see how messed up their TileMap collision really is, but seeing the problem is the first step for fixing it.

That screenshot is from the isometric demo and as you can see all the shapes are misaligned with their shape seams so any e.g. ray query against those seams has a good chance to have a borked result.

![collision_debug ](https://github.com/godotengine/godot/assets/52464204/d1a9497d-1de7-4b7b-b407-f2657f5c58f4)

Note, there is no way to have the debug display without the TileMap visuals because the debug canvas item is hard-linked to the layer canvas visibility and color modulate which imo should be fixed as well.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
