### PR TITLE
Remove some unused SceneTree properties

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -120,7 +120,6 @@ void SceneTreeTimer::release_connections() {
 SceneTreeTimer::SceneTreeTimer() {}
 
 void SceneTree::tree_changed() {
-	tree_version++;
 	emit_signal(tree_changed_name);
 }
 
@@ -153,7 +152,6 @@ SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_nod
 
 	ERR_FAIL_COND_V_MSG(E->value.nodes.has(p_node), &E->value, "Already in group: " + p_group + ".");
 	E->value.nodes.push_back(p_node);
-	//E->value.last_tree_version=0;
 	E->value.changed = true;
 	return &E->value;
 }
@@ -476,8 +474,6 @@ void SceneTree::iteration_prepare() {
 }
 
 bool SceneTree::physics_process(double p_time) {
-	root_lock++;
-
 	current_frame++;
 
 	flush_transform_notifications();
@@ -501,7 +497,6 @@ bool SceneTree::physics_process(double p_time) {
 	process_tweens(p_time, true);
 
 	flush_transform_notifications();
-	root_lock--;
 
 	_flush_delete_queue();
 	_call_idle_callbacks();
@@ -510,8 +505,6 @@ bool SceneTree::physics_process(double p_time) {
 }
 
 bool SceneTree::process(double p_time) {
-	root_lock++;
-
 	if (MainLoop::process(p_time)) {
 		_quit = true;
 	}
@@ -536,8 +529,6 @@ bool SceneTree::process(double p_time) {
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
 	flush_transform_notifications(); //transforms after world update, to avoid unnecessary enter/exit notifications
-
-	root_lock--;
 
 	_flush_delete_queue();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -122,7 +122,6 @@ private:
 
 	Window *root = nullptr;
 
-	uint64_t tree_version = 1;
 	double physics_process_time = 0.0;
 	double process_time = 0.0;
 	bool accept_quit = true;
@@ -134,7 +133,6 @@ private:
 	bool debug_navigation_hint = false;
 #endif
 	bool paused = false;
-	int root_lock = 0;
 
 	HashMap<StringName, Group> group_map;
 	bool _quit = false;
@@ -165,7 +163,6 @@ private:
 
 	// Safety for when a node is deleted while a group is being called.
 
-	bool processing = false;
 	int nodes_removed_on_group_call_lock = 0;
 	HashSet<Node *> nodes_removed_on_group_call; // Skip erased nodes.
 


### PR DESCRIPTION
This is merely clean up work. While reading the code I've found some SceneTree properties doing nothing really. Probably remains from previous versions.
