### PR TITLE
GDScript: Allow casting enum to int

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3469,6 +3469,8 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 			if (op_type.builtin_type == Variant::INT && cast_type.kind == GDScriptParser::DataType::ENUM) {
 				mark_node_unsafe(p_cast);
 				valid = true;
+			} else if (op_type.kind == GDScriptParser::DataType::ENUM && cast_type.builtin_type == Variant::INT) {
+				valid = true;
 			} else if (op_type.kind == GDScriptParser::DataType::BUILTIN && cast_type.kind == GDScriptParser::DataType::BUILTIN) {
 				valid = Variant::can_convert(op_type.builtin_type, cast_type.builtin_type);
 			} else if (op_type.kind != GDScriptParser::DataType::BUILTIN && cast_type.kind != GDScriptParser::DataType::BUILTIN) {

--- a/modules/gdscript/tests/scripts/analyzer/features/cast_enum_to_int.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/cast_enum_to_int.gd
@@ -1,0 +1,9 @@
+# GH-85882
+
+enum Foo { A, B, C }
+
+func test():
+	var a := Foo.A
+	var b := a as int + 1
+	print(b)
+	

--- a/modules/gdscript/tests/scripts/analyzer/features/cast_enum_to_int.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/cast_enum_to_int.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+1


### PR DESCRIPTION
An enum value is always an integer so the cast is valid. The code here now consider this case to avoid giving an error message.

Fix #85882