### PR TITLE
Fix issue with resolving the path for the Android keystore file

### DIFF
--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -166,6 +166,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	void _fix_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_manifest, bool p_give_internet);
 
+	static String _get_keystore_path(const Ref<EditorExportPreset> &p_preset, bool p_debug);
+
 	static String _parse_string(const uint8_t *p_bytes, bool p_utf8);
 
 	void _fix_resources(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &r_manifest);


### PR DESCRIPTION
The previous logic passed the path to the Android keystore as-is to an external tool. This causes the tool to fail if the path is Godot-specific (e.g: `res://<path_to_keystore>`)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
