### PR TITLE
[3.x] Store `ObjectID` instead of pointer for KinematicCollision owner

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -998,7 +998,7 @@ Ref<KinematicCollision2D> KinematicBody2D::_move(const Vector2 &p_motion, bool p
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->reference_get_count() > 1) {
 			motion_cache.instance();
-			motion_cache->owner = this;
+			motion_cache->owner_id = get_instance_id();
 		}
 
 		motion_cache->collision = col;
@@ -1364,7 +1364,7 @@ Ref<KinematicCollision2D> KinematicBody2D::_get_slide_collision(int p_bounce) {
 	// Create a new instance when the cached reference is invalid or still in use in script.
 	if (slide_colliders[p_bounce].is_null() || slide_colliders[p_bounce]->reference_get_count() > 1) {
 		slide_colliders.write[p_bounce].instance();
-		slide_colliders.write[p_bounce]->owner = this;
+		slide_colliders.write[p_bounce]->owner_id = get_instance_id();
 	}
 
 	slide_colliders.write[p_bounce]->collision = colliders[p_bounce];
@@ -1488,17 +1488,6 @@ KinematicBody2D::KinematicBody2D() :
 	on_wall = false;
 	sync_to_physics = false;
 }
-KinematicBody2D::~KinematicBody2D() {
-	if (motion_cache.is_valid()) {
-		motion_cache->owner = nullptr;
-	}
-
-	for (int i = 0; i < slide_colliders.size(); i++) {
-		if (slide_colliders[i].is_valid()) {
-			slide_colliders.write[i]->owner = nullptr;
-		}
-	}
-}
 
 ////////////////////////
 
@@ -1521,6 +1510,7 @@ real_t KinematicCollision2D::get_angle(const Vector2 &p_up_direction) const {
 }
 
 Object *KinematicCollision2D::get_local_shape() const {
+	PhysicsBody2D *owner = Object::cast_to<PhysicsBody2D>(ObjectDB::get_instance(owner_id));
 	if (!owner) {
 		return nullptr;
 	}
@@ -1596,5 +1586,5 @@ KinematicCollision2D::KinematicCollision2D() {
 	collision.collider = 0;
 	collision.collider_shape = 0;
 	collision.local_shape = 0;
-	owner = nullptr;
+	owner_id = 0;
 }

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -347,7 +347,6 @@ public:
 	bool is_sync_to_physics_enabled() const;
 
 	KinematicBody2D();
-	~KinematicBody2D();
 };
 
 VARIANT_ENUM_CAST(KinematicBody2D::MovingPlatformApplyVelocityOnLeave);
