### PR TITLE
Fix AudioStreamSynchronized playing/finished state

### DIFF
--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -214,22 +214,26 @@ int AudioStreamPlaybackSynchronized::mix(AudioFrame *p_buffer, float p_rate_scal
 	int todo = p_frames;
 
 	bool any_active = false;
+	int total_mixed = 0;
 	while (todo) {
 		int to_mix = MIN(todo, MIX_BUFFER_SIZE);
+		int max_mixed = 0;
 
 		bool first = true;
 		for (int i = 0; i < stream->stream_count; i++) {
 			if (playback[i].is_valid() && playback[i]->is_playing()) {
 				float volume = Math::db_to_linear(stream->audio_stream_volume_db[i]);
 				if (first) {
-					playback[i]->mix(p_buffer, p_rate_scale, to_mix);
+					int mixed = playback[i]->mix(p_buffer, p_rate_scale, to_mix);
+					max_mixed = MAX(max_mixed, mixed);
 					for (int j = 0; j < to_mix; j++) {
 						p_buffer[j] *= volume;
 					}
 					first = false;
 					any_active = true;
 				} else {
-					playback[i]->mix(mix_buffer, p_rate_scale, to_mix);
+					int mixed = playback[i]->mix(mix_buffer, p_rate_scale, to_mix);
+					max_mixed = MAX(max_mixed, mixed);
 					for (int j = 0; j < to_mix; j++) {
 						p_buffer[j] += mix_buffer[j] * volume;
 					}
@@ -246,12 +250,13 @@ int AudioStreamPlaybackSynchronized::mix(AudioFrame *p_buffer, float p_rate_scal
 
 		p_buffer += to_mix;
 		todo -= to_mix;
+		total_mixed += max_mixed;
 	}
 
 	if (!any_active) {
 		active = false;
 	}
-	return p_frames;
+	return total_mixed;
 }
 
 void AudioStreamPlaybackSynchronized::tag_used_streams() {


### PR DESCRIPTION
Updated AudioStreamPlaybackSynchronized::mix to return the number of mixed frames instead of the passed in p_frames value, so AudioServer::_mix_step can tell when it's finished.

Fixes #89723

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
