### PR TITLE
Register the export info correctly when a script is used as the variable type for Node

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4315,39 +4315,55 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 					return false;
 				}
 				break;
-			case GDScriptParser::DataType::CLASS:
+			case GDScriptParser::DataType::CLASS: {
+				StringName class_name;
+				if (export_type.class_type) {
+					class_name = export_type.class_type->get_global_name();
+				}
+				if (class_name == StringName()) {
+					push_error(R"(Script export type must be a global class.)", p_annotation);
+					return false;
+				}
 				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-					variable->export_info.hint_string = export_type.to_string();
+					variable->export_info.hint_string = class_name;
 				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
-					variable->export_info.hint_string = export_type.to_string();
+					variable->export_info.hint_string = class_name;
 				} else {
 					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
 					return false;
 				}
+			} break;
 
-				break;
 			case GDScriptParser::DataType::SCRIPT: {
 				StringName class_name;
-				StringName native_base;
 				if (export_type.script_type.is_valid()) {
-					class_name = export_type.script_type->get_language()->get_global_class_name(export_type.script_type->get_path());
-					native_base = export_type.script_type->get_instance_base_type();
+					class_name = export_type.script_type->get_global_name();
 				}
 				if (class_name == StringName()) {
 					Ref<Script> script = ResourceLoader::load(export_type.script_path, SNAME("Script"));
 					if (script.is_valid()) {
-						class_name = script->get_language()->get_global_class_name(export_type.script_path);
-						native_base = script->get_instance_base_type();
+						class_name = script->get_global_name();
 					}
 				}
-				if (class_name != StringName() && native_base != StringName() && ClassDB::is_parent_class(native_base, SNAME("Resource"))) {
+				if (class_name == StringName()) {
+					push_error(R"(Script export type must be a global class.)", p_annotation);
+					return false;
+				}
+				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
 					variable->export_info.hint_string = class_name;
+				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
+					variable->export_info.type = Variant::OBJECT;
+					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
+					variable->export_info.hint_string = class_name;
+				} else {
+					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
+					return false;
 				}
 			} break;
 			case GDScriptParser::DataType::ENUM: {

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.gd
@@ -1,6 +1,8 @@
+class_name ExportVariableTest
 extends Node
 
 const Utils = preload("../../utils.notest.gd")
+const PreloadedScript = preload("./export_variable.notest.gd")
 
 # Built-in types.
 @export var test_weak_int = 1
@@ -19,6 +21,10 @@ const Utils = preload("../../utils.notest.gd")
 # Resources and nodes.
 @export var test_image: Image
 @export var test_timer: Timer
+
+# Global custom classes.
+@export var test_global_class: ExportVariableTest
+@export var test_preloaded_script: PreloadedScript
 
 # Arrays.
 @export var test_array: Array

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.notest.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.notest.gd
@@ -1,0 +1,2 @@
+class_name ExportPreloadedClassTest
+extends Node

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.out
@@ -23,6 +23,10 @@ var test_image: Image = null
   hint=RESOURCE_TYPE hint_string="Image" usage=DEFAULT|SCRIPT_VARIABLE class_name=&"Image"
 var test_timer: Timer = null
   hint=NODE_TYPE hint_string="Timer" usage=DEFAULT|SCRIPT_VARIABLE class_name=&"Timer"
+var test_global_class: ExportVariableTest = null
+  hint=NODE_TYPE hint_string="ExportVariableTest" usage=DEFAULT|SCRIPT_VARIABLE class_name=&"ExportVariableTest"
+var test_preloaded_script: ExportPreloadedClassTest = null
+  hint=NODE_TYPE hint_string="ExportPreloadedClassTest" usage=DEFAULT|SCRIPT_VARIABLE class_name=&"ExportPreloadedClassTest"
 var test_array: Array = []
   hint=NONE hint_string="" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
 var test_array_bool: Array = Array[bool]([])


### PR DESCRIPTION
This PR fixes #73993

It will allow a preloaded const script to be used as the type of an exported variable in GDScript