### PR TITLE
Fix OpenGL `_shadow_atlas_find_shadow` error when light instance is freed

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1064,7 +1064,11 @@ bool LightStorage::_shadow_atlas_find_shadow(ShadowAtlas *shadow_atlas, int *p_i
 
 		for (int j = 0; j < sc; j++) {
 			LightInstance *sli = light_instance_owner.get_or_null(sarr[j].owner);
-			ERR_CONTINUE(!sli);
+			if (!sli) {
+				// Found a released light instance.
+				found_used_idx = j;
+				break;
+			}
 
 			if (sli->last_scene_pass != RasterizerSceneGLES3::get_singleton()->get_scene_pass()) {
 				// Was just allocated, don't kill it so soon, wait a bit.


### PR DESCRIPTION
- Fixes #84747

In file light_storage.cpp, when engine free a light instance, it didn't free the shadow atlas and set owner of it to RID(). 
https://github.com/godotengine/godot/blob/master/drivers/gles3/storage/light_storage.cpp#L366-L384
So the next time engine try to find a useable shadow atlas, it will have this issue
I think we can just ignore the case sli == null and return the shadow atlas when we meet it, since the light instance of that atlas already freed