### PR TITLE
Fix gizmo on top material option having no effect

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -979,10 +979,11 @@ Ref<StandardMaterial3D> EditorNode3DGizmoPlugin::get_material(const String &p_na
 
 	Ref<StandardMaterial3D> mat = materials[p_name][index];
 
-	if (current_state == ON_TOP && p_gizmo->is_selected()) {
+	bool on_top_mat = mat->get_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST);
+
+	if (!on_top_mat && current_state == ON_TOP && p_gizmo->is_selected()) {
+		mat = mat->duplicate();
 		mat->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	} else {
-		mat->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, false);
 	}
 
 	return mat;


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/44077

I found that the `get_material` function in EditorNode3DGizmoPlugin is changing the gizmo materials directly to add and remove the disable depth test flag to enable/disable them for the 'x-ray' visibility state before returning them. This is causing the original state of the disable depth test flag to be lost so materials that were created with the on_top parameter are never returned with the disable depth test flag enabled when in the regular 'visible' visibility state.

To fix this I have updated `get_material` to change the disable depth test flag on duplicate versions of the gizmo
materials when the gizmo is set to use the 'x-ray' / `ON_TOP` visibility state if the flag is not already set or otherwise return the stored materials without change.

(Since StandardMaterial3D is RefCounted these duplicates should be freed automatically when later unreferenced when the gizmo is redrawn.)