### PR TITLE
Add a Reference Cycle Breaker

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -116,6 +116,12 @@ public:
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
+
+		// For tagging
+		LocalVector<StringName> resource_properties;
+		LocalVector<StringName> array_properties;
+		LocalVector<StringName> dict_properties;
+
 #ifdef DEBUG_METHODS_ENABLED
 		List<StringName> constant_order;
 		List<StringName> method_order;
@@ -478,6 +484,9 @@ public:
 	static void get_native_struct_list(List<StringName> *r_names);
 	static String get_native_struct_code(const StringName &p_name);
 	static uint64_t get_native_struct_size(const StringName &p_name); // Used for asserting
+
+	static void tag_collect_pass(Object *object, uint32_t p_pass, bool p_containers);
+	static void unlink_resources(Object *p_object, bool p_containers);
 };
 
 #define BIND_ENUM_CONSTANT(m_constant) \

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -919,20 +919,25 @@ void Object::notification(int p_notification, bool p_reversed) {
 }
 
 String Object::to_string() {
+	String id = itos(get_instance_id());
 	if (script_instance) {
 		bool valid;
 		String ret = script_instance->to_string(&valid);
 		if (valid) {
 			return ret;
 		}
+		if (script_instance->get_script().is_valid()) {
+			id = script_instance->get_script()->get_script_name();
+		}
 	}
+
 	if (_extension && _extension->to_string) {
 		String ret;
 		GDExtensionBool is_valid;
 		_extension->to_string(_extension_instance, &is_valid, &ret);
 		return ret;
 	}
-	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
+	return "<" + get_class() + "#" + id + ">";
 }
 
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
@@ -2165,6 +2170,34 @@ void ObjectDB::debug_objects(DebugFunc p_func) {
 	spin_lock.unlock();
 }
 
+void Object::tag_collect_pass(uint32_t p_pass, bool p_collect_containers) {
+	if (collect_pass == p_pass) {
+		return; // Already collected.
+	}
+
+	collect_pass = p_pass; // Mark beforehand due to recursion.
+
+	if (script_instance) {
+		script_instance->tag_collect_pass(p_pass, p_collect_containers);
+		Ref<Script> scr = script;
+		if (scr.is_valid()) {
+			scr->tag_collect_pass(p_pass, p_collect_containers);
+		}
+	}
+
+	ClassDB::tag_collect_pass(this, p_pass, p_collect_containers);
+
+	_tag_collect_pass_customv(p_pass, p_collect_containers);
+
+	for (const KeyValue<StringName, Variant> &K : metadata) {
+		K.value.tag_collect_pass(p_pass, p_collect_containers);
+	}
+}
+
+void Object::unlink_resources(bool p_collect_containers) {
+	ClassDB::unlink_resources(this, p_collect_containers);
+}
+
 #ifdef TOOLS_ENABLED
 void Object::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
@@ -2342,4 +2375,21 @@ void ObjectDB::cleanup() {
 	if (object_slots) {
 		memfree(object_slots);
 	}
+}
+
+void ObjectDB::fetch_unliked_objects(uint32_t p_collect_pass, List<ObjectID> &r_unlinked) {
+	spin_lock.lock();
+	for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {
+		if (object_slots[i].validator) {
+			if (object_slots[i].object->get_collect_pass() != p_collect_pass) {
+				uint64_t id = object_slots[i].validator;
+				id <<= OBJECTDB_SLOT_MAX_COUNT_BITS;
+				id |= uint64_t(i);
+
+				r_unlinked.push_back(ObjectID(id));
+			}
+			count--;
+		}
+	}
+	spin_lock.unlock();
 }

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -93,6 +93,8 @@ public:
 
 	virtual const Variant get_rpc_config() const;
 
+	virtual void tag_collect_pass(uint32_t p_pass, bool p_collect_containers = false) {}
+
 	virtual ScriptLanguage *get_language() = 0;
 	virtual ~ScriptInstance();
 };

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -47,6 +47,17 @@ bool ScriptServer::scripting_enabled = true;
 bool ScriptServer::reload_scripts_on_save = false;
 ScriptEditRequestFunction ScriptServer::edit_request_func = nullptr;
 
