### PR TITLE
Fix `_node_assign` will crash  when `base_node` is nullptr

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2755,7 +2755,8 @@ void EditorPropertyNodePath::_node_assign() {
 	Variant val = get_edited_property_value();
 	Node *n = nullptr;
 	if (val.get_type() == Variant::Type::NODE_PATH) {
-		n = get_base_node()->get_node_or_null(val);
+		Node *base_node = get_base_node();
+		n = base_node == nullptr ? nullptr : base_node->get_node_or_null(val);
 	} else {
 		n = Object::cast_to<Node>(val);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90342

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
