### PR TITLE
Fix `RenderingServer.instance_set_transform` docs saying it's not global

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1932,7 +1932,7 @@
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
 			<description>
-				Sets the world space transform of the instance. Equivalent to [member Node3D.transform].
+				Sets the world space transform of the instance. Equivalent to [member Node3D.global_transform].
 			</description>
 		</method>
 		<method name="instance_set_visibility_parent">


### PR DESCRIPTION
It's equivalent to `Node3D.global_transform`, not `Node3D.transform`.

https://github.com/godotengine/godot/blob/dc91479082bd9cd56cd74282573492fe1ba9618a/scene/3d/visual_instance_3d.cpp#L58-L61