### PR TITLE
Fix window Unmovable After Double-Clicking to Maximize on macOS

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3221,7 +3221,6 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	offset.y = (nsrect.origin.y + nsrect.size.height);
 	offset.y -= (windowRect.origin.y + windowRect.size.height);
 
-
 	Point2i position = p_position;
 	// macOS native y-coordinate relative to _get_screens_origin() is negative,
 	// Godot passes a positive value.

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3212,17 +3212,6 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
-	if (NSEqualRects([wd.window_object frame], [[wd.window_object screen] visibleFrame])) {
-		return;
-	}
-
-	Point2i position = p_position;
-	// macOS native y-coordinate relative to _get_screens_origin() is negative,
-	// Godot passes a positive value.
-	position.y *= -1;
-	position += _get_screens_origin();
-	position /= screen_get_max_scale();
-
 	// Remove titlebar / window border size.
 	const NSRect contentRect = [wd.window_view frame];
 	const NSRect windowRect = [wd.window_object frame];
@@ -3231,6 +3220,14 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	offset.x = (nsrect.origin.x - windowRect.origin.x);
 	offset.y = (nsrect.origin.y + nsrect.size.height);
 	offset.y -= (windowRect.origin.y + windowRect.size.height);
+
+
+	Point2i position = p_position;
+	// macOS native y-coordinate relative to _get_screens_origin() is negative,
+	// Godot passes a positive value.
+	position.y *= -1;
+	position += _get_screens_origin();
+	position /= screen_get_max_scale();
 
 	[wd.window_object setFrameTopLeftPoint:NSMakePoint(position.x - offset.x, position.y - offset.y)];
 


### PR DESCRIPTION
**[ Mac Os Specific ]** 

**Bug Description:**
When the editor window is in fill-screen mode ( not in full-screen ) the window becomes
unresponsive to drag movements, meaning when you try to move the window to another
 position it does not allow you. 

**Fix Explanation:**
The fix was based on the deletion of an extra condition
(if statement ) that prevented the window from being moved when in that mode. Basically,
the if statement checked if the size of the window occupied by the editor was equal to the visible 
window size , which for the mode fill-screen it was , in that case the function returned without 
applying the changes in the editor's window position.

**File Location:**
 The changes were made in the platform/macos/display_server_macos.mm file in the 
window_set_position() function.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/86389*
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
