### PR TITLE
Core: Expand `math_defs.h` functionality

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4047,10 +4047,10 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 	// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	Dictionary result;
-	result["max"] = INFINITY;
-	result["mean"] = INFINITY;
-	result["mean_squared"] = INFINITY;
-	result["root_mean_squared"] = INFINITY;
+	result["max"] = Math_INF;
+	result["mean"] = Math_INF;
+	result["mean_squared"] = Math_INF;
+	result["root_mean_squared"] = Math_INF;
 	result["peak_snr"] = 0.0f;
 
 	ERR_FAIL_NULL_V(p_compared_image, result);

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -181,7 +181,7 @@ DynamicBVH::Volume DynamicBVH::_bounds(Node **leaves, int p_count) {
 
 void DynamicBVH::_bottom_up(Node **leaves, int p_count) {
 	while (p_count > 1) {
-		real_t minsize = INFINITY;
+		real_t minsize = Math_INF;
 		int minidx[2] = { -1, -1 };
 		for (int i = 0; i < p_count; ++i) {
 			for (int j = i + 1; j < p_count; ++j) {

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -464,10 +464,10 @@ Error Expression::_get_token(Token &r_token) {
 						r_token.value = Math_TAU;
 					} else if (id == "INF") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = INFINITY;
+						r_token.value = Math_INF;
 					} else if (id == "NAN") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = NAN;
+						r_token.value = Math_NAN;
 					} else if (id == "not") {
 						r_token.type = TK_OP_NOT;
 					} else if (id == "or") {

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -31,18 +31,21 @@
 #ifndef MATH_DEFS_H
 #define MATH_DEFS_H
 
-#define CMP_EPSILON 0.00001
-#define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
+inline constexpr double CMP_EPSILON = 0.00001;
+inline constexpr double CMP_EPSILON2 = CMP_EPSILON * CMP_EPSILON;
 
-#define CMP_NORMALIZE_TOLERANCE 0.000001
-#define CMP_POINT_IN_PLANE_EPSILON 0.00001
+inline constexpr double CMP_NORMALIZE_TOLERANCE = 0.000001;
+inline constexpr double CMP_POINT_IN_PLANE_EPSILON = 0.00001;
 
-#define Math_SQRT12 0.7071067811865475244008443621048490
-#define Math_SQRT2 1.4142135623730950488016887242
-#define Math_LN2 0.6931471805599453094172321215
-#define Math_TAU 6.2831853071795864769252867666
-#define Math_PI 3.1415926535897932384626433833
-#define Math_E 2.7182818284590452353602874714
+inline constexpr double Math_SQRT12 = 0.7071067811865475244008443621048490;
+inline constexpr double Math_SQRT2 = 1.4142135623730950488016887242;
+inline constexpr double Math_LN2 = 0.6931471805599453094172321215;
+inline constexpr double Math_TAU = 6.2831853071795864769252867666;
+inline constexpr double Math_PI = 3.1415926535897932384626433833;
+inline constexpr double Math_E = 2.7182818284590452353602874714;
+
+inline constexpr double Math_INF = __builtin_huge_val();
+inline constexpr double Math_NAN = __builtin_nan("0");
 
 #ifdef DEBUG_ENABLED
 #define MATH_CHECKS
@@ -50,10 +53,10 @@
 
 //this epsilon is for values related to a unit size (scalar or vector len)
 #ifdef PRECISE_MATH_CHECKS
-#define UNIT_EPSILON 0.00001
+inline constexpr double UNIT_EPSILON = 0.00001;
 #else
 //tolerate some more floating point error normally
-#define UNIT_EPSILON 0.001
+inline constexpr double UNIT_EPSILON = 0.001;
 #endif
 
 #define USEC_TO_SEC(m_usec) ((m_usec) / 1000000.0)

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -96,8 +96,8 @@ public:
 	static _ALWAYS_INLINE_ float acosh(float p_x) { return p_x < 1 ? 0 : ::acoshf(p_x); }
 
 	// Always does clamping so always safe to use.
-	static _ALWAYS_INLINE_ double atanh(double p_x) { return p_x <= -1 ? -INFINITY : (p_x >= 1 ? INFINITY : ::atanh(p_x)); }
-	static _ALWAYS_INLINE_ float atanh(float p_x) { return p_x <= -1 ? -INFINITY : (p_x >= 1 ? INFINITY : ::atanhf(p_x)); }
+	static _ALWAYS_INLINE_ double atanh(double p_x) { return p_x <= -1 ? -Math_INF : (p_x >= 1 ? Math_INF : ::atanh(p_x)); }
+	static _ALWAYS_INLINE_ float atanh(float p_x) { return p_x <= -1 ? -Math_INF : (p_x >= 1 ? Math_INF : ::atanhf(p_x)); }
 
 	static _ALWAYS_INLINE_ double sqrt(double p_x) { return ::sqrt(p_x); }
 	static _ALWAYS_INLINE_ float sqrt(float p_x) { return ::sqrtf(p_x); }

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -62,7 +62,7 @@ public:
 		_FORCE_INLINE_ Ray(const Vector3 &p_org,
 				const Vector3 &p_dir,
 				float p_tnear = 0.0f,
-				float p_tfar = INFINITY) :
+				float p_tfar = Math_INF) :
 				org(p_org),
 				tnear(p_tnear),
 				dir(p_dir),

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -129,7 +129,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_float(float p_in, uint32_t p_see
 	if (p_in == 0.0f) {
 		u.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.f = NAN;
+		u.f = Math_NAN;
 	} else {
 		u.f = p_in;
 	}
@@ -152,7 +152,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_double(double p_in, uint32_t p_s
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math_NAN;
 	} else {
 		u.d = p_in;
 	}
@@ -240,7 +240,7 @@ static _FORCE_INLINE_ uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev 
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math_NAN;
 	} else {
 		u.d = p_in;
 	}
@@ -269,7 +269,7 @@ static _FORCE_INLINE_ uint64_t hash_djb2_one_float_64(double p_in, uint64_t p_pr
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math_NAN;
 	} else {
 		u.d = p_in;
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2609,7 +2609,7 @@ static void _register_variant_builtin_methods() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(INFINITY, INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(Math_INF, Math_INF, Math_INF));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
@@ -2635,7 +2635,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_W", Vector4::AXIS_W);
 	_VariantCall::add_variant_constant(Variant::VECTOR4, "ZERO", Vector4(0, 0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR4, "ONE", Vector4(1, 1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4(INFINITY, INFINITY, INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4(Math_INF, Math_INF, Math_INF, Math_INF));
 
 	_VariantCall::add_constant(Variant::VECTOR3I, "AXIS_X", Vector3i::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR3I, "AXIS_Y", Vector3i::AXIS_Y);
@@ -2685,7 +2685,7 @@ static void _register_variant_builtin_methods() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2(0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2(1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(Math_INF, Math_INF));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2(-1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2(1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -148,11 +148,11 @@ const char *VariantParser::tk_name[TK_MAX] = {
 
 static double stor_fix(const String &p_str) {
 	if (p_str == "inf") {
-		return INFINITY;
+		return Math_INF;
 	} else if (p_str == "inf_neg") {
-		return -INFINITY;
+		return -Math_INF;
 	} else if (p_str == "nan") {
-		return NAN;
+		return Math_NAN;
 	}
 	return -1;
 }
@@ -698,11 +698,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 		} else if (id == "null" || id == "nil") {
 			value = Variant();
 		} else if (id == "inf") {
-			value = INFINITY;
+			value = Math_INF;
 		} else if (id == "inf_neg") {
-			value = -INFINITY;
+			value = -Math_INF;
 		} else if (id == "nan") {
-			value = NAN;
+			value = Math_NAN;
 		} else if (id == "Vector2") {
 			Vector<real_t> args;
 			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -752,8 +752,8 @@ void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 
 void AnimationBezierTrackEdit::auto_fit_vertically() {
 	int track_count = animation->get_track_count();
-	real_t minimum_value = INFINITY;
-	real_t maximum_value = -INFINITY;
+	real_t minimum_value = Math_INF;
+	real_t maximum_value = -Math_INF;
 
 	int nb_track_visible = 0;
 	for (int i = 0; i < track_count; ++i) {
@@ -959,10 +959,10 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 
-			real_t minimum_time = INFINITY;
-			real_t maximum_time = -INFINITY;
-			real_t minimum_value = INFINITY;
-			real_t maximum_value = -INFINITY;
+			real_t minimum_time = Math_INF;
+			real_t maximum_time = -Math_INF;
+			real_t minimum_value = Math_INF;
+			real_t maximum_value = -Math_INF;
 
 			for (const IntPair &E : selection) {
 				IntPair key_pair = E;

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -295,7 +295,7 @@ bool EditorUndoRedoManager::redo() {
 	}
 
 	int selected_history = INVALID_HISTORY;
-	double global_timestamp = INFINITY;
+	double global_timestamp = Math_INF;
 
 	// Pick the history with lowest last action timestamp (either global or current scene).
 	{

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2179,8 +2179,8 @@ void GDScriptLanguage::init() {
 
 	_add_global(StaticCString::create("PI"), Math_PI);
 	_add_global(StaticCString::create("TAU"), Math_TAU);
-	_add_global(StaticCString::create("INF"), INFINITY);
-	_add_global(StaticCString::create("NAN"), NAN);
+	_add_global(StaticCString::create("INF"), Math_INF);
+	_add_global(StaticCString::create("NAN"), Math_NAN);
 
 	//populate native classes
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -472,12 +472,12 @@ void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_const
 
 	Pair<String, Variant> infinity;
 	infinity.first = "INF";
-	infinity.second = INFINITY;
+	infinity.second = Math_INF;
 	p_constants->push_back(infinity);
 
 	Pair<String, Variant> nan;
 	nan.first = "NAN";
-	nan.second = NAN;
+	nan.second = Math_NAN;
 	p_constants->push_back(nan);
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2573,10 +2573,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_builtin_constant(Expressio
 			constant->value = Math_TAU;
 			break;
 		case GDScriptTokenizer::Token::CONST_INF:
-			constant->value = INFINITY;
+			constant->value = Math_INF;
 			break;
 		case GDScriptTokenizer::Token::CONST_NAN:
-			constant->value = NAN;
+			constant->value = Math_NAN;
 			break;
 		default:
 			return nullptr; // Unreachable.

--- a/modules/gltf/extensions/gltf_light.h
+++ b/modules/gltf/extensions/gltf_light.h
@@ -48,7 +48,7 @@ private:
 	Color color = Color(1.0f, 1.0f, 1.0f);
 	float intensity = 1.0f;
 	String light_type;
-	float range = INFINITY;
+	float range = Math_INF;
 	float inner_cone_angle = 0.0f;
 	float outer_cone_angle = Math_TAU / 8.0f;
 	Dictionary additional_data;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5920,7 +5920,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 		animation->set_loop_mode(Animation::LOOP_LINEAR);
 	}
 
-	double anim_start = p_trimming ? INFINITY : 0.0;
+	double anim_start = p_trimming ? Math_INF : 0.0;
 	double anim_end = 0.0;
 
 	for (const KeyValue<int, GLTFAnimation::Track> &track_i : anim->get_tracks()) {

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -142,7 +142,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (bounds detection).");
 		}
 
-		float min_x = INFINITY, min_y = INFINITY, max_x = -INFINITY, max_y = -INFINITY;
+		float min_x = Math_INF, min_y = Math_INF, max_x = -Math_INF, max_y = -Math_INF;
 		tvg_get_bounds(picture.get(), min_x, min_y, max_x, max_y);
 
 		float new_h = (max_y - min_y);

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -142,7 +142,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (bounds detection).");
 		}
 
-		float min_x = INFINITY, min_y = INFINITY, max_x = -INFINITY, max_y = -INFINITY;
+		float min_x = Math_INF, min_y = Math_INF, max_x = -Math_INF, max_y = -Math_INF;
 		tvg_get_bounds(picture.get(), min_x, min_y, max_x, max_y);
 
 		float new_h = (max_y - min_y);

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -74,7 +74,7 @@ public:
 		_FORCE_INLINE_ Ray(const Vector3 &p_org,
 				const Vector3 &p_dir,
 				float p_tnear = 0.0f,
-				float p_tfar = INFINITY) :
+				float p_tfar = Math_INF) :
 				org(p_org),
 				tnear(p_tnear),
 				dir(p_dir),

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3011,8 +3011,8 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 	Vector<Vector2> uvs;
 	Vector<int32_t> indices;
 
-	Vector2 min_p = Vector2(INFINITY, INFINITY);
-	Vector2 max_p = Vector2(-INFINITY, -INFINITY);
+	Vector2 min_p = Vector2(Math_INF, Math_INF);
+	Vector2 max_p = Vector2(-Math_INF, -Math_INF);
 
 	int32_t p_size = 0;
 	int32_t i_size = 0;

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -577,8 +577,8 @@ private:
 		Vector<Vector2> triangles;
 		Vector<Vector<ContourPoint>> contours;
 		Vector<ContourInfo> contours_info;
-		Vector2 min_p = Vector2(INFINITY, INFINITY);
-		Vector2 max_p = Vector2(-INFINITY, -INFINITY);
+		Vector2 min_p = Vector2(Math_INF, Math_INF);
+		Vector2 max_p = Vector2(-Math_INF, -Math_INF);
 	};
 	mutable HashMap<GlyphMeshKey, GlyphMeshData, GlyphMeshKeyHasher> cache;
 

--- a/servers/physics_3d/godot_shape_3d.h
+++ b/servers/physics_3d/godot_shape_3d.h
@@ -120,7 +120,7 @@ class GodotWorldBoundaryShape3D : public GodotShape3D {
 public:
 	Plane get_plane() const;
 
-	virtual real_t get_volume() const override { return INFINITY; }
+	virtual real_t get_volume() const override { return Math_INF; }
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_WORLD_BOUNDARY; }
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -1246,7 +1246,7 @@ struct _SoftBodyIntersectSegmentInfo {
 	Vector3 dir;
 	Vector3 hit_position;
 	uint32_t hit_face_index = -1;
-	real_t hit_dist_sq = INFINITY;
+	real_t hit_dist_sq = Math_INF;
 
 	static bool process_hit(uint32_t p_face_index, void *p_userdata) {
 		_SoftBodyIntersectSegmentInfo &query_info = *(static_cast<_SoftBodyIntersectSegmentInfo *>(p_userdata));
@@ -1277,7 +1277,7 @@ bool GodotSoftBodyShape3D::intersect_segment(const Vector3 &p_begin, const Vecto
 
 	soft_body->query_ray(p_begin, p_end, _SoftBodyIntersectSegmentInfo::process_hit, &query_info);
 
-	if (query_info.hit_dist_sq != INFINITY) {
+	if (query_info.hit_dist_sq != Math_INF) {
 		r_result = query_info.hit_position;
 		r_normal = soft_body->get_face_normal(query_info.hit_face_index);
 		return true;

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -462,7 +462,7 @@ TEST_CASE("[AABB] Expanding") {
 
 TEST_CASE("[AABB] Finite number checks") {
 	const Vector3 x(0, 1, 2);
-	const Vector3 infinite(NAN, NAN, NAN);
+	const Vector3 infinite(Math_NAN, Math_NAN, Math_NAN);
 
 	CHECK_MESSAGE(
 			AABB(x, x).is_finite(),

--- a/tests/core/math/test_astar.h
+++ b/tests/core/math/test_astar.h
@@ -281,7 +281,7 @@ TEST_CASE("[Stress][AStar3D] Find paths") {
 		float d[N][N];
 		for (int u = 0; u < N; u++) {
 			for (int v = 0; v < N; v++) {
-				d[u][v] = (u == v || adj[u][v]) ? p[u].distance_to(p[v]) : INFINITY;
+				d[u][v] = (u == v || adj[u][v]) ? p[u].distance_to(p[v]) : Math_INF;
 			}
 		}
 		for (int w = 0; w < N; w++) {

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -265,7 +265,7 @@ TEST_CASE("[Basis] Set axis angle") {
 
 TEST_CASE("[Basis] Finite number checks") {
 	const Vector3 x(0, 1, 2);
-	const Vector3 infinite(NAN, NAN, NAN);
+	const Vector3 infinite(Math_NAN, Math_NAN, Math_NAN);
 
 	CHECK_MESSAGE(
 			Basis(x, x, x).is_finite(),

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -54,8 +54,8 @@ TEST_CASE("[Math] C++ macros") {
 	CHECK(SIGN(-5) == -1.0);
 	CHECK(SIGN(0) == 0.0);
 	CHECK(SIGN(5) == 1.0);
-	// Check that SIGN(NAN) returns 0.0.
-	CHECK(SIGN(NAN) == 0.0);
+	// Check that SIGN(Math_NAN) returns 0.0.
+	CHECK(SIGN(Math_NAN) == 0.0);
 }
 
 TEST_CASE("[Math] Power of two functions") {
@@ -292,10 +292,10 @@ TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
 
 TEST_CASE_TEMPLATE("[Math] is_nan/is_inf", T, float, double) {
 	CHECK(!Math::is_nan((T)0.0));
-	CHECK(Math::is_nan((T)NAN));
+	CHECK(Math::is_nan((T)Math_NAN));
 
 	CHECK(!Math::is_inf((T)0.0));
-	CHECK(Math::is_inf((T)INFINITY));
+	CHECK(Math::is_inf((T)Math_INF));
 }
 
 TEST_CASE_TEMPLATE("[Math] linear_to_db", T, float, double) {

--- a/tests/core/math/test_plane.h
+++ b/tests/core/math/test_plane.h
@@ -170,9 +170,9 @@ TEST_CASE("[Plane] Intersection") {
 
 TEST_CASE("[Plane] Finite number checks") {
 	const Vector3 x(0, 1, 2);
-	const Vector3 infinite_vec(NAN, NAN, NAN);
+	const Vector3 infinite_vec(Math_NAN, Math_NAN, Math_NAN);
 	const real_t y = 0;
-	const real_t infinite_y = NAN;
+	const real_t infinite_y = Math_NAN;
 
 	CHECK_MESSAGE(
 			Plane(x, y).is_finite(),

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -402,7 +402,7 @@ TEST_CASE("[Stress][Quaternion] Many vector xforms") {
 }
 
 TEST_CASE("[Quaternion] Finite number checks") {
-	const real_t x = NAN;
+	const real_t x = Math_NAN;
 
 	CHECK_MESSAGE(
 			Quaternion(0, 1, 2, 3).is_finite(),

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -303,7 +303,7 @@ TEST_CASE("[Rect2] Merging") {
 
 TEST_CASE("[Rect2] Finite number checks") {
 	const Vector2 x(0, 1);
-	const Vector2 infinite(NAN, NAN);
+	const Vector2 infinite(Math_NAN, Math_NAN);
 
 	CHECK_MESSAGE(
 			Rect2(x, x).is_finite(),

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -99,7 +99,7 @@ TEST_CASE("[Transform2D] Interpolation") {
 
 TEST_CASE("[Transform2D] Finite number checks") {
 	const Vector2 x(0, 1);
-	const Vector2 infinite(NAN, NAN);
+	const Vector2 infinite(Math_NAN, Math_NAN);
 
 	CHECK_MESSAGE(
 			Transform2D(x, x, x).is_finite(),

--- a/tests/core/math/test_transform_3d.h
+++ b/tests/core/math/test_transform_3d.h
@@ -87,7 +87,7 @@ TEST_CASE("[Transform3D] rotation") {
 
 TEST_CASE("[Transform3D] Finite number checks") {
 	const Vector3 y(0, 1, 2);
-	const Vector3 infinite_vec(NAN, NAN, NAN);
+	const Vector3 infinite_vec(Math_NAN, Math_NAN, Math_NAN);
 	const Basis x(y, y, y);
 	const Basis infinite_basis(infinite_vec, infinite_vec, infinite_vec);
 

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -471,7 +471,7 @@ TEST_CASE("[Vector2] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector2] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	const double infinite[] = { Math_NAN, Math_INF, -Math_INF };
 
 	CHECK_MESSAGE(
 			Vector2(0, 1).is_finite(),

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -489,7 +489,7 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector3] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	const double infinite[] = { Math_NAN, Math_INF, -Math_INF };
 
 	CHECK_MESSAGE(
 			Vector3(0, 1, 2).is_finite(),

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -324,7 +324,7 @@ TEST_CASE("[Vector4] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector4] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	const double infinite[] = { Math_NAN, Math_INF, -Math_INF };
 
 	CHECK_MESSAGE(
 			Vector4(0, 1, 2, 3).is_finite(),

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -572,16 +572,16 @@ TEST_CASE("[String] String to float") {
 	CHECK(String("1e308").to_float() == 1e308);
 	CHECK(String("-1e308").to_float() == -1e308);
 
-	// Exponent is so high that value is INFINITY/-INFINITY.
-	CHECK(String("1e309").to_float() == INFINITY);
-	CHECK(String("1e511").to_float() == INFINITY);
-	CHECK(String("-1e309").to_float() == -INFINITY);
-	CHECK(String("-1e511").to_float() == -INFINITY);
+	// Exponent is so high that value is Math_INF/-Math_INF.
+	CHECK(String("1e309").to_float() == Math_INF);
+	CHECK(String("1e511").to_float() == Math_INF);
+	CHECK(String("-1e309").to_float() == -Math_INF);
+	CHECK(String("-1e511").to_float() == -Math_INF);
 
-	// Exponent is so high that a warning message is printed. Value is INFINITY/-INFINITY.
+	// Exponent is so high that a warning message is printed. Value is Math_INF/-Math_INF.
 	ERR_PRINT_OFF
-	CHECK(String("1e512").to_float() == INFINITY);
-	CHECK(String("-1e512").to_float() == -INFINITY);
+	CHECK(String("1e512").to_float() == Math_INF);
+	CHECK(String("-1e512").to_float() == -Math_INF);
 	ERR_PRINT_ON
 }
 
@@ -852,7 +852,7 @@ TEST_CASE("[String] sprintf") {
 	// Real (infinity) left-padded
 	format = "fish %11f frog";
 	args.clear();
-	args.push_back(INFINITY);
+	args.push_back(Math_INF);
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish         inf frog"));
@@ -976,7 +976,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector left-padded with inf/nan
 	format = "fish %11v frog";
 	args.clear();
-	args.push_back(Variant(Vector2(INFINITY, NAN)));
+	args.push_back(Variant(Vector2(Math_INF, Math_NAN)));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (        inf,         nan) frog"));


### PR DESCRIPTION
This converts most `math_defs.h` defines to c++17 global variables; that is: making them `inline constexpr`. While a nice QOL on its own, this was primarily to mirror the syntax used in two newly implemented global variables: `Math_INF` and `Math_NAN`. These replace the old `INFINITY`/`NAN` defines with variables that both can be properly deduced by intellisense & can be used in constexpr evaluations without producing invalid/overflow errors.