### PR TITLE
Doc: Add hint for required ios camera plugin in CameraServer documentation

### DIFF
--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 		It is notably used to provide AR modules with a video feed from the camera.
-		[b]Note:[/b] This class is currently only implemented on macOS and iOS. On other platforms, no [CameraFeed]s will be available.
+		[b]Note:[/b] This class is currently only implemented on macOS and iOS. To get a [CameraFeed] on iOS, the camera plugin from [url=https://github.com/godotengine/godot-ios-plugins]godot-ios-plugins[/url] is required. On other platforms, no [CameraFeed]s will be available.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Added hint for using the CameraServer on iOS, since reading the previous docs suggested that the CameraFeed will work out of the box in iOS (which it does not). 