### PR TITLE
Fix `Node2D.look_at` function with viewport scaling

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1146,10 +1146,8 @@ void Window::_update_viewport_size() {
 			offset.x = Math::round(margin.x * viewport_size.y / screen_size.y);
 		}
 
-		if (screen_size.y < video_mode.y) {
-			margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
-			offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
-		}
+		margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
+		offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
 
 		switch (content_scale_mode) {
 			case CONTENT_SCALE_MODE_DISABLED: {


### PR DESCRIPTION
When using "Compatibility" rendering method, "scale_mode" set an integer and viewport height greater than the window height, viewport becomes misaligned with window leading to a rendering offset. This causes the engine's mouse position to no longer match the real mouse position. To fix this issue, the viewport, which was previously render-wise attached to the window's bottom-left corner was changed to be attached to the window's center.

Fixes #89578