### PR TITLE
SCons: Ignore `*.gen.[h|cpp|inc]` files during cleanup

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -199,26 +199,30 @@ env.Depends(
     "#core/io/certs_compressed.gen.h",
     ["#thirdparty/certs/ca-certificates.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
 )
-env.CommandNoCache(
-    "#core/io/certs_compressed.gen.h",
-    "#thirdparty/certs/ca-certificates.crt",
-    env.Run(core_builders.make_certs_header),
+env.NoClean(
+    env.CommandNoCache(
+        "#core/io/certs_compressed.gen.h",
+        "#thirdparty/certs/ca-certificates.crt",
+        env.Run(core_builders.make_certs_header),
+    )
 )
 
 # Authors
 env.Depends("#core/authors.gen.h", "../AUTHORS.md")
-env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header))
+env.NoClean(env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header)))
 
 # Donors
 env.Depends("#core/donors.gen.h", "../DONORS.md")
-env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header))
+env.NoClean(env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header)))
 
 # License
 env.Depends("#core/license.gen.h", ["../COPYRIGHT.txt", "../LICENSE.txt"])
-env.CommandNoCache(
-    "#core/license.gen.h",
-    ["../COPYRIGHT.txt", "../LICENSE.txt"],
-    env.Run(core_builders.make_license_header),
+env.NoClean(
+    env.CommandNoCache(
+        "#core/license.gen.h",
+        ["../COPYRIGHT.txt", "../LICENSE.txt"],
+        env.Run(core_builders.make_license_header),
+    )
 )
 
 # Chain load SCsubs

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -5,11 +5,13 @@ Import("env")
 import make_wrappers
 import make_interface_dumper
 
-env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", env.Run(make_wrappers.run))
-env.CommandNoCache(
-    "gdextension_interface_dump.gen.h",
-    ["gdextension_interface.h", "make_interface_dumper.py"],
-    env.Run(make_interface_dumper.run),
+env.NoClean(env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", env.Run(make_wrappers.run)))
+env.NoClean(
+    env.CommandNoCache(
+        "gdextension_interface_dump.gen.h",
+        ["gdextension_interface.h", "make_interface_dumper.py"],
+        env.Run(make_interface_dumper.run),
+    )
 )
 
 env_extension = env.Clone()

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -11,10 +11,12 @@ controller_databases = [
     "godotcontrollerdb.txt",
 ]
 
-gensource = env.CommandNoCache(
-    "default_controller_mappings.gen.cpp",
-    controller_databases,
-    env.Run(input_builders.make_default_controller_mappings),
+gensource = env.NoClean(
+    env.CommandNoCache(
+        "default_controller_mappings.gen.cpp",
+        controller_databases,
+        env.Run(input_builders.make_default_controller_mappings),
+    )
 )
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 import make_virtuals
 
-env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", env.Run(make_virtuals.run))
+env.NoClean(env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", env.Run(make_virtuals.run)))
 
 env_object = env.Clone()
 

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -15,19 +15,19 @@ if "GLES3_GLSL" in env["BUILDERS"]:
     # compile shaders
 
     # as we have a few, not yet, converted files we name the ones we want to include:
-    env.GLES3_GLSL("canvas.glsl")
-    env.GLES3_GLSL("scene.glsl")
-    env.GLES3_GLSL("sky.glsl")
-    env.GLES3_GLSL("cubemap_filter.glsl")
-    env.GLES3_GLSL("canvas_occlusion.glsl")
-    env.GLES3_GLSL("canvas_sdf.glsl")
-    env.GLES3_GLSL("particles.glsl")
-    env.GLES3_GLSL("particles_copy.glsl")
-    env.GLES3_GLSL("skeleton.glsl")
+    env.NoClean(env.GLES3_GLSL("canvas.glsl"))
+    env.NoClean(env.GLES3_GLSL("scene.glsl"))
+    env.NoClean(env.GLES3_GLSL("sky.glsl"))
+    env.NoClean(env.GLES3_GLSL("cubemap_filter.glsl"))
+    env.NoClean(env.GLES3_GLSL("canvas_occlusion.glsl"))
+    env.NoClean(env.GLES3_GLSL("canvas_sdf.glsl"))
+    env.NoClean(env.GLES3_GLSL("particles.glsl"))
+    env.NoClean(env.GLES3_GLSL("particles_copy.glsl"))
+    env.NoClean(env.GLES3_GLSL("skeleton.glsl"))
 
     # once we finish conversion we can introduce this to cover all files:
     # for glsl_file in glsl_files:
-    #     env.GLES3_GLSL(glsl_file)
+    #     env.NoClean(env.GLES3_GLSL(glsl_file))
 
 
 SConscript("effects/SCsub")

--- a/drivers/gles3/shaders/effects/SCsub
+++ b/drivers/gles3/shaders/effects/SCsub
@@ -14,4 +14,4 @@ if "GLES3_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.GLES3_GLSL(glsl_file)
+        env.NoClean(env.GLES3_GLSL(glsl_file))

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -63,10 +63,12 @@ if env.editor_build:
 
     docs = sorted(docs)
     env.Depends("#editor/doc_data_compressed.gen.h", docs)
-    env.CommandNoCache(
-        "#editor/doc_data_compressed.gen.h",
-        docs,
-        env.Run(editor_builders.make_doc_header),
+    env.NoClean(
+        env.CommandNoCache(
+            "#editor/doc_data_compressed.gen.h",
+            docs,
+            env.Run(editor_builders.make_doc_header),
+        )
     )
 
     # Editor interface and class reference translations incur a significant size
@@ -78,38 +80,46 @@ if env.editor_build:
     # Editor translations
     tlist = glob.glob(env.Dir("#editor/translations/editor").abspath + "/*.po")
     env.Depends("#editor/editor_translations.gen.h", tlist)
-    env.CommandNoCache(
-        "#editor/editor_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_editor_translations_header),
+    env.NoClean(
+        env.CommandNoCache(
+            "#editor/editor_translations.gen.h",
+            tlist,
+            env.Run(editor_builders.make_editor_translations_header),
+        )
     )
 
     # Property translations
     tlist = glob.glob(env.Dir("#editor/translations/properties").abspath + "/*.po")
     env.Depends("#editor/property_translations.gen.h", tlist)
-    env.CommandNoCache(
-        "#editor/property_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_property_translations_header),
+    env.NoClean(
+        env.CommandNoCache(
+            "#editor/property_translations.gen.h",
+            tlist,
+            env.Run(editor_builders.make_property_translations_header),
+        )
     )
 
     # Documentation translations
     tlist = glob.glob(env.Dir("#doc/translations").abspath + "/*.po")
     env.Depends("#editor/doc_translations.gen.h", tlist)
-    env.CommandNoCache(
-        "#editor/doc_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_doc_translations_header),
+    env.NoClean(
+        env.CommandNoCache(
+            "#editor/doc_translations.gen.h",
+            tlist,
+            env.Run(editor_builders.make_doc_translations_header),
+        )
     )
 
     # Extractable translations
     tlist = glob.glob(env.Dir("#editor/translations/extractable").abspath + "/*.po")
     tlist.extend(glob.glob(env.Dir("#editor/translations/extractable").abspath + "/extractable.pot"))
     env.Depends("#editor/extractable_translations.gen.h", tlist)
-    env.CommandNoCache(
-        "#editor/extractable_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_extractable_translations_header),
+    env.NoClean(
+        env.CommandNoCache(
+            "#editor/extractable_translations.gen.h",
+            tlist,
+            env.Run(editor_builders.make_extractable_translations_header),
+        )
     )
 
     env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -22,4 +22,4 @@ for path in env.module_icons_paths:
     else:
         icon_sources += Glob(path + "/*.svg")  # Custom.
 
-env.Alias("editor_icons", [env.MakeEditorIconsBuilder("#editor/themes/editor_icons.gen.h", icon_sources)])
+env.Alias("editor_icons", [env.NoClean(env.MakeEditorIconsBuilder("#editor/themes/editor_icons.gen.h", icon_sources))])

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -13,10 +13,12 @@ flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff"))
 flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff2"))
 flist.sort()
 env.Depends("#editor/themes/builtin_fonts.gen.h", flist)
-env.CommandNoCache(
-    "#editor/themes/builtin_fonts.gen.h",
-    flist,
-    env.Run(editor_theme_builders.make_fonts_header),
+env.NoClean(
+    env.CommandNoCache(
+        "#editor/themes/builtin_fonts.gen.h",
+        flist,
+        env.Run(editor_theme_builders.make_fonts_header),
+    )
 )
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/main/SCsub
+++ b/main/SCsub
@@ -14,25 +14,31 @@ if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
 
 env_main.Depends("#main/splash.gen.h", "#main/splash.png")
-env_main.CommandNoCache(
-    "#main/splash.gen.h",
-    "#main/splash.png",
-    env.Run(main_builders.make_splash),
+env.NoClean(
+    env_main.CommandNoCache(
+        "#main/splash.gen.h",
+        "#main/splash.png",
+        env.Run(main_builders.make_splash),
+    )
 )
 
 if not env_main["no_editor_splash"]:
     env_main.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
-    env_main.CommandNoCache(
-        "#main/splash_editor.gen.h",
-        "#main/splash_editor.png",
-        env.Run(main_builders.make_splash_editor),
+    env.NoClean(
+        env_main.CommandNoCache(
+            "#main/splash_editor.gen.h",
+            "#main/splash_editor.png",
+            env.Run(main_builders.make_splash_editor),
+        )
     )
 
 env_main.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
-env_main.CommandNoCache(
-    "#main/app_icon.gen.h",
-    "#main/app_icon.png",
-    env.Run(main_builders.make_app_icon),
+env.NoClean(
+    env_main.CommandNoCache(
+        "#main/app_icon.gen.h",
+        "#main/app_icon.png",
+        env.Run(main_builders.make_app_icon),
+    )
 )
 
 lib = env_main.add_library("main", env.main_sources)

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -14,10 +14,12 @@ Export("env_modules")
 
 # Header with MODULE_*_ENABLED defines.
 env.Depends("modules_enabled.gen.h", Value(env.module_list))
-env.CommandNoCache(
-    "modules_enabled.gen.h",
-    Value(env.module_list),
-    env.Run(modules_builders.generate_modules_enabled),
+env.NoClean(
+    env.CommandNoCache(
+        "modules_enabled.gen.h",
+        Value(env.module_list),
+        env.Run(modules_builders.generate_modules_enabled),
+    )
 )
 
 
@@ -48,10 +50,12 @@ for name, path in env.module_list.items():
 # Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
 if env["tests"]:
     env.Depends("modules_tests.gen.h", test_headers)
-    env.CommandNoCache(
-        "modules_tests.gen.h",
-        test_headers,
-        env.Run(modules_builders.generate_modules_tests),
+    env.NoClean(
+        env.CommandNoCache(
+            "modules_tests.gen.h",
+            test_headers,
+            env.Run(modules_builders.generate_modules_tests),
+        )
     )
 
 # libmodules.a with only register_module_types.

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -13,4 +13,4 @@ env["BUILDERS"]["MakeGDTemplateBuilder"] = Builder(
 # Template files
 templates_sources = Glob("*/*.gd")
 
-env.Alias("editor_template_gd", [env.MakeGDTemplateBuilder("templates.gen.h", templates_sources)])
+env.Alias("editor_template_gd", [env.NoClean(env.MakeGDTemplateBuilder("templates.gen.h", templates_sources))])

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -4,9 +4,9 @@ Import("env")
 Import("env_modules")
 
 env_lightmapper_rd = env_modules.Clone()
-env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
+env_lightmapper_rd.NoClean(env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl"))
+env_lightmapper_rd.NoClean(env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl"))
+env_lightmapper_rd.NoClean(env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl"))
 env_lightmapper_rd.Depends(Glob("*.glsl.gen.h"), ["lm_common_inc.glsl", "#glsl_builders.py"])
 
 # Godot source files

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -13,4 +13,4 @@ env["BUILDERS"]["MakeCSharpTemplateBuilder"] = Builder(
 # Template files
 templates_sources = Glob("*/*.cs")
 
-env.Alias("editor_template_cs", [env.MakeCSharpTemplateBuilder("templates.gen.h", templates_sources)])
+env.Alias("editor_template_cs", [env.NoClean(env.MakeCSharpTemplateBuilder("templates.gen.h", templates_sources))])

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -471,7 +471,9 @@ if env["builtin_icu4c"]:
 
     if env.editor_build:
         env_icu.Depends("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name)
-        env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, make_icu_data)
+        env_icu.NoClean(
+            env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, make_icu_data)
+        )
         env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
     else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -10,8 +10,10 @@ env.add_source_files(env.scene_sources, "*.cpp")
 SConscript("icons/SCsub")
 
 env.Depends("#scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2")
-env.CommandNoCache(
-    "#scene/theme/default_font.gen.h",
-    "#thirdparty/fonts/OpenSans_SemiBold.woff2",
-    env.Run(default_theme_builders.make_fonts_header),
+env.NoClean(
+    env.CommandNoCache(
+        "#scene/theme/default_font.gen.h",
+        "#thirdparty/fonts/OpenSans_SemiBold.woff2",
+        env.Run(default_theme_builders.make_fonts_header),
+    )
 )

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -16,5 +16,5 @@ icon_sources = Glob("*.svg")
 
 env.Alias(
     "default_theme_icons",
-    [env.MakeDefaultThemeIconsBuilder("#scene/theme/default_theme_icons.gen.h", icon_sources)],
+    [env.NoClean(env.MakeDefaultThemeIconsBuilder("#scene/theme/default_theme_icons.gen.h", icon_sources))],
 )

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -14,7 +14,7 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))
 
 SConscript("effects/SCsub")
 SConscript("environment/SCsub")

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -14,6 +14,6 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))
 
 SConscript("fsr2/SCsub")

--- a/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
@@ -19,4 +19,4 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -14,4 +14,4 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -14,4 +14,4 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -14,4 +14,4 @@ if "RD_GLSL" in env["BUILDERS"]:
 
     # compile shaders
     for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+        env.NoClean(env.RD_GLSL(glsl_file))


### PR DESCRIPTION
When using `--clean` in a local repo, it's done with the intent of clearing out stray object files; so it can be annoying for build-agnostic generated files to also be removed in the process. Some of these files are already skipped during cleanup because they don't invoke SCons directly, but otherwise they will always be removed. This PR addresses this mild annoyance by wrapping any relevant `*.gen.*` SCons actions with `NoClean`, ensuring the generated files will persist after a cleanup while otherwise behaving identically.