+String Script::get_script_name() const {
+	if (get_global_name() != StringName()) {
+		return get_global_name();
+	} else if (!get_path().is_empty()) {
+		return get_path().get_file();
+	} else if (!get_name().is_empty()) {
+		return get_name(); // Resource name.
+	}
+	return get_class();
+}
+
 void Script::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -807,6 +818,19 @@ Variant PlaceHolderScriptInstance::property_get_fallback(const StringName &p_nam
 	}
 
 	return Variant();
+}
+
+void PlaceHolderScriptInstance::tag_collect_pass(uint32_t p_pass, bool p_collect_containers) {
+	if (collect_pass == p_pass) {
+		return;
+	}
+
+	collect_pass = p_pass; // Tag beforehand due to recursion.
+
+	for (const KeyValue<StringName, Variant> &E : values) {
+		const Variant &v = E.value;
+		v.tag_collect_pass(p_pass, p_collect_containers);
+	}
 }
 
 PlaceHolderScriptInstance::PlaceHolderScriptInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner) :

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -131,6 +131,7 @@ public:
 
 	virtual bool can_instantiate() const = 0;
 
+	virtual String get_script_name() const;
 	virtual Ref<Script> get_base_script() const = 0; //for script inheritance
 	virtual StringName get_global_name() const = 0;
 	virtual bool inherits_script(const Ref<Script> &p_script) const = 0;
@@ -434,6 +435,7 @@ class PlaceHolderScriptInstance : public ScriptInstance {
 	HashMap<StringName, Variant> constants;
 	ScriptLanguage *language = nullptr;
 	Ref<Script> script;
+	uint32_t collect_pass = 0;
 
 public:
 	virtual bool set(const StringName &p_name, const Variant &p_value) override;
@@ -475,6 +477,8 @@ public:
 	virtual Variant property_get_fallback(const StringName &p_name, bool *r_valid = nullptr) override;
 
 	virtual const Variant get_rpc_config() const override { return Variant(); }
+
+	virtual void tag_collect_pass(uint32_t p_pass, bool p_collect_containers = false) override;
 
 	PlaceHolderScriptInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner);
 	~PlaceHolderScriptInstance();

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -47,7 +47,27 @@ public:
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	ContainerTypeValidate typed;
+	uint32_t collect_pass = 0;
 };
+
+void Array::tag_collect_pass(uint32_t p_pass, bool p_collect_containers) const {
+	if (_p->collect_pass == p_pass) {
+		return;
+	}
+
+	_p->collect_pass = p_pass; // Mark beforehand due to recursion.
+
+	if (_p->typed.type != Variant::OBJECT && _p->typed.type != Variant::DICTIONARY && _p->typed.type != Variant::ARRAY && _p->typed.type != Variant::NIL) {
+		// None of these types will contain objects, so do not do anything here.
+		return;
+	}
+
+	int len = _p->array.size();
+	const Variant *arr = _p->array.ptr();
+	for (int i = 0; i < len; i++) {
+		arr[i].tag_collect_pass(p_pass, p_collect_containers);
+	}
+}
 
 void Array::_ref(const Array &p_from) const {
 	ArrayPrivate *_fp = p_from._p;

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -193,6 +193,8 @@ public:
 	void make_read_only();
 	bool is_read_only() const;
 
+	void tag_collect_pass(uint32_t p_pass, bool p_collect_containers = false) const;
+
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
 	Array();

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -43,7 +43,25 @@ struct DictionaryPrivate {
 	SafeRefCount refcount;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator> variant_map;
+	uint32_t collect_pass = 0;
 };
+
+void Dictionary::tag_collect_pass(uint32_t p_pass, bool p_collect_containers) const {
+	if (_p->collect_pass == p_pass) {
+		return;
+	}
+
+	/* Add typed dictionary check here eventually */
+
+	_p->collect_pass = p_pass; // Mark beforehand due to recursion.
+
+	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
+		for (int i = 0; i < 2; i++) {
+			const Variant &v = i == 0 ? E.key : E.value;
+			v.tag_collect_pass(p_pass, p_collect_containers);
+		}
+	}
+}
 
 void Dictionary::get_key_list(List<Variant> *p_keys) const {
 	if (_p->variant_map.is_empty()) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -93,6 +93,8 @@ public:
 
 	const void *id() const;
 
+	void tag_collect_pass(uint32_t p_pass, bool p_collect_containers) const;
+
 	Dictionary(const Dictionary &p_from);
 	Dictionary();
 	~Dictionary();

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3605,6 +3605,13 @@ String Variant::get_callable_error_text(const Callable &p_callable, const Varian
 	}
 }
 
