### PR TITLE
Don't pass `self` when calling a static function from a non-static context

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -648,7 +648,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								// Not exact arguments, but still can use method bind call.
 								gen->write_call_method_bind(result, self, method, arguments);
 							}
-						} else if (codegen.is_static || (codegen.function_node && codegen.function_node->is_static) || call->function_name == "new") {
+						} else if (call->is_static || codegen.is_static || (codegen.function_node && codegen.function_node->is_static) || call->function_name == "new") {
 							GDScriptCodeGenerator::Address self;
 							self.mode = GDScriptCodeGenerator::Address::CLASS;
 							if (is_awaited) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -498,6 +498,7 @@ public:
 		Vector<ExpressionNode *> arguments;
 		StringName function_name;
 		bool is_super = false;
+		bool is_static = false;
 
 		CallNode() {
 			type = CALL;


### PR DESCRIPTION
In a recent project, I tried to extract some very hot code into a static function, but found that there were significant slowdowns.
If a static function is called from a non-static context, a `self` argument is passed. This causes a slowdown as profiling showed a significant amount of the overhead came from the destructor (i.e. refcount decrement) of the `self` reference. By recording if a method call is static, we can avoid this during codegen, noticeably improving performance.

```gdscript
func main():
    var r: bool
    # warmup
    for _i in range(500000):
        r = a()

    var start := Time.get_ticks_usec()
    for _i in range(100_000):
        r = a()
    print("method: %dus elapsed" % [Time.get_ticks_usec() - start])

    # warmup
    for _i in range(500000):
        r = b()

    start = Time.get_ticks_usec()
    for _i in range(100_000):
        r = b()
    print("static: %dus elapsed" % [Time.get_ticks_usec() - start])


func a() -> bool:
    return true

static func b() -> bool:
    return true
```
Benchmarks performed with `optimize=speed threads=false linker=mold`, and rebased onto #89962
Pre-patch:
```
method: 10538us elapsed
static: 10318us elapsed
..
method: 10548us elapsed
static: 10335us elapsed
..
method: 10312us elapsed
static: 10402us elapsed
```

Post-patch:
```
method: 10034us elapsed
static: 7811us elapsed
..
method: 10102us elapsed
static: 7660us elapsed
..
method: 9890us elapsed
static: 7693us elapsed
```