### PR TITLE
Fix the initialization order for the iOS driver

### DIFF
--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -149,10 +149,6 @@ void OS_IOS::deinitialize_modules() {
 
 void OS_IOS::set_main_loop(MainLoop *p_main_loop) {
 	main_loop = p_main_loop;
-
-	if (main_loop) {
-		main_loop->initialize();
-	}
 }
 
 MainLoop *OS_IOS::get_main_loop() const {
@@ -181,7 +177,9 @@ bool OS_IOS::iterate() {
 }
 
 void OS_IOS::start() {
-	Main::start();
+	if (Main::start() == EXIT_SUCCESS) {
+		main_loop->initialize();
+	}
 
 	if (joypad_ios) {
 		joypad_ios->start_processing();


### PR DESCRIPTION
The problem is that we were initializating the main loop (SceneTree) when we were supposed to just set it.  Which would cascade into a series of issues, including having the EditorNode being flagged as "inside_tree" and having a tree, before it was supposed to.

This meant that some code would assume it was fully initialized, when
it was not.   And this manifested as the project not being scanned for
resources, which meant that during the importing, the resources would
not match using the uid path, and produce lots of errors.

This is a merged version of https://github.com/godotengine/godot/pull/89684