### PR TITLE
Update lingering `do/while(0)` defines

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -77,15 +77,17 @@ subject to the following restrictions:
 
 #ifdef DEBUG_ENABLED
 #define CHULL_ASSERT(m_cond)                                     \
-	do {                                                         \
+	if constexpr (true) {                                        \
 		if (unlikely(!(m_cond))) {                               \
 			ERR_PRINT("Assertion \"" _STR(m_cond) "\" failed."); \
 		}                                                        \
-	} while (0)
+	} else                                                       \
+		((void)0)
 #else
 #define CHULL_ASSERT(m_cond) \
-	do {                     \
-	} while (0)
+	if constexpr (true) {    \
+	} else                   \
+		((void)0)
 #endif
 
 #if defined(DEBUG_CONVEX_HULL) || defined(SHOW_ITERATIONS)

--- a/core/os/pool_allocator.cpp
+++ b/core/os/pool_allocator.cpp
@@ -36,12 +36,13 @@
 #include "core/string/print_string.h"
 
 #define COMPACT_CHUNK(m_entry, m_to_pos)                      \
-	do {                                                      \
+	if constexpr (true) {                                     \
 		void *_dst = &((unsigned char *)pool)[m_to_pos];      \
 		void *_src = &((unsigned char *)pool)[(m_entry).pos]; \
 		memmove(_dst, _src, aligned((m_entry).len));          \
 		(m_entry).pos = m_to_pos;                             \
-	} while (0);
+	} else                                                    \
+		((void)0)
 
 void PoolAllocator::mt_lock() const {
 }

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -230,18 +230,20 @@ public:
 };
 
 #define register_string_op(m_op_type, m_op_code)                                                               \
-	do {                                                                                                       \
+	if constexpr (true) {                                                                                      \
 		register_op<m_op_type<String, String>>(m_op_code, Variant::STRING, Variant::STRING);                   \
 		register_op<m_op_type<String, StringName>>(m_op_code, Variant::STRING, Variant::STRING_NAME);          \
 		register_op<m_op_type<StringName, String>>(m_op_code, Variant::STRING_NAME, Variant::STRING);          \
 		register_op<m_op_type<StringName, StringName>>(m_op_code, Variant::STRING_NAME, Variant::STRING_NAME); \
-	} while (false)
+	} else                                                                                                     \
+		((void)0)
 
 #define register_string_modulo_op(m_class, m_type)                                                                         \
-	do {                                                                                                                   \
+	if constexpr (true) {                                                                                                  \
 		register_op<OperatorEvaluatorStringFormat<String, m_class>>(Variant::OP_MODULE, Variant::STRING, m_type);          \
 		register_op<OperatorEvaluatorStringFormat<StringName, m_class>>(Variant::OP_MODULE, Variant::STRING_NAME, m_type); \
-	} while (false)
+	} else                                                                                                                 \
+		((void)0)
 
 void Variant::_register_variant_operators() {
 	memset(operator_return_type_table, 0, sizeof(operator_return_type_table));

--- a/modules/openxr/util.h
+++ b/modules/openxr/util.h
@@ -34,21 +34,23 @@
 #define UNPACK(...) __VA_ARGS__
 
 #define INIT_XR_FUNC_V(openxr_api, name)                                                                              \
-	do {                                                                                                              \
+	if constexpr (true) {                                                                                             \
 		XrResult get_instance_proc_addr_result;                                                                       \
 		get_instance_proc_addr_result = openxr_api->get_instance_proc_addr(#name, (PFN_xrVoidFunction *)&name##_ptr); \
 		ERR_FAIL_COND_V(XR_FAILED(get_instance_proc_addr_result), false);                                             \
-	} while (0)
+	} else                                                                                                            \
+		((void)0)
 
 #define EXT_INIT_XR_FUNC_V(name) INIT_XR_FUNC_V(OpenXRAPI::get_singleton(), name)
 #define OPENXR_API_INIT_XR_FUNC_V(name) INIT_XR_FUNC_V(this, name)
 
 #define INIT_XR_FUNC(openxr_api, name)                                                                                \
-	do {                                                                                                              \
+	if constexpr (true) {                                                                                             \
 		XrResult get_instance_proc_addr_result;                                                                       \
 		get_instance_proc_addr_result = openxr_api->get_instance_proc_addr(#name, (PFN_xrVoidFunction *)&name##_ptr); \
 		ERR_FAIL_COND(XR_FAILED(get_instance_proc_addr_result));                                                      \
-	} while (0)
+	} else                                                                                                            \
+		((void)0)
 
 #define EXT_INIT_XR_FUNC(name) INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
 #define OPENXR_API_INIT_XR_FUNC(name) INIT_XR_FUNC(this, name)
@@ -59,16 +61,18 @@
 #define EXT_TRY_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
 #define OPENXR_TRY_API_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(this, name)
 #define GDEXTENSION_INIT_XR_FUNC(name)                                                              \
-	do {                                                                                            \
+	if constexpr (true) {                                                                           \
 		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
 		ERR_FAIL_NULL(name##_ptr);                                                                  \
-	} while (0)
+	} else                                                                                          \
+		((void)0)
 
 #define GDEXTENSION_INIT_XR_FUNC_V(name)                                                            \
-	do {                                                                                            \
+	if constexpr (true) {                                                                           \
 		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
 		ERR_FAIL_NULL_V(name##_ptr, false);                                                         \
-	} while (0)
+	} else                                                                                          \
+		((void)0)
 
 #define EXT_PROTO_XRRESULT_FUNC1(func_name, arg1_type, arg1)                    \
 	PFN_##func_name func_name##_ptr = nullptr;                                  \


### PR DESCRIPTION
The majority of `do { x } while (0/false)` defines across the repo have already been replaced with `if [constexpr] (true) { x } else ((void)0)`, but a handful were still kicking. This PR removes the last of them, replacing them with the newer syntax.