### PR TITLE
Add method to check if a physics server is enabled

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -906,13 +906,6 @@
 				Creates a 2D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [code]length[/code] and [code]slide_on_slope[/code] properties.
 			</description>
 		</method>
-		<method name="set_active">
-			<return type="void" />
-			<param index="0" name="active" type="bool" />
-			<description>
-				Activates or deactivates the 2D physics server. If [param active] is [code]false[/code], then the physics server will not do anything in its physics step.
-			</description>
-		</method>
 		<method name="shape_get_data" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
@@ -996,6 +989,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="active" type="bool" setter="set_active" getter="is_active">
+			If [code]true[/code], the server can be accessed and will update on each physics frame.
+		</member>
+	</members>
 	<constants>
 		<constant name="SPACE_PARAM_CONTACT_RECYCLE_RADIUS" value="0" enum="SpaceParameter">
 			Constant to set/get the maximum distance a pair of bodies has to move before their collision status has to be recalculated. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_recycle_radius].

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -812,6 +812,12 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]init[/code] method.
 			</description>
 		</method>
+		<method name="_is_active" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Overridable version of [method PhysicsServer2D.is_active].
+			</description>
+		</method>
 		<method name="_is_flushing_queries" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -987,13 +987,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_active">
-			<return type="void" />
-			<param index="0" name="active" type="bool" />
-			<description>
-				Activates or deactivates the 3D physics engine.
-			</description>
-		</method>
 		<method name="shape_get_data" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
@@ -1364,6 +1357,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="active" type="bool" setter="set_active" getter="is_active">
+			If [code]true[/code], the server can be accessed and will update on each physics frame.
+		</member>
+	</members>
 	<constants>
 		<constant name="JOINT_TYPE_PIN" value="0" enum="JointType">
 			The [Joint3D] is a [PinJoint3D].

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -760,6 +760,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_is_active" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_is_flushing_queries" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -296,6 +296,7 @@ public:
 	virtual void end_sync() override;
 	virtual void finish() override;
 
+	virtual bool is_active() const override { return active; }
 	virtual bool is_flushing_queries() const override { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info) override;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -374,6 +374,7 @@ public:
 	virtual void end_sync() override;
 	virtual void finish() override;
 
+	virtual bool is_active() const override { return active; }
 	virtual bool is_flushing_queries() const override { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info) override;

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -418,11 +418,11 @@ public:
 
 	virtual void flush_queries() override;
 	virtual bool is_flushing_queries() const override;
+	virtual bool is_active() const override { return active; }
 
 	virtual int get_process_info(PhysicsServer3D::ProcessInfo p_process_info) override;
 
 	bool is_on_separate_thread() const { return on_separate_thread; }
-	bool is_active() const { return active; }
 
 	void free_space(JoltSpace3D *p_space);
 	void free_area(JoltArea3D *p_area);

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -340,6 +340,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_end_sync);
 	GDVIRTUAL_BIND(_finish);
 
+	GDVIRTUAL_BIND(_is_active);
 	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
 }

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -445,6 +445,7 @@ public:
 	EXBIND0(end_sync)
 	EXBIND0(finish)
 
+	EXBIND0RC(bool, is_active)
 	EXBIND0RC(bool, is_flushing_queries)
 	EXBIND1R(int, get_process_info, ProcessInfo)
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -420,6 +420,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_end_sync);
 	GDVIRTUAL_BIND(_finish);
 
+	GDVIRTUAL_BIND(_is_active);
 	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
 }

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -533,6 +533,7 @@ public:
 	EXBIND0(end_sync)
 	EXBIND0(finish)
 
+	EXBIND0RC(bool, is_active)
 	EXBIND0RC(bool, is_flushing_queries)
 	EXBIND1R(int, get_process_info, ProcessInfo)
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -791,8 +791,11 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer2D::free);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer2D::set_active);
+	ClassDB::bind_method(D_METHOD("is_active"), &PhysicsServer2D::is_active);
 
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer2D::get_process_info);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "is_active");
 
 	BIND_ENUM_CONSTANT(SPACE_PARAM_CONTACT_RECYCLE_RADIUS);
 	BIND_ENUM_CONSTANT(SPACE_PARAM_CONTACT_MAX_SEPARATION);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -599,6 +599,7 @@ public:
 	virtual void end_sync() = 0;
 	virtual void finish() = 0;
 
+	virtual bool is_active() const = 0;
 	virtual bool is_flushing_queries() const = 0;
 
 	enum ProcessInfo {

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -342,6 +342,7 @@ public:
 		memdelete(space_state_dummy);
 	}
 
+	virtual bool is_active() const override { return false; }
 	virtual bool is_flushing_queries() const override { return false; }
 
 	virtual int get_process_info(ProcessInfo p_info) override { return 0; }

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -313,6 +313,10 @@ public:
 	virtual void flush_queries() override;
 	virtual void finish() override;
 
+	virtual bool is_active() const override {
+		return physics_server_2d->is_active();
+	}
+
 	virtual bool is_flushing_queries() const override {
 		return physics_server_2d->is_flushing_queries();
 	}

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -1032,8 +1032,11 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer3D::set_active);
+	ClassDB::bind_method(D_METHOD("is_active"), &PhysicsServer3D::is_active);
 
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer3D::get_process_info);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "is_active");
 
 	BIND_ENUM_CONSTANT(SHAPE_WORLD_BOUNDARY);
 	BIND_ENUM_CONSTANT(SHAPE_SEPARATION_RAY);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -800,6 +800,7 @@ public:
 	virtual void end_sync() = 0;
 	virtual void finish() = 0;
 
+	virtual bool is_active() const = 0;
 	virtual bool is_flushing_queries() const = 0;
 
 	enum ProcessInfo {

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -428,6 +428,7 @@ public:
 		memdelete(space_state_dummy);
 	}
 
+	virtual bool is_active() const override { return false; }
 	virtual bool is_flushing_queries() const override { return false; }
 
 	virtual int get_process_info(ProcessInfo p_info) override { return 0; }

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -389,6 +389,10 @@ public:
 	virtual void flush_queries() override;
 	virtual void finish() override;
 
+	virtual bool is_active() const override {
+		return physics_server_3d->is_active();
+	}
+
 	virtual bool is_flushing_queries() const override {
 		return physics_server_3d->is_flushing_queries();
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
It doesn't make much sense to be able to manually toggle the physics server, but not be able to check whether or not it's enabled.
My use case is that the game I'm working on has an editor tool which needs to enable the physics server to scan the level's collisions, which I then form a grid out of. The physics server is then disabled when the method finishes execution, but what if it was enabled before? Anything which relies on the physics server having been active is now broken. It'd be better to be able to restore the state rather than always disable it.
A similar case might appear in the future, where I'd only need the server to be active mid-frame when a mouse movement is detected to cast a ray to terrain, and then I can restore the server state once the ray has been cast.
The only caveat is that I think this would break compatibility with third-party physics engines like Jolt. It should only take a few lines to fix, though.