### PR TITLE
Preview resolution value for curves to alleviate performance issues of long curves

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -177,5 +177,8 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="debug_preview_resolution" type="int" setter="set_debug_preview_resolution" getter="get_debug_preview_resolution" default="32">
+			The number of intervals between two spline points. The larger the resolution, the more preview items are drawn. Lowering this value can help with responsiveness when editing the curve.
+		</member>
 	</members>
 </class>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -207,6 +207,9 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="debug_preview_resolution" type="int" setter="set_debug_preview_resolution" getter="get_debug_preview_resolution" default="32">
+			The number of intervals between two spline points. The larger the resolution, the more preview primitives are generated. Lowering this value can help with responsiveness when editing the curve.
+		</member>
 		<member name="up_vector_enabled" type="bool" setter="set_up_vector_enabled" getter="is_up_vector_enabled" default="true">
 			If [code]true[/code], the curve will bake up vectors used for orientation. This is used when [member PathFollow3D.rotation_mode] is set to [constant PathFollow3D.ROTATION_ORIENTED]. Changing it forces the cache to be recomputed.
 		</member>

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -288,70 +288,74 @@ void Path3DGizmo::redraw() {
 		return;
 	}
 
-	real_t interval = 0.1;
 	const real_t length = c->get_baked_length();
