### PR TITLE
Rename accessor GLTFType to GLTFAccessorType, fix verbose prints, document GLTFAccessor

### DIFF
--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -12,34 +12,50 @@
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<members>
+		<member name="accessor_type" type="int" setter="set_accessor_type" getter="get_accessor_type" default="0">
+			The GLTF accessor type as an enum. Possible values are 0 for "SCALAR", 1 for "VEC2", 2 for "VEC3", 3 for "VEC4", 4 for "MAT2", 5 for "MAT3", and 6 for "MAT4".
+		</member>
 		<member name="buffer_view" type="int" setter="set_buffer_view" getter="get_buffer_view" default="-1">
 			The index of the buffer view this accessor is referencing. If [code]-1[/code], this accessor is not referencing any buffer view.
 		</member>
 		<member name="byte_offset" type="int" setter="set_byte_offset" getter="get_byte_offset" default="0">
+			The offset relative to the start of the buffer view in bytes.
 		</member>
 		<member name="component_type" type="int" setter="set_component_type" getter="get_component_type" default="0">
+			The GLTF component type as an enum. Possible values are 5120 for "BYTE", 5121 for "UNSIGNED_BYTE", 5122 for "SHORT", 5123 for "UNSIGNED_SHORT", 5125 for "UNSIGNED_INT", and 5126 for "FLOAT". A value of 5125 or "UNSIGNED_INT" must not be used for any accessor that is not referenced by mesh.primitive.indices.
 		</member>
 		<member name="count" type="int" setter="set_count" getter="get_count" default="0">
+			The number of elements referenced by this accessor.
 		</member>
 		<member name="max" type="PackedFloat64Array" setter="set_max" getter="get_max" default="PackedFloat64Array()">
+			Maximum value of each component in this accessor.
 		</member>
 		<member name="min" type="PackedFloat64Array" setter="set_min" getter="get_min" default="PackedFloat64Array()">
+			Minimum value of each component in this accessor.
 		</member>
 		<member name="normalized" type="bool" setter="set_normalized" getter="get_normalized" default="false">
+			Specifies whether integer data values are normalized before usage.
 		</member>
 		<member name="sparse_count" type="int" setter="set_sparse_count" getter="get_sparse_count" default="0">
+			Number of deviating accessor values stored in the sparse array.
 		</member>
 		<member name="sparse_indices_buffer_view" type="int" setter="set_sparse_indices_buffer_view" getter="get_sparse_indices_buffer_view" default="0">
+			The index of the buffer view with sparse indices. The referenced buffer view MUST NOT have its target or byteStride properties defined. The buffer view and the optional byteOffset MUST be aligned to the componentType byte length.
 		</member>
 		<member name="sparse_indices_byte_offset" type="int" setter="set_sparse_indices_byte_offset" getter="get_sparse_indices_byte_offset" default="0">
+			The offset relative to the start of the buffer view in bytes.
 		</member>
 		<member name="sparse_indices_component_type" type="int" setter="set_sparse_indices_component_type" getter="get_sparse_indices_component_type" default="0">
+			The indices component data type as an enum. Possible values are 5121 for "UNSIGNED_BYTE", 5123 for "UNSIGNED_SHORT", and 5125 for "UNSIGNED_INT".
 		</member>
 		<member name="sparse_values_buffer_view" type="int" setter="set_sparse_values_buffer_view" getter="get_sparse_values_buffer_view" default="0">
+			The index of the bufferView with sparse values. The referenced buffer view MUST NOT have its target or byteStride properties defined.
 		</member>
 		<member name="sparse_values_byte_offset" type="int" setter="set_sparse_values_byte_offset" getter="get_sparse_values_byte_offset" default="0">
+			The offset relative to the start of the bufferView in bytes.
 		</member>
-		<member name="type" type="int" setter="set_type" getter="get_type" default="0">
+		<member name="type" type="int" setter="set_type" getter="get_type" default="0" deprecated="Use [member accessor_type] instead.">
+			The GLTF accessor type as an enum. Use [member accessor_type] instead.
 		</member>
 	</members>
 </class>

--- a/modules/gltf/gltf_defines.h
+++ b/modules/gltf/gltf_defines.h
@@ -66,14 +66,4 @@ using GLTFSkinIndex = int;
 using GLTFTextureIndex = int;
 using GLTFTextureSamplerIndex = int;
 
-enum GLTFType {
-	TYPE_SCALAR,
-	TYPE_VEC2,
-	TYPE_VEC3,
-	TYPE_VEC4,
-	TYPE_MAT2,
-	TYPE_MAT3,
-	TYPE_MAT4,
-};
-
 #endif // GLTF_DEFINES_H

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -111,8 +111,7 @@ private:
 	int _get_component_type_size(const int p_component_type);
 	Error _parse_scenes(Ref<GLTFState> p_state);
 	Error _parse_nodes(Ref<GLTFState> p_state);
-	String _get_type_name(const GLTFType p_component);
-	String _get_accessor_type_name(const GLTFType p_type);
+	String _get_accessor_type_name(const GLTFAccessorType p_accessor_type);
 	String _sanitize_animation_name(const String &p_name);
 	String _gen_unique_animation_name(Ref<GLTFState> p_state, const String &p_name);
 	String _sanitize_bone_name(const String &p_name);
@@ -132,13 +131,13 @@ private:
 	void _compute_node_heights(Ref<GLTFState> p_state);
 	Error _parse_buffers(Ref<GLTFState> p_state, const String &p_base_path);
 	Error _parse_buffer_views(Ref<GLTFState> p_state);
