### PR TITLE
Change `html_is_valid` function to use a switch statement

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -382,8 +382,14 @@ bool Color::html_is_valid(const String &p_color) {
 
 	// Check if the amount of hex digits is valid.
 	int len = color.length();
-	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
-		return false;
+	switch (len) {
+		case 3:
+		case 4:
+		case 6:
+		case 8:
+			break;
+		default:
+			return false;
 	}
 
 	// Check if each hex digit is valid.


### PR DESCRIPTION
Changed ```html_is_valid``` function to use a ```switch``` statement instead of an ```if``` statement. The change affects the part of the function that checks if the amount of hex digits are valid.

Instead of:
```cpp
	// Check if the amount of hex digits is valid.
	int len = color.length();
	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
		return false;
	}
```
It is changed to:
```cpp
	// Check if the amount of hex digits is valid.
	int len = color.length();
	switch (len) {
		case 3:
		case 4:
		case 6:
		case 8:
			break;
		default:
			return false;
	}
```