### PR TITLE
WorkerThreadPool: Expose yield functions, add anti-starvation mechanism

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -82,6 +82,17 @@ int Engine::get_audio_output_latency() const {
 	return _audio_output_latency;
 }
 
+void Engine::increment_frames_drawn() {
+	if (frame_server_synced) {
+		server_syncs++;
+	} else {
+		server_syncs = 0;
+	}
+	frame_server_synced = false;
+
+	frames_drawn++;
+}
+
 uint64_t Engine::get_frames_drawn() {
 	return frames_drawn;
 }
@@ -362,6 +373,11 @@ Engine *Engine::singleton = nullptr;
 
 Engine *Engine::get_singleton() {
 	return singleton;
+}
+
+bool Engine::notify_frame_server_synced() {
+	frame_server_synced = true;
+	return server_syncs > SERVER_SYNC_FRAME_COUNT_WARNING;
 }
 
 Engine::Engine() {

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -91,6 +91,10 @@ private:
 	String write_movie_path;
 	String shader_cache_path;
 
+	static constexpr int SERVER_SYNC_FRAME_COUNT_WARNING = 5;
+	int server_syncs = 0;
+	bool frame_server_synced = false;
+
 public:
 	static Engine *get_singleton();
 
@@ -178,6 +182,9 @@ public:
 	bool is_validation_layers_enabled() const;
 	bool is_generate_spirv_debug_info_enabled() const;
 	int32_t get_gpu_index() const;
+
+	void increment_frames_drawn();
+	bool notify_frame_server_synced();
 
 	Engine();
 	virtual ~Engine() {}

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -35,6 +35,8 @@
 #include "core/os/thread_safe.h"
 #include "core/templates/command_queue_mt.h"
 
+WorkerThreadPool::Task *const WorkerThreadPool::ThreadData::YIELDING = (Task *)1;
+
 void WorkerThreadPool::Task::free_template_userdata() {
 	ERR_FAIL_NULL(template_userdata);
 	ERR_FAIL_NULL(native_func_userdata);
@@ -391,70 +393,11 @@ Error WorkerThreadPool::wait_for_task_completion(TaskID p_task_id) {
 	task_mutex.unlock();
 
 	if (caller_pool_thread) {
-		while (true) {
-			Task *task_to_process = nullptr;
-			{
-				MutexLock lock(task_mutex);
-				bool was_signaled = caller_pool_thread->signaled;
-				caller_pool_thread->signaled = false;
-
-				if (task->completed) {
-					// This thread was awaken also for some reason, but it's about to exit.
-					// Let's find out what may be pending and forward the requests.
-					if (!exit_threads && was_signaled) {
-						uint32_t to_process = task_queue.first() ? 1 : 0;
-						uint32_t to_promote = caller_pool_thread->current_task->low_priority && low_priority_task_queue.first() ? 1 : 0;
-						if (to_process || to_promote) {
-							// This thread must be left alone since it won't loop again.
-							caller_pool_thread->signaled = true;
-							_notify_threads(caller_pool_thread, to_process, to_promote);
-						}
-					}
-
-					task->waiting_pool--;
-					if (task->waiting_pool == 0 && task->waiting_user == 0) {
-						tasks.erase(p_task_id);
-						task_allocator.free(task);
-					}
-
-					break;
-				}
-
-				if (!exit_threads) {
-					// This is a thread from the pool. It shouldn't just idle.
-					// Let's try to process other tasks while we wait.
-
-					if (caller_pool_thread->current_task->low_priority && low_priority_task_queue.first()) {
-						if (_try_promote_low_priority_task()) {
-							_notify_threads(caller_pool_thread, 1, 0);
-						}
-					}
-
-					if (singleton->task_queue.first()) {
-						task_to_process = task_queue.first()->self();
-						task_queue.remove(task_queue.first());
-					}
-
-					if (!task_to_process) {
-						caller_pool_thread->awaited_task = task;
-
-						if (flushing_cmd_queue) {
-							flushing_cmd_queue->unlock();
-						}
-						caller_pool_thread->cond_var.wait(lock);
-						if (flushing_cmd_queue) {
-							flushing_cmd_queue->lock();
-						}
-
-						DEV_ASSERT(exit_threads || caller_pool_thread->signaled || task->completed);
-						caller_pool_thread->awaited_task = nullptr;
-					}
-				}
-			}
-
-			if (task_to_process) {
-				_process_task(task_to_process);
-			}
+		_wait_collaboratively(caller_pool_thread, task);
+		task->waiting_pool--;
+		if (task->waiting_pool == 0 && task->waiting_user == 0) {
+			tasks.erase(p_task_id);
+			task_allocator.free(task);
 		}
 	} else {
 		task->done_semaphore.wait();
@@ -468,6 +411,99 @@ Error WorkerThreadPool::wait_for_task_completion(TaskID p_task_id) {
 	}
 
 	return OK;
+}
+
+void WorkerThreadPool::_wait_collaboratively(ThreadData *p_caller_pool_thread, Task *p_task) {
+	// Keep processing tasks until the condition to stop waiting is met.
+
+#define IS_WAIT_OVER (unlikely(p_task == ThreadData::YIELDING) ? p_caller_pool_thread->yield_is_over : p_task->completed)
+
+	while (true) {
+		Task *task_to_process = nullptr;
+		{
+			MutexLock lock(task_mutex);
+			bool was_signaled = p_caller_pool_thread->signaled;
+			p_caller_pool_thread->signaled = false;
+
+			if (IS_WAIT_OVER) {
+				p_caller_pool_thread->yield_is_over = false;
+				if (!exit_threads && was_signaled) {
+					// This thread was awaken for some additional reason, but it's about to exit.
+					// Let's find out what may be pending and forward the requests.
+					uint32_t to_process = task_queue.first() ? 1 : 0;
+					uint32_t to_promote = p_caller_pool_thread->current_task->low_priority && low_priority_task_queue.first() ? 1 : 0;
+					if (to_process || to_promote) {
+						// This thread must be left alone since it won't loop again.
+						p_caller_pool_thread->signaled = true;
+						_notify_threads(p_caller_pool_thread, to_process, to_promote);
+					}
+				}
+
+				break;
+			}
+
+			if (!exit_threads) {
+				if (p_caller_pool_thread->current_task->low_priority && low_priority_task_queue.first()) {
+					if (_try_promote_low_priority_task()) {
+						_notify_threads(p_caller_pool_thread, 1, 0);
+					}
+				}
+
+				if (singleton->task_queue.first()) {
+					task_to_process = task_queue.first()->self();
+					task_queue.remove(task_queue.first());
+				}
+
+				if (!task_to_process) {
+					p_caller_pool_thread->awaited_task = p_task;
+
+					if (flushing_cmd_queue) {
+						flushing_cmd_queue->unlock();
+					}
+					p_caller_pool_thread->cond_var.wait(lock);
+					if (flushing_cmd_queue) {
+						flushing_cmd_queue->lock();
+					}
+
+					DEV_ASSERT(exit_threads || p_caller_pool_thread->signaled || IS_WAIT_OVER);
+					p_caller_pool_thread->awaited_task = nullptr;
+				}
+			}
+		}
+
+		if (task_to_process) {
+			_process_task(task_to_process);
+		}
+	}
+}
+
+void WorkerThreadPool::yield() {
+	int th_index = get_thread_index();
+	ERR_FAIL_COND_MSG(th_index == -1, "This function can only be called from a worker thread.");
+	_wait_collaboratively(&threads[th_index], ThreadData::YIELDING);
+}
+
+void WorkerThreadPool::notify_yield_over(TaskID p_task_id) {
+	task_mutex.lock();
+	Task **taskp = tasks.getptr(p_task_id);
+	if (!taskp) {
+		task_mutex.unlock();
+		ERR_FAIL_MSG("Invalid Task ID.");
+	}
+	Task *task = *taskp;
+
+#ifdef DEBUG_ENABLED
+	if (task->pool_thread_index == get_thread_index()) {
+		WARN_PRINT("A worker thread is attempting to notify itself. That makes no sense.");
+	}
+#endif
+
+	ThreadData &td = threads[task->pool_thread_index];
+	td.yield_is_over = true;
+	td.signaled = true;
+	td.cond_var.notify_one();
+
+	task_mutex.unlock();
 }
 
 WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description) {

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -60,11 +60,13 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 		// its pre-created threads can't have ScriptServer::thread_enter() called on them early.
 		// Therefore, we do it late at the first opportunity, so in case the task
 		// about to be run uses scripting, guarantees are held.
+		task_mutex.lock();
 		if (!curr_thread.ready_for_scripting && ScriptServer::are_languages_initialized()) {
+			task_mutex.unlock();
 			ScriptServer::thread_enter();
+			task_mutex.lock();
 			curr_thread.ready_for_scripting = true;
 		}
-		task_mutex.lock();
 		p_task->pool_thread_index = pool_thread_index;
 		prev_task = curr_thread.current_task;
 		curr_thread.current_task = p_task;

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -107,13 +107,21 @@ private:
 	BinaryMutex task_mutex;
 
 	struct ThreadData {
+		static Task *const YIELDING; // Too bad constexpr doesn't work here.
+
 		uint32_t index = 0;
 		Thread thread;
-		bool ready_for_scripting = false;
-		bool signaled = false;
+		bool ready_for_scripting : 1;
+		bool signaled : 1;
+		bool yield_is_over : 1;
 		Task *current_task = nullptr;
-		Task *awaited_task = nullptr; // Null if not awaiting the condition variable. Special value for idle-waiting.
+		Task *awaited_task = nullptr; // Null if not awaiting the condition variable, or special value (YIELDING).
 		ConditionVariable cond_var;
+
+		ThreadData() :
+				ready_for_scripting(false),
+				signaled(false),
+				yield_is_over(false) {}
 	};
 
 	TightLocalVector<ThreadData> threads;
@@ -177,6 +185,8 @@ private:
 		}
 	};
 
+	void _wait_collaboratively(ThreadData *p_caller_pool_thread, Task *p_task);
+
 protected:
 	static void _bind_methods();
 
@@ -195,6 +205,9 @@ public:
 
 	bool is_task_completed(TaskID p_task_id) const;
 	Error wait_for_task_completion(TaskID p_task_id);
+
+	void yield();
+	void notify_yield_over(TaskID p_task_id);
 
 	template <typename C, typename M, typename U>
 	GroupID add_template_group_task(C *p_instance, M p_method, U p_userdata, int p_elements, int p_tasks = -1, bool p_high_priority = false, const String &p_description = String()) {

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -53,6 +53,12 @@ public:
 	typedef int64_t TaskID;
 	typedef int64_t GroupID;
 
+	enum TaskFlags {
+		TASK_FLAGS_NONE = 0,
+		TASK_FLAG_HIGH_PRIORITY = (1 << 0),
+		TASK_FLAG_DAEMON = (1 << 1),
+	};
+
 private:
 	struct Task;
 
@@ -86,13 +92,16 @@ private:
 		SelfList<Task> task_elem;
 		uint32_t waiting_pool = 0;
 		uint32_t waiting_user = 0;
-		bool low_priority = false;
+		bool low_priority : 1;
+		bool daemon : 1;
 		BaseTemplateUserdata *template_userdata = nullptr;
 		int pool_thread_index = -1;
 
 		void free_template_userdata();
 		Task() :
-				task_elem(this) {}
+				task_elem(this),
+				low_priority(false),
+				daemon(false) {}
 	};
 
 	static const uint32_t TASKS_PAGE_SIZE = 1024;
@@ -153,7 +162,7 @@ private:
 
 	void _process_task(Task *task);
 
-	void _post_tasks_and_unlock(Task **p_tasks, uint32_t p_count, bool p_high_priority);
+	void _post_tasks_and_unlock(Task **p_tasks, uint32_t p_count, BitField<TaskFlags> p_flags);
 	void _notify_threads(const ThreadData *p_current_thread_data, uint32_t p_process_count, uint32_t p_promote_count);
 
 	bool _try_promote_low_priority_task();
@@ -162,7 +171,7 @@ private:
 
 	static thread_local CommandQueueMT *flushing_cmd_queue;
 
-	TaskID _add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description);
+	TaskID _add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, BitField<TaskFlags> p_flags, const String &p_description);
 	GroupID _add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description);
 
 	template <typename C, typename M, typename U>
