### PR TITLE
Static allocation bones copy for SkeletonModifier

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -264,6 +264,8 @@ void Skeleton3D::_update_process_order() {
 		}
 	}
 
+	bones_backup.resize(bones.size());
+
 	process_order_dirty = false;
 
 	emit_signal("bone_list_changed");
@@ -310,19 +312,10 @@ void Skeleton3D::_notification(int p_what) {
 
 			// Process modifiers.
 			_find_modifiers();
-			LocalVector<Transform3D> current_bone_poses;
-			LocalVector<Vector3> current_pose_positions;
-			LocalVector<Quaternion> current_pose_rotations;
-			LocalVector<Vector3> current_pose_scales;
-			LocalVector<Transform3D> current_bone_global_poses;
 			if (!modifiers.is_empty()) {
 				// Store unmodified bone poses.
-				for (int i = 0; i < len; i++) {
-					current_bone_poses.push_back(bones[i].pose_cache);
-					current_pose_positions.push_back(bones[i].pose_position);
-					current_pose_rotations.push_back(bones[i].pose_rotation);
-					current_pose_scales.push_back(bones[i].pose_scale);
-					current_bone_global_poses.push_back(bones[i].global_pose);
+				for (int i = 0; i < bones.size(); i++) {
+					bones_backup[i].save(bones[i]);
 				}
 				_process_modifiers();
 			}
@@ -388,12 +381,8 @@ void Skeleton3D::_notification(int p_what) {
 
 			if (!modifiers.is_empty()) {
 				// Restore unmodified bone poses.
-				for (int i = 0; i < len; i++) {
-					bonesptr[i].pose_cache = current_bone_poses[i];
-					bonesptr[i].pose_position = current_pose_positions[i];
-					bonesptr[i].pose_rotation = current_pose_rotations[i];
-					bonesptr[i].pose_scale = current_pose_scales[i];
-					bonesptr[i].global_pose = current_bone_global_poses[i];
+				for (int i = 0; i < bones.size(); i++) {
+					bones_backup[i].restore(bones.write[i]);
 				}
 			}
 

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -88,15 +88,15 @@ private:
 	struct Bone {
 		String name;
 
-		int parent;
+		int parent = -1;
 		Vector<int> child_bones;
 
 		Transform3D rest;
 		Transform3D global_rest;
 
-		bool enabled;
-		Transform3D pose_cache;
+		bool enabled = true;
 		bool pose_cache_dirty = true;
+		Transform3D pose_cache;
 		Vector3 pose_position;
 		Quaternion pose_rotation;
 		Vector3 pose_scale = Vector3(1, 1, 1);
@@ -116,15 +116,29 @@ private:
 		bool global_pose_override_reset = false;
 		Transform3D global_pose_override;
 #endif // _DISABLE_DEPRECATED
+	};
 
-		Bone() {
-			parent = -1;
-			child_bones = Vector<int>();
-			enabled = true;
-#ifndef DISABLE_DEPRECATED
-			global_pose_override_amount = 0;
-			global_pose_override_reset = false;
-#endif // _DISABLE_DEPRECATED
+	struct BonePoseBackup {
+		Transform3D pose_cache;
+		Vector3 pose_position;
+		Quaternion pose_rotation;
+		Vector3 pose_scale = Vector3(1, 1, 1);
+		Transform3D global_pose;
+
+		void save(const Bone &p_bone) {
+			pose_cache = p_bone.pose_cache;
+			pose_position = p_bone.pose_position;
+			pose_rotation = p_bone.pose_rotation;
+			pose_scale = p_bone.pose_scale;
+			global_pose = p_bone.global_pose;
+		}
+
+		void restore(Bone &r_bone) {
+			r_bone.pose_cache = pose_cache;
+			r_bone.pose_position = pose_position;
+			r_bone.pose_rotation = pose_rotation;
+			r_bone.pose_scale = pose_scale;
+			r_bone.global_pose = global_pose;
 		}
 	};
 
@@ -156,6 +170,7 @@ private:
 	void _process_modifiers();
 	void _process_changed();
 	void _make_modifiers_dirty();
+	LocalVector<BonePoseBackup> bones_backup;
 
 #ifndef DISABLE_DEPRECATED
 	void _add_bone_bind_compat_88791(const String &p_name);


### PR DESCRIPTION
Co-authored-by: @SlugFiller

The original bone pose is copied/restored before and after the Skeleton modification process. This PR make it use static allocation ~and memcpy~. 