### PR TITLE
Remove `Popup`'s unused "panel" style

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -23,9 +23,4 @@
 			</description>
 		</signal>
 	</signals>
-	<theme_items>
-		<theme_item name="panel" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [Popup].
-		</theme_item>
-	</theme_items>
 </class>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -768,6 +768,9 @@
 		<theme_item name="labeled_separator_right" data_type="style" type="StyleBox">
 			[StyleBox] for the right side of labeled separator. See [method add_separator].
 		</theme_item>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			[StyleBox] for the the background panel.
+		</theme_item>
 		<theme_item name="separator" data_type="style" type="StyleBox">
 			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>

--- a/doc/classes/PopupPanel.xml
+++ b/doc/classes/PopupPanel.xml
@@ -8,4 +8,9 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<theme_items>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			[StyleBox] for the the background panel.
+		</theme_item>
+	</theme_items>
 </class>

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -194,8 +194,6 @@ Rect2i Popup::_popup_adjust_rect() const {
 
 void Popup::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("popup_hide"));
-
-	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, Popup, panel_style, "panel");
 }
 
 Popup::Popup() {

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -43,10 +43,6 @@ class Popup : public Window {
 	LocalVector<Window *> visible_parents;
 	bool popped_up = false;
 
-	struct ThemeCache {
-		Ref<StyleBox> panel_style;
-	} theme_cache;
-
 	void _initialize_visible_parents();
 	void _deinitialize_visible_parents();
 


### PR DESCRIPTION
It seems that a "panel" style was erroneously added to the `Popup` node in this PR: #65192. Likely a copy-paste mistake, as said style is never used by it.