@@ -198,10 +207,11 @@ public:
 		ud->instance = p_instance;
 		ud->method = p_method;
 		ud->userdata = p_userdata;
-		return _add_task(Callable(), nullptr, nullptr, ud, p_high_priority, p_description);
+		return _add_task(Callable(), nullptr, nullptr, ud, p_high_priority ? TASK_FLAG_HIGH_PRIORITY : TASK_FLAGS_NONE, p_description);
 	}
 	TaskID add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority = false, const String &p_description = String());
 	TaskID add_task(const Callable &p_action, bool p_high_priority = false, const String &p_description = String());
+	TaskID add_task_with_flags(const Callable &p_action, BitField<TaskFlags> p_flags = TASK_FLAGS_NONE, const String &p_description = String());
 
 	bool is_task_completed(TaskID p_task_id) const;
 	Error wait_for_task_completion(TaskID p_task_id);
@@ -237,5 +247,7 @@ public:
 	WorkerThreadPool();
 	~WorkerThreadPool();
 };
+
+VARIANT_BITFIELD_CAST(WorkerThreadPool::TaskFlags);
 
 #endif // WORKER_THREAD_POOL_H

--- a/core/templates/command_queue_mt.cpp
+++ b/core/templates/command_queue_mt.cpp
@@ -70,14 +70,8 @@ CommandQueueMT::SyncSemaphore *CommandQueueMT::_alloc_sync_sem() {
 	return &sync_sems[idx];
 }
 
