### PR TITLE
Implement `Object.remove_user_signal(signal: StringName)`

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -619,6 +619,7 @@ private:
 
 		MethodInfo user;
 		HashMap<Callable, Slot, HashableHasher<Callable>> slot_map;
+		bool removable = false;
 	};
 
 	HashMap<StringName, SignalData> signal_map;
@@ -646,6 +647,7 @@ private:
 
 	void _add_user_signal(const String &p_name, const Array &p_args = Array());
 	bool _has_user_signal(const StringName &p_name) const;
+	void _remove_user_signal(const StringName &p_name);
 	Error _emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	TypedArray<Dictionary> _get_signal_list() const;
 	TypedArray<Dictionary> _get_signal_connection_list(const StringName &p_signal) const;

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -357,7 +357,7 @@
 			<param index="0" name="signal" type="String" />
 			<param index="1" name="arguments" type="Array" default="[]" />
 			<description>
-				Adds a user-defined [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal].
+				Adds a user-defined [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal] and [method remove_user_signal].
 				[codeblocks]
 				[gdscript]
 				add_user_signal("hurt", [
@@ -797,7 +797,7 @@
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given user-defined [param signal] name exists. Only signals added with [method add_user_signal] are included.
+				Returns [code]true[/code] if the given user-defined [param signal] name exists. Only signals added with [method add_user_signal] are included. See also [method remove_user_signal].
 			</description>
 		</method>
 		<method name="is_blocking_signals" qualifiers="const">
@@ -903,6 +903,13 @@
 				Removes the given entry [param name] from the object's metadata. See also [method has_meta], [method get_meta] and [method set_meta].
 				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_identifier] method.
 				[b]Note:[/b] Metadata that has a name starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
+			</description>
+		</method>
+		<method name="remove_user_signal" experimental="">
+			<return type="void" />
+			<param index="0" name="signal" type="StringName" />
+			<description>
+				Removes the given user signal [param signal] from the object. See also [method add_user_signal] and [method has_user_signal].
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
This allows creating and deleting signals at runtime. Example use cases are promise objects and multi-threaded pools.
![image](https://github.com/godotengine/godot/assets/69520693/d53224b7-ea54-4974-89da-aa9f903d28a5)
