### PR TITLE
Tests: Remove NavigationRegion3D race condition that fails on CI

### DIFF
--- a/tests/scene/test_navigation_region_3d.h
+++ b/tests/scene/test_navigation_region_3d.h
@@ -71,15 +71,6 @@ TEST_SUITE("[Navigation]") {
 			CHECK_NE(navigation_mesh->get_vertices().size(), 0);
 		}
 
-		// Race condition is present in the below subcase, but baking should take many
-		// orders of magnitude longer than basic checks on the main thread, so it's fine.
-		SUBCASE("Asynchronous bake should not be immediate") {
-			navigation_region->bake_navigation_mesh(true);
-			CHECK(navigation_region->is_baking());
-			CHECK_EQ(navigation_mesh->get_polygon_count(), 0);
-			CHECK_EQ(navigation_mesh->get_vertices().size(), 0);
-		}
-
 		memdelete(mesh_instance);
 		memdelete(navigation_region);
 		memdelete(node_3d);


### PR DESCRIPTION
As the comment pointed it out, it's a race condition, and evidently no, "it's [not] fine" ;)

It occasionally fails on macOS editor builds with:
```
./tests/scene/test_navigation_region_3d.h:79: ERROR: CHECK_EQ( navigation_mesh->get_polygon_count(), 0 ) is NOT correct!
  values: CHECK_EQ( 2, 0 )

./tests/scene/test_navigation_region_3d.h:80: ERROR: CHECK_EQ( navigation_mesh->get_vertices().size(), 0 ) is NOT correct!
  values: CHECK_EQ( 4, 0 )
```