### PR TITLE
Make expression recognize float ending with dot

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -329,7 +329,7 @@ Error Expression::_get_token(Token &r_token) {
 				}
 
 				char32_t next_char = (str_ofs >= expression.length()) ? 0 : expression[str_ofs];
-				if (is_digit(cchar) || (cchar == '.' && is_digit(next_char))) {
+				if (is_digit(cchar) || cchar == '.') {
 					//a number
 
 					String num;
@@ -1039,6 +1039,9 @@ Expression::ENode *Expression::_parse_expression() {
 			case TK_OP_BIT_INVERT:
 				op = Variant::OP_BIT_NEGATE;
 				break;
+			case TK_IDENTIFIER:
+				_set_error("Unexpected character.");
+				return nullptr;
 			default: {
 			}
 		}

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -990,8 +990,8 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 	for (int texture_i = 0; texture_i < static_cast<int>(fbx_scene->texture_files.count); texture_i++) {
 		const ufbx_texture_file &fbx_texture_file = fbx_scene->texture_files[texture_i];
 		String path = _as_string(fbx_texture_file.filename);
-		path = ProjectSettings::get_singleton()->localize_path(path);
-		if (path.is_absolute_path() && !path.is_resource_file()) {
+		// Use only filename for absolute paths to avoid portability issues.
+		if (path.is_absolute_path()) {
 			path = path.get_file();
 		}
 		if (!p_base_path.is_empty()) {
@@ -2239,6 +2239,10 @@ Error FBXDocument::_parse_lights(Ref<FBXState> p_state) {
 }
 
 String FBXDocument::_get_texture_path(const String &p_base_dir, const String &p_source_file_path) const {
+	// Check if the original path exists first.
+	if (FileAccess::exists(p_source_file_path)) {
+		return p_source_file_path.strip_edges();
+	}
 	const String tex_file_name = p_source_file_path.get_file();
 	const Vector<String> subdirs = {
 		"", "textures/", "Textures/", "images/",


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90593

Note that now the following exp won't cause any error, "100." is a const float, "s" is a identifier, which maybe unexpected.
```
func _ready() -> void:
	var exp := Expression.new()
	exp.parse("100.ss")
	print(exp.execute())
```
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
