### PR TITLE
Enable `EditorPlugin` added by modules and GDExtensions (reverted)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3492,6 +3492,7 @@ void EditorNode::add_extension_editor_plugin(const StringName &p_class_name) {
 	EditorPlugin *plugin = Object::cast_to<EditorPlugin>(ClassDB::instantiate(p_class_name));
 	singleton->editor_data.add_extension_editor_plugin(p_class_name, plugin);
 	add_editor_plugin(plugin);
+	plugin->enable_plugin();
 }
 
 void EditorNode::remove_extension_editor_plugin(const StringName &p_class_name) {
@@ -7217,7 +7218,9 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
-		add_editor_plugin(EditorPlugins::create(i));
+		EditorPlugin *plugin = EditorPlugins::create(i);
+		add_editor_plugin(plugin);
+		plugin->enable_plugin();
 	}
 
 	for (const StringName &extension_class_name : GDExtensionEditorPlugins::get_extension_classes()) {


### PR DESCRIPTION
Before this PR, plugins coming from modules/GDExtensions were never enabled so the virtual method `_enable_plugin` was never called. This can be confusing behavior for users implementing `EditorPlugin` coming from addons/scripting. I assume GDExtension plugins are considered _always enabled_, so I expect the `_enable_plugin` to be called exactly once when they are initially added.

**MRP**:  [GDExtensionEditorPluginCpp.zip](https://github.com/user-attachments/files/15598997/GDExtensionEditorPluginCpp-master.zip)
