### PR TITLE
Don't generate type checks when matching on a builtin 

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -174,6 +174,19 @@ String Variant::get_type_name(Variant::Type p_type) {
 	return "";
 }
 
+bool Variant::can_match(Variant::Type p_type_test, Variant::Type p_type_pattern) {
+	if (p_type_test == p_type_pattern) {
+		return true;
+	}
+	if (p_type_test == STRING && p_type_pattern == STRING_NAME) {
+		return true;
+	}
+	if (p_type_test == STRING_NAME && p_type_pattern == STRING) {
+		return true;
+	}
+	return false;
+}
+
 bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 	if (p_type_from == p_type_to) {
 		return true;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -331,6 +331,7 @@ public:
 		return type;
 	}
 	static String get_type_name(Variant::Type p_type);
+	static bool can_match(Type p_type_test, Type p_type_pattern);
 	static bool can_convert(Type p_type_from, Type p_type_to);
 	static bool can_convert_strict(Type p_type_from, Type p_type_to);
 	static bool is_type_shared(Variant::Type p_type);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1393,7 +1393,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 	}
 }
 
-GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested) {
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested, const GDScriptDataType &p_test_type) {
+	bool is_builtin_type_match = p_test_type.kind == GDScriptDataType::BUILTIN;
 	switch (p_pattern->pattern_type) {
 		case GDScriptParser::PatternNode::PT_LITERAL: {
 			if (p_is_nested) {
@@ -1404,7 +1405,6 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 
 			// Get literal type into constant map.
 			Variant::Type literal_type = p_pattern->literal->value.get_type();
-			GDScriptCodeGenerator::Address literal_type_addr = codegen.add_constant(literal_type);
 
 			// Equality is always a boolean.
 			GDScriptDataType equality_type;
@@ -1412,49 +1412,54 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			equality_type.kind = GDScriptDataType::BUILTIN;
 			equality_type.builtin_type = Variant::BOOL;
 
-			// Check type equality.
-			GDScriptCodeGenerator::Address type_equality_addr = codegen.add_temporary(equality_type);
-			codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_EQUAL, p_type_addr, literal_type_addr);
-
-			if (literal_type == Variant::STRING) {
-				GDScriptCodeGenerator::Address type_stringname_addr = codegen.add_constant(Variant::STRING_NAME);
-
-				// Check StringName <-> String type equality.
-				GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
-
-				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
-				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
-
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
-			} else if (literal_type == Variant::STRING_NAME) {
-				GDScriptCodeGenerator::Address type_string_addr = codegen.add_constant(Variant::STRING);
-
-				// Check String <-> StringName type equality.
-				GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
-
-				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
-				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
-
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
-			}
-
-			codegen.generator->write_and_left_operand(type_equality_addr);
-
+			GDScriptCodeGenerator::Address equality_addr = codegen.add_temporary(equality_type);
 			// Get literal.
 			GDScriptCodeGenerator::Address literal_addr = _parse_expression(codegen, r_error, p_pattern->literal);
 			if (r_error) {
 				return GDScriptCodeGenerator::Address();
 			}
 
-			// Check value equality.
-			GDScriptCodeGenerator::Address equality_addr = codegen.add_temporary(equality_type);
-			codegen.generator->write_binary_operator(equality_addr, Variant::OP_EQUAL, p_value_addr, literal_addr);
-			codegen.generator->write_and_right_operand(equality_addr);
+			if (is_builtin_type_match && Variant::can_match(p_test_type.builtin_type, literal_type)) {
+				codegen.generator->write_binary_operator(equality_addr, Variant::OP_EQUAL, p_value_addr, literal_addr);
+			} else {
+				// Check type equality.
+				GDScriptCodeGenerator::Address literal_type_addr = codegen.add_constant(literal_type);
+				codegen.generator->write_binary_operator(equality_addr, Variant::OP_EQUAL, p_type_addr, literal_type_addr);
 
-			// AND both together (reuse temporary location).
-			codegen.generator->write_end_and(type_equality_addr);
+				if (literal_type == Variant::STRING) {
+					GDScriptCodeGenerator::Address type_stringname_addr = codegen.add_constant(Variant::STRING_NAME);
 
-			codegen.generator->pop_temporary(); // Remove equality_addr from stack.
+					// Check StringName <-> String type equality.
+					GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
+
+					codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
+					codegen.generator->write_binary_operator(equality_addr, Variant::OP_OR, equality_addr, tmp_comp_addr);
+
+					codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
+				} else if (literal_type == Variant::STRING_NAME) {
+					GDScriptCodeGenerator::Address type_string_addr = codegen.add_constant(Variant::STRING);
+
+					// Check String <-> StringName type equality.
+					GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
+
+					codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
+					codegen.generator->write_binary_operator(equality_addr, Variant::OP_OR, equality_addr, tmp_comp_addr);
+
+					codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
+				}
+
+				codegen.generator->write_and_left_operand(equality_addr);
+
+				// Check value equality.
+				GDScriptCodeGenerator::Address value_equality_addr = codegen.add_temporary(equality_type);
+				codegen.generator->write_binary_operator(value_equality_addr, Variant::OP_EQUAL, p_value_addr, literal_addr);
+				codegen.generator->write_and_right_operand(value_equality_addr);
+
+				// AND both together
+				codegen.generator->write_end_and(equality_addr);
+
+				codegen.generator->pop_temporary(); // Remove value_equality_addr from stack.
+			}
 
 			if (literal_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				codegen.generator->pop_temporary();
@@ -1463,17 +1468,17 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
 			if (p_is_nested) {
 				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_and_right_operand(type_equality_addr);
+				codegen.generator->write_and_right_operand(equality_addr);
 				codegen.generator->write_end_and(p_previous_test);
 			} else if (!p_is_first) {
 				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_or_right_operand(type_equality_addr);
+				codegen.generator->write_or_right_operand(equality_addr);
 				codegen.generator->write_end_or(p_previous_test);
 			} else {
 				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign(p_previous_test, type_equality_addr);
+				codegen.generator->write_assign(p_previous_test, equality_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove type_equality_addr.
+			codegen.generator->pop_temporary(); // Remove equality_addr.
 
 			return p_previous_test;
 		} break;
@@ -1495,10 +1500,6 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 
 			// Create the result temps first since it's the last to go away.
 			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address equality_test_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address stringy_comp_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address stringy_comp_addr_2 = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address expr_type_addr = codegen.add_temporary();
 
 			// Evaluate expression.
 			GDScriptCodeGenerator::Address expr_addr;
@@ -1507,44 +1508,58 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				return GDScriptCodeGenerator::Address();
 			}
 
-			// Evaluate expression type.
-			Vector<GDScriptCodeGenerator::Address> typeof_args;
-			typeof_args.push_back(expr_addr);
-			codegen.generator->write_call_utility(expr_type_addr, "typeof", typeof_args);
+			GDScriptParser::DataType expr_type = p_pattern->expression->datatype;
+			if (is_builtin_type_match && expr_type.kind == GDScriptParser::DataType::BUILTIN) {
+				if (Variant::can_match(p_test_type.builtin_type, expr_type.builtin_type)) {
+					codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_value_addr, expr_addr);
+				} else {
+					codegen.generator->write_assign_false(result_addr);
+				}
+			} else {
+				GDScriptCodeGenerator::Address equality_test_addr = codegen.add_temporary(equality_type);
+				GDScriptCodeGenerator::Address stringy_comp_addr = codegen.add_temporary(equality_type);
+				GDScriptCodeGenerator::Address stringy_comp_addr_2 = codegen.add_temporary(equality_type);
+				GDScriptCodeGenerator::Address expr_type_addr = codegen.add_temporary();
+				// Evaluate expression type.
+				Vector<GDScriptCodeGenerator::Address> typeof_args;
+				typeof_args.push_back(expr_addr);
+				codegen.generator->write_call_utility(expr_type_addr, "typeof", typeof_args);
 
-			// Check type equality.
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, expr_type_addr);
+				// Check type equality.
+				codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, expr_type_addr);
 
-			// Check for String <-> StringName comparison.
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_stringname_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
+				// Check for String <-> StringName comparison.
+				codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
+				codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_stringname_addr);
+				codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
+				codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
 
-			// Check for StringName <-> String comparison.
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_string_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
+				// Check for StringName <-> String comparison.
+				codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
+				codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_string_addr);
+				codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
+				codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
 
