### PR TITLE
Bump GitHub workflows to SCons 4.7

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -23,5 +23,5 @@ runs:
       shell: bash
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install scons==4.4.0
+        python -m pip install scons==4.7.0
         scons --version


### PR DESCRIPTION
Hi All - 

There are some changes in SCons 4.7 (which I was involved with over the past year) around [job scheduling and caching](https://github.com/SCons/scons/blob/8c85b35cb6c81045a9ab229228beec832bc2ae20/CHANGES.txt#L97-L111). Godot users building from source may well encounter 4.7 (it is, for instance, recently the [default SCons in homebrew](https://github.com/Homebrew/homebrew-core/commit/e33241de8996b149323fb6b65e637627f52cf454)), so it seems like a worthwhile idea to validate that it works, at least within the context of Godot's GH workflows.