### PR TITLE
SCons: Make new `debug_paths_relative` option opt-in

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -180,7 +180,7 @@ opts.Add(
 )
 opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", False))
 opts.Add(BoolVariable("separate_debug_symbols", "Extract debugging symbols to a separate file", False))
-opts.Add(BoolVariable("debug_paths_relative", "Make file paths in debug symbols relative (if supported)", True))
+opts.Add(BoolVariable("debug_paths_relative", "Make file paths in debug symbols relative (if supported)", False))
 opts.Add(EnumVariable("lto", "Link-time optimization (production builds)", "none", ("none", "auto", "thin", "full")))
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
 opts.Add(BoolVariable("threads", "Enable threading support", True))


### PR DESCRIPTION
As pointed out in https://github.com/godotengine/godot/pull/78232#issuecomment-2056467297, it actually makes it harder to run Godot locally while keeping the relationship with the header files it was compiled from.