-			codegen.generator->pop_temporary(); // Remove expr_type_addr from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr_2 from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr from stack.
+				codegen.generator->pop_temporary(); // Remove expr_type_addr from stack.
+				codegen.generator->pop_temporary(); // Remove stringy_comp_addr_2 from stack.
+				codegen.generator->pop_temporary(); // Remove stringy_comp_addr from stack.
 
-			codegen.generator->write_and_left_operand(result_addr);
+				codegen.generator->write_and_left_operand(result_addr);
 
-			// Check value equality.
-			codegen.generator->write_binary_operator(equality_test_addr, Variant::OP_EQUAL, p_value_addr, expr_addr);
-			codegen.generator->write_and_right_operand(equality_test_addr);
+				// Check value equality.
+				codegen.generator->write_binary_operator(equality_test_addr, Variant::OP_EQUAL, p_value_addr, expr_addr);
+				codegen.generator->write_and_right_operand(equality_test_addr);
 
-			// AND both type and value equality.
-			codegen.generator->write_end_and(result_addr);
+				// AND both type and value equality.
+				codegen.generator->write_end_and(result_addr);
+
+				codegen.generator->pop_temporary(); // Remove equality_test_addr from stack.
+			}
 
 			// We don't need the expression temporary anymore.
 			if (expr_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				codegen.generator->pop_temporary();
 			}
