### PR TITLE
Allow skipping imported resource files from export

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -313,7 +313,7 @@
 		<method name="skip">
 			<return type="void" />
 			<description>
-				To be called inside [method _export_file]. Skips the current file, so it's not included in the export.
+				To be called inside [method _export_file], [method _customize_resource], or [method _customize_scene]. Skips the current file, so it's not included in the export.
 			</description>
 		</method>
 	</methods>

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -791,6 +791,10 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 		if (!customize_scenes_plugins.is_empty()) {
 			for (Ref<EditorExportPlugin> &plugin : customize_scenes_plugins) {
 				Node *customized = plugin->_customize_scene(node, p_path);
+				if (plugin->skipped) {
+					plugin->_clear();
+					return String();
+				}
 				if (customized != nullptr) {
 					node = customized;
 					modified = true;
@@ -824,6 +828,10 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 		if (!customize_resources_plugins.is_empty()) {
 			for (Ref<EditorExportPlugin> &plugin : customize_resources_plugins) {
 				Ref<Resource> new_res = plugin->_customize_resource(res, p_path);
+				if (plugin->skipped) {
+					plugin->_clear();
+					return String();
+				}
 				if (new_res.is_valid()) {
 					modified = true;
 					if (new_res != res) {
@@ -1139,6 +1147,10 @@ Error EditorExportPlatform::export_project_files(bool p_main_pack, const Ref<Edi
 			// Before doing this, try to see if it can be customized.
 
 			String export_path = _export_customize(path, customize_resources_plugins, customize_scenes_plugins, export_cache, export_base_path, false);
+			if (export_path.is_empty()) {
+				// Skipped from plugin.
+				continue;
+			}
 
 			if (export_path != path) {
 				// It was actually customized.


### PR DESCRIPTION
Fixes #67844 (it *technically* resolves the issue in a different way)

Imported resources go through a different code path, so `_export_file()` is not called for them. However they have a separate customization code, so I just allowed to use `skip()` when customizing to skip the resource.

The only problem is that customization has some cache, so the skip may be ignored if the file was cached and customization does not modify it. But it still at least makes it possible to skip these files, so that's good enough perhaps.