### PR TITLE
Improve UX when saving newer files on disk

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7165,6 +7165,8 @@ EditorNode::EditorNode() {
 
 	disk_changed = memnew(ConfirmationDialog);
 	{
+		disk_changed->set_title(TTR("Files have been modified on disk"));
+
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		disk_changed->add_child(vbc);
 
@@ -7178,9 +7180,9 @@ EditorNode::EditorNode() {
 
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_modified_scenes));
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_project_settings));
-		disk_changed->set_ok_button_text(TTR("Reload"));
+		disk_changed->set_ok_button_text(TTR("Discard local changes and reload"));
 
-		disk_changed->add_button(TTR("Resave"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
+		disk_changed->add_button(TTR("Keep local changes and overwrite"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &EditorNode::_resave_scenes));
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4170,12 +4170,18 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 
 	disk_changed = memnew(ConfirmationDialog);
 	{
+		disk_changed->set_title(TTR("Files have been modified on disk"));
+
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		disk_changed->add_child(vbc);
 
-		Label *dl = memnew(Label);
-		dl->set_text(TTR("The following files are newer on disk.\nWhat action should be taken?:"));
-		vbc->add_child(dl);
+		Label *files_are_newer_label = memnew(Label);
+		files_are_newer_label->set_text(TTR("The following files are newer on disk."));
+		vbc->add_child(files_are_newer_label);
+
+		Label *what_action_label = memnew(Label);
+		what_action_label->set_text(TTR("What action should be taken?:"));
+		vbc->add_child(what_action_label);
 
 		disk_changed_list = memnew(Tree);
 		vbc->add_child(disk_changed_list);
@@ -4183,9 +4189,9 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
 
 		disk_changed->connect("confirmed", callable_mp(this, &ScriptEditor::reload_scripts).bind(false));
-		disk_changed->set_ok_button_text(TTR("Reload"));
+		disk_changed->set_ok_button_text(TTR("Discard local changes and reload"));
 
-		disk_changed->add_button(TTR("Resave"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
+		disk_changed->add_button(TTR("Keep local changes and overwrite"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &ScriptEditor::_resave_scripts));
 	}
 


### PR DESCRIPTION
Makes sure that people really understand the actions available when trying to save a file that is newer on disk than in the editor.

| Before | After |
| --- | --- |
| ![Capture d’écran du 2024-04-14 07-17-26](https://github.com/godotengine/godot/assets/270928/7b082f6e-baa2-4a35-b348-7d76e6094c94) | ![Capture d’écran du 2024-04-14 07-49-48](https://github.com/godotengine/godot/assets/270928/ee2eaeba-6297-499f-a9a7-fbaf40781896) |

Took inspiration from these prompts:

![Capture d’écran du 2024-04-14 06-37-08](https://github.com/godotengine/godot/assets/270928/139660a8-092d-498c-a845-f61c6e2812fc)

![Capture d’écran du 2024-04-14 06-38-24](https://github.com/godotengine/godot/assets/270928/4f7211ac-e458-4d55-9fa0-a429192e0156)

![Capture d’écran du 2024-04-14 06-41-24](https://github.com/godotengine/godot/assets/270928/33f0b7fe-e6eb-47d4-846b-5569513f7d40)

Special thanks to [Therron Keen on Twitter](https://twitter.com/TherronKeen/status/1779340702150705219) for flagging this issue.
