### PR TITLE
SCons: Fix `silence_msvc` regression

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -411,10 +411,13 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
             ret = old_spawn(sh, escape, cmd, args, env)
 
             try:
-                with open(tmp_stdout_name, "rt", encoding=sys.stdout.encoding) as tmp_stdout:
-                    # First line is always bloat, subsequent lines are always errors. This filter sends
-                    # either just the errors to stderr, or an empty string to effectively do nothing.
-                    sys.stderr.write("".join(tmp_stdout.readlines()[1:]))
+                with open(tmp_stdout_name, "rb") as tmp_stdout:
+                    # First line is always bloat, subsequent lines are always errors. If content
+                    # exists after discarding the first line, safely decode & send to stderr.
+                    tmp_stdout.readline()
+                    content = tmp_stdout.read()
+                    if content:
+                        sys.stderr.write(content.decode(sys.stdout.encoding, "replace"))
                 os.remove(tmp_stdout_name)
             except OSError:
                 pass


### PR DESCRIPTION
Fixes #90617

While I couldn't directly recreate the situation in the issue, knowing that the problem was a `UnicodeDecodeError` made solving it mercifully straightforward. Instead of the direct approach via my text-based method, this adopts a process closer to what's used in SCons natively: parsing as bytes initially & decoding after the fact with the error handler "replace"[^1]. This would've been quite bulky if it remained a one-liner, so the logic has been spread out; consequently, performance should be improved by gathering a file's content exactly once & performing a decode only if it's guaranteed to be an error.

[^1]: https://docs.python.org/3/library/codecs.html#error-handlers