### PR TITLE
[iOS Export] Fix adding static libs to the Xcode project.

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1316,7 +1316,7 @@ Error EditorExportPlatformIOS::_export_additional_assets(const Ref<EditorExportP
 		if (asset.begins_with("res://")) {
 			Error err = _copy_asset(p_preset, p_out_dir, asset, nullptr, p_is_framework, p_should_embed, r_exported_assets);
 			ERR_FAIL_COND_V(err != OK, err);
-		} else if (ProjectSettings::get_singleton()->localize_path(asset).begins_with("res://")) {
+		} else if (asset.is_absolute_path() && ProjectSettings::get_singleton()->localize_path(asset).begins_with("res://")) {
 			Error err = _copy_asset(p_preset, p_out_dir, ProjectSettings::get_singleton()->localize_path(asset), nullptr, p_is_framework, p_should_embed, r_exported_assets);
 			ERR_FAIL_COND_V(err != OK, err);
 		} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90173 (I was not able to fully test it since `godot-kotlin-jvm` seems to be not functional with current master and never generate `usercode.a`, but file is created manually it is exported and included to the project). 
