### PR TITLE
Fix selection rect drawing in `TileSet` editor when create/remove tiles with separation

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1838,7 +1838,8 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_draw() {
 		Vector2i separation = tile_set_atlas_source->get_separation();
 		Vector2i tile_size = tile_set_atlas_source->get_texture_region_size();
 		Vector2i origin = margins + (area.position * (tile_size + separation));
-		TilesEditorUtils::draw_selection_rect(tile_atlas_control, Rect2i(origin, area.size * tile_size));
+		Vector2i size = area.size * tile_size + (area.size - Vector2i(1, 1)).max(Vector2i(0, 0)) * separation;
+		TilesEditorUtils::draw_selection_rect(tile_atlas_control, Rect2i(origin, size));
 	} else {
 		Vector2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 		if (hovered_base_tile_coords.x >= 0 && hovered_base_tile_coords.y >= 0 && hovered_base_tile_coords.x < grid_size.x && hovered_base_tile_coords.y < grid_size.y) {


### PR DESCRIPTION
When <kbd>Ctrl</kbd>-creating/removing tiles in a TileSetAtlasSource with non-zero separation the selection rect was drawn incorrectly:

| Before<br>(v4.3.dev5.official [89f70e98d]) | After<br>(this PR) |
|--------|--------|
|![AefTjkbi7O](https://github.com/godotengine/godot/assets/9283098/129516cb-0e58-4f5b-b555-67af3aa7eb53)|![RePPyVwGNA](https://github.com/godotengine/godot/assets/9283098/8dfff7ca-b693-44c2-8827-7cb42ad708fb)|
