### PR TITLE
Fix strange visual bug with camera and external change.

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -722,6 +722,7 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		new_scene->set_scene_file_path(edited_scene[p_idx].root->get_scene_file_path());
 		Node *old_root = edited_scene[p_idx].root;
+		edited_scene.write[p_idx].root = new_scene;
 		old_root->replace_by(new_scene, false, false);
 		memdelete(old_root);
 		edited_scene.write[p_idx].selection = new_selection;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3674,7 +3674,9 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 		if (old_edited_scene_root->get_parent() == scene_root) {
 			scene_root->remove_child(old_edited_scene_root);
 		}
-		old_edited_scene_root->disconnect(SNAME("replacing_by"), callable_mp(this, &EditorNode::set_edited_scene));
+		if (old_edited_scene_root->is_connected("replacing_by", callable_mp(this, &EditorNode::set_edited_scene))) {
+			old_edited_scene_root->disconnect(SNAME("replacing_by"), callable_mp(this, &EditorNode::set_edited_scene));
+		}
 	}
 	get_editor_data().set_edited_scene_root(p_scene);
 


### PR DESCRIPTION
Fixes #90301
Sincerely I don't know what was happening with this bug but it was because check and update was called later then before. So I reverted this change but had to defer the connection to the `set_edited_scene` as it needs the scene it replace to be the currently edited one. Moreover since the actual replace in editor_data is only happening later I had to defer the deletion of the old root hence the `queue_free`.

Edit : realised it was misbehaving with selection so I had to tweak it a bit more for selection to be properly kept