### PR TITLE
[iOS export] Add support for privacy manifest configuration.

### DIFF
--- a/misc/dist/ios_xcode/PrivacyInfo.xcprivacy
+++ b/misc/dist/ios_xcode/PrivacyInfo.xcprivacy
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	$priv_api_types
+	$priv_tracking
+	$priv_collection
+</dict>
+</plist>

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9039D3BE24C093AC0020482C /* MoltenVK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9039D3BD24C093AC0020482C /* MoltenVK.xcframework */; };
 		D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE4418AEBDA2004A7AAE /* InfoPlist.strings */; };
 		D0BCFE7818AEBFEB004A7AAE /* $binary.pck in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE7718AEBFEB004A7AAE /* $binary.pck */; };
+		F965960D2BC2C3A800579C7E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F965960C2BC2C3A800579C7E /* PrivacyInfo.xcprivacy */; };
 		$pbx_launch_screen_build_reference
 /* End PBXBuildFile section */
 
@@ -47,6 +48,7 @@
 		D0BCFE4518AEBDA2004A7AAE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		$pbx_locale_file_reference
 		D0BCFE7718AEBFEB004A7AAE /* $binary.pck */ = {isa = PBXFileReference; lastKnownFileType = file; path = "$binary.pck"; sourceTree = "<group>"; };
+		F965960C2BC2C3A800579C7E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		$pbx_launch_screen_file_reference
 /* End PBXFileReference section */
 
@@ -75,6 +77,7 @@
 				D0BCFE4118AEBDA2004A7AAE /* $binary */,
 				D0BCFE3618AEBDA2004A7AAE /* Frameworks */,
 				D0BCFE3518AEBDA2004A7AAE /* Products */,
+				F965960C2BC2C3A800579C7E /* PrivacyInfo.xcprivacy */,
 				$additional_pbx_resources_refs
 			);
 			sourceTree = "<group>";
@@ -186,6 +189,7 @@
 				D0BCFE7818AEBFEB004A7AAE /* $binary.pck in Resources */,
 				$pbx_launch_screen_build_phase
 				D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */,
+				F965960D2BC2C3A800579C7E /* PrivacyInfo.xcprivacy in Resources */,
 				$additional_pbx_resources_build
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -123,11 +123,440 @@
 		<member name="icons/spotlight_80x80" type="String" setter="" getter="">
 			Spotlight icon file on iPad and iPhone (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
+		<member name="privacy/active_keyboard_access_reasons" type="int" setter="" getter="">
+			The reasons your app use active keyboard API. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api]Describing use of required reason API[/url].
+		</member>
 		<member name="privacy/camera_usage_description" type="String" setter="" getter="">
 			A message displayed when requesting access to the device's camera (in English).
 		</member>
 		<member name="privacy/camera_usage_description_localized" type="Dictionary" setter="" getter="">
 			A message displayed when requesting access to the device's camera (localized).
