### PR TITLE
Improve error when scene/resource is saved with newer format

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1445,6 +1445,9 @@ void EditorNode::_dialog_display_load_error(String p_file, Error p_error) {
 			case ERR_FILE_NOT_FOUND: {
 				show_accept(vformat(TTR("Missing file '%s' or one of its dependencies."), p_file.get_file()), TTR("OK"));
 			} break;
+			case ERR_FILE_UNRECOGNIZED: {
+				show_accept(vformat(TTR("File '%s' is saved in a format that is newer than the formats supported by this version of Godot, so it can't be opened."), p_file.get_file()), TTR("OK"));
+			} break;
 			default: {
 				show_accept(vformat(TTR("Error while loading file '%s'."), p_file.get_file()), TTR("OK"));
 			} break;
@@ -6642,6 +6645,8 @@ EditorNode::EditorNode() {
 	main_menu->set_menu_tooltip(0, TTR("Operations with scene files."));
 
 	accept = memnew(AcceptDialog);
+	accept->set_autowrap(true);
+	accept->set_min_size(Vector2i(600, 0));
 	accept->set_unparent_when_invisible(true);
 
 	save_accept = memnew(AcceptDialog);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1067,7 +1067,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 		if (fmt > FORMAT_VERSION) {
 			error_text = "Saved with newer format version";
 			_printerr();
-			error = ERR_PARSE_ERROR;
+			error = ERR_FILE_UNRECOGNIZED;
 			return;
 		}
 	}


### PR DESCRIPTION
Currently opening a scene saved in a new format results in very unhelpful message:
![](https://chat.godotengine.org/file-upload/6618fd09c97662628588ce3f/Clipboard%20-%20April%2012,%202024%2011:21.png)

This PR improves it:
![image](https://github.com/godotengine/godot/assets/2223172/83aa0bad-7e50-48b4-95d2-612a5da2ce0a)
