### PR TITLE
Fix sharing World2D between SubViewports causes 2D lights of one SubViewport to go missing

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -203,7 +203,7 @@ void Light2D::_physics_interpolated_changed() {
 
 void Light2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_ENTER_CANVAS: {
 			RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, get_canvas());
 			_update_light_visibility();
 		} break;
@@ -227,7 +227,7 @@ void Light2D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_EXIT_TREE: {
+		case NOTIFICATION_EXIT_CANVAS: {
 			RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, RID());
 			_update_light_visibility();
 		} break;


### PR DESCRIPTION
This PR fixes an issue where Light2D is seemingly lost or invisible when its parent SubViewport's world_2d is set to another SubViewport's.  Originally Light2D only reattached itself to a canvas on the NOTIFICATION_ENTER_TREE notification.  Since in the world-sharing use case the Light2D is not entering the node tree, it remained associated with the canvas of the orignal world.  The update uses the NOTIFICATION_ENTER_CANVAS and NOTIFICATION_EXIT_CANVAS notifications instead.  This brings Light2D in line with LightOccluder2D which works fine.

Edited:

Fixes: #84221