### PR TITLE
Fix `Resource::get_rid override` not working in GDExtension

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -424,8 +424,7 @@ RID Resource::get_rid() const {
 		}
 	}
 	if (_get_extension() && _get_extension()->get_rid) {
-		RID ret;
-		ret.from_uint64(_get_extension()->get_rid(_get_extension_instance()));
+		RID ret = RID::from_uint64(_get_extension()->get_rid(_get_extension_instance()));
 		if (ret.is_valid()) {
 			return ret;
 		}


### PR DESCRIPTION
Since `RID::from_uint64` is a static method, the original code did not work at all.
https://github.com/godotengine/godot/blob/655e93d5846b2ef8ebb7d22c8878f51b8f22b312/core/templates/rid.h#L66-L70
