### PR TITLE
Optimization by replacing `%` in cycles

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -357,11 +357,15 @@ public:
 		}
 		const Vector2 *p = p_polygon.ptr();
 		real_t sum = 0;
-		for (int i = 0; i < c; i++) {
+		int polygon_end_index = c - 1;
+		for (int i = 0; i < polygon_end_index; i++) {
 			const Vector2 &v1 = p[i];
-			const Vector2 &v2 = p[(i + 1) % c];
+			const Vector2 &v2 = p[i + 1];
 			sum += (v2.x - v1.x) * (v2.y + v1.y);
 		}
+		const Vector2 &v1 = p[polygon_end_index];
+		const Vector2 &v2 = p[0];
+		sum += (v2.x - v1.x) * (v2.y + v1.y);
 
 		return sum > 0.0f;
 	}
@@ -385,9 +389,10 @@ public:
 		further_away += (further_away - further_away_opposite) * Vector2(1.221313, 1.512312);
 
 		int intersections = 0;
-		for (int i = 0; i < c; i++) {
+		int polygon_end_index = c - 1;
+		for (int i = 0; i < polygon_end_index; i++) {
 			const Vector2 &v1 = p[i];
-			const Vector2 &v2 = p[(i + 1) % c];
+			const Vector2 &v2 = p[i + 1];
 
 			Vector2 res;
 			if (segment_intersects_segment(v1, v2, p_point, further_away, &res)) {
@@ -398,20 +403,38 @@ public:
 				}
 			}
 		}
