### PR TITLE
Fix multiline array/dictionary match statements

### DIFF
--- a/modules/gdscript/tests/scripts/parser/features/match_array.gd
+++ b/modules/gdscript/tests/scripts/parser/features/match_array.gd
@@ -1,0 +1,33 @@
+func foo(x):
+	match x:
+		["value1"]:
+			print('["value1"]')
+		["value1", "value2"]:
+			print('["value1", "value2"]')
+
+func bar(x):
+	match x:
+		[
+			"value1"
+		]:
+			print('multiline ["value1"]')
+		[
+			"value1",
+			"value2",
+		]:
+			print('multiline ["value1", "value2",]')
+		[
+			"value1",
+			[
+				"value2",
+				..,
+			],
+		]:
+			print('multiline ["value1", ["value2", ..,],]')
+
+func test():
+	foo(["value1"])
+	foo(["value1", "value2"])
+	bar(["value1"])
+	bar(["value1", "value2"])
+	bar(["value1", ["value2", "value3"]])

--- a/modules/gdscript/tests/scripts/parser/features/match_array.out
+++ b/modules/gdscript/tests/scripts/parser/features/match_array.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+["value1"]
+["value1", "value2"]
+multiline ["value1"]
+multiline ["value1", "value2",]
+multiline ["value1", ["value2", ..,],]

--- a/modules/gdscript/tests/scripts/parser/features/match_dictionary.gd
+++ b/modules/gdscript/tests/scripts/parser/features/match_dictionary.gd
@@ -26,6 +26,24 @@ func bar(x):
 		_:
 			print("wildcard")
 
+func baz(x):
+	match x:
+		{
+			"key1": "value1"
+		}:
+			print('multiline {"key1": "value1"}')
+		{
+			"key2": "value2",
+		}:
+			print('multiline {"key2": "value2",}')
+		{
+			"key3": {
+				"key1",
+				..,
+			},
+		}:
+			print('multiline {"key3": {"key1", ..,},}')
+
 func test():
 	foo({"key1": "value1", "key2": "value2"})
 	foo({"key1": "value1", "key2": ""})
@@ -41,3 +59,6 @@ func test():
 	bar({1: "1"})
 	bar({2: "2"})
 	bar({3: "3"})
+	baz({"key1": "value1"})
+	baz({"key2": "value2"})
+	baz({"key3": {"key1": "value1", "key2": "value2"}})

--- a/modules/gdscript/tests/scripts/parser/features/match_dictionary.out
+++ b/modules/gdscript/tests/scripts/parser/features/match_dictionary.out
@@ -13,3 +13,6 @@ wildcard
 1
 2
 wildcard
+multiline {"key1": "value1"}
+multiline {"key2": "value2",}
+multiline {"key3": {"key1", ..,},}


### PR DESCRIPTION
Currently array and dictionary expressions cannot be spread over multiple lines in match statements.

Adding mutliline push/pop while parsing the pattern for bracket and brace enables the ability for these to be multiline. This enables more complex patterns to be matched without exceeding line limits.

Fixes #90372