### PR TITLE
Fix infinite while loop on empty added file.

### DIFF
--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -73,7 +73,7 @@ for f in sys.argv[1:]:
         line = fileread.readline()
         header_done = False
 
-        while line.strip() == "":  # Skip empty lines at the top
+        while line.strip() == "" and line != "":  # Skip empty lines at the top
             line = fileread.readline()
 
         if line.find("/**********") == -1:  # Godot header starts this way


### PR DESCRIPTION
In case an empty file was added in a commit `copyright_headers` would enter in an infinite loop as the file only contains empty lines which the scripts try to remove. Added a check to make sure that it would exit the loop it cases it reaches the last line.
this happened in #82198 