### PR TITLE
[3.x] Fix SceneTree not respecting virtual process methods

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -579,7 +579,9 @@ bool SceneTree::iteration(float p_time) {
 
 	flush_transform_notifications();
 
-	MainLoop::iteration(p_time);
+	if (MainLoop::iteration(p_time)) {
+		_quit = true;
+	}
 	physics_process_time = p_time;
 
 	emit_signal("physics_frame");
@@ -620,7 +622,9 @@ bool SceneTree::idle(float p_time) {
 
 	root_lock++;
 
-	MainLoop::idle(p_time);
+	if (MainLoop::idle(p_time)) {
+		_quit = true;
+	}
 
 	idle_process_time = p_time;
 


### PR DESCRIPTION
When writing reproduction scripts for #90669, I noticed that the return value of `MainLoop::_idle()` and `MainLoop::_iteration()` does not work when the script extends `SceneTree`.

This has been fixed since 4.1 by #78415.