### PR TITLE
Fix `window_has_focus` not being set

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2215,7 +2215,7 @@ bool DisplayServerWindows::window_is_focused(WindowID p_window) const {
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
 	const WindowData &wd = windows[p_window];
 
-	return wd.window_focused;
+	return wd.window_has_focus;
 }
 
 DisplayServerWindows::WindowID DisplayServerWindows::get_focused_window() const {
@@ -4791,7 +4791,6 @@ void DisplayServerWindows::_process_activate_event(WindowID p_window_id, WPARAM 
 		if (!IsIconic(windows[p_window_id].hWnd)) {
 			SetFocus(windows[p_window_id].hWnd);
 		}
-		windows[p_window_id].window_focused = true;
 		windows[p_window_id].window_has_focus = true;
 		_send_window_event(windows[p_window_id], WINDOW_EVENT_FOCUS_IN);
 	} else { // WM_INACTIVE.
@@ -4800,7 +4799,6 @@ void DisplayServerWindows::_process_activate_event(WindowID p_window_id, WPARAM 
 		// Release capture unconditionally because it can be set due to dragging, in addition to captured mode.
 		ReleaseCapture();
 		alt_mem = false;
-		windows[p_window_id].window_focused = false;
 		windows[p_window_id].window_has_focus = false;
 		_send_window_event(windows[p_window_id], WINDOW_EVENT_FOCUS_OUT);
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4792,6 +4792,7 @@ void DisplayServerWindows::_process_activate_event(WindowID p_window_id, WPARAM 
 			SetFocus(windows[p_window_id].hWnd);
 		}
 		windows[p_window_id].window_focused = true;
+		windows[p_window_id].window_has_focus = true;
 		_send_window_event(windows[p_window_id], WINDOW_EVENT_FOCUS_IN);
 	} else { // WM_INACTIVE.
 		Input::get_singleton()->release_pressed_events();
@@ -4800,6 +4801,7 @@ void DisplayServerWindows::_process_activate_event(WindowID p_window_id, WPARAM 
 		ReleaseCapture();
 		alt_mem = false;
 		windows[p_window_id].window_focused = false;
+		windows[p_window_id].window_has_focus = false;
 		_send_window_event(windows[p_window_id], WINDOW_EVENT_FOCUS_OUT);
 	}
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -387,7 +387,6 @@ class DisplayServerWindows : public DisplayServer {
 		bool multiwindow_fs = false;
 		bool borderless = false;
 		bool resizable = true;
-		bool window_focused = false;
 		bool was_maximized = false;
 		bool always_on_top = false;
 		bool no_focus = false;


### PR DESCRIPTION
When raw input is being used, no mouse movement events where being sent if the mouse was captured due. Not entirely sure if this is correct as it looks like 02cb74e2234228c2888d56e11db2c7ea9f91725d touched a lot of this stuff.

`window_has_focus` currently seems unused anywhere so when detecting mouse moves no input events would be parsed with `Input::get_singleton()->parse_input_event(mm);`
