### PR TITLE
SceneTreeEditor: Fix crash when TreeItem is removed before callback

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -897,6 +897,14 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	}
 }
 
+void SceneTreeEditor::_tree_scroll_to_item(ObjectID p_item_id) {
+	ERR_FAIL_NULL(tree);
+	TreeItem *item = Object::cast_to<TreeItem>(ObjectDB::get_instance(p_item_id));
+	if (item) {
+		tree->scroll_to_item(item, true);
+	}
+}
+
 void SceneTreeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -942,7 +950,8 @@ void SceneTreeEditor::_notification(int p_what) {
 
 				if (item) {
 					// Must wait until tree is properly sized before scrolling.
-					callable_mp(tree, &Tree::scroll_to_item).call_deferred(item, true);
+					ObjectID item_id = item->get_instance_id();
+					callable_mp(this, &SceneTreeEditor::_tree_scroll_to_item).call_deferred(item_id);
 				}
 			}
 		} break;

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -123,6 +123,7 @@ class SceneTreeEditor : public Control {
 	void _set_item_custom_color(TreeItem *p_item, Color p_color);
 	void _update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _queue_update_node_tooltip(Node *p_node, TreeItem *p_item);
+	void _tree_scroll_to_item(ObjectID p_item_id);
 
 	void _selection_changed();
 	Node *get_scene_node() const;


### PR DESCRIPTION
Fixes #90235.

Quick fix, I went with an ad hoc callback instead of adding a new public API to `Tree`.

Can be reworked further if someone is interested, especially to figure out why we're deferring scroll calls to TreeItems that seem to fairly systematically get removed. Maybe there's some inefficiency to solve here.