### PR TITLE
Apply vertex attribute fixing to the LOD system for rigged meshes.

### DIFF
--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -33,6 +33,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/sort_array.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
 #include "scene/resources/mesh.h"
@@ -47,6 +48,10 @@
 class ImporterMesh : public Resource {
 	GDCLASS(ImporterMesh, Resource)
 
+public:
+	static constexpr int bone_influence_lod_count = 8;
+
+public:
 	struct Surface {
 		Mesh::PrimitiveType primitive;
 		Array arrays;
@@ -81,6 +86,18 @@ class ImporterMesh : public Resource {
 	Ref<ImporterMesh> shadow_mesh;
 
 	Size2i lightmap_size_hint;
+	struct MergedAttribute {
+		Vector3 normal;
+		LocalVector<float> primary_bone_influence = {};
+		MergedAttribute(int32_t p_influences = bone_influence_lod_count) {
+			primary_bone_influence.resize(p_influences);
+			for (int32_t i = 0; i < p_influences; i++) {
+				primary_bone_influence[i] = primary_bone_influence[i];
+			}
+		}
+	};
+	LocalVector<LocalVector<float>> _get_sorted_bone_influences(int32_t p_vertex_count, const int32_t p_influence_count, Vector<int> p_bones, Vector<float> p_weights);
+	Vector<float> _merged_attribute_to_float32_array(const LocalVector<MergedAttribute> &p_attributes);
 
 protected:
 	void _set_data(const Dictionary &p_data);

--- a/thirdparty/meshoptimizer/simplifier.cpp
+++ b/thirdparty/meshoptimizer/simplifier.cpp
@@ -441,7 +441,7 @@ static void rescaleAttributes(float* result, const float* vertex_attributes_data
 	}
 }
 
-static const size_t kMaxAttributes = 16;
+static const size_t kMaxAttributes = 32;
 
 struct Quadric
 {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84479

Here's a sample video with me toggling the mesh lod settings in the background.

[Godot Engine autolod patch rig lod success 02](https://www.youtube.com/watch?v=SjvvWxidm0g)

https://youtu.be/JodufVyd3Ow and https://youtu.be/BMvh1J9ril0

- [ ] Fix crash on same fbx repository.