### PR TITLE
Remove border roundness inside panels of `AcceptDialog` windows

### DIFF
--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -639,7 +639,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// Dialogs
 
 	// AcceptDialog is currently the base dialog, so this defines styles for all extending nodes.
-	theme->set_stylebox("panel", "AcceptDialog", make_flat_stylebox(style_popup_color, Math::round(8 * scale), Math::round(8 * scale), Math::round(8 * scale), Math::round(8 * scale)));
+	theme->set_stylebox("panel", "AcceptDialog", make_flat_stylebox(style_popup_color, Math::round(8 * scale), Math::round(8 * scale), Math::round(8 * scale), Math::round(8 * scale), 0));
 	theme->set_constant("buttons_separation", "AcceptDialog", Math::round(10 * scale));
 
 	// File Dialog


### PR DESCRIPTION
It's quite hard to notice, but it's there.
|Before:|After:|
|-|-|
![Screenshot_20240405_200610](https://github.com/godotengine/godot/assets/30739239/7f933625-7e99-42e5-bf02-10f5fc5520a4)|![Screenshot_20240405_195727](https://github.com/godotengine/godot/assets/30739239/96d2c5e2-8975-449c-97d9-63ff28a68794)|