### PR TITLE
Clarification in printraw() documentation stating OS Terminal is not same as Editor Console

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -901,6 +901,7 @@
 		<method name="printraw" qualifiers="vararg">
 			<description>
 				Prints one or more arguments to strings in the best way possible to the OS terminal. Unlike [method print], no newline is automatically added at the end.
+				[b]Note:[/b] The OS terminal is NOT the Editor's Console, the output can be seen using the console versions of the Godot Engine.
 				[codeblocks]
 				[gdscript]
 				printraw("A")


### PR DESCRIPTION
This is in reference to #89323 (https://github.com/godotengine/godot/issues/89323)
Target Branch: master