### PR TITLE
Fix per-node physics interpolation setting

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3780,7 +3780,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_thread_messages", PROPERTY_HINT_FLAGS, "Process,Physics Process"), "set_process_thread_messages", "get_process_thread_messages");
 
 	ADD_GROUP("Physics Interpolation", "physics_interpolation_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_interpolation_mode", PROPERTY_HINT_ENUM, "Inherit,Off,On"), "set_physics_interpolation_mode", "get_physics_interpolation_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_interpolation_mode", PROPERTY_HINT_ENUM, "Inherit,On,Off"), "set_physics_interpolation_mode", "get_physics_interpolation_mode");
 
 	ADD_GROUP("Auto Translate", "auto_translate_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
@@ -3833,7 +3833,7 @@ Node::Node() {
 	data.unhandled_input = false;
 	data.unhandled_key_input = false;
 
-	data.physics_interpolated = false;
+	data.physics_interpolated = true;
 
 	data.parent_owned = false;
 	data.in_constructor = true;


### PR DESCRIPTION
The per-node internal default should be ON (only takes effect when physics interpolation is globally enabled).

The incorrect default was preventing the setter from running correctly.

Also the labels on the property were swapped (after the order in the `enum` was swapped).

- Fixes https://github.com/godotengine/godot/issues/90238