### PR TITLE
Fix Area2D.get_overlapping_areas() not including areas after disable/enable

### DIFF
--- a/servers/physics_2d/godot_area_2d.cpp
+++ b/servers/physics_2d/godot_area_2d.cpp
@@ -75,6 +75,10 @@ void GodotArea2D::set_space(GodotSpace2D *p_space) {
 	monitored_areas.clear();
 
 	_set_space(p_space);
+
+	if (!moved_list.in_list() && get_space()) {
+		get_space()->area_add_to_moved_list(&moved_list);
+	}
 }
 
 void GodotArea2D::set_monitor_callback(const Callable &p_callback) {


### PR DESCRIPTION
Added area to moved list on space change, to get picked up on next collision check

Fixes #89615

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
