### PR TITLE
Inspect hovered node while dragging

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -160,6 +160,7 @@ public:
 
 	void set_marked(const HashSet<Node *> &p_marked, bool p_selectable = true, bool p_children_selectable = true);
 	void set_marked(Node *p_marked, bool p_selectable = true, bool p_children_selectable = true);
+	bool has_marked() const { return !marked.is_empty(); }
 	void set_selected(Node *p_node, bool p_emit_selected = true);
 	Node *get_selected();
 	void set_can_rename(bool p_can_rename) { can_rename = p_can_rename; }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -234,6 +234,14 @@ class SceneTreeDock : public VBoxContainer {
 	void _node_prerenamed(Node *p_node, const String &p_new_name);
 
 	void _nodes_drag_begin();
+
+	void _handle_hover_to_inspect();
+	void _inspect_hovered_node();
+	void _reset_hovering_timer();
+	Timer *inspect_hovered_node_delay = nullptr;
+	Node *node_hovered_now = nullptr;
+	Node *node_hovered_previously = nullptr;
+
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _scene_tree_gui_input(Ref<InputEvent> p_event);


### PR DESCRIPTION
Allow to edit in the inspector the hovered node while dragging other node(s) over it for 1 second in the editor scene tree dock.
This is to avoid having to rely on the workaround and add the missing piece mentioned here : https://github.com/godotengine/godot/pull/89406
It also propagate the notification to the inspector dock to highlight the valid properties for the drop