### PR TITLE
[Unix / DirAccess] Fix removing directory symlinks with `remove`, ensure `erase_contents_recursive` is not following directory symlinks.

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -84,7 +84,7 @@ static Error _erase_recursive(DirAccess *da) {
 	String n = da->get_next();
 	while (!n.is_empty()) {
 		if (n != "." && n != "..") {
-			if (da->current_is_dir()) {
+			if (da->current_is_dir() && !da->is_link(n)) {
 				dirs.push_back(n);
 			} else {
 				files.push_back(n);

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -419,7 +419,7 @@ Error DirAccessUnix::remove(String p_path) {
 		return FAILED;
 	}
 
-	if (S_ISDIR(flags.st_mode)) {
+	if (S_ISDIR(flags.st_mode) && !is_link(p_path)) {
 		return ::rmdir(p_path.utf8().get_data()) == 0 ? OK : FAILED;
 	} else {
 		return ::unlink(p_path.utf8().get_data()) == 0 ? OK : FAILED;
@@ -435,7 +435,7 @@ bool DirAccessUnix::is_link(String p_file) {
 
 	struct stat flags = {};
 	if ((lstat(p_file.utf8().get_data(), &flags) != 0)) {
-		return FAILED;
+		return false;
 	}
 
 	return S_ISLNK(flags.st_mode);


### PR DESCRIPTION
- Fix removing directory symlinks with `remove`.
- Ensure `erase_contents_recursive` is not following directory symlinks.