-
 	// 1. Draw curve and bones.
 	if (length > CMP_EPSILON) {
-		const int sample_count = int(length / interval) + 2;
-		interval = length / (sample_count - 1); // Recalculate real interval length.
+		const int point_count = c->get_point_count();
+		const int sample_count = c->get_debug_preview_resolution() + 2;
+		for (int point = 0; point < point_count - 1; point++) {
+			const real_t section_length = c->get_baked_distance_at_point(point + 1) - c->get_baked_distance_at_point(point);
+			const real_t interval = section_length / (sample_count - 1); // Recalculate real interval length of section.
+			Vector<Transform3D> frames;
+			frames.resize(sample_count);
 
-		Vector<Transform3D> frames;
-		frames.resize(sample_count);
+			real_t offset;
+			point == 0 ? offset = 0 : offset = c->get_baked_distance_at_point(point);
 
-		{
-			Transform3D *w = frames.ptrw();
+			// Get info at sample point
+			{
+				Transform3D *w = frames.ptrw();
+
+				for (int i = 0; i < sample_count; i++) {
+					w[i] = c->sample_baked_with_rotation(offset + (i * interval), true, true);
+				}
+			}
+			const Transform3D *r = frames.ptr();
+
+			Vector<Vector3> _collision_segments;
+			_collision_segments.resize((sample_count - 1) * 2);
+			Vector3 *_collisions_ptr = _collision_segments.ptrw();
+
+			Vector<Vector3> bones;
+			bones.resize(sample_count * 4);
+			Vector3 *bones_ptr = bones.ptrw();
+
+			Vector<Vector3> ribbon;
+			ribbon.resize(sample_count);
+			Vector3 *ribbon_ptr = ribbon.ptrw();
 
 			for (int i = 0; i < sample_count; i++) {
-				w[i] = c->sample_baked_with_rotation(i * interval, true, true);
-			}
-		}
+				const Vector3 p1 = r[i].origin;
+				const Vector3 side = r[i].basis.get_column(0);
+				const Vector3 up = r[i].basis.get_column(1);
+				const Vector3 forward = r[i].basis.get_column(2);
 
-		const Transform3D *r = frames.ptr();
+				// Collision segments.
+				if (i != sample_count - 1) {
+					const Vector3 p2 = r[i + 1].origin;
+					_collisions_ptr[(i * 2)] = p1;
+					_collisions_ptr[(i * 2) + 1] = p2;
+				}
 
-		Vector<Vector3> _collision_segments;
-		_collision_segments.resize((sample_count - 1) * 2);
-		Vector3 *_collisions_ptr = _collision_segments.ptrw();
+				// Path3D as a ribbon.
+				ribbon_ptr[i] = p1;
 
-		Vector<Vector3> bones;
-		bones.resize(sample_count * 4);
-		Vector3 *bones_ptr = bones.ptrw();
+				// Fish Bone.
+				const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
+				const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
 
-		Vector<Vector3> ribbon;
-		ribbon.resize(sample_count);
-		Vector3 *ribbon_ptr = ribbon.ptrw();
+				const int bone_idx = i * 4;
 
-		for (int i = 0; i < sample_count; i++) {
-			const Vector3 p1 = r[i].origin;
-			const Vector3 side = r[i].basis.get_column(0);
-			const Vector3 up = r[i].basis.get_column(1);
-			const Vector3 forward = r[i].basis.get_column(2);
-
-			// Collision segments.
-			if (i != sample_count - 1) {
-				const Vector3 p2 = r[i + 1].origin;
-				_collisions_ptr[(i * 2)] = p1;
-				_collisions_ptr[(i * 2) + 1] = p2;
+				bones_ptr[bone_idx] = p1;
+				bones_ptr[bone_idx + 1] = p_left;
+				bones_ptr[bone_idx + 2] = p1;
+				bones_ptr[bone_idx + 3] = p_right;
 			}
 
-			// Path3D as a ribbon.
-			ribbon_ptr[i] = p1;
-
-			// Fish Bone.
-			const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
-			const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
-
-			const int bone_idx = i * 4;
-
-			bones_ptr[bone_idx] = p1;
-			bones_ptr[bone_idx + 1] = p_left;
-			bones_ptr[bone_idx + 2] = p1;
-			bones_ptr[bone_idx + 3] = p_right;
+			add_collision_segments(_collision_segments);
+			add_lines(bones, path_material);
+			add_vertices(ribbon, path_material, Mesh::PRIMITIVE_LINE_STRIP);
 		}
-
-		add_collision_segments(_collision_segments);
-		add_lines(bones, path_material);
-		add_vertices(ribbon, path_material, Mesh::PRIMITIVE_LINE_STRIP);
 	}
 
 	// 2. Draw handles when selected.

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -138,7 +138,6 @@ class Path3DEditorPlugin : public EditorPlugin {
 	Path3D *path = nullptr;
 
 	void _update_theme();
-
 	void _mode_changed(int p_mode);
 	void _close_curve();
 	void _handle_option_pressed(int p_option);

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -182,6 +182,7 @@ class Curve2D : public Resource {
 	mutable PackedVector2Array baked_forward_vector_cache;
 	mutable Vector<real_t> baked_dist_cache;
 	mutable real_t baked_max_ofs = 0.0;
+	mutable Vector<real_t> baked_point_dist_cache;
 
 	void mark_dirty();
 
@@ -189,6 +190,7 @@ class Curve2D : public Resource {
 	void _bake() const;
 
 	real_t bake_interval = 5.0;
+	int debug_preview_resolution = 32;
 
 	struct Interval {
 		int idx;
@@ -233,8 +235,11 @@ public:
 
 	void set_bake_interval(real_t p_tolerance);
 	real_t get_bake_interval() const;
+	void set_debug_preview_resolution(int p_resolution);
+	int get_debug_preview_resolution() const;
 
 	real_t get_baked_length() const;
+	real_t get_baked_distance_at_point(int p_index) const;
 	Vector2 sample_baked(real_t p_offset, bool p_cubic = false) const;
 	Transform2D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false) const;
 	PackedVector2Array get_points() const;
@@ -271,6 +276,7 @@ class Curve3D : public Resource {
 	mutable PackedVector3Array baked_forward_vector_cache;
 	mutable Vector<real_t> baked_dist_cache;
 	mutable real_t baked_max_ofs = 0.0;
+	mutable Vector<real_t> baked_point_dist_cache;
 
 	void mark_dirty();
 
@@ -288,6 +294,7 @@ class Curve3D : public Resource {
 	Basis _compose_posture(int p_index) const;
 
 	real_t bake_interval = 0.2;
+	int debug_preview_resolution = 32;
 	bool up_vector_enabled = true;
 
 	void _bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
@@ -332,10 +339,13 @@ public:
 
 	void set_bake_interval(real_t p_tolerance);
 	real_t get_bake_interval() const;
+	void set_debug_preview_resolution(int p_resolution);
+	int get_debug_preview_resolution() const;
 	void set_up_vector_enabled(bool p_enable);
 	bool is_up_vector_enabled() const;
 
 	real_t get_baked_length() const;
+	real_t get_baked_distance_at_point(int p_index) const;
 	Vector3 sample_baked(real_t p_offset, bool p_cubic = false) const;
 	Transform3D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false, bool p_apply_tilt = false) const;
 	real_t sample_baked_tilt(real_t p_offset) const;


### PR DESCRIPTION
Fixes #81707
Curves now preview in editor with a fixed resolution per curve section that can be defined by the user. This helps avoid the issue with long curves producing a very large amount of primitives/draw items, which decrease the responsiveness of editing path3d/path2d curves.

- [ ] Closed-curve support https://github.com/godotengine/godot/pull/86195

https://github.com/godotengine/godot/assets/138934452/5970b2b2-9c85-4cfc-a437-25430062ef6f




