### PR TITLE
Restore mouse position in debugger

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -114,6 +114,9 @@ void ScriptEditorDebugger::debug_ignore_error_breaks() {
 void ScriptEditorDebugger::debug_out() {
 	ERR_FAIL_COND(!is_breaked());
 
+	restore_mouse_position = get_local_mouse_position();
+	restore_mouse_by_time = OS::get_singleton()->get_ticks_msec() + restore_mouse_within_ms;
+
 	_put_msg("out", Array(), debugging_thread_id);
 	_clear_execution();
 }
@@ -121,12 +124,18 @@ void ScriptEditorDebugger::debug_out() {
 void ScriptEditorDebugger::debug_next() {
 	ERR_FAIL_COND(!is_breaked());
 
+	restore_mouse_position = get_local_mouse_position();
+	restore_mouse_by_time = OS::get_singleton()->get_ticks_msec() + restore_mouse_within_ms;
+
 	_put_msg("next", Array(), debugging_thread_id);
 	_clear_execution();
 }
 
 void ScriptEditorDebugger::debug_step() {
 	ERR_FAIL_COND(!is_breaked());
+
+	restore_mouse_position = get_local_mouse_position();
+	restore_mouse_by_time = OS::get_singleton()->get_ticks_msec() + restore_mouse_within_ms;
 
 	_put_msg("step", Array(), debugging_thread_id);
 	_clear_execution();
@@ -146,6 +155,9 @@ void ScriptEditorDebugger::debug_continue() {
 	if (remote_pid && EditorNode::get_singleton()->has_child_process(remote_pid)) {
 		DisplayServer::get_singleton()->enable_for_stealing_focus(remote_pid);
 	}
+
+	restore_mouse_position = get_local_mouse_position();
+	restore_mouse_by_time = OS::get_singleton()->get_ticks_msec() + restore_mouse_within_ms;
 
 	_clear_execution();
 	_put_msg("continue", Array(), debugging_thread_id);
@@ -371,6 +383,11 @@ void ScriptEditorDebugger::_msg_debug_enter(uint64_t p_thread_id, const Array &p
 		}
 		profiler->set_enabled(false, false);
 		visual_profiler->set_enabled(false);
+
+		if (restore_mouse_by_time > OS::get_singleton()->get_ticks_msec()) {
+			warp_mouse(restore_mouse_position);
+		}
+		restore_mouse_by_time = 0;
 	}
 	_update_buttons_state();
 }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -161,6 +161,10 @@ private:
 	bool move_to_foreground = true;
 	bool can_request_idle_draw = false;
 
+	Vector2 restore_mouse_position;
+	uint64_t restore_mouse_by_time = 0;
+	const uint64_t restore_mouse_within_ms = 300;
+
 	bool live_debug = true;
 
 	uint64_t debugging_thread_id = Thread::UNASSIGNED_ID;


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/45945

On debug next, step, out, and continue, the mouse will be restored to its previous position if the debugger breaks again within 300 ms.

The duration should be small enough to not really be noticeable if the mouse wasn't captured/confined, but long enough for code to run before the debugger breaks again.
If we want, I can make the duration into an editor setting.

The reason I don't prevent the mouse from being re-captured instead is because that may affect game logic, and getting a timeout into the remote debugger wouldn't be simple.