### PR TITLE
Fix submenus erroneously closing on some occasions

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -640,9 +640,15 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 
 		for (const Rect2 &E : autohide_areas) {
 			if (!Rect2(Point2(), get_size()).has_point(m->get_position()) && E.has_point(m->get_position())) {
+				// The mouse left the safe area, prepare to close.
 				_close_pressed();
 				return;
 			}
+		}
+
+		if (!minimum_lifetime_timer->is_stopped()) {
+			// The mouse left the safe area, but came back again, so cancel the auto-closing.
+			minimum_lifetime_timer->stop();
 		}
 
 		if (!item_clickable_area.has_point(m->get_position())) {


### PR DESCRIPTION
A submenu from a `PopupMenu` is programmed to auto-close if the mouse leaves its safe area (the area of the hovered item in the parent menu) after 0.3 seconds. However, if the mouse comes back to the safe area, the submenu will still auto-close after its timer runs out.

This PR makes that the auto-close timer is stopped if the mouse is again inside the safe area.