### PR TITLE
Fix duplicated folder reference in Godot Editor after changing filename case

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1367,6 +1367,10 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 	String f = ProjectSettings::get_singleton()->localize_path(p_file);
 
+	// Note: Only checks if base directory is case sensitive.
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	bool fs_case_sensitive = dir->is_case_sensitive("res://");
+
 	if (!f.begins_with("res://")) {
 		return false;
 	}
@@ -1390,9 +1394,16 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 		int idx = -1;
 		for (int j = 0; j < fs->get_subdir_count(); j++) {
-			if (fs->get_subdir(j)->get_name() == path[i]) {
-				idx = j;
-				break;
+			if (fs_case_sensitive) {
+				if (fs->get_subdir(j)->get_name() == path[i]) {
+					idx = j;
+					break;
+				}
+			} else {
+				if (fs->get_subdir(j)->get_name().to_lower() == path[i].to_lower()) {
+					idx = j;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #76021
EDIT: Also apparently fixes #22475 

If the folder a Scene was in had the case of its name changed changed (either through deleting and recreating it in the editor, or changing in the OS), then in case-insensitive OS platforms (Windows, recent MacOS), saving that Scene would create duplicate folder references in the Godot editor.

This fixes that by checking whether the base folder of the Godot project is case sensitive or insensitive when seeing whether a new Editor folder will need to be created on Scene save.