### PR TITLE
Expose `ClassDB.class_get_api_type()` method

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1413,6 +1413,11 @@ Variant ClassDB::instantiate(const StringName &p_class) const {
 	}
 }
 
+ClassDB::APIType ClassDB::class_get_api_type(const StringName &p_class) const {
+	::ClassDB::APIType api_type = ::ClassDB::get_api_type(p_class);
+	return (APIType)api_type;
+}
+
 bool ClassDB::class_has_signal(const StringName &p_class, const StringName &p_signal) const {
 	return ::ClassDB::has_signal(p_class, p_signal);
 }
@@ -1609,7 +1614,7 @@ void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List
 				pf == "class_has_method" || pf == "class_get_method_list" ||
 				pf == "class_get_integer_constant_list" || pf == "class_has_integer_constant" || pf == "class_get_integer_constant" ||
 				pf == "class_has_enum" || pf == "class_get_enum_list" || pf == "class_get_enum_constants" || pf == "class_get_integer_constant_enum" ||
-				pf == "is_class_enabled" || pf == "is_class_enum_bitfield");
+				pf == "is_class_enabled" || pf == "is_class_enum_bitfield" || pf == "class_get_api_type");
 	}
 	if (first_argument_is_class || pf == "is_parent_class") {
 		for (const String &E : get_class_list()) {
@@ -1629,6 +1634,8 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("is_parent_class", "class", "inherits"), &ClassDB::is_parent_class);
 	::ClassDB::bind_method(D_METHOD("can_instantiate", "class"), &ClassDB::can_instantiate);
 	::ClassDB::bind_method(D_METHOD("instantiate", "class"), &ClassDB::instantiate);
+
+	::ClassDB::bind_method(D_METHOD("class_get_api_type", "class"), &ClassDB::class_get_api_type);
 
 	::ClassDB::bind_method(D_METHOD("class_has_signal", "class", "signal"), &ClassDB::class_has_signal);
 	::ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &ClassDB::class_get_signal);
@@ -1663,6 +1670,12 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("is_class_enum_bitfield", "class", "enum", "no_inheritance"), &ClassDB::is_class_enum_bitfield, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);
+
+	BIND_ENUM_CONSTANT(API_CORE);
+	BIND_ENUM_CONSTANT(API_EDITOR);
+	BIND_ENUM_CONSTANT(API_EXTENSION);
+	BIND_ENUM_CONSTANT(API_EDITOR_EXTENSION);
+	BIND_ENUM_CONSTANT(API_NONE);
 }
 
 } // namespace special

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -441,6 +441,14 @@ protected:
 	static void _bind_methods();
 
 public:
+	enum APIType {
+		API_CORE,
+		API_EDITOR,
+		API_EXTENSION,
+		API_EDITOR_EXTENSION,
+		API_NONE,
+	};
+
 	PackedStringArray get_class_list() const;
 	PackedStringArray get_inheriters_from_class(const StringName &p_class) const;
 	StringName get_parent_class(const StringName &p_class) const;
@@ -449,6 +457,7 @@ public:
 	bool can_instantiate(const StringName &p_class) const;
 	Variant instantiate(const StringName &p_class) const;
 
+	APIType class_get_api_type(const StringName &p_class) const;
 	bool class_has_signal(const StringName &p_class, const StringName &p_signal) const;
 	Dictionary class_get_signal(const StringName &p_class, const StringName &p_signal) const;
 	TypedArray<Dictionary> class_get_signal_list(const StringName &p_class, bool p_no_inheritance = false) const;
@@ -627,5 +636,7 @@ VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyJoinType);
 VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyEndType);
 
 VARIANT_ENUM_CAST(core_bind::Thread::Priority);
+
+VARIANT_ENUM_CAST(core_bind::special::ClassDB::APIType);
 
 #endif // CORE_BIND_H

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -31,6 +31,13 @@
 				Returns whether the specified [param class] is available or not.
 			</description>
 		</method>
+		<method name="class_get_api_type" qualifiers="const">
+			<return type="int" enum="ClassDB.APIType" />
+			<param index="0" name="class" type="StringName" />
+			<description>
+				Returns the API type of [param class]. See [enum APIType].
+			</description>
+		</method>
 		<method name="class_get_enum_constants" qualifiers="const">
 			<return type="PackedStringArray" />
 			<param index="0" name="class" type="StringName" />
@@ -242,4 +249,21 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="API_CORE" value="0" enum="APIType">
+			Native Core class type.
+		</constant>
+		<constant name="API_EDITOR" value="1" enum="APIType">
+			Native Editor class type.
+		</constant>
+		<constant name="API_EXTENSION" value="2" enum="APIType">
+			GDExtension class type.
+		</constant>
+		<constant name="API_EDITOR_EXTENSION" value="3" enum="APIType">
+			GDExtension Editor class type.
+		</constant>
+		<constant name="API_NONE" value="4" enum="APIType">
+			Unknown class type.
+		</constant>
+	</constants>
 </class>


### PR DESCRIPTION
Expose `ClassDB::class_get_api_type()` for editor-plugins and other languages wrapper generator.

- Closes https://github.com/godotengine/godot-proposals/issues/9526
