### PR TITLE
Add verification step in the Export system

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -274,6 +274,12 @@
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
+		<member name="application/config/export_checklists" type="Dictionary" setter="" getter="" default="{}">
+			The checklists to export either the project, the pck/zip or all the presets. Leave both this and [member application/config/export_phrase] empty to export seamlessly.
+		</member>
+		<member name="application/config/export_phrase" type="String" setter="" getter="" default="&quot;&quot;">
+			The phrase to export either the project, the pck/zip or all the presets. Leave both this and [member application/config/export_checklists] empty to export seamlessly.
+		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon as a fallback if necessary.
 		</member>

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_verify_dialog.h"
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
@@ -107,7 +108,7 @@ void ProjectExportDialog::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			duplicate_preset->set_icon(presets->get_editor_theme_icon(SNAME("Duplicate")));
 			delete_preset->set_icon(presets->get_editor_theme_icon(SNAME("Remove")));
-			connect("confirmed", callable_mp(this, &ProjectExportDialog::_export_pck_zip));
+			connect("confirmed", callable_mp(this, &ProjectExportDialog::_verify_export).bind(EXPORT_PCK_ZIP));
 			_update_export_all();
 		} break;
 	}
@@ -1196,6 +1197,24 @@ void ProjectExportDialog::_export_all(bool p_debug) {
 	exporting = false;
 }
 
+void ProjectExportDialog::_verify_export(int p_export_type) {
+	if (verify_dialog->reload(p_export_type, callable_mp(this, &ProjectExportDialog::_export_all_dialog), callable_mp(this, &ProjectExportDialog::_export_project), callable_mp(this, &ProjectExportDialog::_export_pck_zip))) {
+		verify_dialog->popup_centered();
+	} else {
+		switch (p_export_type) {
+			case EXPORT_ALL:
+				_export_all_dialog();
+				break;
+			case EXPORT:
+				_export_project();
+				break;
+			case EXPORT_PCK_ZIP:
+				_export_pck_zip();
+				break;
+		}
+	}
+}
+
 void ProjectExportDialog::_bind_methods() {
 	ClassDB::bind_method("set_export_path", &ProjectExportDialog::set_export_path);
 	ClassDB::bind_method("get_export_path", &ProjectExportDialog::get_export_path);
@@ -1478,7 +1497,9 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_button = add_button(TTR("Export Project..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
 	export_button->set_tooltip_text(TTR("Export the project as a playable build (Godot executable and project data) for the selected preset."));
 #endif
-	export_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_project));
+	verify_dialog = memnew(EditorVerifyDialog);
+	add_child(verify_dialog);
+	export_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_verify_export).bind(EXPORT));
 	// Disable initially before we select a valid preset
 	export_button->set_disabled(true);
 
@@ -1498,7 +1519,7 @@ ProjectExportDialog::ProjectExportDialog() {
 #else
 	export_all_button = add_button(TTR("Export All..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
 #endif
-	export_all_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_all_dialog));
+	export_all_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_verify_export).bind(EXPORT_ALL));
 	export_all_button->set_disabled(true);
 
 	export_pck_zip = memnew(EditorFileDialog);

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -40,6 +40,7 @@ class EditorFileDialog;
 class EditorFileSystemDirectory;
 class EditorInspector;
 class EditorPropertyPath;
+class EditorVerifyDialog;
 class ItemList;
 class LinkButton;
 class MenuButton;
