### PR TITLE
Core: Replace `_NO_DISCARD_` macro with `[[nodiscard]]`

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -41,7 +41,7 @@
 
 class Variant;
 
-struct _NO_DISCARD_ AABB {
+struct [[nodiscard]] AABB {
 	Vector3 position;
 	Vector3 size;
 

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -34,7 +34,7 @@
 #include "core/math/quaternion.h"
 #include "core/math/vector3.h"
 
-struct _NO_DISCARD_ Basis {
+struct [[nodiscard]] Basis {
 	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -35,7 +35,7 @@
 
 class String;
 
-struct _NO_DISCARD_ Color {
+struct [[nodiscard]] Color {
 	union {
 		struct {
 			float r;

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -36,7 +36,7 @@
 #include "core/math/transform_3d.h"
 #include "core/math/vector3.h"
 
-struct _NO_DISCARD_ Face3 {
+struct [[nodiscard]] Face3 {
 	enum Side {
 		SIDE_OVER,
 		SIDE_UNDER,

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -35,7 +35,7 @@
 
 class Variant;
 
-struct _NO_DISCARD_ Plane {
+struct [[nodiscard]] Plane {
 	Vector3 normal;
 	real_t d = 0;
 

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -43,7 +43,7 @@ struct Rect2;
 struct Transform3D;
 struct Vector2;
 
-struct _NO_DISCARD_ Projection {
+struct [[nodiscard]] Projection {
 	enum Planes {
 		PLANE_NEAR,
 		PLANE_FAR,

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -35,7 +35,7 @@
 #include "core/math/vector3.h"
 #include "core/string/ustring.h"
 
-struct _NO_DISCARD_ Quaternion {
+struct [[nodiscard]] Quaternion {
 	union {
 		struct {
 			real_t x;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -38,7 +38,7 @@ class String;
 struct Rect2i;
 struct Transform2D;
 
-struct _NO_DISCARD_ Rect2 {
+struct [[nodiscard]] Rect2 {
 	Point2 position;
 	Size2 size;
 

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -37,7 +37,7 @@
 class String;
 struct Rect2;
 
-struct _NO_DISCARD_ Rect2i {
+struct [[nodiscard]] Rect2i {
 	Point2i position;
 	Size2i size;
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -38,7 +38,7 @@
 
 class String;
 
-struct _NO_DISCARD_ Transform2D {
+struct [[nodiscard]] Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of columns array, the basis matrix looks like "on paper":
 	// M = (columns[0][0] columns[1][0])
 	//     (columns[0][1] columns[1][1])

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -36,7 +36,7 @@
 #include "core/math/plane.h"
 #include "core/templates/vector.h"
 
-struct _NO_DISCARD_ Transform3D {
+struct [[nodiscard]] Transform3D {
 	Basis basis;
 	Vector3 origin;
 

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -37,7 +37,7 @@
 class String;
 struct Vector2i;
 
-struct _NO_DISCARD_ Vector2 {
+struct [[nodiscard]] Vector2 {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -37,7 +37,7 @@
 class String;
 struct Vector2;
 
-struct _NO_DISCARD_ Vector2i {
+struct [[nodiscard]] Vector2i {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -39,7 +39,7 @@ struct Basis;
 struct Vector2;
 struct Vector3i;
 
-struct _NO_DISCARD_ Vector3 {
+struct [[nodiscard]] Vector3 {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -37,7 +37,7 @@
 class String;
 struct Vector3;
 
-struct _NO_DISCARD_ Vector3i {
+struct [[nodiscard]] Vector3i {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -36,7 +36,7 @@
 
 class String;
 
-struct _NO_DISCARD_ Vector4 {
+struct [[nodiscard]] Vector4 {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -37,7 +37,7 @@
 class String;
 struct Vector4;
 
-struct _NO_DISCARD_ Vector4i {
+struct [[nodiscard]] Vector4i {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -71,12 +71,7 @@
 #endif
 #endif
 
-// No discard allows the compiler to flag warnings if we don't use the return value of functions / classes
-#ifndef _NO_DISCARD_
-#define _NO_DISCARD_ [[nodiscard]]
-#endif
-
-// In some cases _NO_DISCARD_ will get false positives,
+// In some cases [[nodiscard]] will get false positives,
 // we can prevent the warning in specific cases by preceding the call with a cast.
 #ifndef _ALLOW_DISCARD_
 #define _ALLOW_DISCARD_ (void)


### PR DESCRIPTION
Changes all existing uses of the `_NO_DISCARD_` macro to the `[[nodiscard]]` attribute. This was a bit overdue[^1] now that we're in C++17 by default, but was probably never a high priority because it's pretty scarcely used atm.

[^1]: https://github.com/godotengine/godot/pull/56972/files#r788698104