### PR TITLE
Add `ExportPlugin::get_platform_os_name`; use in C# export plugin

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -310,6 +310,12 @@
 				Returns the current value of an export option supplied by [method _get_export_options].
 			</description>
 		</method>
+		<method name="get_platform_os_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the export operating system of the current export preset. See [method EditorExportPlatform.get_os_name].
+			</description>
+		</method>
 		<method name="skip">
 			<return type="void" />
 			<description>

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -132,6 +132,10 @@ Variant EditorExportPlugin::get_option(const StringName &p_name) const {
 	return export_preset->get(p_name);
 }
 
+String EditorExportPlugin::get_platform_os_name() const {
+	return export_preset->get_platform()->get_os_name();
+}
+
 String EditorExportPlugin::_has_valid_export_configuration(const Ref<EditorExportPlatform> &p_export_platform, const Ref<EditorExportPreset> &p_preset) {
 	String warning;
 	if (!supports_platform(p_export_platform)) {
@@ -316,6 +320,7 @@ void EditorExportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_macos_plugin_file", "path"), &EditorExportPlugin::add_macos_plugin_file);
 	ClassDB::bind_method(D_METHOD("skip"), &EditorExportPlugin::skip);
 	ClassDB::bind_method(D_METHOD("get_option", "name"), &EditorExportPlugin::get_option);
+	ClassDB::bind_method(D_METHOD("get_platform_os_name"), &EditorExportPlugin::get_platform_os_name);
 
 	GDVIRTUAL_BIND(_export_file, "path", "type", "features");
 	GDVIRTUAL_BIND(_export_begin, "features", "is_debug", "path", "flags");

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -181,6 +181,7 @@ public:
 	String get_ios_cpp_code() const;
 	const Vector<String> &get_macos_plugin_files() const;
 	Variant get_option(const StringName &p_name) const;
+	String get_platform_os_name() const;
 
 	EditorExportPlugin();
 };

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -144,7 +144,10 @@ namespace GodotTools.Export
             if (!ProjectContainsDotNet())
                 return;
 
-            if (!DeterminePlatformFromFeatures(features, out string? platform))
+            string osName = GetPlatformOsName();
+
+            // Check if the OS name corresponds to one of the supported platforms.
+            if (!TryDeterminePlatformFromOSName(osName, out string? platform))
                 throw new NotSupportedException("Target platform not supported.");
 
             if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS }
@@ -459,12 +462,20 @@ namespace GodotTools.Export
             }
         }
 
-        private static bool DeterminePlatformFromFeatures(IEnumerable<string> features, [NotNullWhen(true)] out string? platform)
+        /// <summary>
+        /// Tries to determine the platform from the export preset's platform OS name.
+        /// </summary>
+        /// <param name="osName">Name of the export operating system.</param>
+        /// <param name="platform">Platform name for the recognized supported platform.</param>
+        /// <returns>
+        /// <see langword="true"/> when the platform OS name is recognized as a supported platform,
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        private static bool TryDeterminePlatformFromOSName(string osName, [NotNullWhen(true)] out string? platform)
         {
-            foreach (var feature in features)
+            if (OS.PlatformFeatureMap.TryGetValue(osName, out platform))
             {
-                if (OS.PlatformFeatureMap.TryGetValue(feature, out platform))
-                    return true;
+                return true;
             }
 
             platform = null;


### PR DESCRIPTION
- Add `ExportPlugin::get_platform_os_name` method to retrieve the OS name for the current export's preset OS name from an export plugin without having to guess from the features.
- Use the new `ExportPlugin::get_platform_os_name` in the C# export plugin to get the platform name.
  - On its own it's not enough, but this may be of interest to @shana as part of making the export plugin more _extensible_ to make it work with _unknown_ platforms (i.e. consoles). For now the list of supported platforms is still hardcoded.

### Alternative design

We could alternatively expose a method in `ExportPlugin` to retrieve the `EditorExportPlatform` and then we can just use the `EditorExportPlatform::get_os_name` that is already exposed.