### PR TITLE
[macOS] Add option to include Applications symlink to exported DMG.

### DIFF
--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -167,6 +167,9 @@
 		<member name="display/high_res" type="bool" setter="" getter="">
 			If [code]true[/code], the application is rendered at native display resolution, otherwise it is always rendered at loDPI resolution and upscaled by OS when required.
 		</member>
+		<member name="dmg/add_applications_symlink" type="bool" setter="" getter="">
+			If [code]true[/code], adds symlink to the system [code]Applications[/code] folder to the exported [code]DMG[/code] image.
+		</member>
 		<member name="export/distribution_type" type="int" setter="" getter="">
 			Application distribution target.
 		</member>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -400,6 +400,8 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/additional_plist_content", PROPERTY_HINT_MULTILINE_TEXT), ""));
 
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "dmg/add_applications_symlink"), true));
+
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "xcode/platform_build"), "14C18"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "xcode/sdk_version"), "13.1"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "xcode/sdk_build"), "22C55"));
@@ -2018,10 +2020,22 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		if (export_format == "dmg") {
 			// Create a DMG.
 			if (err == OK) {
+				bool app_link = p_preset->get("dmg/add_applications_symlink");
+				Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 				if (ep.step(TTR("Making DMG"), 3)) {
 					return ERR_SKIP;
 				}
+				if (app_link) {
+					if (da->create_link("/Applications", tmp_base_path_name.path_join("Applications")) != OK) {
+						add_message(EXPORT_MESSAGE_WARNING, TTR("Making DMG"), vformat(TTR("Could not create symlink \"%s\"."), tmp_base_path_name.path_join("Applications")));
+					}
+				}
 				err = _create_dmg(p_path, pkg_name, tmp_base_path_name);
+				if (app_link) {
+					if (da->remove(tmp_base_path_name.path_join("Applications")) != OK) {
+						add_message(EXPORT_MESSAGE_WARNING, TTR("Making DMG"), vformat(TTR("Could not remove symlink \"%s\"."), tmp_base_path_name.path_join("Applications")));
+					}
+				}
 			}
 			// Sign DMG.
 			if (err == OK && sign_enabled && !ad_hoc) {


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/90562 (without it, it will attempt to delete system `Applications` folder content during cleanup).

Implements https://github.com/godotengine/godot-proposals/discussions/9498