### PR TITLE
Use `likely()` in `PtrToArg<T *>` when checking for null `Object *`s

### DIFF
--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -159,10 +159,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <typename T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		if (p_ptr == nullptr) {
-			return nullptr;
-		}
-		return const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr));
+		return likely(p_ptr) ? const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr)) : nullptr;
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -173,10 +170,7 @@ struct PtrToArg<T *> {
 template <typename T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		if (p_ptr == nullptr) {
-			return nullptr;
-		}
-		return *reinterpret_cast<T *const *>(p_ptr);
+		return likely(p_ptr) ? *reinterpret_cast<T *const *>(p_ptr) : nullptr;
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {


### PR DESCRIPTION
In https://github.com/godotengine/godot-cpp/pull/1405, @reduz requested that `likely()` be added to `PtrToArg<T *>` when checking for null `Object *`s in godot-cpp.

This is doing the same thing for the equivalent code in Godot, so that we are consistent between Godot and godot-cpp.

I also switched to using a ternary to match the godot-cpp code. I'd be fine going the other way and switching godot-cpp to use an `if`-statement, but however we do it, it'd be nice to be somewhat consistent. (Unfortunately, the casts can't be made consistent due to other differences.)
