### PR TITLE
Don't store deprecated `auto_translate` property

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -937,7 +937,7 @@
 		<member name="anchor_top" type="float" setter="_set_anchor" getter="get_anchor" default="0.0">
 			Anchors the top edge of the node to the origin, the center or the end of its parent control. It changes how the top offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>
-		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" default="true" deprecated="Use [member Node.auto_translate_mode] instead.">
+		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" deprecated="Use [member Node.auto_translate_mode] instead.">
 			Toggles if any text should automatically change to its translated version depending on the current locale.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3549,7 +3549,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "localize_numeral_system"), "set_localize_numeral_system", "is_localizing_numeral_system");
 
 #ifndef DISABLE_DEPRECATED
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_auto_translate", "is_auto_translating");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");
 #endif
 
 	ADD_GROUP("Tooltip", "tooltip_");


### PR DESCRIPTION
With the introduction of `Node.auto_translate_mode`, `Control.auto_translate` becomes a proxy for it.

But `auto_translate` is currently still stored in `tscn` files. This results in unexpected behavior: If a parent node is set to have disabled translate mode, all child nodes will set the mode to "disabled" when that scene is instantiated (instead of keeping "inherit") .

This PR makes `Control.auto_translate` property not stored. It is still OK to open old scenes using `auto_translate`. But the property will not exist anymore once the scene is saved.

CC @YeldhamDev 

---

To reproduce the problem, save the following script and run `godot --headless -s /path/to/mrp.gd`.

<details><summary>mrp.gd</summary>

```gdscript
extends SceneTree

func _process(delta: float) -> bool:
    var parent := Node.new()
    parent.name = "Parent"
    root.add_child(parent)
    var child := Control.new()
    child.name = "Child"
    parent.add_child(child)
    child.owner = parent

    print("=== Init State ===")
    _show_state(parent)

    print("=== Disable Parent ===")
    parent.auto_translate_mode = 2
    _show_state(parent)

    print("=== Instantiated ===")
    var packed := PackedScene.new()
    packed.pack(parent)
    var scene := packed.instantiate()
    _show_state(scene)
    scene.free()

    return true


func _show_state(node: Node) -> void:
    var mode: String
    match node.auto_translate_mode:
        0:
            mode = "Inherit"
        1:
            mode = "Always"
        2:
            mode = "Disabled"

    if node is Control:
        print("%8s\tMode:%8s\tAuto:%s" % [node.name, mode, node.is_auto_translating()])
    else:
        print("%8s\tMode:%8s" % [node.name, mode])

    for child in node.get_children():
        _show_state(child)
```
</details>

Output:

```
=== Init State ===
  Parent	Mode: Inherit
   Child	Mode: Inherit	Auto:true
=== Disable Parent ===
  Parent	Mode:Disabled
   Child	Mode: Inherit	Auto:false
=== Instantiated ===
  Parent	Mode:Disabled
   Child	Mode:Disabled	Auto:false
```

The "Instantiated" section should be the same as the "Disable Parent" section.