### PR TITLE
Implement documentation comments and tooltips for shader uniform in the inspector.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3379,7 +3379,12 @@ void EditorInspector::update_tree() {
 				if (use_doc_hints) {
 					// `|` separators used in `EditorHelpBit`.
 					if (theme_item_name.is_empty()) {
-						if (p.usage & PROPERTY_USAGE_INTERNAL) {
+						if (p.name.contains("shader_parameter/")) {
+							ShaderMaterial *shader_material = Object::cast_to<ShaderMaterial>(object);
+							if (shader_material) {
+								ep->set_tooltip_text("property|" + shader_material->get_shader()->get_path() + "|" + property_prefix + p.name);
+							}
+						} else if (p.usage & PROPERTY_USAGE_INTERNAL) {
 							ep->set_tooltip_text("internal_property|" + classname + "|" + property_prefix + p.name);
 						} else {
 							ep->set_tooltip_text("property|" + classname + "|" + property_prefix + p.name);

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -311,6 +311,9 @@ void ShaderTextEditor::_load_theme_settings() {
 	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 	syntax_highlighter->add_color_region("//", "", comment_color, true);
 
+	const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+	syntax_highlighter->add_color_region("/**", "*/", doc_comment_color, false);
+
 	// Disabled preprocessor branches use translucent text color to be easier to distinguish from comments.
 	syntax_highlighter->set_disabled_branch_color(Color(EDITOR_GET("text_editor/theme/highlighting/text_color")) * Color(1, 1, 1, 0.5));
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -37,6 +37,15 @@
 #include "servers/rendering_server.h"
 #include "texture.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_help.h"
+
+#include "modules/modules_enabled.gen.h" // For regex.
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif
+#endif
+
 Shader::Mode Shader::get_mode() const {
 	return mode;
 }
@@ -121,6 +130,11 @@ void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_gr
 	List<PropertyInfo> local;
 	RenderingServer::get_singleton()->get_shader_parameter_list(shader, &local);
 
+#ifdef TOOLS_ENABLED
+	DocData::ClassDoc class_doc;
+	class_doc.name = get_path();
+	class_doc.is_script_doc = true;
+#endif
 	for (PropertyInfo &pi : local) {
 		bool is_group = pi.usage == PROPERTY_USAGE_GROUP || pi.usage == PROPERTY_USAGE_SUBGROUP;
 		if (!p_get_groups && is_group) {
@@ -136,9 +150,38 @@ void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_gr
 			if (pi.type == Variant::RID) {
 				pi.type = Variant::OBJECT;
 			}
+#ifdef TOOLS_ENABLED
+			if (Engine::get_singleton()->is_editor_hint()) {
+#ifdef MODULE_REGEX_ENABLED
+				const RegEx pattern("/\\*\\*([^*]|[\\r\\n]|(\\*+([^*/]|[\\r\\n])))*\\*+/\\s*uniform\\s+\\w+\\s+" + pi.name + "(?=[\\s:;=])");
+				Ref<RegExMatch> pattern_ref = pattern.search(code);
+				if (pattern_ref != nullptr) {
+					RegExMatch *match = pattern_ref.ptr();
+					const RegEx pattern_tip("\\/\\*\\*([\\s\\S]*?)\\*/");
+					Ref<RegExMatch> pattern_tip_ref = pattern_tip.search(match->get_string(0));
+					RegExMatch *match_tip = pattern_tip_ref.ptr();
+					const RegEx pattern_stripped("\\n\\s*\\*\\s*");
+					DocData::PropertyDoc prop_doc;
+					prop_doc.name = "shader_parameter/" + pi.name;
+					prop_doc.description = pattern_stripped.sub(match_tip->get_string(1), "\n", true);
+					class_doc.properties.push_back(prop_doc);
+				}
+#else
+				DocData::PropertyDoc prop_doc;
+				prop_doc.name = "shader_parameter/" + pi.name;
+				// prop_doc.description = "(Regex module is not enabled, shader parameter documentation will not be available.)";
+				class_doc.properties.push_back(prop_doc);
+#endif
+			}
+#endif
 			p_params->push_back(pi);
 		}
 	}
+#ifdef TOOLS_ENABLED
+	if (!class_doc.name.is_empty() && p_params) {
+		EditorHelp::get_doc_data()->add_doc(class_doc);
+	}
+#endif
 }
 
 RID Shader::get_rid() const {


### PR DESCRIPTION
Initially, the implementation was done by modifying `shader_language.cpp`,look at.
https://github.com/magian1127/godot/commit/49fe127a0a3d92a73af6a387d63a4a0a71c30a8a
However, some issues were discovered, so it was decided to switch to using regular expressions and modify `shader.cpp` to achieve the desired outcome.
Using `/** */` on top of uniform will do the trick.
```
/** tip
tip2*/
uniform float test1= 2.0;
```
![image](https://github.com/godotengine/godot/assets/14800320/5e637c50-5453-4259-a29b-adff2d0874d8)

一开始是修改 shader_language.cpp 来实现的, 代码看这里.
https://github.com/magian1127/godot/commit/49fe127a0a3d92a73af6a387d63a4a0a71c30a8a
但是发现有些问题, 还是改用正则表达式, 以及修改 shader.cpp 来实现.
在 uniform 上面使用 `/** */` 就可以实现.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/7846.*