### PR TITLE
Add root motion to Skeleton3D to resolve conflicts between Animation and SkeletonModifier which may modify root bone transform

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -161,6 +161,20 @@
 				Returns an array with all of the bones that are parentless. Another way to look at this is that it returns the indexes of all the bones that are not dependent or modified by other bones in the Skeleton.
 			</description>
 		</method>
+		<method name="get_root_motion_position" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the root motion position.
+				[b]Note:[/b] If you get this value outside of the update process, it may not be the correct value, as it may be overwritten from [SkeletonModifier3D]. See also [member root_motion_target].
+			</description>
+		</method>
+		<method name="get_root_motion_rotation" qualifiers="const">
+			<return type="Quaternion" />
+			<description>
+				Returns the root motion rotation.
+				[b]Note:[/b] If you get this value outside of the update process, it may not be the correct value, as it may be overwritten from [SkeletonModifier3D]. See also [member root_motion_target].
+			</description>
+		</method>
 		<method name="get_version" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -340,6 +354,9 @@
 			Multiplies the 3D position track animation.
 			[b]Note:[/b] Unless this value is [code]1.0[/code], the key value in animation will not match the actual position value.
 		</member>
+		<member name="root_motion_target" type="NodePath" setter="set_root_motion_target" getter="get_root_motion_target" default="NodePath(&quot;&quot;)">
+			When the root motion is set from [AnimationMixer] or [SkeletonModifier3D], the motion is added to the [NodePath] transform.
+		</member>
 		<member name="show_rest_only" type="bool" setter="set_show_rest_only" getter="is_show_rest_only" default="false">
 			If [code]true[/code], forces the bones in their default rest pose, regardless of their values. In the editor, this also prevents the bones from being edited.
 		</member>
@@ -359,6 +376,13 @@
 			<description>
 				Emitted when the pose is updated.
 				[b]Note:[/b] During the update process, this signal is not fired, so modification by [SkeletonModifier3D] is not detected.
+			</description>
+		</signal>
+		<signal name="root_motion_processed">
+			<param index="0" name="root_motion_position" type="Vector3" />
+			<param index="1" name="root_motion_rotation" type="Quaternion" />
+			<description>
+				Emitted when the root motion is applied to [member root_motion_target], or can be applied for setting the root motion manually within the update process.
 			</description>
 		</signal>
 		<signal name="show_rest_only_changed">

--- a/doc/classes/XRBodyModifier3D.xml
+++ b/doc/classes/XRBodyModifier3D.xml
@@ -22,7 +22,11 @@
 			Specifies the type of updates to perform on the bones.
 		</member>
 		<member name="show_when_tracked" type="bool" setter="set_show_when_tracked" getter="get_show_when_tracked" default="true">
-			If true then the nodes visibility is determined by whether tracking data is available.
+			If [code]true[/code], then the nodes visibility is determined by whether tracking data is available.
+		</member>
+		<member name="use_root_motion" type="bool" setter="set_use_root_motion" getter="is_using_root_motion" default="false">
+			If [code]true[/code], apply root delta as root motion to [Skeleton3D].
+			If [code]false[/code], transforms the root bone directly.
 		</member>
 	</members>
 	<constants>

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -271,4 +271,40 @@ public:
 	Skeleton3DGizmoPlugin();
 };
 
+class RootMotionGizmo : public EditorNode3DGizmo {
+	GDCLASS(RootMotionGizmo, EditorNode3DGizmo);
+
+	Skeleton3D *skeleton = nullptr;
+
+	Ref<Material> immediate_material;
+	const real_t cell_size = 1.0;
+	const real_t radius = 5.0;
+	const Color color = Color(0.5, 0.5, 1.0);
+
+	Transform3D accumulated = Transform3D();
+
+	Vector3 root_motion_position = Vector3();
+	Quaternion root_motion_rotation = Quaternion();
+
+	void _redraw(const Vector3 &p_root_motion_position, const Quaternion &p_root_motion_rotation);
+
+public:
+	virtual void redraw() override;
+	RootMotionGizmo(Skeleton3D *skeleton = nullptr);
+};
+
+class RootMotionGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(RootMotionGizmoPlugin, EditorNode3DGizmoPlugin);
+
+protected:
+	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial) override;
+
+public:
+	bool has_gizmo(Node3D *p_spatial) override;
+	String get_gizmo_name() const override;
+	int get_priority() const override;
+
+	RootMotionGizmoPlugin();
+};
+
 #endif // SKELETON_3D_EDITOR_PLUGIN_H

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -144,9 +144,14 @@ private:
 	bool show_rest_only = false;
 	float motion_scale = 1.0;
 
+	NodePath root_motion_target;
+
 	uint64_t version = 1;
 
 	void _update_process_order();
+
+	Vector3 root_motion_position = Vector3();
+	Quaternion root_motion_rotation = Quaternion();
 
 	// To process modifiers.
 	ModifierCallbackModeProcess modifier_callback_mode_process = MODIFIER_CALLBACK_MODE_PROCESS_IDLE;
@@ -213,6 +218,9 @@ public:
 	void set_motion_scale(float p_motion_scale);
 	float get_motion_scale() const;
 
