### PR TITLE
Don't print warning messages for DisplayServer functions in headless mode

### DIFF
--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -57,6 +57,9 @@ public:
 	bool has_feature(Feature p_feature) const override { return false; }
 	String get_name() const override { return "headless"; }
 
+	// Stub implementations to prevent warnings from being printed for methods
+	// that don't affect the project's behavior in headless mode.
+
 	int get_screen_count() const override { return 0; }
 	int get_primary_screen() const override { return 0; };
 	Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Point2i(); }
@@ -66,6 +69,8 @@ public:
 	float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return 1; }
 	float screen_get_max_scale() const override { return 1; }
 	float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return SCREEN_REFRESH_RATE_FALLBACK; }
+	void screen_set_orientation(ScreenOrientation p_orientation, int p_screen = SCREEN_OF_MAIN_WINDOW) override {}
+	void screen_set_keep_on(bool p_enable) override {}
 
 	Vector<DisplayServer::WindowID> get_window_list() const override { return Vector<DisplayServer::WindowID>(); }
 
@@ -130,9 +135,47 @@ public:
 	void window_set_ime_active(const bool p_active, WindowID p_window = MAIN_WINDOW_ID) override {}
 	void window_set_ime_position(const Point2i &p_pos, WindowID p_window = MAIN_WINDOW_ID) override {}
 
+	int64_t window_get_native_handle(HandleType p_handle_type, WindowID p_window = MAIN_WINDOW_ID) const override { return 0; }
+
 	void process_events() override {}
 
+	void set_native_icon(const String &p_filename) override {}
 	void set_icon(const Ref<Image> &p_icon) override {}
+
+	void help_set_search_callbacks(const Callable &p_search_callback = Callable(), const Callable &p_action_callback = Callable()) override {}
+
+	bool tts_is_speaking() const override { return false; }
+	bool tts_is_paused() const override { return false; }
+	TypedArray<Dictionary> tts_get_voices() const override { return TypedArray<Dictionary>(); }
+	void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.0f, float p_rate = 1.0f, int p_utterance_id = 0, bool p_interrupt = false) override {}
+	void tts_pause() override {}
+	void tts_resume() override {}
+	void tts_stop() override {}
+
+	void mouse_set_mode(MouseMode p_mode) override {}
+	void clipboard_set(const String &p_text) override {}
+	void clipboard_set_primary(const String &p_text) override {}
+
+	void virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), VirtualKeyboardType p_type = KEYBOARD_TYPE_DEFAULT, int p_max_length = -1, int p_cursor_start = -1, int p_cursor_end = -1) override {}
+	void virtual_keyboard_hide() override {}
+
+	void cursor_set_shape(CursorShape p_shape) override {}
+	void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override {}
+
+	Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
+	Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
+	Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
+	Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
+
+	void release_rendering_thread() override {}
+	void make_rendering_thread() override {}
+	void swap_buffers() override {}
+
+	IndicatorID create_status_indicator(const Ref<Image> &p_icon, const String &p_tooltip, const Callable &p_callback) override { return INVALID_INDICATOR_ID; }
+	void status_indicator_set_icon(IndicatorID p_id, const Ref<Image> &p_icon) override {}
+	void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) override {}
+	void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override {}
+	void delete_status_indicator(IndicatorID p_id) override {}
 
 	DisplayServerHeadless() {
 		native_menu = memnew(NativeMenu);


### PR DESCRIPTION
DisplayServer methods that only have a cosmetic effect print a warning (instead of an error). These warnings can be silenced in headless mode, as it's assumed that the cosmetic effect is undesired in headless mode anyway (e.g. changing mouse cursor shape).

This prevents spurious warnings from appearing when running the editor in headless mode, e.g. on CI to export a project.

Methods that print an error will continue to do so, as their returned value may not match expectations and have cascading consequences on the project (e.g. clipboard data not being retrievable).

- See [Supressing mouse warnings from running server in –headless mode - Godot Forum](https://forum.godotengine.org/t/supressing-mouse-warnings-from-running-server-in-headless-mode/54116).

**Testing project:** [test_headless_methods.zip](https://github.com/godotengine/godot/files/14951654/test_headless_methods.zip)
Run with and without `--headless` from a terminal and compare output.

## Preview

### Before

```
$ godot --headless 
Godot Engine v4.3.dev.custom_build.b091162a9 (2024-04-10 15:49:59 UTC) - https://godotengine.org

WARNING: Custom cursor shape not supported by this display server.
     at: cursor_set_custom_image (servers/display_server.cpp:636)
WARNING: Clipboard is not supported by this display server.
     at: clipboard_set (servers/display_server.cpp:506)
ERROR: Clipboard is not supported by this display server.
   at: clipboard_get (servers/display_server.cpp:510)

ERROR: Virtual keyboard not supported by this display server.
   at: virtual_keyboard_get_height (servers/display_server.cpp:624)
0
WARNING: Native dialogs not supported by this display server.
     at: dialog_input_text (servers/display_server.cpp:652)
```

### After

```
$ godot --headless
Godot Engine v4.3.dev.custom_build.67b915f63 (2024-04-11 21:14:41 UTC) - https://godotengine.org

ERROR: Clipboard is not supported by this display server.
   at: clipboard_get (servers/display_server.cpp:517)

ERROR: Virtual keyboard not supported by this display server.
   at: virtual_keyboard_get_height (servers/display_server.cpp:631)
0
```

### Non-headless output for comparison

*This is left unchanged in this PR.*

```
$ godot           
Godot Engine v4.3.dev.custom_build.67b915f63 (2024-04-11 21:14:41 UTC) - https://godotengine.org
Vulkan 1.3.277 - Forward+ - Using Device #0: NVIDIA - NVIDIA GeForce RTX 4090

test
ERROR: Virtual keyboard not supported by this display server.
   at: virtual_keyboard_get_height (servers/display_server.cpp:631)
0
WARNING: Native dialogs not supported by this display server.
     at: dialog_input_text (servers/display_server.cpp:663)
```