@@ -103,6 +104,8 @@ class ProjectExportDialog : public ConfirmationDialog {
 	Button *export_button = nullptr;
 	Button *export_all_button = nullptr;
 	AcceptDialog *export_all_dialog = nullptr;
+
+	EditorVerifyDialog *verify_dialog = nullptr;
 
 	RBSet<String> feature_set;
 	LineEdit *custom_features = nullptr;
@@ -174,6 +177,8 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _export_all_dialog_action(const String &p_str);
 	void _export_all(bool p_debug);
 
+	void _verify_export(int p_export_type);
+
 	void _update_feature_list();
 	void _custom_features_changed(const String &p_text);
 
@@ -196,6 +201,12 @@ protected:
 	static void _bind_methods();
 
 public:
+	enum {
+		EXPORT_ALL,
+		EXPORT,
+		EXPORT_PCK_ZIP
+	};
+
 	void popup_export();
 
 	void set_export_path(const String &p_value);

--- a/editor/gui/editor_verify_dialog.cpp
+++ b/editor/gui/editor_verify_dialog.cpp
@@ -1,0 +1,190 @@
+/**************************************************************************/
+/*  editor_verify_dialog.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_verify_dialog.h"
+
+#include "core/config/project_settings.h"
+#include "editor/export/project_export.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/tree.h"
+
+bool EditorVerifyDialog::reload(int p_export_type, const Callable &p_export_all_callable, const Callable &p_export_callable, const Callable &p_export_pck_zip_callable) {
+	phrase = GLOBAL_GET("application/config/export_phrase");
+	Dictionary checklists = GLOBAL_GET("application/config/export_checklists");
+
+	if (phrase.is_empty() && checklists.is_empty()) {
+		return false;
+	}
+
+	items_count = 0;
+	evaluation_bit = (!checklists.is_empty() << 1) | !phrase.is_empty();
+
+	checklists_label->hide();
+	checklists_tree->hide();
+
+	phrase_label->hide();
+	phrase_line_edit->hide();
+
+	Button *ok_bttn = get_ok_button();
+
+	ok_bttn->set_disabled(true);
+
+	if (ok_bttn->is_connected("pressed", p_export_all_callable)) {
+		ok_bttn->disconnect("pressed", p_export_all_callable);
+	} else if (ok_bttn->is_connected("pressed", p_export_callable)) {
+		ok_bttn->disconnect("pressed", p_export_callable);
+	} else if (ok_bttn->is_connected("pressed", p_export_pck_zip_callable)) {
+		ok_bttn->disconnect("pressed", p_export_pck_zip_callable);
+	}
+
+	switch (p_export_type) {
+		case ProjectExportDialog::EXPORT_ALL:
+			ok_bttn->connect("pressed", p_export_all_callable);
+			break;
+		case ProjectExportDialog::EXPORT:
+			ok_bttn->connect("pressed", p_export_callable);
+			break;
+		case ProjectExportDialog::EXPORT_PCK_ZIP:
+			ok_bttn->connect("pressed", p_export_pck_zip_callable);
+			break;
+	}
+
+	switch (evaluation_bit) {
+		case 0b0001:
+			evaluation_bit = 0b0010;
+			set_size(Size2(0, 0));
+			ok_bttn->set_tooltip_text(TTR("Enter the phrase defined in the Project Settings to proceed."));
+			_show_phrase();
+			break;
+		case 0b0010:
+			evaluation_bit = 0b0001;
+			set_size(Size2(0, 400) * EDSCALE);
+			ok_bttn->set_tooltip_text(TTR("Check all items defined in the Project Settings to proceed."));
+			_show_checklists(checklists);
+			break;
+		case 0b0011:
+			evaluation_bit = 0;
+			set_size(Size2(0, 500) * EDSCALE);
+			ok_bttn->set_tooltip_text(TTR("Check all items and enter the phrase defined in the Project Settings to proceed."));
+			_show_phrase();
+			_show_checklists(checklists);
+			break;
+	}
+
+	return true;
+}
+
+void EditorVerifyDialog::_show_phrase() {
+	phrase_label->set_text(vformat(TTR("Enter the phrase \"%s\" below:"), phrase));
+
+	phrase_line_edit->set_text("");
+	callable_mp((Control *)phrase_line_edit, &Control::grab_focus).call_deferred();
+
+	phrase_label->show();
+	phrase_line_edit->show();
+}
+
+void EditorVerifyDialog::_show_checklists(const Dictionary &p_checklists) {
+	checklists_tree->clear();
+
+	checklists_tree->create_item()->set_text(0, "Items");
+
+	Array titles = p_checklists.keys();
+
+	for (int i = 0; i < titles.size(); ++i) {
+		String checklist_title = static_cast<String>(titles[i]);
+
+		TreeItem *root = checklists_tree->create_item();
+		root->set_text(0, checklist_title);
+
+		PackedStringArray items = static_cast<PackedStringArray>(p_checklists[checklist_title]);
+
+		items_count += items.size();
+
+		for (const String &item : items) {
+			TreeItem *new_item = checklists_tree->create_item(root);
+			new_item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+			new_item->set_text(0, item);
+			new_item->set_editable(0, true);
+		}
+	}
+
+	checklists_label->show();
+	checklists_tree->show();
+}
+
+void EditorVerifyDialog::_item_edited() {
+	if (checklists_tree->get_edited()->is_checked(0)) {
+		if (--items_count == 0) {
+			evaluation_bit |= 0b0010;
+		}
+	} else {
+		++items_count;
+		evaluation_bit &= 0b1101;
+	}
+
+	_evaluate();
+}
+
+void EditorVerifyDialog::_validate_phrase(const String &p_text) {
+	if (p_text == phrase) {
+		evaluation_bit |= 0b0001;
+	} else {
+		evaluation_bit &= 0b1110;
+	}
+
+	_evaluate();
+}
+
+void EditorVerifyDialog::_evaluate() {
+	if (evaluation_bit == 0b0011) {
+		get_ok_button()->set_disabled(false);
+	} else {
+		get_ok_button()->set_disabled(true);
+	}
+}
+
+EditorVerifyDialog::EditorVerifyDialog() {
+	set_title(TTR("Verify before exporting"));
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
+
+	checklists_tree = memnew(Tree);
+	checklists_tree->connect("item_edited", callable_mp(this, &EditorVerifyDialog::_item_edited));
+	vb->add_margin_child("Check the items below:", checklists_tree, true);
+	checklists_label = Object::cast_to<Label>(vb->get_child(0));
+
+	phrase_line_edit = memnew(LineEdit(TTR("Case-sensitive")));
+	phrase_line_edit->connect("text_changed", callable_mp(this, &EditorVerifyDialog::_validate_phrase));
+	vb->add_margin_child("", phrase_line_edit);
+	phrase_label = Object::cast_to<Label>(vb->get_child(2));
+}

--- a/editor/gui/editor_verify_dialog.h
+++ b/editor/gui/editor_verify_dialog.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  editor_verify_dialog.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_VERIFY_DIALOG_H
+#define EDITOR_VERIFY_DIALOG_H
+
+#include "scene/gui/dialogs.h"
+
+class Label;
+class Tree;
+class LineEdit;
+
+class EditorVerifyDialog : public ConfirmationDialog {
+	GDCLASS(EditorVerifyDialog, ConfirmationDialog);
+
+	int items_count = 0;
+	unsigned evaluation_bit = 0;
+
+	String phrase = "";
+
+	Label *checklists_label = nullptr;
+	Tree *checklists_tree = nullptr;
+
+	Label *phrase_label = nullptr;
+	LineEdit *phrase_line_edit = nullptr;
+
+	void _show_phrase();
+	void _show_checklists(const Dictionary &p_checklists);
+
+	void _item_edited();
+	void _validate_phrase(const String &p_text);
+
+	void _evaluate();
+
+public:
+	bool reload(int p_export_type, const Callable &p_export_all_callable, const Callable &p_export_callable, const Callable &p_export_pck_zip_callable);
+
+	EditorVerifyDialog();
+};
+
+#endif // EDITOR_VERIFY_DIALOG_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2903,6 +2903,8 @@ Error Main::setup2() {
 				GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 
 		GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/icon", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), String());
+		GLOBAL_DEF_BASIC("application/config/export_phrase", "");
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::DICTIONARY, "application/config/export_checklists"), Dictionary());
 		GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"), String());
 		GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/windows_native_icon", PROPERTY_HINT_FILE, "*.ico"), String());
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Add verification step in the Export system to recap everything before releasing the app.

This basically intercepts the Export buttons to only continue after the user has verified that they have not missed any essential task.

https://github.com/godotengine/godot/assets/37383316/0256f5c3-d0dd-4c1c-b353-012576fd2afe

If both `application/config/export_phrase` and `application/config/export_checklists` are empty (default) the verification step won't show up