-CommandQueueMT::CommandQueueMT(bool p_sync) {
-	if (p_sync) {
-		sync = memnew(Semaphore);
-	}
+CommandQueueMT::CommandQueueMT() {
 }
 
 CommandQueueMT::~CommandQueueMT() {
-	if (sync) {
-		memdelete(sync);
-	}
 }

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -248,16 +248,17 @@
 #define CMD_TYPE(N) Command##N<T, M COMMA(N) COMMA_SEP_LIST(TYPE_ARG, N)>
 #define CMD_ASSIGN_PARAM(N) cmd->p##N = p##N
 
-#define DECL_PUSH(N)                                                         \
-	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
-	void push(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) { \
-		CMD_TYPE(N) *cmd = allocate_and_lock<CMD_TYPE(N)>();                 \
-		cmd->instance = p_instance;                                          \
-		cmd->method = p_method;                                              \
-		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                 \
-		unlock();                                                            \
-		if (sync)                                                            \
-			sync->post();                                                    \
+#define DECL_PUSH(N)                                                            \
+	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>    \
+	void push(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) {    \
+		CMD_TYPE(N) *cmd = allocate_and_lock<CMD_TYPE(N)>();                    \
+		cmd->instance = p_instance;                                             \
+		cmd->method = p_method;                                                 \
+		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                    \
+		unlock();                                                               \
+		if (pump_task_id != WorkerThreadPool::INVALID_TASK_ID) {                \
+			WorkerThreadPool::get_singleton()->notify_yield_over(pump_task_id); \
+		}                                                                       \
 	}
 
 #define CMD_RET_TYPE(N) CommandRet##N<T, M, COMMA_SEP_LIST(TYPE_ARG, N) COMMA(N) R>
@@ -273,8 +274,9 @@
 		cmd->ret = r_ret;                                                                      \
 		cmd->sync_sem = ss;                                                                    \
 		unlock();                                                                              \
-		if (sync)                                                                              \
-			sync->post();                                                                      \
+		if (pump_task_id != WorkerThreadPool::INVALID_TASK_ID) {                               \
+			WorkerThreadPool::get_singleton()->notify_yield_over(pump_task_id);                \
+		}                                                                                      \
 		ss->sem.wait();                                                                        \
 		ss->in_use = false;                                                                    \
 	}
@@ -291,8 +293,9 @@
 		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                          \
 		cmd->sync_sem = ss;                                                           \
 		unlock();                                                                     \
-		if (sync)                                                                     \
-			sync->post();                                                             \
+		if (pump_task_id != WorkerThreadPool::INVALID_TASK_ID) {                      \
+			WorkerThreadPool::get_singleton()->notify_yield_over(pump_task_id);       \
+		}                                                                             \
 		ss->sem.wait();                                                               \
 		ss->in_use = false;                                                           \
 	}
@@ -340,7 +343,7 @@ class CommandQueueMT {
 	LocalVector<uint8_t> command_mem;
 	SyncSemaphore sync_sems[SYNC_SEMAPHORES];
 	Mutex mutex;
-	Semaphore *sync = nullptr;
+	WorkerThreadPool::TaskID pump_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	uint64_t flush_read_ptr = 0;
 
 	template <typename T>
@@ -421,12 +424,16 @@ public:
 	}
 
 	void wait_and_flush() {
-		ERR_FAIL_NULL(sync);
-		sync->wait();
+		ERR_FAIL_COND(pump_task_id == WorkerThreadPool::INVALID_TASK_ID);
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(pump_task_id);
 		_flush();
 	}
 
