### PR TITLE
Increase contrast in audio bus editor VU meter display

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -76,11 +76,11 @@ void EditorAudioBus::_notification(int p_what) {
 			Ref<Texture2D> active_bus_texture = get_editor_theme_icon(SNAME("BusVuActive"));
 			for (int i = 0; i < CHANNELS_MAX; i++) {
 				channel[i].vu_l->set_under_texture(active_bus_texture);
-				channel[i].vu_l->set_tint_under(Color(0.75, 0.75, 0.75));
+				channel[i].vu_l->set_tint_under(Color(0.4, 0.4, 0.4));
 				channel[i].vu_l->set_progress_texture(active_bus_texture);
 
 				channel[i].vu_r->set_under_texture(active_bus_texture);
-				channel[i].vu_r->set_tint_under(Color(0.75, 0.75, 0.75));
+				channel[i].vu_r->set_tint_under(Color(0.4, 0.4, 0.4));
 				channel[i].vu_r->set_progress_texture(active_bus_texture);
 				channel[i].prev_active = true;
 			}


### PR DESCRIPTION
This makes it easier to see the VU meter intensity by making the unfilled part of the meter darker. This works on both dark and light editor themes.

Frozen (blue) VU meter appearance is not changed by this PR. We could perhaps turn it grayscale to make it clearer that it's in a "disabled" state, but I left it as-is for now.

## Preview

### Dark theme

Before | After *(this PR)* | Frozen VU meter (for reference)
-|-|-
![Screenshot_20240411_215521](https://github.com/godotengine/godot/assets/180032/24f0a13a-ddaf-44e6-966d-8173081735b7) | ![Screenshot_20240411_220116](https://github.com/godotengine/godot/assets/180032/219f5336-742f-475b-b4bd-7004f99cce3d) | ![Screenshot_20240411_220100](https://github.com/godotengine/godot/assets/180032/23cc9320-0160-4f95-a3a2-f651eba1ec71)

### Light theme

Before | After *(this PR)* | Frozen VU meter (for reference)
-|-|-
![Screenshot_20240411_220155](https://github.com/godotengine/godot/assets/180032/bfa1c48d-b9a5-4a93-8b10-65708e3ec5fc) | ![Screenshot_20240411_220131](https://github.com/godotengine/godot/assets/180032/e08031f2-cd9f-4b4f-b03e-510ae78abf7d) | ![Screenshot_20240411_220137](https://github.com/godotengine/godot/assets/180032/1b8b5544-9a45-4b44-b9a3-ac984408ce58)
