### PR TITLE
Clear RIDs of weight buffers when freeing to avoid double free

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -130,9 +130,10 @@ void RenderSceneBuffersRD::cleanup() {
 	named_textures.clear();
 
 	// Clear weight_buffer / blur textures.
-	for (const WeightBuffers &weight_buffer : weight_buffers) {
+	for (WeightBuffers &weight_buffer : weight_buffers) {
 		if (weight_buffer.weight.is_valid()) {
 			RD::get_singleton()->free(weight_buffer.weight);
+			weight_buffer.weight = RID();
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/90452

As Bastiaan pointed out, we need to clear the RID ensure that subsequent calls to `is_valid()` fail. 