### PR TITLE
[Audio] Prevent crash in interactive playback

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -976,6 +976,8 @@ void AudioStreamPlaybackInteractive::switch_to_clip_by_name(const StringName &p_
 		return;
 	}
 
+	ERR_FAIL_COND_MSG(stream.is_null(), "Attempted to switch while not playing back any stream.");
+
 	for (int i = 0; i < stream->get_clip_count(); i++) {
 		if (stream->get_clip_name(i) == p_name) {
 			switch_request = i;

--- a/modules/interactive_music/register_types.cpp
+++ b/modules/interactive_music/register_types.cpp
@@ -42,11 +42,11 @@
 void initialize_interactive_music_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(AudioStreamPlaylist);
-		GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackPlaylist);
+		GDREGISTER_ABSTRACT_CLASS(AudioStreamPlaybackPlaylist);
 		GDREGISTER_CLASS(AudioStreamInteractive);
-		GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackInteractive);
+		GDREGISTER_ABSTRACT_CLASS(AudioStreamPlaybackInteractive);
 		GDREGISTER_CLASS(AudioStreamSynchronized);
-		GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackSynchronized);
+		GDREGISTER_ABSTRACT_CLASS(AudioStreamPlaybackSynchronized);
 	}
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {


### PR DESCRIPTION
This is in two parts, first part is fixing the crash itself, second part is ensuring the class can't be created on its own, can remove if desired but I'd say it makes sense as these make no sense created independently as they are unconfigured

* Fixes: https://github.com/godotengine/godot/issues/90474
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
