### PR TITLE
[3.x] Add `is_zero_approx` methods to `Vector{2,3}`

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -199,6 +199,10 @@ bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y);
 }
 
+bool Vector2::is_zero_approx() const {
+	return Math::is_zero_approx(x) && Math::is_zero_approx(y);
+}
+
 /* Vector2i */
 
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -115,6 +115,7 @@ struct _NO_DISCARD_CLASS_ Vector2 {
 	Vector2 reflect(const Vector2 &p_normal) const;
 
 	bool is_equal_approx(const Vector2 &p_v) const;
+	bool is_zero_approx() const;
 
 	Vector2 operator+(const Vector2 &p_v) const;
 	void operator+=(const Vector2 &p_v);

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -151,6 +151,10 @@ bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z);
 }
 
+bool Vector3::is_zero_approx() const {
+	return Math::is_zero_approx(x) && Math::is_zero_approx(y) && Math::is_zero_approx(z);
+}
+
 Vector3::operator String() const {
 	return (rtos(x) + ", " + rtos(y) + ", " + rtos(z));
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -133,6 +133,7 @@ struct _NO_DISCARD_CLASS_ Vector3 {
 
 	bool is_equal_approx(const Vector3 &p_v) const;
 	inline bool is_equal_approx(const Vector3 &p_v, real_t p_tolerance) const;
+	bool is_zero_approx() const;
 
 	/* Operators */
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -385,6 +385,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Vector2, normalized);
 	VCALL_LOCALMEM0R(Vector2, is_normalized);
 	VCALL_LOCALMEM1R(Vector2, is_equal_approx);
+	VCALL_LOCALMEM0R(Vector2, is_zero_approx);
 	VCALL_LOCALMEM1R(Vector2, posmod);
 	VCALL_LOCALMEM1R(Vector2, posmodv);
 	VCALL_LOCALMEM1R(Vector2, project);
@@ -437,6 +438,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Vector3, normalized);
 	VCALL_LOCALMEM0R(Vector3, is_normalized);
 	VCALL_LOCALMEM1R(Vector3, is_equal_approx);
+	VCALL_LOCALMEM0R(Vector3, is_zero_approx);
 	VCALL_LOCALMEM0R(Vector3, inverse);
 	VCALL_LOCALMEM1R(Vector3, snapped);
 	VCALL_LOCALMEM2R(Vector3, rotated);
@@ -1800,6 +1802,7 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, normalized, varray());
 	ADDFUNC0R(VECTOR2, BOOL, Vector2, is_normalized, varray());
 	ADDFUNC1R(VECTOR2, BOOL, Vector2, is_equal_approx, VECTOR2, "v", varray());
+	ADDFUNC0R(VECTOR2, BOOL, Vector2, is_zero_approx, varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, posmod, REAL, "mod", varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, posmodv, VECTOR2, "modv", varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, project, VECTOR2, "b", varray());
@@ -1851,6 +1854,7 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, normalized, varray());
 	ADDFUNC0R(VECTOR3, BOOL, Vector3, is_normalized, varray());
 	ADDFUNC1R(VECTOR3, BOOL, Vector3, is_equal_approx, VECTOR3, "v", varray());
+	ADDFUNC0R(VECTOR3, BOOL, Vector3, is_zero_approx, varray());
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, inverse, varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, snapped, VECTOR3, "by", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, rotated, VECTOR3, "axis", REAL, "angle", varray());

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -152,6 +152,13 @@
 				Returns [code]true[/code] if the vector is normalized, [code]false[/code] otherwise.
 			</description>
 		</method>
+		<method name="is_zero_approx">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this vector's values are approximately zero, by running [method @GDScript.is_zero_approx] on each component.
+				This method is faster than using [method is_equal_approx] with one value as a zero vector.
+			</description>
+		</method>
 		<method name="length">
 			<return type="float" />
 			<description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -125,6 +125,13 @@
 				Returns [code]true[/code] if the vector is normalized, [code]false[/code] otherwise.
 			</description>
 		</method>
+		<method name="is_zero_approx">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this vector's values are approximately zero, by running [method @GDScript.is_zero_approx] on each component.
+				This method is faster than using [method is_equal_approx] with one value as a zero vector.
+			</description>
+		</method>
 		<method name="length">
 			<return type="float" />
 			<description>

--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -113,7 +113,7 @@ PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_i
 	bone_shape->set_transform(capsule_transform);
 
 	Vector3 up = Vector3(0, 1, 0);
-	if (up.cross(child_rest.origin).is_equal_approx(Vector3())) {
+	if (up.cross(child_rest.origin).is_zero_approx()) {
 		up = Vector3(0, 0, 1);
 	}
 

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -434,7 +434,7 @@ Ref<Material3D> FBXMaterial::import_material(ImportState &state) {
 					print_verbose("Emissive real value: " + rtos(real_value->Value()));
 					spatial_material->set_emission_energy(real_value->Value());
 					material_info.features.push_back(Material3D::Feature::FEATURE_EMISSION);
-				} else if (vector_value && !vector_value->Value().is_equal_approx(Vector3(0, 0, 0))) {
+				} else if (vector_value && !vector_value->Value().is_zero_approx()) {
 					const Vector3 &color = vector_value->Value();
 					Color c;
 					c[0] = color[0];
@@ -445,7 +445,7 @@ Ref<Material3D> FBXMaterial::import_material(ImportState &state) {
 				}
 			} break;
 			case PROPERTY_DESC_EMISSIVE_COLOR: {
-				if (vector_value && !vector_value->Value().is_equal_approx(Vector3(0, 0, 0))) {
+				if (vector_value && !vector_value->Value().is_zero_approx()) {
 					const Vector3 &color = vector_value->Value();
 					Color c;
 					c[0] = color[0];

--- a/modules/fbx/data/pivot_transform.cpp
+++ b/modules/fbx/data/pivot_transform.cpp
@@ -225,7 +225,7 @@ void PivotTransform::ComputePivotTransform() {
 	Sp.set_origin(scaling_pivot);
 
 	// Scaling node
-	if (!scaling.is_equal_approx(Vector3())) {
+	if (!scaling.is_zero_approx()) {
 		S.scale(scaling);
 	} else {
 		S.scale(Vector3(1, 1, 1));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -440,7 +440,7 @@ Error GLTFDocument::_serialize_nodes(Ref<GLTFState> p_state) {
 			node["scale"] = _vec3_to_arr(gltf_node->scale);
 		}
 
-		if (!gltf_node->translation.is_equal_approx(Vector3())) {
+		if (!gltf_node->translation.is_zero_approx()) {
 			node["translation"] = _vec3_to_arr(gltf_node->translation);
 		}
 		if (gltf_node->children.size()) {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -684,7 +684,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	const bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
 	// Only enable antialiasing if it is actually needed. This improve performances
 	// and maximizes sharpness for non-skewed StyleBoxes with sharp corners.
-	const bool aa_on = (rounded_corners || !skew.is_equal_approx(Vector2())) && anti_aliased;
+	const bool aa_on = (rounded_corners || !skew.is_zero_approx()) && anti_aliased;
 
 	const bool blend_on = blend_border && draw_border;
 


### PR DESCRIPTION
Originally proposed in https://github.com/godotengine/godot-proposals/issues/3746.

These methods are convenient, already implemented in 4.0.