### PR TITLE
Keep alpha when saving RGBAH and RGBAF pngs

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -474,12 +474,14 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Saves the image as a PNG file to the file at [param path].
+				[b]Note:[/b] The image will be saved using 8 bits per channel, regardless of [enum Format] value.
 			</description>
 		</method>
 		<method name="save_png_to_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
 				Saves the image as a PNG file to a byte array.
+				[b]Note:[/b] The image will be saved using 8 bits per channel, regardless of [enum Format] value.
 			</description>
 		</method>
 		<method name="save_webp" qualifiers="const">

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -152,6 +152,11 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 		case Image::FORMAT_RGBA8:
 			png_img.format = PNG_FORMAT_RGBA;
 			break;
+		case Image::FORMAT_RGBAH:
+		case Image::FORMAT_RGBAF:
+			source_image->convert(Image::FORMAT_RGBA8);
+			png_img.format = PNG_FORMAT_RGBA;
+			break;
 		default:
 			if (source_image->detect_alpha()) {
 				source_image->convert(Image::FORMAT_RGBA8);


### PR DESCRIPTION
Save RGBAH and RGBAF in RGBA format instead of RGB

Fixes #90618

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
