### PR TITLE
Fix `ZIPReader.get_files()` error on empty zip files

### DIFF
--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -58,7 +58,14 @@ Error ZIPReader::close() {
 PackedStringArray ZIPReader::get_files() {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedStringArray(), "ZIPReader must be opened before use.");
 
-	int err = unzGoToFirstFile(uzf);
+	unz_global_info gi;
+	int err = unzGetGlobalInfo(uzf, &gi);
+	ERR_FAIL_COND_V(err != UNZ_OK, PackedStringArray());
+	if (gi.number_entry == 0) {
+		return PackedStringArray();
+	}
+
+	err = unzGoToFirstFile(uzf);
 	ERR_FAIL_COND_V(err != UNZ_OK, PackedStringArray());
 
 	List<String> s;


### PR DESCRIPTION
Added check for empty zip file before trying to look at first file

Fixes #90388

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
