### PR TITLE
Fix the logic to load export preset's options overrides

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -364,6 +364,7 @@ void EditorExport::update_export_presets() {
 		if (platform_options.has(preset->get_platform()->get_name())) {
 			export_presets_updated = true;
 
+			bool update_value_overrides = false;
 			List<EditorExportPlatform::ExportOption> options = platform_options[preset->get_platform()->get_name()];
 
 			// Clear the preset properties prior to reloading, keep the values to preserve options from plugins that may be currently disabled.
@@ -377,6 +378,13 @@ void EditorExport::update_export_presets() {
 					preset->values[option_name] = E.default_value;
 				}
 				preset->update_visibility[option_name] = E.update_visibility;
+				if (E.update_visibility) {
+					update_value_overrides = true;
+				}
+			}
+
+			if (update_value_overrides) {
+				preset->update_value_overrides();
 			}
 		}
 	}


### PR DESCRIPTION
Update the logic to load export preset's options overrides when an editor export plugin is added.
Without this update, the options overrides don't kick in until the export preset is selected.

Follow up to https://github.com/godotengine/godot/pull/88291

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
