### PR TITLE
Improve named class display in the Create New Node dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -288,7 +288,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_metadata(0, p_type);
 		r_item->set_text(0, p_type);
 		String script_path = ScriptServer::get_global_class_path(p_type);
-		r_item->set_suffix(0, "(" + script_path.get_file() + ")");
+		r_item->add_button(0, get_editor_theme_icon("Script"), 0, false, vformat(TTR("Class \"%s\" is provided by a script in the current project:\n%s"), p_type, script_path));
 
 		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
 		ERR_FAIL_COND(!scr.is_valid());
@@ -296,6 +296,9 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);
 		r_item->set_text(0, p_type);
+		r_item->add_button(0, get_editor_theme_icon("Script"), 0, false, vformat(TTR("Class \"%s\" is a custom type provided by an editor plugin."), p_type));
+		// Match coloring in the Scene tree dock for custom types.
+		r_item->set_button_color(0, r_item->get_button_count(0) - 1, Color(1, 1, 1, 0.5));
 	}
 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
@@ -315,9 +318,9 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	bool is_experimental = (class_doc && class_doc->value.is_experimental);
 
 	if (is_deprecated) {
-		r_item->add_button(0, get_editor_theme_icon("StatusError"), 0, false, TTR("This class is marked as deprecated."));
+		r_item->add_button(0, get_editor_theme_icon("StatusError"), 0, false, vformat(TTR("Class \"%s\" is marked as deprecated."), p_type));
 	} else if (is_experimental) {
-		r_item->add_button(0, get_editor_theme_icon("NodeWarning"), 0, false, TTR("This class is marked as experimental."));
+		r_item->add_button(0, get_editor_theme_icon("NodeWarning"), 0, false, vformat(TTR("Class \"%s\" is marked as experimental."), p_type));
 	}
 
 	if (!search_box->get_text().is_empty()) {


### PR DESCRIPTION
- Display script icon on the right for nodes that are sourced from custom types and `class_name` scripts. Custom types use a more faint script icon to mimic the one displayed in the Scene tree dock.
- Display the class name in the tooltip for experimental/deprecated classes, so you always know which class the tooltip is referring to.

___

- This closes https://github.com/godotengine/godot-proposals/discussions/9423.

## Preview

### `class_name` script

![Screenshot_20240411_231031](https://github.com/godotengine/godot/assets/180032/06619413-c44c-492f-8d49-96a0821fc02b)

### Custom type

![Screenshot_20240411_231036](https://github.com/godotengine/godot/assets/180032/db5e50f9-b26d-4af1-892c-b581288e1f7b)

### Experimental class

![Screenshot_20240411_231056](https://github.com/godotengine/godot/assets/180032/f35518df-0afb-474b-8366-112386bb543f)
