### PR TITLE
Add `get_date_dict_from_date_string` to `Time`

### DIFF
--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -287,6 +287,22 @@ String Time::get_datetime_string_from_datetime_dict(const Dictionary &p_datetime
 	return timestamp;
 }
 
+
+Dictionary Time::get_date_dict_from_date_string(const String &p_date, bool p_weekday) const {
+	PARSE_ISO8601_STRING(Dictionary())
+	Dictionary dict;
+	dict[YEAR_KEY] = year;
+	dict[MONTH_KEY] = (uint8_t)month;
+	dict[DAY_KEY] = day;
+	if (p_weekday) {
+		YMD_TO_DAY_NUMBER
+		// Unix epoch was a Thursday (day 0 aka 1970-01-01).
+		dict[WEEKDAY_KEY] = Math::posmod(day_number + WEEKDAY_THURSDAY, 7);
+	}
+
+	return dict;
+}
+
 int64_t Time::get_unix_time_from_datetime_dict(const Dictionary &p_datetime) const {
 	ERR_FAIL_COND_V_MSG(p_datetime.is_empty(), 0, "Invalid datetime Dictionary: Dictionary is empty");
 	EXTRACT_FROM_DICTIONARY

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -419,6 +419,7 @@ void Time::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_time_string_from_unix_time", "unix_time_val"), &Time::get_time_string_from_unix_time);
 	ClassDB::bind_method(D_METHOD("get_datetime_dict_from_datetime_string", "datetime", "weekday"), &Time::get_datetime_dict_from_datetime_string);
 	ClassDB::bind_method(D_METHOD("get_datetime_string_from_datetime_dict", "datetime", "use_space"), &Time::get_datetime_string_from_datetime_dict);
+	ClassDB::bind_method(D_METHOD("get_date_dict_from_date_string", "date", "weekday"), &Time::get_date_dict_from_date_string);
 	ClassDB::bind_method(D_METHOD("get_unix_time_from_datetime_dict", "datetime"), &Time::get_unix_time_from_datetime_dict);
 	ClassDB::bind_method(D_METHOD("get_unix_time_from_datetime_string", "datetime"), &Time::get_unix_time_from_datetime_string);
 	ClassDB::bind_method(D_METHOD("get_offset_string_from_offset_minutes", "offset_minutes"), &Time::get_offset_string_from_offset_minutes);


### PR DESCRIPTION
Added a function to create a date dict from a date string. The same already exists for date_time string to date_time dict. I believe the PARSE_ISO8601 should already work and just fail the "has_time" check. I have not added the bindings.

It is my first time trying to contribute or write c++ so apologies for not doing the bindings or if I've made a mistake.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
