### PR TITLE
Send mouse-enter notification, when viewport receives a mouse motion event

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -646,6 +646,7 @@ void Viewport::_notification(int p_what) {
 
 		case NOTIFICATION_VP_MOUSE_EXIT: {
 			gui.mouse_in_viewport = false;
+			gui.drag_mouse_over = nullptr;
 			_drop_physics_mouseover();
 			// When the mouse exits the viewport, we don't want to end
 			// mouse_focus, because, for example, we want to continue
@@ -2965,6 +2966,12 @@ void Viewport::_update_mouse_over() {
 	if (is_attached_in_viewport()) {
 		// Execute this function only, when it is processed by a native Window or a SubViewport, that has no SubViewportContainer as parent.
 		return;
+	}
+
+	if (!gui.mouse_in_viewport) {
+		// This is a hack, that makes pushing mouse motion events to SubViewports more user-friendly.
+		// Without this, a user needs to take care of sending mouse-enter/exit notifications to SubViewports.
+		notification(NOTIFICATION_VP_MOUSE_ENTER);
 	}
 
 	if (get_tree()->get_root()->is_embedding_subwindows() || is_sub_viewport()) {

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -113,6 +113,7 @@ public:
 	void simulate_event(Ref<InputEvent> p_event) {
 		Ref<InputEvent> event = p_event;
 		Ref<InputEventMouse> me = p_event;
+		bool parse_event = true;
 		if (me.is_valid()) {
 			Ref<InputEventMouseMotion> mm = p_event;
 			if (mm.is_valid()) {
@@ -120,8 +121,14 @@ public:
 				event = mm;
 			}
 			_set_mouse_position(me->get_position());
+			if (mm.is_valid() && !window_over) {
+				parse_event = false;
+			}
 		}
-		Input::get_singleton()->parse_input_event(event);
+
+		if (parse_event) {
+			Input::get_singleton()->parse_input_event(event);
+		}
 	}
 
 	// Returns the current cursor shape.

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -1192,7 +1192,6 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 				// Move outside of window.
 				SEND_GUI_MOUSE_MOTION_EVENT(on_outside, MouseButtonMask::LEFT, Key::NONE);
-				CHECK(DS->get_cursor_shape() == DisplayServer::CURSOR_ARROW);
 				CHECK(root->gui_is_dragging());
 
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_outside, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);


### PR DESCRIPTION
Ensure, that a `SubViewport` receives a `NOTIFICATION_VP_MOUSE_ENTER`, when an `InputEventMouseMotion` is sent to a viewport, that currently doesn't have the mouse inside.

In the following case the changed code makes a difference: By default the viewport has the state, that the mouse is not over the viewport.
When the user pushes an `InputEventMouseMotion` to a `SubViewport`, then because of the default state, the Viewport assumes, that the mouse is not over itself and acts accordingly, leading to the behavior described in #89757.
With this change, the Viewport automatically switches its state.

Make necessary adjustments to unit-tests.

The behavior got introduced by #88992, which by itself was a step in the right direction, but caused undesired behavior.
This change would have introduced problems before #89920, because sometimes it was possible, that a Viewport received mouse motion events even when the mouse was outside of the viewport.
Resolve #89757 and also duplicate #90413. (I have verified the MRPs of both reports)
Supersedes #89868

Instead of this change, the problem can also be solved, by updating the documentation and explaining, that the user not only needs to push input events to `SubViewports`, but is also responsible for sending `NOTIFICATION_VP_MOUSE_ENTER` and `NOTIFICATION_VP_MOUSE_EXIT` when necessary.

While I believe, that this documentation change would be conceptually the correct way to go forward, it would be less user-friendy and I don't forsee direct problems with the approach of this PR, because before #88992 the `SubViewports` be default had as state `gui.mouse_in_viewport == true`.

All in all, this PR seems a bit hacky to me.