### PR TITLE
Added right-click drag functionality to the 2D editor, while keeping the right-click pop-up menu.  

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2343,7 +2343,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			is_right_button_down = true;
 		}
 		if (is_right_button_down == true && b.is_valid() && !b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
-			my_flag = false;
+			is_right_button_down = false;
 			add_node_menu->clear();
 			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Add")), TTR("Add Node Here..."), ADD_NODE);
 			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Instance")), TTR("Instantiate Scene Here..."), ADD_INSTANCE);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1275,18 +1275,18 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 	panner->set_enable_rmb(true);
 	bool panner_active = panner->gui_input(p_event, warped_panning ? viewport->get_global_rect() : Rect2());
 	if (panner->is_panning() != pan_pressed) {
-		if (my_flag == true)
+		if (is_right_button_down == true)
 		{
 			Ref<InputEventMouseMotion> m = p_event;
 			if (m.is_valid()) {
 				//print_line(m->get_relative());
-				my_move_record += m->get_relative();
-				if (my_move_record.length() > 5) {
+				mouse_move_record += m->get_relative();
+				if (mouse_move_record.length() > 5) {
 					pan_pressed = panner->is_panning();
 					_update_cursor();
-					my_flag = false;
-					my_move_record.x = 0;
-					my_move_record.y = 0;
+					is_right_button_down = false;
+					mouse_move_record.x = 0;
+					mouse_move_record.y = 0;
 				}
 			}
 		} else {
@@ -2340,9 +2340,9 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 		}
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
-			my_flag = true;
+			is_right_button_down = true;
 		}
-		if (my_flag == true && b.is_valid() && !b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
+		if (is_right_button_down == true && b.is_valid() && !b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
 			my_flag = false;
 			add_node_menu->clear();
 			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Add")), TTR("Add Node Here..."), ADD_NODE);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1275,8 +1275,24 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 	panner->set_enable_rmb(true);
 	bool panner_active = panner->gui_input(p_event, warped_panning ? viewport->get_global_rect() : Rect2());
 	if (panner->is_panning() != pan_pressed) {
-		pan_pressed = panner->is_panning();
-		_update_cursor();
+		if (my_flag == true)
+		{
+			Ref<InputEventMouseMotion> m = p_event;
+			if (m.is_valid()) {
+				//print_line(m->get_relative());
+				my_move_record += m->get_relative();
+				if (my_move_record.length() > 5) {
+					pan_pressed = panner->is_panning();
+					_update_cursor();
+					my_flag = false;
+					my_move_record.x = 0;
+					my_move_record.y = 0;
+				}
+			}
+		} else {
+			pan_pressed = panner->is_panning();
+			_update_cursor();
+		}
 	}
 
 	if (panner_active) {
@@ -2324,6 +2340,10 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 		}
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
+			my_flag = true;
+		}
+		if (my_flag == true && b.is_valid() && !b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
+			my_flag = false;
 			add_node_menu->clear();
 			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Add")), TTR("Add Node Here..."), ADD_NODE);
 			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Instance")), TTR("Instantiate Scene Here..."), ADD_INSTANCE);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1272,6 +1272,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 
 bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bool p_already_accepted) {
 	panner->set_force_drag(tool == TOOL_PAN);
+	panner->set_enable_rmb(true);
 	bool panner_active = panner->gui_input(p_event, warped_panning ? viewport->get_global_rect() : Rect2());
 	if (panner->is_panning() != pan_pressed) {
 		pan_pressed = panner->is_panning();

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -186,6 +186,8 @@ private:
 		GRID_VISIBILITY_HIDE,
 	};
 
+	bool my_flag = false;
+	Vector2 my_move_record = Vector2(0,0);
 	bool selection_menu_additive_selection = false;
 
 	Tool tool = TOOL_SELECT;

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -186,8 +186,9 @@ private:
 		GRID_VISIBILITY_HIDE,
 	};
 
-	bool my_flag = false;
-	Vector2 my_move_record = Vector2(0,0);
+	bool is_right_button_down = false;
+	Vector2 mouse_move_record = Vector2(0,0);
+
 	bool selection_menu_additive_selection = false;
 
 	Tool tool = TOOL_SELECT;


### PR DESCRIPTION
Added right-click drag functionality to the 2D editor, while keeping the right-click pop-up menu. Specifically: When the right mouse button is pressed and the mouse is lifted without moving the mouse, the menu will pop up, and when the mouse is dragged after the right mouse button is pressed, the scene will be dragged and the menu will not be popped up after being lifted.