### PR TITLE
Make TextEdit autocompletion replace word unless Shift is held

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -510,12 +510,15 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_text_completion_query", inputs);
 
 	inputs = List<Ref<InputEvent>>();
-	inputs.push_back(InputEventKey::create_reference(Key::ENTER));
-	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::TAB));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::ENTER));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::KP_ENTER));
 	default_builtin_cache.insert("ui_text_completion_accept", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::TAB));
+	inputs.push_back(InputEventKey::create_reference(Key::ENTER));
+	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER));
 	default_builtin_cache.insert("ui_text_completion_replace", inputs);
 
 	// Newlines
@@ -525,7 +528,6 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_text_newline", inputs);
 
 	inputs = List<Ref<InputEvent>>();
-
 	inputs.push_back(InputEventKey::create_reference(Key::ENTER | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_newline_blank", inputs);


### PR DESCRIPTION
This makes <kbd>Tab</kbd> and <kbd>Enter</kbd> act identical by default for autocompletion. Note that this change only has an effect when using autocompletion when **not** at the end of the word. For instance, in this situation (caret is represented by `|`):

```
Box|Container
```

If you accept a suggestion `BoxMesh` here, you will end up with `BoxMesh` when pressing either <kbd>Tab</kbd> or <kbd>Enter</kbd> now. Previously, you'd end up with `BoxMesh` when pressing <kbd>Tab</kbd>, but `BoxMeshContainer` when pressing <kbd>Enter</kbd>.

If <kbd>Shift</kbd> is held, the suggestion is added in-place without the word being replaced. This matches the behavior found in Visual Studio Code where the following occurs:

- Pressing <kbd>Tab</kbd> accepts the suggestion and replaces the word.
- Pressing <kbd>Enter</kbd> accepts the suggestion and replaces the word.
- Pressing <kbd>Shift + Tab</kbd> accepts the suggestion and doesn't replace the word.
- Pressing <kbd>Shift + Enter</kbd> accepts the suggestion and doesn't replace the word.

___

- See https://github.com/godotengine/godot-proposals/issues/9528.
