### PR TITLE
Fix OpenGL convert linear to srgb with additive lighting

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1761,20 +1761,6 @@ void main() {
 #endif // !DISABLE_FOG
 #endif // !FOG_DISABLED
 
-	// Tonemap before writing as we are writing to an sRGB framebuffer
-	frag_color.rgb *= exposure;
-#ifdef APPLY_TONEMAPPING
-	frag_color.rgb = apply_tonemapping(frag_color.rgb, white);
-#endif
-	frag_color.rgb = linear_to_srgb(frag_color.rgb);
-
-#ifdef USE_BCS
-	frag_color.rgb = apply_bcs(frag_color.rgb, bcs);
-#endif
-
-#ifdef USE_COLOR_CORRECTION
-	frag_color.rgb = apply_color_correction(frag_color.rgb, color_correction);
-#endif
 #else // !BASE_PASS
 	frag_color = vec4(0.0, 0.0, 0.0, alpha);
 #endif // !BASE_PASS
@@ -1979,26 +1965,27 @@ void main() {
 #endif // !DISABLE_FOG
 #endif // !FOG_DISABLED
 
-	// Tonemap before writing as we are writing to an sRGB framebuffer
-	additive_light_color *= exposure;
-#ifdef APPLY_TONEMAPPING
-	additive_light_color = apply_tonemapping(additive_light_color, white);
-#endif
-	additive_light_color = linear_to_srgb(additive_light_color);
-
-#ifdef USE_BCS
-	additive_light_color = apply_bcs(additive_light_color, bcs);
-#endif
-
-#ifdef USE_COLOR_CORRECTION
-	additive_light_color = apply_color_correction(additive_light_color, color_correction);
-#endif
-
 	frag_color.rgb += additive_light_color;
 #endif // USE_ADDITIVE_LIGHTING
 
 	frag_color.rgb *= scene_data.luminance_multiplier;
 
 #endif // !RENDER_MATERIAL
+
+	frag_color.rgb *= exposure;
+
+    // Tonemap before writing as we are writing to an sRGB framebuffer
+#ifdef APPLY_TONEMAPPING
+	frag_color.rgb = apply_tonemapping(frag_color.rgb, white);
+#endif
+	frag_color.rgb = linear_to_srgb(frag_color.rgb);
+
+#ifdef USE_BCS
+	frag_color.rgb = apply_bcs(frag_color.rgb, bcs);
+#endif
+
+#ifdef USE_COLOR_CORRECTION
+	frag_color.rgb = apply_color_correction(frag_color.rgb, color_correction);
+#endif
 #endif // !MODE_RENDER_DEPTH
 }


### PR DESCRIPTION
For issue: #90259
With this change, color will more match vulkan with 1 additive lighting active. 
Multiple additive lightings still look brighter cause it use blending func between pass
