### PR TITLE
Fix `NavigationServer.set_debug_enabled()` doing nothing

### DIFF
--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -294,7 +294,11 @@ void NavigationServer3D::set_debug_enabled(bool p_enabled) {
 	debug_enabled = p_enabled;
 
 	if (debug_dirty) {
+		navigation_debug_dirty = true;
 		callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
+
+		avoidance_debug_dirty = true;
+		callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
 	}
 #endif // DEBUG_ENABLED
 }


### PR DESCRIPTION
Fixes `NavigationServer.set_debug_enabled()` doing nothing at runtime because it was not updated for newer dirty flags.

Fixes https://github.com/godotengine/godot/issues/81204

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