@@ -355,7 +354,7 @@ VARIANT_ENUM_CAST(KinematicBody2D::MovingPlatformApplyVelocityOnLeave);
 class KinematicCollision2D : public Reference {
 	GDCLASS(KinematicCollision2D, Reference);
 
-	KinematicBody2D *owner;
+	ObjectID owner_id;
 	friend class KinematicBody2D;
 	KinematicBody2D::Collision collision;
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -972,7 +972,7 @@ Ref<KinematicCollision> KinematicBody::_move(const Vector3 &p_motion, bool p_inf
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->reference_get_count() > 1) {
 			motion_cache.instance();
-			motion_cache->owner = this;
+			motion_cache->owner_id = get_instance_id();
 		}
 
 		motion_cache->collision = col;
@@ -1369,7 +1369,7 @@ Ref<KinematicCollision> KinematicBody::_get_slide_collision(int p_bounce) {
 	// Create a new instance when the cached reference is invalid or still in use in script.
 	if (slide_colliders[p_bounce].is_null() || slide_colliders[p_bounce]->reference_get_count() > 1) {
 		slide_colliders.write[p_bounce].instance();
-		slide_colliders.write[p_bounce]->owner = this;
+		slide_colliders.write[p_bounce]->owner_id = get_instance_id();
 	}
 
 	slide_colliders.write[p_bounce]->collision = colliders[p_bounce];
@@ -1508,18 +1508,6 @@ KinematicBody::KinematicBody() :
 	set_safe_margin(0.001);
 }
 
-KinematicBody::~KinematicBody() {
-	if (motion_cache.is_valid()) {
-		motion_cache->owner = nullptr;
-	}
-
-	for (int i = 0; i < slide_colliders.size(); i++) {
-		if (slide_colliders[i].is_valid()) {
-			slide_colliders.write[i]->owner = nullptr;
-		}
-	}
-}
-
 ///////////////////////////////////////
 
 Vector3 KinematicCollision::get_position() const {
@@ -1541,6 +1529,7 @@ real_t KinematicCollision::get_angle(const Vector3 &p_up_direction) const {
 }
 
 Object *KinematicCollision::get_local_shape() const {
+	PhysicsBody *owner = Object::cast_to<PhysicsBody>(ObjectDB::get_instance(owner_id));
 	if (!owner) {
 		return nullptr;
 	}
@@ -1616,7 +1605,7 @@ KinematicCollision::KinematicCollision() {
 	collision.collider = 0;
 	collision.collider_shape = 0;
 	collision.local_shape = 0;
-	owner = nullptr;
+	owner_id = 0;
 }
 
 ///////////////////////////////////////

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -347,7 +347,6 @@ public:
 	bool is_sync_to_physics_enabled() const;
 
 	KinematicBody();
-	~KinematicBody();
 };
 
 VARIANT_ENUM_CAST(KinematicBody::MovingPlatformApplyVelocityOnLeave);
@@ -355,7 +354,7 @@ VARIANT_ENUM_CAST(KinematicBody::MovingPlatformApplyVelocityOnLeave);
 class KinematicCollision : public Reference {
 	GDCLASS(KinematicCollision, Reference);
 
-	KinematicBody *owner;
+	ObjectID owner_id;
 	friend class KinematicBody;
 	KinematicBody::Collision collision;
 


### PR DESCRIPTION
`3.x` version of #90668

---

Reproduction scripts (run with `godot --no-window -s /path/to/script.gd`, no window not necessary):

<details><summary>move_and_collide.gd</summary>

```gdscript
extends SceneTree

var player
var saved_collision

func _initialize() -> void:
    _build_scene()


func _iteration(delta: float) -> bool:
    match Engine.get_physics_frames():
        0:
            # Move and save collision info.
            var collision = player.move_and_collide(Vector3.DOWN)
            saved_collision = collision
            print("[Frame 0] Saved collision: ", saved_collision)

        1:
            # Generate another collision info.
            var collision = player.move_and_collide(Vector3.DOWN)
            print("[Frame 1] Collision: ", collision)

        2:
            print("[Frame 2] Deleting player...")
            player.queue_free()
            player = null

        3:
            print("[Frame 3] Trying to access freed shape...")
            print(saved_collision.get_local_shape())
            quit()
    
    return false


func _build_scene() -> void:
    # A sphere on the top of a box.
    _build_player()
    _build_floor()


func _build_player() -> void:
    var shape = SphereShape.new()

    var body = KinematicBody.new()
    body.position = Vector3(0, shape.radius, 0)

    var collision = CollisionShape.new()
    collision.shape = shape
    body.add_child(collision)

    root.add_child(body)
    player = body


func _build_floor() -> void:
    var shape = BoxShape.new()

    var body = StaticBody.new()
    body.position = Vector3(0, -shape.extents.y, 0)

    var collision = CollisionShape.new()
    collision.shape = shape
    body.add_child(collision)

    root.add_child(body)
```
</details>

<details><summary>get_slide_collision.gd</summary>

```gdscript
extends SceneTree

var player
var saved_collision

func _initialize() -> void:
    _build_scene()


func _iteration(delta: float) -> bool:
    match Engine.get_physics_frames():
        0:
            # Move and save collision info.
            player.move_and_slide_with_snap(Vector3(1, -1, 0) * delta, Vector3.DOWN)
            var collision = player.get_slide_collision(0)
            saved_collision = collision
            print("[Frame 0] Saved collision: ", saved_collision)

        1:
            # Generate another collision info.
            player.move_and_slide_with_snap(Vector3(1, -1, 0) * delta, Vector3.DOWN)
            var collision = player.get_slide_collision(0)
            print("[Frame 1] Collision: ", collision)

        2:
            print("[Frame 2] Deleting player...")
            player.queue_free()
            player = null

        3:
            print("[Frame 3] Trying to access freed shape...")
            print(saved_collision.get_local_shape())
            quit()

    return false


func _build_scene() -> void:
    # A sphere on the top of a box.
    _build_player()
    _build_floor()


func _build_player() -> void:
    var shape = SphereShape.new()

    var body = KinematicBody.new()
    body.position = Vector3(0, shape.radius, 0)

    var collision = CollisionShape.new()
    collision.shape = shape
    body.add_child(collision)

    root.add_child(body)
    player = body


func _build_floor() -> void:
    var shape = BoxShape.new()

    var body = StaticBody.new()
    body.position = Vector3(0, -shape.extents.y, 0)

    var collision = CollisionShape.new()
    collision.shape = shape
    body.add_child(collision)

    root.add_child(body)
```
</details>