### PR TITLE
SCons: Fix SCU build regression on Windows

### DIFF
--- a/scu_builders.py
+++ b/scu_builders.py
@@ -23,8 +23,9 @@ def clear_out_stale_files(output_folder, extension, fresh_files):
         return
 
     for file in glob.glob(output_folder + "/*." + extension):
+        file = Path(file)
         if not file in fresh_files:
-            # print("removed stale file: " + file)
+            # print("removed stale file: " + str(file))
             os.remove(file)
 
 
@@ -97,7 +98,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
     elif _verbose:
         print("SCU: Generation not needed for: " + short_filename)
 
-    return output_filename
+    return output_path
 
 
 def write_exception_output_file(file_count, exception_string, output_folder, output_filename_prefix, extension):
@@ -124,7 +125,7 @@ def write_exception_output_file(file_count, exception_string, output_folder, out
     elif _verbose:
         print("SCU: Generation not needed for: " + short_filename)
 
-    return output_filename
+    return output_path
 
 
 def find_section_name(sub_folder):


### PR DESCRIPTION
#89452 made assumptions on comparing paths as strings which doesn't work when composing them as POSIX paths (`/`) but processing them on NT (`\`, `\\`).

This is more of a PoC of what needs to be done, we should get rid of any string comparisons and standardize everything around `pathlib.Path`, or `os.path.join()`, but not a mix of concatenating `base + "/scu/" + tail` and then trying to compare that to Windows paths, because we end up with stuff like this: `C:\\Users\\Remi\\Dev\\Godot\\godot\\servers\\audio\\effects\\scu/scu_servers_audio_effects.gen.cpp` and failing comparisons.

- Fixes #90216.