### PR TITLE
Add progress bar when opening scenes

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2324,8 +2324,11 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				selected = tree->get_next_selected(selected);
 			}
 			// Open the file.
+			EditorProgress ep("Open Scenes", TTR("Open Scenes"), p_selected.size());
+			int step_count = 0;
 			for (int i = 0; i < p_selected.size(); i++) {
 				_select_file(p_selected[i]);
+				ep.step(TTR("Opening Scenes..."), step_count++);
 			}
 		} break;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90658

Shall we only open the scene when the scene size is bigger than or the scene count is larger than some threshold value? 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