-	CommandQueueMT(bool p_sync);
+	void set_pump_task_id(WorkerThreadPool::TaskID p_task_id) {
+		pump_task_id = p_task_id;
+	}
+
+	CommandQueueMT();
 	~CommandQueueMT();
 };
 

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -260,21 +260,6 @@ void EGLManager::release_current() {
 	eglMakeCurrent(current_display.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
-void EGLManager::make_current() {
-	if (!current_window) {
-		return;
-	}
-
-	if (!current_window->initialized) {
-		WARN_PRINT("Current OpenGL window is uninitialized!");
-		return;
-	}
-
-	GLDisplay &current_display = displays[current_window->gldisplay_id];
-
-	eglMakeCurrent(current_display.egl_display, current_window->egl_surface, current_window->egl_surface, current_display.egl_context);
-}
-
 void EGLManager::swap_buffers() {
 	if (!current_window) {
 		return;

--- a/drivers/egl/egl_manager.h
+++ b/drivers/egl/egl_manager.h
@@ -98,7 +98,6 @@ public:
 	void window_destroy(DisplayServer::WindowID p_window_id);
 
 	void release_current();
-	void make_current();
 	void swap_buffers();
 
 	void window_make_current(DisplayServer::WindowID p_window_id);

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -135,7 +135,6 @@ bool ParticlesStorage::particles_get_emitting(RID p_particles) {
 		return false;
 	}
 
-	ERR_FAIL_COND_V_MSG(RSG::threaded, false, "This function should never be used with threaded rendering, as it stalls the renderer.");
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 
@@ -380,10 +379,6 @@ void ParticlesStorage::particles_request_process(RID p_particles) {
 }
 
 AABB ParticlesStorage::particles_get_current_aabb(RID p_particles) {
-	if (RSG::threaded) {
-		WARN_PRINT_ONCE("Calling this function with threaded rendering enabled stalls the renderer, use with care.");
-	}
-
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, AABB());
 
@@ -1207,7 +1202,6 @@ Dependency *ParticlesStorage::particles_get_dependency(RID p_particles) const {
 }
 
 bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
-	ERR_FAIL_COND_V_MSG(RSG::threaded, false, "This function should never be used with threaded rendering, as it stalls the renderer.");
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 	return !particles->emitting && particles->inactive;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2266,6 +2266,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// Editor and project manager cannot run with rendering in a separate thread (they will crash on startup).
 			rtm = OS::RENDER_THREAD_SAFE;
 		}
+#if !defined(THREADS_ENABLED)
+		rtm = OS::RENDER_THREAD_SAFE;
+#endif
 		OS::get_singleton()->_render_thread_mode = OS::RenderThreadMode(rtm);
 	}
 
@@ -2709,7 +2712,9 @@ Error Main::setup2() {
 	}
 
 	if (OS::get_singleton()->_render_thread_mode == OS::RENDER_SEPARATE_THREAD) {
-		WARN_PRINT("The Multi-Threaded rendering thread model is experimental, and has known issues which can lead to project crashes. Use the Single-Safe option in the project settings instead.");
+		WARN_PRINT("The Multi-Threaded rendering thread model is experimental. Feel free to try it since it will eventually become a stable feature.\n"
+				   "However, bear in mind that at the moment it can lead to project crashes or instability.\n"
+				   "So, unless you want to test the engine, use the Single-Safe option in the project settings instead.");
 	}
 
 	/* Initialize Pen Tablet Driver */
@@ -4017,11 +4022,11 @@ bool Main::iteration() {
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (RenderingServer::get_singleton()->has_changed()) {
 				RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands
-				Engine::get_singleton()->frames_drawn++;
+				Engine::get_singleton()->increment_frames_drawn();
 			}
 		} else {
 			RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands
-			Engine::get_singleton()->frames_drawn++;
+			Engine::get_singleton()->increment_frames_drawn();
 			force_redraw_requested = false;
 		}
 	}

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1174,14 +1174,6 @@ void DisplayServerWayland::release_rendering_thread() {
 #endif
 }
 
-void DisplayServerWayland::make_rendering_thread() {
-#ifdef GLES3_ENABLED
-	if (egl_manager) {
-		egl_manager->make_current();
-	}
-#endif
-}
-
 void DisplayServerWayland::swap_buffers() {
 #ifdef GLES3_ENABLED
 	if (egl_manager) {

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -276,7 +276,6 @@ public:
 	virtual void process_events() override;
 
 	virtual void release_rendering_thread() override;
-	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;
 
 	virtual void set_context(Context p_context) override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4268,7 +4268,7 @@ bool DisplayServerX11::_window_focus_check() {
 }
 
 void DisplayServerX11::process_events() {
-	_THREAD_SAFE_METHOD_
+	_THREAD_SAFE_LOCK_
 
 #ifdef DISPLAY_SERVER_X11_DEBUG_LOGS_ENABLED
 	static int frame = 0;
@@ -5097,6 +5097,8 @@ void DisplayServerX11::process_events() {
 		*/
 	}
 
+	_THREAD_SAFE_UNLOCK_
+
 	Input::get_singleton()->flush_buffered_events();
 }
 
@@ -5107,17 +5109,6 @@ void DisplayServerX11::release_rendering_thread() {
 	}
 	if (gl_manager_egl) {
 		gl_manager_egl->release_current();
-	}
-#endif
-}
-
-void DisplayServerX11::make_rendering_thread() {
-#if defined(GLES3_ENABLED)
-	if (gl_manager) {
-		gl_manager->make_current();
-	}
-	if (gl_manager_egl) {
-		gl_manager_egl->make_current();
 	}
 #endif
 }

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -526,7 +526,6 @@ public:
 	virtual void process_events() override;
 
 	virtual void release_rendering_thread() override;
-	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;
 
 	virtual void set_context(Context p_context) override;

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -311,20 +311,6 @@ void GLManager_X11::window_make_current(DisplayServer::WindowID p_window_id) {
 	_internal_set_current_window(&win);
 }
 
-void GLManager_X11::make_current() {
-	if (!_current_window) {
-		return;
-	}
-	if (!_current_window->in_use) {
-		WARN_PRINT("current window not in use!");
-		return;
-	}
-	const GLDisplay &disp = get_current_display();
-	if (!glXMakeCurrent(_x_windisp.x11_display, _x_windisp.x11_window, disp.context->glx_context)) {
-		ERR_PRINT("glXMakeCurrent failed");
-	}
-}
-
 void GLManager_X11::swap_buffers() {
 	if (!_current_window) {
 		return;

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -117,7 +117,6 @@ public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 
 	void release_current();
-	void make_current();
 	void swap_buffers();
 
 	void window_make_current(DisplayServer::WindowID p_window_id);

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -426,7 +426,6 @@ public:
 	virtual void force_process_and_drop_events() override;
 
 	virtual void release_rendering_thread() override;
-	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;
 
 	virtual void set_native_icon(const String &p_filename) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -358,7 +358,6 @@ void DisplayServerMacOS::_dispatch_input_events(const Ref<InputEvent> &p_event) 
 }
 
 void DisplayServerMacOS::_dispatch_input_event(const Ref<InputEvent> &p_event) {
-	_THREAD_SAFE_METHOD_
 	if (!in_dispatch_input_event) {
 		in_dispatch_input_event = true;
 
@@ -2986,7 +2985,7 @@ Key DisplayServerMacOS::keyboard_get_label_from_physical(Key p_keycode) const {
 }
 
 void DisplayServerMacOS::process_events() {
-	_THREAD_SAFE_METHOD_
+	_THREAD_SAFE_LOCK_
 
 	while (true) {
 		NSEvent *event = [NSApp
@@ -3019,7 +3018,9 @@ void DisplayServerMacOS::process_events() {
 
 	if (!drop_events) {
 		_process_key_events();
+		_THREAD_SAFE_UNLOCK_
 		Input::get_singleton()->flush_buffered_events();
+		_THREAD_SAFE_LOCK_
 	}
 
 	for (KeyValue<WindowID, WindowData> &E : windows) {
@@ -3056,9 +3057,14 @@ void DisplayServerMacOS::force_process_and_drop_events() {
 }
 
 void DisplayServerMacOS::release_rendering_thread() {
-}
-
-void DisplayServerMacOS::make_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->release_current();
+	}
+	if (gl_manager_legacy) {
+		gl_manager_legacy->release_current();
+	}
+#endif
 }
 
 void DisplayServerMacOS::swap_buffers() {

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -73,7 +73,6 @@ public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 
 	void release_current();
-	void make_current();
 	void swap_buffers();
 
 	void window_make_current(DisplayServer::WindowID p_window_id);

--- a/platform/macos/gl_manager_macos_legacy.mm
+++ b/platform/macos/gl_manager_macos_legacy.mm
@@ -117,6 +117,7 @@ void GLManagerLegacy_MacOS::release_current() {
 	}
 
 	[NSOpenGLContext clearCurrentContext];
+	current_window = DisplayServer::INVALID_WINDOW_ID;
 }
 
 void GLManagerLegacy_MacOS::window_make_current(DisplayServer::WindowID p_window_id) {
@@ -131,18 +132,6 @@ void GLManagerLegacy_MacOS::window_make_current(DisplayServer::WindowID p_window
 	[win.context makeCurrentContext];
 
 	current_window = p_window_id;
-}
-
-void GLManagerLegacy_MacOS::make_current() {
-	if (current_window == DisplayServer::INVALID_WINDOW_ID) {
-		return;
-	}
-	if (!windows.has(current_window)) {
-		return;
-	}
-
-	GLWindow &win = windows[current_window];
-	[win.context makeCurrentContext];
 }
 
 void GLManagerLegacy_MacOS::swap_buffers() {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2951,7 +2951,7 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 }
 
 void DisplayServerWindows::process_events() {
-	_THREAD_SAFE_METHOD_
+	_THREAD_SAFE_LOCK_
 
 	MSG msg;
 
@@ -2966,7 +2966,10 @@ void DisplayServerWindows::process_events() {
 
 	if (!drop_events) {
 		_process_key_events();
+		_THREAD_SAFE_UNLOCK_
 		Input::get_singleton()->flush_buffered_events();
+	} else {
+		_THREAD_SAFE_UNLOCK_
 	}
 }
 
@@ -2979,9 +2982,14 @@ void DisplayServerWindows::force_process_and_drop_events() {
 }
 
 void DisplayServerWindows::release_rendering_thread() {
-}
-
-void DisplayServerWindows::make_rendering_thread() {
+#if defined(GLES3_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->release_current();
+	}
+	if (gl_manager_native) {
+		gl_manager_native->release_current();
+	}
+#endif
 }
 
 void DisplayServerWindows::swap_buffers() {
@@ -3422,7 +3430,6 @@ void DisplayServerWindows::_dispatch_input_events(const Ref<InputEvent> &p_event
 }
 
 void DisplayServerWindows::_dispatch_input_event(const Ref<InputEvent> &p_event) {
-	_THREAD_SAFE_METHOD_
 	if (in_dispatch_input_event) {
 		return;
 	}

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -679,7 +679,6 @@ public:
 	virtual void force_process_and_drop_events() override;
 
 	virtual void release_rendering_thread() override;
-	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;
 
 	virtual void set_native_icon(const String &p_filename) override;

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -68,9 +68,6 @@ private:
 
 	PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = nullptr;
 
-	// funcs
-	void _internal_set_current_window(GLWindow *p_win);
-
 	GLWindow &get_window(unsigned int id) { return _windows[id]; }
 	const GLWindow &get_window(unsigned int id) const { return _windows[id]; }
 
@@ -91,7 +88,6 @@ public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
 
 	void release_current();
-	void make_current();
 	void swap_buffers();
 
 	void window_make_current(DisplayServer::WindowID p_window_id);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1579,6 +1579,7 @@ bool Window::_can_consume_input_events() const {
 }
 
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
+	ERR_MAIN_THREAD_GUARD;
 	if (EngineDebugger::is_active()) {
 		// Quit from game window using the stop shortcut (F8 by default).
 		// The custom shortcut is provided via environment variable when running from the editor.

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -697,10 +697,6 @@ void DisplayServer::release_rendering_thread() {
 	WARN_PRINT("Rendering thread not supported by this display server.");
 }
 
-void DisplayServer::make_rendering_thread() {
-	WARN_PRINT("Rendering thread not supported by this display server.");
-}
-
 void DisplayServer::swap_buffers() {
 	WARN_PRINT("Swap buffers not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -559,7 +559,6 @@ public:
 	virtual void force_process_and_drop_events();
 
 	virtual void release_rendering_thread();
-	virtual void make_rendering_thread();
 	virtual void swap_buffers();
 
 	virtual void set_native_icon(const String &p_filename);

--- a/servers/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_server_2d_wrap_mt.cpp
@@ -96,7 +96,6 @@ void PhysicsServer2DWrapMT::end_sync() {
 
 void PhysicsServer2DWrapMT::init() {
 	if (create_thread) {
-		//OS::get_singleton()->release_rendering_thread();
 		thread.start(_thread_callback, this);
 		while (!step_thread_up.is_set()) {
 			OS::get_singleton()->delay_usec(1000);

--- a/servers/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_server_2d_wrap_mt.cpp
@@ -33,7 +33,7 @@
 #include "core/os/os.h"
 
 void PhysicsServer2DWrapMT::thread_exit() {
-	exit.set();
+	exit = true;
 }
 
 void PhysicsServer2DWrapMT::thread_step(real_t p_delta) {
@@ -41,25 +41,18 @@ void PhysicsServer2DWrapMT::thread_step(real_t p_delta) {
 	step_sem.post();
 }
 
-void PhysicsServer2DWrapMT::_thread_callback(void *_instance) {
-	PhysicsServer2DWrapMT *vsmt = reinterpret_cast<PhysicsServer2DWrapMT *>(_instance);
-
-	vsmt->thread_loop();
-}
-
 void PhysicsServer2DWrapMT::thread_loop() {
 	server_thread = Thread::get_caller_id();
 
 	physics_server_2d->init();
 
-	exit.clear();
-	step_thread_up.set();
-	while (!exit.is_set()) {
-		// flush commands one by one, until exit is requested
-		command_queue.wait_and_flush();
+	command_queue.set_pump_task_id(server_task_id);
+	while (!exit) {
+		WorkerThreadPool::get_singleton()->yield();
+		command_queue.flush_all();
 	}
 
-	command_queue.flush_all(); // flush all
+	command_queue.flush_all();
 
 	physics_server_2d->finish();
 }
@@ -70,18 +63,14 @@ void PhysicsServer2DWrapMT::step(real_t p_step) {
 	if (create_thread) {
 		command_queue.push(this, &PhysicsServer2DWrapMT::thread_step, p_step);
 	} else {
-		command_queue.flush_all(); //flush all pending from other threads
+		command_queue.flush_all(); // Flush all pending from other threads.
 		physics_server_2d->step(p_step);
 	}
 }
 
 void PhysicsServer2DWrapMT::sync() {
 	if (create_thread) {
-		if (first_frame) {
-			first_frame = false;
-		} else {
-			step_sem.wait(); //must not wait if a step was not issued
-		}
+		step_sem.wait();
 	}
 	physics_server_2d->sync();
 }
@@ -96,39 +85,34 @@ void PhysicsServer2DWrapMT::end_sync() {
 
 void PhysicsServer2DWrapMT::init() {
 	if (create_thread) {
-		thread.start(_thread_callback, this);
-		while (!step_thread_up.is_set()) {
-			OS::get_singleton()->delay_usec(1000);
-		}
+		exit = false;
+		server_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &PhysicsServer2DWrapMT::thread_loop), true);
+		step_sem.post();
 	} else {
 		physics_server_2d->init();
 	}
 }
 
 void PhysicsServer2DWrapMT::finish() {
-	if (thread.is_started()) {
+	if (create_thread) {
 		command_queue.push(this, &PhysicsServer2DWrapMT::thread_exit);
-		thread.wait_to_finish();
+		if (server_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(server_task_id);
+			server_task_id = WorkerThreadPool::INVALID_TASK_ID;
+		}
 	} else {
 		physics_server_2d->finish();
 	}
 }
 
-PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread) :
-		command_queue(p_create_thread) {
+PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread) {
 	physics_server_2d = p_contained;
 	create_thread = p_create_thread;
-
-	if (!p_create_thread) {
-		server_thread = Thread::get_caller_id();
-	} else {
-		server_thread = 0;
+	if (!create_thread) {
+		server_thread = Thread::MAIN_ID;
 	}
-
-	main_thread = Thread::get_caller_id();
 }
 
 PhysicsServer2DWrapMT::~PhysicsServer2DWrapMT() {
 	memdelete(physics_server_2d);
-	//finish();
 }

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -32,6 +32,7 @@
 #define PHYSICS_SERVER_2D_WRAP_MT_H
 
 #include "core/config/project_settings.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
 #include "core/templates/safe_refcount.h"
@@ -43,29 +44,26 @@
 #define SYNC_DEBUG
 #endif
 
+#ifdef DEBUG_ENABLED
+#define MAIN_THREAD_SYNC_WARN WARN_PRINT("Call to " + String(__FUNCTION__) + " causing PhysicsServer2D synchronizations on every frame. This significantly affects performance.");
+#endif
+
 class PhysicsServer2DWrapMT : public PhysicsServer2D {
-	mutable PhysicsServer2D *physics_server_2d;
+	mutable PhysicsServer2D *physics_server_2d = nullptr;
 
 	mutable CommandQueueMT command_queue;
 
-	static void _thread_callback(void *_instance);
 	void thread_loop();
 
-	Thread::ID server_thread;
-	Thread::ID main_thread;
-	SafeFlag exit;
-	Thread thread;
-	SafeFlag step_thread_up;
+	Thread::ID server_thread = Thread::UNASSIGNED_ID;
+	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	bool exit = false;
+	Semaphore step_sem;
 	bool create_thread = false;
 
-	Semaphore step_sem;
 	void thread_step(real_t p_delta);
 
 	void thread_exit();
-
-	bool first_frame = true;
-
-	Mutex alloc_mutex;
 
 public:
 #define ServerName PhysicsServer2D
@@ -94,7 +92,7 @@ public:
 
 	//these work well, but should be used from the main thread only
 	bool shape_collide(RID p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, RID p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, Vector2 *r_results, int p_result_max, int &r_result_count) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 		return physics_server_2d->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
 	}
 
@@ -109,18 +107,18 @@ public:
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState2D *space_get_direct_state(RID p_space) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
 		return physics_server_2d->space_get_direct_state(p_space);
 	}
 
 	FUNC2(space_set_debug_contacts, RID, int);
 	virtual Vector<Vector2> space_get_contacts(RID p_space) const override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), Vector<Vector2>());
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), Vector<Vector2>());
 		return physics_server_2d->space_get_contacts(p_space);
 	}
 
 	virtual int space_get_contact_count(RID p_space) const override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), 0);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), 0);
 		return physics_server_2d->space_get_contact_count(p_space);
 	}
 
@@ -261,13 +259,13 @@ public:
 	FUNC2(body_set_pickable, RID, bool);
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 		return physics_server_2d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
 		return physics_server_2d->body_get_direct_state(p_body);
 	}
 
@@ -337,5 +335,9 @@ public:
 #undef DEBUG_SYNC
 #endif
 #undef SYNC_DEBUG
+
+#ifdef DEBUG_ENABLED
+#undef MAIN_THREAD_SYNC_WARN
+#endif
 
 #endif // PHYSICS_SERVER_2D_WRAP_MT_H

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -96,7 +96,6 @@ void PhysicsServer3DWrapMT::end_sync() {
 
 void PhysicsServer3DWrapMT::init() {
 	if (create_thread) {
-		//OS::get_singleton()->release_rendering_thread();
 		thread.start(_thread_callback, this);
 		while (!step_thread_up) {
 			OS::get_singleton()->delay_usec(1000);

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -41,22 +41,15 @@ void PhysicsServer3DWrapMT::thread_step(real_t p_delta) {
 	step_sem.post();
 }
 
-void PhysicsServer3DWrapMT::_thread_callback(void *_instance) {
-	PhysicsServer3DWrapMT *vsmt = reinterpret_cast<PhysicsServer3DWrapMT *>(_instance);
-
-	vsmt->thread_loop();
-}
-
 void PhysicsServer3DWrapMT::thread_loop() {
 	server_thread = Thread::get_caller_id();
 
 	physics_server_3d->init();
 
-	exit = false;
-	step_thread_up = true;
+	command_queue.set_pump_task_id(server_task_id);
 	while (!exit) {
-		// flush commands one by one, until exit is requested
-		command_queue.wait_and_flush();
+		WorkerThreadPool::get_singleton()->yield();
+		command_queue.flush_all();
 	}
 
 	command_queue.flush_all(); // flush all
@@ -70,18 +63,14 @@ void PhysicsServer3DWrapMT::step(real_t p_step) {
 	if (create_thread) {
 		command_queue.push(this, &PhysicsServer3DWrapMT::thread_step, p_step);
 	} else {
-		command_queue.flush_all(); //flush all pending from other threads
+		command_queue.flush_all(); // Flush all pending from other threads.
 		physics_server_3d->step(p_step);
 	}
 }
 
 void PhysicsServer3DWrapMT::sync() {
 	if (create_thread) {
-		if (first_frame) {
-			first_frame = false;
-		} else {
-			step_sem.wait(); //must not wait if a step was not issued
-		}
+		step_sem.wait();
 	}
 	physics_server_3d->sync();
 }
@@ -96,39 +85,34 @@ void PhysicsServer3DWrapMT::end_sync() {
 
 void PhysicsServer3DWrapMT::init() {
 	if (create_thread) {
-		thread.start(_thread_callback, this);
-		while (!step_thread_up) {
-			OS::get_singleton()->delay_usec(1000);
-		}
+		exit = false;
+		server_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &PhysicsServer3DWrapMT::thread_loop), true);
+		step_sem.post();
 	} else {
 		physics_server_3d->init();
 	}
 }
 
 void PhysicsServer3DWrapMT::finish() {
-	if (thread.is_started()) {
+	if (create_thread) {
 		command_queue.push(this, &PhysicsServer3DWrapMT::thread_exit);
-		thread.wait_to_finish();
+		if (server_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(server_task_id);
+			server_task_id = WorkerThreadPool::INVALID_TASK_ID;
+		}
 	} else {
 		physics_server_3d->finish();
 	}
 }
 
-PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread) :
-		command_queue(p_create_thread) {
+PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread) {
 	physics_server_3d = p_contained;
 	create_thread = p_create_thread;
-
-	if (!p_create_thread) {
-		server_thread = Thread::get_caller_id();
-	} else {
-		server_thread = 0;
+	if (!create_thread) {
+		server_thread = Thread::MAIN_ID;
 	}
-
-	main_thread = Thread::get_caller_id();
 }
 
 PhysicsServer3DWrapMT::~PhysicsServer3DWrapMT() {
 	memdelete(physics_server_3d);
-	//finish();
 }

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -32,6 +32,7 @@
 #define PHYSICS_SERVER_3D_WRAP_MT_H
 
 #include "core/config/project_settings.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_server_3d.h"
@@ -42,29 +43,26 @@
 #define SYNC_DEBUG
 #endif
 
+#ifdef DEBUG_ENABLED
+#define MAIN_THREAD_SYNC_WARN WARN_PRINT("Call to " + String(__FUNCTION__) + " causing PhysicsServer3D synchronizations on every frame. This significantly affects performance.");
+#endif
+
 class PhysicsServer3DWrapMT : public PhysicsServer3D {
-	mutable PhysicsServer3D *physics_server_3d;
+	mutable PhysicsServer3D *physics_server_3d = nullptr;
 
 	mutable CommandQueueMT command_queue;
 
-	static void _thread_callback(void *_instance);
 	void thread_loop();
 
-	Thread::ID server_thread;
-	Thread::ID main_thread;
-	volatile bool exit = false;
-	Thread thread;
-	volatile bool step_thread_up = false;
+	Thread::ID server_thread = Thread::UNASSIGNED_ID;
+	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	bool exit = false;
+	Semaphore step_sem;
 	bool create_thread = false;
 
-	Semaphore step_sem;
 	void thread_step(real_t p_delta);
 
 	void thread_exit();
-
-	bool first_frame = true;
-
-	Mutex alloc_mutex;
 
 public:
 #define ServerName PhysicsServer3D
@@ -98,7 +96,7 @@ public:
 #if 0
 	//these work well, but should be used from the main thread only
 	bool shape_collide(RID p_shape_A, const Transform &p_xform_A, const Vector3 &p_motion_A, RID p_shape_B, const Transform &p_xform_B, const Vector3 &p_motion_B, Vector3 *r_results, int p_result_max, int &r_result_count) {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 		return physics_server_3d->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
 	}
 #endif
@@ -113,18 +111,18 @@ public:
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState3D *space_get_direct_state(RID p_space) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
 		return physics_server_3d->space_get_direct_state(p_space);
 	}
 
 	FUNC2(space_set_debug_contacts, RID, int);
 	virtual Vector<Vector3> space_get_contacts(RID p_space) const override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), Vector<Vector3>());
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), Vector<Vector3>());
 		return physics_server_3d->space_get_contacts(p_space);
 	}
 
 	virtual int space_get_contact_count(RID p_space) const override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), 0);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), 0);
 		return physics_server_3d->space_get_contact_count(p_space);
 	}
 
@@ -260,13 +258,13 @@ public:
 	FUNC2(body_set_ray_pickable, RID, bool);
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
 		return physics_server_3d->body_get_direct_state(p_body);
 	}
 
@@ -410,5 +408,9 @@ public:
 #undef DEBUG_SYNC
 #endif
 #undef SYNC_DEBUG
+
+#ifdef DEBUG_ENABLED
+#undef MAIN_THREAD_SYNC_WARN
+#endif
 
 #endif // PHYSICS_SERVER_3D_WRAP_MT_H

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -257,7 +257,6 @@ void ParticlesStorage::particles_set_emitting(RID p_particles, bool p_emitting) 
 }
 
 bool ParticlesStorage::particles_get_emitting(RID p_particles) {
-	ERR_FAIL_COND_V_MSG(RSG::threaded, false, "This function should never be used with threaded rendering, as it stalls the renderer.");
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 
@@ -608,10 +607,6 @@ void ParticlesStorage::particles_request_process(RID p_particles) {
 }
 
 AABB ParticlesStorage::particles_get_current_aabb(RID p_particles) {
-	if (RSG::threaded) {
-		WARN_PRINT_ONCE("Calling this function with threaded rendering enabled stalls the renderer, use with care.");
-	}
-
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, AABB());
 
@@ -1642,7 +1637,6 @@ Dependency *ParticlesStorage::particles_get_dependency(RID p_particles) const {
 }
 
 bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
-	ERR_FAIL_COND_V_MSG(RSG::threaded, false, "This function should never be used with threaded rendering, as it stalls the renderer.");
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 	return !particles->emitting && particles->inactive;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -356,8 +356,7 @@ void RenderingServerDefault::_thread_callback(void *_instance) {
 void RenderingServerDefault::_thread_loop() {
 	server_thread = Thread::get_caller_id();
 
-	DisplayServer::get_singleton()->make_rendering_thread();
-
+	DisplayServer::get_singleton()->gl_window_make_current(DisplayServer::MAIN_WINDOW_ID); // Move GL to this thread.
 	_init();
 
 	draw_thread_up.set();

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -31,6 +31,7 @@
 #ifndef RENDERING_SERVER_DEFAULT_H
 #define RENDERING_SERVER_DEFAULT_H
 
+#include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
 #include "core/templates/hash_map.h"
@@ -75,21 +76,16 @@ class RenderingServerDefault : public RenderingServer {
 
 	mutable CommandQueueMT command_queue;
 
-	static void _thread_callback(void *_instance);
 	void _thread_loop();
 
-	Thread::ID server_thread = 0;
-	SafeFlag exit;
-	Thread thread;
-	SafeFlag draw_thread_up;
-	bool create_thread;
+	Thread::ID server_thread = Thread::UNASSIGNED_ID;
+	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	bool exit = false;
+	bool create_thread = false;
 
 	void _thread_draw(bool p_swap_buffers, double frame_step);
-	void _thread_flush();
 
 	void _thread_exit();
-
-	Mutex alloc_mutex;
 
 	void _draw(bool p_swap_buffers, double frame_step);
 	void _init();
@@ -125,6 +121,10 @@ public:
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));
 #else
 #define SYNC_DEBUG
+#endif
+
+#ifdef DEBUG_ENABLED
+#define MAIN_THREAD_SYNC_WARN WARN_PRINT("Call to " + String(__FUNCTION__) + " causing RenderingServer synchronizations on every frame. This significantly affects performance.");
 #endif
 
 #include "servers/server_wrap_mt_common.h"
@@ -1013,6 +1013,9 @@ public:
 #undef ServerName
 #undef WRITE_ACTION
 #undef SYNC_DEBUG
+#ifdef DEBUG_ENABLED
+#undef MAIN_THREAD_SYNC_WARN
+#endif
 
 	virtual uint64_t get_rendering_info(RenderingInfo p_info) override;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -83,25 +83,16 @@ static PackedInt64Array to_int_array(const Vector<ObjectID> &ids) {
 }
 
 PackedInt64Array RenderingServer::_instances_cull_aabb_bind(const AABB &p_aabb, RID p_scenario) const {
-	if (RSG::threaded) {
-		WARN_PRINT_ONCE("Using this function with a threaded renderer hurts performance, as it causes a server stall.");
-	}
 	Vector<ObjectID> ids = instances_cull_aabb(p_aabb, p_scenario);
 	return to_int_array(ids);
 }
 
 PackedInt64Array RenderingServer::_instances_cull_ray_bind(const Vector3 &p_from, const Vector3 &p_to, RID p_scenario) const {
-	if (RSG::threaded) {
-		WARN_PRINT_ONCE("Using this function with a threaded renderer hurts performance, as it causes a server stall.");
-	}
 	Vector<ObjectID> ids = instances_cull_ray(p_from, p_to, p_scenario);
 	return to_int_array(ids);
 }
 
 PackedInt64Array RenderingServer::_instances_cull_convex_bind(const TypedArray<Plane> &p_convex, RID p_scenario) const {
-	if (RSG::threaded) {
-		WARN_PRINT_ONCE("Using this function with a threaded renderer hurts performance, as it causes a server stall.");
-	}
 	Vector<Plane> planes;
 	for (int i = 0; i < p_convex.size(); ++i) {
 		const Variant &v = p_convex[i];

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -31,12 +31,22 @@
 #ifndef SERVER_WRAP_MT_COMMON_H
 #define SERVER_WRAP_MT_COMMON_H
 
+#ifdef DEBIG_ENABLED
+#define MAIN_THREAD_SYNC_CHECK                                                                         \
+	if (unlikely(Thread::is_main_thread() && Engine::get_singleton()->notify_frame_server_synced())) { \
+		MAIN_THREAD_SYNC_WARN                                                                          \
+	}
+#else
+#define MAIN_THREAD_SYNC_CHECK
+#endif
+
 #define FUNC0R(m_r, m_type)                                                     \
 	virtual m_r m_type() override {                                             \
 		if (Thread::get_caller_id() != server_thread) {                         \
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
+			MAIN_THREAD_SYNC_CHECK                                              \
 			return ret;                                                         \
 		} else {                                                                \
 			command_queue.flush_if_pending();                                   \
@@ -68,6 +78,7 @@
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
+			MAIN_THREAD_SYNC_CHECK                                              \
 			return ret;                                                         \
 		} else {                                                                \
 			command_queue.flush_if_pending();                                   \
@@ -102,6 +113,7 @@
 		if (Thread::get_caller_id() != server_thread) {                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
+			MAIN_THREAD_SYNC_CHECK                                         \
 		} else {                                                           \
 			command_queue.flush_if_pending();                              \
 			server_name->m_type();                                         \
@@ -113,6 +125,7 @@
 		if (Thread::get_caller_id() != server_thread) {                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
+			MAIN_THREAD_SYNC_CHECK                                         \
 		} else {                                                           \
 			command_queue.flush_if_pending();                              \
 			server_name->m_type();                                         \
@@ -128,6 +141,7 @@
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, &ret); \
 			SYNC_DEBUG                                                              \
+			MAIN_THREAD_SYNC_CHECK                                                  \
 			return ret;                                                             \
 		} else {                                                                    \
 			command_queue.flush_if_pending();                                       \
@@ -141,6 +155,7 @@
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, &ret); \
 			SYNC_DEBUG                                                              \
+			MAIN_THREAD_SYNC_CHECK                                                  \
 			return ret;                                                             \
 		} else {                                                                    \
 			command_queue.flush_if_pending();                                       \
@@ -154,6 +169,7 @@
 		if (Thread::get_caller_id() != server_thread) {                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
+			MAIN_THREAD_SYNC_CHECK                                             \
 		} else {                                                               \
 			command_queue.flush_if_pending();                                  \
 			server_name->m_type(p1);                                           \
@@ -165,6 +181,7 @@
 		if (Thread::get_caller_id() != server_thread) {                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
+			MAIN_THREAD_SYNC_CHECK                                             \
 		} else {                                                               \
 			command_queue.flush_if_pending();                                  \
 			server_name->m_type(p1);                                           \
@@ -199,6 +216,7 @@
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, &ret); \
 			SYNC_DEBUG                                                                  \
+			MAIN_THREAD_SYNC_CHECK                                                      \
 			return ret;                                                                 \
 		} else {                                                                        \
 			command_queue.flush_if_pending();                                           \
@@ -212,6 +230,7 @@
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, &ret); \
 			SYNC_DEBUG                                                                  \
+			MAIN_THREAD_SYNC_CHECK                                                      \
 			return ret;                                                                 \
 		} else {                                                                        \
 			command_queue.flush_if_pending();                                           \
@@ -225,6 +244,7 @@
 		if (Thread::get_caller_id() != server_thread) {                            \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
+			MAIN_THREAD_SYNC_CHECK                                                 \
 		} else {                                                                   \
 			command_queue.flush_if_pending();                                      \
 			server_name->m_type(p1, p2);                                           \
@@ -236,6 +256,7 @@
 		if (Thread::get_caller_id() != server_thread) {                            \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
+			MAIN_THREAD_SYNC_CHECK                                                 \
 		} else {                                                                   \
 			command_queue.flush_if_pending();                                      \
 			server_name->m_type(p1, p2);                                           \
@@ -270,6 +291,7 @@
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, &ret); \
 			SYNC_DEBUG                                                                      \
+			MAIN_THREAD_SYNC_CHECK                                                          \
 			return ret;                                                                     \
 		} else {                                                                            \
 			command_queue.flush_if_pending();                                               \
@@ -283,6 +305,7 @@
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, &ret); \
 			SYNC_DEBUG                                                                      \
+			MAIN_THREAD_SYNC_CHECK                                                          \
 			return ret;                                                                     \
 		} else {                                                                            \
 			command_queue.flush_if_pending();                                               \
@@ -296,6 +319,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
+			MAIN_THREAD_SYNC_CHECK                                                     \
 		} else {                                                                       \
 			command_queue.flush_if_pending();                                          \
 			server_name->m_type(p1, p2, p3);                                           \
@@ -307,6 +331,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
+			MAIN_THREAD_SYNC_CHECK                                                     \
 		} else {                                                                       \
 			command_queue.flush_if_pending();                                          \
 			server_name->m_type(p1, p2, p3);                                           \
@@ -341,6 +366,7 @@
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, &ret); \
 			SYNC_DEBUG                                                                          \
+			MAIN_THREAD_SYNC_CHECK                                                              \
 			return ret;                                                                         \
 		} else {                                                                                \
 			command_queue.flush_if_pending();                                                   \
@@ -354,6 +380,7 @@
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, &ret); \
 			SYNC_DEBUG                                                                          \
+			MAIN_THREAD_SYNC_CHECK                                                              \
 			return ret;                                                                         \
 		} else {                                                                                \
 			command_queue.flush_if_pending();                                                   \
@@ -367,6 +394,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
+			MAIN_THREAD_SYNC_CHECK                                                         \
 		} else {                                                                           \
 			command_queue.flush_if_pending();                                              \
 			server_name->m_type(p1, p2, p3, p4);                                           \
@@ -378,6 +406,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
+			MAIN_THREAD_SYNC_CHECK                                                         \
 		} else {                                                                           \
 			command_queue.flush_if_pending();                                              \
 			server_name->m_type(p1, p2, p3, p4);                                           \
@@ -412,6 +441,7 @@
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, &ret); \
 			SYNC_DEBUG                                                                              \
+			MAIN_THREAD_SYNC_CHECK                                                                  \
 			return ret;                                                                             \
 		} else {                                                                                    \
 			command_queue.flush_if_pending();                                                       \
@@ -425,6 +455,7 @@
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, &ret); \
 			SYNC_DEBUG                                                                              \
+			MAIN_THREAD_SYNC_CHECK                                                                  \
 			return ret;                                                                             \
 		} else {                                                                                    \
 			command_queue.flush_if_pending();                                                       \
@@ -438,6 +469,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                         \
+			MAIN_THREAD_SYNC_CHECK                                                             \
 		} else {                                                                               \
 			command_queue.flush_if_pending();                                                  \
 			server_name->m_type(p1, p2, p3, p4, p5);                                           \
@@ -449,6 +481,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                         \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);  \
 			SYNC_DEBUG                                                                          \
+			MAIN_THREAD_SYNC_CHECK                                                              \
 		} else {                                                                                \
 			command_queue.flush_if_pending();                                                   \
 			server_name->m_type(p1, p2, p3, p4, p5);                                            \
@@ -483,6 +516,7 @@
 			m_r ret;                                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, &ret); \
 			SYNC_DEBUG                                                                                  \
+			MAIN_THREAD_SYNC_CHECK                                                                      \
 			return ret;                                                                                 \
 		} else {                                                                                        \
 			command_queue.flush_if_pending();                                                           \
@@ -496,6 +530,7 @@
 			m_r ret;                                                                                      \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, &ret);   \
 			SYNC_DEBUG                                                                                    \