+		</member>
+		<member name="privacy/collected_data/advertising_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects advertising data.
+		</member>
+		<member name="privacy/collected_data/advertising_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects advertising data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/advertising_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links advertising data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/advertising_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses advertising data for tracking.
+		</member>
+		<member name="privacy/collected_data/audio_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects audio data data.
+		</member>
+		<member name="privacy/collected_data/audio_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects audio data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/audio_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links audio data data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/audio_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses audio data data for tracking.
+		</member>
+		<member name="privacy/collected_data/browsing_history/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects browsing history.
+		</member>
+		<member name="privacy/collected_data/browsing_history/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects browsing history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/browsing_history/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links browsing history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/browsing_history/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses browsing history for tracking.
+		</member>
+		<member name="privacy/collected_data/coarse_location/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects coarse location data.
+		</member>
+		<member name="privacy/collected_data/coarse_location/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects coarse location data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/coarse_location/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links coarse location data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/coarse_location/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses coarse location data for tracking.
+		</member>
+		<member name="privacy/collected_data/contacts/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects contacts.
+		</member>
+		<member name="privacy/collected_data/contacts/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects contacts. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/contacts/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links contacts to the user's identity.
+		</member>
+		<member name="privacy/collected_data/contacts/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses contacts for tracking.
+		</member>
+		<member name="privacy/collected_data/crash_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects crash data.
+		</member>
+		<member name="privacy/collected_data/crash_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects crash data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/crash_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links crash data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/crash_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses crash data for tracking.
+		</member>
+		<member name="privacy/collected_data/credit_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects credit information.
+		</member>
+		<member name="privacy/collected_data/credit_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects credit information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/credit_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links credit information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/credit_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses credit information for tracking.
+		</member>
+		<member name="privacy/collected_data/customer_support/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects customer support data.
+		</member>
+		<member name="privacy/collected_data/customer_support/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects customer support data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/customer_support/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links customer support data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/customer_support/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses customer support data for tracking.
+		</member>
+		<member name="privacy/collected_data/device_id/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects device IDs.
+		</member>
+		<member name="privacy/collected_data/device_id/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects device IDs. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/device_id/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links device IDs to the user's identity.
+		</member>
+		<member name="privacy/collected_data/device_id/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses device IDs for tracking.
+		</member>
+		<member name="privacy/collected_data/email_address/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects email address.
+		</member>
+		<member name="privacy/collected_data/email_address/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects email address. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/email_address/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links email address to the user's identity.
+		</member>
+		<member name="privacy/collected_data/email_address/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses email address for tracking.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects emails or text messages.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects emails or text messages. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links emails or text messages to the user's identity.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses emails or text messages for tracking.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects environment scanning data.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects environment scanning data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/environment_scanning/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links environment scanning data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses environment scanning data for tracking.
+		</member>
+		<member name="privacy/collected_data/fitness/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects fitness and exercise data.
+		</member>
+		<member name="privacy/collected_data/fitness/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects fitness and exercise data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/fitness/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links fitness and exercise data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/fitness/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses fitness and exercise data for tracking.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects gameplay content.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects gameplay content. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/gameplay_content/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links gameplay content to the user's identity.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses gameplay content for tracking.
+		</member>
+		<member name="privacy/collected_data/hands/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's hand structure and hand movements.
+		</member>
+		<member name="privacy/collected_data/hands/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's hand structure and hand movements. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/hands/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's hand structure and hand movements to the user's identity.
+		</member>
+		<member name="privacy/collected_data/hands/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's hand structure and hand movements for tracking.
+		</member>
+		<member name="privacy/collected_data/head/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's head movement.
+		</member>
+		<member name="privacy/collected_data/head/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's head movement. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/head/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's head movement to the user's identity.
+		</member>
+		<member name="privacy/collected_data/head/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's head movement for tracking.
+		</member>
+		<member name="privacy/collected_data/health/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects health and medical data.
+		</member>
+		<member name="privacy/collected_data/health/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects health and medical data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/health/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links health and medical data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/health/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses health and medical data for tracking.
+		</member>
+		<member name="privacy/collected_data/name/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's name.
+		</member>
+		<member name="privacy/collected_data/name/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's name. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/name/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's name to the user's identity.
+		</member>
+		<member name="privacy/collected_data/name/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's name for tracking.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other contact information.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other contact information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_contact_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other contact information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other contact information for tracking.
+		</member>
+		<member name="privacy/collected_data/other_data_types/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other data.
+		</member>
+		<member name="privacy/collected_data/other_data_types/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_data_types/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_data_types/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other diagnostic data.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other diagnostic data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other diagnostic data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other diagnostic data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other financial information.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other financial information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_financial_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other financial information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other financial information for tracking.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other usage data.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other usage data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_usage_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other usage data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other usage data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_user_content/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other user generated content.
+		</member>
+		<member name="privacy/collected_data/other_user_content/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other user generated content. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_user_content/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other user generated content to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_user_content/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other user generated content for tracking.
+		</member>
+		<member name="privacy/collected_data/payment_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects payment information.
+		</member>
+		<member name="privacy/collected_data/payment_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects payment information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/payment_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links payment information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/payment_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses payment information for tracking.
+		</member>
+		<member name="privacy/collected_data/performance_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects performance data.
+		</member>
+		<member name="privacy/collected_data/performance_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects performance data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/performance_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links performance data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/performance_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses performance data for tracking.
+		</member>
+		<member name="privacy/collected_data/phone_number/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects phone number.
+		</member>
+		<member name="privacy/collected_data/phone_number/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects phone number. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/phone_number/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links phone number to the user's identity.
+		</member>
+		<member name="privacy/collected_data/phone_number/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses phone number for tracking.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects photos or videos.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects photos or videos. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links photos or videos to the user's identity.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses photos or videos for tracking.
+		</member>
+		<member name="privacy/collected_data/physical_address/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects physical address.
+		</member>
+		<member name="privacy/collected_data/physical_address/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects physical address. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/physical_address/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links physical address to the user's identity.
+		</member>
+		<member name="privacy/collected_data/physical_address/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses physical address for tracking.
+		</member>
+		<member name="privacy/collected_data/precise_location/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects precise location data.
+		</member>
+		<member name="privacy/collected_data/precise_location/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects precise location data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/precise_location/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links precise location data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/precise_location/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses precise location data for tracking.
+		</member>
+		<member name="privacy/collected_data/product_interaction/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects product interaction data.
+		</member>
+		<member name="privacy/collected_data/product_interaction/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects product interaction data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/product_interaction/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links product interaction data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/product_interaction/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses product interaction data for tracking.
+		</member>
+		<member name="privacy/collected_data/purchase_history/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects purchase history.
+		</member>
+		<member name="privacy/collected_data/purchase_history/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects purchase history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/purchase_history/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links purchase history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/purchase_history/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses purchase history for tracking.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects search history.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects search history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/search_hhistory/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links search history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses search history for tracking.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects sensitive user information.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects sensitive user information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/sensitive_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links sensitive user information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses sensitive user information for tracking.
+		</member>
+		<member name="privacy/collected_data/user_id/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user IDs.
+		</member>
+		<member name="privacy/collected_data/user_id/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user IDs. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/user_id/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user IDs to the user's identity.
+		</member>
+		<member name="privacy/collected_data/user_id/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user IDs for tracking.
+		</member>
+		<member name="privacy/disk_space_access_reasons" type="int" setter="" getter="">
+			The reasons your app use free disk space API. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api]Describing use of required reason API[/url].
+		</member>
+		<member name="privacy/file_timestamp_access_reasons" type="int" setter="" getter="">
+			The reasons your app use file timestamp/metadata API. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api]Describing use of required reason API[/url].
 		</member>
 		<member name="privacy/microphone_usage_description" type="String" setter="" getter="">
 			A message displayed when requesting access to the device's microphone (in English).
