### PR TITLE
Add tests for signal await with parameters

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/await_signal_with_parameters.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/await_signal_with_parameters.gd
@@ -1,0 +1,25 @@
+signal no_parameters()
+signal one_parameter(number)
+signal two_parameters(number1, number2)
+
+func await_no_parameters():
+	var result = await no_parameters
+	print(result)
+
+func await_one_parameter():
+	var result = await one_parameter
+	print(result)
+
+func await_two_parameters():
+	var result = await two_parameters
+	print(result)
+
+func test():
+	await_no_parameters()
+	no_parameters.emit()
+
+	await_one_parameter()
+	one_parameter.emit(1)
+
+	await_two_parameters()
+	two_parameters.emit(1, 2)

--- a/modules/gdscript/tests/scripts/runtime/features/await_signal_with_parameters.out
+++ b/modules/gdscript/tests/scripts/runtime/features/await_signal_with_parameters.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+<null>
+1
+[1, 2]


### PR DESCRIPTION
You can await a signal and assign the result to a variable. It will be null, Variant or Array, depending on emitted signal parameters.

This feature doesn't seem documented anywhere and it's generally not very known, so this PR adds some tests so it's not lost at least.