### PR TITLE
Expose `goto_help` for GDExtension on `ScriptEditor`

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -34,6 +34,35 @@
 				Returns an array with all [Script] objects which are currently open in editor.
 			</description>
 		</method>
+		<method name="goto_help">
+			<return type="void" />
+			<param index="0" name="topic" type="String" />
+			<description>
+				Opens help for the given topic. The [param topic] is an encoded string that controls which class, method, constant, signal, annotation, property, or theme item should be focused.
+				The supported [param topic] formats include [code]class_name:class[/code], [code]class_method:class:method[/code], [code]class_constant:class:constant[/code], [code]class_signal:class:signal[/code], [code]class_annotation:class:@annotation[/code], [code]class_property:class:property[/code], and [code]class_theme_item:class:item[/code], where [code]class[/code] is the class name, [code]method[/code] is the method name, [code]constant[/code] is the constant name, [code]signal[/code] is the signal name, [code]annotation[/code] is the annotation name, [code]property[/code] is the property name, and [code]item[/code] is the theme item.
+				[b]Examples:[/b]
+				[codeblock]
+				# Shows help for the Node class.
+				class_name:Node
+				# Shows help for the global min function.
+				# Global objects are accessible in the `@GlobalScope` namespace, shown here.
+				class_method:@GlobalScope:min
+				# Shows help for get_viewport in the Node class.
+				class_method:Node:get_viewport
+				# Shows help for the Input constant MOUSE_BUTTON_MIDDLE.
+				class_constant:Input:MOUSE_BUTTON_MIDDLE
+				# Shows help for the BaseButton signal pressed.
+				class_signal:BaseButton:pressed
+				# Shows help for the CanvasItem property visible.
+				class_property:CanvasItem:visible
+				# Shows help for the GDScript annotation export.
+				# Annotations should be prefixed with the `@` symbol in the descriptor, as shown here.
+				class_annotation:@GDScript:@export
+				# Shows help for the GraphNode theme item named panel_selected.
+				class_theme_item:GraphNode:panel_selected
+				[/codeblock]
+			</description>
+		</method>
 		<method name="goto_line">
 			<return type="void" />
 			<param index="0" name="line_number" type="int" />

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3877,6 +3877,8 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
 
+	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
+
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }


### PR DESCRIPTION
Exposes a helper method `goto_help` on the `ScriptEditor` that enables GDExtension and other tooling to request help to be displayed for a given help encoded descriptor string.