### PR TITLE
Make `replacing_by` emit slightly earlier

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1067,7 +1067,7 @@
 			<param index="0" name="node" type="Node" />
 			<description>
 				Emitted when this node is being replaced by the [param node], see [method replace_by].
-				This signal is emitted [i]after[/i] [param node] has been added as a child of the original parent node, but [i]before[/i] all original child nodes have been reparented to [param node].
+				This signal is emitted [i]before[/i] [param node] is added as a child of the original parent node.
 			</description>
 		</signal>
 		<signal name="tree_entered">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3015,16 +3015,15 @@ void Node::replace_by(Node *p_node, bool p_keep_groups) {
 		_clean_up_owner();
 	}
 
-	Node *parent = data.parent;
-	int index_in_parent = get_index(false);
+	emit_signal(SNAME("replacing_by"), p_node);
 
+	Node *parent = data.parent;
 	if (data.parent) {
+		int index_in_parent = get_index(false);
 		parent->remove_child(this);
 		parent->add_child(p_node);
 		parent->move_child(p_node, index_in_parent);
 	}
-
-	emit_signal(SNAME("replacing_by"), p_node);
 
 	while (get_child_count()) {
 		Node *child = get_child(0);


### PR DESCRIPTION
This mainly fixes bugs that occur when replacing scene roots with certain node types.

To reproduce the bug:
1. Create a new scene,
2. Add some visible 2D child nodes to the scene,
3. Select the scene root node, right-click to open the menu, select Change Type, and then select the Camera2D type to change.
4. The display of nodes in the 2D screen is offset.

| 248e5bfba | This PR |
| :----------: | :-----------: |
| ![0](https://github.com/godotengine/godot/assets/30386067/d0548bb6-8b56-4f91-80c3-95a91e1afae0) | ![1](https://github.com/godotengine/godot/assets/30386067/7fe510bb-e33d-4dfc-9dc7-72de3ccf4093) |

Fix #73009, 





