### PR TITLE
Ensure `clang-tidy` checks headers, uses `clang-format`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,8 @@
 ---
 Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,cppcoreguidelines-pro-type-member-init,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements,readability-redundant-member-init'
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
-FormatStyle: none
+HeaderFilterRegex: '.'
+FormatStyle: file
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes
     value:           'L;LL;LU;LLU'


### PR DESCRIPTION
Two very small tweaks to `clang-tidy` that did wonders for me locally: enabling analysis of header files & formatting based off our `clang-format` rules.