### PR TITLE
[3.x] Tighter shadow culling - fix light colinear to frustum edge

### DIFF
--- a/servers/visual/visual_server_light_culler.cpp
+++ b/servers/visual/visual_server_light_culler.cpp
@@ -376,15 +376,19 @@ bool VisualServerLightCuller::_add_light_camera_planes(const LightSource &p_ligh
 	uint8_t *entry = &data.LUT_entries[lookup][0];
 	int n_edges = data.LUT_entry_sizes[lookup] - 1;
 
+	const Vector3 &pt2 = p_light_source.pos;
+
 	for (int e = 0; e < n_edges; e++) {
 		int i0 = entry[e];
 		int i1 = entry[e + 1];
 		const Vector3 &pt0 = data.frustum_points[i0];
 		const Vector3 &pt1 = data.frustum_points[i1];
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, p_light_source.pos);
-		add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			add_cull_plane(p);
+		}
 	}
 
 	// Last to 0 edge.
@@ -395,9 +399,11 @@ bool VisualServerLightCuller::_add_light_camera_planes(const LightSource &p_ligh
 		const Vector3 &pt0 = data.frustum_points[i0];
 		const Vector3 &pt1 = data.frustum_points[i1];
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, p_light_source.pos);
-		add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			add_cull_plane(p);
+		}
 	}
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING


### PR DESCRIPTION
In rare situations if a light is placed near colinear to a frustum edge, the extra culling plane derived can have an inaccurate normal due to floating point error. This PR detects colinear triangles, and prevents adding a culling plane in this situation.

Fixes #89702 (for 3.x)
3.x version of #89714 

## Notes
* This is exactly the same as the master version which has been tested and merged so should only need a cursory check here.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
