### PR TITLE
Core: Use `<type_traits>` where applicable

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -195,7 +195,7 @@ public:
 	template <typename T>
 	static void register_class(bool p_virtual = false) {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
+		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -210,7 +210,7 @@ public:
 	template <typename T>
 	static void register_abstract_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
+		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -223,7 +223,7 @@ public:
 	template <typename T>
 	static void register_internal_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
+		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -238,7 +238,7 @@ public:
 	template <typename T>
 	static void register_runtime_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
+		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -263,7 +263,7 @@ public:
 	template <typename T>
 	static void register_custom_instance_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
+		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -33,31 +33,7 @@
 
 #include "core/typedefs.h"
 
-template <bool C, typename T = void>
-struct EnableIf {
-	typedef T type;
-};
-
-template <typename T>
-struct EnableIf<false, T> {
-};
-
-template <typename, typename>
-inline constexpr bool types_are_same_v = false;
-
-template <typename T>
-inline constexpr bool types_are_same_v<T, T> = true;
-
-template <typename B, typename D>
-struct TypeInherits {
-	static D *get_d();
-
-	static char (&test(B *))[1];
-	static char (&test(...))[2];
-
-	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
-			!types_are_same_v<B volatile const, void volatile const>;
-};
+#include <type_traits>
 
 namespace GodotTypeInfo {
 enum Metadata {
@@ -223,16 +199,7 @@ MAKE_TEMPLATE_TYPE_INFO(Vector, Face3, Variant::PACKED_VECTOR3_ARRAY)
 MAKE_TEMPLATE_TYPE_INFO(Vector, StringName, Variant::PACKED_STRING_ARRAY)
 
 template <typename T>
-struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(StringName(T::get_class_static()));
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
+struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {


### PR DESCRIPTION
Instead of utilizing alternative implementations for metaprogramming types, this PR instead makes `type_info.h` include `<type_traits>` instead. The only other file that was using `type_info.h` functions was *already* including `<type_traits>`, so that takes care of an existing reduncancy. `GetTypeInfo` for Objects was able to be simplified to a single template, as the `is_base_of_v` conditional handles const conversion automatically.

Granted, I *really* like the idea of having a custom, trimmed-down version of `<type_traits>` for our own use, similar to our trimmed down String vs `std::string`. Though, that's better suited as a dedicated file imo. I'll probably look into a version of that sometime soon; but, for now, uniformly utilizing `<type_traits>` is the way to go.