### PR TITLE
Add tooltip for tabs in TabBar and TabContainer

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -111,6 +111,13 @@
 				Returns the title of the tab at index [param tab_idx].
 			</description>
 		</method>
+		<method name="get_tab_tooltip_text" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the tooltip text of the tab at index [param tab_idx].
+			</description>
+		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
@@ -222,6 +229,14 @@
 			<param index="1" name="title" type="String" />
 			<description>
 				Sets a [param title] for the tab at index [param tab_idx].
+			</description>
+		</method>
+		<method name="set_tab_tooltip_text">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="tooltip_text" type="String" />
+			<description>
+				Sets the tooltip text for the tab at index [param tab_idx].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -92,6 +92,13 @@
 				Returns the title of the tab at index [param tab_idx]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
 			</description>
 		</method>
+		<method name="get_tab_tooltip_text" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the tooltip text of the tab at index [param tab_idx].
+			</description>
+		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
@@ -171,6 +178,14 @@
 			<param index="1" name="title" type="String" />
 			<description>
 				Sets a custom title for the tab at index [param tab_idx] (tab titles default to the name of the indexed child node). Set it back to the child's name to make the tab default to it again.
+			</description>
+		</method>
+		<method name="set_tab_tooltip_text">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="tooltip_text" type="String" />
+			<description>
+				Sets the tooltip text for the tab at index [param tab_idx].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -108,6 +108,21 @@ Size2 TabBar::get_minimum_size() const {
 	return ms;
 }
 
