### PR TITLE
Fix GeometryInstance3D Custom AABB assignment in the editor not working

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1029,7 +1029,6 @@ inline bool is_geometry_instance(RenderingServer::InstanceType p_type) {
 void RendererSceneCull::instance_set_custom_aabb(RID p_instance, AABB p_aabb) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL(instance);
-	ERR_FAIL_COND(!is_geometry_instance(instance->base_type));
 
 	if (p_aabb != AABB()) {
 		// Set custom AABB


### PR DESCRIPTION
This also fixes error spam when changing Custom AABB on a MeshInstance3D that has no Mesh resource assigned yet (which is allowed in the editor). This avoids pitfalls when assigning a custom AABB in a script when loading meshes at runtime.

I've tested this in all rendering methods and it works as expected.

- This closes https://github.com/godotengine/godot/issues/86369.

**Testing project:** [test_custom_aabb.zip](https://github.com/godotengine/godot/files/14921759/test_custom_aabb.zip)

### Before

*An AABB that is too small for the mesh is intentionally used to cull objects earlier than intended, so it makes a difference on screen. Here, the custom AABB is ignored when the scene is loaded due to the bug:*

https://github.com/godotengine/godot/assets/180032/53d9cefe-d1cf-4ec2-a97f-e00404539283

### After *(this PR)*

*An AABB that is too small for the mesh is intentionally used to cull objects earlier than intended, so it makes a difference on screen. Here, the custom AABB is being obeyed as expected:*

https://github.com/godotengine/godot/assets/180032/cae752f3-2911-4262-9fb0-344224f4a371