+void Variant::_tag_collect_pass_object(uint32_t p_pass, bool p_collect_containers) const {
+	Object *instance = ObjectDB::get_instance(_get_obj().id);
+	if (instance) {
+		instance->tag_collect_pass(p_pass, p_collect_containers);
+	}
+}
+
 void Variant::register_types() {
 	_register_variant_operators();
 	_register_variant_methods();

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -326,6 +326,8 @@ private:
 	Variant(const Variant *) {}
 	Variant(const Variant **) {}
 
+	void _tag_collect_pass_object(uint32_t p_pass, bool p_collect_containers) const;
+
 public:
 	_FORCE_INLINE_ Type get_type() const {
 		return type;
@@ -786,6 +788,18 @@ public:
 
 	static void register_types();
 	static void unregister_types();
+
+	_FORCE_INLINE_ void tag_collect_pass(uint32_t p_pass, bool p_collect_containers = false) const {
+		if (type == OBJECT) {
+			_tag_collect_pass_object(p_pass, p_collect_containers);
+		} else if (p_collect_containers) {
+			if (type == ARRAY) {
+				reinterpret_cast<const Array *>(_data._mem)->tag_collect_pass(p_pass, p_collect_containers);
+			} else if (type == DICTIONARY) {
+				reinterpret_cast<const Dictionary *>(_data._mem)->tag_collect_pass(p_pass, p_collect_containers);
+			}
+		}
+	}
 
 	Variant(const Variant &p_variant);
 	_FORCE_INLINE_ Variant() :

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1352,6 +1352,24 @@ void GDScript::_collect_dependencies(RBSet<GDScript *> &p_dependencies, const GD
 	}
 }
 
+void GDScript::_tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const {
+	for (int i = 0; i < static_variables.size(); i++) {
+		static_variables[i].tag_collect_pass(p_pass, p_containers);
+	}
+
+	for (const KeyValue<StringName, Variant> &K : constants) {
+		K.value.tag_collect_pass(p_pass, p_containers);
+	}
+
+	for (const KeyValue<StringName, Ref<GDScript>> &SC : subclasses) {
+		SC.value->tag_collect_pass(p_pass, p_containers);
+	}
+
+	for (const KeyValue<StringName, GDScriptFunction *> &F : member_functions) {
+		F.value->tag_collect_pass(p_pass, p_containers);
+	}
+}
+
 GDScript::GDScript() :
 		script_list(this) {
 	{
@@ -1402,6 +1420,13 @@ void GDScript::_save_orphaned_subclasses(ClearData *p_clear_data) {
 		// subclass is not released
 		GDScriptLanguage::get_singleton()->add_orphan_subclass(subclass.fully_qualified_name, subclass.id);
 	}
+}
+
+String GDScript::get_script_name() const {
+	if (get_local_name() != StringName()) {
+		return get_local_name();
+	}
+	return get_fully_qualified_name().get_file();
 }
 
 #ifdef DEBUG_ENABLED
@@ -2043,6 +2068,21 @@ ScriptLanguage *GDScriptInstance::get_language() {
 
 const Variant GDScriptInstance::get_rpc_config() const {
 	return script->get_rpc_config();
+}
+
+void GDScriptInstance::tag_collect_pass(uint32_t p_pass, bool p_collect_containers) {
+	if (collect_pass == p_pass) {
+		return;
+	}
+
+	collect_pass = p_pass; // Set beforehand due to recursion.
+
+	int mb_count = members.size();
+	const Variant *mb = members.ptr();
+
+	for (int i = 0; i < mb_count; i++) {
+		mb[i].tag_collect_pass(p_pass, p_collect_containers);
+	}
 }
 
 void GDScriptInstance::reload_members() {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -230,6 +230,8 @@ public:
 	static String debug_get_script_name(const Ref<Script> &p_script);
 #endif
 
+	virtual String get_script_name() const override;
+
 	static String canonicalize_path(const String &p_path);
 	_FORCE_INLINE_ static bool is_canonically_equal_paths(const String &p_path_a, const String &p_path_b) {
 		return canonicalize_path(p_path_a) == canonicalize_path(p_path_b);
@@ -341,6 +343,8 @@ public:
 	virtual bool is_placeholder_fallback_enabled() const override { return placeholder_fallback_enabled; }
 #endif
 
+	void _tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const;
+
 	GDScript();
 	~GDScript();
 };
@@ -362,6 +366,8 @@ class GDScriptInstance : public ScriptInstance {
 #endif
 	Vector<Variant> members;
 	bool base_ref_counted;
+
+	uint32_t collect_pass = 0;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 
@@ -398,6 +404,8 @@ public:
 	void reload_members();
 
 	virtual const Variant get_rpc_config() const;
+
+	virtual void tag_collect_pass(uint32_t p_pass, bool p_collect_containers = false);
 
 	GDScriptInstance();
 	~GDScriptInstance();

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -546,6 +546,12 @@ public:
 	void disassemble(const Vector<String> &p_code_lines) const;
 #endif
 
+	void tag_collect_pass(uint32_t p_pass, bool p_containers) {
+		for (int i = 0; i < constants.size(); i++) {
+			constants[i].tag_collect_pass(p_pass, p_containers);
+		}
+	}
+
 	GDScriptFunction();
 	~GDScriptFunction();
 };

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -51,6 +51,12 @@ int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;
 
+void Node::_tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const {
+	for (const KeyValue<StringName, Node *> &K : data.children) {
+		K.value->tag_collect_pass(p_pass, p_containers);
+	}
+}
+
 void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_PROCESS: {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -313,6 +313,7 @@ protected:
 	void _block() { data.blocked++; }
 	void _unblock() { data.blocked--; }
 
+	void _tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const;
 	void _notification(int p_notification);
 
 	virtual void _physics_interpolated_changed();

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -907,6 +907,59 @@ bool SceneTree::is_paused() const {
 	return paused;
 }
 
+int SceneTree::break_reference_cycles(bool p_scripts_only, bool p_collect_containers, bool p_verbose) {
+	static uint32_t pass = 1;
+	pass++;
+	tag_collect_pass(pass, p_collect_containers);
+
+	List<Engine::Singleton> singletons;
+	Engine::get_singleton()->get_singletons(&singletons);
+	for (const Engine::Singleton &S : singletons) {
+		S.ptr->tag_collect_pass(pass, p_collect_containers);
+	}
+	if (root) {
+		root->tag_collect_pass(pass, p_collect_containers);
+	}
+
+	List<ObjectID> collect_unlinked;
+	ObjectDB::fetch_unliked_objects(pass, collect_unlinked);
+
+	int unlinked_total = 0;
+
+	while (collect_unlinked.size()) {
+		Object *obj = ObjectDB::get_instance(collect_unlinked.front()->get());
+		if (obj) {
+			bool unlinked = false;
+			if (obj->get_script_instance()) {
+				if (p_verbose) {
+					print_line("Breaking cycle on: ", obj->to_string());
+				}
+
+				Ref<RefCounted> ref;
+				if (obj->is_ref_counted()) {
+					ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj)); // Keep a reference while breaking the link as this can cause a crash otherwise.
+				}
+				obj->set_script(Ref<Script>());
+				ref.unref();
+				unlinked = true;
+			}
+
+			if (!p_scripts_only) {
+				obj->unlink_resources(p_collect_containers);
+				unlinked = true;
+			}
+
+			if (unlinked) {
+				unlinked_total++;
+			}
+		}
+
+		collect_unlinked.pop_front();
+	}
+
+	return unlinked_total;
+}
+
 void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
 	// When reading this function, keep in mind that this code must work in a way where
 	// if any node is removed, this needs to continue working.
@@ -1657,6 +1710,8 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_multiplayer", "for_path"), &SceneTree::get_multiplayer, DEFVAL(NodePath()));
 	ClassDB::bind_method(D_METHOD("set_multiplayer_poll_enabled", "enabled"), &SceneTree::set_multiplayer_poll_enabled);
 	ClassDB::bind_method(D_METHOD("is_multiplayer_poll_enabled"), &SceneTree::is_multiplayer_poll_enabled);
+
+	ClassDB::bind_method(D_METHOD("break_reference_cycles", "scripts_only", "collect_containers", "verbose"), &SceneTree::break_reference_cycles, DEFVAL(true), DEFVAL(false), DEFVAL(false));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_accept_quit"), "set_auto_accept_quit", "is_auto_accept_quit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quit_on_go_back"), "set_quit_on_go_back", "is_quit_on_go_back");

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -330,6 +330,8 @@ public:
 	_FORCE_INLINE_ double get_physics_process_time() const { return physics_process_time; }
 	_FORCE_INLINE_ double get_process_time() const { return process_time; }
 
+	int break_reference_cycles(bool p_scripts_only = true, bool p_collect_containers = false, bool p_verbose = false);
+
 	void set_pause(bool p_enabled);
 	bool is_paused() const;
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1705,6 +1705,17 @@ void AudioServer::get_argument_options(const StringName &p_function, int p_idx, 
 }
 #endif
 
+void AudioServer::_tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const {
+	for (int i = 0; i < buses.size(); i++) {
+		Bus *bus = buses[i];
+		for (int j = 0; j < bus->effects.size(); j++) {
+			if (bus->effects[j].effect.is_valid()) {
+				bus->effects[j].effect->tag_collect_pass(p_pass, p_containers);
+			}
+		}
+	}
+}
+
 void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bus_count", "amount"), &AudioServer::set_bus_count);
 	ClassDB::bind_method(D_METHOD("get_bus_count"), &AudioServer::get_bus_count);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -299,6 +299,7 @@ private:
 	void _driver_process(int p_frames, int32_t *p_buffer);
 
 protected:
+	void _tag_collect_pass_custom(uint32_t p_pass, bool p_containers) const;
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
As you may know Godot does not use a garbage collector and thanks to that there are no collection stalls. Instead, it uses reference counting.

While Godot resoucres are designed so its extremely hard to have reference cycles, it is possible on the script side to have a reference cycle and thus leak script resources. Godot will report these leaked objects on exit, but sometimes it can be hard to find and track them down.

This PR adds a cycle breaker. It is used like this:

```GDScript
get_tree().break_reference_cycles()
```

The cycle breaker basically tracks and tags anything connected to the scene tree and engine singletons. It does this very quickly, so you can call this function during loading screen, game exit or pauses.

It has a few modes in which it functions:

* Script only: This only tracks cycles in script classes not connected to the scene tree and singletons and breaks them. This mode should be safe to use.
* All objects: This tracks any object not connected to the scene tree and singletons and clears all resources properties on them to clear cycles. This is not advisable to use unless you know what you are doing.

Additionally, the type of tagging can be customized:
* Only scan resources, do not get into containers: This is the fastest mode, but if you have scripts referenced from containers (array or dictionary) it will miss them.
* Containers: This mode will go into containers. It is more effective, but slower.

Finally, there is the option to print what was collected. This is intended in case you want to debug a leak and resolve it instead of relying on the cycle breaker.

This function returns how many cycles were broken, which may add in debugging and CI tasks.

Example of what it fixes:

```GDScript
class MyClass:
	var other

func _ready() -> void:
	var a = MyClass.new()
	var b = MyClass.new()

	a.other=b
	b.other=a

	# After this function ends, the instances are is leaked.

func _exit_tree() -> void:
	var broken = get_tree().break_reference_cycles() 
        print("Broken cycles: ", broken)
```

TODO:

- [ ] I think some GDScript globals and static variables are not being tracked, but need to ask the GDScript team about this.
- [ ] Container mode is not being used to break scripts from containers, which may be an issue if both scripts are referenced from inside containers, even though this is quite rare, it should still be added.
- [ ] Some singletons or global objects may not be tracked or may be too hard to track. Possibly may be good to simply add them to an ignore list (via some virtual function to ignore them on tagging).
- [ ] Maybe warn the user if there are threads running (likely via WorkerThreadPool query). While the ObjectID access is thread safe, this function shoud ideally be run after joining all threads.

Feedback welcome!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
