### PR TITLE
Clarify `rotate` methods

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -145,7 +145,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Rotates the local transformation around axis, a unit [Vector3], by specified angle in radians.
+				Rotates the local transformation, relative to the parent's local transformation, around axis, a unit [Vector3], by specified angle in radians.
 			</description>
 		</method>
 		<method name="rotate_object_local">
@@ -160,21 +160,21 @@
 			<return type="void" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Rotates the local transformation around the X axis by angle in radians.
+				Rotates the local transformation, relative to the parent's local transformation, around the X axis by angle in radians.
 			</description>
 		</method>
 		<method name="rotate_y">
 			<return type="void" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Rotates the local transformation around the Y axis by angle in radians.
+				Rotates the local transformation, relative to the parent's local transformation, around the Y axis by angle in radians.
 			</description>
 		</method>
 		<method name="rotate_z">
 			<return type="void" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Rotates the local transformation around the Z axis by angle in radians.
+				Rotates the local transformation, relative to the parent's local transformation, around the Z axis by angle in radians.
 			</description>
 		</method>
 		<method name="scale_object_local">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Updates the description of `rotate`, `rotate_x`, `rotate_y`, and `rotate_z` to clarify that the rotation is relative to the axes of the parent node.