### PR TITLE
Reduce and prevent unnecessary random-access to `List`

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -38,10 +38,10 @@
 Array DebuggerMarshalls::ScriptStackDump::serialize() {
 	Array arr;
 	arr.push_back(frames.size() * 3);
-	for (int i = 0; i < frames.size(); i++) {
-		arr.push_back(frames[i].file);
-		arr.push_back(frames[i].line);
-		arr.push_back(frames[i].func);
+	for (const ScriptLanguage::StackInfo &frame : frames) {
+		arr.push_back(frame.file);
+		arr.push_back(frame.line);
+		arr.push_back(frame.func);
 	}
 	return arr;
 }

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -206,8 +206,7 @@ void RemoteDebugger::flush_output() {
 		Vector<String> joined_log_strings;
 		Vector<String> strings;
 		Vector<int> types;
-		for (int i = 0; i < output_strings.size(); i++) {
-			const OutputString &output_string = output_strings[i];
+		for (const OutputString &output_string : output_strings) {
 			if (output_string.type == MESSAGE_TYPE_ERROR) {
 				if (!joined_log_strings.is_empty()) {
 					strings.push_back(String("\n").join(joined_log_strings));

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -45,7 +45,7 @@ bool RemoteDebuggerPeerTCP::has_message() {
 Array RemoteDebuggerPeerTCP::get_message() {
 	MutexLock lock(mutex);
 	ERR_FAIL_COND_V(!has_message(), Array());
-	Array out = in_queue[0];
+	Array out = in_queue.front()->get();
 	in_queue.pop_front();
 	return out;
 }
@@ -100,7 +100,7 @@ void RemoteDebuggerPeerTCP::_write_out() {
 				break; // Nothing left to send
 			}
 			mutex.lock();
-			Variant var = out_queue[0];
+			Variant var = out_queue.front()->get();
 			out_queue.pop_front();
 			mutex.unlock();
 			int size = 0;

--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -152,9 +152,10 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 
 	return_doc_from_retinfo(p_method, p_methodinfo.return_val);
 
-	for (int i = 0; i < p_methodinfo.arguments.size(); i++) {
+	int i = 0;
+	for (List<PropertyInfo>::ConstIterator itr = p_methodinfo.arguments.begin(); itr != p_methodinfo.arguments.end(); ++itr, ++i) {
 		DocData::ArgumentDoc argument;
-		argument_doc_from_arginfo(argument, p_methodinfo.arguments[i]);
+		argument_doc_from_arginfo(argument, *itr);
 		int default_arg_index = i - (p_methodinfo.arguments.size() - p_methodinfo.default_arguments.size());
 		if (default_arg_index >= 0) {
 			Variant default_arg = p_methodinfo.default_arguments[default_arg_index];

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1018,14 +1018,26 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						d2["is_virtual"] = true;
 						// virtual functions have no hash since no MethodBind is involved
 						bool has_return = mi.return_val.type != Variant::NIL || (mi.return_val.usage & PROPERTY_USAGE_NIL_IS_VARIANT);
-						Array arguments;
-						for (int i = (has_return ? -1 : 0); i < mi.arguments.size(); i++) {
-							PropertyInfo pinfo = i == -1 ? mi.return_val : mi.arguments[i];
+						if (has_return) {
+							PropertyInfo pinfo = mi.return_val;
 							Dictionary d3;
 
-							if (i >= 0) {
-								d3["name"] = pinfo.name;
+							d3["type"] = get_property_info_type_name(pinfo);
+
+							if (mi.get_argument_meta(-1) > 0) {
+								d3["meta"] = get_type_meta_name((GodotTypeInfo::Metadata)mi.get_argument_meta(-1));
 							}
+
+							d2["return_value"] = d3;
+						}
+
+						Array arguments;
+						int i = 0;
+						for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
+							const PropertyInfo &pinfo = *itr;
+							Dictionary d3;
+
+							d3["name"] = pinfo.name;
 
 							d3["type"] = get_property_info_type_name(pinfo);
 
@@ -1033,11 +1045,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 								d3["meta"] = get_type_meta_name((GodotTypeInfo::Metadata)mi.get_argument_meta(i));
 							}
 
-							if (i == -1) {
-								d2["return_value"] = d3;
-							} else {
-								arguments.push_back(d3);
-							}
+							arguments.push_back(d3);
 						}
 
 						if (arguments.size()) {
@@ -1151,10 +1159,11 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 					Array arguments;
 
-					for (int i = 0; i < F.arguments.size(); i++) {
+					int i = 0;
+					for (List<PropertyInfo>::ConstIterator itr = F.arguments.begin(); itr != F.arguments.end(); ++itr, ++i) {
 						Dictionary d3;
-						d3["name"] = F.arguments[i].name;
-						d3["type"] = get_property_info_type_name(F.arguments[i]);
+						d3["name"] = itr->name;
+						d3["type"] = get_property_info_type_name(*itr);
 						if (F.get_argument_meta(i) > 0) {
 							d3["meta"] = get_type_meta_name((GodotTypeInfo::Metadata)F.get_argument_meta(i));
 						}

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -211,14 +211,14 @@ protected:
 		if (p_arg < 0) {
 			return return_value_info.type;
 		} else {
-			return arguments_info[p_arg].type;
+			return arguments_info.get(p_arg).type;
 		}
 	}
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const override {
 		if (p_arg < 0) {
 			return return_value_info;
 		} else {
-			return arguments_info[p_arg];
+			return arguments_info.get(p_arg);
 		}
 	}
 
@@ -232,7 +232,7 @@ public:
 		if (p_arg < 0) {
 			return return_value_metadata;
 		} else {
-			return arguments_metadata[p_arg];
+			return arguments_metadata.get(p_arg);
 		}
 	}
 #endif
@@ -319,8 +319,9 @@ public:
 			return false;
 		}
 
-		for (uint32_t i = 0; i < p_method_info->argument_count; i++) {
-			if (arguments_info[i].type != (Variant::Type)p_method_info->arguments_info[i].type) {
+		List<PropertyInfo>::ConstIterator itr = arguments_info.begin();
+		for (uint32_t i = 0; i < p_method_info->argument_count; ++itr, ++i) {
+			if (itr->type != (Variant::Type)p_method_info->arguments_info[i].type) {
 				return false;
 			}
 		}

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -148,8 +148,8 @@ PackedStringArray IP::resolve_hostname_addresses(const String &p_hostname, Type 
 	resolver->mutex.unlock();
 
 	PackedStringArray result;
-	for (int i = 0; i < res.size(); ++i) {
-		result.push_back(String(res[i]));
+	for (const IPAddress &E : res) {
+		result.push_back(String(E));
 	}
 	return result;
 }
@@ -206,9 +206,9 @@ IPAddress IP::get_resolve_item_address(ResolverID p_id) const {
 
 	List<IPAddress> res = resolver->queue[p_id].response;
 
-	for (int i = 0; i < res.size(); ++i) {
-		if (res[i].is_valid()) {
-			return res[i];
+	for (const IPAddress &E : res) {
+		if (E.is_valid()) {
+			return E;
 		}
 	}
 	return IPAddress();
@@ -226,9 +226,9 @@ Array IP::get_resolve_item_addresses(ResolverID p_id) const {
 	List<IPAddress> res = resolver->queue[p_id].response;
 
 	Array result;
-	for (int i = 0; i < res.size(); ++i) {
-		if (res[i].is_valid()) {
-			result.push_back(String(res[i]));
+	for (const IPAddress &E : res) {
+		if (E.is_valid()) {
+			result.push_back(String(E));
 		}
 	}
 	return result;

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -161,7 +161,7 @@ Ref<PacketPeerUDP> UDPServer::take_connection() {
 		return conn;
 	}
 
-	Peer peer = pending[0];
+	Peer peer = pending.front()->get();
 	pending.pop_front();
 	peers.push_back(peer);
 	return peer.peer;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -425,8 +425,8 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			for (const StringName &F : snames) {
 				MethodInfo &mi = t->signal_map[F];
 				hash = hash_murmur3_one_64(F.hash(), hash);
-				for (int i = 0; i < mi.arguments.size(); i++) {
-					hash = hash_murmur3_one_64(mi.arguments[i].type, hash);
+				for (const PropertyInfo &pi : mi.arguments) {
+					hash = hash_murmur3_one_64(pi.type, hash);
 				}
 			}
 		}
@@ -1856,8 +1856,9 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 		if (p_arg_names.size() != mi.arguments.size()) {
 			WARN_PRINT("Mismatch argument name count for virtual method: " + String(p_class) + "::" + p_method.name);
 		} else {
-			for (int i = 0; i < p_arg_names.size(); i++) {
-				mi.arguments[i].name = p_arg_names[i];
+			List<PropertyInfo>::Iterator itr = mi.arguments.begin();
+			for (int i = 0; i < p_arg_names.size(); ++itr, ++i) {
+				itr->name = p_arg_names[i];
 			}
 		}
 	}

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -152,7 +152,7 @@ public:
 		if (p_arg < 0) {
 			return _gen_return_type_info();
 		} else if (p_arg < method_info.arguments.size()) {
-			return method_info.arguments[p_arg];
+			return method_info.arguments.get(p_arg);
 		} else {
 			return PropertyInfo(Variant::NIL, "arg_" + itos(p_arg), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 		}
@@ -193,10 +193,11 @@ public:
 			Vector<StringName> names;
 			names.resize(method_info.arguments.size());
 #endif
-			for (int i = 0; i < method_info.arguments.size(); i++) {
-				at[i + 1] = method_info.arguments[i].type;
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+				at[i + 1] = itr->type;
 #ifdef DEBUG_METHODS_ENABLED
-				names.write[i] = method_info.arguments[i].name;
+				names.write[i] = itr->name;
 #endif
 			}
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1302,9 +1302,8 @@ TypedArray<Dictionary> Object::_get_signal_connection_list(const StringName &p_s
 
 TypedArray<Dictionary> Object::_get_incoming_connections() const {
 	TypedArray<Dictionary> ret;
-	int connections_amount = connections.size();
-	for (int idx_conn = 0; idx_conn < connections_amount; idx_conn++) {
-		ret.push_back(connections[idx_conn]);
+	for (const Object::Connection &connection : connections) {
+		ret.push_back(connection);
 	}
 
 	return ret;

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -139,31 +139,6 @@ public:
 
 	typedef T ValueType;
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return E->get();
-		}
-		_FORCE_INLINE_ T *operator->() const { return &E->get(); }
-		_FORCE_INLINE_ Iterator &operator++() {
-			E = E->next();
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			E = E->prev();
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
-
-		Iterator(Element *p_E) { E = p_E; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { E = p_it.E; }
-
-	private:
-		Element *E = nullptr;
-	};
-
 	struct ConstIterator {
 		_FORCE_INLINE_ const T &operator*() const {
 			return E->get();
@@ -187,6 +162,35 @@ public:
 
 	private:
 		const Element *E = nullptr;
+	};
+
+	struct Iterator {
+		_FORCE_INLINE_ T &operator*() const {
+			return E->get();
+		}
+		_FORCE_INLINE_ T *operator->() const { return &E->get(); }
+		_FORCE_INLINE_ Iterator &operator++() {
+			E = E->next();
+			return *this;
+		}
+		_FORCE_INLINE_ Iterator &operator--() {
+			E = E->prev();
+			return *this;
+		}
+
+		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
+		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+
+		Iterator(Element *p_E) { E = p_E; }
+		Iterator() {}
+		Iterator(const Iterator &p_it) { E = p_it.E; }
+
+		operator ConstIterator() const {
+			return ConstIterator(E);
+		}
+
+	private:
+		Element *E = nullptr;
 	};
 
 	_FORCE_INLINE_ Iterator begin() {
@@ -519,7 +523,9 @@ public:
 		}
 	}
 
-	T &operator[](int p_index) {
+	// Random access to elements, use with care,
+	// do not use for iteration.
+	T &get(int p_index) {
 		CRASH_BAD_INDEX(p_index, size());
 
 		Element *I = front();
@@ -532,7 +538,9 @@ public:
 		return I->get();
 	}
 
-	const T &operator[](int p_index) const {
+	// Random access to elements, use with care,
+	// do not use for iteration.
+	const T &get(int p_index) const {
 		CRASH_BAD_INDEX(p_index, size());
 
 		const Element *I = front();

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -289,7 +289,7 @@ String DirAccessUnix::get_drive(int p_drive) {
 
 	ERR_FAIL_INDEX_V(p_drive, list.size(), "");
 
-	return list[p_drive];
+	return list.get(p_drive);
 }
 
 int DirAccessUnix::get_current_drive() {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -546,8 +546,8 @@ Dictionary OS_Unix::execute_with_pipe(const String &p_path, const List<String> &
 		// The child process.
 		Vector<CharString> cs;
 		cs.push_back(p_path.utf8());
-		for (int i = 0; i < p_arguments.size(); i++) {
-			cs.push_back(p_arguments[i].utf8());
+		for (const String &arg : p_arguments) {
+			cs.push_back(arg.utf8());
 		}
 
 		Vector<char *> args;
@@ -606,8 +606,8 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, St
 #else
 	if (r_pipe) {
 		String command = "\"" + p_path + "\"";
-		for (int i = 0; i < p_arguments.size(); i++) {
-			command += String(" \"") + p_arguments[i] + "\"";
+		for (const String &arg : p_arguments) {
+			command += String(" \"") + arg + "\"";
 		}
 		if (read_stderr) {
 			command += " 2>&1"; // Include stderr
@@ -647,8 +647,8 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, St
 		// The child process
 		Vector<CharString> cs;
 		cs.push_back(p_path.utf8());
-		for (int i = 0; i < p_arguments.size(); i++) {
-			cs.push_back(p_arguments[i].utf8());
+		for (const String &arg : p_arguments) {
+			cs.push_back(arg.utf8());
 		}
 
 		Vector<char *> args;
@@ -689,8 +689,8 @@ Error OS_Unix::create_process(const String &p_path, const List<String> &p_argume
 
 		Vector<CharString> cs;
 		cs.push_back(p_path.utf8());
-		for (int i = 0; i < p_arguments.size(); i++) {
-			cs.push_back(p_arguments[i].utf8());
+		for (const String &arg : p_arguments) {
+			cs.push_back(arg.utf8());
 		}
 
 		Vector<char *> args;

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1397,8 +1397,10 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				// 6-(undo) reinsert overlapped keys
-				for (int i = 0; i < to_restore.size(); i++) {
-					const AnimMoveRestore &amr = to_restore[i];
+				List<AnimMoveRestore>::ConstIterator restore_itr = to_restore.begin();
+				List<Animation::HandleMode>::ConstIterator handle_itr = to_restore_handle_modes.begin();
+				for (; restore_itr != to_restore.end() && handle_itr != to_restore_handle_modes.end(); ++restore_itr, ++handle_itr) {
+					const AnimMoveRestore &amr = *restore_itr;
 					Array key = amr.key;
 					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
 					undo_redo->add_undo_method(
@@ -1409,7 +1411,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 							key[0],
 							Vector2(key[1], key[2]),
 							Vector2(key[3], key[4]),
-							to_restore_handle_modes[i]);
+							*handle_itr);
 				}
 
 				undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -694,7 +694,7 @@ void AnimationMultiTrackKeyEdit::_key_ofs_changed(const Ref<Animation> &p_anim, 
 			}
 
 			int track = E.key;
-			key_ofs_map[track][key] = to;
+			key_ofs_map[track].get(key) = to;
 
 			if (setting) {
 				return;
@@ -3803,8 +3803,8 @@ void AnimationTrackEditor::commit_insert_queue() {
 		reset_allowed = false;
 	} else {
 		bool some_resettable = false;
-		for (int i = 0; i < insert_data.size(); i++) {
-			if (track_type_is_resettable(insert_data[i].type)) {
+		for (const AnimationTrackEditor::InsertData &E : insert_data) {
+			if (track_type_is_resettable(E.type)) {
 				some_resettable = true;
 				break;
 			}
@@ -3818,21 +3818,21 @@ void AnimationTrackEditor::commit_insert_queue() {
 	int num_tracks = 0;
 	String last_track_query;
 	bool all_bezier = true;
-	for (int i = 0; i < insert_data.size(); i++) {
-		if (insert_data[i].type != Animation::TYPE_VALUE && insert_data[i].type != Animation::TYPE_BEZIER) {
+	for (const AnimationTrackEditor::InsertData &E : insert_data) {
+		if (E.type != Animation::TYPE_VALUE && E.type != Animation::TYPE_BEZIER) {
 			all_bezier = false;
 		}
 
-		if (insert_data[i].track_idx == -1) {
+		if (E.track_idx == -1) {
 			++num_tracks;
-			last_track_query = insert_data[i].query;
+			last_track_query = E.query;
 		}
 
-		if (insert_data[i].type != Animation::TYPE_VALUE) {
+		if (E.type != Animation::TYPE_VALUE) {
 			continue;
 		}
 
-		switch (insert_data[i].value.get_type()) {
+		switch (E.value.get_type()) {
 			case Variant::INT:
 			case Variant::FLOAT:
 			case Variant::VECTOR2:
@@ -5317,14 +5317,15 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 			Array params;
 			int first_defarg = E.arguments.size() - E.default_arguments.size();
 
-			for (int i = 0; i < E.arguments.size(); i++) {
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = E.arguments.begin(); itr != E.arguments.end(); ++itr, ++i) {
 				if (i >= first_defarg) {
 					Variant arg = E.default_arguments[i - first_defarg];
 					params.push_back(arg);
 				} else {
 					Callable::CallError ce;
 					Variant arg;
-					Variant::construct(E.arguments[i].type, arg, nullptr, 0, ce);
+					Variant::construct(itr->type, arg, nullptr, 0, ce);
 					params.push_back(arg);
 				}
 			}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -529,12 +529,13 @@ String ConnectDialog::get_signature(const MethodInfo &p_method, PackedStringArra
 	signature.append(p_method.name);
 	signature.append("(");
 
-	for (int i = 0; i < p_method.arguments.size(); i++) {
-		if (i > 0) {
+	int i = 0;
+	for (List<PropertyInfo>::ConstIterator itr = p_method.arguments.begin(); itr != p_method.arguments.end(); ++itr, ++i) {
+		if (itr != p_method.arguments.begin()) {
 			signature.append(", ");
 		}
 
-		const PropertyInfo &pi = p_method.arguments[i];
+		const PropertyInfo &pi = *itr;
 		String type_name;
 		switch (pi.type) {
 			case Variant::NIL:

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -407,9 +407,10 @@ Dictionary DebugAdapterParser::req_scopes(const Dictionary &p_params) const {
 	HashMap<DAP::StackFrame, List<int>, DAP::StackFrame>::Iterator E = DebugAdapterProtocol::get_singleton()->stackframe_list.find(frame);
 	if (E) {
 		ERR_FAIL_COND_V(E->value.size() != 3, prepare_error_response(p_params, DAP::ErrorType::UNKNOWN));
-		for (int i = 0; i < 3; i++) {
+		List<int>::ConstIterator itr = E->value.begin();
+		for (int i = 0; i < 3; ++itr, ++i) {
 			DAP::Scope scope;
-			scope.variablesReference = E->value[i];
+			scope.variablesReference = *itr;
 			switch (i) {
 				case 0:
 					scope.name = "Locals";

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -967,7 +967,7 @@ void DebugAdapterProtocol::on_debug_stack_frame_var(const Array &p_data) {
 	List<int> scope_ids = stackframe_list.find(frame)->value;
 	ERR_FAIL_COND(scope_ids.size() != 3);
 	ERR_FAIL_INDEX(stack_var.type, 3);
-	int var_id = scope_ids[stack_var.type];
+	int var_id = scope_ids.get(stack_var.type);
 
 	DAP::Variable variable;
 

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -146,9 +146,9 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 	debug_obj->prop_list.clear();
 	int new_props_added = 0;
 	HashSet<String> changed;
-	for (int i = 0; i < obj.properties.size(); i++) {
-		PropertyInfo &pinfo = obj.properties[i].first;
-		Variant &var = obj.properties[i].second;
+	for (SceneDebuggerObject::SceneDebuggerProperty &property : obj.properties) {
+		PropertyInfo &pinfo = property.first;
+		Variant &var = property.second;
 
 		if (pinfo.type == Variant::OBJECT) {
 			if (var.get_type() == Variant::STRING) {

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -147,17 +147,16 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 
 	// Nodes are in a flatten list, depth first. Use a stack of parents, avoid recursion.
 	List<Pair<TreeItem *, int>> parents;
-	for (int i = 0; i < p_tree->nodes.size(); i++) {
+	for (const SceneDebuggerTree::RemoteNode &node : p_tree->nodes) {
 		TreeItem *parent = nullptr;
 		if (parents.size()) { // Find last parent.
-			Pair<TreeItem *, int> &p = parents[0];
+			Pair<TreeItem *, int> &p = parents.front()->get();
 			parent = p.first;
 			if (!(--p.second)) { // If no child left, remove it.
 				parents.pop_front();
 			}
 		}
 		// Add this node.
-		const SceneDebuggerTree::RemoteNode &node = p_tree->nodes[i];
 		TreeItem *item = create_item(parent);
 		item->set_text(0, node.name);
 		if (node.scene_file_path.is_empty()) {
@@ -244,8 +243,8 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 				item = parent;
 				parent = item->get_parent();
 				// Check if parent expects more children.
-				for (int j = 0; j < parents.size(); j++) {
-					if (parents[j].first == item) {
+				for (const Pair<TreeItem *, int> &pair : parents) {
+					if (pair.first == item) {
 						parent = nullptr;
 						break; // Might have more children.
 					}
@@ -326,8 +325,8 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 			Ref<PackedScene> sd = memnew(PackedScene);
 			ResourceSaver::get_recognized_extensions(sd, &extensions);
 			file_dialog->clear_filters();
-			for (int i = 0; i < extensions.size(); i++) {
-				file_dialog->add_filter("*." + extensions[i], extensions[i].to_upper());
+			for (const String &extension : extensions) {
+				file_dialog->add_filter("*." + extension, extension.to_upper());
 			}
 
 			String filename = get_selected_path().get_file() + "." + extensions.front()->get().to_lower();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -440,13 +440,14 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 
 		Array stack_dump_info;
 
-		for (int i = 0; i < stack.frames.size(); i++) {
+		int i = 0;
+		for (List<ScriptLanguage::StackInfo>::Iterator itr = stack.frames.begin(); itr != stack.frames.end(); ++itr, ++i) {
 			TreeItem *s = stack_dump->create_item(r);
 			Dictionary d;
 			d["frame"] = i;
-			d["file"] = stack.frames[i].file;
-			d["function"] = stack.frames[i].func;
-			d["line"] = stack.frames[i].line;
+			d["file"] = itr->file;
+			d["function"] = itr->func;
+			d["line"] = itr->line;
 			stack_dump_info.push_back(d);
 			s->set_metadata(0, d);
 
@@ -725,20 +726,20 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 			metric.categories.push_back(frame_time);
 		}
 
-		for (int i = 0; i < frame.servers.size(); i++) {
-			const ServersDebugger::ServerInfo &srv = frame.servers[i];
+		for (const ServersDebugger::ServerInfo &srv : frame.servers) {
 			EditorProfiler::Metric::Category c;
 			const String name = srv.name;
 			c.name = EditorPropertyNameProcessor::get_singleton()->process_name(name, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 			c.items.resize(srv.functions.size());
 			c.total_time = 0;
 			c.signature = "categ::" + name;
-			for (int j = 0; j < srv.functions.size(); j++) {
+			int j = 0;
+			for (List<ServersDebugger::ServerFunctionInfo>::ConstIterator itr = srv.functions.begin(); itr != srv.functions.end(); ++itr, ++j) {
 				EditorProfiler::Metric::Category::Item item;
 				item.calls = 1;
 				item.line = 0;
-				item.name = srv.functions[j].name;
-				item.self = srv.functions[j].time;
+				item.name = itr->name;
+				item.self = itr->time;
 				item.total = item.self;
 				item.signature = "categ::" + name + "::" + item.name;
 				item.name = EditorPropertyNameProcessor::get_singleton()->process_name(item.name, EditorPropertyNameProcessor::STYLE_CAPITALIZED);

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -476,10 +476,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				ResourceImporter *resimp = Object::cast_to<ResourceImporter>(ClassDB::instantiate(name));
 				List<ResourceImporter::ImportOption> options;
 				resimp->get_import_options("", &options);
-				for (int i = 0; i < options.size(); i++) {
-					const PropertyInfo &prop = options[i].option;
+				for (const ResourceImporter::ImportOption &option : options) {
+					const PropertyInfo &prop = option.option;
 					properties.push_back(prop);
-					import_options_default[prop.name] = options[i].default_value;
+					import_options_default[prop.name] = option.default_value;
 				}
 				own_properties = properties;
 				memdelete(resimp);
@@ -665,8 +665,8 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				for (List<MethodInfo>::Element *EV = signal_list.front(); EV; EV = EV->next()) {
 					DocData::MethodDoc signal;
 					signal.name = EV->get().name;
-					for (int i = 0; i < EV->get().arguments.size(); i++) {
-						const PropertyInfo &arginfo = EV->get().arguments[i];
+					for (List<PropertyInfo>::Element *EA = EV->get().arguments.front(); EA; EA = EA->next()) {
+						const PropertyInfo &arginfo = EA->get();
 						DocData::ArgumentDoc argument;
 						DocData::argument_doc_from_arginfo(argument, arginfo);
 
@@ -857,10 +857,11 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 			method.name = mi.name;
 
-			for (int j = 0; j < mi.arguments.size(); j++) {
-				PropertyInfo arginfo = mi.arguments[j];
+			int j = 0;
+			for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
+				PropertyInfo arginfo = *itr;
 				DocData::ArgumentDoc ad;
-				DocData::argument_doc_from_arginfo(ad, mi.arguments[j]);
+				DocData::argument_doc_from_arginfo(ad, arginfo);
 				ad.name = arginfo.name;
 
 				int darg_idx = mi.default_arguments.size() - mi.arguments.size() + j;
@@ -1047,9 +1048,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 				DocData::return_doc_from_retinfo(md, mi.return_val);
 
-				for (int j = 0; j < mi.arguments.size(); j++) {
+				int j = 0;
+				for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
 					DocData::ArgumentDoc ad;
-					DocData::argument_doc_from_arginfo(ad, mi.arguments[j]);
+					DocData::argument_doc_from_arginfo(ad, *itr);
 
 					int darg_idx = j - (mi.arguments.size() - mi.default_arguments.size());
 					if (darg_idx >= 0) {
@@ -1091,9 +1093,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 				DocData::return_doc_from_retinfo(atd, ai.return_val);
 
-				for (int j = 0; j < ai.arguments.size(); j++) {
+				int j = 0;
+				for (List<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++j) {
 					DocData::ArgumentDoc ad;
-					DocData::argument_doc_from_arginfo(ad, ai.arguments[j]);
+					DocData::argument_doc_from_arginfo(ad, *itr);
 
 					int darg_idx = j - (ai.arguments.size() - ai.default_arguments.size());
 					if (darg_idx >= 0) {

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -107,13 +107,14 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 
 	Ref<StyleBoxEmpty> empty_stylebox = memnew(StyleBoxEmpty);
 
-	for (int i = 0; i < p_sections.size(); i++) {
+	int i = 0;
+	for (List<String>::ConstIterator itr = p_sections.begin(); itr != p_sections.end(); ++itr, ++i) {
 		bool single_column = p_single_column_flags & (1 << i);
 		const char *const *names_ptr = p_src[i];
 		if (*names_ptr) {
 			Label *lbl = memnew(Label);
 			lbl->set_theme_type_variation("HeaderSmall");
-			lbl->set_text(p_sections[i]);
+			lbl->set_text(*itr);
 			vbc->add_child(lbl);
 
 			ItemList *il = memnew(ItemList);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1426,9 +1426,9 @@ Size2 EditorAudioMeterNotches::get_minimum_size() const {
 	float width = 0;
 	float height = top_padding + btm_padding;
 
-	for (int i = 0; i < notches.size(); i++) {
-		if (notches[i].render_db_value) {
-			width = MAX(width, font->get_string_size(String::num(Math::abs(notches[i].db_value)) + "dB", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x);
+	for (const EditorAudioMeterNotches::AudioNotch &notch : notches) {
+		if (notch.render_db_value) {
+			width = MAX(width, font->get_string_size(String::num(Math::abs(notch.db_value)) + "dB", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x);
 			height += font_height;
 		}
 	}
@@ -1462,8 +1462,7 @@ void EditorAudioMeterNotches::_notification(int p_what) {
 void EditorAudioMeterNotches::_draw_audio_notches() {
 	float font_height = theme_cache.font->get_height(theme_cache.font_size);
 
-	for (int i = 0; i < notches.size(); i++) {
-		AudioNotch n = notches[i];
+	for (const AudioNotch &n : notches) {
 		draw_line(Vector2(0, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
 				Vector2(line_length * EDSCALE, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
 				theme_cache.notch_color,

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2563,16 +2563,16 @@ EditorProperty *EditorInspector::instantiate_property_editor(Object *p_object, c
 	for (int i = inspector_plugin_count - 1; i >= 0; i--) {
 		inspector_plugins[i]->parse_property(p_object, p_type, p_path, p_hint, p_hint_text, p_usage, p_wide);
 		if (inspector_plugins[i]->added_editors.size()) {
-			for (int j = 1; j < inspector_plugins[i]->added_editors.size(); j++) { //only keep first one
-				memdelete(inspector_plugins[i]->added_editors[j].property_editor);
+			for (List<EditorInspectorPlugin::AddedEditor>::Element *E = inspector_plugins[i]->added_editors.front()->next(); E; E = E->next()) { //only keep first one
+				memdelete(E->get().property_editor);
 			}
 
-			EditorProperty *prop = Object::cast_to<EditorProperty>(inspector_plugins[i]->added_editors[0].property_editor);
+			EditorProperty *prop = Object::cast_to<EditorProperty>(inspector_plugins[i]->added_editors.front()->get().property_editor);
 			if (prop) {
 				inspector_plugins[i]->added_editors.clear();
 				return prop;
 			} else {
-				memdelete(inspector_plugins[i]->added_editors[0].property_editor);
+				memdelete(inspector_plugins[i]->added_editors.front()->get().property_editor);
 				inspector_plugins[i]->added_editors.clear();
 			}
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2603,8 +2603,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			List<String> extensions;
 			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
 			file->clear_filters();
-			for (int i = 0; i < extensions.size(); i++) {
-				file->add_filter("*." + extensions[i], extensions[i].to_upper());
+			for (const String &extension : extensions) {
+				file->add_filter("*." + extension, extension.to_upper());
 			}
 
 			Node *scene = editor_data.get_edited_scene_root();
@@ -2722,8 +2722,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			Ref<PackedScene> sd = memnew(PackedScene);
 			ResourceSaver::get_recognized_extensions(sd, &extensions);
 			file->clear_filters();
-			for (int i = 0; i < extensions.size(); i++) {
-				file->add_filter("*." + extensions[i], extensions[i].to_upper());
+			for (const String &extension : extensions) {
+				file->add_filter("*." + extension, extension.to_upper());
 			}
 
 			if (!scene->get_scene_file_path().is_empty()) {
@@ -3054,14 +3054,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			List<String> extensions;
 			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
 			file->clear_filters();
-			for (int i = 0; i < extensions.size(); i++) {
-				file->add_filter("*." + extensions[i], extensions[i].to_upper());
+			for (const String &extension : extensions) {
+				file->add_filter("*." + extension, extension.to_upper());
 			}
 
 			Node *scene = editor_data.get_edited_scene_root();
 			if (scene) {
 				file->set_current_path(scene->get_scene_file_path());
-			};
+			}
 			file->set_title(TTR("Pick a Main Scene"));
 			file->popup_file_dialog();
 

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -93,8 +93,8 @@ void EditorTranslationParser::get_recognized_extensions(List<String> *r_extensio
 		custom_parsers[i]->get_recognized_extensions(&temp);
 	}
 	// Remove duplicates.
-	for (int i = 0; i < temp.size(); i++) {
-		extensions.insert(temp[i]);
+	for (const String &E : temp) {
+		extensions.insert(E);
 	}
 	for (const String &E : extensions) {
 		r_extensions->push_back(E);
@@ -104,8 +104,8 @@ void EditorTranslationParser::get_recognized_extensions(List<String> *r_extensio
 bool EditorTranslationParser::can_parse(const String &p_extension) const {
 	List<String> extensions;
 	get_recognized_extensions(&extensions);
-	for (int i = 0; i < extensions.size(); i++) {
-		if (p_extension == extensions[i]) {
+	for (const String &extension : extensions) {
+		if (p_extension == extension) {
 			return true;
 		}
 	}
@@ -117,8 +117,8 @@ Ref<EditorTranslationParserPlugin> EditorTranslationParser::get_parser(const Str
 	for (int i = 0; i < custom_parsers.size(); i++) {
 		List<String> temp;
 		custom_parsers[i]->get_recognized_extensions(&temp);
-		for (int j = 0; j < temp.size(); j++) {
-			if (temp[j] == p_extension) {
+		for (const String &E : temp) {
+			if (E == p_extension) {
 				return custom_parsers[i];
 			}
 		}
@@ -127,8 +127,8 @@ Ref<EditorTranslationParserPlugin> EditorTranslationParser::get_parser(const Str
 	for (int i = 0; i < standard_parsers.size(); i++) {
 		List<String> temp;
 		standard_parsers[i]->get_recognized_extensions(&temp);
-		for (int j = 0; j < temp.size(); j++) {
-			if (temp[j] == p_extension) {
+		for (const String &E : temp) {
+			if (E == p_extension) {
 				return standard_parsers[i];
 			}
 		}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -270,8 +270,8 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 
 	List<String> extension_list = current->get_platform()->get_binary_extensions(current);
 	Vector<String> extension_vector;
-	for (int i = 0; i < extension_list.size(); i++) {
-		extension_vector.push_back("*." + extension_list[i]);
+	for (const String &extension : extension_list) {
+		extension_vector.push_back("*." + extension);
 	}
 
 	export_path->setup(extension_vector, false, true);
@@ -1089,16 +1089,16 @@ void ProjectExportDialog::_export_project() {
 	export_project->clear_filters();
 
 	List<String> extension_list = platform->get_binary_extensions(current);
-	for (int i = 0; i < extension_list.size(); i++) {
+	for (const String &extension : extension_list) {
 		// TRANSLATORS: This is the name of a project export file format. %s will be replaced by the platform name.
-		export_project->add_filter("*." + extension_list[i], vformat(TTR("%s Export"), platform->get_name()));
+		export_project->add_filter("*." + extension, vformat(TTR("%s Export"), platform->get_name()));
 	}
 
 	if (!current->get_export_path().is_empty()) {
 		export_project->set_current_path(current->get_export_path());
 	} else {
 		if (extension_list.size() >= 1) {
-			export_project->set_current_file(default_filename + "." + extension_list[0]);
+			export_project->set_current_file(default_filename + "." + extension_list.front()->get());
 		} else {
 			export_project->set_current_file(default_filename);
 		}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2268,11 +2268,11 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 
 			const bool is_directory = fpath.ends_with("/");
-			for (int i = 0; i < terminal_emulator_args.size(); i++) {
+			for (String &terminal_emulator_arg : terminal_emulator_args) {
 				if (is_directory) {
-					terminal_emulator_args[i] = terminal_emulator_args[i].replace("{directory}", ProjectSettings::get_singleton()->globalize_path(fpath));
+					terminal_emulator_arg = terminal_emulator_arg.replace("{directory}", ProjectSettings::get_singleton()->globalize_path(fpath));
 				} else {
-					terminal_emulator_args[i] = terminal_emulator_args[i].replace("{directory}", ProjectSettings::get_singleton()->globalize_path(fpath).get_base_dir());
+					terminal_emulator_arg = terminal_emulator_arg.replace("{directory}", ProjectSettings::get_singleton()->globalize_path(fpath).get_base_dir());
 				}
 			}
 
@@ -2288,8 +2288,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			const Error err = OS::get_singleton()->create_process(chosen_terminal_emulator, terminal_emulator_args, nullptr, true);
 			if (err != OK) {
 				String args_string;
-				for (int i = 0; i < terminal_emulator_args.size(); i++) {
-					args_string += terminal_emulator_args[i];
+				for (const String &terminal_emulator_arg : terminal_emulator_args) {
+					args_string += terminal_emulator_arg;
 				}
 				ERR_PRINT_ED(vformat(TTR("Couldn't run external terminal program (error code %d): %s %s\nCheck `filesystem/external_programs/terminal_emulator` and `filesystem/external_programs/terminal_emulator_flags` in the Editor Settings."), err, chosen_terminal_emulator, args_string));
 			}

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -755,11 +755,11 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 					node->get_groups(&group_info_list);
 
 					bool term_in_groups = false;
-					for (int j = 0; j < group_info_list.size(); j++) {
-						if (!group_info_list[j].persistent) {
+					for (const Node::GroupInfo &group_info : group_info_list) {
+						if (!group_info.persistent) {
 							continue; // Ignore internal groups.
 						}
-						if (String(group_info_list[j].name).to_lower().contains(argument)) {
+						if (String(group_info.name).to_lower().contains(argument)) {
 							term_in_groups = true;
 							break;
 						}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1392,7 +1392,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					List<StringName> anim_list;
 					anim_player->get_animation_list(&anim_list);
 					if (anim_list.size() == 1) {
-						selected_animation_name = anim_list[0];
+						selected_animation_name = anim_list.front()->get();
 					}
 					rest_animation = anim_player->get_animation(selected_animation_name);
 					if (rest_animation.is_valid()) {
@@ -1408,7 +1408,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						List<StringName> anim_list;
 						library->get_animation_list(&anim_list);
 						if (anim_list.size() == 1) {
-							selected_animation_name = String(anim_list[0]);
+							selected_animation_name = String(anim_list.front()->get());
 						}
 						rest_animation = library->get_animation(selected_animation_name);
 					}
@@ -2203,7 +2203,7 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 						List<StringName> anim_list;
 						library->get_animation_list(&anim_list);
 						if (anim_list.size() == 1) {
-							selected_animation_name = String(anim_list[0]);
+							selected_animation_name = String(anim_list.front()->get());
 						}
 						if (library->has_animation(selected_animation_name)) {
 							anim = library->get_animation(selected_animation_name);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -144,7 +144,7 @@ class SceneImportSettingsData : public Object {
 						List<StringName> anim_names;
 						library->get_animation_list(&anim_names);
 						if (anim_names.size() == 1) {
-							(*settings)["rest_pose/selected_animation"] = String(anim_names[0]);
+							(*settings)["rest_pose/selected_animation"] = String(anim_names.front()->get());
 						}
 						for (StringName anim_name : anim_names) {
 							hint_string += "," + anim_name; // Include preceding, as a catch-all.

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -213,7 +213,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 				current->get_method_list(&methods);
 
 				ERR_FAIL_INDEX(idx, methods.size());
-				String name = methods[idx].name;
+				String name = methods.get(idx).name;
 
 				current->call(name);
 			}
@@ -232,8 +232,8 @@ void InspectorDock::_load_resource(const String &p_type) {
 	ResourceLoader::get_recognized_extensions_for_type(p_type, &extensions);
 
 	load_resource_dialog->clear_filters();
-	for (int i = 0; i < extensions.size(); i++) {
-		load_resource_dialog->add_filter("*." + extensions[i], extensions[i].to_upper());
+	for (const String &extension : extensions) {
+		load_resource_dialog->add_filter("*." + extension, extension.to_upper());
 	}
 
 	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1025,8 +1025,7 @@ void AnimationPlayerEditor::_update_name_dialog_library_dropdown() {
 	}
 
 	int current_lib_id = index_offset; // Don't default to [Global] if it doesn't exist yet.
-	for (int i = 0; i < libraries.size(); i++) {
-		StringName library_name = libraries[i];
+	for (const StringName &library_name : libraries) {
 		if (!EditorNode::get_singleton()->is_resource_read_only(player->get_animation_library(library_name))) {
 			library->add_item((library_name == StringName()) ? String(TTR("[Global]")) : String(library_name));
 			library->set_item_metadata(valid_library_count, String(library_name));
@@ -1043,8 +1042,7 @@ void AnimationPlayerEditor::_update_name_dialog_library_dropdown() {
 	// one which isn't a read-only library.
 	bool auto_assigning_non_global_library = false;
 	if (current_library_name == StringName() && valid_library_count > 0) {
-		for (int i = 0; i < libraries.size(); i++) {
-			StringName library_name = libraries[i];
+		for (const StringName &library_name : libraries) {
 			if (!EditorNode::get_singleton()->is_resource_read_only(player->get_animation_library(library_name))) {
 				current_library_name = library_name;
 				current_lib_id = 0;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -453,8 +453,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		Point2 offset = grid_offset;
 		if (snap_relative) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
-			if (selection.size() == 1 && Object::cast_to<Node2D>(selection[0])) {
-				offset = Object::cast_to<Node2D>(selection[0])->get_global_position();
+			if (selection.size() == 1 && Object::cast_to<Node2D>(selection.front()->get())) {
+				offset = Object::cast_to<Node2D>(selection.front()->get())->get_global_position();
 			} else if (selection.size() > 0) {
 				offset = _get_encompassing_rect_from_list(selection).position;
 			}
@@ -756,7 +756,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			still_selected = false;
 
 			if (editor_selection->get_selected_node_list().size() == 1) {
-				EditorNode::get_singleton()->push_item(editor_selection->get_selected_node_list()[0]);
+				EditorNode::get_singleton()->push_item(editor_selection->get_selected_node_list().front()->get());
 			}
 		} else {
 			// Add the item to the selection
@@ -1373,7 +1373,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 				drag_from = transform.affine_inverse().xform(event_pos);
 				Vector2 new_pos;
 				if (drag_selection.size() == 1) {
-					new_pos = snap_point(drag_from, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection[0]);
+					new_pos = snap_point(drag_from, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.front()->get());
 				} else {
 					new_pos = snap_point(drag_from, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, nullptr, drag_selection);
 				}
@@ -1394,7 +1394,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 			_restore_canvas_item_state(drag_selection);
 			Vector2 new_pos;
 			if (drag_selection.size() == 1) {
-				new_pos = snap_point(drag_to, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection[0]);
+				new_pos = snap_point(drag_to, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.front()->get());
 			} else {
 				new_pos = snap_point(drag_to, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL);
 			}
@@ -1412,9 +1412,9 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 					drag_selection,
 					vformat(
 							TTR("Set CanvasItem \"%s\" Pivot Offset to (%d, %d)"),
-							drag_selection[0]->get_name(),
-							drag_selection[0]->_edit_get_pivot().x,
-							drag_selection[0]->_edit_get_pivot().y));
+							drag_selection.front()->get()->get_name(),
+							drag_selection.front()->get()->_edit_get_pivot().x,
+							drag_selection.front()->get()->_edit_get_pivot().y));
 			_reset_drag();
 			return true;
 		}
@@ -1465,7 +1465,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				if (drag_selection.size() > 0) {
 					drag_type = DRAG_ROTATE;
 					drag_from = transform.affine_inverse().xform(b->get_position());
-					CanvasItem *ci = drag_selection[0];
+					CanvasItem *ci = drag_selection.front()->get();
 					if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
 						drag_rotation_center = temp_pivot;
 					} else if (ci->_edit_use_pivot()) {
@@ -1514,8 +1514,8 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Rotate CanvasItem \"%s\" to %d degrees"),
-								drag_selection[0]->get_name(),
-								Math::rad_to_deg(drag_selection[0]->_edit_get_rotation())),
+								drag_selection.front()->get()->get_name(),
+								Math::rad_to_deg(drag_selection.front()->get()->_edit_get_rotation())),
 						true);
 			}
 
@@ -1545,7 +1545,7 @@ bool CanvasItemEditor::_gui_input_open_scene_on_double_click(const Ref<InputEven
 	if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && b->is_double_click() && tool == TOOL_SELECT) {
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (selection.size() == 1) {
-			CanvasItem *ci = selection[0];
+			CanvasItem *ci = selection.front()->get();
 			if (!ci->get_scene_file_path().is_empty() && ci != EditorNode::get_singleton()->get_edited_scene()) {
 				EditorNode::get_singleton()->open_request(ci->get_scene_file_path());
 				return true;
@@ -1564,7 +1564,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && tool == TOOL_SELECT) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
 			if (selection.size() == 1) {
-				Control *control = Object::cast_to<Control>(selection[0]);
+				Control *control = Object::cast_to<Control>(selection.front()->get());
 				if (control && _is_node_movable(control)) {
 					Vector2 anchor_pos[4];
 					anchor_pos[0] = Vector2(control->get_anchor(SIDE_LEFT), control->get_anchor(SIDE_TOP));
@@ -1613,7 +1613,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		// Drag the anchor
 		if (m.is_valid()) {
 			_restore_canvas_item_state(drag_selection);
-			Control *control = Object::cast_to<Control>(drag_selection[0]);
+			Control *control = Object::cast_to<Control>(drag_selection.front()->get());
 
 			drag_to = transform.affine_inverse().xform(m->get_position());
 
@@ -1684,7 +1684,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == MouseButton::LEFT && !b->is_pressed()) {
 			_commit_canvas_item_state(
 					drag_selection,
-					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection[0]->get_name()));
+					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection.front()->get()->get_name()));
 			_reset_drag();
 			return true;
 		}
@@ -1709,7 +1709,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && tool == TOOL_SELECT) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
 			if (selection.size() == 1) {
-				CanvasItem *ci = selection[0];
+				CanvasItem *ci = selection.front()->get();
 				if (ci->_edit_use_rect() && _is_node_movable(ci)) {
 					Rect2 rect = ci->_edit_get_rect();
 					Transform2D xform = transform * ci->get_global_transform_with_canvas();
@@ -1770,7 +1770,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			drag_type == DRAG_TOP_LEFT || drag_type == DRAG_TOP_RIGHT || drag_type == DRAG_BOTTOM_LEFT || drag_type == DRAG_BOTTOM_RIGHT) {
 		// Resize the node
 		if (m.is_valid()) {
-			CanvasItem *ci = drag_selection[0];
+			CanvasItem *ci = drag_selection.front()->get();
 			CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci);
 			//Reset state
 			ci->_edit_set_state(se->undo_state);
@@ -1855,7 +1855,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 		// Confirm resize
 		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == MouseButton::LEFT && !b->is_pressed()) {
-			const Node2D *node2d = Object::cast_to<Node2D>(drag_selection[0]);
+			const Node2D *node2d = Object::cast_to<Node2D>(drag_selection.front()->get());
 			if (node2d) {
 				// Extends from Node2D.
 				// Node2D doesn't have an actual stored rect size, unlike Controls.
@@ -1863,9 +1863,9 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						drag_selection,
 						vformat(
 								TTR("Scale Node2D \"%s\" to (%s, %s)"),
-								drag_selection[0]->get_name(),
-								Math::snapped(drag_selection[0]->_edit_get_scale().x, 0.01),
-								Math::snapped(drag_selection[0]->_edit_get_scale().y, 0.01)),
+								drag_selection.front()->get()->get_name(),
+								Math::snapped(drag_selection.front()->get()->_edit_get_scale().x, 0.01),
+								Math::snapped(drag_selection.front()->get()->_edit_get_scale().y, 0.01)),
 						true);
 			} else {
 				// Extends from Control.
@@ -1873,9 +1873,9 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						drag_selection,
 						vformat(
 								TTR("Resize Control \"%s\" to (%d, %d)"),
-								drag_selection[0]->get_name(),
-								drag_selection[0]->_edit_get_rect().size.x,
-								drag_selection[0]->_edit_get_rect().size.y),
+								drag_selection.front()->get()->get_name(),
+								drag_selection.front()->get()->_edit_get_rect().size.x,
+								drag_selection.front()->get()->_edit_get_rect().size.y),
 						true);
 			}
 
@@ -1912,7 +1912,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && ((b->is_alt_pressed() && b->is_command_or_control_pressed()) || tool == TOOL_SCALE)) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
 			if (selection.size() == 1) {
-				CanvasItem *ci = selection[0];
+				CanvasItem *ci = selection.front()->get();
 
 				if (_is_node_movable(ci)) {
 					Transform2D xform = transform * ci->get_global_transform_with_canvas();
@@ -1947,7 +1947,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 		// Resize the node
 		if (m.is_valid()) {
 			_restore_canvas_item_state(drag_selection);
-			CanvasItem *ci = drag_selection[0];
+			CanvasItem *ci = drag_selection.front()->get();
 
 			drag_to = transform.affine_inverse().xform(m->get_position());
 
@@ -2015,9 +2015,9 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Scale CanvasItem \"%s\" to (%s, %s)"),
-								drag_selection[0]->get_name(),
-								Math::snapped(drag_selection[0]->_edit_get_scale().x, 0.01),
-								Math::snapped(drag_selection[0]->_edit_get_scale().y, 0.01)),
+								drag_selection.front()->get()->get_name(),
+								Math::snapped(drag_selection.front()->get()->_edit_get_scale().x, 0.01),
+								Math::snapped(drag_selection.front()->get()->_edit_get_scale().y, 0.01)),
 						true);
 			}
 			if (key_auto_insert_button->is_pressed()) {
@@ -2053,15 +2053,15 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 
 				if (selection.size() > 0) {
 					drag_selection.clear();
-					for (int i = 0; i < selection.size(); i++) {
-						if (_is_node_movable(selection[i], true)) {
-							drag_selection.push_back(selection[i]);
+					for (CanvasItem *E : selection) {
+						if (_is_node_movable(E, true)) {
+							drag_selection.push_back(E);
 						}
 					}
 
 					drag_type = DRAG_MOVE;
 
-					CanvasItem *ci = selection[0];
+					CanvasItem *ci = selection.front()->get();
 					Transform2D parent_xform = ci->get_global_transform_with_canvas() * ci->get_transform().affine_inverse();
 					Transform2D unscaled_transform = (transform * parent_xform * ci->_edit_get_transform()).orthonormalized();
 					Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
@@ -2095,8 +2095,8 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			drag_to = transform.affine_inverse().xform(m->get_position());
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D parent_xform = drag_selection[0]->get_global_transform_with_canvas() * drag_selection[0]->get_transform().affine_inverse();
-				previous_pos = parent_xform.xform(drag_selection[0]->_edit_get_position());
+				Transform2D parent_xform = drag_selection.front()->get()->get_global_transform_with_canvas() * drag_selection.front()->get()->get_transform().affine_inverse();
+				previous_pos = parent_xform.xform(drag_selection.front()->get()->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
 			}
@@ -2147,9 +2147,9 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 							drag_selection,
 							vformat(
 									TTR("Move CanvasItem \"%s\" to (%d, %d)"),
-									drag_selection[0]->get_name(),
-									drag_selection[0]->_edit_get_position().x,
-									drag_selection[0]->_edit_get_position().y),
+									drag_selection.front()->get()->get_name(),
+									drag_selection.front()->get()->_edit_get_position().x,
+									drag_selection.front()->get()->_edit_get_position().y),
 							true);
 				}
 			}
@@ -2225,15 +2225,15 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D xform = drag_selection[0]->get_global_transform_with_canvas() * drag_selection[0]->get_transform().affine_inverse();
-				previous_pos = xform.xform(drag_selection[0]->_edit_get_position());
+				Transform2D xform = drag_selection.front()->get()->get_global_transform_with_canvas() * drag_selection.front()->get()->get_transform().affine_inverse();
+				previous_pos = xform.xform(drag_selection.front()->get()->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
 			}
 
 			Point2 new_pos;
 			if (drag_selection.size() == 1) {
-				Node2D *node_2d = Object::cast_to<Node2D>(drag_selection[0]);
+				Node2D *node_2d = Object::cast_to<Node2D>(drag_selection.front()->get());
 				if (node_2d && move_local_base_rotated) {
 					Transform2D m2;
 					m2.rotate(node_2d->get_rotation());
@@ -2271,9 +2271,9 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Move CanvasItem \"%s\" to (%d, %d)"),
-								drag_selection[0]->get_name(),
-								drag_selection[0]->_edit_get_position().x,
-								drag_selection[0]->_edit_get_position().y),
+								drag_selection.front()->get()->get_name(),
+								drag_selection.front()->get()->_edit_get_position().x,
+								drag_selection.front()->get()->_edit_get_position().y),
 						true);
 			}
 			_reset_drag();
@@ -2440,9 +2440,9 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				List<CanvasItem *> selection2 = _get_edited_canvas_items();
 
 				drag_selection.clear();
-				for (int i = 0; i < selection2.size(); i++) {
-					if (_is_node_movable(selection2[i], true)) {
-						drag_selection.push_back(selection2[i]);
+				for (CanvasItem *E : selection2) {
+					if (_is_node_movable(E, true)) {
+						drag_selection.push_back(E);
 					}
 				}
 
@@ -2474,7 +2474,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 				_find_canvas_items_in_rect(Rect2(bsfrom, bsto - bsfrom), scene, &selitems);
 				if (selitems.size() == 1 && editor_selection->get_selected_node_list().is_empty()) {
-					EditorNode::get_singleton()->push_item(selitems[0]);
+					EditorNode::get_singleton()->push_item(selitems.front()->get());
 				}
 				for (CanvasItem *E : selitems) {
 					editor_selection->add_node(E);
@@ -2722,7 +2722,7 @@ Control::CursorShape CanvasItemEditor::get_cursor_shape(const Point2 &p_pos) con
 
 	List<CanvasItem *> selection = _get_edited_canvas_items();
 	if (selection.size() == 1) {
-		const double angle = Math::fposmod((double)selection[0]->get_global_transform_with_canvas().get_rotation(), Math_PI);
+		const double angle = Math::fposmod((double)selection.front()->get()->get_global_transform_with_canvas().get_rotation(), Math_PI);
 		if (angle > Math_PI * 7.0 / 8.0) {
 			rotation_array_index = 0;
 		} else if (angle > Math_PI * 5.0 / 8.0) {
@@ -6057,8 +6057,8 @@ void CanvasItemEditorViewport::_show_resource_type_selector() {
 	List<BaseButton *> btn_list;
 	button_group->get_buttons(&btn_list);
 
-	for (int i = 0; i < btn_list.size(); i++) {
-		CheckBox *check = Object::cast_to<CheckBox>(btn_list[i]);
+	for (BaseButton *btn : btn_list) {
+		CheckBox *check = Object::cast_to<CheckBox>(btn);
 		check->set_pressed(check->get_text() == default_texture_node_type);
 	}
 	selector->set_title(vformat(TTR("Add %s"), default_texture_node_type));
@@ -6091,7 +6091,7 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
 	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() > 0) {
-		Node *selected_node = selected_nodes[0];
+		Node *selected_node = selected_nodes.front()->get();
 		target_node = selected_node;
 		if (is_alt) {
 			target_node = root_node;
@@ -6119,8 +6119,8 @@ void CanvasItemEditorViewport::_update_theme() {
 	List<BaseButton *> btn_list;
 	button_group->get_buttons(&btn_list);
 
-	for (int i = 0; i < btn_list.size(); i++) {
-		CheckBox *check = Object::cast_to<CheckBox>(btn_list[i]);
+	for (BaseButton *btn : btn_list) {
+		CheckBox *check = Object::cast_to<CheckBox>(btn);
 		check->set_icon(get_editor_theme_icon(check->get_text()));
 	}
 

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -140,8 +140,8 @@ EditorDebuggerPlugin::~EditorDebuggerPlugin() {
 }
 
 void EditorDebuggerPlugin::clear() {
-	for (int i = 0; i < sessions.size(); i++) {
-		sessions[i]->detach_debugger();
+	for (Ref<EditorDebuggerSession> &session : sessions) {
+		session->detach_debugger();
 	}
 	sessions.clear();
 }
@@ -157,13 +157,13 @@ void EditorDebuggerPlugin::setup_session(int p_idx) {
 
 Ref<EditorDebuggerSession> EditorDebuggerPlugin::get_session(int p_idx) {
 	ERR_FAIL_INDEX_V(p_idx, sessions.size(), nullptr);
-	return sessions[p_idx];
+	return sessions.get(p_idx);
 }
 
 Array EditorDebuggerPlugin::get_sessions() {
 	Array ret;
-	for (int i = 0; i < sessions.size(); i++) {
-		ret.push_back(sessions[i]);
+	for (const Ref<EditorDebuggerSession> &session : sessions) {
+		ret.push_back(session);
 	}
 	return ret;
 }

--- a/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
@@ -295,7 +295,7 @@ void Joint3DGizmoPlugin::incremental_update_gizmos() {
 	if (!current_gizmos.is_empty()) {
 		update_idx++;
 		update_idx = update_idx % current_gizmos.size();
-		redraw(current_gizmos[update_idx]);
+		redraw(current_gizmos.get(update_idx));
 	}
 }
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -253,8 +253,8 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
 	file->clear_filters();
 	file->set_title(TTR("Import Scene"));
-	for (int i = 0; i < extensions.size(); i++) {
-		file->add_filter("*." + extensions[i], extensions[i].to_upper());
+	for (const String &extension : extensions) {
+		file->add_filter("*." + extension, extension.to_upper());
 	}
 	add_child(file);
 	file->connect("file_selected", callable_mp(this, &MeshLibraryEditor::_import_scene_cbk));

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1162,8 +1162,8 @@ void EditorNode3DGizmoPlugin::commit_subgizmos(const EditorNode3DGizmo *p_gizmo,
 
 void EditorNode3DGizmoPlugin::set_state(int p_state) {
 	current_state = p_state;
-	for (int i = 0; i < current_gizmos.size(); ++i) {
-		current_gizmos[i]->set_hidden(current_state == HIDDEN);
+	for (EditorNode3DGizmo *current : current_gizmos) {
+		current->set_hidden(current_state == HIDDEN);
 	}
 }
 
@@ -1180,9 +1180,9 @@ EditorNode3DGizmoPlugin::EditorNode3DGizmoPlugin() {
 }
 
 EditorNode3DGizmoPlugin::~EditorNode3DGizmoPlugin() {
-	for (int i = 0; i < current_gizmos.size(); ++i) {
-		current_gizmos[i]->set_plugin(nullptr);
-		current_gizmos[i]->get_node_3d()->remove_gizmo(current_gizmos[i]);
+	for (EditorNode3DGizmo *current : current_gizmos) {
+		current->set_plugin(nullptr);
+		current->get_node_3d()->remove_gizmo(current);
 	}
 	if (Node3DEditor::get_singleton()) {
 		Node3DEditor::get_singleton()->update_all_gizmos();

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -764,7 +764,7 @@ void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
 		}
 
 		if (editor_selection->get_selected_node_list().size() == 1) {
-			EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list()[0]);
+			EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list().front()->get());
 		}
 	}
 }
@@ -1084,7 +1084,7 @@ void Node3DEditorViewport::_select_region() {
 	}
 
 	if (editor_selection->get_selected_node_list().size() == 1) {
-		EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list()[0]);
+		EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list().front()->get());
 	}
 }
 
@@ -4592,7 +4592,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
 	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() > 0) {
-		Node *selected_node = selected_nodes[0];
+		Node *selected_node = selected_nodes.front()->get();
 		target_node = selected_node;
 		if (is_alt) {
 			target_node = root_node;
@@ -6069,9 +6069,9 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 				continue;
 			}
 			int state = EditorNode3DGizmoPlugin::VISIBLE;
-			for (int i = 0; i < keys.size(); i++) {
-				if (gizmo_plugins_by_name.write[j]->get_gizmo_name() == String(keys[i])) {
-					state = gizmos_status[keys[i]];
+			for (const Variant &key : keys) {
+				if (gizmo_plugins_by_name.write[j]->get_gizmo_name() == String(key)) {
+					state = gizmos_status[key];
 					break;
 				}
 			}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -90,8 +90,8 @@ void ResourcePreloaderEditor::_load_pressed() {
 	file->clear_filters();
 	List<String> extensions;
 	ResourceLoader::get_recognized_extensions_for_type("", &extensions);
-	for (int i = 0; i < extensions.size(); i++) {
-		file->add_filter("*." + extensions[i]);
+	for (const String &extension : extensions) {
+		file->add_filter("*." + extension);
 	}
 
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1275,8 +1275,8 @@ void ScriptEditor::_menu_option(int p_option) {
 			List<String> extensions;
 			ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
 			file_dialog->clear_filters();
-			for (int i = 0; i < extensions.size(); i++) {
-				file_dialog->add_filter("*." + extensions[i], extensions[i].to_upper());
+			for (const String &extension : extensions) {
+				file_dialog->add_filter("*." + extension, extension.to_upper());
 			}
 
 			for (const String &E : textfile_extensions) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -531,9 +531,9 @@ void ScriptTextEditor::_validate_script() {
 
 		if (errors.size() > 0) {
 			// TRANSLATORS: Script error pointing to a line and column number.
-			String error_text = vformat(TTR("Error at (%d, %d):"), errors[0].line, errors[0].column) + " " + errors[0].message;
+			String error_text = vformat(TTR("Error at (%d, %d):"), errors.front()->get().line, errors.front()->get().column) + " " + errors.front()->get().message;
 			code_editor->set_error(error_text);
-			code_editor->set_error_pos(errors[0].line - 1, errors[0].column - 1);
+			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
 		}
 		script_is_valid = false;
 	} else {
@@ -1217,8 +1217,8 @@ void ScriptTextEditor::_update_connected_methods() {
 			while (base_class) {
 				List<MethodInfo> methods;
 				ClassDB::get_method_list(base_class, &methods, true);
-				for (int j = 0; j < methods.size(); j++) {
-					if (methods[j].name == name) {
+				for (const MethodInfo &mi : methods) {
+					if (mi.name == name) {
 						found_base_class = "builtin:" + base_class;
 						break;
 					}

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -60,8 +60,8 @@ void SpriteFramesEditor::_open_sprite_sheet() {
 	file_split_sheet->clear_filters();
 	List<String> extensions;
 	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
-	for (int i = 0; i < extensions.size(); i++) {
-		file_split_sheet->add_filter("*." + extensions[i]);
+	for (const String &extension : extensions) {
+		file_split_sheet->add_filter("*." + extension);
 	}
 
 	file_split_sheet->popup_file_dialog();
@@ -668,8 +668,8 @@ void SpriteFramesEditor::_load_pressed() {
 	file->clear_filters();
 	List<String> extensions;
 	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
-	for (int i = 0; i < extensions.size(); i++) {
-		file->add_filter("*." + extensions[i]);
+	for (const String &extension : extensions) {
+		file->add_filter("*." + extension);
 	}
 
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
@@ -1117,10 +1117,10 @@ void SpriteFramesEditor::_animation_remove_confirmed() {
 	frames->get_animation_list(&anim_names);
 	anim_names.sort_custom<StringName::AlphCompare>();
 	if (anim_names.size() >= 2) {
-		if (edited_anim == anim_names[0]) {
-			new_edited = anim_names[1];
+		if (edited_anim == anim_names.get(0)) {
+			new_edited = anim_names.get(1);
 		} else {
-			new_edited = anim_names[0];
+			new_edited = anim_names.get(0);
 		}
 	} else {
 		new_edited = StringName();
@@ -1648,7 +1648,7 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 	Node *selected = nullptr;
 	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	if (editor_selection->get_selected_node_list().size() == 1) {
-		selected = editor_selection->get_selected_node_list()[0];
+		selected = editor_selection->get_selected_node_list().front()->get();
 	}
 
 	bool show_node_edit = false;

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -583,9 +583,7 @@ void ShaderTextEditor::_update_warning_panel() {
 	int warning_count = 0;
 
 	warnings_panel->push_table(2);
-	for (int i = 0; i < warnings.size(); i++) {
-		ShaderWarning &w = warnings[i];
-
+	for (const ShaderWarning &w : warnings) {
 		if (warning_count == 0) {
 			if (saved_treat_warning_as_errors) {
 				String error_text = "error(" + itos(w.get_line()) + "): " + w.get_message() + " " + TTR("Warnings should be fixed to prevent errors.");

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -75,8 +75,8 @@ void VersionControlEditorPlugin::_notification(int p_what) {
 
 void VersionControlEditorPlugin::_populate_available_vcs_names() {
 	set_up_choice->clear();
-	for (int i = 0; i < available_plugins.size(); i++) {
-		set_up_choice->add_item(available_plugins[i]);
+	for (const StringName &available_plugin : available_plugins) {
+		set_up_choice->add_item(available_plugin);
 	}
 }
 
@@ -193,10 +193,11 @@ void VersionControlEditorPlugin::_refresh_branch_list() {
 
 	String current_branch = EditorVCSInterface::get_singleton()->get_current_branch_name();
 
-	for (int i = 0; i < branch_list.size(); i++) {
-		branch_select->add_icon_item(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("VcsBranches"), EditorStringName(EditorIcons)), branch_list[i], i);
+	int i = 0;
+	for (List<String>::ConstIterator itr = branch_list.begin(); itr != branch_list.end(); ++itr, ++i) {
+		branch_select->add_icon_item(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("VcsBranches"), EditorStringName(EditorIcons)), *itr, i);
 
-		if (branch_list[i] == current_branch) {
+		if (*itr == current_branch) {
 			branch_select->select(i);
 		}
 	}
@@ -253,11 +254,12 @@ void VersionControlEditorPlugin::_refresh_remote_list() {
 
 	remote_select->set_disabled(remotes.is_empty());
 
-	for (int i = 0; i < remotes.size(); i++) {
-		remote_select->add_icon_item(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("ArrowUp"), EditorStringName(EditorIcons)), remotes[i], i);
-		remote_select->set_item_metadata(i, remotes[i]);
+	int i = 0;
+	for (List<String>::ConstIterator itr = remotes.begin(); itr != remotes.end(); ++itr, ++i) {
+		remote_select->add_icon_item(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("ArrowUp"), EditorStringName(EditorIcons)), *itr, i);
+		remote_select->set_item_metadata(i, *itr);
 
-		if (remotes[i] == current_remote) {
+		if (*itr == current_remote) {
 			remote_select->select(i);
 		}
 	}
@@ -589,9 +591,7 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 		diff->pop();
 	}
 
-	for (int i = 0; i < diff_content.size(); i++) {
-		EditorVCSInterface::DiffFile diff_file = diff_content[i];
-
+	for (const EditorVCSInterface::DiffFile &diff_file : diff_content) {
 		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
 		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor)));
 		diff->add_text(TTR("File:") + " " + diff_file.new_file);
@@ -599,9 +599,7 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 		diff->pop();
 
 		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("status_source"), EditorStringName(EditorFonts)));
-		for (int j = 0; j < diff_file.diff_hunks.size(); j++) {
-			EditorVCSInterface::DiffHunk hunk = diff_file.diff_hunks[j];
-
+		for (EditorVCSInterface::DiffHunk hunk : diff_file.diff_hunks) {
 			String old_start = String::num_int64(hunk.old_start);
 			String new_start = String::num_int64(hunk.new_start);
 			String old_lines = String::num_int64(hunk.old_lines);
@@ -628,10 +626,9 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 }
 
 void VersionControlEditorPlugin::_display_diff_split_view(List<EditorVCSInterface::DiffLine> &p_diff_content) {
-	List<EditorVCSInterface::DiffLine> parsed_diff;
+	LocalVector<EditorVCSInterface::DiffLine> parsed_diff;
 
-	for (int i = 0; i < p_diff_content.size(); i++) {
-		EditorVCSInterface::DiffLine diff_line = p_diff_content[i];
+	for (EditorVCSInterface::DiffLine diff_line : p_diff_content) {
 		String line = diff_line.content.strip_edges(false, true);
 
 		if (diff_line.new_line_no >= 0 && diff_line.old_line_no >= 0) {
@@ -643,12 +640,12 @@ void VersionControlEditorPlugin::_display_diff_split_view(List<EditorVCSInterfac
 			diff_line.old_text = line;
 			parsed_diff.push_back(diff_line);
 		} else if (diff_line.old_line_no == -1) {
-			int j = parsed_diff.size() - 1;
+			int32_t j = parsed_diff.size() - 1;
 			while (j >= 0 && parsed_diff[j].new_line_no == -1) {
 				j--;
 			}
 
-			if (j == parsed_diff.size() - 1) {
+			if (j == (int32_t)parsed_diff.size() - 1) {
 				// no lines are modified
 				diff_line.new_text = line;
 				diff_line.old_text = "";
@@ -677,7 +674,7 @@ void VersionControlEditorPlugin::_display_diff_split_view(List<EditorVCSInterfac
 	diff->set_table_column_expand(2, true);
 	diff->set_table_column_expand(5, true);
 
-	for (int i = 0; i < parsed_diff.size(); i++) {
+	for (uint32_t i = 0; i < parsed_diff.size(); i++) {
 		EditorVCSInterface::DiffLine diff_line = parsed_diff[i];
 
 		bool has_change = diff_line.status != " ";
@@ -757,8 +754,7 @@ void VersionControlEditorPlugin::_display_diff_unified_view(List<EditorVCSInterf
 		[cell]status[/cell]
 		[cell]code[/cell]
 	*/
-	for (int i = 0; i < p_diff_content.size(); i++) {
-		EditorVCSInterface::DiffLine diff_line = p_diff_content[i];
+	for (const EditorVCSInterface::DiffLine &diff_line : p_diff_content) {
 		String line = diff_line.content.strip_edges(false, true);
 
 		Color color;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -748,8 +748,9 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 		bool first = true;
 		VBoxContainer *vbox = nullptr;
 
-		for (int i = 0; i < custom_node->dp_props.size(); i++) {
-			const VisualShaderNodeCustom::DropDownListProperty &dp = custom_node->dp_props[i];
+		int i = 0;
+		for (List<VisualShaderNodeCustom::DropDownListProperty>::ConstIterator itr = custom_node->dp_props.begin(); itr != custom_node->dp_props.end(); ++itr, ++i) {
+			const VisualShaderNodeCustom::DropDownListProperty &dp = *itr;
 
 			if (first) {
 				first = false;
@@ -1828,9 +1829,9 @@ void VisualShaderEditor::_update_nodes() {
 		List<StringName> class_list;
 		ScriptServer::get_global_class_list(&class_list);
 
-		for (int i = 0; i < class_list.size(); i++) {
-			if (ScriptServer::get_global_class_native_base(class_list[i]) == "VisualShaderNodeCustom") {
-				String script_path = ScriptServer::get_global_class_path(class_list[i]);
+		for (const StringName &E : class_list) {
+			if (ScriptServer::get_global_class_native_base(E) == "VisualShaderNodeCustom") {
+				String script_path = ScriptServer::get_global_class_path(E);
 				Ref<Resource> res = ResourceLoader::load(script_path);
 				ERR_CONTINUE(res.is_null());
 				ERR_CONTINUE(!res->is_class("Script"));
@@ -1858,16 +1859,16 @@ void VisualShaderEditor::_update_nodes() {
 		List<StringName> class_list;
 		ClassDB::get_class_list(&class_list);
 
-		for (int i = 0; i < class_list.size(); i++) {
-			if (ClassDB::get_parent_class(class_list[i]) == "VisualShaderNodeCustom") {
-				Object *instance = ClassDB::instantiate(class_list[i]);
+		for (const StringName &E : class_list) {
+			if (ClassDB::get_parent_class(E) == "VisualShaderNodeCustom") {
+				Object *instance = ClassDB::instantiate(E);
 				Ref<VisualShaderNodeCustom> ref = Object::cast_to<VisualShaderNodeCustom>(instance);
 				ERR_CONTINUE(ref.is_null());
 				if (!ref->is_available(visual_shader->get_mode(), visual_shader->get_shader_type())) {
 					continue;
 				}
 				Dictionary dict = get_custom_node_data(ref);
-				dict["type"] = class_list[i];
+				dict["type"] = E;
 				dict["script"] = Ref<Script>();
 
 				String key;
@@ -3982,7 +3983,7 @@ void VisualShaderEditor::_handle_node_drop_on_connection() {
 		return;
 	}
 
-	int selected_node_id = drag_buffer[0].node;
+	int selected_node_id = drag_buffer.front()->get().node;
 	VisualShader::Type shader_type = get_current_shader_type();
 	Ref<VisualShaderNode> selected_vsnode = visual_shader->get_node(shader_type, selected_node_id);
 
@@ -7540,8 +7541,9 @@ void VisualShaderNodePortPreview::_shader_changed() {
 	preview_shader.instantiate();
 	preview_shader->set_code(shader_code);
 	for (int i = 0; i < default_textures.size(); i++) {
-		for (int j = 0; j < default_textures[i].params.size(); j++) {
-			preview_shader->set_default_texture_parameter(default_textures[i].name, default_textures[i].params[j], j);
+		int j = 0;
+		for (List<Ref<Texture2D>>::ConstIterator itr = default_textures[i].params.begin(); itr != default_textures[i].params.end(); ++itr, ++j) {
+			preview_shader->set_default_texture_parameter(default_textures[i].name, *itr, j);
 		}
 	}
 

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -92,8 +92,8 @@ void POTGenerator::generate_pot(const String &p_file) {
 	}
 
 	if (GLOBAL_GET("internationalization/locale/translation_add_builtin_strings_to_pot")) {
-		for (int i = 0; i < extractable_msgids.size(); i++) {
-			_add_new_msgid(extractable_msgids[i], "", "", "");
+		for (const StringName &extractable_msgid : extractable_msgids) {
+			_add_new_msgid(extractable_msgid, "", "", "");
 		}
 	}
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -299,20 +299,20 @@ void PropertySelector::_update_search() {
 
 			desc += vformat(" %s(", mi.name);
 
-			for (int i = 0; i < mi.arguments.size(); i++) {
-				if (i > 0) {
+			for (List<PropertyInfo>::Iterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
+				if (arg_itr != mi.arguments.begin()) {
 					desc += ", ";
 				}
 
-				desc += mi.arguments[i].name;
+				desc += arg_itr->name;
 
-				if (mi.arguments[i].type == Variant::NIL) {
+				if (arg_itr->type == Variant::NIL) {
 					desc += ": Variant";
-				} else if (mi.arguments[i].name.contains(":")) {
-					desc += vformat(": %s", mi.arguments[i].name.get_slice(":", 1));
-					mi.arguments[i].name = mi.arguments[i].name.get_slice(":", 0);
+				} else if (arg_itr->name.contains(":")) {
+					desc += vformat(": %s", arg_itr->name.get_slice(":", 1));
+					arg_itr->name = arg_itr->name.get_slice(":", 0);
 				} else {
-					desc += vformat(": %s", Variant::get_type_name(mi.arguments[i].type));
+					desc += vformat(": %s", Variant::get_type_name(arg_itr->type));
 				}
 			}
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -591,12 +591,12 @@ void RenameDialog::rename() {
 		undo_redo->create_action(TTR("Batch Rename"), UndoRedo::MERGE_DISABLE, root_node, true);
 
 		// Make sure to iterate reversed so that child nodes will find parents.
-		for (int i = to_rename.size() - 1; i >= 0; --i) {
-			Node *n = root_node->get_node(to_rename[i].first);
-			const String &new_name = to_rename[i].second;
+		for (List<Pair<NodePath, String>>::Element *E = to_rename.back(); E; E = E->prev()) {
+			Node *n = root_node->get_node(E->get().first);
+			const String &new_name = E->get().second;
 
 			if (!n) {
-				ERR_PRINT("Skipping missing node: " + to_rename[i].first.get_concatenated_subnames());
+				ERR_PRINT("Skipping missing node: " + E->get().first.get_concatenated_subnames());
 				continue;
 			}
 			scene_tree_editor->rename_node(n, new_name);

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -282,7 +282,7 @@ void ShaderCreateDialog::_load_exist() {
 
 void ShaderCreateDialog::_type_changed(int p_language) {
 	current_type = p_language;
-	ShaderTypeData shader_type_data = type_data[p_language];
+	ShaderTypeData shader_type_data = type_data.get(p_language);
 
 	String selected_ext = "." + shader_type_data.default_extension;
 	String path = file_path->get_text();
@@ -342,7 +342,7 @@ void ShaderCreateDialog::_browse_path() {
 	file_browse->set_disable_overwrite_warning(true);
 	file_browse->clear_filters();
 
-	List<String> extensions = type_data[type_menu->get_selected()].extensions;
+	List<String> extensions = type_data.get(type_menu->get_selected()).extensions;
 
 	for (const String &E : extensions) {
 		file_browse->add_filter("*." + E);
@@ -397,7 +397,7 @@ void ShaderCreateDialog::_path_submitted(const String &p_path) {
 void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled, int p_preferred_type, int p_preferred_mode) {
 	if (!p_base_path.is_empty()) {
 		initial_base_path = p_base_path.get_basename();
-		file_path->set_text(initial_base_path + "." + type_data[type_menu->get_selected()].default_extension);
+		file_path->set_text(initial_base_path + "." + type_data.get(type_menu->get_selected()).default_extension);
 		current_type = type_menu->get_selected();
 	} else {
 		initial_base_path = "";
@@ -450,8 +450,9 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 	String extension = p.get_extension();
 	HashSet<String> extensions;
 
-	for (int i = 0; i < SHADER_TYPE_MAX; i++) {
-		for (const String &ext : type_data[i].extensions) {
+	List<ShaderCreateDialog::ShaderTypeData>::ConstIterator itr = type_data.begin();
+	for (int i = 0; i < SHADER_TYPE_MAX; ++itr, ++i) {
+		for (const String &ext : itr->extensions) {
 			if (!extensions.has(ext)) {
 				extensions.insert(ext);
 			}
@@ -464,7 +465,7 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 	for (const String &ext : extensions) {
 		if (ext.nocasecmp_to(extension) == 0) {
 			found = true;
-			for (const String &type_ext : type_data[current_type].extensions) {
+			for (const String &type_ext : type_data.get(current_type).extensions) {
 				if (type_ext.nocasecmp_to(extension) == 0) {
 					match = true;
 					break;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -995,74 +995,77 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	I = args.front();
 	while (I) {
+		List<String>::Element *N = I->next();
+
+		const String &arg = I->get();
+
 #ifdef MACOS_ENABLED
 		// Ignore the process serial number argument passed by macOS Gatekeeper.
 		// Otherwise, Godot would try to open a non-existent project on the first start and abort.
-		if (I->get().begins_with("-psn_")) {
-			I = I->next();
+		if (arg.begins_with("-psn_")) {
+			I = N;
 			continue;
 		}
 #endif
 
-		List<String>::Element *N = I->next();
-
 #ifdef TOOLS_ENABLED
-		if (I->get() == "--debug" ||
-				I->get() == "--verbose" ||
-				I->get() == "--disable-crash-handler") {
-			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->get());
-			forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->get());
+		if (arg == "--debug" ||
+				arg == "--verbose" ||
+				arg == "--disable-crash-handler") {
+			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
+			forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(arg);
 		}
-		if (I->get() == "--single-window") {
-			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->get());
+		if (arg == "--single-window") {
+			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
 		}
-		if (I->get() == "--audio-driver" ||
-				I->get() == "--display-driver" ||
-				I->get() == "--rendering-method" ||
-				I->get() == "--rendering-driver") {
-			if (I->next()) {
-				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->get());
-				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->next()->get());
+		if (arg == "--audio-driver" ||
+				arg == "--display-driver" ||
+				arg == "--rendering-method" ||
+				arg == "--rendering-driver") {
+			if (N) {
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(N->get());
 			}
 		}
 		// If gpu is specified, both editor and debug instances started from editor will inherit.
-		if (I->get() == "--gpu-index") {
-			if (I->next()) {
-				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->get());
-				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->next()->get());
-				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->get());
-				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->next()->get());
+		if (arg == "--gpu-index") {
+			if (N) {
+				const String &next_arg = N->get();
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(next_arg);
+				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(arg);
+				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(next_arg);
 			}
 		}
 #endif
 
 		if (adding_user_args) {
-			user_args.push_back(I->get());
-		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
+			user_args.push_back(arg);
+		} else if (arg == "-h" || arg == "--help" || arg == "/?") { // display help
 
 			show_help = true;
 			exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
-		} else if (I->get() == "--version") {
+		} else if (arg == "--version") {
 			print_line(get_full_version_string());
 			exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
-		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
+		} else if (arg == "-v" || arg == "--verbose") { // verbose output
 
 			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "-q" || I->get() == "--quiet") { // quieter output
+		} else if (arg == "-q" || arg == "--quiet") { // quieter output
 
 			quiet_stdout = true;
 
-		} else if (I->get() == "--no-header") {
+		} else if (arg == "--no-header") {
 			Engine::get_singleton()->_print_header = false;
 
-		} else if (I->get() == "--audio-driver") { // audio driver
+		} else if (arg == "--audio-driver") { // audio driver
 
-			if (I->next()) {
-				audio_driver = I->next()->get();
+			if (N) {
+				audio_driver = N->get();
 
 				bool found = false;
 				for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
@@ -1090,32 +1093,32 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					goto error;
 				}
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing audio driver argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--audio-output-latency") {
-			if (I->next()) {
-				audio_output_latency = I->next()->get().to_int();
-				N = I->next()->next();
+		} else if (arg == "--audio-output-latency") {
+			if (N) {
+				audio_output_latency = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing audio output latency argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--text-driver") {
-			if (I->next()) {
-				text_driver = I->next()->get();
-				N = I->next()->next();
+		} else if (arg == "--text-driver") {
+			if (N) {
+				text_driver = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing text driver argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--display-driver") { // force video driver
+		} else if (arg == "--display-driver") { // force video driver
 
-			if (I->next()) {
-				display_driver = I->next()->get();
+			if (N) {
+				display_driver = N->get();
 
 				bool found = false;
 				for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
@@ -1143,63 +1146,63 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					goto error;
 				}
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing display driver argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--rendering-method") {
-			if (I->next()) {
-				rendering_method = I->next()->get();
-				N = I->next()->next();
+		} else if (arg == "--rendering-method") {
+			if (N) {
+				rendering_method = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing renderer name argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--rendering-driver") {
-			if (I->next()) {
-				rendering_driver = I->next()->get();
-				N = I->next()->next();
+		} else if (arg == "--rendering-driver") {
+			if (N) {
+				rendering_driver = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing rendering driver argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
+		} else if (arg == "-f" || arg == "--fullscreen") { // force fullscreen
 			init_fullscreen = true;
 			window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
-		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
+		} else if (arg == "-m" || arg == "--maximized") { // force maximized window
 			init_maximized = true;
 			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
-		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
+		} else if (arg == "-w" || arg == "--windowed") { // force windowed window
 
 			init_windowed = true;
-		} else if (I->get() == "--gpu-index") {
-			if (I->next()) {
-				Engine::singleton->gpu_idx = I->next()->get().to_int();
-				N = I->next()->next();
+		} else if (arg == "--gpu-index") {
+			if (N) {
+				Engine::singleton->gpu_idx = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing GPU index argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--gpu-validation") {
+		} else if (arg == "--gpu-validation") {
 			Engine::singleton->use_validation_layers = true;
 #ifdef DEBUG_ENABLED
-		} else if (I->get() == "--gpu-abort") {
+		} else if (arg == "--gpu-abort") {
 			Engine::singleton->abort_on_gpu_errors = true;
 #endif
-		} else if (I->get() == "--generate-spirv-debug-info") {
+		} else if (arg == "--generate-spirv-debug-info") {
 			Engine::singleton->generate_spirv_debug_info = true;
-		} else if (I->get() == "--tablet-driver") {
-			if (I->next()) {
-				tablet_driver = I->next()->get();
-				N = I->next()->next();
+		} else if (arg == "--tablet-driver") {
+			if (N) {
+				tablet_driver = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing tablet driver argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--delta-smoothing") {
-			if (I->next()) {
-				String string = I->next()->get();
+		} else if (arg == "--delta-smoothing") {
+			if (N) {
+				String string = N->get();
 				bool recognized = false;
 				if (string == "enable") {
 					OS::get_singleton()->set_delta_smoothing(true);
@@ -1215,21 +1218,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					OS::get_singleton()->print("Delta-smoothing argument not recognized, aborting.\n");
 					goto error;
 				}
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing delta-smoothing argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--single-window") { // force single window
+		} else if (arg == "--single-window") { // force single window
 
 			single_window = true;
-		} else if (I->get() == "-t" || I->get() == "--always-on-top") { // force always-on-top window
+		} else if (arg == "-t" || arg == "--always-on-top") { // force always-on-top window
 
 			init_always_on_top = true;
-		} else if (I->get() == "--resolution") { // force resolution
+		} else if (arg == "--resolution") { // force resolution
 
-			if (I->next()) {
-				String vm = I->next()->get();
+			if (N) {
+				String vm = N->get();
 
 				if (!vm.contains("x")) { // invalid parameter format
 
@@ -1251,28 +1254,28 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				window_size.height = h;
 				force_res = true;
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing resolution argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--screen") { // set window screen
+		} else if (arg == "--screen") { // set window screen
 
-			if (I->next()) {
-				init_screen = I->next()->get().to_int();
+			if (N) {
+				init_screen = N->get().to_int();
 				init_use_custom_screen = true;
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing screen argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--position") { // set window position
+		} else if (arg == "--position") { // set window position
 
-			if (I->next()) {
-				String vm = I->next()->get();
+			if (N) {
+				String vm = N->get();
 
 				if (!vm.contains(",")) { // invalid parameter format
 
@@ -1287,103 +1290,103 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				init_custom_pos = Point2(x, y);
 				init_use_custom_pos = true;
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing position argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--headless") { // enable headless mode (no audio, no rendering).
+		} else if (arg == "--headless") { // enable headless mode (no audio, no rendering).
 
 			audio_driver = NULL_AUDIO_DRIVER;
 			display_driver = NULL_DISPLAY_DRIVER;
 
-		} else if (I->get() == "--log-file") { // write to log file
+		} else if (arg == "--log-file") { // write to log file
 
-			if (I->next()) {
-				log_file = I->next()->get();
-				N = I->next()->next();
+			if (N) {
+				log_file = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing log file path argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--profiling") { // enable profiling
+		} else if (arg == "--profiling") { // enable profiling
 
 			use_debug_profiler = true;
 
-		} else if (I->get() == "-l" || I->get() == "--language") { // language
+		} else if (arg == "-l" || arg == "--language") { // language
 
-			if (I->next()) {
-				locale = I->next()->get();
-				N = I->next()->next();
+			if (N) {
+				locale = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing language argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--remote-fs") { // remote filesystem
+		} else if (arg == "--remote-fs") { // remote filesystem
 
-			if (I->next()) {
-				remotefs = I->next()->get();
-				N = I->next()->next();
+			if (N) {
+				remotefs = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing remote filesystem address, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
+		} else if (arg == "--remote-fs-password") { // remote filesystem password
 
-			if (I->next()) {
-				remotefs_pass = I->next()->get();
-				N = I->next()->next();
+			if (N) {
+				remotefs_pass = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing remote filesystem password, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--render-thread") { // render thread mode
+		} else if (arg == "--render-thread") { // render thread mode
 
-			if (I->next()) {
-				if (I->next()->get() == "safe") {
+			if (N) {
+				if (N->get() == "safe") {
 					rtm = OS::RENDER_THREAD_SAFE;
-				} else if (I->next()->get() == "unsafe") {
+				} else if (N->get() == "unsafe") {
 					rtm = OS::RENDER_THREAD_UNSAFE;
-				} else if (I->next()->get() == "separate") {
+				} else if (N->get() == "separate") {
 					rtm = OS::RENDER_SEPARATE_THREAD;
 				} else {
 					OS::get_singleton()->print("Unknown render thread mode, aborting.\nValid options are 'unsafe', 'safe' and 'separate'.\n");
 					goto error;
 				}
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing render thread mode argument, aborting.\n");
 				goto error;
 			}
 #ifdef TOOLS_ENABLED
-		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
+		} else if (arg == "-e" || arg == "--editor") { // starts editor
 
 			editor = true;
-		} else if (I->get() == "-p" || I->get() == "--project-manager") { // starts project manager
+		} else if (arg == "-p" || arg == "--project-manager") { // starts project manager
 			project_manager = true;
-		} else if (I->get() == "--debug-server") {
-			if (I->next()) {
-				debug_server_uri = I->next()->get();
+		} else if (arg == "--debug-server") {
+			if (N) {
+				debug_server_uri = N->get();
 				if (!debug_server_uri.contains("://")) { // wrong address
 					OS::get_singleton()->print("Invalid debug server uri. It should be of the form <protocol>://<bind_address>:<port>.\n");
 					goto error;
 				}
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing remote debug server uri, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--single-threaded-scene") {
+		} else if (arg == "--single-threaded-scene") {
 			single_threaded_scene = true;
-		} else if (I->get() == "--build-solutions") { // Build the scripting solution such C#
+		} else if (arg == "--build-solutions") { // Build the scripting solution such C#
 
 			auto_build_solutions = true;
 			editor = true;
 			cmdline_tool = true;
-		} else if (I->get() == "--dump-gdextension-interface") {
+		} else if (arg == "--dump-gdextension-interface") {
 			// Register as an editor instance to use low-end fallback if relevant.
 			editor = true;
 			cmdline_tool = true;
@@ -1392,8 +1395,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// Hack. Not needed but otherwise we end up detecting that this should
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
-			main_args.push_back(I->get());
-		} else if (I->get() == "--dump-extension-api") {
+			main_args.push_back(arg);
+		} else if (arg == "--dump-extension-api") {
 			// Register as an editor instance to use low-end fallback if relevant.
 			editor = true;
 			cmdline_tool = true;
@@ -1402,8 +1405,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// Hack. Not needed but otherwise we end up detecting that this should
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
-			main_args.push_back(I->get());
-		} else if (I->get() == "--dump-extension-api-with-docs") {
+			main_args.push_back(arg);
+		} else if (arg == "--dump-extension-api-with-docs") {
 			// Register as an editor instance to use low-end fallback if relevant.
 			editor = true;
 			cmdline_tool = true;
@@ -1413,8 +1416,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// Hack. Not needed but otherwise we end up detecting that this should
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
-			main_args.push_back(I->get());
-		} else if (I->get() == "--validate-extension-api") {
+			main_args.push_back(arg);
+		} else if (arg == "--validate-extension-api") {
 			// Register as an editor instance to use low-end fallback if relevant.
 			editor = true;
 			cmdline_tool = true;
@@ -1422,64 +1425,64 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// Hack. Not needed but otherwise we end up detecting that this should
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 
-			if (I->next()) {
-				validate_extension_api_file = I->next()->get();
+			if (N) {
+				validate_extension_api_file = N->get();
 
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing file to load argument after --validate-extension-api, aborting.");
 				goto error;
 			}
-		} else if (I->get() == "--import") {
+		} else if (arg == "--import") {
 			editor = true;
 			cmdline_tool = true;
 			wait_for_import = true;
 			quit_after = 1;
-		} else if (I->get() == "--export-release" || I->get() == "--export-debug" ||
-				I->get() == "--export-pack") { // Export project
+		} else if (arg == "--export-release" || arg == "--export-debug" ||
+				arg == "--export-pack") { // Export project
 			// Actually handling is done in start().
 			editor = true;
 			cmdline_tool = true;
 			wait_for_import = true;
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 #ifndef DISABLE_DEPRECATED
-		} else if (I->get() == "--export") { // For users used to 3.x syntax.
+		} else if (arg == "--export") { // For users used to 3.x syntax.
 			OS::get_singleton()->print("The Godot 3 --export option was changed to more explicit --export-release / --export-debug / --export-pack options.\nSee the --help output for details.\n");
 			goto error;
-		} else if (I->get() == "--convert-3to4") {
+		} else if (arg == "--convert-3to4") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 
-			if (I->next() && !I->next()->get().begins_with("-")) {
-				if (itos(I->next()->get().to_int()) == I->next()->get()) {
-					converter_max_kb_file = I->next()->get().to_int();
+			if (N && !N->get().begins_with("-")) {
+				if (itos(N->get().to_int()) == N->get()) {
+					converter_max_kb_file = N->get().to_int();
 				}
-				if (I->next()->next() && !I->next()->next()->get().begins_with("-")) {
-					if (itos(I->next()->next()->get().to_int()) == I->next()->next()->get()) {
-						converter_max_line_length = I->next()->next()->get().to_int();
+				if (N->next() && !N->next()->get().begins_with("-")) {
+					if (itos(N->next()->get().to_int()) == N->next()->get()) {
+						converter_max_line_length = N->next()->get().to_int();
 					}
 				}
 			}
-		} else if (I->get() == "--validate-conversion-3to4") {
+		} else if (arg == "--validate-conversion-3to4") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 
-			if (I->next() && !I->next()->get().begins_with("-")) {
-				if (itos(I->next()->get().to_int()) == I->next()->get()) {
-					converter_max_kb_file = I->next()->get().to_int();
+			if (N && !N->get().begins_with("-")) {
+				if (itos(N->get().to_int()) == N->get()) {
+					converter_max_kb_file = N->get().to_int();
 				}
-				if (I->next()->next() && !I->next()->next()->get().begins_with("-")) {
-					if (itos(I->next()->next()->get().to_int()) == I->next()->next()->get()) {
-						converter_max_line_length = I->next()->next()->get().to_int();
+				if (N->next() && !N->next()->get().begins_with("-")) {
+					if (itos(N->next()->get().to_int()) == N->next()->get()) {
+						converter_max_line_length = N->next()->get().to_int();
 					}
 				}
 			}
 #endif // DISABLE_DEPRECATED
-		} else if (I->get() == "--doctool") {
+		} else if (arg == "--doctool") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
 
@@ -1487,49 +1490,49 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// and speed up class reference generation.
 			audio_driver = NULL_AUDIO_DRIVER;
 			display_driver = NULL_DISPLAY_DRIVER;
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 #ifdef MODULE_GDSCRIPT_ENABLED
-		} else if (I->get() == "--gdscript-docs") {
-			if (I->next()) {
-				project_path = I->next()->get();
+		} else if (arg == "--gdscript-docs") {
+			if (N) {
+				project_path = N->get();
 				// Will be handled in start()
-				main_args.push_back(I->get());
-				main_args.push_back(I->next()->get());
-				N = I->next()->next();
+				main_args.push_back(arg);
+				main_args.push_back(N->get());
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing relative or absolute path to project for --gdscript-docs, aborting.\n");
 				goto error;
 			}
 #endif // MODULE_GDSCRIPT_ENABLED
 #endif // TOOLS_ENABLED
-		} else if (I->get() == "--path") { // set path of project to start or edit
+		} else if (arg == "--path") { // set path of project to start or edit
 
-			if (I->next()) {
-				String p = I->next()->get();
+			if (N) {
+				String p = N->get();
 				if (OS::get_singleton()->set_cwd(p) != OK) {
 					OS::get_singleton()->print("Invalid project path specified: \"%s\", aborting.\n", p.utf8().get_data());
 					goto error;
 				}
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
+		} else if (arg == "-u" || arg == "--upwards") { // scan folders upwards
 			upwards = true;
-		} else if (I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
+		} else if (arg == "--quit") { // Auto quit at the end of the first main loop iteration
 			quit_after = 1;
-		} else if (I->get() == "--quit-after") { // Quit after the given number of iterations
-			if (I->next()) {
-				quit_after = I->next()->get().to_int();
-				N = I->next()->next();
+		} else if (arg == "--quit-after") { // Quit after the given number of iterations
+			if (N) {
+				quit_after = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing number of iterations, aborting.\n");
 				goto error;
 			}
-		} else if (I->get().ends_with("project.godot")) {
+		} else if (arg.ends_with("project.godot")) {
 			String path;
-			String file = I->get();
+			String file = arg;
 			int sep = MAX(file.rfind("/"), file.rfind("\\"));
 			if (sep == -1) {
 				path = ".";
@@ -1544,108 +1547,108 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 			editor = true;
 #endif
-		} else if (I->get() == "-b" || I->get() == "--breakpoints") { // add breakpoints
+		} else if (arg == "-b" || arg == "--breakpoints") { // add breakpoints
 
-			if (I->next()) {
-				String bplist = I->next()->get();
+			if (N) {
+				String bplist = N->get();
 				breakpoints = bplist.split(",");
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing list of breakpoints, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--max-fps") { // set maximum rendered FPS
+		} else if (arg == "--max-fps") { // set maximum rendered FPS
 
-			if (I->next()) {
-				max_fps = I->next()->get().to_int();
-				N = I->next()->next();
+			if (N) {
+				max_fps = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing maximum FPS argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--frame-delay") { // force frame delay
+		} else if (arg == "--frame-delay") { // force frame delay
 
-			if (I->next()) {
-				frame_delay = I->next()->get().to_int();
-				N = I->next()->next();
+			if (N) {
+				frame_delay = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing frame delay argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--time-scale") { // force time scale
+		} else if (arg == "--time-scale") { // force time scale
 
-			if (I->next()) {
-				Engine::get_singleton()->set_time_scale(I->next()->get().to_float());
-				N = I->next()->next();
+			if (N) {
+				Engine::get_singleton()->set_time_scale(N->get().to_float());
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing time scale argument, aborting.\n");
 				goto error;
 			}
 
-		} else if (I->get() == "--main-pack") {
-			if (I->next()) {
-				main_pack = I->next()->get();
-				N = I->next()->next();
+		} else if (arg == "--main-pack") {
+			if (N) {
+				main_pack = N->get();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing path to main pack file, aborting.\n");
 				goto error;
-			};
+			}
 
-		} else if (I->get() == "-d" || I->get() == "--debug") {
+		} else if (arg == "-d" || arg == "--debug") {
 			debug_uri = "local://";
 			OS::get_singleton()->_debug_stdout = true;
 #if defined(DEBUG_ENABLED)
-		} else if (I->get() == "--debug-collisions") {
+		} else if (arg == "--debug-collisions") {
 			debug_collisions = true;
-		} else if (I->get() == "--debug-paths") {
+		} else if (arg == "--debug-paths") {
 			debug_paths = true;
-		} else if (I->get() == "--debug-navigation") {
+		} else if (arg == "--debug-navigation") {
 			debug_navigation = true;
-		} else if (I->get() == "--debug-avoidance") {
+		} else if (arg == "--debug-avoidance") {
 			debug_avoidance = true;
-		} else if (I->get() == "--debug-canvas-item-redraw") {
+		} else if (arg == "--debug-canvas-item-redraw") {
 			debug_canvas_item_redraw = true;
-		} else if (I->get() == "--debug-stringnames") {
+		} else if (arg == "--debug-stringnames") {
 			StringName::set_debug_stringnames(true);
 #endif
-		} else if (I->get() == "--remote-debug") {
-			if (I->next()) {
-				debug_uri = I->next()->get();
+		} else if (arg == "--remote-debug") {
+			if (N) {
+				debug_uri = N->get();
 				if (!debug_uri.contains("://")) { // wrong address
 					OS::get_singleton()->print(
 							"Invalid debug host address, it should be of the form <protocol>://<host/IP>:<port>.\n");
 					goto error;
 				}
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--editor-pid") { // not exposed to user
-			if (I->next()) {
-				editor_pid = I->next()->get().to_int();
-				N = I->next()->next();
+		} else if (arg == "--editor-pid") { // not exposed to user
+			if (N) {
+				editor_pid = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--disable-render-loop") {
+		} else if (arg == "--disable-render-loop") {
 			disable_render_loop = true;
-		} else if (I->get() == "--fixed-fps") {
-			if (I->next()) {
-				fixed_fps = I->next()->get().to_int();
-				N = I->next()->next();
+		} else if (arg == "--fixed-fps") {
+			if (N) {
+				fixed_fps = N->get().to_int();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing fixed-fps argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--write-movie") {
-			if (I->next()) {
-				Engine::get_singleton()->set_write_movie_path(I->next()->get());
-				N = I->next()->next();
+		} else if (arg == "--write-movie") {
+			if (N) {
+				Engine::get_singleton()->set_write_movie_path(N->get());
+				N = N->next();
 				if (fixed_fps == -1) {
 					fixed_fps = 60;
 				}
@@ -1654,21 +1657,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing write-movie argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--disable-vsync") {
+		} else if (arg == "--disable-vsync") {
 			disable_vsync = true;
-		} else if (I->get() == "--print-fps") {
+		} else if (arg == "--print-fps") {
 			print_fps = true;
-		} else if (I->get() == "--profile-gpu") {
+		} else if (arg == "--profile-gpu") {
 			profile_gpu = true;
-		} else if (I->get() == "--disable-crash-handler") {
+		} else if (arg == "--disable-crash-handler") {
 			OS::get_singleton()->disable_crash_handler();
-		} else if (I->get() == "--skip-breakpoints") {
+		} else if (arg == "--skip-breakpoints") {
 			skip_breakpoints = true;
 #ifndef _3D_DISABLED
-		} else if (I->get() == "--xr-mode") {
-			if (I->next()) {
-				String xr_mode = I->next()->get().to_lower();
-				N = I->next()->next();
+		} else if (arg == "--xr-mode") {
+			if (N) {
+				String xr_mode = N->get().to_lower();
+				N = N->next();
 				if (xr_mode == "default") {
 					XRServer::set_xr_mode(XRServer::XRMODE_DEFAULT);
 				} else if (xr_mode == "off") {
@@ -1684,37 +1687,37 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 #endif // _3D_DISABLED
-		} else if (I->get() == "--benchmark") {
+		} else if (arg == "--benchmark") {
 			OS::get_singleton()->set_use_benchmark(true);
-		} else if (I->get() == "--benchmark-file") {
-			if (I->next()) {
+		} else if (arg == "--benchmark-file") {
+			if (N) {
 				OS::get_singleton()->set_use_benchmark(true);
-				String benchmark_file = I->next()->get();
+				String benchmark_file = N->get();
 				OS::get_singleton()->set_benchmark_file(benchmark_file);
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing <path> argument for --benchmark-file <path>.\n");
 				goto error;
 			}
 #if defined(TOOLS_ENABLED) && defined(MODULE_GDSCRIPT_ENABLED) && !defined(GDSCRIPT_NO_LSP)
-		} else if (I->get() == "--lsp-port") {
-			if (I->next()) {
-				int port_override = I->next()->get().to_int();
+		} else if (arg == "--lsp-port") {
+			if (N) {
+				int port_override = N->get().to_int();
 				if (port_override < 0 || port_override > 65535) {
 					OS::get_singleton()->print("<port> argument for --lsp-port <port> must be between 0 and 65535.\n");
 					goto error;
 				}
 				GDScriptLanguageServer::port_override = port_override;
-				N = I->next()->next();
+				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing <port> argument for --lsp-port <port>.\n");
 				goto error;
 			}
 #endif // TOOLS_ENABLED && MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
-		} else if (I->get() == "--" || I->get() == "++") {
+		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
 		} else {
-			main_args.push_back(I->get());
+			main_args.push_back(arg);
 		}
 
 		I = N;
@@ -3201,56 +3204,56 @@ int Main::start() {
 	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 
-	for (int i = 0; i < args.size(); i++) {
+	for (List<String>::Element *E = args.front(); E; E = E->next()) {
 		// First check parameters that do not have an argument to the right.
 
 		// Doctest Unit Testing Handler
 		// Designed to override and pass arguments to the unit test handler.
-		if (args[i] == "--check-only") {
+		if (E->get() == "--check-only") {
 			check_only = true;
 #ifdef TOOLS_ENABLED
-		} else if (args[i] == "--no-docbase") {
+		} else if (E->get() == "--no-docbase") {
 			gen_flags.set_flag(DocTools::GENERATE_FLAG_SKIP_BASIC_TYPES);
 #ifndef DISABLE_DEPRECATED
-		} else if (args[i] == "--convert-3to4") {
+		} else if (E->get() == "--convert-3to4") {
 			converting_project = true;
-		} else if (args[i] == "--validate-conversion-3to4") {
+		} else if (E->get() == "--validate-conversion-3to4") {
 			validating_converting_project = true;
 #endif // DISABLE_DEPRECATED
-		} else if (args[i] == "-e" || args[i] == "--editor") {
+		} else if (E->get() == "-e" || E->get() == "--editor") {
 			editor = true;
-		} else if (args[i] == "-p" || args[i] == "--project-manager") {
+		} else if (E->get() == "-p" || E->get() == "--project-manager") {
 			project_manager = true;
-		} else if (args[i] == "--install-android-build-template") {
+		} else if (E->get() == "--install-android-build-template") {
 			install_android_build_template = true;
 #endif // TOOLS_ENABLED
-		} else if (args[i].length() && args[i][0] != '-' && positional_arg.is_empty()) {
-			positional_arg = args[i];
+		} else if (E->get().length() && E->get()[0] != '-' && positional_arg.is_empty()) {
+			positional_arg = E->get();
 
-			if (args[i].ends_with(".scn") ||
-					args[i].ends_with(".tscn") ||
-					args[i].ends_with(".escn") ||
-					args[i].ends_with(".res") ||
-					args[i].ends_with(".tres")) {
+			if (E->get().ends_with(".scn") ||
+					E->get().ends_with(".tscn") ||
+					E->get().ends_with(".escn") ||
+					E->get().ends_with(".res") ||
+					E->get().ends_with(".tres")) {
 				// Only consider the positional argument to be a scene path if it ends with
 				// a file extension associated with Godot scenes. This makes it possible
 				// for projects to parse command-line arguments for custom CLI arguments
 				// or other file extensions without trouble. This can be used to implement
 				// "drag-and-drop onto executable" logic, which can prove helpful
 				// for non-game applications.
-				game_path = args[i];
+				game_path = E->get();
 			}
 		}
 		// Then parameters that have an argument to the right.
-		else if (i < (args.size() - 1)) {
+		else if (E->next()) {
 			bool parsed_pair = true;
-			if (args[i] == "-s" || args[i] == "--script") {
-				script = args[i + 1];
-			} else if (args[i] == "--main-loop") {
-				main_loop_type = args[i + 1];
+			if (E->get() == "-s" || E->get() == "--script") {
+				script = E->next()->get();
+			} else if (E->get() == "--main-loop") {
+				main_loop_type = E->next()->get();
 #ifdef TOOLS_ENABLED
-			} else if (args[i] == "--doctool") {
-				doc_tool_path = args[i + 1];
+			} else if (E->get() == "--doctool") {
+				doc_tool_path = E->next()->get();
 				if (doc_tool_path.begins_with("-")) {
 					// Assuming other command line arg, so default to cwd.
 					doc_tool_path = ".";
@@ -3258,19 +3261,19 @@ int Main::start() {
 					parsed_pair = false;
 				}
 #ifdef MODULE_GDSCRIPT_ENABLED
-			} else if (args[i] == "--gdscript-docs") {
-				gdscript_docs_path = args[i + 1];
+			} else if (E->get() == "--gdscript-docs") {
+				gdscript_docs_path = E->next()->get();
 #endif
-			} else if (args[i] == "--export-release") {
+			} else if (E->get() == "--export-release") {
 				editor = true; //needs editor
-				_export_preset = args[i + 1];
-			} else if (args[i] == "--export-debug") {
+				_export_preset = E->next()->get();
+			} else if (E->get() == "--export-debug") {
 				editor = true; //needs editor
-				_export_preset = args[i + 1];
+				_export_preset = E->next()->get();
 				export_debug = true;
-			} else if (args[i] == "--export-pack") {
+			} else if (E->get() == "--export-pack") {
 				editor = true;
-				_export_preset = args[i + 1];
+				_export_preset = E->next()->get();
 				export_pack_only = true;
 #endif
 			} else {
@@ -3278,12 +3281,12 @@ int Main::start() {
 				parsed_pair = false;
 			}
 			if (parsed_pair) {
-				i++;
+				E = E->next();
 			}
 		}
 #ifdef TOOLS_ENABLED
 		// Handle case where no path is given to --doctool.
-		else if (args[i] == "--doctool") {
+		else if (E->get() == "--doctool") {
 			doc_tool_path = ".";
 			doc_tool_implicit_cwd = true;
 		}

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -124,9 +124,9 @@ Error ENetMultiplayerPeer::add_mesh_peer(int p_id, Ref<ENetConnection> p_host) {
 	ERR_FAIL_COND_V_MSG(active_mode != MODE_MESH, ERR_UNCONFIGURED, "The multiplayer instance is not configured as a mesh. Call 'create_mesh' first.");
 	List<Ref<ENetPacketPeer>> host_peers;
 	p_host->get_peers(host_peers);
-	ERR_FAIL_COND_V_MSG(host_peers.size() != 1 || host_peers[0]->get_state() != ENetPacketPeer::STATE_CONNECTED, ERR_INVALID_PARAMETER, "The provided host must have exactly one peer in the connected state.");
+	ERR_FAIL_COND_V_MSG(host_peers.size() != 1 || host_peers.front()->get()->get_state() != ENetPacketPeer::STATE_CONNECTED, ERR_INVALID_PARAMETER, "The provided host must have exactly one peer in the connected state.");
 	hosts[p_id] = p_host;
-	peers[p_id] = host_peers[0];
+	peers[p_id] = host_peers.front()->get();
 	emit_signal(SNAME("peer_connected"), p_id);
 	return OK;
 }

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3129,24 +3129,28 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 					bool types_match = true;
 
-					for (int i = 0; i < p_call->arguments.size(); i++) {
-						GDScriptParser::DataType par_type = type_from_property(info.arguments[i], true);
-						GDScriptParser::DataType arg_type = p_call->arguments[i]->get_datatype();
-						if (!is_type_compatible(par_type, arg_type, true)) {
-							types_match = false;
-							break;
+					{
+						List<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
+						for (int i = 0; i < p_call->arguments.size(); ++arg_itr, ++i) {
+							GDScriptParser::DataType par_type = type_from_property(*arg_itr, true);
+							GDScriptParser::DataType arg_type = p_call->arguments[i]->get_datatype();
+							if (!is_type_compatible(par_type, arg_type, true)) {
+								types_match = false;
+								break;
 #ifdef DEBUG_ENABLED
-						} else {
-							if (par_type.builtin_type == Variant::INT && arg_type.builtin_type == Variant::FLOAT && builtin_type != Variant::INT) {
-								parser->push_warning(p_call, GDScriptWarning::NARROWING_CONVERSION, function_name);
-							}
+							} else {
+								if (par_type.builtin_type == Variant::INT && arg_type.builtin_type == Variant::FLOAT && builtin_type != Variant::INT) {
+									parser->push_warning(p_call, GDScriptWarning::NARROWING_CONVERSION, function_name);
+								}
 #endif
+							}
 						}
 					}
 
 					if (types_match) {
-						for (int i = 0; i < p_call->arguments.size(); i++) {
-							GDScriptParser::DataType par_type = type_from_property(info.arguments[i], true);
+						List<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
+						for (int i = 0; i < p_call->arguments.size(); ++arg_itr, ++i) {
+							GDScriptParser::DataType par_type = type_from_property(*arg_itr, true);
 							if (p_call->arguments[i]->is_constant) {
 								update_const_expression_builtin_type(p_call->arguments[i], par_type, "pass");
 							}
@@ -3366,8 +3370,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		// If the function requires typed arrays we must make literals be typed.
 		for (const KeyValue<int, GDScriptParser::ArrayNode *> &E : arrays) {
 			int index = E.key;
-			if (index < par_types.size() && par_types[index].is_hard_type() && par_types[index].has_container_element_type(0)) {
-				update_array_literal_element_type(E.value, par_types[index].get_container_element_type(0));
+			if (index < par_types.size() && par_types.get(index).is_hard_type() && par_types.get(index).has_container_element_type(0)) {
+				update_array_literal_element_type(E.value, par_types.get(index).get_container_element_type(0));
 			}
 		}
 		validate_call_arg(par_types, default_arg_count, method_flags.has_flag(METHOD_FLAG_VARARG), p_call);
@@ -5225,12 +5229,13 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 		push_error(vformat(R"*(Too many arguments for "%s()" call. Expected at most %d but received %d.)*", p_call->function_name, p_par_types.size(), p_call->arguments.size()), p_call->arguments[p_par_types.size()]);
 	}
 
-	for (int i = 0; i < p_call->arguments.size(); i++) {
+	List<GDScriptParser::DataType>::ConstIterator par_itr = p_par_types.begin();
+	for (int i = 0; i < p_call->arguments.size(); ++par_itr, ++i) {
 		if (i >= p_par_types.size()) {
 			// Already on vararg place.
 			break;
 		}
-		GDScriptParser::DataType par_type = p_par_types[i];
+		GDScriptParser::DataType par_type = *par_itr;
 
 		if (par_type.is_hard_type() && p_call->arguments[i]->is_constant) {
 			update_const_expression_builtin_type(p_call->arguments[i], par_type, "pass");

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -241,9 +241,9 @@ static bool _can_use_validate_call(const MethodBind *p_method, const Vector<GDSc
 	}
 	MethodInfo info;
 	ClassDB::get_method_info(p_method->get_instance_class(), p_method->get_name(), &info);
-	for (int i = 0; i < p_arguments.size(); i++) {
-		const PropertyInfo &prop = info.arguments[i];
-		if (!_is_exact_type(prop, p_arguments[i].type)) {
+	int i = 0;
+	for (List<PropertyInfo>::ConstIterator itr = info.arguments.begin(); itr != info.arguments.end(); ++itr, ++i) {
+		if (!_is_exact_type(*itr, p_arguments[i].type)) {
 			return false;
 		}
 	}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2733,9 +2733,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 								// Handle user preference.
 								if (opt.is_quoted()) {
 									opt = opt.unquote().quote(quote_style);
-									if (use_string_names && info.arguments[p_argidx].type == Variant::STRING_NAME) {
+									if (use_string_names && info.arguments.get(p_argidx).type == Variant::STRING_NAME) {
 										opt = opt.indent("&");
-									} else if (use_node_paths && info.arguments[p_argidx].type == Variant::NODE_PATH) {
+									} else if (use_node_paths && info.arguments.get(p_argidx).type == Variant::NODE_PATH) {
 										opt = opt.indent("^");
 									}
 								}
@@ -2746,7 +2746,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 
 					if (p_argidx < method_args) {
-						PropertyInfo arg_info = info.arguments[p_argidx];
+						const PropertyInfo &arg_info = info.arguments.get(p_argidx);
 						if (arg_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) {
 							_find_enumeration_candidates(p_context, arg_info.class_name, r_result);
 						}
@@ -3334,19 +3334,17 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				}
 				method_hint += "(";
 
-				if (mi.arguments.size()) {
-					for (int i = 0; i < mi.arguments.size(); i++) {
-						if (i > 0) {
-							method_hint += ", ";
-						}
-						String arg = mi.arguments[i].name;
-						if (arg.contains(":")) {
-							arg = arg.substr(0, arg.find(":"));
-						}
-						method_hint += arg;
-						if (use_type_hint) {
-							method_hint += ": " + _get_visual_datatype(mi.arguments[i], true, class_name);
-						}
+				for (List<PropertyInfo>::ConstIterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
+					if (arg_itr != mi.arguments.begin()) {
+						method_hint += ", ";
+					}
+					String arg = arg_itr->name;
+					if (arg.contains(":")) {
+						arg = arg.substr(0, arg.find(":"));
+					}
+					method_hint += arg;
+					if (use_type_hint) {
+						method_hint += ": " + _get_visual_datatype(*arg_itr, true, class_name);
 					}
 				}
 				method_hint += ")";

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -760,7 +760,7 @@ Variant::Type GDScriptUtilityFunctions::get_function_argument_type(const StringN
 	GDScriptUtilityFunctionInfo *info = utility_function_table.lookup_ptr(p_function);
 	ERR_FAIL_NULL_V(info, Variant::NIL);
 	ERR_FAIL_COND_V(p_arg >= info->info.arguments.size(), Variant::NIL);
-	return info->info.arguments[p_arg].type;
+	return info->info.arguments.get(p_arg).type;
 }
 
 int GDScriptUtilityFunctions::get_function_argument_count(const StringName &p_function) {

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -510,7 +510,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 	node_stack.push_back(p_func->body);
 
 	while (!node_stack.is_empty()) {
-		GDScriptParser::Node *node = node_stack[0];
+		GDScriptParser::Node *node = node_stack.front()->get();
 		node_stack.pop_front();
 
 		switch (node->type) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -223,7 +223,7 @@ void GDScriptWorkspace::reload_all_workspace_scripts() {
 			HashMap<String, ExtendGDScriptParser *>::Iterator S = parse_results.find(path);
 			String err_msg = "Failed parse script " + path;
 			if (S) {
-				err_msg += "\n" + S->value->get_errors()[0].message;
+				err_msg += "\n" + S->value->get_errors().front()->get().message;
 			}
 			ERR_CONTINUE_MSG(err != OK, err_msg);
 		}
@@ -619,8 +619,8 @@ Node *GDScriptWorkspace::_get_owner_scene_node(String p_path) {
 
 	_get_owners(EditorFileSystem::get_singleton()->get_filesystem(), p_path, owners);
 
-	for (int i = 0; i < owners.size(); i++) {
-		NodePath owner_path = owners[i];
+	for (const String &owner : owners) {
+		NodePath owner_path = owner;
 		Ref<Resource> owner_res = ResourceLoader::load(owner_path);
 		if (Object::cast_to<PackedScene>(owner_res.ptr())) {
 			Ref<PackedScene> owner_packed_scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*owner_res));

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -573,7 +573,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
 		if (!errors.is_empty()) {
 			// Only the first error since the following might be cascading.
-			result.output += errors[0].message + "\n"; // TODO: line, column?
+			result.output += errors.front()->get().message + "\n"; // TODO: line, column?
 		}
 		if (!p_is_generating) {
 			result.passed = check_output(result.output);
@@ -592,7 +592,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
 		if (!errors.is_empty()) {
 			// Only the first error since the following might be cascading.
-			result.output += errors[0].message + "\n"; // TODO: line, column?
+			result.output += errors.front()->get().message + "\n"; // TODO: line, column?
 		}
 		if (!p_is_generating) {
 			result.passed = check_output(result.output);

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -81,11 +81,10 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 
 	SUBCASE("[Modules][GDScript] Validate built-in methods") {
 		for (const MethodInfo &mi : builtin_methods) {
-			for (int j = 0; j < mi.arguments.size(); j++) {
-				PropertyInfo arg = mi.arguments[j];
-
-				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
-						vformat("Unnamed argument in position %d of built-in method '%s'.", j, mi.name));
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
+				TEST_COND((itr->name.is_empty() || itr->name.begins_with("_unnamed_arg")),
+						vformat("Unnamed argument in position %d of built-in method '%s'.", i, mi.name));
 			}
 		}
 	}
@@ -96,11 +95,10 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 
 	SUBCASE("[Modules][GDScript] Validate built-in annotations") {
 		for (const MethodInfo &ai : builtin_annotations) {
-			for (int j = 0; j < ai.arguments.size(); j++) {
-				PropertyInfo arg = ai.arguments[j];
-
-				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
-						vformat("Unnamed argument in position %d of built-in annotation '%s'.", j, ai.name));
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++i) {
+				TEST_COND((itr->name.is_empty() || itr->name.begins_with("_unnamed_arg")),
+						vformat("Unnamed argument in position %d of built-in annotation '%s'.", i, ai.name));
 			}
 		}
 	}

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -188,11 +188,11 @@ static void recursively_disassemble_functions(const Ref<GDScript> script, const 
 
 		const MethodInfo &mi = func->get_method_info();
 		String signature = "Disassembling " + mi.name + "(";
-		for (int i = 0; i < mi.arguments.size(); i++) {
-			if (i > 0) {
+		for (List<PropertyInfo>::ConstIterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
+			if (arg_itr != mi.arguments.begin()) {
 				signature += ", ";
 			}
-			signature += mi.arguments[i].name;
+			signature += arg_itr->name;
 		}
 		print_line(signature + ")");
 #ifdef TOOLS_ENABLED

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -166,10 +166,10 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 				Array arguments;
 				signal_dict["arguments"] = arguments;
-				for (int i = 0; i < mi.arguments.size(); i++) {
+				for (const PropertyInfo &pi : mi.arguments) {
 					Dictionary argument_dict;
 					arguments.push_back(argument_dict);
-					argument_dict["type"] = mi.arguments[i].type;
+					argument_dict["type"] = pi.type;
 				}
 			}
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2308,8 +2308,9 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 			output << imethod.proxy_name << "(";
 
-			for (int i = 0; i < imethod.arguments.size(); i++) {
-				const ArgumentInterface &iarg = imethod.arguments[i];
+			int i = 0;
+			for (List<BindingsGenerator::ArgumentInterface>::ConstIterator itr = imethod.arguments.begin(); itr != imethod.arguments.end(); ++itr, ++i) {
+				const ArgumentInterface &iarg = *itr;
 
 				const TypeInterface *arg_type = _get_type_or_null(iarg.type);
 				ERR_FAIL_NULL_V(arg_type, ERR_BUG); // Argument type not found
@@ -3727,8 +3728,6 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			const MethodInfo &method_info = E.first;
 			const uint32_t hash = E.second;
 
-			int argc = method_info.arguments.size();
-
 			if (method_info.name.is_empty()) {
 				continue;
 			}
@@ -3820,8 +3819,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				imethod.return_type.cname = _get_type_name_from_meta(return_info.type, m ? m->get_argument_meta(-1) : (GodotTypeInfo::Metadata)method_info.return_val_metadata);
 			}
 
-			for (int i = 0; i < argc; i++) {
-				PropertyInfo arginfo = method_info.arguments[i];
+			int idx = 0;
+			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
+				const PropertyInfo &arginfo = *itr;
 
 				String orig_arg_name = arginfo.name;
 
@@ -3841,13 +3841,13 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					iarg.type.cname = _get_type_name_from_meta(arginfo.type, m ? m->get_argument_meta(i) : (GodotTypeInfo::Metadata)method_info.get_argument_meta(i));
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, m ? m->get_argument_meta(idx) : (GodotTypeInfo::Metadata)method_info.get_argument_meta(idx));
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));
 
-				if (m && m->has_default_argument(i)) {
-					bool defval_ok = _arg_default_value_from_variant(m->get_default_argument(i), iarg);
+				if (m && m->has_default_argument(idx)) {
+					bool defval_ok = _arg_default_value_from_variant(m->get_default_argument(idx), iarg);
 					ERR_FAIL_COND_V_MSG(!defval_ok, false,
 							"Cannot determine default value for argument '" + orig_arg_name + "' of method '" + itype.name + "." + imethod.name + "'.");
 				}
@@ -3946,10 +3946,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			isignal.name = method_info.name;
 			isignal.cname = method_info.name;
 
-			int argc = method_info.arguments.size();
-
-			for (int i = 0; i < argc; i++) {
-				PropertyInfo arginfo = method_info.arguments[i];
+			int idx = 0;
+			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
+				const PropertyInfo &arginfo = *itr;
 
 				String orig_arg_name = arginfo.name;
 
@@ -3969,7 +3968,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					iarg.type.cname = _get_type_name_from_meta(arginfo.type, (GodotTypeInfo::Metadata)method_info.get_argument_meta(i));
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, (GodotTypeInfo::Metadata)method_info.get_argument_meta(idx));
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));
@@ -4770,9 +4769,11 @@ bool BindingsGenerator::_method_has_conflicting_signature(const MethodInterface 
 		return false;
 	}
 
-	for (int i = 0; i < p_imethod_left.arguments.size(); i++) {
-		const ArgumentInterface &iarg_left = p_imethod_left.arguments[i];
-		const ArgumentInterface &iarg_right = p_imethod_right.arguments[i];
+	List<BindingsGenerator::ArgumentInterface>::ConstIterator left_itr = p_imethod_left.arguments.begin();
+	List<BindingsGenerator::ArgumentInterface>::ConstIterator right_itr = p_imethod_right.arguments.begin();
+	for (; left_itr != p_imethod_left.arguments.end(); ++left_itr, ++right_itr) {
+		const ArgumentInterface &iarg_left = *left_itr;
+		const ArgumentInterface &iarg_right = *right_itr;
 
 		if (iarg_left.type.cname != iarg_right.type.cname) {
 			// Different types for arguments in the same position, so no conflict.

--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -48,7 +48,7 @@ bool SceneReplicationConfig::_set(const StringName &p_name, const Variant &p_val
 			return true;
 		}
 		ERR_FAIL_INDEX_V(idx, properties.size(), false);
-		ReplicationProperty &prop = properties[idx];
+		const ReplicationProperty &prop = properties.get(idx);
 		if (what == "replication_mode") {
 			ERR_FAIL_COND_V(p_value.get_type() != Variant::INT, false);
 			ReplicationMode mode = (ReplicationMode)p_value.operator int();
@@ -80,7 +80,7 @@ bool SceneReplicationConfig::_get(const StringName &p_name, Variant &r_ret) cons
 		int idx = prop_name.get_slicec('/', 1).to_int();
 		String what = prop_name.get_slicec('/', 2);
 		ERR_FAIL_INDEX_V(idx, properties.size(), false);
-		const ReplicationProperty &prop = properties[idx];
+		const ReplicationProperty &prop = properties.get(idx);
 		if (what == "path") {
 			r_ret = prop.name;
 			return true;
@@ -147,8 +147,8 @@ void SceneReplicationConfig::remove_property(const NodePath &p_path) {
 }
 
 bool SceneReplicationConfig::has_property(const NodePath &p_path) const {
-	for (int i = 0; i < properties.size(); i++) {
-		if (properties[i].name == p_path) {
+	for (const ReplicationProperty &property : properties) {
+		if (property.name == p_path) {
 			return true;
 		}
 	}
@@ -156,8 +156,9 @@ bool SceneReplicationConfig::has_property(const NodePath &p_path) const {
 }
 
 int SceneReplicationConfig::property_get_index(const NodePath &p_path) const {
-	for (int i = 0; i < properties.size(); i++) {
-		if (properties[i].name == p_path) {
+	int i = 0;
+	for (List<ReplicationProperty>::ConstIterator itr = properties.begin(); itr != properties.end(); ++itr, ++i) {
+		if (itr->name == p_path) {
 			return i;
 		}
 	}

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -243,7 +243,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		// Try to apply synchronizer Net ID
 		ERR_FAIL_COND_V_MSG(pending_sync_net_ids.is_empty(), ERR_INVALID_DATA, vformat("The MultiplayerSynchronizer at path \"%s\" is unable to process the pending spawn since it has no network ID. This might happen when changing the multiplayer authority during the \"_ready\" callback. Make sure to only change the authority of multiplayer synchronizers during \"_enter_tree\" or the \"_spawn_custom\" callback of their multiplayer spawner.", sync->get_path()));
 		ERR_FAIL_COND_V(!peers_info.has(pending_spawn_remote), ERR_INVALID_DATA);
-		uint32_t net_id = pending_sync_net_ids[0];
+		uint32_t net_id = pending_sync_net_ids.front()->get();
 		pending_sync_net_ids.pop_front();
 		peers_info[pending_spawn_remote].recv_sync_ids[net_id] = sync->get_instance_id();
 		sync->set_net_id(net_id);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1335,8 +1335,8 @@ bool OpenXRAPI::on_state_synchronized() {
 	// Just in case, see if we already have active trackers...
 	List<RID> trackers;
 	tracker_owner.get_owned_list(&trackers);
-	for (int i = 0; i < trackers.size(); i++) {
-		tracker_check_profile(trackers[i]);
+	for (const RID &tracker : trackers) {
+		tracker_check_profile(tracker);
 	}
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
@@ -1963,8 +1963,8 @@ bool OpenXRAPI::poll_events() {
 
 				List<RID> trackers;
 				tracker_owner.get_owned_list(&trackers);
-				for (int i = 0; i < trackers.size(); i++) {
-					tracker_check_profile(trackers[i], event->session);
+				for (const RID &tracker : trackers) {
+					tracker_check_profile(tracker, event->session);
 				}
 
 			} break;

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -59,7 +59,7 @@ int WebRTCMultiplayerPeer::get_packet_channel() const {
 
 MultiplayerPeer::TransferMode WebRTCMultiplayerPeer::get_packet_mode() const {
 	ERR_FAIL_INDEX_V(next_packet_channel, channels_modes.size(), TRANSFER_MODE_RELIABLE);
-	return channels_modes[next_packet_channel];
+	return channels_modes.get(next_packet_channel);
 }
 
 bool WebRTCMultiplayerPeer::is_server() const {
@@ -308,18 +308,18 @@ Error WebRTCMultiplayerPeer::add_peer(Ref<WebRTCPeerConnection> p_peer, int p_pe
 	cfg["ordered"] = true;
 
 	cfg["id"] = 1;
-	peer->channels[CH_RELIABLE] = p_peer->create_data_channel("reliable", cfg);
-	ERR_FAIL_COND_V(peer->channels[CH_RELIABLE].is_null(), FAILED);
+	peer->channels.get(CH_RELIABLE) = p_peer->create_data_channel("reliable", cfg);
+	ERR_FAIL_COND_V(peer->channels.get(CH_RELIABLE).is_null(), FAILED);
 
 	cfg["id"] = 2;
 	cfg["maxPacketLifetime"] = p_unreliable_lifetime;
-	peer->channels[CH_ORDERED] = p_peer->create_data_channel("ordered", cfg);
-	ERR_FAIL_COND_V(peer->channels[CH_ORDERED].is_null(), FAILED);
+	peer->channels.get(CH_ORDERED) = p_peer->create_data_channel("ordered", cfg);
+	ERR_FAIL_COND_V(peer->channels.get(CH_ORDERED).is_null(), FAILED);
 
 	cfg["id"] = 3;
 	cfg["ordered"] = false;
-	peer->channels[CH_UNRELIABLE] = p_peer->create_data_channel("unreliable", cfg);
-	ERR_FAIL_COND_V(peer->channels[CH_UNRELIABLE].is_null(), FAILED);
+	peer->channels.get(CH_UNRELIABLE) = p_peer->create_data_channel("unreliable", cfg);
+	ERR_FAIL_COND_V(peer->channels.get(CH_UNRELIABLE).is_null(), FAILED);
 
 	for (const Dictionary &dict : channels_config) {
 		Ref<WebRTCDataChannel> ch = p_peer->create_data_channel(String::num_int64(dict["id"]), dict);
@@ -400,8 +400,8 @@ Error WebRTCMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_si
 		ERR_FAIL_COND_V_MSG(!E, ERR_INVALID_PARAMETER, "Invalid target peer: " + itos(target_peer) + ".");
 
 		ERR_FAIL_COND_V_MSG(E->value->channels.size() <= ch, ERR_INVALID_PARAMETER, vformat("Unable to send packet on channel %d, max channels: %d", ch, E->value->channels.size()));
-		ERR_FAIL_COND_V(E->value->channels[ch].is_null(), ERR_BUG);
-		return E->value->channels[ch]->put_packet(p_buffer, p_buffer_size);
+		ERR_FAIL_COND_V(E->value->channels.get(ch).is_null(), ERR_BUG);
+		return E->value->channels.get(ch)->put_packet(p_buffer, p_buffer_size);
 
 	} else {
 		int exclude = -target_peer;
@@ -413,8 +413,8 @@ Error WebRTCMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_si
 			}
 
 			ERR_CONTINUE_MSG(F.value->channels.size() <= ch, vformat("Unable to send packet on channel %d, max channels: %d", ch, F.value->channels.size()));
-			ERR_CONTINUE(F.value->channels[ch].is_null());
-			F.value->channels[ch]->put_packet(p_buffer, p_buffer_size);
+			ERR_CONTINUE(F.value->channels.get(ch).is_null());
+			F.value->channels.get(ch)->put_packet(p_buffer, p_buffer_size);
 		}
 	}
 	return OK;

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -74,7 +74,7 @@ void RemoteDebuggerPeerWebSocket::poll() {
 	}
 
 	while (ws_peer->get_ready_state() == WebSocketPeer::STATE_OPEN && out_queue.size() > 0) {
-		Array var = out_queue[0];
+		Array var = out_queue.front()->get();
 		Error err = ws_peer->put_var(var);
 		ERR_BREAK(err != OK); // Peer buffer full?
 		out_queue.pop_front();
@@ -92,7 +92,7 @@ bool RemoteDebuggerPeerWebSocket::has_message() {
 
 Array RemoteDebuggerPeerWebSocket::get_message() {
 	ERR_FAIL_COND_V(in_queue.is_empty(), Array());
-	Array msg = in_queue[0];
+	Array msg = in_queue.front()->get();
 	in_queue.pop_front();
 	return msg;
 }

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2974,11 +2974,11 @@ void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_
 
 String EditorExportPlatformAndroid::join_list(const List<String> &p_parts, const String &p_separator) {
 	String ret;
-	for (int i = 0; i < p_parts.size(); ++i) {
-		if (i > 0) {
+	for (List<String>::ConstIterator itr = p_parts.begin(); itr != p_parts.end(); ++itr) {
+		if (itr != p_parts.begin()) {
 			ret += p_separator;
 		}
-		ret += p_parts[i];
+		ret += *itr;
 	}
 	return ret;
 }

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -351,8 +351,9 @@ int GodotJavaWrapper::create_new_godot_instance(const List<String> &args) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, 0);
 		jobjectArray jargs = env->NewObjectArray(args.size(), env->FindClass("java/lang/String"), env->NewStringUTF(""));
-		for (int i = 0; i < args.size(); i++) {
-			jstring j_arg = env->NewStringUTF(args[i].utf8().get_data());
+		int i = 0;
+		for (List<String>::ConstIterator itr = args.begin(); itr != args.end(); ++itr, ++i) {
+			jstring j_arg = env->NewStringUTF(itr->utf8().get_data());
 			env->SetObjectArrayElement(jargs, i, j_arg);
 			env->DeleteLocalRef(j_arg);
 		}

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -212,8 +212,8 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 		List<String> keys;
 		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, &keys);
 
-		for (int i = 0; i < keys.size(); i++) {
-			Vector<String> key_components = keys[i].split(":");
+		for (const String &key : keys) {
+			Vector<String> key_components = key.split(":");
 
 			String key_value = "";
 			PluginConfigIOS::PlistItemType key_type = PluginConfigIOS::PlistItemType::UNKNOWN;
@@ -245,29 +245,29 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 
 			switch (key_type) {
 				case PluginConfigIOS::PlistItemType::STRING: {
-					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, key, String());
 					value = "<string>" + raw_value + "</string>";
 				} break;
 				case PluginConfigIOS::PlistItemType::INTEGER: {
-					int raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], 0);
+					int raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, key, 0);
 					Dictionary value_dictionary;
 					String value_format = "<integer>$value</integer>";
 					value_dictionary["value"] = raw_value;
 					value = value_format.format(value_dictionary, "$_");
 				} break;
 				case PluginConfigIOS::PlistItemType::BOOLEAN:
-					if (config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], false)) {
+					if (config_file->get_value(PluginConfigIOS::PLIST_SECTION, key, false)) {
 						value = "<true/>";
 					} else {
 						value = "<false/>";
 					}
 					break;
 				case PluginConfigIOS::PlistItemType::RAW: {
-					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, key, String());
 					value = raw_value;
 				} break;
 				case PluginConfigIOS::PlistItemType::STRING_INPUT: {
-					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, key, String());
 					value = raw_value;
 				} break;
 				default:

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3427,7 +3427,7 @@ bool WaylandThread::window_get_idle_inhibition(DisplayServer::WindowID p_window_
 WaylandThread::ScreenData WaylandThread::screen_get_data(int p_screen) const {
 	ERR_FAIL_INDEX_V(p_screen, registry.wl_outputs.size(), ScreenData());
 
-	return wl_output_get_screen_state(registry.wl_outputs[p_screen])->data;
+	return wl_output_get_screen_state(registry.wl_outputs.get(p_screen))->data;
 }
 
 int WaylandThread::get_screen_count() const {

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -276,8 +276,8 @@ OS_Web::OS_Web() {
 	if (AudioDriverWeb::is_available()) {
 		audio_drivers.push_back(memnew(AudioDriverWorklet));
 	}
-	for (int i = 0; i < audio_drivers.size(); i++) {
-		AudioDriverManager::add_driver(audio_drivers[i]);
+	for (AudioDriverWeb *audio_driver : audio_drivers) {
+		AudioDriverManager::add_driver(audio_driver);
 	}
 
 	idb_available = godot_js_os_fs_is_persistent();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2525,7 +2525,7 @@ Error DisplayServerWindows::dialog_show(String p_title, String p_description, Ve
 
 	Char16String title = p_title.utf16();
 	Char16String message = p_description.utf16();
-	List<Char16String> buttons;
+	LocalVector<Char16String> buttons;
 	for (String s : p_buttons) {
 		buttons.push_back(s.utf16());
 	}
@@ -2533,7 +2533,7 @@ Error DisplayServerWindows::dialog_show(String p_title, String p_description, Ve
 	config.pszWindowTitle = (LPCWSTR)(title.get_data());
 	config.pszContent = (LPCWSTR)(message.get_data());
 
-	const int button_count = MIN(buttons.size(), 8);
+	const int button_count = MIN((int)buttons.size(), 8);
 	config.cButtons = button_count;
 
 	// No dynamic stack array size :(

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -427,7 +427,7 @@ void JoypadWindows::process_joypads() {
 		const LONG axes[] = { DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ, (LONG)DIJOFS_SLIDER(0), (LONG)DIJOFS_SLIDER(1) };
 		int values[] = { js.lX, js.lY, js.lZ, js.lRx, js.lRy, js.lRz, js.rglSlider[0], js.rglSlider[1] };
 
-		for (int j = 0; j < joy->joy_axis.size(); j++) {
+		for (uint32_t j = 0; j < joy->joy_axis.size(); j++) {
 			for (int k = 0; k < count; k++) {
 				if (joy->joy_axis[j] == axes[k]) {
 					input->joy_axis(joy->id, (JoyAxis)j, axis_correct(values[k]));

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -77,7 +77,7 @@ private:
 		DWORD last_pad;
 
 		LPDIRECTINPUTDEVICE8 di_joy;
-		List<LONG> joy_axis;
+		LocalVector<LONG> joy_axis;
 		GUID guid;
 
 		dinput_gamepad() {

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -305,7 +305,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
-				set_animation(al[0]);
+				set_animation(al.front()->get());
 			}
 			if (!frames->has_animation(autoplay)) {
 				autoplay = String();

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -212,8 +212,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 	// Free all quadrants.
 	if (forced_cleanup || quandrant_shape_changed) {
 		for (const KeyValue<Vector2i, Ref<RenderingQuadrant>> &kv : rendering_quadrant_map) {
-			for (int i = 0; i < kv.value->canvas_items.size(); i++) {
-				const RID &ci = kv.value->canvas_items[i];
+			for (const RID &ci : kv.value->canvas_items) {
 				if (ci.is_valid()) {
 					rs->free(ci);
 				}
@@ -354,8 +353,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 			} else {
 				// Free the quadrant.
-				for (int i = 0; i < rendering_quadrant->canvas_items.size(); i++) {
-					const RID &ci = rendering_quadrant->canvas_items[i];
+				for (const RID &ci : rendering_quadrant->canvas_items) {
 					if (ci.is_valid()) {
 						rs->free(ci);
 					}

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -852,7 +852,7 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 	bones_to_process.push_back(p_bone_idx);
 
 	while (bones_to_process.size() > 0) {
-		int current_bone_idx = bones_to_process[0];
+		int current_bone_idx = bones_to_process.front()->get();
 		bones_to_process.erase(current_bone_idx);
 
 		Bone &b = bonesptr[current_bone_idx];

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1191,7 +1191,7 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
-				set_animation(al[0]);
+				set_animation(al.front()->get());
 			}
 			if (!frames->has_animation(autoplay)) {
 				autoplay = String();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -350,18 +350,18 @@ float AnimationNodeStateMachinePlayback::get_fading_pos() const {
 void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
 	List<AnimationNode::ChildNode> child_nodes;
 	p_state_machine->get_child_nodes(&child_nodes);
-	for (int i = 0; i < child_nodes.size(); i++) {
-		Ref<AnimationNodeStateMachine> anodesm = child_nodes[i].node;
+	for (const AnimationNode::ChildNode &child_node : child_nodes) {
+		Ref<AnimationNodeStateMachine> anodesm = child_node.node;
 		if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
-			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + child_nodes[i].name + "/playback");
+			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + child_node.name + "/playback");
 			ERR_FAIL_COND(!playback.is_valid());
-			playback->_set_base_path(base_path + child_nodes[i].name + "/");
+			playback->_set_base_path(base_path + child_node.name + "/");
 			if (p_test_only) {
 				playback = playback->duplicate();
 			}
 			playback->path.clear();
 			playback->_clear_path_children(p_tree, anodesm.ptr(), p_test_only);
-			if (current != child_nodes[i].name) {
+			if (current != child_node.name) {
 				playback->_start(anodesm.ptr()); // Can restart.
 			}
 		}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -854,10 +854,10 @@ void AnimationTree::_setup_animation_player() {
 		}
 		List<StringName> list;
 		player->get_animation_library_list(&list);
-		for (int i = 0; i < list.size(); i++) {
-			Ref<AnimationLibrary> lib = player->get_animation_library(list[i]);
+		for (const StringName &E : list) {
+			Ref<AnimationLibrary> lib = player->get_animation_library(E);
 			if (lib.is_valid()) {
-				add_animation_library(list[i], lib);
+				add_animation_library(E, lib);
 			}
 		}
 	}

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -421,9 +421,9 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 
 void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 	Array send_props;
-	for (int i = 0; i < properties.size(); i++) {
-		const PropertyInfo &pi = properties[i].first;
-		Variant &var = properties[i].second;
+	for (SceneDebuggerObject::SceneDebuggerProperty &property : properties) {
+		const PropertyInfo &pi = property.first;
+		Variant &var = property.second;
 
 		Ref<Resource> res = var;
 
@@ -510,7 +510,7 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 	const StringName &is_visible_sn = SNAME("is_visible");
 	const StringName &is_visible_in_tree_sn = SNAME("is_visible_in_tree");
 	while (stack.size()) {
-		Node *n = stack[0];
+		Node *n = stack.front()->get();
 		stack.pop_front();
 
 		int count = n->get_child_count();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -458,8 +458,8 @@ void ColorPicker::set_editor_settings(Object *p_editor_settings) {
 		}
 	}
 
-	for (int i = 0; i < preset_cache.size(); i++) {
-		presets.push_back(preset_cache[i]);
+	for (const Color &preset : preset_cache) {
+		presets.push_back(preset);
 	}
 
 	if (recent_preset_cache.is_empty()) {
@@ -469,8 +469,8 @@ void ColorPicker::set_editor_settings(Object *p_editor_settings) {
 		}
 	}
 
-	for (int i = 0; i < recent_preset_cache.size(); i++) {
-		recent_presets.push_back(recent_preset_cache[i]);
+	for (const Color &preset : recent_preset_cache) {
+		recent_presets.push_back(preset);
 	}
 
 	_update_presets();
@@ -660,8 +660,8 @@ void ColorPicker::_update_presets() {
 		for (int i = 1; i < preset_container->get_child_count(); i++) {
 			preset_container->get_child(i)->queue_free();
 		}
-		for (int i = 0; i < preset_cache.size(); i++) {
-			_add_preset_button(preset_size, preset_cache[i]);
+		for (const Color &preset : preset_cache) {
+			_add_preset_button(preset_size, preset);
 		}
 		_notification(NOTIFICATION_VISIBILITY_CHANGED);
 	}
@@ -677,13 +677,13 @@ void ColorPicker::_update_recent_presets() {
 		}
 
 		recent_presets.clear();
-		for (int i = 0; i < recent_preset_cache.size(); i++) {
-			recent_presets.push_back(recent_preset_cache[i]);
+		for (const Color &preset : recent_preset_cache) {
+			recent_presets.push_back(preset);
 		}
 
 		int preset_size = _get_preset_size();
-		for (int i = 0; i < recent_presets.size(); i++) {
-			_add_recent_preset_button(preset_size, recent_presets[i]);
+		for (const Color &preset : recent_presets) {
+			_add_recent_preset_button(preset_size, preset);
 		}
 
 		_notification(NOTIFICATION_VISIBILITY_CHANGED);
@@ -937,8 +937,9 @@ void ColorPicker::erase_recent_preset(const Color &p_color) {
 PackedColorArray ColorPicker::get_presets() const {
 	PackedColorArray arr;
 	arr.resize(presets.size());
-	for (int i = 0; i < presets.size(); i++) {
-		arr.set(i, presets[i]);
+	int i = 0;
+	for (List<Color>::ConstIterator itr = presets.begin(); itr != presets.end(); ++itr, ++i) {
+		arr.set(i, *itr);
 	}
 	return arr;
 }
@@ -946,8 +947,9 @@ PackedColorArray ColorPicker::get_presets() const {
 PackedColorArray ColorPicker::get_recent_presets() const {
 	PackedColorArray arr;
 	arr.resize(recent_presets.size());
-	for (int i = 0; i < recent_presets.size(); i++) {
-		arr.set(i, recent_presets[i]);
+	int i = 0;
+	for (List<Color>::ConstIterator itr = recent_presets.begin(); itr != recent_presets.end(); ++itr, ++i) {
+		arr.set(i, *itr);
 	}
 	return arr;
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3231,7 +3231,7 @@ void Node::print_orphan_nodes() {
 	ObjectDB::debug_objects(_print_orphan_nodes_routine);
 
 	for (const KeyValue<ObjectID, List<String>> &E : _print_orphan_nodes_map) {
-		print_line(itos(E.key) + " - Stray Node: " + E.value[0] + " (Type: " + E.value[1] + ")");
+		print_line(itos(E.key) + " - Stray Node: " + E.value.get(0) + " (Type: " + E.value.get(1) + ")");
 	}
 
 	// Flush it after use.

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -194,7 +194,7 @@ void SkeletonModification2DPhysicalBones::fetch_physical_bones() {
 	node_queue.push_back(stack->skeleton);
 
 	while (node_queue.size() > 0) {
-		Node *node_to_process = node_queue[0];
+		Node *node_to_process = node_queue.front()->get();
 		node_queue.pop_front();
 
 		if (node_to_process != nullptr) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -585,12 +585,12 @@ int VisualShaderNodeCustom::get_input_port_count() const {
 
 VisualShaderNodeCustom::PortType VisualShaderNodeCustom::get_input_port_type(int p_port) const {
 	ERR_FAIL_INDEX_V(p_port, input_ports.size(), PORT_TYPE_SCALAR);
-	return (PortType)input_ports[p_port].type;
+	return (PortType)input_ports.get(p_port).type;
 }
 
 String VisualShaderNodeCustom::get_input_port_name(int p_port) const {
 	ERR_FAIL_INDEX_V(p_port, input_ports.size(), "");
-	return input_ports[p_port].name;
+	return input_ports.get(p_port).name;
 }
 
 int VisualShaderNodeCustom::get_default_input_port(PortType p_type) const {
@@ -605,12 +605,12 @@ int VisualShaderNodeCustom::get_output_port_count() const {
 
 VisualShaderNodeCustom::PortType VisualShaderNodeCustom::get_output_port_type(int p_port) const {
 	ERR_FAIL_INDEX_V(p_port, output_ports.size(), PORT_TYPE_SCALAR);
-	return (PortType)output_ports[p_port].type;
+	return (PortType)output_ports.get(p_port).type;
 }
 
 String VisualShaderNodeCustom::get_output_port_name(int p_port) const {
 	ERR_FAIL_INDEX_V(p_port, output_ports.size(), "");
-	return output_ports[p_port].name;
+	return output_ports.get(p_port).name;
 }
 
 String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -865,7 +865,7 @@ int VisualShader::get_varyings_count() const {
 
 const VisualShader::Varying *VisualShader::get_varying_by_index(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, varyings_list.size(), nullptr);
-	return &varyings_list[p_idx];
+	return &varyings_list.get(p_idx);
 }
 
 void VisualShader::set_varying_mode(const String &p_name, VaryingMode p_mode) {
@@ -2478,10 +2478,11 @@ void VisualShader::_update_shader() const {
 		}
 	}
 
-	for (int i = 0; i < parameters.size(); i++) {
-		VisualShaderNodeParameter *parameter = parameters[i];
+	int idx = 0;
+	for (List<VisualShaderNodeParameter *>::Iterator itr = parameters.begin(); itr != parameters.end(); ++itr, ++idx) {
+		VisualShaderNodeParameter *parameter = *itr;
 		if (used_parameter_names.has(parameter->get_parameter_name())) {
-			global_code += parameter->generate_global(get_mode(), Type(i), -1);
+			global_code += parameter->generate_global(get_mode(), Type(idx), -1);
 			const_cast<VisualShaderNodeParameter *>(parameter)->set_global_code_generated(true);
 		} else {
 			const_cast<VisualShaderNodeParameter *>(parameter)->set_global_code_generated(false);
@@ -2791,8 +2792,9 @@ void VisualShader::_update_shader() const {
 
 	const_cast<VisualShader *>(this)->set_code(final_code);
 	for (int i = 0; i < default_tex_params.size(); i++) {
-		for (int j = 0; j < default_tex_params[i].params.size(); j++) {
-			const_cast<VisualShader *>(this)->set_default_texture_parameter(default_tex_params[i].name, default_tex_params[i].params[j], j);
+		int j = 0;
+		for (List<Ref<Texture2D>>::ConstIterator itr = default_tex_params[i].params.begin(); itr != default_tex_params[i].params.end(); ++itr, ++j) {
+			const_cast<VisualShader *>(this)->set_default_texture_parameter(default_tex_params[i].name, *itr, j);
 		}
 	}
 	if (previous_code != final_code) {
@@ -3684,7 +3686,7 @@ String VisualShaderNodeParameterRef::get_parameter_name_by_index(int p_idx) cons
 	ERR_FAIL_COND_V(!shader_rid.is_valid(), String());
 
 	if (p_idx >= 0 && p_idx < parameters[shader_rid].size()) {
-		return parameters[shader_rid][p_idx].name;
+		return parameters[shader_rid].get(p_idx).name;
 	}
 	return "";
 }
@@ -3692,9 +3694,9 @@ String VisualShaderNodeParameterRef::get_parameter_name_by_index(int p_idx) cons
 VisualShaderNodeParameterRef::ParameterType VisualShaderNodeParameterRef::get_parameter_type_by_name(const String &p_name) const {
 	ERR_FAIL_COND_V(!shader_rid.is_valid(), PARAMETER_TYPE_FLOAT);
 
-	for (int i = 0; i < parameters[shader_rid].size(); i++) {
-		if (parameters[shader_rid][i].name == p_name) {
-			return parameters[shader_rid][i].type;
+	for (const VisualShaderNodeParameterRef::Parameter &parameter : parameters[shader_rid]) {
+		if (parameter.name == p_name) {
+			return parameter.type;
 		}
 	}
 	return PARAMETER_TYPE_FLOAT;
@@ -3704,7 +3706,7 @@ VisualShaderNodeParameterRef::ParameterType VisualShaderNodeParameterRef::get_pa
 	ERR_FAIL_COND_V(!shader_rid.is_valid(), PARAMETER_TYPE_FLOAT);
 
 	if (p_idx >= 0 && p_idx < parameters[shader_rid].size()) {
-		return parameters[shader_rid][p_idx].type;
+		return parameters[shader_rid].get(p_idx).type;
 	}
 	return PARAMETER_TYPE_FLOAT;
 }
@@ -3713,7 +3715,7 @@ VisualShaderNodeParameterRef::PortType VisualShaderNodeParameterRef::get_port_ty
 	ERR_FAIL_COND_V(!shader_rid.is_valid(), PORT_TYPE_SCALAR);
 
 	if (p_idx >= 0 && p_idx < parameters[shader_rid].size()) {
-		switch (parameters[shader_rid][p_idx].type) {
+		switch (parameters[shader_rid].get(p_idx).type) {
 			case PARAMETER_TYPE_FLOAT:
 				return PORT_TYPE_SCALAR;
 			case PARAMETER_TYPE_INT:
@@ -4984,15 +4986,15 @@ int VisualShaderNodeVarying::get_varyings_count() const {
 
 String VisualShaderNodeVarying::get_varying_name_by_index(int p_idx) const {
 	if (p_idx >= 0 && p_idx < varyings.size()) {
-		return varyings[p_idx].name;
+		return varyings.get(p_idx).name;
 	}
 	return "";
 }
 
 VisualShader::VaryingType VisualShaderNodeVarying::get_varying_type_by_name(const String &p_name) const {
-	for (int i = 0; i < varyings.size(); i++) {
-		if (varyings[i].name == p_name) {
-			return varyings[i].type;
+	for (const VisualShaderNodeVarying::Varying &varying : varyings) {
+		if (varying.name == p_name) {
+			return varying.type;
 		}
 	}
 	return VisualShader::VARYING_TYPE_FLOAT;
@@ -5000,15 +5002,15 @@ VisualShader::VaryingType VisualShaderNodeVarying::get_varying_type_by_name(cons
 
 VisualShader::VaryingType VisualShaderNodeVarying::get_varying_type_by_index(int p_idx) const {
 	if (p_idx >= 0 && p_idx < varyings.size()) {
-		return varyings[p_idx].type;
+		return varyings.get(p_idx).type;
 	}
 	return VisualShader::VARYING_TYPE_FLOAT;
 }
 
 VisualShader::VaryingMode VisualShaderNodeVarying::get_varying_mode_by_name(const String &p_name) const {
-	for (int i = 0; i < varyings.size(); i++) {
-		if (varyings[i].name == p_name) {
-			return varyings[i].mode;
+	for (const VisualShaderNodeVarying::Varying &varying : varyings) {
+		if (varying.name == p_name) {
+			return varying.mode;
 		}
 	}
 	return VisualShader::VARYING_MODE_VERTEX_TO_FRAG_LIGHT;
@@ -5016,14 +5018,14 @@ VisualShader::VaryingMode VisualShaderNodeVarying::get_varying_mode_by_name(cons
 
 VisualShader::VaryingMode VisualShaderNodeVarying::get_varying_mode_by_index(int p_idx) const {
 	if (p_idx >= 0 && p_idx < varyings.size()) {
-		return varyings[p_idx].mode;
+		return varyings.get(p_idx).mode;
 	}
 	return VisualShader::VARYING_MODE_VERTEX_TO_FRAG_LIGHT;
 }
 
 VisualShaderNodeVarying::PortType VisualShaderNodeVarying::get_port_type_by_index(int p_idx) const {
 	if (p_idx >= 0 && p_idx < varyings.size()) {
-		return get_port_type(varyings[p_idx].type, 0);
+		return get_port_type(varyings.get(p_idx).type, 0);
 	}
 	return PORT_TYPE_SCALAR;
 }

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -1641,11 +1641,11 @@ String VisualShaderNodeParticleEmit::generate_code(Shader::Mode p_mode, VisualSh
 
 	String flags_str;
 
-	for (int i = 0; i < flags_arr.size(); i++) {
-		if (i > 0) {
+	for (List<String>::ConstIterator itr = flags_arr.begin(); itr != flags_arr.end(); ++itr) {
+		if (itr != flags_arr.begin()) {
 			flags_str += "|";
 		}
-		flags_str += flags_arr[i];
+		flags_str += *itr;
 	}
 
 	if (flags_str.is_empty()) {

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -97,12 +97,10 @@ Array ServersDebugger::ServersProfilerFrame::serialize() {
 	arr.push_back(script_time);
 
 	arr.push_back(servers.size());
-	for (int i = 0; i < servers.size(); i++) {
-		ServerInfo &s = servers[i];
+	for (const ServerInfo &s : servers) {
 		arr.push_back(s.name);
 		arr.push_back(s.functions.size() * 2);
-		for (int j = 0; j < s.functions.size(); j++) {
-			ServerFunctionInfo &f = s.functions[j];
+		for (const ServerFunctionInfo &f : s.functions) {
 			arr.push_back(f.name);
 			arr.push_back(f.time);
 		}

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -687,8 +687,8 @@ void ShaderRD::enable_group(int p_group) {
 	// Compile all versions again to include the new group.
 	List<RID> all_versions;
 	version_owner.get_owned_list(&all_versions);
-	for (int i = 0; i < all_versions.size(); i++) {
-		Version *version = version_owner.get_or_null(all_versions[i]);
+	for (const RID &E : all_versions) {
+		Version *version = version_owner.get_or_null(E);
 		_compile_version(version, p_group);
 	}
 }

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -85,7 +85,7 @@ Vector<RendererViewport::Viewport *> RendererViewport::_sort_active_viewports() 
 	}
 
 	while (!nodes.is_empty()) {
-		const Viewport *node = nodes[0];
+		const Viewport *node = nodes.front()->get();
 		nodes.pop_front();
 
 		for (int i = active_viewports.size() - 1; i >= 0; --i) {

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -479,8 +479,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				struct_code += _mkid(pnode->vstructs[i].name);
 				struct_code += " ";
 				struct_code += "{\n";
-				for (int j = 0; j < st->members.size(); j++) {
-					SL::MemberNode *m = st->members[j];
+				for (SL::MemberNode *m : st->members) {
 					if (m->datatype == SL::TYPE_STRUCT) {
 						struct_code += _mkid(m->struct_name);
 					} else {
@@ -807,10 +806,11 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				code += _mktab(p_level - 1) + "{\n";
 			}
 
-			for (int i = 0; i < bnode->statements.size(); i++) {
-				String scode = _dump_node_code(bnode->statements[i], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+			int i = 0;
+			for (List<ShaderLanguage::Node *>::ConstIterator itr = bnode->statements.begin(); itr != bnode->statements.end(); ++itr, ++i) {
+				String scode = _dump_node_code(*itr, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
 
-				if (bnode->statements[i]->type == SL::Node::NODE_TYPE_CONTROL_FLOW || bnode->single_statement) {
+				if ((*itr)->type == SL::Node::NODE_TYPE_CONTROL_FLOW || bnode->single_statement) {
 					code += scode; //use directly
 					if (bnode->use_comma_between_statements && i + 1 < bnode->statements.size()) {
 						code += ",";

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -496,7 +496,7 @@ ShaderTypes::ShaderTypes() {
 	shader_types_list.push_back("sky");
 	shader_types_list.push_back("fog");
 
-	for (int i = 0; i < shader_types_list.size(); i++) {
-		shader_types.insert(shader_types_list[i]);
+	for (const String &type : shader_types_list) {
+		shader_types.insert(type);
 	}
 }

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -550,8 +550,6 @@ void add_exposed_classes(Context &r_context) {
 		for (const MethodInfo &E : method_list) {
 			const MethodInfo &method_info = E;
 
-			int argc = method_info.arguments.size();
-
 			if (method_info.name.is_empty()) {
 				continue;
 			}
@@ -613,8 +611,9 @@ void add_exposed_classes(Context &r_context) {
 				method.return_type.name = Variant::get_type_name(return_info.type);
 			}
 
-			for (int i = 0; i < argc; i++) {
-				PropertyInfo arg_info = method_info.arguments[i];
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+				const PropertyInfo &arg_info = *itr;
 
 				String orig_arg_name = arg_info.name;
 
@@ -686,10 +685,9 @@ void add_exposed_classes(Context &r_context) {
 			TEST_FAIL_COND(!String(signal.name).is_valid_identifier(),
 					"Signal name is not a valid identifier: '", exposed_class.name, ".", signal.name, "'.");
 
-			int argc = method_info.arguments.size();
-
-			for (int i = 0; i < argc; i++) {
-				PropertyInfo arg_info = method_info.arguments[i];
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+				const PropertyInfo &arg_info = *itr;
 
 				String orig_arg_name = arg_info.name;
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -142,7 +142,7 @@ TEST_CASE("[Object] Core getters") {
 			inheritance_list.size() == 1,
 			"The inheritance list should consist of Object only");
 	CHECK_MESSAGE(
-			inheritance_list[0] == "Object",
+			inheritance_list.front()->get() == "Object",
 			"The inheritance list should consist of Object only");
 }
 

--- a/tests/core/os/test_os.h
+++ b/tests/core/os/test_os.h
@@ -79,8 +79,8 @@ TEST_CASE("[OS] Non-UTF-8 environment variables") {
 TEST_CASE("[OS] Command line arguments") {
 	List<String> arguments = OS::get_singleton()->get_cmdline_args();
 	bool found = false;
-	for (int i = 0; i < arguments.size(); i++) {
-		if (arguments[i] == "--test") {
+	for (const String &arg : arguments) {
+		if (arg == "--test") {
 			found = true;
 			break;
 		}

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -105,7 +105,7 @@ TEST_CASE("[Dictionary] get_key_lists()") {
 	map[1] = 3;
 	map.get_key_list(ptr);
 	CHECK(keys.size() == 1);
-	CHECK(int(keys[0]) == 1);
+	CHECK(int(keys.front()->get()) == 1);
 	map[2] = 4;
 	map.get_key_list(ptr);
 	CHECK(keys.size() == 3);

--- a/tests/scene/test_sprite_frames.h
+++ b/tests/scene/test_sprite_frames.h
@@ -74,9 +74,10 @@ TEST_CASE("[SpriteFrames] Animation addition, list getter, renaming, removal, an
 			sname_list.size() == test_names.size(),
 			"StringName List getter returned list of expected size");
 
-	for (int i = 0; i < test_names.size(); i++) {
+	int idx = 0;
+	for (List<StringName>::ConstIterator itr = sname_list.begin(); itr != sname_list.end(); ++itr, ++idx) {
 		CHECK_MESSAGE(
-				sname_list[i] == StringName(test_names[i]),
+				*itr == StringName(test_names[idx]),
 				"StringName List getter returned expected values");
 	}
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -187,7 +187,7 @@ int test_main(int argc, char *argv[]) {
 	}
 	// Doctest runner.
 	doctest::Context test_context;
-	List<String> test_args;
+	LocalVector<String> test_args;
 
 	// Clean arguments of "--test" from the args.
 	for (int x = 0; x < argc; x++) {
@@ -200,7 +200,7 @@ int test_main(int argc, char *argv[]) {
 	if (test_args.size() > 0) {
 		// Convert Godot command line arguments back to standard arguments.
 		char **doctest_args = new char *[test_args.size()];
-		for (int x = 0; x < test_args.size(); x++) {
+		for (uint32_t x = 0; x < test_args.size(); x++) {
 			// Operation to convert Godot string to non wchar string.
 			CharString cs = test_args[x].utf8();
 			const char *str = cs.get_data();
@@ -212,7 +212,7 @@ int test_main(int argc, char *argv[]) {
 
 		test_context.applyCommandLine(test_args.size(), doctest_args);
 
-		for (int x = 0; x < test_args.size(); x++) {
+		for (uint32_t x = 0; x < test_args.size(); x++) {
 			delete[] doctest_args[x];
 		}
 		delete[] doctest_args;


### PR DESCRIPTION
Random-access access to `List` when iterating is `O(n^2)` (`O(n)` when accessing a single element)

* Removed subscript operator, in favor of a more explicit `get`
* Added conversion from `Iterator` to `ConstIterator`
* Remade existing operations into other solutions when applicable

Didn't (generally) replace uses of `List` with other structures except a few cases where it avoided a lot of code weirdness, it takes a lot more detailed evaluation of uses to handle that side, better left for other PRs by area maintainers

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
