### PR TITLE
iOS: Implement OS::move_to_trash for platform parity 

### DIFF
--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -72,6 +72,7 @@ private:
 	virtual MainLoop *get_main_loop() const override;
 
 	virtual void delete_main_loop() override;
+	virtual Error move_to_trash(const String &p_path) override;
 
 	virtual void finalize() override;
 

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -331,6 +331,19 @@ String OS_IOS::get_user_data_dir() const {
 	return ret;
 }
 
+Error OS_IOS::move_to_trash(const String &p_path) {
+	NSFileManager *fm = [NSFileManager defaultManager];
+	NSURL *url = [NSURL fileURLWithPath:@(p_path.utf8().get_data())];
+	NSError *err;
+
+	if (![fm trashItemAtURL:url resultingItemURL:nil error:&err]) {
+		ERR_PRINT("trashItemAtURL error: " + String::utf8(err.localizedDescription.UTF8String));
+		return FAILED;
+	}
+
+	return OK;
+}
+
 String OS_IOS::get_cache_path() const {
 	static String ret;
 	if (ret.is_empty()) {


### PR DESCRIPTION
This implements the move_to_trash method for the iOS platform, merely a replica of the
MacOS implementation.