-			codegen.generator->pop_temporary(); // Remove equality_test_addr from stack.
 
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
 			if (p_is_nested) {
@@ -1559,7 +1574,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, result_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
+			codegen.generator->pop_temporary(); // Remove temp result_addr.
 
 			return p_previous_test;
 		} break;
@@ -1569,19 +1584,27 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			} else if (!p_is_first) {
 				codegen.generator->write_or_left_operand(p_previous_test);
 			}
-			// Get array type into constant map.
-			GDScriptCodeGenerator::Address array_type_addr = codegen.add_constant((int)Variant::ARRAY);
 
 			// Equality is always a boolean.
 			GDScriptDataType temp_type;
 			temp_type.has_type = true;
 			temp_type.kind = GDScriptDataType::BUILTIN;
 			temp_type.builtin_type = Variant::BOOL;
-
-			// Check type equality.
 			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, array_type_addr);
-			codegen.generator->write_and_left_operand(result_addr);
+			// FIXME: Avoid generating true && <value comparison>, just compare directly
+			if (is_builtin_type_match) {
+				if (Variant::can_match(p_test_type.builtin_type, Variant::Type::ARRAY)) {
+					codegen.generator->write_assign_true(result_addr);
+				} else {
+					codegen.generator->write_assign_false(result_addr);
+				}
+				codegen.generator->write_and_left_operand(result_addr);
+			} else {
+				// Get array type into constant map.
+				GDScriptCodeGenerator::Address array_type_addr = codegen.add_constant((int)Variant::ARRAY);
+				codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, array_type_addr);
+				codegen.generator->write_and_left_operand(result_addr);
+			}
 
 			// Store pattern length in constant map.
 			GDScriptCodeGenerator::Address array_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->array.size() - 1 : p_pattern->array.size());
@@ -1657,7 +1680,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, result_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
+			codegen.generator->pop_temporary(); // Remove temp result_addr.
 
 			return p_previous_test;
 		} break;
@@ -1667,19 +1690,29 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			} else if (!p_is_first) {
 				codegen.generator->write_or_left_operand(p_previous_test);
 			}
-			// Get dictionary type into constant map.
-			GDScriptCodeGenerator::Address dict_type_addr = codegen.add_constant((int)Variant::DICTIONARY);
 
 			// Equality is always a boolean.
 			GDScriptDataType temp_type;
 			temp_type.has_type = true;
 			temp_type.kind = GDScriptDataType::BUILTIN;
 			temp_type.builtin_type = Variant::BOOL;
-
-			// Check type equality.
 			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, dict_type_addr);
-			codegen.generator->write_and_left_operand(result_addr);
+			if (is_builtin_type_match) {
+				// FIXME: Avoid generating true && <value comparison>, just compare directly
+				if (Variant::can_match(p_test_type.builtin_type, Variant::Type::DICTIONARY)) {
+					codegen.generator->write_assign_true(result_addr);
+				} else {
+					codegen.generator->write_assign_false(result_addr);
+				}
+				codegen.generator->write_and_left_operand(result_addr);
+			} else {
+				// Get dictionary type into constant map.
+				GDScriptCodeGenerator::Address array_type_addr = codegen.add_constant((int)Variant::DICTIONARY);
+
+				// Check type equality.
+				codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, array_type_addr);
+				codegen.generator->write_and_left_operand(result_addr);
+			}
 
 			// Store pattern length in constant map.
 			GDScriptCodeGenerator::Address dict_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->dictionary.size() - 1 : p_pattern->dictionary.size());
@@ -1877,8 +1910,9 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 
 				codegen.start_block();
 
+				GDScriptDataType test_type = _gdtype_from_datatype(match->test->get_datatype(), codegen.script);
 				// Evaluate the match expression.
-				GDScriptCodeGenerator::Address value = codegen.add_local("@match_value", _gdtype_from_datatype(match->test->get_datatype(), codegen.script));
+				GDScriptCodeGenerator::Address value = codegen.add_local("@match_value", test_type);
 				GDScriptCodeGenerator::Address value_expr = _parse_expression(codegen, err, match->test);
 				if (err) {
 					return err;
@@ -1892,13 +1926,15 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					codegen.generator->pop_temporary();
 				}
 
