### PR TITLE
GLTF export: Propagate `property_list_changed` from extensions

### DIFF
--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -84,6 +84,11 @@ void EditorSceneExporterGLTFSettings::_get_property_list(List<PropertyInfo> *p_l
 	}
 }
 
+void EditorSceneExporterGLTFSettings::_on_extension_property_list_changed() {
+	generate_property_list(_document);
+	emit_signal("property_list_changed");
+}
+
 bool EditorSceneExporterGLTFSettings::_set_extension_setting(const String &p_name_str, const Variant &p_value) {
 	PackedStringArray split = String(p_name_str).split("/", true, 1);
 	if (!_config_name_to_extension_map.has(split[0])) {
@@ -130,6 +135,10 @@ void EditorSceneExporterGLTFSettings::generate_property_list(Ref<GLTFDocument> p
 	String image_format_hint_string = "None,PNG,JPEG";
 	// Add properties from all document extensions.
 	for (Ref<GLTFDocumentExtension> &extension : GLTFDocument::get_all_gltf_document_extensions()) {
+		const Callable on_prop_changed = callable_mp(this, &EditorSceneExporterGLTFSettings::_on_extension_property_list_changed);
+		if (!extension->is_connected("property_list_changed", on_prop_changed)) {
+			extension->connect("property_list_changed", on_prop_changed);
+		}
 		const String config_prefix = get_friendly_config_prefix(extension);
 		_config_name_to_extension_map[config_prefix] = extension;
 		// If the extension allows saving in different image formats, add to the enum.

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
@@ -48,6 +48,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _on_extension_property_list_changed();
 
 	bool _set_extension_setting(const String &p_name_str, const Variant &p_value);
 	bool _get_extension_setting(const String &p_name_str, Variant &r_ret) const;


### PR DESCRIPTION
Before this PR, GLTFDocumentExtension `property_list_changed` signals were being ignored. With this PR, the signal is passed to the exporter settings object, which causes it to regenerate the property list and then bounce the changed signal. This allows GLTFDocumentExtension classes to selectively hide or show properties in the inspector UI, like is already possible with inspecting most things in Godot.