### PR TITLE
Add layer related methods in ProjectSettings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1342,6 +1342,73 @@ const HashMap<StringName, HashSet<StringName>> &ProjectSettings::get_scene_group
 	return scene_groups_cache;
 }
 
+int ProjectSettings::find_layer(LayerType p_type, const String &p_name) const {
+	String basename;
+	switch (p_type) {
+		case LAYER_RENDER_2D: {
+			basename = "layer_names/2d_render";
+		} break;
+
+		case LAYER_PHYSICS_2D: {
+			basename = "layer_names/2d_physics";
+		} break;
+
+		case LAYER_NAVIGATION_2D: {
+			basename = "layer_names/2d_navigation";
+		} break;
+
+		case LAYER_RENDER_3D: {
+			basename = "layer_names/3d_render";
+		} break;
+
+		case LAYER_PHYSICS_3D: {
+			basename = "layer_names/3d_physics";
+		} break;
+
+		case LAYER_NAVIGATION_3D: {
+			basename = "layer_names/3d_navigation";
+		} break;
+
+		case LAYER_AVOIDANCE: {
+			basename = "layer_names/avoidance";
+		} break;
+
+		default: {
+			ERR_FAIL_V_MSG(0, "Unknown layer type: " + itos(p_type));
+		} break;
+	}
+	const int layer_count = get_layer_count(p_type);
+	for (int i = 0; i < layer_count; i++) {
+		const String name = basename + vformat("/layer_%d", i + 1);
+		if (has_setting(name)) {
+			if (get_setting(name) == p_name) {
+				return i + 1;
+			}
+		} else if (p_name.is_empty()) {
+			return i + 1;
+		}
+	}
+	return 0;
+}
+
+int ProjectSettings::get_layer_count(LayerType p_type) const {
+	switch (p_type) {
+		case LAYER_RENDER_2D:
+		case LAYER_RENDER_3D: {
+			return 20;
+		} break;
+
+		case LAYER_PHYSICS_2D:
+		case LAYER_PHYSICS_3D:
+		case LAYER_NAVIGATION_2D:
+		case LAYER_NAVIGATION_3D:
+		case LAYER_AVOIDANCE: {
+			return 32;
+		} break;
+	}
+	ERR_FAIL_V_MSG(0, "Unknown layer type: " + itos(p_type));
+}
+
 #ifdef TOOLS_ENABLED
 void ProjectSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
@@ -1380,10 +1447,19 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
-
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
+	ClassDB::bind_method(D_METHOD("find_layer", "type", "name"), &ProjectSettings::find_layer);
+	ClassDB::bind_method(D_METHOD("get_layer_count", "type"), &ProjectSettings::get_layer_count);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
+
+	BIND_ENUM_CONSTANT(LAYER_PHYSICS_2D);
+	BIND_ENUM_CONSTANT(LAYER_RENDER_2D);
+	BIND_ENUM_CONSTANT(LAYER_NAVIGATION_2D);
+	BIND_ENUM_CONSTANT(LAYER_PHYSICS_3D);
+	BIND_ENUM_CONSTANT(LAYER_RENDER_3D);
+	BIND_ENUM_CONSTANT(LAYER_NAVIGATION_3D);
+	BIND_ENUM_CONSTANT(LAYER_AVOIDANCE);
 }
 
 void ProjectSettings::_add_builtin_input_map() {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -52,6 +52,16 @@ public:
 		NO_BUILTIN_ORDER_BASE = 1 << 16
 	};
 
+	enum LayerType {
+		LAYER_PHYSICS_2D,
+		LAYER_RENDER_2D,
+		LAYER_NAVIGATION_2D,
+		LAYER_PHYSICS_3D,
+		LAYER_RENDER_3D,
+		LAYER_NAVIGATION_3D,
+		LAYER_AVOIDANCE,
+	};
+
 #ifdef TOOLS_ENABLED
 	const static PackedStringArray get_required_features();
 	const static PackedStringArray get_unsupported_features(const PackedStringArray &p_project_features);
@@ -219,6 +229,9 @@ public:
 	String get_scene_groups_cache_path() const;
 	void load_scene_groups_cache();
 
+	int find_layer(LayerType p_type, const String &p_name) const;
+	int get_layer_count(LayerType p_type) const;
+
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif
@@ -226,6 +239,8 @@ public:
 	ProjectSettings();
 	~ProjectSettings();
 };
+
+VARIANT_ENUM_CAST(ProjectSettings::LayerType);
 
 // Not a macro any longer.
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -60,6 +60,16 @@
 				Clears the whole configuration (not recommended, may break things).
 			</description>
 		</method>
+		<method name="find_layer" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="type" type="int" enum="ProjectSettings.LayerType" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Returns the first layer of the given type with the name matching [param name]. Returns [code]0[/code] if no such layer is found.
+				[b]Note:[/b] This function returns the layer number. Useful for methods like [method CollisionObject2D.set_collision_layer_value].
+				[b]Note:[/b] Finding a layer by name may not be optimal in terms of performance. It's recommended to cache the result. See also annotations like [annotation @GDScript.@export_flags_2d_navigation], which can export variables as a bit field consisting of multiple layers.
+			</description>
+		</method>
 		<method name="get_global_class_list">
 			<return type="Dictionary[]" />
 			<description>
@@ -70,6 +80,13 @@
 				- [code]language[/code] is a name of a programming language in which the global class is written;
 				- [code]path[/code] is a path to a file containing the global class.
 				[b]Note:[/b] Both the script and the icon paths are local to the project filesystem, i.e. they start with [code]res://[/code].
+			</description>
+		</method>
+		<method name="get_layer_count" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="type" type="int" enum="ProjectSettings.LayerType" />
+			<description>
+				Returns the number of layers of the specified type.
 			</description>
 		</method>
 		<method name="get_order" qualifiers="const">
@@ -2918,4 +2935,27 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="LAYER_PHYSICS_2D" value="0" enum="LayerType">
+			2D physics layer.
+		</constant>
+		<constant name="LAYER_RENDER_2D" value="1" enum="LayerType">
+			2D render layer.
+		</constant>
+		<constant name="LAYER_NAVIGATION_2D" value="2" enum="LayerType">
+			2D navigation layer.
+		</constant>
+		<constant name="LAYER_PHYSICS_3D" value="3" enum="LayerType">
+			3D physics layer.
+		</constant>
+		<constant name="LAYER_RENDER_3D" value="4" enum="LayerType">
+			3D render layer.
+		</constant>
+		<constant name="LAYER_NAVIGATION_3D" value="5" enum="LayerType">
+			3D navigation layer.
+		</constant>
+		<constant name="LAYER_AVOIDANCE" value="6" enum="LayerType">
+			Navigation avoidance layer.
+		</constant>
+	</constants>
 </class>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1572
Closes https://github.com/godotengine/godot-proposals/issues/3930

This PR adds two methods to `ProjectSettings`:

- `get_layer_count(type)`: The only way to avoid hard-coding layer count as a magic number. Useful when the user decide to do something layer related.
- `find_layer(type, name)`: Helper method to find layer number by name. Toggling a layer dynamically in code is not uncommon. This avoids using magic numbers or boilerplate code.