### PR TITLE
Force script lookup on all loaded assemblies, not just the main one.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -43,6 +43,7 @@ namespace GodotPlugins.Game
                 ManagedCallbacks.Create(outManagedCallbacks);
 
                 ScriptManagerBridge.LookupScriptsInAssembly(typeof(global::GodotPlugins.Game.Main).Assembly);
+                AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
 
                 return godot_bool.True;
             }
@@ -51,6 +52,11 @@ namespace GodotPlugins.Game
                 global::System.Console.Error.WriteLine(e);
                 return false.ToGodotBool();
             }
+        }
+
+        private static void OnAssemblyLoad(object obj, AssemblyLoadEventArgs args) 
+        {
+            ScriptManagerBridge.LookupScriptsInAssembly(args.LoadedAssembly);
         }
     }
 }


### PR DESCRIPTION
Proposed fix for issues #75352 and #77675 

Currently it is impossible to load a script inside a different csproj into the engine, as the C# glue only looks and registers scripts from the main assembly.

The proposed fix in this PR addresses this by doing the script lookup on all assemblies that get loaded initially, or later on in the runtime.

There are several caveats that can be addressed in future PRs:

1. All script files from the secondary assembly must still be within the godot project's project folder, so they can be assigned valid "res://" filepaths. This can be resolved in the future by moving away from the "res://" filepath for C# scripts and instead pathing to them based on a different path, such as "dotnet://{Assembly.FullTypeName}"
2. The secondary C# project's .csproj file must override `<GodotProjectDir>` to point to the actual project, as it will usually default to `$(MSBuildProjectDirectory)`. For this, it's best to use a relative path and store the project files close together. This step is not required if the .csproj file is in the root directory of the godot project.
3. The runtime must have already loaded the project assembly into the domain before methods such as `GD.Load("res://script.cs")` can be called for scripts in that assembly. This can be done in multitude of ways, but the easiest "hacky" solution is to have a static class in the main project such as `ScriptAssemblyLoader` and in the static constructor of that class, make a trivial reference to any type in the secondary assembly (for example `GD.Print(typeof(ClassInSecondaryAssembly));`

Point 3 is the most annoying part of this process and should be dealt with in the future to ensure there is less friction when using this workflow. One method of doing so would be to use a resource similar to the Unity Assembly configuration, where the user lists all of the script assemblies they need, and they are manually loaded by the engine on boot.

I think this is a good first step in at least supporting this workflow as it makes it viable, but I'm open to any changes proposed and feedback.

* *Bugsquad edit, fixes: #75352*
* *Bugsquad edit, fixes: #77675*