### PR TITLE
Fix `Window.hide()` crash when `force_native` changes

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1215,10 +1215,10 @@ void Window::set_force_native(bool p_force_native) {
 	if (force_native == p_force_native) {
 		return;
 	}
-	force_native = p_force_native;
 	if (is_visible() && !is_in_edited_scene_root()) {
-		WARN_PRINT("Can't change \"force_native\" while a window is displayed. Consider hiding window before changing this value.");
+		ERR_FAIL_MSG("Can't change \"force_native\" while a window is displayed. Consider hiding window before changing this value.");
 	}
+	force_native = p_force_native;
 }
 
 bool Window::get_force_native() const {


### PR DESCRIPTION
Moved force_native = p_force_native assignment to after is_visible() check, to prevent value from changing after window is shown.

Fixes #90609

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
