### PR TITLE
Expose `Node3D.scale()` as `scale_object()`

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -177,6 +177,13 @@
 				Rotates the local transformation around the Z axis by angle in radians.
 			</description>
 		</method>
+		<method name="scale_object">
+			<return type="void" />
+			<param index="0" name="ratio" type="Vector3" />
+			<description>
+				Scales the local transformation by given 3D scale factors.
+			</description>
+		</method>
 		<method name="scale_object_local">
 			<return type="void" />
 			<param index="0" name="scale" type="Vector3" />

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1174,6 +1174,7 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &Node3D::is_transform_notification_enabled);
 
 	ClassDB::bind_method(D_METHOD("rotate", "axis", "angle"), &Node3D::rotate);
+	ClassDB::bind_method(D_METHOD("scale_object", "ratio"), &Node3D::scale);
 	ClassDB::bind_method(D_METHOD("global_rotate", "axis", "angle"), &Node3D::global_rotate);
 	ClassDB::bind_method(D_METHOD("global_scale", "scale"), &Node3D::global_scale);
 	ClassDB::bind_method(D_METHOD("global_translate", "offset"), &Node3D::global_translate);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Expose `Node3D.scale()` to the editor side as `scale_object()`.