### PR TITLE
mbedTLS: Fix build without the module on MinGW

### DIFF
--- a/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
@@ -50,4 +50,11 @@
 #define MBEDTLS_PLATFORM_ZEROIZE_ALT
 #define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
 
+// This is only to pass a check in the mbedtls check_config.h header, none of
+// the files we include as part of the core build uses it anyway, we already
+// define MBEDTLS_PLATFORM_ZEROIZE_ALT which is the only relevant function.
+#if defined(__MINGW32__)
+#define MBEDTLS_PLATFORM_C
+#endif
+
 #endif // GODOT_CORE_MBEDTLS_CONFIG_H


### PR DESCRIPTION
The `include/mbedtls/check_config.h` header file has a generic check which requires `MBEDTLS_PLATFORM_C` to be defined on Windows when building with MinGW and ancient MSVC versions.
    
The few mbedTLS files we include in builds without the module don't really require anything from the mbedTLS platform file beside the `mbedtls_platform_zeroize` function which we already override with a custom one by defining `MBEDTLS_PLATFORM_ZEROIZE_ALT`.
    
So we simply add the same check and force the define in such case.

Fixes #90652