### PR TITLE
[Core] Fix incorrect comparison for `Array` const iterator

### DIFF
--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -54,7 +54,7 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--();
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_other) const { return element_ptr == p_other.element_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_other) const { return element_ptr == p_other.element_ptr; }
+		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_other) const { return element_ptr != p_other.element_ptr; }
 
 		_FORCE_INLINE_ ConstIterator(const Variant *p_element_ptr, Variant *p_read_only = nullptr) :
 				element_ptr(p_element_ptr), read_only(p_read_only) {}

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -555,12 +555,16 @@ TEST_CASE("[Array] Iteration") {
 		idx++;
 	}
 
+	CHECK_EQ(idx, a1.size());
+
 	idx = 0;
 
 	for (const Variant &E : (const Array &)a1) {
 		CHECK_EQ(int(a2[idx]), int(E));
 		idx++;
 	}
+
+	CHECK_EQ(idx, a1.size());
 
 	a1.clear();
 }


### PR DESCRIPTION
My bad, somehow slipped through, added some tests just to be safe

* Fixes: https://github.com/godotengine/godot/issues/90629

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
