### PR TITLE
Make physics debug respect shape outline setting inside editor

### DIFF
--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -111,11 +111,6 @@ void Shape2D::_bind_methods() {
 }
 
 bool Shape2D::is_collision_outline_enabled() {
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		return true;
-	}
-#endif
 	return GLOBAL_GET("debug/shapes/collision/draw_2d_outlines");
 }
 


### PR DESCRIPTION
Make physics debug respect shape outline setting inside editor instead of always returning `true` no matter the actual setting.

I noticed that Godot already has a ProjectSetting to control if the polyline for shape outlines should be drawn, just that it did not react to the setting. This is a point of performance discussion with the TileMap debug here https://github.com/godotengine/godot/pull/90106.

As mentioned in dev chat I do not understand why this was forced to be always true inside the Editor, maybe someone else knows why. That setting `"debug/shapes/collision/draw_2d_outlines"` is enabled by default so nothing changes for users that did not turn it off deliberately.

If a user goes in the ProjectSettings to disable the shape outlines in the debug settings the expectation is likely ... to not have shape outlines drawn ... instead of only no outlines at runtime with debug enabled on only some shapes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
