### PR TITLE
Fix searching for custom script node with compile error crashes the engine

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -250,6 +250,11 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 				String extends;
 				scr->get_language()->get_global_class_name(scr->get_path(), &extends);
 
+				// Not a valid script (has compile errors), we therefore ignore it as it can not be instantiated anyway (when selected).
+				if (extends.is_empty()) {
+					return;
+				}
+
 				inherits = extends;
 				inherited_type = TypeCategory::CPP_TYPE;
 			} else {


### PR DESCRIPTION
Trying to fix https://github.com/godotengine/godot/issues/90463

The problem seems to lie here:

https://github.com/godotengine/godot/blob/a7b860250f305f6cbaf61c30f232ff3bbdfdda0b/editor/create_dialog.cpp#L248-L255

It looks like when there is compile error like what happens in the issue description, `base` is null , `extends` is null,  so the recursive `_add_type` failed at line 271:

https://github.com/godotengine/godot/blob/a7b860250f305f6cbaf61c30f232ff3bbdfdda0b/editor/create_dialog.cpp#L270-L273

and so this line did not retrieve the value, it created a new `nullptr` in `search_options_types[inherits]`

https://github.com/godotengine/godot/blob/a7b860250f305f6cbaf61c30f232ff3bbdfdda0b/editor/create_dialog.cpp#L275

and so the crash happens at here since `to_select` is nullptr.

https://github.com/godotengine/godot/blob/a7b860250f305f6cbaf61c30f232ff3bbdfdda0b/editor/create_dialog.cpp#L501-L503

This pr prevents the crash by simply check whether the `inherits` is added to `search_options_types`, quick but only supress the crash.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
