### PR TITLE
Separate Shape3D resource logic in GLTFPhysicsShape

### DIFF
--- a/modules/gltf/doc_classes/GLTFPhysicsBody.xml
+++ b/modules/gltf/doc_classes/GLTFPhysicsBody.xml
@@ -22,7 +22,7 @@
 			<return type="GLTFPhysicsBody" />
 			<param index="0" name="body_node" type="CollisionObject3D" />
 			<description>
-				Create a new GLTFPhysicsBody instance from the given Godot [CollisionObject3D] node.
+				Creates a new GLTFPhysicsBody instance from the given Godot [CollisionObject3D] node.
 			</description>
 		</method>
 		<method name="to_dictionary" qualifiers="const">

--- a/modules/gltf/doc_classes/GLTFPhysicsShape.xml
+++ b/modules/gltf/doc_classes/GLTFPhysicsShape.xml
@@ -23,7 +23,14 @@
 			<return type="GLTFPhysicsShape" />
 			<param index="0" name="shape_node" type="CollisionShape3D" />
 			<description>
-				Create a new GLTFPhysicsShape instance from the given Godot [CollisionShape3D] node.
+				Creates a new GLTFPhysicsShape instance from the given Godot [CollisionShape3D] node.
+			</description>
+		</method>
+		<method name="from_resource" qualifiers="static">
+			<return type="GLTFPhysicsShape" />
+			<param index="0" name="shape_resource" type="Shape3D" />
+			<description>
+				Creates a new GLTFPhysicsShape instance from the given Godot [Shape3D] resource.
 			</description>
 		</method>
 		<method name="to_dictionary" qualifiers="const">
@@ -37,6 +44,13 @@
 			<param index="0" name="cache_shapes" type="bool" default="false" />
 			<description>
 				Converts this GLTFPhysicsShape instance into a Godot [CollisionShape3D] node.
+			</description>
+		</method>
+		<method name="to_resource">
+			<return type="Shape3D" />
+			<param index="0" name="cache_shapes" type="bool" default="false" />
+			<description>
+				Converts this GLTFPhysicsShape instance into a Godot [Shape3D] resource.
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -355,6 +355,7 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 	if (cast_to<CollisionShape3D>(p_scene_node)) {
 		CollisionShape3D *godot_shape = Object::cast_to<CollisionShape3D>(p_scene_node);
 		Ref<GLTFPhysicsShape> gltf_shape = GLTFPhysicsShape::from_node(godot_shape);
+		ERR_FAIL_COND_MSG(gltf_shape.is_null(), "GLTF Physics: Could not convert CollisionShape3D to GLTFPhysicsShape. Does it have a valid Shape3D?");
 		{
 			Ref<ImporterMesh> importer_mesh = gltf_shape->get_importer_mesh();
 			if (importer_mesh.is_valid()) {

--- a/modules/gltf/extensions/physics/gltf_physics_shape.h
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.h
@@ -55,7 +55,7 @@ private:
 	bool is_trigger = false;
 	GLTFMeshIndex mesh_index = -1;
 	Ref<ImporterMesh> importer_mesh = nullptr;
-	// Internal only, for caching Godot shape resources. Used in `to_node`.
+	// Internal only, for caching Godot shape resources. Used in `to_resource` and `to_node`.
 	Ref<Shape3D> _shape_cache = nullptr;
 
 public:
@@ -82,6 +82,9 @@ public:
 
 	static Ref<GLTFPhysicsShape> from_node(const CollisionShape3D *p_shape_node);
 	CollisionShape3D *to_node(bool p_cache_shapes = false);
+
+	static Ref<GLTFPhysicsShape> from_resource(const Ref<Shape3D> &p_shape_resource);
+	Ref<Shape3D> to_resource(bool p_cache_shapes = false);
 
 	static Ref<GLTFPhysicsShape> from_dictionary(const Dictionary p_dictionary);
 	Dictionary to_dictionary() const;


### PR DESCRIPTION
I ran into a case where I need to use GLTFPhysicsShape to generate a Shape3D resource without generating a CollisionShape3D node. Initially I did not expose this for API simplicity, but since I have a use case, we should expose it.