+			MAIN_THREAD_SYNC_CHECK                                                                        \
 			return ret;                                                                                   \
 		} else {                                                                                          \
 			command_queue.flush_if_pending();                                                             \
@@ -509,6 +544,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                              \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);   \
 			SYNC_DEBUG                                                                               \
+			MAIN_THREAD_SYNC_CHECK                                                                   \
 		} else {                                                                                     \
 			command_queue.flush_if_pending();                                                        \
 			server_name->m_type(p1, p2, p3, p4, p5, p6);                                             \
@@ -520,6 +556,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);         \
 			SYNC_DEBUG                                                                                     \
+			MAIN_THREAD_SYNC_CHECK                                                                         \
 		} else {                                                                                           \
 			command_queue.flush_if_pending();                                                              \
 			server_name->m_type(p1, p2, p3, p4, p5, p6);                                                   \
@@ -554,6 +591,7 @@
 			m_r ret;                                                                                           \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, &ret);    \
 			SYNC_DEBUG                                                                                         \
+			MAIN_THREAD_SYNC_CHECK                                                                             \
 			return ret;                                                                                        \
 		} else {                                                                                               \
 			command_queue.flush_if_pending();                                                                  \
@@ -567,6 +605,7 @@
 			m_r ret;                                                                                                 \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, &ret);          \
 			SYNC_DEBUG                                                                                               \
