### PR TITLE
Fix NavigationMeshSourceGeometryData merge crash

### DIFF
--- a/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
@@ -120,6 +120,8 @@ void NavigationMeshSourceGeometryData2D::add_obstruction_outline(const PackedVec
 }
 
 void NavigationMeshSourceGeometryData2D::merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry) {
+	ERR_FAIL_NULL(p_other_geometry);
+
 	// No need to worry about `root_node_transform` here as the data is already xformed.
 	traversable_outlines.append_array(p_other_geometry->traversable_outlines);
 	obstruction_outlines.append_array(p_other_geometry->obstruction_outlines);

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
@@ -172,6 +172,8 @@ void NavigationMeshSourceGeometryData3D::add_faces(const PackedVector3Array &p_f
 }
 
 void NavigationMeshSourceGeometryData3D::merge(const Ref<NavigationMeshSourceGeometryData3D> &p_other_geometry) {
+	ERR_FAIL_NULL(p_other_geometry);
+
 	// No need to worry about `root_node_transform` here as the vertices are already xformed.
 	const int64_t number_of_vertices_before_merge = vertices.size();
 	const int64_t number_of_indices_before_merge = indices.size();


### PR DESCRIPTION
Fixes crash when trying to merge with a null source geometry.

resolves https://github.com/godotengine/godot/issues/90500

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
