### PR TITLE
[XR] Fix binds for composition layer virtuals

### DIFF
--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -61,8 +61,8 @@ void OpenXRExtensionWrapperExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_on_state_exiting);
 	GDVIRTUAL_BIND(_on_event_polled, "event");
 	GDVIRTUAL_BIND(_set_viewport_composition_layer_and_get_next_pointer, "layer", "property_values", "next_pointer");
-	GDVIRTUAL_BIND(_get_viewport_composition_layer_extension_properties, "layer");
-	GDVIRTUAL_BIND(_get_viewport_composition_layer_extension_property_defaults, "layer");
+	GDVIRTUAL_BIND(_get_viewport_composition_layer_extension_properties);
+	GDVIRTUAL_BIND(_get_viewport_composition_layer_extension_property_defaults);
 	GDVIRTUAL_BIND(_on_viewport_composition_layer_destroyed, "layer");
 
 	ClassDB::bind_method(D_METHOD("get_openxr_api"), &OpenXRExtensionWrapperExtension::get_openxr_api);


### PR DESCRIPTION
As they are called with no arguments I assume the binds were invalid, likely copy-paste error

* Fixes: https://github.com/godotengine/godot/issues/90390
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