+		const Vector2 &v1 = p[polygon_end_index];
+		const Vector2 &v2 = p[0];
+
+		Vector2 res;
+		if (segment_intersects_segment(v1, v2, p_point, further_away, &res)) {
+			intersections++;
+			if (res.is_equal_approx(p_point)) {
+				// Point is in one of the polygon edges.
+				return true;
+			}
+		}
 
 		return (intersections & 1);
 	}
 
 	static bool is_segment_intersecting_polygon(const Vector2 &p_from, const Vector2 &p_to, const Vector<Vector2> &p_polygon) {
-		int c = p_polygon.size();
+		int polygon_end_index = p_polygon.size() - 1;
 		const Vector2 *p = p_polygon.ptr();
-		for (int i = 0; i < c; i++) {
+		for (int i = 0; i < polygon_end_index; i++) {
 			const Vector2 &v1 = p[i];
-			const Vector2 &v2 = p[(i + 1) % c];
+			const Vector2 &v2 = p[i + 1];
 			if (segment_intersects_segment(p_from, p_to, v1, v2, nullptr)) {
 				return true;
 			}
 		}
+
+		const Vector2 &v1 = p[polygon_end_index];
+		const Vector2 &v2 = p[0];
+		if (segment_intersects_segment(p_from, p_to, v1, v2, nullptr)) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -629,7 +629,10 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 			}
 
 			for (uint32_t k = 0; k < vertices.size(); k++) {
-				int k_n = (k + 1) % vertices.size();
+				uint32_t k_n = k + 1;
+				if (k_n == vertices.size()) {
+					k_n = 0;
+				}
 
 				Vector3 edge0_A = vertices[k];
 				Vector3 edge1_A = vertices[k_n];
@@ -692,8 +695,12 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 		// Add edge.
 
 		for (uint32_t j = 0; j < face.indices.size(); j++) {
+			uint32_t j_n = j + 1;
+			if (j_n == face.indices.size()) {
+				j_n = 0;
+			}
 			int a = face.indices[j];
-			int b = face.indices[(j + 1) % face.indices.size()];
+			int b = face.indices[j_n];
 
 			bool found = false;
 			int found_idx = -1;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -370,8 +370,12 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		Geometry3D::MeshData::Face &f = E->get();
 
 		for (uint32_t i = 0; i < f.indices.size(); i++) {
+			uint32_t i_n = i + 1;
+			if (i_n == f.indices.size()) {
+				i_n = 0;
+			}
 			int a = E->get().indices[i];
-			int b = E->get().indices[(i + 1) % f.indices.size()];
+			int b = E->get().indices[i_n];
 			Edge e(a, b);
 
 			HashMap<Edge, RetFaceConnect, Edge>::Iterator F = ret_edges.find(e);
@@ -390,8 +394,16 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 					if (O->get().indices[j] == a) {
 						//append the rest
 						for (int k = 0; k < o_index_size; k++) {
-							int idx = O->get().indices[(k + j) % o_index_size];
-							int idxn = O->get().indices[(k + j + 1) % o_index_size];
+							int k_plus_j = k + j;
+							if (k_plus_j >= o_index_size) {
+								k_plus_j -= o_index_size;
+							}
+							int k_plus_j_n = k_plus_j + 1;
+							if (k_plus_j_n == o_index_size) {
+								k_plus_j_n = 0;
+							}
+							int idx = O->get().indices[k_plus_j];
+							int idxn = O->get().indices[k_plus_j_n];
 							if (idx == b && idxn == a) { //already have b!
 								break;
 							}

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -394,12 +394,12 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 						//append the rest
 						for (uint32_t k = 0; k < o_index_size; k++) {
 							uint32_t k_plus_j = k + j;
-							if (k_plus_j >= o_index_size) {
-								k_plus_j -= o_index_size;
-							}
 							uint32_t k_plus_j_n = k_plus_j + 1;
-							if (k_plus_j_n == o_index_size) {
-								k_plus_j_n = 0;
+							if (k_plus_j_n >= o_index_size) {
+								k_plus_j_n -= o_index_size;
+								if (k_plus_j >= o_index_size) {
+									k_plus_j -= o_index_size;
+								}
 							}
 							int idx = O->get().indices[k_plus_j];
 							int idxn = O->get().indices[k_plus_j_n];

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -387,18 +387,17 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 			if (O->get().plane.is_equal_approx(f.plane)) {
 				//merge and delete edge and contiguous face, while repointing edges (uuugh!)
-				int o_index_size = O->get().indices.size();
-
-				for (int j = 0; j < o_index_size; j++) {
+				uint32_t o_index_size = O->get().indices.size();
+				for (uint32_t j = 0; j < o_index_size; j++) {
 					//search a
 					if (O->get().indices[j] == a) {
 						//append the rest
-						for (int k = 0; k < o_index_size; k++) {
-							int k_plus_j = k + j;
+						for (uint32_t k = 0; k < o_index_size; k++) {
+							uint32_t k_plus_j = k + j;
 							if (k_plus_j >= o_index_size) {
 								k_plus_j -= o_index_size;
 							}
-							int k_plus_j_n = k_plus_j + 1;
+							uint32_t k_plus_j_n = k_plus_j + 1;
 							if (k_plus_j_n == o_index_size) {
 								k_plus_j_n = 0;
 							}

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -247,7 +247,11 @@ void WorkerThreadPool::_notify_threads(const ThreadData *p_current_thread_data, 
 	// 2. For promoting: since it's exclusive with processing, we fin threads able to promote low-prio tasks now.
 	for (uint32_t i = 0;
 			i < thread_count && (to_process || to_promote);
-			i++, notify_index = (notify_index + 1) % thread_count) {
+			i++) {
+		notify_index++;
+		if (notify_index == thread_count) {
+			notify_index = 0;
+		}
 		ThreadData &th = threads[notify_index];
 
 		if (th.signaled) {
@@ -277,7 +281,11 @@ void WorkerThreadPool::_notify_threads(const ThreadData *p_current_thread_data, 
 	// For processing: if the first round wasn't enough, let's try now with threads processing tasks but currently awaiting.
 	for (uint32_t i = 0;
 			i < thread_count && to_process;
-			i++, notify_index = (notify_index + 1) % thread_count) {
+			i++) {
+		notify_index++;
+		if (notify_index == thread_count) {
+			notify_index = 0;
+		}
 		ThreadData &th = threads[notify_index];
 
 		if (th.signaled) {

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2194,7 +2194,10 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 			// some hardware expects multiple semaphores to be used.
 			present_semaphore = command_queue->present_semaphores[command_queue->present_semaphore_index];
 			signal_semaphores.push_back(present_semaphore);
-			command_queue->present_semaphore_index = (command_queue->present_semaphore_index + 1) % command_queue->present_semaphores.size();
+			command_queue->present_semaphore_index++;
+			if (command_queue->present_semaphore_index == command_queue->present_semaphores.size()) {
+				command_queue->present_semaphore_index = 0;
+			}
 		}
 
 		VkSubmitInfo submit_info = {};

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -530,9 +530,13 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 			const Color col = Color(0.5, 0.5, 0.5); // FIXME polygon->get_outline_color();
 			const int n = pre_move_edit.size();
 			for (int i = 0; i < n - (is_closed ? 0 : 1); i++) {
+				int next = i + 1;
+				if (next == n) {
+					next = 0;
+				}
 				Vector2 p, p2;
 				p = pre_move_edit[i] + offset;
-				p2 = pre_move_edit[(i + 1) % n] + offset;
+				p2 = pre_move_edit[next] + offset;
 
 				Vector2 point = xform.xform(p);
 				Vector2 next_point = xform.xform(p2);
@@ -552,11 +556,15 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 
 			if (is_closed || i < n_points - 1) {
 				Vector2 p2;
+				int next = i + 1;
+				if (next == n_points) {
+					next = 0;
+				}
 				if (j == edited_point.polygon &&
-						((wip_active && i == n_points - 1) || (((i + 1) % n_points) == edited_point.vertex))) {
+						((wip_active && i == n_points - 1) || (next == edited_point.vertex))) {
 					p2 = edited_point.pos;
 				} else {
-					p2 = points[(i + 1) % n_points] + offset;
+					p2 = points[next] + offset;
 				}
 
 				const Vector2 next_point = xform.xform(p2);
@@ -699,8 +707,12 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 		const int n_segments = n_points - (_is_line() ? 1 : 0);
 
 		for (int i = 0; i < n_segments; i++) {
+			int next = i + 1;
+			if (next == n_points) {
+				next = 0;
+			}
 			Vector2 segment[2] = { xform.xform(points[i] + offset),
-				xform.xform(points[(i + 1) % n_points] + offset) };
+				xform.xform(points[next] + offset) };
 
 			Vector2 cp = Geometry2D::get_closest_point_to_segment(p_pos, segment);
 

--- a/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
@@ -64,7 +64,10 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	Vector<Vector3> lines;
 	for (int i = 0; i < points.size(); i++) {
-		int n = (i + 1) % points.size();
+		int n = i + 1;
+		if (n == points.size()) {
+			n = 0;
+		}
 		lines.push_back(Vector3(points[i].x, points[i].y, depth));
 		lines.push_back(Vector3(points[n].x, points[n].y, depth));
 		lines.push_back(Vector3(points[i].x, points[i].y, -depth));

--- a/editor/plugins/gizmos/light_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/light_3d_gizmo_plugin.cpp
@@ -181,10 +181,14 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			for (int i = 0; i < arrow_sides; i++) {
 				for (int j = 0; j < arrow_points; j++) {
+					int next = j + 1;
+					if (next == arrow_points) {
+						next = 0;
+					}
 					Basis ma(Vector3(0, 0, 1), Math_PI * i / arrow_sides);
 
 					Vector3 v1 = arrow[j] - Vector3(0, 0, arrow_length);
-					Vector3 v2 = arrow[(j + 1) % arrow_points] - Vector3(0, 0, arrow_length);
+					Vector3 v2 = arrow[next] - Vector3(0, 0, arrow_length);
 
 					lines.push_back(ma.xform(v1));
 					lines.push_back(ma.xform(v2));

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -198,9 +198,13 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditor::forward_3d_gui_input(Cam
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
 							for (int i = 0; i < poly.size(); i++) {
+								int next = i + 1;
+								if (next == poly.size()) {
+									next = 0;
+								}
 								Vector2 points[2] = {
 									p_camera->unproject_position(gt.xform(Vector3(poly[i].x, 0.0, poly[i].y))),
-									p_camera->unproject_position(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, 0.0, poly[(i + 1) % poly.size()].y)))
+									p_camera->unproject_position(gt.xform(Vector3(poly[next].x, 0.0, poly[next].y)))
 								};
 
 								Vector2 cp = Geometry2D::get_closest_point_to_segment(gpoint, points);
@@ -382,6 +386,10 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 	Rect2 rect;
 
 	for (int i = 0; i < poly.size(); i++) {
+		int next = i + 1;
+		if (next == poly.size()) {
+			next = 0;
+		}
 		Vector2 p, p2;
 		if (i == edited_point) {
 			p = edited_point_pos;
@@ -389,10 +397,10 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 			p = poly[i];
 		}
 
-		if ((wip_active && i == poly.size() - 1) || (((i + 1) % poly.size()) == edited_point)) {
+		if ((wip_active && i == poly.size() - 1) || (next == edited_point)) {
 			p2 = edited_point_pos;
 		} else {
-			p2 = poly[(i + 1) % poly.size()];
+			p2 = poly[next];
 		}
 
 		if (i == 0) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6868,11 +6868,19 @@ void fragment() {
 				}
 
 				for (int j = 0; j < n; ++j) {
+					int j_next = j + 1;
+					if (j_next == n) {
+						j_next = 0;
+					}
 					for (int k = 0; k < m; ++k) {
+						int k_next = k + 1;
+						if (k_next == m) {
+							k_next = 0;
+						}
 						int current_ring = j * m;
-						int next_ring = ((j + 1) % n) * m;
+						int next_ring = j_next * m;
 						int current_segment = k;
-						int next_segment = (k + 1) % m;
+						int next_segment = k_next;
 
 						surftool->add_index(current_ring + next_segment);
 						surftool->add_index(current_ring + current_segment);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1157,7 +1157,13 @@ void Polygon2DEditor::_uv_draw() {
 	}
 
 	for (int i = 0; i < uvs.size(); i++) {
-		int next = uv_draw_max > 0 ? (i + 1) % uv_draw_max : 0;
+		int next = 0;
+		if (uv_draw_max > 0) {
+			next = i + 1;
+			if (next >= uv_draw_max) {
+				next -= uv_draw_max;
+			}
+		}
 
 		if (i < uv_draw_max && uv_drag && uv_move_current == UV_MODE_EDIT_POINT && EDITOR_GET("editors/polygon_editor/show_previous_outline")) {
 			uv_edit_draw->draw_line(mtx.xform(points_prev[i]), mtx.xform(points_prev[next]), prev_color, Math::round(EDSCALE));
@@ -1176,7 +1182,10 @@ void Polygon2DEditor::_uv_draw() {
 		Vector<int> points = polygons[i];
 		Vector<Vector2> polypoints;
 		for (int j = 0; j < points.size(); j++) {
-			int next = (j + 1) % points.size();
+			int next = j + 1;
+			if (next == points.size()) {
+				next = 0;
+			}
 
 			int idx = points[j];
 			int idx_next = points[next];

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -202,9 +202,13 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
 							for (int i = 0; i < poly.size(); i++) {
+								uint32_t point_num = i + 1;
+								if (point_num == poly.size()) {
+									point_num = 0;
+								}
 								Vector2 points[2] = {
 									p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth))),
-									p_camera->unproject_position(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, poly[(i + 1) % poly.size()].y, depth)))
+									p_camera->unproject_position(gt.xform(Vector3(poly[point_num].x, poly[point_num].y, depth)))
 								};
 
 								Vector2 cp = Geometry2D::get_closest_point_to_segment(gpoint, points);
@@ -394,11 +398,15 @@ void Polygon3DEditor::_polygon_draw() {
 
 	for (int i = 0; i < poly.size(); i++) {
 		Vector2 p, p2;
+		int poly_next = i + 1;
+		if (poly_next == poly.size()) {
+			poly_next = 0;
+		}
 		p = i == edited_point ? edited_point_pos : poly[i];
-		if ((wip_active && i == poly.size() - 1) || (((i + 1) % poly.size()) == edited_point)) {
+		if ((wip_active && i == poly.size() - 1) || ((poly_next) == edited_point)) {
 			p2 = edited_point_pos;
 		} else {
-			p2 = poly[(i + 1) % poly.size()];
+			p2 = poly[poly_next];
 		}
 
 		if (i == 0) {

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -191,9 +191,10 @@ void GenericTilePolygonEditor::_base_control_draw() {
 		base_control->draw_polygon(polygon, v_color);
 
 		color.a = 0.7;
-		for (int j = 0; j < polygon.size(); j++) {
-			base_control->draw_line(polygon[j], polygon[(j + 1) % polygon.size()], color);
+		for (int j = 0; j < polygon.size() - 1; j++) {
+			base_control->draw_line(polygon[j], polygon[j + 1], color);
 		}
+		base_control->draw_line(polygon[polygon.size() - 1], polygon[0], color);
 	}
 
 	// Draw the polygon in creation.
@@ -403,7 +404,11 @@ void GenericTilePolygonEditor::_grab_polygon_segment_point(Vector2 p_pos, const 
 	for (unsigned int i = 0; i < polygons.size(); i++) {
 		const Vector<Vector2> &polygon = polygons[i];
 		for (int j = 0; j < polygon.size(); j++) {
-			Vector2 segment[2] = { polygon[j], polygon[(j + 1) % polygon.size()] };
+			int polygon_next = j + 1;
+			if (polygon_next == polygon.size()) {
+				polygon_next = 0;
+			}
+			Vector2 segment[2] = { polygon[j], polygon[polygon_next] };
 			Vector2 closest_point = Geometry2D::get_closest_point_to_segment(point, segment);
 			float distance = closest_point.distance_to(point);
 			if (distance < grab_threshold / editor_zoom_widget->get_zoom() && distance < closest_distance) {
@@ -439,7 +444,11 @@ void GenericTilePolygonEditor::_snap_to_tile_shape(Point2 &r_point, float &r_cur
 	// Snap to edges if we did not snap to vertices.
 	if (!snapped) {
 		for (int i = 0; i < polygon.size(); i++) {
-			Point2 segment[2] = { polygon[i], polygon[(i + 1) % polygon.size()] };
+			int polygon_next = i + 1;
+			if (polygon_next == polygon.size()) {
+				polygon_next = 0;
+			}
+			Point2 segment[2] = { polygon[i], polygon[polygon_next] };
 			Point2 point = Geometry2D::get_closest_point_to_segment(r_point, segment);
 			float distance = r_point.distance_to(point);
 			if (distance < p_snap_dist && distance < r_current_snapped_dist) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2046,7 +2046,10 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			}
 
 			for (int y0 = 0; y0 < shape_sides; y0++) {
-				int y1 = (y0 + 1) % shape_sides;
+				int y1 = y0 + 1;
+				if (y1 == shape_sides) {
+					y1 = 0;
+				}
 				// Use the top half of the texture.
 				double v0 = (y0 * v_step) / 2;
 				double v1 = ((y0 + 1) * v_step) / 2;

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -631,13 +631,17 @@ Vector3 NavMap::get_closest_point_to_segment(const Vector3 &p_from, const Vector
 
 		if (use_collision == false) {
 			for (size_t point_id = 0; point_id < p.points.size(); point_id += 1) {
+				size_t point_id_next = point_id + 1;
+				if (point_id_next == p.points.size()) {
+					point_id_next = 0;
+				}
 				Vector3 a, b;
 
 				Geometry3D::get_closest_points_between_segments(
 						p_from,
 						p_to,
 						p.points[point_id].pos,
-						p.points[(point_id + 1) % p.points.size()].pos,
+						p.points[point_id_next].pos,
 						a,
 						b);
 
@@ -953,7 +957,10 @@ void NavMap::sync() {
 		HashMap<gd::EdgeKey, Vector<gd::Edge::Connection>, gd::EdgeKey> connections;
 		for (gd::Polygon &poly : polygons) {
 			for (uint32_t p = 0; p < poly.points.size(); p++) {
-				int next_point = (p + 1) % poly.points.size();
+				uint32_t next_point = p + 1;
+				if (next_point == poly.points.size()) {
+					next_point = 0;
+				}
 				gd::EdgeKey ek(poly.points[p].key, poly.points[next_point].key);
 
 				HashMap<gd::EdgeKey, Vector<gd::Edge::Connection>, gd::EdgeKey>::Iterator connection = connections.find(ek);

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -170,10 +170,23 @@ void LineBuilder::build() {
 	Vector2 first_pos_up, first_pos_down;
 	bool is_first_joint_sharp = false;
 
-	// For each additional segment
+	// For each additional segment.
 	for (int i = first_point; i <= segments_count; ++i) {
-		pos1 = points[(i == -1) ? point_count - 1 : i % point_count]; // First point.
-		Vector2 pos2 = points[(i + 1) % point_count]; // Second point.
+		int pos1_index = i;
+		int pos2_index = i + 1;
+		if (pos1_index == -1) {
+			pos1_index = point_count - 1;
+		} else {
+			if (pos2_index == point_count) {
+				pos2_index = 0;
+			} else if (pos1_index == point_count) {
+				pos1_index = 0;
+				pos2_index = 1;
+			}
+		}
+
+		pos1 = points[pos1_index]; // First point.
+		Vector2 pos2 = points[pos2_index]; // Second point.
 
 		Vector2 f1 = (pos2 - pos1).normalized();
 		Vector2 u1 = f1.orthogonal();

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -67,11 +67,13 @@ void CollisionPolygon2D::_build_polygon() {
 		Vector<Vector2> segments;
 		segments.resize(polygon.size() * 2);
 		Vector2 *w = segments.ptrw();
-
-		for (int i = 0; i < polygon.size(); i++) {
+		int polygon_end_position = polygon.size() - 1;
+		for (int i = 0; i < polygon_end_position; i++) {
 			w[(i << 1) + 0] = polygon[i];
-			w[(i << 1) + 1] = polygon[(i + 1) % polygon.size()];
+			w[(i << 1) + 1] = polygon[i + 1];
 		}
+		w[(polygon_end_position << 1) + 0] = polygon[polygon_end_position];
+		w[(polygon_end_position << 1) + 1] = polygon[0];
 
 		concave->set_segments(segments);
 

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -178,7 +178,10 @@ void Polygon2D::_notification(int p_what) {
 						highest_idx = i;
 						highest_y = points[i].y;
 					}
-					int ni = (i + 1) % len;
+					int ni = i + 1;
+					if (ni == len) {
+						ni = 0;
+					}
 					sum += (points[ni].x - points[i].x) * (points[ni].y + points[i].y);
 				}
 

--- a/scene/resources/2d/convex_polygon_shape_2d.cpp
+++ b/scene/resources/2d/convex_polygon_shape_2d.cpp
@@ -50,13 +50,22 @@ bool left_test(const Vector2 &p1, const Vector2 &p2, const Vector2 &p3) {
 bool is_convex(const Vector<Vector2> &p_points) {
 	// Pre-condition: Polygon is in counter-clockwise order.
 	int polygon_size = p_points.size();
-	for (int i = 0; i < polygon_size && polygon_size > 3; i++) {
-		int j = (i + 1) % polygon_size;
-		int k = (j + 1) % polygon_size;
+	if (polygon_size <= 3) {
+		return true;
+	}
+
+	int polygon_end_minus_one_index = p_points.size() - 2;
+	for (int i = 0; i < polygon_end_minus_one_index; i++) {
 		// If any consecutive three points fail left-test, then there is a concavity.
-		if (!left_test(p_points[i], p_points[j], p_points[k])) {
+		if (!left_test(p_points[i], p_points[i + 1], p_points[i + 2])) {
 			return false;
 		}
+	}
+	if (!left_test(p_points[polygon_end_minus_one_index], p_points[polygon_end_minus_one_index + 1], p_points[0])) {
+		return false;
+	}
+	if (!left_test(p_points[polygon_end_minus_one_index], p_points[0], p_points[1])) {
+		return false;
 	}
 
 	return true;

--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -279,10 +279,13 @@ void NavigationPolygon::make_polygons_from_outlines() {
 			}
 			const Vector2 *r2 = ol2.ptr();
 
-			for (int l = 0; l < olsize2; l++) {
-				if (Geometry2D::segment_intersects_segment(r[0], outside_point, r2[l], r2[(l + 1) % olsize2], nullptr)) {
+			for (int l = 0; l < olsize2 - 1; l++) {
+				if (Geometry2D::segment_intersects_segment(r[0], outside_point, r2[l], r2[l + 1], nullptr)) {
 					interscount++;
 				}
+			}
+			if (Geometry2D::segment_intersects_segment(r[0], outside_point, r2[olsize2 - 1], r2[0], nullptr)) {
+				interscount++;
 			}
 		}
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -313,10 +313,24 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 	// Fill the indices and the colors for the border.
 
 	if (draw_border) {
-		for (int i = 0; i < ring_vert_count; i++) {
-			indices.push_back(vert_offset + ((i + 0) % ring_vert_count));
-			indices.push_back(vert_offset + ((i + 2) % ring_vert_count));
-			indices.push_back(vert_offset + ((i + 1) % ring_vert_count));
+		if (ring_vert_count == 1) {
+			indices.push_back(vert_offset);
+			indices.push_back(vert_offset);
+			indices.push_back(vert_offset);
+		} else {
+			for (int i = 0; i < ring_vert_count; i++) {
+				int i_next = i + 1;
+				int i_next2 = i + 2;
+				if (i_next == ring_vert_count) {
+					i_next = 0;
+				}
+				if (i_next2 >= ring_vert_count) {
+					i_next2 -= ring_vert_count;
+				}
+				indices.push_back(vert_offset + i);
+				indices.push_back(vert_offset + i_next2);
+				indices.push_back(vert_offset + i_next);
+			}
 		}
 	}
 

--- a/servers/audio/effects/audio_effect_hard_limiter.cpp
+++ b/servers/audio/effects/audio_effect_hard_limiter.cpp
@@ -77,7 +77,10 @@ void AudioEffectHardLimiterInstance::process(const AudioFrame *p_src_frames, Aud
 
 		gain_buckets[bucket_id] = MIN(gain_buckets[bucket_id], gain);
 
-		gain_bucket_cursor = (gain_bucket_cursor + 1) % gain_samples_to_store;
+		gain_bucket_cursor++;
+		if (gain_bucket_cursor == gain_samples_to_store) {
+			gain_bucket_cursor = 0;
+		}
 
 		for (int j = 0; j < (int)gain_buckets.size(); j++) {
 			gain = MIN(gain, gain_buckets[j]);
@@ -92,7 +95,10 @@ void AudioEffectHardLimiterInstance::process(const AudioFrame *p_src_frames, Aud
 		sample_buffer_left[sample_cursor] = sample_left;
 		sample_buffer_right[sample_cursor] = sample_right;
 
-		sample_cursor = (sample_cursor + 1) % sample_buffer_left.size();
+		sample_cursor++;
+		if ((uint32_t)sample_cursor == sample_buffer_left.size()) {
+			sample_cursor = 0;
+		}
 
 		p_dst_frames[i].left = dst_buffer_left * gain;
 		p_dst_frames[i].right = dst_buffer_right * gain;

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -129,7 +129,11 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 			//time to do a FFT
 			smbFft(fftw, fft_size * 2, -1);
 			smbFft(fftw + fft_size * 4, fft_size * 2, -1);
-			int next = (fft_pos + 1) % fft_count;
+
+			int next = fft_pos + 1;
+			if (next == fft_count) {
+				next = 0;
+			}
 
 			AudioFrame *hw = (AudioFrame *)fft_history[next].ptr(); //do not use write, avoid cow
 

--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -505,9 +505,13 @@ void GodotConvexPolygonShape2D::get_supports(const Vector2 &p_normal, Vector2 *r
 
 		//test segment
 		if (points[i].normal.dot(p_normal) > segment_is_valid_support_threshold) {
+			int i_next = i + 1;
+			if (i_next == point_count) {
+				i_next = 0;
+			}
 			r_amount = 2;
 			r_supports[0] = points[i].pos;
-			r_supports[1] = points[(i + 1) % point_count].pos;
+			r_supports[1] = points[i_next].pos;
 			return;
 		}
 	}
@@ -540,9 +544,13 @@ bool GodotConvexPolygonShape2D::intersect_segment(const Vector2 &p_begin, const 
 	bool inters = false;
 
 	for (int i = 0; i < point_count; i++) {
+		int i_next = i + 1;
+		if (i_next == point_count) {
+			i_next = 0;
+		}
 		Vector2 res;
 
-		if (!Geometry2D::segment_intersects_segment(p_begin, p_end, points[i].pos, points[(i + 1) % point_count].pos, &res)) {
+		if (!Geometry2D::segment_intersects_segment(p_begin, p_end, points[i].pos, points[i_next].pos, &res)) {
 			continue;
 		}
 
@@ -594,8 +602,12 @@ void GodotConvexPolygonShape2D::set_data(const Variant &p_data) {
 		}
 
 		for (int i = 0; i < point_count; i++) {
+			int i_next = i + 1;
+			if (i_next == point_count) {
+				i_next = 0;
+			}
 			Vector2 p = points[i].pos;
-			Vector2 pn = points[(i + 1) % point_count].pos;
+			Vector2 pn = points[i_next].pos;
 			points[i].normal = (pn - p).orthogonal().normalized();
 		}
 	} else {

--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -303,7 +303,10 @@ static void _generate_contacts_face_face(const Vector3 *p_points_A, int p_point_
 
 	// go through all of B points
 	for (int i = 0; i < p_point_count_B; i++) {
-		int i_n = (i + 1) % p_point_count_B;
+		int i_n = i + 1;
+		if (i_n == p_point_count_B) {
+			i_n = 0;
+		}
 
 		Vector3 edge0_B = p_points_B[i];
 		Vector3 edge1_B = p_points_B[i_n];
@@ -316,7 +319,10 @@ static void _generate_contacts_face_face(const Vector3 *p_points_A, int p_point_
 		int dst_idx = 0;
 		bool edge = clipbuf_len == 2;
 		for (int j = 0; j < clipbuf_len; j++) {
-			int j_n = (j + 1) % clipbuf_len;
+			int j_n = j + 1;
+			if (j_n == clipbuf_len) {
+				j_n = 0;
+			}
 
 			Vector3 edge0_A = clipbuf_src[j];
 			Vector3 edge1_A = clipbuf_src[j_n];
@@ -400,7 +406,10 @@ static void _generate_contacts_face_circle(const Vector3 *p_points_A, int p_poin
 	int num_points = 0;
 
 	for (int i = 0; i < p_point_count_A; i++) {
-		int i_n = (i + 1) % p_point_count_A;
+		int i_n = i + 1;
+		if (i_n == p_point_count_A) {
+			i_n = 0;
+		}
 
 		const Vector3 &edge0_A = p_points_A[i];
 		const Vector3 &edge1_A = p_points_A[i_n];

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -1042,14 +1042,21 @@ Vector3 GodotConvexPolygonShape3D::get_closest_point_to(const Vector3 &p_point) 
 		int ic = faces[i].indices.size();
 		const int *indices = faces[i].indices.ptr();
 
-		for (int j = 0; j < ic; j++) {
+		for (int j = 0; j < ic - 1; j++) {
 			Vector3 a = vertices[indices[j]];
-			Vector3 b = vertices[indices[(j + 1) % ic]];
+			Vector3 b = vertices[indices[j + 1]];
 			Vector3 n = (a - b).cross(faces[i].plane.normal).normalized();
 			if (Plane(n, a).is_point_over(p_point)) {
 				is_inside = false;
 				break;
 			}
+		}
+		Vector3 a = vertices[indices[ic - 1]];
+		Vector3 b = vertices[indices[0]];
+		Vector3 n = (a - b).cross(faces[i].plane.normal).normalized();
+		if (Plane(n, a).is_point_over(p_point)) {
+			is_inside = false;
+			break;
 		}
 
 		if (is_inside) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1977,14 +1977,18 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 			const Vector2 *r = p_points.ptr();
 
 			int max = lc / 2;
-			if (!p_closed) {
-				max--;
-			}
-			for (int i = 0; i < max; i++) {
+			for (int i = 0; i < max - 1; i++) {
 				Vector2 a = r[i];
-				Vector2 b = r[(i + 1) % (lc / 2)];
+				Vector2 b = r[i + 1];
 				w[i * 2 + 0] = a;
 				w[i * 2 + 1] = b;
+			}
+
+			if (p_closed) {
+				Vector2 a = r[max - 1];
+				Vector2 b = r[0];
+				w[(max - 1) * 2 + 0] = a;
+				w[(max - 1) * 2 + 1] = b;
 			}
 		}
 	}
@@ -2086,10 +2090,13 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 			sdf_indices.resize(max * 2);
 
 			int *iw = sdf_indices.ptrw();
-			for (int i = 0; i < max; i++) {
+			int max_minus_one = max - 1;
+			for (int i = 0; i < max_minus_one; i++) {
 				iw[i * 2 + 0] = i;
-				iw[i * 2 + 1] = (i + 1) % max;
+				iw[i * 2 + 1] = i + 1;
 			}
+			iw[max_minus_one * 2 + 0] = max_minus_one;
+			iw[max_minus_one * 2 + 1] = 0;
 			oc->sdf_is_lines = true;
 		}
 	}

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1976,7 +1976,10 @@ void RenderingDeviceGraph::end(RDD::CommandBufferID p_command_buffer, bool p_reo
 	}
 
 	// Advance the frame counter. It's not necessary to do this if no commands are recorded because that means no secondary command buffers were used.
-	frame = (frame + 1) % frames.size();
+	frame++;
+	if (frame == frames.size()) {
+		frame = 0;
+	}
 }
 
 #if PRINT_RESOURCE_TRACKER_TOTAL


### PR DESCRIPTION
I replaced the complex `%` with simple conditions, or by moving the body of the loop outside the loop. This does not seem to be optimized by the compiler, https://godbolt.org/z/6bW9v38dG.

**Benchmarks**
Used this https://quick-bench.com.
Clang 17
![image](https://github.com/godotengine/godot/assets/116561933/c158ab42-af06-42c5-a5e0-a3d113b72cb2)

GCC 13.2
![image](https://github.com/godotengine/godot/assets/116561933/7c9f4381-b82f-4c91-8deb-fb1879f7dcf8)
