### PR TITLE
Fix collisions with AnimatableBody2D

### DIFF
--- a/scene/2d/physics/animatable_body_2d.cpp
+++ b/scene/2d/physics/animatable_body_2d.cpp
@@ -54,11 +54,9 @@ void AnimatableBody2D::_update_kinematic_motion() {
 	if (sync_to_physics) {
 		PhysicsServer2D::get_singleton()->body_set_state_sync_callback(get_rid(), callable_mp(this, &AnimatableBody2D::_body_state_changed));
 		set_only_update_transform_changes(true);
-		set_notify_local_transform(true);
 	} else {
 		PhysicsServer2D::get_singleton()->body_set_state_sync_callback(get_rid(), Callable());
 		set_only_update_transform_changes(false);
-		set_notify_local_transform(false);
 	}
 }
 
@@ -68,9 +66,9 @@ void AnimatableBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	}
 
 	last_valid_transform = p_state->get_transform();
-	set_notify_local_transform(false);
+	set_notify_transform(false);
 	set_global_transform(last_valid_transform);
-	set_notify_local_transform(true);
+	set_notify_transform(true);
 }
 
 void AnimatableBody2D::_notification(int p_what) {
@@ -85,16 +83,20 @@ void AnimatableBody2D::_notification(int p_what) {
 			set_notify_local_transform(false);
 		} break;
 
-		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (!sync_to_physics || Engine::get_singleton()->is_editor_hint()) {
+				return;
+			}
+
 			// Used by sync to physics, send the new transform to the physics...
 			Transform2D new_transform = get_global_transform();
 
 			PhysicsServer2D::get_singleton()->body_set_state(get_rid(), PhysicsServer2D::BODY_STATE_TRANSFORM, new_transform);
 
 			// ... but then revert changes.
-			set_notify_local_transform(false);
+			set_notify_transform(false);
 			set_global_transform(last_valid_transform);
-			set_notify_local_transform(true);
+			set_notify_transform(true);
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes issue #58269 where moving the parent of AnimatableBody2D will not move the body in the physics server. Thus collisions will still be detected in the original position of the object.

For the test case to work, AnimationPlayer needs `callback_mode_process` set to physics.

[AnimatableBodyTest.zip](https://github.com/godotengine/godot/files/14946173/AnimatableBodyTest.zip)

Edit: It's probably adding some jittering when "snap 2d transforms to pixel" is enabled. Needs more testing.
