### PR TITLE
Fix "Create C# solution" dialog

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -167,8 +167,8 @@ namespace GodotTools
 
         public void ShowConfirmCreateSlnDialog()
         {
-            _confirmCreateSlnDialog.Title = "C# solution already exists. This will override the existing C# project file, any manual changes will be lost.".TTR();
-            _confirmCreateSlnDialog.DialogText = "Create C# solution".TTR();
+            _confirmCreateSlnDialog.Title = "Create C# solution".TTR();
+            _confirmCreateSlnDialog.DialogText = "C# solution already exists. This will override the existing C# project file, any manual changes will be lost.".TTR();
             EditorInterface.Singleton.PopupDialogCentered(_confirmCreateSlnDialog);
         }
 


### PR DESCRIPTION
Flipped the title and dialog text to how they should be. It seemed that the title was being put in the dialog text, and vice versa.
