### PR TITLE
Make `Vector.bsearch` and `bsearch_custom` const

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -120,14 +120,14 @@ public:
 		sorter.sort(data, len);
 	}
 
-	Size bsearch(const T &p_value, bool p_before) {
+	Size bsearch(const T &p_value, bool p_before) const {
 		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
 	}
 
 	template <typename Comparator, typename Value, typename... Args>
-	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) const {
 		SearchArray<T, Comparator> search{ args... };
-		return search.bisect(ptrw(), size(), p_value, p_before);
+		return search.bisect(ptr(), size(), p_value, p_before);
 	}
 
 	Vector<T> duplicate() {

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -46,7 +46,7 @@
 				Appends a [PackedByteArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -49,7 +49,7 @@
 				Appends a [PackedColorArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Color" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -46,7 +46,7 @@
 				Appends a [PackedFloat32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -46,7 +46,7 @@
 				Appends a [PackedFloat64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -46,7 +46,7 @@
 				Appends a [PackedInt32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -46,7 +46,7 @@
 				Appends a [PackedInt64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -52,7 +52,7 @@
 				Appends a [PackedStringArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="String" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -50,7 +50,7 @@
 				Appends a [PackedVector2Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector2" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -49,7 +49,7 @@
 				Appends a [PackedVector3Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector3" />
 			<param index="1" name="before" type="bool" default="true" />


### PR DESCRIPTION
# Description
This pull request updates `Vector`'s `bsearch` and `bsearch_custom` methods to be marked as const by using `ptr()` instead of the write pointer `ptrw()`. This adjustment ensures that these methods don't modify the Vector instance, aligning the behavior with `Array.bsearch`, which is already const.

This change is particularly relevant when using GDExtensions, as it enables the use of const references for `PackedXXXArrays` casted from `Variants` when using bsearch.

# Backward compatibility
The transition to const methods is straightforward in theory, as non-const methods can call const methods without issue. However, this modification alters the "is_const" property in the API dictionary [generation](https://github.com/godotengine/godot/blob/e5b4ef8e9522e950033cbece39a31a4a76da19c1/core/extension/extension_api_dump.cpp#L786C6-L786C75) and affects method [hashes](https://github.com/godotengine/godot/blob/e5b4ef8e9522e950033cbece39a31a4a76da19c1/core/variant/variant_call.cpp#L1403C1-L1420C2) due to their dependency on method constness.
Even though this is not an issue for me, it does affect backward compatibility for some GDExtension modules. At least those modules that use bsearch need to be recompiled with the newly dumped api currently. 
So, this might be a major issue.

I believe backward compatibility issues have been addressed before in scenarios like this, but I'm not entirely sure how. If you have any insights or previous experiences on providing backward compatibility, I'd be glad to collaborate.

# Documentation
Const qualifiers get added to PackedXXXArray.xml like so:
```<method name="bsearch" qualifiers="const">```

My knowledge regarding documentation is limited. So, if there is more to do, I am happy about any input.