### PR TITLE
BasisUniversal: Use RGTC compression when available

### DIFF
--- a/modules/basis_universal/image_compress_basisu.h
+++ b/modules/basis_universal/image_compress_basisu.h
@@ -38,6 +38,7 @@ enum BasisDecompressFormat {
 	BASIS_DECOMPRESS_RGB,
 	BASIS_DECOMPRESS_RGBA,
 	BASIS_DECOMPRESS_RG_AS_RA,
+	BASIS_DECOMPRESS_R,
 };
 
 void basis_universal_init();


### PR DESCRIPTION
Depends on #89426

Changes BasisUniversal's destination format for normal maps from `(DXT5/ETC2)_RA-As-RG` to `RGTC_RG`/`ETC2_RG11`, which results in a slight quality gain. 
Also adds support for encoding R-channel only images and decoding them as `RGTC_R`/`ETC2_R11`.

This needs testing on mobile devices, but I suspect the difference in quality will be most significant there.

|master|PR|diff|
|-----|------|----|
|![dxt5](https://github.com/godotengine/godot/assets/53150244/3e6e1e2c-599c-49ae-96e8-767e18c2f0f7)|![rgtc](https://github.com/godotengine/godot/assets/53150244/d5636e0f-c789-4398-8ed0-616020d41712)|![nrmdiff](https://github.com/godotengine/godot/assets/53150244/2e37c785-192b-4fe0-ac4d-cba2db27cec4)|
|![main](https://github.com/godotengine/godot/assets/53150244/0dfd3524-922d-4b4d-87c3-3f1e7678b9e9)|![rgtc_red](https://github.com/godotengine/godot/assets/53150244/28448ea7-1ba9-4035-bfa7-4ca94d83a3fd)|![red_diff](https://github.com/godotengine/godot/assets/53150244/ede11005-5902-40e9-bd5d-84e40f3ad9f1)|

MRP:
[basisurgtctest.zip](https://github.com/godotengine/godot/files/14851695/basisurgtctest.zip)
