### PR TITLE
Fix choosing `EditorSyntaxHighlighter` in `TextEdit` crashes the project

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -495,8 +495,13 @@ Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
-		ERR_PRINT("Class '" + String(p_class) + "' can only be instantiated by editor.");
-		return nullptr;
+		if (ti->inherits == "SyntaxHighlighter") {
+			WARN_PRINT("Class '" + String(p_class) + "' should only be instantiated by editor.");
+			return ti->creation_func();
+		} else {
+			ERR_PRINT("Class '" + String(p_class) + "' can only be instantiated by editor.");
+			return nullptr;
+		}
 	}
 #endif
 	if (ti->gdextension && ti->gdextension->create_instance) {


### PR DESCRIPTION
Instead of crashing without any debug console information, it now at least creates an instance and gives a warning. Not an ideal solution, since it doesn't say which object called the EditorSyntaxHighlighter.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
