### PR TITLE
Fix caret last fit when moving to line end

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2582,8 +2582,6 @@ void TextEdit::_move_caret_to_line_end(bool p_select) {
 			set_caret_column(row_end_col, i == 0, i);
 		}
 
-		carets.write[i].last_fit_x = INT_MAX;
-
 		if (p_select) {
 			_post_shift_selection(i);
 		}


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/90420

INT_MAX was being used and it overflowed when subtracting 0.0 from it, which caused it to become negative, so the caret went to the start of the line.
It's not needed to be set here, since set_caret_column handles it. 
It should be set to the end of the line anyway and not a high value, judging by behavior in other text editors.

For the other point in the issue, I couldn't find any problems with the caret moving down incorrectly. The caret will only go not straight down if the last fit was set to a column higher than the line end, which is intended.