### PR TITLE
Change pre-commit entry exe from python3 to python.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: make-rst
         name: make-rst
-        entry: python3 doc/tools/make_rst.py doc/classes modules platform --dry-run --color
+        entry: python doc/tools/make_rst.py doc/classes modules platform --dry-run --color
         pass_filenames: false
         language: python
         files: ^(doc|modules|platform).*xml$
@@ -36,7 +36,7 @@ repos:
         name: copyright-headers
         language: python
         files: \.(c|h|cpp|hpp|cc|cxx|m|mm|inc|java)$
-        entry: python3 misc/scripts/copyright_headers.py
+        entry: python misc/scripts/copyright_headers.py
         exclude: |
           (?x)^(
             .*thirdparty.*|
@@ -51,5 +51,5 @@ repos:
       - id: dotnet-format
         name: dotnet-format
         language: python
-        entry: python3 misc/scripts/dotnet_format.py
+        entry: python misc/scripts/dotnet_format.py
         types_or: [c#]


### PR DESCRIPTION
On my Windows 10 desktop, pre-commit was unable to find my Python installation because it looked for `python3` instead of `python`. Changing the entry point in `.pre-commit-config.yaml` from `python3` to `python` fixed the problem for me. I'm not sure if this is the best solution for other platforms and setups, so it would be great of others could test this change on their setups.