### PR TITLE
FBX: Fix material colors

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1178,7 +1178,11 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 			}
 
 			// Combined textures and factors are very unreliable in FBX
-			material->set_albedo(Color(1, 1, 1));
+			Color albedo_factor = Color(1, 1, 1);
+			if (fbx_material->pbr.base_factor.has_value) {
+				albedo_factor *= (float)fbx_material->pbr.base_factor.value_real;
+			}
+			material->set_albedo(albedo_factor.linear_to_srgb());
 
 			// TODO: Does not support rotation, could be inverted?
 			material->set_uv1_offset(_as_vec3(base_texture->uv_transform.translation));

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1236,7 +1236,7 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 			material->set_emission_energy_multiplier(float(fbx_material->pbr.emission_factor.value_real));
 		}
 
-		const ufbx_texture *emission_texture = _get_file_texture(fbx_material->pbr.ambient_occlusion.texture);
+		const ufbx_texture *emission_texture = _get_file_texture(fbx_material->pbr.emission_color.texture);
 		if (emission_texture) {
 			material->set_texture(BaseMaterial3D::TEXTURE_EMISSION, _get_texture(p_state, GLTFTextureIndex(emission_texture->file_index), TEXTURE_TYPE_GENERIC));
 			material->set_feature(BaseMaterial3D::FEATURE_EMISSION, true);

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1080,7 +1080,7 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 
 		if (fbx_material->pbr.base_color.has_value) {
 			Color albedo = _material_color(fbx_material->pbr.base_color, fbx_material->pbr.base_factor);
-			material->set_albedo(albedo);
+			material->set_albedo(albedo.linear_to_srgb());
 		}
 
 		if (fbx_material->features.double_sided.enabled) {
@@ -1232,7 +1232,7 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 
 		if (fbx_material->pbr.emission_color.has_value) {
 			material->set_feature(BaseMaterial3D::FEATURE_EMISSION, true);
-			material->set_emission(_material_color(fbx_material->pbr.emission_color));
+			material->set_emission(_material_color(fbx_material->pbr.emission_color).linear_to_srgb());
 			material->set_emission_energy_multiplier(float(fbx_material->pbr.emission_factor.value_real));
 		}
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1266,7 +1266,7 @@ Error FBXDocument::_parse_cameras(Ref<FBXState> p_state) {
 			camera->set_fov(Math::deg_to_rad(real_t(fbx_camera->field_of_view_deg.y)));
 		} else {
 			camera->set_perspective(false);
-			camera->set_size_mag(real_t(fbx_camera->orthographic_size.y));
+			camera->set_size_mag(real_t(fbx_camera->orthographic_size.y * 0.5f));
 		}
 		if (fbx_camera->near_plane != 0.0f) {
 			camera->set_depth_near(fbx_camera->near_plane);


### PR DESCRIPTION
Fixes #90527

Using ufbx test case to validate importing: https://github.com/ufbx/ufbx/blob/picort-refactor/data/maya_material_chart_7700_ascii.fbx 
This test case consists of a 4x3 grid of planes, all with different materials, which should resolve to the same color in a correct renderer.

Reference image: All squares should be the same color (not accounting for some minor quantization inaccuarcies)
![reference_ufbx_render](https://github.com/godotengine/godot/assets/3875461/7435d67e-9bd4-412e-a788-28dd17d49295)

Godot ufbx before: Emissive textures were not imported correctly and linear material colors were not converted to sRGB:
![reference_godot_previous](https://github.com/godotengine/godot/assets/3875461/e010f533-4561-461d-968c-2b8e66d65d89)

Godot ufbx with this PR: Base color factors are currently ignored in Godot if textures are connected, as some files may contain garbage factors:
![reference_godot_no_factor](https://github.com/godotengine/godot/assets/3875461/a92d3037-d537-4a1f-9130-d70b6869cbc4)

Godot ufbx with factor support (see note below):
![reference_godot_fixes](https://github.com/godotengine/godot/assets/3875461/282d9d6e-d23b-4360-b48f-8d7e40de3131)

The following diff would fix the factor support, but it is unclear if it is worth it as it may break other files. One approach would be to add an import option for it but it's probably a too fringe case to support.

```diff
// Combined textures and factors are very unreliable in FBX
- material->set_albedo(Color(1, 1, 1));
+ Color albedo_factor = Color(1, 1, 1);
+ if (fbx_material->pbr.base_factor.has_value) {
+     albedo_factor *= (float)fbx_material->pbr.base_factor.value_real;
+ }
+ material->set_albedo(albedo_factor.linear_to_srgb());
```

Test project: [ufbx_material_chart.zip](https://github.com/godotengine/godot/files/14952821/ufbx_material_chart.zip)