### PR TITLE
Fix folder colors not saving after `project.godot` is modified externally

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3693,6 +3693,10 @@ void FileSystemDock::_feature_profile_changed() {
 	_update_display_mode(true);
 }
 
+void FileSystemDock::_project_settings_changed() {
+	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
+}
+
 void FileSystemDock::set_file_sort(FileSortOption p_file_sort) {
 	for (int i = 0; i != FILE_SORT_MAX; i++) {
 		tree_button_sort->get_popup()->set_item_checked(i, (i == (int)p_file_sort));
@@ -4122,6 +4126,7 @@ FileSystemDock::FileSystemDock() {
 	old_display_mode = DISPLAY_MODE_TREE_ONLY;
 	file_list_display_mode = FILE_LIST_DISPLAY_THUMBNAILS;
 
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &FileSystemDock::_project_settings_changed));
 	add_resource_tooltip_plugin(memnew(EditorTextureTooltipPlugin));
 }
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -362,6 +362,7 @@ private:
 	bool _is_file_type_disabled_by_feature_profile(const StringName &p_class);
 
 	void _feature_profile_changed();
+	void _project_settings_changed();
 	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
 	void _change_bottom_dock_placement();


### PR DESCRIPTION
1. Open a project
2. Open `project.godot` in text editor, modify and save it
3. When external modification prompt appears in Godot editor, reload the file
4. Assign folder colors
5. The colors won't be saved until you restart the editor, meaning all your new colors are lost

This PR updates Dictionary reference when project settings are changed, so it can be saved properly.