+			MAIN_THREAD_SYNC_CHECK                                                                                   \
 			return ret;                                                                                              \
 		} else {                                                                                                     \
 			command_queue.flush_if_pending();                                                                        \
@@ -580,6 +619,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                                         \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);          \
 			SYNC_DEBUG                                                                                          \
+			MAIN_THREAD_SYNC_CHECK                                                                              \
 		} else {                                                                                                \
 			command_queue.flush_if_pending();                                                                   \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                    \
@@ -591,6 +631,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                                               \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                \
 			SYNC_DEBUG                                                                                                \
+			MAIN_THREAD_SYNC_CHECK                                                                                    \
 		} else {                                                                                                      \
 			command_queue.flush_if_pending();                                                                         \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                          \
@@ -625,6 +666,7 @@
 			m_r ret;                                                                                                      \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, &ret);           \
 			SYNC_DEBUG                                                                                                    \
+			MAIN_THREAD_SYNC_CHECK                                                                                        \
 			return ret;                                                                                                   \
 		} else {                                                                                                          \
 			command_queue.flush_if_pending();                                                                             \
@@ -638,6 +680,7 @@
 			m_r ret;                                                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, &ret);                 \
 			SYNC_DEBUG                                                                                                          \
+			MAIN_THREAD_SYNC_CHECK                                                                                              \
 			return ret;                                                                                                         \
 		} else {                                                                                                                \
 			command_queue.flush_if_pending();                                                                                   \
@@ -651,6 +694,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                 \
 			SYNC_DEBUG                                                                                                     \
+			MAIN_THREAD_SYNC_CHECK                                                                                         \
 		} else {                                                                                                           \
 			command_queue.flush_if_pending();                                                                              \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                           \
@@ -662,6 +706,7 @@
 		if (Thread::get_caller_id() != server_thread) {                                                                          \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                       \
 			SYNC_DEBUG                                                                                                           \
+			MAIN_THREAD_SYNC_CHECK                                                                                               \
 		} else {                                                                                                                 \
 			command_queue.flush_if_pending();                                                                                    \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                                 \


### PR DESCRIPTION
Built on top of #90268. Reason for this PR told in a comment there:
> I realized that, unless there's some sort of prevention mechanism, users can easily shoot themselves in the foot because a dameon-like task could starve legit tasks. The usage in this PR is safe because those dameons are launched when there are free slots for sure so each of them is the bottommost in the call stack. I've started implementing a mechanism to prevent that, but it started to get messy so I'll put it in a draft PR together with re-exposing the yielding functions.