### PR TITLE
Place imported files in the hovered EditorFileDock folder

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -63,6 +63,14 @@
 				Forces an update to the list size based on its items. This happens automatically whenever size of the items, or other relevant settings like [member auto_height], change. The method can be used to trigger the update ahead of next drawing pass.
 			</description>
 		</method>
+		<method name="get_item_at_mouse_position" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="exact" type="bool" default="false" />
+			<description>
+				Returns the item index at the current mouse position.
+				See [method ItemList.get_item_at_position].
+			</description>
+		</method>
 		<method name="get_item_at_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -191,7 +191,13 @@
 			<return type="TreeItem" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the tree item at the specified position (relative to the tree origin position).
+				Returns the [TreeItem] at the specified position (relative to the tree origin position).
+			</description>
+		</method>
+		<method name="get_item_at_mouse_position" qualifiers="const">
+			<return type="TreeItem" />
+			<description>
+				Returns the [TreeItem] at the current mouse position (as determined by this tree's viewport).
 			</description>
 		</method>
 		<method name="get_next_selected">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5444,7 +5444,18 @@ PopupMenu *EditorNode::get_export_as_menu() {
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files) {
-	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_current_directory());
+	String to_path;
+
+	ItemList *item_list_control = FileSystemDock::get_singleton()->get_file_list_control();
+	int item_index = item_list_control->get_item_at_mouse_position(true);
+	if (item_index != -1) {
+		to_path = item_list_control->get_item_text(item_index).get_base_dir();
+	} else if (TreeItem *item = FileSystemDock::get_singleton()->get_tree_control()->get_item_at_mouse_position()) {
+		const String file_metadata = item->get_metadata(0);
+		to_path = file_metadata.get_base_dir();
+	} else {
+		to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_current_directory());
+	}
 
 	_add_dropped_files_recursive(p_files, to_path);
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -412,6 +412,7 @@ public:
 	FileListDisplayMode get_file_list_display_mode() const { return file_list_display_mode; };
 
 	Tree *get_tree_control() { return tree; }
+	ItemList *get_file_list_control() { return files; }
 
 	void add_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);
 	void remove_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/string/translation.h"
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 
 void ItemList::_shape_text(int p_idx) {
@@ -1491,6 +1492,11 @@ void ItemList::_mouse_exited() {
 	}
 }
 
+int ItemList::get_item_at_mouse_position(bool p_exact) const {
+	Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
+	return get_item_at_position(mouse_position, p_exact);
+}
+
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	Vector2 pos = p_pos;
 	pos -= theme_cache.panel_style->get_offset();
@@ -1817,6 +1823,7 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_anything_selected"), &ItemList::is_anything_selected);
 
 	ClassDB::bind_method(D_METHOD("get_item_at_position", "position", "exact"), &ItemList::get_item_at_position, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_item_at_mouse_position", "exact"), &ItemList::get_item_at_position, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("ensure_current_is_visible"), &ItemList::ensure_current_is_visible);
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -277,6 +277,7 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 	int get_item_at_position(const Point2 &p_pos, bool p_exact = false) const;
+	int get_item_at_mouse_position(bool p_exact = false) const;
 	bool is_pos_at_end_of_items(const Point2 &p_pos) const;
 
 	void set_icon_scale(real_t p_scale);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5307,6 +5307,11 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 	return -100;
 }
 
+TreeItem *Tree::get_item_at_mouse_position() const {
+	Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
+	return get_item_at_position(mouse_position);
+}
+
 TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
@@ -5529,6 +5534,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_custom_popup_rect"), &Tree::get_custom_popup_rect);
 	ClassDB::bind_method(D_METHOD("get_item_area_rect", "item", "column", "button_index"), &Tree::get_item_rect, DEFVAL(-1), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_item_at_position", "position"), &Tree::get_item_at_position);
+	ClassDB::bind_method(D_METHOD("get_item_at_mouse_position"), &Tree::get_item_at_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_column_at_position", "position"), &Tree::get_column_at_position);
 	ClassDB::bind_method(D_METHOD("get_drop_section_at_position", "position"), &Tree::get_drop_section_at_position);
 	ClassDB::bind_method(D_METHOD("get_button_id_at_position", "position"), &Tree::get_button_id_at_position);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -696,6 +696,7 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	TreeItem *get_item_at_mouse_position() const;
 	TreeItem *get_item_at_position(const Point2 &p_pos) const;
 	int get_column_at_position(const Point2 &p_pos) const;
 	int get_drop_section_at_position(const Point2 &p_pos) const;


### PR DESCRIPTION
Fixes #80667

Files that are dragged into Godot from the File Explorer will now attempt to place themselves into the hovered location of the EditorFileDock. Both the Tree view and the split view are supported. If a file is hovered, it will use the base dir, meaning it's placed as a sibling.

If no file is hovered, the file will revert to the original logic, which is to place the file into the last selected tree item, or the root, if none is selected. 

WARNING: This PR lacks any hovered animation or UX support. This is because when a file is being dragged into Godot, Godot lacks focus. Additionally, the support for highlights/hover effect in the Tree node requires the `can_drop_data` callback to return true, which isn't the case because OS file drag isn't using the standard file drag/drop system that Control nodes do.

As part of this PR, I created and exposed methods on ItemList and Tree, for getting items under the mouse cursor. I believe these to be useful methods as I've often written them myself for my own editor plugins. The position is calculated relative to the parent node, which I believe will always be correct.