+String TabBar::get_tooltip(const Point2 &p_pos) const {
+	for (int i = offset; i <= max_drawn_tab; i++) {
+		if (tabs[i].hidden) {
+			continue;
+		}
+
+		Rect2 rect = get_tab_rect(i);
+		if (rect.has_point(p_pos)) {
+			return tabs[i].tooltip_text;
+		}
+	}
+
+	return Control::get_tooltip(p_pos);
+}
+
 void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -792,6 +807,16 @@ void TabBar::set_tab_language(int p_tab, const String &p_language) {
 String TabBar::get_tab_language(int p_tab) const {
 	ERR_FAIL_INDEX_V(p_tab, tabs.size(), "");
 	return tabs[p_tab].language;
+}
+
+void TabBar::set_tab_tooltip_text(int p_tab, const String &p_tooltip_text) {
+	ERR_FAIL_INDEX(p_tab, tabs.size());
+	tabs.write[p_tab].tooltip_text = p_tooltip_text;
+}
+
+String TabBar::get_tab_tooltip_text(int p_tab) const {
+	ERR_FAIL_INDEX_V(p_tab, tabs.size(), String());
+	return tabs[p_tab].tooltip_text;
 }
 
 void TabBar::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
@@ -1786,6 +1811,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_text_direction", "tab_idx"), &TabBar::get_tab_text_direction);
 	ClassDB::bind_method(D_METHOD("set_tab_language", "tab_idx", "language"), &TabBar::set_tab_language);
 	ClassDB::bind_method(D_METHOD("get_tab_language", "tab_idx"), &TabBar::get_tab_language);
+	ClassDB::bind_method(D_METHOD("set_tab_tooltip_text", "tab_idx", "tooltip_text"), &TabBar::set_tab_tooltip_text);
+	ClassDB::bind_method(D_METHOD("get_tab_tooltip_text", "tab_idx"), &TabBar::get_tab_tooltip_text);
 	ClassDB::bind_method(D_METHOD("set_tab_icon", "tab_idx", "icon"), &TabBar::set_tab_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_icon", "tab_idx"), &TabBar::get_tab_icon);
 	ClassDB::bind_method(D_METHOD("set_tab_icon_max_width", "tab_idx", "width"), &TabBar::set_tab_icon_max_width);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -55,6 +55,7 @@ public:
 private:
 	struct Tab {
 		String text;
+		String tooltip_text;
 
 		String language;
 		Control::TextDirection text_direction = Control::TEXT_DIRECTION_INHERITED;
@@ -190,6 +191,9 @@ public:
 	void set_tab_language(int p_tab, const String &p_language);
 	String get_tab_language(int p_tab) const;
 
+	void set_tab_tooltip_text(int p_tab, const String &p_tooltip_text);
+	String get_tab_tooltip_text(int p_tab) const;
+
 	void set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_tab_icon(int p_tab) const;
 
@@ -265,6 +269,8 @@ public:
 
 	Rect2 get_tab_rect(int p_tab) const;
 	Size2 get_minimum_size() const override;
+
+	String get_tooltip(const Point2 &p_pos) const override;
 
 	TabBar();
 };

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -30,9 +30,6 @@
 
 #include "tab_container.h"
 
-#include "scene/gui/box_container.h"
-#include "scene/gui/label.h"
-#include "scene/gui/texture_rect.h"
 #include "scene/theme/theme_db.h"
 
 int TabContainer::_get_tab_height() const {
@@ -403,6 +400,7 @@ void TabContainer::move_tab_from_tab_container(TabContainer *p_from, int p_from_
 
 	// Get the tab properties before they get erased by the child removal.
 	String tab_title = p_from->get_tab_title(p_from_index);
+	String tab_tooltip_text = p_from->get_tab_tooltip_text(p_from_index);
 	Ref<Texture2D> tab_icon = p_from->get_tab_icon(p_from_index);
 	Ref<Texture2D> tab_button_icon = p_from->get_tab_button_icon(p_from_index);
 	bool tab_disabled = p_from->is_tab_disabled(p_from_index);
@@ -420,6 +418,7 @@ void TabContainer::move_tab_from_tab_container(TabContainer *p_from, int p_from_
 	move_child(moving_tabc, get_tab_control(p_to_index)->get_index(false));
 
 	set_tab_title(p_to_index, tab_title);
+	set_tab_tooltip_text(p_to_index, tab_tooltip_text);
 	set_tab_icon(p_to_index, tab_icon);
 	set_tab_button_icon(p_to_index, tab_button_icon);
 	set_tab_disabled(p_to_index, tab_disabled);
@@ -770,6 +769,14 @@ String TabContainer::get_tab_title(int p_tab) const {
 	return tab_bar->get_tab_title(p_tab);
 }
 
+void TabContainer::set_tab_tooltip_text(int p_tab, const String &p_tooltip_text) {
+	tab_bar->set_tab_tooltip_text(p_tab, p_tooltip_text);
+}
+
+String TabContainer::get_tab_tooltip_text(int p_tab) const {
+	return tab_bar->get_tab_tooltip_text(p_tab);
+}
+
 void TabContainer::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	if (tab_bar->get_tab_icon(p_tab) == p_icon) {
 		return;
@@ -977,6 +984,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_all_tabs_in_front"), &TabContainer::is_all_tabs_in_front);
 	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabContainer::set_tab_title);
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabContainer::get_tab_title);
+	ClassDB::bind_method(D_METHOD("set_tab_tooltip_text", "tab_idx", "tooltip_text"), &TabContainer::set_tab_tooltip_text);
+	ClassDB::bind_method(D_METHOD("get_tab_tooltip_text", "tab_idx"), &TabContainer::get_tab_tooltip_text);
 	ClassDB::bind_method(D_METHOD("set_tab_icon", "tab_idx", "icon"), &TabContainer::set_tab_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_icon", "tab_idx"), &TabContainer::get_tab_icon);
 	ClassDB::bind_method(D_METHOD("set_tab_disabled", "tab_idx", "disabled"), &TabContainer::set_tab_disabled);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -154,6 +154,9 @@ public:
 	void set_tab_title(int p_tab, const String &p_title);
 	String get_tab_title(int p_tab) const;
 
+	void set_tab_tooltip_text(int p_tab, const String &p_tooltip_text);
+	String get_tab_tooltip_text(int p_tab) const;
+
 	void set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_tab_icon(int p_tab) const;
 


### PR DESCRIPTION
![Peek 2024-04-09 16-49](https://github.com/godotengine/godot/assets/372476/b91e0e33-e159-4b68-9476-b06b46b68ac7)
