### PR TITLE
Make InstancePlaceholders in charge of resolving node references in instances

### DIFF
--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -88,16 +88,16 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 	if (!ps.is_valid()) {
 		return nullptr;
 	}
-	Node *scene = ps->instantiate();
-	if (!scene) {
+	Node *instance = ps->instantiate();
+	if (!instance) {
 		return nullptr;
 	}
-	scene->set_name(get_name());
-	scene->set_multiplayer_authority(get_multiplayer_authority());
+	instance->set_name(get_name());
+	instance->set_multiplayer_authority(get_multiplayer_authority());
 	int pos = get_index();
 
 	for (const PropSet &E : stored_values) {
-		scene->set(E.name, E.value);
+		set_value_on_instance(this, instance, E);
 	}
 
 	if (p_replace) {
@@ -105,10 +105,125 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		base->remove_child(this);
 	}
 
-	base->add_child(scene);
-	base->move_child(scene, pos);
+	base->add_child(instance);
+	base->move_child(instance, pos);
 
-	return scene;
+	return instance;
+}
+
+// This method will attempt to set the correct values on the placeholder instance
+// for regular types this is trivial and unnecessary.
+// For nodes however this becomes a bit tricky because they might now have existed until the instantiation,
+// so this method will try to find the correct nodes and resolve them.
+void InstancePlaceholder::set_value_on_instance(InstancePlaceholder *p_placeholder, Node *p_instance, const PropSet &p_set) {
+	bool is_valid;
+
+	// If we don't have any info, we can't do anything,
+	// so try setting the value directly.
+	Variant current = p_instance->get(p_set.name, &is_valid);
+	if (!is_valid) {
+		p_instance->set(p_set.name, p_set.value, &is_valid);
+		return;
+	}
+
+	Variant::Type current_type = current.get_type();
+	Variant::Type placeholder_type = p_set.value.get_type();
+
+	// Arrays are a special case, because their containing type might be different.
+	if (current_type != Variant::Type::ARRAY) {
+		// Check if the variant types match.
+		if (Variant::evaluate(Variant::OP_EQUAL, current_type, placeholder_type)) {
+			p_instance->set(p_set.name, p_set.value, &is_valid);
+			if (is_valid) {
+				return;
+			}
+			// Types match but setting failed? This is strange, so let's print a warning!
+			WARN_PRINT(vformat("Property '%s' with type '%s' could not be set when creating instance of '%s'.", p_set.name, Variant::get_type_name(current_type), p_placeholder->get_name()));
+			return;
+		}
+	} else {
+		// We are dealing with an Array.
+		// Let's check if the subtype of the array matches first.
+		// This is needed because the set method of ScriptInstance checks for type,
+		// but the ClassDB set method doesn't! So we cannot reliably know what actually happens.
+		Array current_array = current;
+		Array placeholder_array = p_set.value;
+		if (current_array.is_same_typed(placeholder_array)) {
+			p_instance->set(p_set.name, p_set.value, &is_valid);
+			if (is_valid) {
+				return;
+			}
+			// Internal array types match but setting failed? This is strange, so let's print a warning!
+			WARN_PRINT(vformat("Array Property '%s' with type '%s' could not be set when creating instance of '%s'.", p_set.name, Variant::get_type_name(Variant::Type(current_array.get_typed_builtin())), p_placeholder->get_name()));
+		}
+		// Arrays are not the same internal type. This should be happening because we have a NodePath Array,
+		// but the instance wants a Node Array.
+	}
+
+	switch (current_type) {
+		case Variant::Type::NIL:
+			if (placeholder_type != Variant::Type::NODE_PATH) {
+				break;
+			}
+			// If it's nil but we have a NodePath, we guess what works.
+
+			p_instance->set(p_set.name, p_set.value, &is_valid);
+			if (is_valid) {
+				break;
+			}
+
+			p_instance->set(p_set.name, try_get_node(p_placeholder, p_instance, p_set.value), &is_valid);
+			break;
+		case Variant::Type::OBJECT:
+			if (placeholder_type != Variant::Type::NODE_PATH) {
+				break;
+			}
+			// Easiest case, we want a node, but we have a deferred NodePath.
+			p_instance->set(p_set.name, try_get_node(p_placeholder, p_instance, p_set.value));
+			break;
+		case Variant::Type::ARRAY: {
+			// If we have reached here it means our array types don't match,
+			// so we will convert the placeholder array into the correct type
+			// and resolve nodes if necessary.
+			Array current_array = current;
+			Array converted_array;
+			Array placeholder_array = p_set.value;
+			converted_array = current_array.duplicate();
+			converted_array.resize(placeholder_array.size());
+
+			if (Variant::evaluate(Variant::OP_EQUAL, current_array.get_typed_builtin(), Variant::Type::NODE_PATH)) {
+				// We want a typed NodePath array.
+				for (int i = 0; i < placeholder_array.size(); i++) {
+					converted_array.set(i, placeholder_array[i]);
+				}
+			} else {
+				// We want Nodes, convert NodePaths.
+				for (int i = 0; i < placeholder_array.size(); i++) {
+					converted_array.set(i, try_get_node(p_placeholder, p_instance, placeholder_array[i]));
+				}
+			}
+
+			p_instance->set(p_set.name, converted_array, &is_valid);
+			if (!is_valid) {
+				WARN_PRINT(vformat("Property '%s' with type '%s' could not be set when creating instance of '%s'.", p_set.name, Variant::get_type_name(current_type), p_placeholder->get_name()));
+			}
+			break;
+		}
+		default:
+			WARN_PRINT(vformat("Property '%s' with type '%s' could not be set when creating instance of '%s'.", p_set.name, Variant::get_type_name(current_type), p_placeholder->get_name()));
+			break;
+	}
+}
+
+Node *InstancePlaceholder::try_get_node(InstancePlaceholder *p_placeholder, Node *p_instance, const NodePath &p_path) {
+	// First try to resolve internally,
+	// if that fails try resolving externally.
+	Node *node = p_instance->get_node_or_null(p_path);
+	if (node == nullptr) {
+		node = p_placeholder->get_node_or_null(p_path);
+	}
+
+	return node;
 }
 
 Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {

--- a/scene/main/instance_placeholder.h
+++ b/scene/main/instance_placeholder.h
@@ -46,6 +46,10 @@ class InstancePlaceholder : public Node {
 
 	List<PropSet> stored_values;
 
+private:
+	void set_value_on_instance(InstancePlaceholder *p_placeholder, Node *p_instance, const PropSet &p_set);
+	Node *try_get_node(InstancePlaceholder *p_placeholder, Node *p_instance, const NodePath &p_path);
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -314,6 +314,16 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					ERR_FAIL_INDEX_V(nprops[j].value, prop_count, nullptr);
 
 					if (nprops[j].name & FLAG_PATH_PROPERTY_IS_NODE) {
+						if (!Engine::get_singleton()->is_editor_hint() && node->get_scene_instance_load_placeholder()) {
+							// We cannot know if the referenced nodes exist yet, so instead of deferring, we write the NodePaths directly.
+
+							uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
+							ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
+
+							node->set(snames[name_idx], props[nprops[j].value], &valid);
+							continue;
+						}
+
 						uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
 						ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
 

--- a/tests/scene/test_instance_placeholder.h
+++ b/tests/scene/test_instance_placeholder.h
@@ -1,0 +1,532 @@
+/**************************************************************************/
+/*  test_instance_placeholder.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_INSTANCE_PLACEHOLDER_H
+#define TEST_INSTANCE_PLACEHOLDER_H
+
+#include "scene/main/instance_placeholder.h"
+#include "scene/resources/packed_scene.h"
+
+#include "tests/test_macros.h"
+
+class _TestInstancePlaceholderNode : public Node {
+	GDCLASS(_TestInstancePlaceholderNode, Node);
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_int_property", "int_property"), &_TestInstancePlaceholderNode::set_int_property);
+		ClassDB::bind_method(D_METHOD("get_int_property"), &_TestInstancePlaceholderNode::get_int_property);
+
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "int_property"), "set_int_property", "get_int_property");
+
+		ClassDB::bind_method(D_METHOD("set_reference_property", "reference_property"), &_TestInstancePlaceholderNode::set_reference_property);
+		ClassDB::bind_method(D_METHOD("get_reference_property"), &_TestInstancePlaceholderNode::get_reference_property);
+
+		ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "reference_property", PROPERTY_HINT_NODE_TYPE), "set_reference_property", "get_reference_property");
+
+		ClassDB::bind_method(D_METHOD("set_reference_array_property", "reference_array_property"), &_TestInstancePlaceholderNode::set_reference_array_property);
+		ClassDB::bind_method(D_METHOD("get_reference_array_property"), &_TestInstancePlaceholderNode::get_reference_array_property);
+
+		// The hint string value "24/34:Node" is determined from existing PackedScenes with typed Array properties.
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "reference_array_property", PROPERTY_HINT_TYPE_STRING, "24/34:Node"), "set_reference_array_property", "get_reference_array_property");
+	}
+
+public:
+	int int_property = 0;
+
+	void set_int_property(int p_int) {
+		int_property = p_int;
+	}
+
+	int get_int_property() const {
+		return int_property;
+	}
+
+	Variant reference_property;
+
+	void set_reference_property(const Variant &p_node) {
+		reference_property = p_node;
+	}
+
+	Variant get_reference_property() const {
+		return reference_property;
+	}
+
+	Array reference_array_property;
+
+	void set_reference_array_property(const Array &p_array) {
+		reference_array_property = p_array;
+	}
+
+	Array get_reference_array_property() const {
+		return reference_array_property;
+	}
+
+	_TestInstancePlaceholderNode() {
+		reference_array_property.set_typed(Variant::OBJECT, "Node", Variant());
+	}
+};
+
+namespace TestInstancePlaceholder {
+
+TEST_CASE("[SceneTree][InstancePlaceholder] Instantiate from placeholder with no overrides") {
+	GDREGISTER_CLASS(_TestInstancePlaceholderNode);
+
+	SUBCASE("with non-node values") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		ip->set_name("TestScene");
+		Node *root = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		root->add_child(ip);
+		// Create a scene to instance.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		scene->set_int_property(12);
+
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		const Error err = packed_scene->pack(scene);
+		REQUIRE(err == OK);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_name() == "TestScene");
+		CHECK(created->get_int_property() == 12);
+
+		root->queue_free();
+		memdelete(scene);
+	}
+
+	SUBCASE("with node value") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		ip->set_name("TestScene");
+		Node *root = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		root->add_child(ip);
+		// Create a scene to instance.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		Node *referenced = memnew(Node);
+		scene->add_child(referenced);
+		referenced->set_owner(scene);
+		scene->set_reference_property(referenced);
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		const Error err = packed_scene->pack(scene);
+		REQUIRE(err == OK);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_name() == "TestScene");
+		CHECK(created->get_child_count() == 1);
+		CHECK(created->get_reference_property().identity_compare(created->get_child(0, false)));
+		CHECK_FALSE(created->get_reference_property().identity_compare(referenced));
+
+		root->queue_free();
+		memdelete(scene);
+	}
+
+	SUBCASE("with node-array value") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		ip->set_name("TestScene");
+		Node *root = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		root->add_child(ip);
+		// Create a scene to instance.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		Node *referenced1 = memnew(Node);
+		Node *referenced2 = memnew(Node);
+		scene->add_child(referenced1);
+		scene->add_child(referenced2);
+		referenced1->set_owner(scene);
+		referenced2->set_owner(scene);
+		Array node_array;
+		node_array.set_typed(Variant::OBJECT, "Node", Variant());
+		node_array.push_back(referenced1);
+		node_array.push_back(referenced2);
+		scene->set_reference_array_property(node_array);
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		const Error err = packed_scene->pack(scene);
+		REQUIRE(err == OK);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_name() == "TestScene");
+		CHECK(created->get_child_count() == 2);
+		Array created_array = created->get_reference_array_property();
+		REQUIRE(created_array.size() == node_array.size());
+		REQUIRE(created_array.size() == created->get_child_count());
+
+		// Iterate over all nodes, since the ordering is not guaranteed.
+		for (int i = 0; i < node_array.size(); i++) {
+			bool node_found = false;
+			for (int j = 0; j < created->get_child_count(); j++) {
+				if (created_array[i].identity_compare(created->get_child(j, true))) {
+					node_found = true;
+				}
+			}
+			CHECK(node_found);
+		}
+		root->queue_free();
+		memdelete(scene);
+	}
+}
+
+TEST_CASE("[SceneTree][InstancePlaceholder] Instantiate from placeholder with overrides") {
+	GDREGISTER_CLASS(_TestInstancePlaceholderNode);
+
+	SUBCASE("with non-node values") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		Node *root = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		root->add_child(ip);
+		ip->set_name("TestScene");
+		ip->set("int_property", 45);
+		// Create a scene to pack.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		scene->set_int_property(12);
+
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		packed_scene->pack(scene);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_int_property() == 45);
+
+		root->queue_free();
+		memdelete(scene);
+	}
+
+	SUBCASE("with node values") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		ip->set_name("TestScene");
+		Node *root = memnew(Node);
+		Node *overriding = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		root->add_child(ip);
+		root->add_child(overriding);
+		ip->set("reference_property", overriding);
+		// Create a scene to instance.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		Node *referenced = memnew(Node);
+		scene->add_child(referenced);
+		referenced->set_owner(scene);
+		scene->set_reference_property(referenced);
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		const Error err = packed_scene->pack(scene);
+		REQUIRE(err == OK);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_name() == "TestScene");
+		CHECK(created->get_child_count() == 1);
+		CHECK(created->get_reference_property().identity_compare(overriding));
+		CHECK_FALSE(created->get_reference_property().identity_compare(referenced));
+
+		root->queue_free();
+		memdelete(scene);
+	}
+
+	SUBCASE("with node-array value") {
+		InstancePlaceholder *ip = memnew(InstancePlaceholder);
+		ip->set_name("TestScene");
+		Node *root = memnew(Node);
+		SceneTree::get_singleton()->get_root()->add_child(root);
+
+		Node *override1 = memnew(Node);
+		Node *override2 = memnew(Node);
+		Node *override3 = memnew(Node);
+		root->add_child(ip);
+		root->add_child(override1);
+		root->add_child(override2);
+		root->add_child(override3);
+
+		Array override_node_array;
+		override_node_array.set_typed(Variant::OBJECT, "Node", Variant());
+		override_node_array.push_back(override1);
+		override_node_array.push_back(override2);
+		override_node_array.push_back(override3);
+
+		ip->set("reference_array_property", override_node_array);
+
+		// Create a scene to instance.
+		_TestInstancePlaceholderNode *scene = memnew(_TestInstancePlaceholderNode);
+		Node *referenced1 = memnew(Node);
+		Node *referenced2 = memnew(Node);
+
+		scene->add_child(referenced1);
+		scene->add_child(referenced2);
+
+		referenced1->set_owner(scene);
+		referenced2->set_owner(scene);
+		Array referenced_array;
+		referenced_array.set_typed(Variant::OBJECT, "Node", Variant());
+		referenced_array.push_back(referenced1);
+		referenced_array.push_back(referenced2);
+
+		scene->set_reference_array_property(referenced_array);
+		// Pack the scene.
+		PackedScene *packed_scene = memnew(PackedScene);
+		const Error err = packed_scene->pack(scene);
+		REQUIRE(err == OK);
+
+		// Instantiate the scene.
+		_TestInstancePlaceholderNode *created = Object::cast_to<_TestInstancePlaceholderNode>(ip->create_instance(true, packed_scene));
+		REQUIRE(created != nullptr);
+		CHECK(created->get_name() == "TestScene");
+		CHECK(created->get_child_count() == 2);
+		Array created_array = created->get_reference_array_property();
+		REQUIRE_FALSE(created_array.size() == referenced_array.size());
+		REQUIRE(created_array.size() == override_node_array.size());
+		REQUIRE_FALSE(created_array.size() == created->get_child_count());
+
+		// Iterate over all nodes, since the ordering is not guaranteed.
+		for (int i = 0; i < override_node_array.size(); i++) {
+			bool node_found = false;
+			for (int j = 0; j < created_array.size(); j++) {
+				if (override_node_array[i].identity_compare(created_array[j])) {
+					node_found = true;
+				}
+			}
+			CHECK(node_found);
+		}
+		root->queue_free();
+		memdelete(scene);
+	}
+}
+
+TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an InstancePlaceholder with no overrides") {
+	GDREGISTER_CLASS(_TestInstancePlaceholderNode);
+
+	// Create the internal scene.
+	_TestInstancePlaceholderNode *internal = memnew(_TestInstancePlaceholderNode);
+	internal->set_name("InternalNode");
+	Node *referenced = memnew(Node);
+	referenced->set_name("OriginalReference");
+	internal->add_child(referenced);
+	referenced->set_owner(internal);
+	internal->set_reference_property(referenced);
+
+	// Pack the internal scene.
+	PackedScene *internal_scene = memnew(PackedScene);
+	Error err = internal_scene->pack(internal);
+	REQUIRE(err == OK);
+
+	const String internal_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_internal.tscn");
+	err = ResourceSaver::save(internal_scene, internal_path);
+	REQUIRE(err == OK);
+
+	Ref<PackedScene> internal_scene_loaded = ResourceLoader::load(internal_path, "PackedScene", ResourceFormatLoader::CacheMode::CACHE_MODE_IGNORE, &err);
+	REQUIRE(err == OK);
+
+	// Create the main scene.
+	Node *root = memnew(Node);
+	root->set_name("MainNode");
+	Node *overriding = memnew(Node);
+	overriding->set_name("OverridingReference");
+
+	_TestInstancePlaceholderNode *internal_created = Object::cast_to<_TestInstancePlaceholderNode>(internal_scene_loaded->instantiate(PackedScene::GEN_EDIT_STATE_MAIN_INHERITED));
+	internal_created->set_scene_instance_load_placeholder(true);
+	root->add_child(internal_created);
+	internal_created->set_owner(root);
+
+	root->add_child(overriding);
+	overriding->set_owner(root);
+	// Here we introduce an error, we override the property with an internal node to the instance placeholder.
+	// The InstancePlaceholder is now forced to properly resolve the Node.
+	internal_created->set("reference_property", NodePath("OriginalReference"));
+
+	// Pack the main scene.
+	PackedScene *main_scene = memnew(PackedScene);
+	err = main_scene->pack(root);
+	REQUIRE(err == OK);
+
+	const String main_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_main.tscn");
+	err = ResourceSaver::save(main_scene, main_path);
+	REQUIRE(err == OK);
+
+	// // Instantiate the scene.
+	Ref<PackedScene> main_scene_loaded = ResourceLoader::load(main_path, "PackedScene", ResourceFormatLoader::CacheMode::CACHE_MODE_IGNORE, &err);
+	REQUIRE(err == OK);
+
+	Node *instanced_main_node = main_scene_loaded->instantiate();
+	REQUIRE(instanced_main_node != nullptr);
+	SceneTree::get_singleton()->get_root()->add_child(instanced_main_node);
+	CHECK(instanced_main_node->get_name() == "MainNode");
+	REQUIRE(instanced_main_node->get_child_count() == 2);
+	InstancePlaceholder *instanced_placeholder = Object::cast_to<InstancePlaceholder>(instanced_main_node->get_child(0, true));
+	REQUIRE(instanced_placeholder != nullptr);
+
+	_TestInstancePlaceholderNode *final_node = Object::cast_to<_TestInstancePlaceholderNode>(instanced_placeholder->create_instance(true));
+	REQUIRE(final_node != nullptr);
+	REQUIRE(final_node->get_child_count() == 1);
+	REQUIRE(final_node->get_reference_property().identity_compare(final_node->get_child(0, true)));
+
+	instanced_main_node->queue_free();
+	memdelete(overriding);
+	memdelete(root);
+	memdelete(internal);
+	DirAccess::remove_file_or_error(internal_path);
+	DirAccess::remove_file_or_error(main_path);
+}
+
+TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an InstancePlaceholder with overrides") {
+	GDREGISTER_CLASS(_TestInstancePlaceholderNode);
+
+	// Create the internal scene.
+	_TestInstancePlaceholderNode *internal = memnew(_TestInstancePlaceholderNode);
+	internal->set_name("InternalNode");
+	Node *referenced = memnew(Node);
+	referenced->set_name("OriginalReference");
+	internal->add_child(referenced);
+	referenced->set_owner(internal);
+	internal->set_reference_property(referenced);
+
+	Node *array_ref1 = memnew(Node);
+	array_ref1->set_name("ArrayRef1");
+	internal->add_child(array_ref1);
+	array_ref1->set_owner(internal);
+	Node *array_ref2 = memnew(Node);
+	array_ref2->set_name("ArrayRef2");
+	internal->add_child(array_ref2);
+	array_ref2->set_owner(internal);
+	Array referenced_array;
+	referenced_array.set_typed(Variant::OBJECT, "Node", Variant());
+	referenced_array.push_back(array_ref1);
+	referenced_array.push_back(array_ref2);
+	internal->set_reference_array_property(referenced_array);
+
+	// Pack the internal scene.
+	PackedScene *internal_scene = memnew(PackedScene);
+	Error err = internal_scene->pack(internal);
+	REQUIRE(err == OK);
+
+	const String internal_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_internal_override.tscn");
+	err = ResourceSaver::save(internal_scene, internal_path);
+	REQUIRE(err == OK);
+
+	Ref<PackedScene> internal_scene_loaded = ResourceLoader::load(internal_path, "PackedScene", ResourceFormatLoader::CacheMode::CACHE_MODE_IGNORE, &err);
+	REQUIRE(err == OK);
+
+	// Create the main scene.
+	Node *root = memnew(Node);
+	root->set_name("MainNode");
+	Node *overriding = memnew(Node);
+	overriding->set_name("OverridingReference");
+	Node *array_ext = memnew(Node);
+	array_ext->set_name("ExternalArrayMember");
+
+	_TestInstancePlaceholderNode *internal_created = Object::cast_to<_TestInstancePlaceholderNode>(internal_scene_loaded->instantiate(PackedScene::GEN_EDIT_STATE_MAIN_INHERITED));
+	internal_created->set_scene_instance_load_placeholder(true);
+	root->add_child(internal_created);
+	internal_created->set_owner(root);
+
+	root->add_child(overriding);
+	overriding->set_owner(root);
+	root->add_child(array_ext);
+	array_ext->set_owner(root);
+	// Here we introduce an error, we override the property with an internal node to the instance placeholder.
+	// The InstancePlaceholder is now forced to properly resolve the Node.
+	internal_created->set_reference_property(overriding);
+	Array internal_array = internal_created->get_reference_array_property();
+	Array override_array;
+	override_array.set_typed(Variant::OBJECT, "Node", Variant());
+	for (int i = 0; i < internal_array.size(); i++) {
+		override_array.push_back(internal_array[i]);
+	}
+	override_array.push_back(array_ext);
+	internal_created->set_reference_array_property(override_array);
+
+	// Pack the main scene.
+	PackedScene *main_scene = memnew(PackedScene);
+	err = main_scene->pack(root);
+	REQUIRE(err == OK);
+
+	const String main_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_main_override.tscn");
+	err = ResourceSaver::save(main_scene, main_path);
+	REQUIRE(err == OK);
+
+	// // Instantiate the scene.
+	Ref<PackedScene> main_scene_loaded = ResourceLoader::load(main_path, "PackedScene", ResourceFormatLoader::CacheMode::CACHE_MODE_IGNORE, &err);
+	REQUIRE(err == OK);
+
+	Node *instanced_main_node = main_scene_loaded->instantiate();
+	REQUIRE(instanced_main_node != nullptr);
+	SceneTree::get_singleton()->get_root()->add_child(instanced_main_node);
+	CHECK(instanced_main_node->get_name() == "MainNode");
+	REQUIRE(instanced_main_node->get_child_count() == 3);
+	InstancePlaceholder *instanced_placeholder = Object::cast_to<InstancePlaceholder>(instanced_main_node->get_child(0, true));
+	REQUIRE(instanced_placeholder != nullptr);
+
+	_TestInstancePlaceholderNode *final_node = Object::cast_to<_TestInstancePlaceholderNode>(instanced_placeholder->create_instance(true));
+	REQUIRE(final_node != nullptr);
+	REQUIRE(final_node->get_child_count() == 3);
+	REQUIRE(final_node->get_reference_property().identity_compare(instanced_main_node->get_child(1, true)));
+	Array final_array = final_node->get_reference_array_property();
+	REQUIRE(final_array.size() == 3);
+	Array wanted_node_array;
+	wanted_node_array.push_back(instanced_main_node->get_child(2, true)); // ExternalArrayMember
+	wanted_node_array.push_back(final_node->get_child(1, true)); // ArrayRef1
+	wanted_node_array.push_back(final_node->get_child(2, true)); // ArrayRef2
+
+	// Iterate over all nodes, since the ordering is not guaranteed.
+	for (int i = 0; i < wanted_node_array.size(); i++) {
+		bool node_found = false;
+		for (int j = 0; j < final_array.size(); j++) {
+			if (wanted_node_array[i].identity_compare(final_array[j])) {
+				node_found = true;
+			}
+		}
+		CHECK(node_found);
+	}
+
+	instanced_main_node->queue_free();
+	memdelete(array_ext);
+	memdelete(overriding);
+	memdelete(root);
+	memdelete(internal);
+	DirAccess::remove_file_or_error(internal_path);
+	DirAccess::remove_file_or_error(main_path);
+}
+
+} //namespace TestInstancePlaceholder
+
+#endif // TEST_INSTANCE_PLACEHOLDER_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -111,6 +111,7 @@
 #include "tests/scene/test_curve_3d.h"
 #include "tests/scene/test_gradient.h"
 #include "tests/scene/test_image_texture.h"
+#include "tests/scene/test_instance_placeholder.h"
 #include "tests/scene/test_node.h"
 #include "tests/scene/test_node_2d.h"
 #include "tests/scene/test_packed_scene.h"


### PR DESCRIPTION
This is my attempt at resolving #88662 

From what I could figure out with my limited understanding of the codebase, the issue seems deeper than just the suspected PR https://github.com/godotengine/godot/pull/83343 

I have created an even bigger repro project that tries to really abuse node properties, arrays and their resolutions during the instantiation process.

[PlaceholderInstanceRepro.zip](https://github.com/godotengine/godot/files/14893922/PlaceholderInstanceRepro.zip)

This project not only fails in versions 4.3-dev.X, but also in 4.2.1, where arrays of external and mixed node references hit the error here https://github.com/godotengine/godot/blob/b09f793f564a6c95dc76acc654b390e68441bd01/scene/resources/packed_scene.cpp#L493 

I am not nearly comfortable enough with the system to truly say that this is the correct solution, but I hope it can through reviews and discussion serve as a base of finding one.

*Bugsquad edit:*
- Fixes #88662
