### PR TITLE
Fix rounding in Window::get_clamped_minimum_size

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -997,7 +997,7 @@ bool Window::is_visible() const {
 
 Size2i Window::_clamp_window_size(const Size2i &p_size) {
 	Size2i window_size_clamped = p_size;
-	Size2 minsize = get_clamped_minimum_size();
+	Size2i minsize = get_clamped_minimum_size();
 	window_size_clamped = window_size_clamped.max(minsize);
 
 	if (max_size_used != Size2i()) {
@@ -1903,13 +1903,13 @@ Size2 Window::get_contents_minimum_size() const {
 	return _get_contents_minimum_size();
 }
 
-Size2 Window::get_clamped_minimum_size() const {
-	ERR_READ_THREAD_GUARD_V(Size2());
+Size2i Window::get_clamped_minimum_size() const {
+	ERR_READ_THREAD_GUARD_V(Size2i());
 	if (!wrap_controls) {
 		return min_size;
 	}
 
-	return min_size.max(get_contents_minimum_size());
+	return min_size.max(get_contents_minimum_size().ceil());
 }
 
 void Window::grab_focus() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -388,7 +388,7 @@ public:
 
 	Rect2i fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) const;
 	Size2 get_contents_minimum_size() const;
-	Size2 get_clamped_minimum_size() const;
+	Size2i get_clamped_minimum_size() const;
 
 	void grab_focus();
 	bool has_focus() const;


### PR DESCRIPTION
Fixes #89482

Previously, `Window::get_clamped_minimum_size` calculated the clamped minimum size as the maximum of `min_size` (which is of type `Size2i`) and `Window::get_contents_minimum_size` (which returns a `Size2`), without accounting for the conversion from floats to integers. This results in the contents' min size being rounded down, causing some windows to have a smaller size than the min size especially when using a custom display scale.
\
To resolve this, I've adjusted the calculation to round these values up by applying the ceiling function to the contents' minimum size.
\
Additionally, I've updated the return type of this function from `Size2` to `Size2i` to clarify the expected result of calling the function. I also replaced the type of the `minsize` value in `Window::_clamp_window_size` to reflect this change.
