### PR TITLE
Add missing platform implementations of release/make_rendering_thread()

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3047,9 +3047,25 @@ void DisplayServerMacOS::force_process_and_drop_events() {
 }
 
 void DisplayServerMacOS::release_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->release_current();
+	}
+	if (gl_manager_legacy) {
+		gl_manager_legacy->release_current();
+	}
+#endif
 }
 
 void DisplayServerMacOS::make_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->make_current();
+	}
+	if (gl_manager_legacy) {
+		gl_manager_legacy->make_current();
+	}
+#endif
 }
 
 void DisplayServerMacOS::swap_buffers() {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2979,9 +2979,25 @@ void DisplayServerWindows::force_process_and_drop_events() {
 }
 
 void DisplayServerWindows::release_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->release_current();
+	}
+	if (gl_manager_native) {
+		gl_manager_native->release_current();
+	}
+#endif
 }
 
 void DisplayServerWindows::make_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->make_current();
+	}
+	if (gl_manager_native) {
+		gl_manager_native->make_current();
+	}
+#endif
 }
 
 void DisplayServerWindows::swap_buffers() {


### PR DESCRIPTION
There may not be used in practice (at least for now), but I don't see a big reason why they should have no-op implementations.