### PR TITLE
[3.x] GDScript: Fix base classes not marked as dependencies if referred to by autoload/class name

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -859,6 +859,10 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					bfn = true;
 				}
 
+				if (!bfn && ScriptServer::is_global_class(identifier)) {
+					dependencies.push_back(ScriptServer::get_global_class_path(identifier));
+				}
+
 				if (!dependencies_only) {
 					if (!bfn && ScriptServer::is_global_class(identifier)) {
 						Ref<Script> scr = ResourceLoader::load(ScriptServer::get_global_class_path(identifier));
@@ -3649,13 +3653,6 @@ void GDScriptParser::_parse_extends(ClassNode *p_class) {
 		p_class->extends_file = constant;
 		tokenizer->advance();
 
-		// Add parent script as a dependency
-		String parent = constant;
-		if (parent.is_rel_path()) {
-			parent = base_path.plus_file(parent).simplify_path();
-		}
-		dependencies.push_back(parent);
-
 		if (tokenizer->get_token() != GDScriptTokenizer::TK_PERIOD) {
 			return;
 		} else {
@@ -5471,6 +5468,21 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 }
 
 void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive) {
+	if (!_determine_inheritance_step(p_class)) {
+		return;
+	}
+
+	if (p_recursive) {
+		// Recursively determine subclasses
+		for (int i = 0; i < p_class->subclasses.size(); i++) {
+			_determine_inheritance(p_class->subclasses[i], p_recursive);
+		}
+	}
+}
+
+// Returns true to indicate OK; false to indicate some kind of error.
+// This is a separate function because a lot of this logic needs to return early if we're doing dependencies-only.
+bool GDScriptParser::_determine_inheritance_step(ClassNode *p_class) {
 	if (p_class->base_type.has_type) {
 		// Already determined
 	} else if (p_class->extends_used) {
@@ -5489,18 +5501,25 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 
 				if (base == "" || base.is_rel_path()) {
 					_set_error("Couldn't resolve relative path for the parent class: " + path, p_class->line);
-					return;
+					return false;
 				}
 				path = base.plus_file(path).simplify_path();
 			}
+
+			// add parent script as a dependency
+			dependencies.push_back(path);
+			if (dependencies_only) {
+				return true;
+			}
+
 			script = ResourceLoader::load(path);
 			if (script.is_null()) {
 				_set_error("Couldn't load the base class: " + path, p_class->line);
-				return;
+				return false;
 			}
 			if (!script->is_valid()) {
 				_set_error("Script isn't fully loaded (cyclic preload?): " + path, p_class->line);
-				return;
+				return false;
 			}
 
 			if (p_class->extends_class.size()) {
@@ -5511,7 +5530,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 						script = subclass;
 					} else {
 						_set_error("Couldn't find the subclass: " + sub, p_class->line);
-						return;
+						return false;
 					}
 				}
 			}
@@ -5519,7 +5538,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 		} else {
 			if (p_class->extends_class.size() == 0) {
 				_set_error("Parser bug: undecidable inheritance.", p_class->line);
-				ERR_FAIL();
+				ERR_FAIL_V(false);
 			}
 			//look around for the subclasses
 
@@ -5529,22 +5548,37 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 			Ref<GDScript> base_script;
 
 			if (ScriptServer::is_global_class(base)) {
-				base_script = ResourceLoader::load(ScriptServer::get_global_class_path(base));
+				String class_path = ScriptServer::get_global_class_path(base);
+				dependencies.push_back(class_path);
+				if (dependencies_only) {
+					return true;
+				}
+				base_script = ResourceLoader::load(class_path);
 				if (!base_script.is_valid()) {
 					_set_error("The class \"" + base + "\" couldn't be fully loaded (script error or cyclic dependency).", p_class->line);
-					return;
+					return false;
 				}
 				p = nullptr;
 			} else {
 				String autoload_path = _lookup_autoload_path_for_identifier(base);
 				if (!autoload_path.empty()) {
+					dependencies.push_back(autoload_path);
+					if (dependencies_only) {
+						return true;
+					}
 					base_script = ResourceLoader::load(autoload_path);
 					if (!base_script.is_valid()) {
 						_set_error("Class '" + base + "' could not be fully loaded (script error or cyclic inheritance).", p_class->line);
-						return;
+						return false;
 					}
 					p = nullptr;
 				}
+			}
+
+			// Dependency finding only cares about external file references
+			// We don't need to actually find inheritance errors
+			if (dependencies_only) {
+				return true;
 			}
 
 			while (p) {
@@ -5556,7 +5590,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 						while (test) {
 							if (test == p_class) {
 								_set_error("Cyclic inheritance.", test->line);
-								return;
+								return false;
 							}
 							if (test->base_type.kind == DataType::CLASS) {
 								test = test->base_type.class_type;
@@ -5586,13 +5620,13 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 				if (p->constant_expressions.has(base)) {
 					if (p->constant_expressions[base].expression->type != Node::TYPE_CONSTANT) {
 						_set_error("Couldn't resolve the constant \"" + base + "\".", p_class->line);
-						return;
+						return false;
 					}
 					const ConstantNode *cn = static_cast<const ConstantNode *>(p->constant_expressions[base].expression);
 					base_script = cn->value;
 					if (base_script.is_null()) {
 						_set_error("Constant isn't a class: " + base, p_class->line);
-						return;
+						return false;
 					}
 					break;
 				}
@@ -5615,12 +5649,12 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 						Ref<GDScript> new_base_class = find_subclass->get_constants()[subclass];
 						if (new_base_class.is_null()) {
 							_set_error("Constant isn't a class: " + ident, p_class->line);
-							return;
+							return false;
 						}
 						find_subclass = new_base_class;
 					} else {
 						_set_error("Couldn't find the subclass: " + ident, p_class->line);
-						return;
+						return false;
 					}
 				}
 
@@ -5629,12 +5663,12 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 			} else if (!base_class) {
 				if (p_class->extends_class.size() > 1) {
 					_set_error("Invalid inheritance (unknown class + subclasses).", p_class->line);
-					return;
+					return false;
 				}
 				//if not found, try engine classes
 				if (!GDScriptLanguage::get_singleton()->get_global_map().has(base)) {
 					_set_error("Unknown class: \"" + base + "\"", p_class->line);
-					return;
+					return false;
 				}
 
 				native = base;
@@ -5656,7 +5690,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 			p_class->base_type.native_type = native;
 		} else {
 			_set_error("Couldn't determine inheritance.", p_class->line);
-			return;
+			return false;
 		}
 
 	} else {
@@ -5665,13 +5699,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 		p_class->base_type.kind = DataType::NATIVE;
 		p_class->base_type.native_type = "Reference";
 	}
