### PR TITLE
Fix Skeleton3D build error with `deprecated=no`

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -32,6 +32,7 @@
 #include "skeleton_3d.compat.inc"
 
 #include "core/variant/type_info.h"
+#include "scene/3d/skeleton_modifier_3d.h"
 #include "scene/resources/surface_tool.h"
 #include "scene/scene_string_names.h"
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
* Introduced by #87888