### PR TITLE
[3.x] Add `Node.is_node_ready()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -395,6 +395,13 @@
 				Returns [code]true[/code] if the local system is the master of this node.
 			</description>
 		</method>
+		<method name="is_node_ready" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node is ready, i.e. it's inside scene tree and all its children are initialized.
+				[method request_ready] resets it back to [code]false[/code].
+			</description>
+		</method>
 		<method name="is_physics_interpolated" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3022,6 +3022,10 @@ bool Node::is_displayed_folded() const {
 	return data.display_folded;
 }
 
+bool Node::is_node_ready() const {
+	return !data.ready_first;
+}
+
 void Node::request_ready() {
 	data.ready_first = true;
 }
@@ -3122,6 +3126,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_free"), &Node::queue_delete);
 
 	ClassDB::bind_method(D_METHOD("request_ready"), &Node::request_ready);
+	ClassDB::bind_method(D_METHOD("is_node_ready"), &Node::is_node_ready);
 
 	ClassDB::bind_method(D_METHOD("set_network_master", "id", "recursive"), &Node::set_network_master, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_network_master"), &Node::get_network_master);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -455,6 +455,7 @@ public:
 	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();
 
+	bool is_node_ready() const;
 	void request_ready();
 
 	static void print_stray_nodes();


### PR DESCRIPTION
This method was introduced in 4.1.

This is only reliable way to check if a node is ready, as this state can be affected by `request_ready()`.