### PR TITLE
[Core] Remove unnecessary checks for `ERR_INDEXs` in `error_macros.h`

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -118,33 +118,57 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
-		((void)0)
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                             \
+	if constexpr (sizeof(m_index) == 8) {                                                                           \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                  \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return;                                                                                                 \
+		}                                                                                                           \
+                                                                                                                    \
+	} else {                                                                                                        \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                  \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return;                                                                                                 \
+		}                                                                                                           \
+	}                                                                                                               \
+	((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
-		((void)0)
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                         \
+	if constexpr (sizeof(m_index) == 8) {                                                                                  \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                         \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return;                                                                                                        \
+		}                                                                                                                  \
+                                                                                                                           \
+	} else {                                                                                                               \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                         \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return;                                                                                                        \
+		}                                                                                                                  \
+	}                                                                                                                      \
+	((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
-		((void)0)
+#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                             \
+	if constexpr (sizeof(m_index) == 8) {                                                                                        \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+			return;                                                                                                              \
+		}                                                                                                                        \
+                                                                                                                                 \
+	} else {                                                                                                                     \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+			return;                                                                                                              \
+		}                                                                                                                        \
+	}                                                                                                                            \
+	((void)0)
 
 /**
  * Try using `ERR_FAIL_INDEX_V_MSG`.
@@ -153,33 +177,57 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
-		((void)0)
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
+	if constexpr (sizeof(m_index) == 8) {                                                                           \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                  \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return m_retval;                                                                                        \
+		}                                                                                                           \
+                                                                                                                    \
+	} else {                                                                                                        \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                  \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return m_retval;                                                                                        \
+		}                                                                                                           \
+	}                                                                                                               \
+	((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                               \
-	} else                                                                                                             \
-		((void)0)
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                             \
+	if constexpr (sizeof(m_index) == 8) {                                                                                  \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                         \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval;                                                                                               \
+		}                                                                                                                  \
+                                                                                                                           \
+	} else {                                                                                                               \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                         \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval;                                                                                               \
+		}                                                                                                                  \
+	}                                                                                                                      \
+	((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
-		((void)0)
+#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                                 \
+	if constexpr (sizeof(m_index) == 8) {                                                                                        \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+			return m_retval;                                                                                                     \
+		}                                                                                                                        \
+                                                                                                                                 \
+	} else {                                                                                                                     \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+			return m_retval;                                                                                                     \
+		}                                                                                                                        \
+	}                                                                                                                            \
+	((void)0)
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -189,13 +237,22 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
-		((void)0)
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                             \
+	if constexpr (sizeof(m_index) == 8) {                                                                                            \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                                   \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
+			_err_flush_stdout();                                                                                                     \
+			GENERATE_TRAP();                                                                                                         \
+		}                                                                                                                            \
+                                                                                                                                     \
+	} else {                                                                                                                         \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                                   \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
+			_err_flush_stdout();                                                                                                     \
+			GENERATE_TRAP();                                                                                                         \
+		}                                                                                                                            \
+	}                                                                                                                                \
+	((void)0)
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -204,13 +261,22 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                         \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
-		((void)0)
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                     \
+	if constexpr (sizeof(m_index) == 8) {                                                                                               \
+		if (unlikely((uint64_t)(m_index) >= (uint64_t)(m_size))) {                                                                      \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
+			_err_flush_stdout();                                                                                                        \
+			GENERATE_TRAP();                                                                                                            \
+		}                                                                                                                               \
+                                                                                                                                        \
+	} else {                                                                                                                            \
+		if (unlikely((uint32_t)(m_index) >= (uint32_t)(m_size))) {                                                                      \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
+			_err_flush_stdout();                                                                                                        \
+			GENERATE_TRAP();                                                                                                            \
+		}                                                                                                                               \
+	}                                                                                                                                   \
+	((void)0)
 
 // Unsigned integer index out of bounds error macros.
 


### PR DESCRIPTION
Removed an unnecessary check for `m_index`. Instead, I made the number convert to an `unsigned` type, where numbers smaller than zero will become very large, which will definitely be larger than `m_size`.

Before:
```
        test    eax, eax
        js      .L102
        cmp     DWORD PTR [rbx-8], eax
        jle     .L102
```
After:
```
        cmp     eax, DWORD PTR [rbx-8]
        jnb     .L102
```