-	GLTFType _get_type_from_str(const String &p_string);
+	GLTFAccessorType _get_accessor_type_from_str(const String &p_string);
 	Error _parse_accessors(Ref<GLTFState> p_state);
 	Error _decode_buffer_view(Ref<GLTFState> p_state, double *p_dst,
 			const GLTFBufferViewIndex p_buffer_view,
 			const int p_skip_every, const int p_skip_bytes,
 			const int p_element_size, const int p_count,
-			const GLTFType p_type, const int p_component_count,
+			const GLTFAccessorType p_accessor_type, const int p_component_count,
 			const int p_component_type, const int p_component_size,
 			const bool p_normalized, const int p_byte_offset,
 			const bool p_for_vertex);
@@ -267,7 +266,7 @@ private:
 			const Vector<Transform3D> p_attribs,
 			const bool p_for_vertex);
 	Error _encode_buffer_view(Ref<GLTFState> p_state, const double *p_src,
-			const int p_count, const GLTFType p_type,
+			const int p_count, const GLTFAccessorType p_accessor_type,
 			const int p_component_type, const bool p_normalized,
 			const int p_byte_offset, const bool p_for_vertex,
 			GLTFBufferViewIndex &r_accessor, const bool p_for_indices = false);

--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -41,8 +41,10 @@ void GLTFAccessor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_normalized", "normalized"), &GLTFAccessor::set_normalized);
 	ClassDB::bind_method(D_METHOD("get_count"), &GLTFAccessor::get_count);
 	ClassDB::bind_method(D_METHOD("set_count", "count"), &GLTFAccessor::set_count);
-	ClassDB::bind_method(D_METHOD("get_type"), &GLTFAccessor::get_type);
-	ClassDB::bind_method(D_METHOD("set_type", "type"), &GLTFAccessor::set_type);
+	ClassDB::bind_method(D_METHOD("get_accessor_type"), &GLTFAccessor::get_accessor_type);
+	ClassDB::bind_method(D_METHOD("set_accessor_type", "accessor_type"), &GLTFAccessor::set_accessor_type);
+	ClassDB::bind_method(D_METHOD("get_type"), &GLTFAccessor::get_accessor_type);
+	ClassDB::bind_method(D_METHOD("set_type", "type"), &GLTFAccessor::set_accessor_type);
 	ClassDB::bind_method(D_METHOD("get_min"), &GLTFAccessor::get_min);
 	ClassDB::bind_method(D_METHOD("set_min", "min"), &GLTFAccessor::set_min);
 	ClassDB::bind_method(D_METHOD("get_max"), &GLTFAccessor::get_max);
@@ -65,7 +67,8 @@ void GLTFAccessor::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "component_type"), "set_component_type", "get_component_type"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "normalized"), "set_normalized", "get_normalized"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "count"), "set_count", "get_count"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // GLTFType
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "accessor_type"), "set_accessor_type", "get_accessor_type"); // GLTFAccessorType
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // Deprecated, GLTFAccessorType
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT64_ARRAY, "min"), "set_min", "get_min"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT64_ARRAY, "max"), "set_max", "get_max"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sparse_count"), "set_sparse_count", "get_sparse_count"); // int
@@ -116,12 +119,12 @@ void GLTFAccessor::set_count(int p_count) {
 	count = p_count;
 }
 
-int GLTFAccessor::get_type() {
-	return (int)type;
+int GLTFAccessor::get_accessor_type() {
+	return (int)accessor_type;
 }
 
-void GLTFAccessor::set_type(int p_type) {
-	type = (GLTFType)p_type; // TODO: Register enum
+void GLTFAccessor::set_accessor_type(int p_accessor_type) {
+	accessor_type = (GLTFAccessorType)p_accessor_type; // TODO: Register enum
 }
 
 Vector<double> GLTFAccessor::get_min() {

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -35,6 +35,16 @@
 
 #include "core/io/resource.h"
 
+enum GLTFAccessorType {
+	TYPE_SCALAR,
+	TYPE_VEC2,
+	TYPE_VEC3,
+	TYPE_VEC4,
+	TYPE_MAT2,
+	TYPE_MAT3,
+	TYPE_MAT4,
+};
+
 struct GLTFAccessor : public Resource {
 	GDCLASS(GLTFAccessor, Resource);
 	friend class GLTFDocument;
@@ -45,7 +55,7 @@ private:
 	int component_type = 0;
 	bool normalized = false;
 	int count = 0;
-	GLTFType type = GLTFType::TYPE_SCALAR;
+	GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_SCALAR;
 	Vector<double> min;
 	Vector<double> max;
 	int sparse_count = 0;
@@ -74,8 +84,8 @@ public:
 	int get_count();
 	void set_count(int p_count);
 
-	int get_type();
-	void set_type(int p_type);
+	int get_accessor_type();
+	void set_accessor_type(int p_accessor_type);
 
 	Vector<double> get_min();
 	void set_min(Vector<double> p_min);


### PR DESCRIPTION
Follow-up to #36382 and #89317. The name `type` by itself is too generic and should be avoided.

This PR renames GLTFAccessor `get_type` to `get_accessor_type`, renames the GLTFType enum to GLTFAccessorType, moves GLTFAccessorType to `gltf_accessor.h`, and documents all of GLTFAccessor's properties. It also fixes the verbose prints using a duplicate and incorrect `_get_type_name` that used lowercase and "float", but the correct values per the GLTF spec are all uppercase and the float one is "SCALAR".

For now the old names are still bound for compatibility, but this change will fix these warnings when building C# assemblies the next time we break compatibility and we remove the old method names:

```
GltfAccessor.cs(287,18): warning CS0108: 'GltfAccessor.GetType()' hides inherited member 'object.GetType()'. Use the new keyword if hiding was intended.
GltfAccessor.cs(578,43): warning CS0108: 'GltfAccessor.MethodName.GetType' hides inherited member 'object.GetType()'. Use the new keyword if hiding was intended.
```