### PR TITLE
Allow to open script documentation from script editor

### DIFF
--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -271,6 +271,7 @@ class ScriptEditor : public PanelContainer {
 		FILE_MENU_COPY_PATH,
 		FILE_MENU_COPY_UID,
 		FILE_MENU_SHOW_IN_FILE_SYSTEM,
+		FILE_MENU_OPEN_GENERATED_DOCUMENTATION,
 
 		FILE_MENU_HISTORY_PREV,
 		FILE_MENU_HISTORY_NEXT,
@@ -325,7 +326,9 @@ class ScriptEditor : public PanelContainer {
 	MenuButton *edit_menu = nullptr;
 	MenuButton *script_search_menu = nullptr;
 	MenuButton *debug_menu = nullptr;
+	PopupMenu *docs_submenu = nullptr;
 	PopupMenu *context_menu = nullptr;
+	PopupMenu *context_docs_submenu = nullptr;
 	Timer *autosave_timer = nullptr;
 	uint64_t idle = 0;
 
@@ -435,6 +438,10 @@ class ScriptEditor : public PanelContainer {
 
 	void _copy_script_path();
 	void _copy_script_uid();
+
+	PackedStringArray _get_script_docs(const Ref<Script> &p_script) const;
+	void _add_docs_to_menu(PopupMenu *p_menu, const Ref<Script> &p_from_script) const;
+	void _open_generated_doc(int p_idx, PopupMenu *p_from_menu);
 
 	void _ask_close_current_unsaved_tab(ScriptEditorBase *current);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1925,7 +1925,10 @@ void PopupMenu::add_submenu_node_item(const String &p_label, PopupMenu *p_submen
 	queue_accessibility_update();
 	control->queue_redraw();
 
-	p_submenu->connect("popup_hide", callable_mp(this, &PopupMenu::_submenu_hidden));
+	// Can be already connected if the submenu was not freed with clear().
+	if (!p_submenu->is_connected("popup_hide", callable_mp(this, &PopupMenu::_submenu_hidden))) {
+		p_submenu->connect("popup_hide", callable_mp(this, &PopupMenu::_submenu_hidden));
+	}
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();


### PR DESCRIPTION
Adds "Open Generated Documentation" option, available when a script has doc page generated.

https://github.com/godotengine/godot/assets/2223172/434710e4-31e9-45e9-b8c6-b8b4cae65053

It's especially useful when you are writing documentation for a script.

Closes https://github.com/godotengine/godot-proposals/issues/4862