### PR TITLE
Ignore `ERR_FILE_CANT_OPEN` error when loading

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1027,7 +1027,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				Error err = p_res_parser->ext_func(p_res_parser->userdata, p_stream, res, line, r_err_str);
 				if (err) {
 					// If the file is missing, the error can be ignored.
-					if (err != ERR_FILE_NOT_FOUND && err != ERR_CANT_OPEN) {
+					if (err != ERR_FILE_NOT_FOUND && err != ERR_CANT_OPEN && err != ERR_FILE_CANT_OPEN) {
 						return err;
 					}
 				}


### PR DESCRIPTION
Follow-up to #85159
Fixes #80324

I didn't try to find out why there is *yet another* error for missing files, but my guess is that different loaders just return inconsistent values.