@@ -140,6 +569,18 @@
 		</member>
 		<member name="privacy/photolibrary_usage_description_localized" type="Dictionary" setter="" getter="">
 			A message displayed when requesting access to the user's photo library (localized).
+		</member>
+		<member name="privacy/system_boot_time_access_reasons" type="int" setter="" getter="">
+			The reasons your app use system boot time / absolute time API. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api]Describing use of required reason API[/url].
+		</member>
+		<member name="privacy/tracking_domains" type="PackedStringArray" setter="" getter="">
+			The list of internet domains your app connects to that engage in tracking. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files]Privacy manifest files[/url].
+		</member>
+		<member name="privacy/tracking_enabled" type="bool" setter="" getter="">
+			Indicates whether your app uses data for tracking. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files]Privacy manifest files[/url].
+		</member>
+		<member name="privacy/user_defaults_access_reasons" type="int" setter="" getter="">
+			The reasons your app use user defaults API. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api]Describing use of required reason API[/url].
 		</member>
 		<member name="storyboard/custom_bg_color" type="Color" setter="" getter="">
 			A custom background color of the storyboard launch screen.

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -106,6 +106,94 @@ static const IconInfo icon_infos[] = {
 	{ PNAME("icons/notification_60x60"), "iphone", "Icon-60.png", "60", "3x", "20x20", false }
 };
 
