### PR TITLE
Allow `ExportPlugin` to add export messages; use in C# export plugin

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -18,4 +18,18 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="EXPORT_MESSAGE_NONE" value="0" enum="ExportMessageType">
+			Invalid message type used as the default value when no type is specified.
+		</constant>
+		<constant name="EXPORT_MESSAGE_INFO" value="1" enum="ExportMessageType">
+			Message type for informational messages that have no effect on the export.
+		</constant>
+		<constant name="EXPORT_MESSAGE_WARNING" value="2" enum="ExportMessageType">
+			Message type for warning messages that should be addressed but still allow to complete the export.
+		</constant>
+		<constant name="EXPORT_MESSAGE_ERROR" value="3" enum="ExportMessageType">
+			Message type for error messages that must be addressed and fail the export.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -292,6 +292,15 @@
 				[b]Note:[/b] This is useful only for macOS exports.
 			</description>
 		</method>
+		<method name="add_message" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="EditorExportPlatform.ExportMessageType" />
+			<param index="1" name="category" type="String" />
+			<param index="2" name="message" type="String" />
+			<description>
+				Adds a message to the export log that will be displayed when exporting ends.
+			</description>
+		</method>
 		<method name="add_shared_object">
 			<return type="void" />
 			<param index="0" name="path" type="String" />

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -71,7 +71,7 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 	p_log->add_text(" ");
 	p_log->add_text(get_name());
 	p_log->add_text(" - ");
-	if (p_err == OK) {
+	if (p_err == OK && get_worst_message_type() < EditorExportPlatform::EXPORT_MESSAGE_ERROR) {
 		if (get_worst_message_type() >= EditorExportPlatform::EXPORT_MESSAGE_WARNING) {
 			p_log->add_image(p_log->get_editor_theme_icon(SNAME("StatusWarning")), 16 * EDSCALE, 16 * EDSCALE, Color(1.0, 1.0, 1.0), INLINE_ALIGNMENT_CENTER);
 			p_log->add_text(" ");
@@ -2026,6 +2026,11 @@ Error EditorExportPlatform::ssh_push_to_remote(const String &p_host, const Strin
 
 void EditorExportPlatform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_os_name"), &EditorExportPlatform::get_os_name);
+
+	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_NONE);
+	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_INFO);
+	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_WARNING);
+	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_ERROR);
 }
 
 EditorExportPlatform::EditorExportPlatform() {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -256,4 +256,6 @@ public:
 	EditorExportPlatform();
 };
 
+VARIANT_ENUM_CAST(EditorExportPlatform::ExportMessageType);
+
 #endif // EDITOR_EXPORT_PLATFORM_H

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -48,6 +48,10 @@ Ref<EditorExportPreset> EditorExportPlugin::get_export_preset() const {
 	return export_preset;
 }
 
+void EditorExportPlugin::add_message(EditorExportPlatform::ExportMessageType p_type, const String &p_category, const String &p_message) const {
+	get_export_preset()->get_platform()->add_message(p_type, p_category, p_message);
+}
+
 void EditorExportPlugin::add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap) {
 	ExtraFile ef;
 	ef.data = p_file;
@@ -304,6 +308,7 @@ void EditorExportPlugin::skip() {
 }
 
 void EditorExportPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_message", "type", "category", "message"), &EditorExportPlugin::add_message);
 	ClassDB::bind_method(D_METHOD("add_shared_object", "path", "tags", "target"), &EditorExportPlugin::add_shared_object);
 	ClassDB::bind_method(D_METHOD("add_ios_project_static_lib", "path"), &EditorExportPlugin::add_ios_project_static_lib);
 	ClassDB::bind_method(D_METHOD("add_file", "path", "file", "remap"), &EditorExportPlugin::add_file);

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -92,6 +92,8 @@ protected:
 	void set_export_preset(const Ref<EditorExportPreset> &p_preset);
 	Ref<EditorExportPreset> get_export_preset() const;
 
+	void add_message(EditorExportPlatform::ExportMessageType p_type, const String &p_category, const String &p_message) const;
+
 	void add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap);
 	void add_shared_object(const String &p_path, const Vector<String> &tags, const String &p_target = String());
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -265,11 +265,6 @@ namespace GodotTools.Build
                 success = Publish(buildInfo);
             }
 
-            if (!success)
-            {
-                ShowBuildErrorDialog("Failed to publish .NET project");
-            }
-
             return success;
         }
 


### PR DESCRIPTION
- Expose `EditorExportPlatform::add_message` as a method in `ExportPlugin` so plugins can add messages that will be displayed in the export log at the end of exporting.
- Use the new `ExportPlugin::add_message` in the C# export plugin to add error messages instead of a custom error dialog. Integrates the .NET error messages with the export log dialog so only one dialog is displayed.

![add_message](https://github.com/godotengine/godot/assets/3903059/52c35f36-7eca-4b24-8bd7-069f951e85d2)


### Alternative design

We could alternatively expose the method in `EditorExportPlatform` and add a `get_export_platform` method to `ExportPlugin` so we could retrieve the export platform from the plugin.