-
-	if (p_recursive) {
-		// Recursively determine subclasses
-		for (int i = 0; i < p_class->subclasses.size(); i++) {
-			_determine_inheritance(p_class->subclasses[i], p_recursive);
-		}
-	}
+	return true;
 }
 
 String GDScriptParser::DataType::to_string() const {
@@ -8753,11 +8781,14 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 		return ERR_PARSE_ERROR;
 	}
 
+	_determine_inheritance(main_class);
+
+	// Inheritance must be determined to resolve global classes to dependencies.
+	// If this isn't done, exports can lose base classes.
+	// Unfortunately, this can't be pushed forward much further with the current parser without loading resources, I think...
 	if (dependencies_only) {
 		return OK;
 	}
-
-	_determine_inheritance(main_class);
 
 	if (error_set) {
 		return ERR_PARSE_ERROR;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -620,6 +620,7 @@ private:
 	void _set_end_statement_error(String p_name);
 
 	void _determine_inheritance(ClassNode *p_class, bool p_recursive = true);
+	bool _determine_inheritance_step(ClassNode *p_class);
 	bool _parse_type(DataType &r_type, bool p_can_be_void = false);
 	DataType _resolve_type(const DataType &p_source, int p_line);
 	DataType _type_from_variant(const Variant &p_value) const;


### PR DESCRIPTION
This is both a bug report and a suggested partial fix, since I have no idea if there's a colliding issue or not (I tried looking, but didn't find one? There's also no label for 3.x bugs in specific, it seems, though.)

However, I'm not totally certain I'm doing this correctly, so be wary of that.

In Godot 3.5.3, with the attached project:
[gdscript-dependencies-test-project.zip](https://github.com/godotengine/godot/files/14842166/gdscript-dependencies-test-project.zip)

1. `example2.gd` should depend on `example1.gd` but does not
2. `example3.gd` should depend on `some_autoload_somewhere.gd` but does not
3. `class_references_are_dependencies_too.gd` should depend on `example1.gd`.

This PR fixes cases 1 and 2, but does not fix case 3 as this would likely require a more comprehensive parser rework (perhaps transforming class name/autoload references during parsing).

The reason that this is a problem is that it causes exports of scenes with dependencies to fail to correctly identify and export those dependencies, leading to runtime errors.

A workaround is to either manually include the resources or to include functions for the purpose of causing preloading.