-				// Then, let's save the type of the value in the stack too, so we can reuse for later comparisons.
+				GDScriptCodeGenerator::Address type;
+				// Save the type of the value in the stack too, so we can reuse for later comparisons.
+				// FIXME: If the type of the match test is known, we can do this lazily, i.e. only call typeof if
+				// one of our patterns is of unknown type and needs a runtime check.
 				GDScriptDataType typeof_type;
 				typeof_type.has_type = true;
 				typeof_type.kind = GDScriptDataType::BUILTIN;
 				typeof_type.builtin_type = Variant::INT;
-				GDScriptCodeGenerator::Address type = codegen.add_local("@match_type", typeof_type);
-
+				type = codegen.add_local("@match_type", typeof_type);
 				Vector<GDScriptCodeGenerator::Address> typeof_args;
 				typeof_args.push_back(value);
 				gen->write_call_utility(type, "typeof", typeof_args);
@@ -1925,7 +1961,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					// For each pattern in branch.
 					GDScriptCodeGenerator::Address pattern_result = codegen.add_temporary();
 					for (int k = 0; k < branch->patterns.size(); k++) {
-						pattern_result = _parse_match_pattern(codegen, err, branch->patterns[k], value, type, pattern_result, k == 0, false);
+						pattern_result = _parse_match_pattern(codegen, err, branch->patterns[k], value, type, pattern_result, k == 0, false, test_type);
 						if (err != OK) {
 							return err;
 						}

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -156,7 +156,7 @@ class GDScriptCompiler {
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
-	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested);
+	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested, const GDScriptDataType &p_test_type = GDScriptDataType());
 	List<GDScriptCodeGenerator::Address> _add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
 	void _clear_addresses(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_addresses);
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_reset_locals = true);

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -38,6 +38,8 @@
 
 #include "core/templates/hash_set.h"
 
+#include <functional>
+
 class GDScriptCompiler {
 	const GDScriptParser *parser = nullptr;
 	HashSet<GDScript *> parsed_classes;
@@ -156,7 +158,7 @@ class GDScriptCompiler {
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
-	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested, const GDScriptDataType &p_test_type = GDScriptDataType());
+	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, std::function<GDScriptCodeGenerator::Address(void)> &p_get_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested, const GDScriptDataType &p_test_type = GDScriptDataType());
 	List<GDScriptCodeGenerator::Address> _add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
 	void _clear_addresses(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_addresses);
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_reset_locals = true);


### PR DESCRIPTION
```gdscript
func main():
	match 1:
		1: foo()
		2: bar()
```

Before
```
Disassembling main()
 0: line 2: 	match 1:
 2: assign stack(3) = const(1)
 5: call-utility stack(4) = typeof(stack(3))
 11: line 3: 		1: foo()
 13: validated operator stack(6) = stack(4) == const(2)
 18: jump-if-not stack(6) to 33
 21: validated operator stack(7) = stack(3) == const(1)
 26: jump-if-not stack(7) to 33
 29: assign stack(6) = true
 31: jump 35
 33: assign stack(6) = false
 35: assign stack(5) = stack(6)
 38: jump-if-not stack(5) to 55
 41: assign stack(5) = false
 43: line 3: 		1: foo()
 45: call self.foo()
 51: assign stack(5) = false
 53: jump 97
 55: line 4: 		2: bar()
 57: validated operator stack(7) = stack(4) == const(2)
 62: jump-if-not stack(7) to 77
 65: validated operator stack(6) = stack(3) == const(2)
 70: jump-if-not stack(6) to 77
 73: assign stack(7) = true
 75: jump 79
 77: assign stack(7) = false
 79: assign stack(5) = stack(7)
 82: jump-if-not stack(5) to 97
 85: assign stack(5) = false
 87: line 4: 		2: bar()
 89: call self.bar()
 95: assign stack(5) = false
 97: == END ==
```


After
```
Disassembling main()
 0: line 2: 	match 1:
 2: assign stack(3) = const(1)
 5: call-utility stack(4) = typeof(stack(3))
 11: line 3: 		1: foo()
 13: validated operator stack(6) = stack(3) == const(1)
 18: assign stack(5) = stack(6)
 21: jump-if-not stack(5) to 38
 24: assign stack(5) = false
 26: line 3: 		1: foo()
 28: call self.foo()
 34: assign stack(5) = false
 36: jump 63
 38: line 4: 		2: bar()
 40: validated operator stack(6) = stack(3) == const(2)
 45: assign stack(5) = stack(6)
 48: jump-if-not stack(5) to 63
 51: assign stack(5) = false
 53: line 4: 		2: bar()
 55: call self.bar()
 61: assign stack(5) = false
 63: == END ==
```

(lots of indentation changes - easier to review with `&w=1` at the end of the URL!)