### PR TITLE
Add `--import` command-line flag

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -304,6 +304,7 @@ public:
 	EditorFileSystemDirectory *get_filesystem();
 	bool is_scanning() const;
 	bool is_importing() const { return importing; }
+	bool doing_first_scan() const { return first_scan; }
 	float get_scanning_progress() const;
 	void scan();
 	void scan_changes();


### PR DESCRIPTION
Closes godotengine/godot-proposals#1362.
Supersedes #68461.

This adds a new command-line option called `--import`, the purpose if which is to launch the editor (headless or not) solely to import any non-imported resources and then quit, meaning it implies `--editor` and `--quit`.

This also changes `--export-release`, `--export-debug` and `--export-pack` to imply `--import`.

This should hopefully remove the need for hacks such as `timeout 25s godot --editor` or `godot --editor --quit-after 1000`.

This is fairly similar to #68461 in that it uses `EditorFileSystem::first_scan` as the condition variable by which to wait for, which seems to more or less guarantee that the scan thread has had time to finish and that any imports have gotten queued up and processed.

This PR differs from #68461 in that it does not imply `--headless`. As talked about in that PR there may still potentially be issues with exporting from headless (although I haven't seen any showstoppers in my limited testing), so I figured it's best to leave that choice up to the user. Any such issues should in my opinion be considered separate anyway, and not block this seemingly straight-forward and useful addition.

(I'll create a corresponding godotengine/godot-docs PR shortly.)