### PR TITLE
Fix error when loading SVG imported as Image

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -173,9 +173,17 @@ void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
-	String svg = p_fileaccess->get_as_utf8_string();
+	const uint64_t len = p_fileaccess->get_length() - p_fileaccess->get_position();
+	Vector<uint8_t> buffer;
+	buffer.resize(len);
+	p_fileaccess->get_buffer(buffer.ptrw(), buffer.size());
 
-	Error err;
+	String svg;
+	Error err = svg.parse_utf8((const char *)buffer.ptr(), buffer.size());
+	if (err != OK) {
+		return err;
+	}
+
 	if (p_flags & FLAG_CONVERT_COLORS) {
 		err = create_image_from_string(p_image, svg, p_scale, false, forced_color_map);
 	} else {


### PR DESCRIPTION
If an SVG file is imported as Image, trying to open it in the editor produces these error:

```
core/io/file_access.cpp:504 - Condition "r != len" is true. Returning: String()
Failed loading resource: res://.godot/imported/new.svg-43c58458c66d384f2ca7a4ce4dd3ac63.image. Make sure resources have been imported by opening the project in the editor at least once.
Failed loading resource: res://new.svg. Make sure resources have been imported by opening the project in the editor at least once.
editor/editor_node.cpp:1225 - Condition "!res.is_valid()" is true. Returning: ERR_CANT_OPEN
```

It's because `get_as_utf8_string()` is used to load SVG string. This method expects a brand new `FileAccess`, however for an `Image`, a header is already stripped from file content. So this PR reads the rest of the file manually.
