### PR TITLE
Fix double click in CJK characters and create unit test

### DIFF
--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -128,4 +128,12 @@ static _FORCE_INLINE_ bool is_underscore(char32_t p_char) {
 	return (p_char == '_');
 }
 
+static _FORCE_INLINE_ bool is_cjk_character(char32_t c) {
+	return (c >= 0x4E00 && c <= 0x9FFF) || (c >= 0x3400 && c <= 0x4DBF) || (c >= 0x3040 && c <= 0x30FF) || (c >= 0x31F0 && c <= 0x31FF) || (c >= 0xAC00 && c <= 0xD7AF) || (c >= 0x1100 && c <= 0x11FF) || (c >= 0x3130 && c <= 0x318F);
+}
+
+static _FORCE_INLINE_ bool is_cjk_punctuation(char32_t c) {
+	return (c >= 0x3000 && c <= 0x303F) || (c >= 0xFF00 && c <= 0xFFEF);
+}
+
 #endif // CHAR_UTILS_H

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5400,13 +5400,18 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 			} else {
 				while (ubrk_next(bi) != UBRK_DONE) {
 					int pos = _convert_pos(sd, ubrk_current(bi)) + r_start;
-					if ((ubrk_getRuleStatus(bi) >= UBRK_LINE_HARD) && (ubrk_getRuleStatus(bi) < UBRK_LINE_HARD_LIMIT)) {
+					int pos_p = pos - 1 - sd->start;
+					char32_t c = sd->text[pos_p];
+
+					if (is_cjk_character(c)) {
+						if (is_cjk_punctuation(c)) {
+							sd->breaks[pos] = true;
+						}
+					} else if ((ubrk_getRuleStatus(bi) >= UBRK_LINE_HARD) && (ubrk_getRuleStatus(bi) < UBRK_LINE_HARD_LIMIT)) {
 						sd->breaks[pos] = true;
 					} else if ((ubrk_getRuleStatus(bi) >= UBRK_LINE_SOFT) && (ubrk_getRuleStatus(bi) < UBRK_LINE_SOFT_LIMIT)) {
 						sd->breaks[pos] = false;
 					}
-					int pos_p = pos - 1 - sd->start;
-					char32_t c = sd->text[pos_p];
 					if (pos - sd->start != sd->end && !is_whitespace(c) && (c != 0xfffc)) {
 						sd->break_inserts++;
 					}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -31,12 +31,28 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H
 
+#include "core/string/char_utils.h"
+#include "tests/test_macros.h"
+
 class String;
 
 namespace TestUtils {
 
 String get_data_path(const String &p_file);
 String get_executable_dir();
+
+TEST_CASE("[UTILS] Test cjk chr") {
+	CHECK(is_cjk_character(0x53D8) == true); // '变'
+	CHECK(is_cjk_character(0x5909) == true); // '変'
+	CHECK(is_cjk_character(0xB3D9) == true); // '변'
+}
+
+TEST_CASE("[UTILS] Test cjk chr") {
+	CHECK(is_cjk_punctuation(0x3002) == true); // Ideographic full stop
+	CHECK(is_cjk_punctuation(0x3001) == true); // Ideographic comma
+	CHECK(is_cjk_punctuation(0x3005) == true); // Ideographic iteration mark
+}
+
 } // namespace TestUtils
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
Fixes #75808 -> selecting chinese, japanese and korean characters with double click. The problem was with the external library UBreakIterator.
Solution: Check manually if the character is cjk.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
