### PR TITLE
Specify that `get_floor_normal()` does not return the surface normal

### DIFF
--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -31,7 +31,8 @@
 		<method name="get_floor_normal" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+				Returns the collision normal of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+				[b]Warning:[/b] The collision normal is not always the same as the surface normal.
 			</description>
 		</method>
 		<method name="get_last_motion" qualifiers="const">


### PR DESCRIPTION
Specified that get_floor_normal() does not return the surface normal, but rather the collision normal.

Also see godotengine/godot-proposals#8324

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
