### PR TITLE
Fix mistakes in functions srgb_to_linear() and linear_to_srgb()

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -174,16 +174,17 @@ struct _NO_DISCARD_ Color {
 
 	_FORCE_INLINE_ Color srgb_to_linear() const {
 		return Color(
-				r < 0.04045f ? r * (1.0f / 12.92f) : Math::pow((r + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-				g < 0.04045f ? g * (1.0f / 12.92f) : Math::pow((g + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-				b < 0.04045f ? b * (1.0f / 12.92f) : Math::pow((b + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+				r <= 0.04045f ? r / 12.92f : Math::pow((r + 0.055f) / 1.055f, 2.4f),
+				g <= 0.04045f ? g / 12.92f : Math::pow((g + 0.055f) / 1.055f, 2.4f),
+				b <= 0.04045f ? b / 12.92f : Math::pow((b + 0.055f) / 1.055f, 2.4f),
 				a);
 	}
 	_FORCE_INLINE_ Color linear_to_srgb() const {
 		return Color(
-				r < 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * Math::pow(r, 1.0f / 2.4f) - 0.055f,
-				g < 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * Math::pow(g, 1.0f / 2.4f) - 0.055f,
-				b < 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * Math::pow(b, 1.0f / 2.4f) - 0.055f, a);
+				r <= 0.0031308f ? 12.92f * r : 1.055f * Math::pow(r, 1.0f / 2.4f) - 0.055f,
+				g <= 0.0031308f ? 12.92f * g : 1.055f * Math::pow(g, 1.0f / 2.4f) - 0.055f,
+				b <= 0.0031308f ? 12.92f * b : 1.055f * Math::pow(b, 1.0f / 2.4f) - 0.055f,
+				a);
 	}
 
 	static Color hex(uint32_t p_hex);


### PR DESCRIPTION
The correct formulas uses "<=", not just "<".
This can be seen in IEC 61966-2-1:1999 or in the Wikipedia article "sRGB".
Also, some mathematical operations do not make sense and can be removed.