+struct APIAccessInfo {
+	String prop_name;
+	String type_name;
+	Vector<String> prop_flag_value;
+	Vector<String> prop_flag_name;
+	int default_value;
+};
+
+static const APIAccessInfo api_info[] = {
+	{ "file_timestamp",
+			"NSPrivacyAccessedAPICategoryFileTimestamp",
+			{ "DDA9.1", "C617.1", "3B52.1" },
+			{ "Display to user on-device:", "Inside app or group container", "Files provided to app by user" },
+			3 },
+	{ "system_boot_time",
+			"NSPrivacyAccessedAPICategorySystemBootTime",
+			{ "35F9.1", "8FFB.1", "3D61.1" },
+			{ "Measure time on-device", "Calculate absolute event timestamps", "User-initiated bug report" },
+			1 },
+	{ "disk_space",
+			"NSPrivacyAccessedAPICategoryDiskSpace",
+			{ "E174.1", "85F4.1", "7D9E.1", "B728.1" },
+			{ "Write or delete file on-device", "Display to user on-device", "User-initiated bug report", "Health research app" },
+			3 },
+	{ "active_keyboard",
+			"NSPrivacyAccessedAPICategoryActiveKeyboards",
+			{ "3EC4.1", "54BD.1" },
+			{ "Custom keyboard app on-device", "Customize UI on-device:2" },
+			0 },
+	{ "user_defaults",
+			"NSPrivacyAccessedAPICategoryUserDefaults",
+			{ "1C8F.1", "AC6B.1", "CA92.1" },
+			{ "Access info from same App Group", "Access managed app configuration", "Access info from same app" },
+			0 }
+};
+
+struct DataCollectionInfo {
+	String prop_name;
+	String type_name;
+};
+
+static const DataCollectionInfo data_collect_type_info[] = {
+	{ "name", "NSPrivacyCollectedDataTypeName" },
+	{ "email_address", "NSPrivacyCollectedDataTypeEmailAddress" },
+	{ "phone_number", "NSPrivacyCollectedDataTypePhoneNumber" },
+	{ "physical_address", "NSPrivacyCollectedDataTypePhysicalAddress" },
+	{ "other_contact_info", "NSPrivacyCollectedDataTypeOtherUserContactInfo" },
+	{ "health", "NSPrivacyCollectedDataTypeHealth" },
+	{ "fitness", "NSPrivacyCollectedDataTypeFitness" },
+	{ "payment_info", "NSPrivacyCollectedDataTypePaymentInfo" },
+	{ "credit_info", "NSPrivacyCollectedDataTypeCreditInfo" },
+	{ "other_financial_info", "NSPrivacyCollectedDataTypeOtherFinancialInfo" },
+	{ "precise_location", "NSPrivacyCollectedDataTypePreciseLocation" },
+	{ "coarse_location", "NSPrivacyCollectedDataTypeCoarseLocation" },
+	{ "sensitive_info", "NSPrivacyCollectedDataTypeSensitiveInfo" },
+	{ "contacts", "NSPrivacyCollectedDataTypeContacts" },
+	{ "emails_or_text_messages", "NSPrivacyCollectedDataTypeEmailsOrTextMessages" },
+	{ "photos_or_videos", "NSPrivacyCollectedDataTypePhotosorVideos" },
+	{ "audio_data", "NSPrivacyCollectedDataTypeAudioData" },
+	{ "gameplay_content", "NSPrivacyCollectedDataTypeGameplayContent" },
+	{ "customer_support", "NSPrivacyCollectedDataTypeCustomerSupport" },
+	{ "other_user_content", "NSPrivacyCollectedDataTypeOtherUserContent" },
+	{ "browsing_history", "NSPrivacyCollectedDataTypeBrowsingHistory" },
+	{ "search_hhistory", "NSPrivacyCollectedDataTypeSearchHistory" },
+	{ "user_id", "NSPrivacyCollectedDataTypeUserID" },
+	{ "device_id", "NSPrivacyCollectedDataTypeDeviceID" },
+	{ "purchase_history", "NSPrivacyCollectedDataTypePurchaseHistory" },
+	{ "product_interaction", "NSPrivacyCollectedDataTypeProductInteraction" },
+	{ "advertising_data", "NSPrivacyCollectedDataTypeAdvertisingData" },
+	{ "other_usage_data", "NSPrivacyCollectedDataTypeOtherUsageData" },
+	{ "crash_data", "NSPrivacyCollectedDataTypeCrashData" },
+	{ "performance_data", "NSPrivacyCollectedDataTypePerformanceData" },
+	{ "other_diagnostic_data", "NSPrivacyCollectedDataTypeOtherDiagnosticData" },
+	{ "environment_scanning", "NSPrivacyCollectedDataTypeEnvironmentScanning" },
+	{ "hands", "NSPrivacyCollectedDataTypeHands" },
+	{ "head", "NSPrivacyCollectedDataTypeHead" },
+	{ "other_data_types", "NSPrivacyCollectedDataTypeOtherDataTypes" },
+};
+
+static const DataCollectionInfo data_collect_purpose_info[] = {
+	{ "Analytics", "NSPrivacyCollectedDataTypePurposeAnalytics" },
+	{ "App Functionality", "NSPrivacyCollectedDataTypePurposeAppFunctionality" },
+	{ "Developer Advertising", "NSPrivacyCollectedDataTypePurposeDeveloperAdvertising" },
+	{ "Third-party Advertising", "NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising" },
+	{ "Product Personalization", "NSPrivacyCollectedDataTypePurposeProductPersonalization" },
+	{ "Other", "NSPrivacyCollectedDataTypePurposeOther" },
+};
+
 String EditorExportPlatformIOS::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {
 	if (p_preset) {
 		if (p_name == "application/app_store_team_id") {
@@ -118,6 +206,21 @@ String EditorExportPlatformIOS::get_export_option_warning(const EditorExportPres
 			String pn_err;
 			if (!is_package_name_valid(identifier, &pn_err)) {
 				return TTR("Invalid Identifier:") + " " + pn_err;
+			}
+		} else if (p_name == "privacy/file_timestamp_access_reasons") {
+			int access = p_preset->get("privacy/file_timestamp_access_reasons");
+			if (access == 0) {
+				return TTR("At least one file timestamp access reason should be selected.");
+			}
+		} else if (p_name == "privacy/disk_space_access_reasons") {
+			int access = p_preset->get("privacy/disk_space_access_reasons");
+			if (access == 0) {
+				return TTR("At least one disk space access reason should be selected.");
+			}
+		} else if (p_name == "privacy/system_boot_time_access_reasons") {
+			int access = p_preset->get("privacy/system_boot_time_access_reasons");
+			if (access == 0) {
+				return TTR("At least one system boot time access reason should be selected.");
 			}
 		}
 	}
@@ -138,6 +241,15 @@ bool EditorExportPlatformIOS::get_export_option_visibility(const EditorExportPre
 	// Hide unsupported .NET embedding option.
 	if (p_option == "dotnet/embed_build_outputs") {
 		return false;
+	}
+
+	if (p_preset == nullptr) {
+		return true;
+	}
+
+	bool advanced_options_enabled = p_preset->are_advanced_options_enabled();
+	if (p_option.begins_with("privacy")) {
+		return advanced_options_enabled;
 	}
 
 	return true;
@@ -219,6 +331,37 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "privacy/microphone_usage_description_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need access to the photo library"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "privacy/photolibrary_usage_description_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
+
+	for (uint64_t i = 0; i < sizeof(api_info) / sizeof(api_info[0]); ++i) {
+		String prop_name = vformat("privacy/%s_access_reasons", api_info[i].prop_name);
+		String hint;
+		for (int j = 0; j < api_info[i].prop_flag_value.size(); j++) {
+			if (j != 0) {
+				hint += ",";
+			}
+			hint += vformat("%s - %s:%d", api_info[i].prop_flag_value[j], api_info[i].prop_flag_name[j], (1 << j));
+		}
+		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, prop_name, PROPERTY_HINT_FLAGS, hint), api_info[i].default_value));
+	}
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "privacy/tracking_enabled"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "privacy/tracking_domains"), Vector<String>()));
+
+	{
+		String hint;
+		for (uint64_t i = 0; i < sizeof(data_collect_purpose_info) / sizeof(data_collect_purpose_info[0]); ++i) {
+			if (i != 0) {
+				hint += ",";
+			}
+			hint += vformat("%s:%d", data_collect_purpose_info[i].prop_name, (1 << i));
+		}
+		for (uint64_t i = 0; i < sizeof(data_collect_type_info) / sizeof(data_collect_type_info[0]); ++i) {
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/collected", data_collect_type_info[i].prop_name)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[i].prop_name)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[i].prop_name)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::INT, vformat("privacy/collected_data/%s/collection_purposes", data_collect_type_info[i].prop_name), PROPERTY_HINT_FLAGS, hint), 0));
+		}
+	}
 
 	HashSet<String> used_names;
 	for (uint64_t i = 0; i < sizeof(icon_infos) / sizeof(icon_infos[0]); ++i) {
@@ -522,6 +665,87 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$swift_runtime_build_phase") != -1) {
 			String value = !p_config.use_swift_runtime ? "" : "90B4C2B62680C7E90039117A /* dummy.swift */,";
 			strnew += lines[i].replace("$swift_runtime_build_phase", value) + "\n";
+		} else if (lines[i].find("$priv_collection") != -1) {
+			bool section_opened = false;
+			for (uint64_t j = 0; j < sizeof(data_collect_type_info) / sizeof(data_collect_type_info[0]); ++j) {
+				bool data_collected = p_preset->get(vformat("privacy/collected_data/%s/collected", data_collect_type_info[j].prop_name));
+				bool linked = p_preset->get(vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[j].prop_name));
+				bool tracking = p_preset->get(vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[j].prop_name));
+				int purposes = p_preset->get(vformat("privacy/collected_data/%s/collection_purposes", data_collect_type_info[j].prop_name));
+				if (data_collected) {
+					if (!section_opened) {
+						section_opened = true;
+						strnew += "\t<key>NSPrivacyCollectedDataTypes</key>\n";
+						strnew += "\t<array>\n";
+					}
+					strnew += "\t\t<dict>\n";
+					strnew += "\t\t\t<key>NSPrivacyCollectedDataType</key>\n";
+					strnew += vformat("\t\t\t<string>%s</string>\n", data_collect_type_info[j].type_name);
+					strnew += "\t\t\t\t<key>NSPrivacyCollectedDataTypeLinked</key>\n";
+					if (linked) {
+						strnew += "\t\t\t\t<true/>\n";
+					} else {
+						strnew += "\t\t\t\t<false/>\n";
+					}
+					strnew += "\t\t\t\t<key>NSPrivacyCollectedDataTypeTracking</key>\n";
+					if (tracking) {
+						strnew += "\t\t\t\t<true/>\n";
+					} else {
+						strnew += "\t\t\t\t<false/>\n";
+					}
+					if (purposes != 0) {
+						strnew += "\t\t\t\t<key>NSPrivacyCollectedDataTypePurposes</key>\n";
+						strnew += "\t\t\t\t<array>\n";
+						for (uint64_t k = 0; k < sizeof(data_collect_purpose_info) / sizeof(data_collect_purpose_info[0]); ++k) {
+							if (purposes & (1 << k)) {
+								strnew += vformat("\t\t\t\t\t<string>%s</string>\n", data_collect_purpose_info[k].type_name);
+							}
+						}
+						strnew += "\t\t\t\t</array>\n";
+					}
+					strnew += "\t\t\t</dict>\n";
+				}
+			}
+			if (section_opened) {
+				strnew += "\t</array>\n";
+			}
+		} else if (lines[i].find("$priv_tracking") != -1) {
+			bool tracking = p_preset->get("privacy/tracking_enabled");
+			strnew += "\t<key>NSPrivacyTracking</key>\n";
+			if (tracking) {
+				strnew += "\t<true/>\n";
+			} else {
+				strnew += "\t<false/>\n";
+			}
+			Vector<String> tracking_domains = p_preset->get("privacy/tracking_domains");
+			if (!tracking_domains.is_empty()) {
+				strnew += "\t<key>NSPrivacyTrackingDomains</key>\n";
+				strnew += "\t<array>\n";
+				for (const String &E : tracking_domains) {
+					strnew += "\t\t<string>" + E + "</string>\n";
+				}
+				strnew += "\t</array>\n";
+			}
+		} else if (lines[i].find("$priv_api_types") != -1) {
+			strnew += "\t<array>\n";
+			for (uint64_t j = 0; j < sizeof(api_info) / sizeof(api_info[0]); ++j) {
+				int api_access = p_preset->get(vformat("privacy/%s_access_reasons", api_info[j].prop_name));
+				if (api_access != 0) {
+					strnew += "\t\t<dict>\n";
+					strnew += "\t\t\t<key>NSPrivacyAccessedAPITypeReasons</key>\n";
+					strnew += "\t\t\t<array>\n";
+					for (int k = 0; k < api_info[j].prop_flag_value.size(); k++) {
+						if (api_access & (1 << k)) {
+							strnew += vformat("\t\t\t\t<string>%s</string>\n", api_info[j].prop_flag_value[k]);
+						}
+					}
+					strnew += "\t\t\t</array>\n";
+					strnew += "\t\t\t<key>NSPrivacyAccessedAPIType</key>\n";
+					strnew += vformat("\t\t\t<string>%s</string>\n", api_info[j].type_name);
+					strnew += "\t\t</dict>\n";
+				}
+			}
+			strnew += "\t</array>\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}
@@ -1694,6 +1918,7 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 	files_to_parse.insert("godot_ios.xcodeproj/xcshareddata/xcschemes/godot_ios.xcscheme");
 	files_to_parse.insert("godot_ios/godot_ios.entitlements");
 	files_to_parse.insert("godot_ios/Launch Screen.storyboard");
+	files_to_parse.insert("PrivacyInfo.xcprivacy");
 
 	IOSConfigData config_data = {
 		pkg_name,


### PR DESCRIPTION
Adds export settings to configure iOS privacy manifest.

<details>
  <summary>Click to expand</summary>

<img width="929" alt="Screenshot 2024-04-08 at 08 35 16" src="https://github.com/godotengine/godot/assets/7645683/72b0e810-eabb-4d8a-bfb9-7017d82876db">

</details>

Fixes https://github.com/godotengine/godot/issues/90323