### PR TITLE
Use threads for baking navigation mesh inside editor

### DIFF
--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -72,7 +72,7 @@ NavMeshGenerator2D::NavMeshGenerator2D() {
 
 	// Using threads might cause problems on certain exports or with the Editor on certain devices.
 	// This is the main switch to turn threaded navmesh baking off should the need arise.
-	use_threads = baking_use_multiple_threads && !Engine::get_singleton()->is_editor_hint();
+	use_threads = baking_use_multiple_threads;
 }
 
 NavMeshGenerator2D::~NavMeshGenerator2D() {

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -85,7 +85,7 @@ NavMeshGenerator3D::NavMeshGenerator3D() {
 
 	// Using threads might cause problems on certain exports or with the Editor on certain devices.
 	// This is the main switch to turn threaded navmesh baking off should the need arise.
-	use_threads = baking_use_multiple_threads && !Engine::get_singleton()->is_editor_hint();
+	use_threads = baking_use_multiple_threads;
 }
 
 NavMeshGenerator3D::~NavMeshGenerator3D() {

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -99,7 +99,7 @@ void NavigationMeshEditor::_bake_pressed() {
 		}
 	}
 
-	node->bake_navigation_mesh(false);
+	node->bake_navigation_mesh(true);
 
 	node->update_gizmos();
 }


### PR DESCRIPTION
Enables threaded navigation mesh baking inside the editor.

Closes https://github.com/godotengine/godot/issues/90120

The baking with threads inside the editor was disabled because especially the SceneTree caused crashes in the past.

Now that the problematic parsing step and the baking step are split and a few new guards exist the baking can run on a thread again.

Note that there are still editor freezes from the parsing process with this as that needs to stay on the main-thread due to the SceneTree and nodes.

Longer freezes are primarily caused by the RenderingServer when visual meshes are parsed because the RenderingServer needs to shuffle all that Mesh data from the GPU back to the CPU.

Use collision shapes as source geometry instead of visual meshes to avoid most issues!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
