### PR TITLE
Add Blender Import Y-up Option

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -145,9 +145,12 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	parameters_map["filepath"] = sink_global;
 	parameters_map["export_keep_originals"] = unpack_original_images;
 	parameters_map["export_format"] = "GLTF_SEPARATE";
-	parameters_map["export_yup"] = true;
+	if (p_options.has(SNAME("blender/nodes/y_up")) && p_options[SNAME("blender/nodes/y_up")]) {
+		parameters_map["export_yup"] = true;
+	} else {
+		parameters_map["export_yup"] = false;
+	}
 	parameters_map["export_import_convert_lighting_mode"] = "COMPAT";
-
 	if (p_options.has(SNAME("blender/nodes/custom_properties")) && p_options[SNAME("blender/nodes/custom_properties")]) {
 		parameters_map["export_extras"] = true;
 	} else {
@@ -372,6 +375,7 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	ADD_OPTION_BOOL("blender/nodes/cameras", true);
 	ADD_OPTION_BOOL("blender/nodes/custom_properties", true);
 	ADD_OPTION_ENUM("blender/nodes/modifiers", "No Modifiers,All Modifiers", BLEND_MODIFIERS_ALL);
+	ADD_OPTION_BOOL("blender/nodes/y_up", true);
 	ADD_OPTION_BOOL("blender/meshes/colors", false);
 	ADD_OPTION_BOOL("blender/meshes/uvs", true);
 	ADD_OPTION_BOOL("blender/meshes/normals", true);


### PR DESCRIPTION
This is an implementation of an issue that I've just filed in godot-proposals. In essence it exposes the blender option to convert a blender scene to Y-up or not.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9434*