### PR TITLE
Change `set_max_fps` function to be more readable

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -67,7 +67,12 @@ double Engine::get_physics_jitter_fix() const {
 }
 
 void Engine::set_max_fps(int p_fps) {
-	_max_fps = p_fps > 0 ? p_fps : 0;
+	if (p_fps > 0) {
+    	_max_fps = p_fps;
+	} else {
+		_max_fps = 0;
+	}
+
 }
 
 int Engine::get_max_fps() const {

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -72,7 +72,6 @@ void Engine::set_max_fps(int p_fps) {
 	} else {
 		_max_fps = 0;
 	}
-
 }
 
 int Engine::get_max_fps() const {


### PR DESCRIPTION
Changed ```set_max_fps``` so that it is more readable. The ternary operator is replaced with an ```if``` statement to make the code more readable.

Changed from:
```cpp
_max_fps = p_fps > 0 ? p_fps : 0;
```

to: 
```cpp
if (p_fps > 0) {
   _max_fps = p_fps;
} else {
  _max_fps = 0;
}
```