+	void set_root_motion_target(const NodePath &p_root_motion_target);
+	NodePath get_root_motion_target() const;
+
 	// Posing API
 	Transform3D get_bone_pose(int p_bone) const;
 	Vector3 get_bone_pose_position(int p_bone) const;
@@ -238,6 +246,13 @@ public:
 	void force_update_all_dirty_bones();
 	void force_update_all_bone_transforms();
 	void force_update_bone_children_transforms(int bone_idx);
+
+	// These root motion setters should be available only from AnimationMixer and SkeletonModifier3D.
+	void set_root_motion_position(const Vector3 &p_position);
+	void set_root_motion_rotation(const Quaternion &p_rotation);
+
+	Vector3 get_root_motion_position() const;
+	Quaternion get_root_motion_rotation() const;
 
 	void set_modifier_callback_mode_process(ModifierCallbackModeProcess p_mode);
 	ModifierCallbackModeProcess get_modifier_callback_mode_process() const;

--- a/scene/3d/xr_body_modifier_3d.h
+++ b/scene/3d/xr_body_modifier_3d.h
@@ -69,6 +69,9 @@ public:
 	void set_show_when_tracked(bool p_show_when_tracked);
 	bool get_show_when_tracked() const;
 
+	void set_use_root_motion(bool p_use_root_motion);
+	bool is_using_root_motion() const;
+
 	void _notification(int p_what);
 
 protected:
@@ -87,6 +90,11 @@ private:
 	BitField<BodyUpdate> body_update = BODY_UPDATE_UPPER_BODY | BODY_UPDATE_LOWER_BODY | BODY_UPDATE_HANDS;
 	BoneUpdate bone_update = BONE_UPDATE_FULL;
 	bool show_when_tracked = true;
+
+	bool use_root_motion = false;
+	Vector3 prev_root_bone_position = Vector3();
+	Quaternion prev_root_bone_rotation = Quaternion();
+
 	JointData joints[XRBodyTracker::JOINT_MAX];
 
 	void _get_joint_data();

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1695,6 +1695,18 @@ void AnimationMixer::_blend_apply() {
 					root_motion_position_accumulator = t->loc;
 					root_motion_rotation_accumulator = t->rot;
 					root_motion_scale_accumulator = t->scale;
+					if (t->skeleton_id.is_valid()) {
+						Skeleton3D *t_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(t->skeleton_id));
+						if (!t_skeleton) {
+							return;
+						}
+						Node3D *node = cast_to<Node3D>(t_skeleton->get_node_or_null(t_skeleton->get_root_motion_target()));
+						if (!node) {
+							return;
+						}
+						t_skeleton->set_root_motion_position((root_motion_rotation_accumulator.inverse() * node->get_quaternion() * root_motion_rotation).xform(root_motion_position));
+						t_skeleton->set_root_motion_rotation(root_motion_rotation);
+					}
 				} else if (t->skeleton_id.is_valid() && t->bone_idx >= 0) {
 					Skeleton3D *t_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(t->skeleton_id));
 					if (!t_skeleton) {

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -66,6 +66,7 @@ SceneStringNames::SceneStringNames() {
 	skeleton_updated = StaticCString::create("skeleton_updated");
 	bone_enabled_changed = StaticCString::create("bone_enabled_changed");
 	show_rest_only_changed = StaticCString::create("show_rest_only_changed");
+	root_motion_processed = StaticCString::create("root_motion_processed");
 
 	mouse_entered = StaticCString::create("mouse_entered");
 	mouse_exited = StaticCString::create("mouse_exited");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -102,6 +102,7 @@ public:
 	StringName skeleton_updated;
 	StringName bone_enabled_changed;
 	StringName show_rest_only_changed;
+	StringName root_motion_processed;
 
 	StringName body_shape_entered;
 	StringName body_entered;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/9470

It is still experimental. It is debatable how to get Gizmo out and whether this is a good way to move Skeleton.

Skeleton3D only exposes the setter `set_root_motion()` to the core. This is because it is impossible to process the root motion by looking only at the Skeleton3D root bone since it must be processed by an AnimationMixer external to Skeleton3D in order to take the root motion of the loop animation into account.

It needs to be processed in the deferred update process of skeleton as well as pose. This means that if you want to manually apply root motion to any Node via get_root_motion(), you must subscribe to the `root_motion_processed` signal (is `root_motion_fixed` better naming?).

If the `Apply Root Motion` option is enabled, the root motion is added to the Skeleton3D transform at runtime, see Class reference.

The root motion of the AnimationMixer and the root motion of the Skeleton3D are different values, because the rotation of the accumulator and the actual object must be taken into account, as done in https://github.com/godotengine/godot/pull/72931. In other words, Skeleton3D's root motion is an easily applicable value.

@BastiaanOlij @Malcolmnixon @dsnopek See if this is helpful and useful for XRBodyModifier's root transformation.

If the use root motion option is disabled, it should move the root bone, and if enabled, it should set delta as the root motion to the skeleton.

However, I do not have the XR debugging environment, so I do not know if the calculations are correct. Especially, I don't know which is processed first in the OpenXR tracker, the rotation or the translation (whether the root translation takes the rotation into account or not).
