### PR TITLE
Fix `Node3D.set_global_rotation()` resetting node scale.

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -293,7 +293,7 @@ Vector3 Node3D::get_global_rotation_degrees() const {
 void Node3D::set_global_rotation(const Vector3 &p_euler_rad) {
 	ERR_THREAD_GUARD;
 	Transform3D transform = get_global_transform();
-	transform.basis = Basis::from_euler(p_euler_rad);
+	transform.basis = Basis::from_euler(p_euler_rad) * Basis::from_scale(transform.basis.get_scale());
 	set_global_transform(transform);
 }
 


### PR DESCRIPTION
Fixes #74162.

The error was caused because the basis for the target global transform was entirely recreated. This process did not account for the scale of the basis of the current global transform.
This PR amends this by scaling the recreated basis for the global transform by the current global scale of the Node3D. Note that this scaling has to be done from the current global scale and not from the local scale of the Node3D.
This is important, otherwise a scaled parent of the Node3D would cause incorrect results on overwriting the global transform basis.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
