### PR TITLE
[TextServer] Expose ICU title case string conversion to scripting.

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1736,6 +1736,16 @@
 				[b]Note:[/b] The result may be longer or shorter than the original.
 			</description>
 		</method>
+		<method name="string_to_title" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="string" type="String" />
+			<param index="1" name="language" type="String" default="&quot;&quot;" />
+			<description>
+				Returns the string converted to title case.
+				[b]Note:[/b] Casing is locale dependent and context sensitive if server support [constant FEATURE_CONTEXT_SENSITIVE_CASE_CONVERSION] feature (supported by [TextServerAdvanced]).
+				[b]Note:[/b] The result may be longer or shorter than the original.
+			</description>
+		</method>
 		<method name="string_to_upper" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1913,6 +1913,15 @@
 				Returns the string converted to lowercase.
 			</description>
 		</method>
+		<method name="_string_to_title" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="string" type="String" />
+			<param index="1" name="language" type="String" />
+			<description>
+				[b]Optional.[/b]
+				Returns the string converted to title case.
+			</description>
+		</method>
 		<method name="_string_to_upper" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -991,6 +991,7 @@ public:
 
 	MODBIND2RC(String, string_to_upper, const String &, const String &);
 	MODBIND2RC(String, string_to_lower, const String &, const String &);
+	MODBIND2RC(String, string_to_title, const String &, const String &);
 
 	MODBIND0(cleanup);
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -4439,6 +4439,10 @@ String TextServerFallback::_string_to_lower(const String &p_string, const String
 	return p_string.to_lower();
 }
 
+String TextServerFallback::_string_to_title(const String &p_string, const String &p_language) const {
+	return p_string.capitalize();
+}
+
 PackedInt32Array TextServerFallback::_string_get_word_breaks(const String &p_string, const String &p_language, int64_t p_chars_per_line) const {
 	PackedInt32Array ret;
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -848,6 +848,7 @@ public:
 
 	MODBIND2RC(String, string_to_upper, const String &, const String &);
 	MODBIND2RC(String, string_to_lower, const String &, const String &);
+	MODBIND2RC(String, string_to_title, const String &, const String &);
 
 	MODBIND0(cleanup);
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -341,6 +341,7 @@ void TextServerExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_string_to_upper, "string", "language");
 	GDVIRTUAL_BIND(_string_to_lower, "string", "language");
+	GDVIRTUAL_BIND(_string_to_title, "string", "language");
 
 	GDVIRTUAL_BIND(_parse_structured_text, "parser_type", "args", "text");
 
@@ -1502,6 +1503,14 @@ String TextServerExtension::strip_diacritics(const String &p_string) const {
 String TextServerExtension::string_to_upper(const String &p_string, const String &p_language) const {
 	String ret;
 	if (GDVIRTUAL_CALL(_string_to_upper, p_string, p_language, ret)) {
+		return ret;
+	}
+	return p_string;
+}
+
+String TextServerExtension::string_to_title(const String &p_string, const String &p_language) const {
+	String ret;
+	if (GDVIRTUAL_CALL(_string_to_title, p_string, p_language, ret)) {
 		return ret;
 	}
 	return p_string;

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -566,8 +566,10 @@ public:
 
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const override;
 	virtual String string_to_lower(const String &p_string, const String &p_language = "") const override;
+	virtual String string_to_title(const String &p_string, const String &p_language = "") const override;
 	GDVIRTUAL2RC(String, _string_to_upper, const String &, const String &);
 	GDVIRTUAL2RC(String, _string_to_lower, const String &, const String &);
+	GDVIRTUAL2RC(String, _string_to_title, const String &, const String &);
 
 	TypedArray<Vector3i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 	GDVIRTUAL3RC(TypedArray<Vector3i>, _parse_structured_text, StructuredTextParser, const Array &, const String &);

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -491,6 +491,7 @@ void TextServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("string_to_upper", "string", "language"), &TextServer::string_to_upper, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("string_to_lower", "string", "language"), &TextServer::string_to_lower, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("string_to_title", "string", "language"), &TextServer::string_to_title, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("parse_structured_text", "parser_type", "args", "text"), &TextServer::parse_structured_text);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -546,6 +546,7 @@ public:
 	// Other string operations.
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const = 0;
 	virtual String string_to_lower(const String &p_string, const String &p_language = "") const = 0;
+	virtual String string_to_title(const String &p_string, const String &p_language = "") const = 0;
 
 	TypedArray<Vector3i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 


### PR DESCRIPTION
In addition to `string_to_lower` and `string_to_upper` exposes ICU backed `string_to_title`.