### PR TITLE
[Core] Optimize the out-of-bounds check in templates

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -190,20 +190,31 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) {
+#if defined(_MSC_VER)
 		ERR_FAIL_INDEX(p_index, size());
+#else
+		ERR_FAIL_UNSIGNED_INDEX((USize)p_index, (USize)size());
+#endif
 		_copy_on_write();
 		_ptr[p_index] = p_elem;
 	}
 
 	_FORCE_INLINE_ T &get_m(Size p_index) {
+#if defined(_MSC_VER)
 		CRASH_BAD_INDEX(p_index, size());
+#else
+		CRASH_BAD_UNSIGNED_INDEX((USize)p_index, (USize)size());
+#endif
 		_copy_on_write();
 		return _ptr[p_index];
 	}
 
 	_FORCE_INLINE_ const T &get(Size p_index) const {
+#if defined(_MSC_VER)
 		CRASH_BAD_INDEX(p_index, size());
-
+#else
+		CRASH_BAD_UNSIGNED_INDEX((USize)p_index, (USize)size());
+#endif
 		return _ptr[p_index];
 	}
 
@@ -211,7 +222,7 @@ public:
 	Error resize(Size p_size);
 
 	_FORCE_INLINE_ void remove_at(Size p_index) {
-		ERR_FAIL_INDEX(p_index, size());
+		ERR_FAIL_UNSIGNED_INDEX((USize)p_index, (USize)size());
 		T *p = ptrw();
 		Size len = size();
 		for (Size i = p_index; i < len - 1; i++) {
@@ -222,7 +233,7 @@ public:
 	}
 
 	Error insert(Size p_pos, const T &p_val) {
-		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
+		ERR_FAIL_UNSIGNED_INDEX_V((USize)p_pos, (USize)size() + 1, ERR_INVALID_PARAMETER);
 		resize(size() + 1);
 		for (Size i = (size() - 1); i > p_pos; i--) {
 			set(i, get(i - 1));

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -47,9 +47,12 @@
 
 template <typename T>
 class VectorWriteProxy {
+private:
+	typedef typename CowData<T>::USize USize;
+
 public:
-	_FORCE_INLINE_ T &operator[](typename CowData<T>::Size p_index) {
-		CRASH_BAD_INDEX(p_index, ((Vector<T> *)(this))->_cowdata.size());
+	_FORCE_INLINE_ T &operator[](USize p_index) {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, (USize)(((Vector<T> *)(this))->_cowdata.size()));
 
 		return ((Vector<T> *)(this))->_cowdata.ptrw()[p_index];
 	}


### PR DESCRIPTION
This removes an unnecessary check to see if `index` is less than zero. Instead, the index is cast to `unsigned` and if its value is less than zero, it will become very large, which will definitely be larger than `size`. 