### PR TITLE
Fix Area2D/3D not using node rotation for directional gravity

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -304,7 +304,7 @@ void GodotArea2D::compute_gravity(const Vector2 &p_position, Vector2 &r_gravity)
 			r_gravity = v.normalized() * get_gravity();
 		}
 	} else {
-		r_gravity = get_gravity_vector() * get_gravity();
+		r_gravity = get_transform().basis_xform(get_gravity_vector() * get_gravity());
 	}
 }
 

--- a/modules/godot_physics_3d/godot_area_3d.cpp
+++ b/modules/godot_physics_3d/godot_area_3d.cpp
@@ -334,7 +334,7 @@ void GodotArea3D::compute_gravity(const Vector3 &p_position, Vector3 &r_gravity)
 			r_gravity = v.normalized() * get_gravity();
 		}
 	} else {
-		r_gravity = get_gravity_vector() * get_gravity();
+		r_gravity = get_transform().basis.xform(get_gravity_vector() * get_gravity());
 	}
 }
 


### PR DESCRIPTION
In the current master of Godot, Area2D/3D does not use the rotation of the node for directional gravity. It always behaves as if the node was not rotated. I believe this is a bug because 1) It makes sense to account for rotation and 2) Area2D/3D already accounts for node rotation when using point gravity, so it makes sense to be consistent with the modes.

This technically breaks compatibility as it's a behavior change, but I would guess that this would affect very few users, as probably few users are using gravity at all, and most of those are not rotating gravity fields (or else they'd run into this).

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/79243*
* *Bugsquad edit, alternative to: https://github.com/godotengine/godot/pull/79268*