### PR TITLE
Cherry-picks for the 4.2 branch (future 4.2.2) - 5th batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,7 @@ branches, and linked at the [end of this file](#Past-releases).
 - Properly calculate binormal when creating SurfaceTool from arrays ([GH-88725](https://github.com/godotengine/godot/pull/88725)).
 - Multiple fixes for compressed meshes ([GH-88738](https://github.com/godotengine/godot/pull/88738)).
 - Fix wrong indexing when generating dummy tangents in GLTF import ([GH-88931](https://github.com/godotengine/godot/pull/88931)).
+- Add `--import` command-line flag ([GH-90431](https://github.com/godotengine/godot/pull/90431)).
 
 #### Input
 
@@ -449,11 +450,14 @@ branches, and linked at the [end of this file](#Past-releases).
 - Fix 2D normals for transposed texture ([GH-87225](https://github.com/godotengine/godot/pull/87225)).
 - Disable scissor test after rendering batches in compatibility renderer ([GH-87489](https://github.com/godotengine/godot/pull/87489)).
 - Significantly improve the speed of shader compilation in compatibility backend ([GH-87553](https://github.com/godotengine/godot/pull/87553)).
+- Free dummy renderer objects ([GH-87710](https://github.com/godotengine/godot/pull/87710)).
 - Do not reflect the origin lines in a mirror ([GH-87757](https://github.com/godotengine/godot/pull/87757)).
+- Fix missing instance type in dummy renderer ([GH-88097](https://github.com/godotengine/godot/pull/88097)).
 - Make `RID_Owner<Texture>` threadsafe in `TextureStorage` for GLES3 ([GH-88205](https://github.com/godotengine/godot/pull/88205)).
 - Disable ReShade in the editor and project manager (if run via Vulkan) ([GH-88316](https://github.com/godotengine/godot/pull/88316)).
 - Make dummy rendering server appear as a high end platform to fix vulkan shader compile error when exporting ([GH-88409](https://github.com/godotengine/godot/pull/88409)).
 - Fix shader cache with transform feedback on some Android devices ([GH-88573](https://github.com/godotengine/godot/pull/88573)).
+- Fail early if shader mode is invalid in dummy renderer ([GH-88581](https://github.com/godotengine/godot/pull/88581)).
 - Add fix for TAA passes rendering black meshes on XR ([GH-88830](https://github.com/godotengine/godot/pull/88830)).
 - Make Overdraw, Lighting and Shadow Splits debug draw modes ignore decals ([GH-89253](https://github.com/godotengine/godot/pull/89253)).
 - Fix missed light clusters when inside clipped lights ([GH-89450](https://github.com/godotengine/godot/pull/89450)).
@@ -465,6 +469,8 @@ branches, and linked at the [end of this file](#Past-releases).
 
 - Fix visual shader's `screen_uv` input preview uses position of node rather than a sample area like uv ([GH-84348](https://github.com/godotengine/godot/pull/84348)).
 - Check if the ref shader is valid in visual shader's `_update_option_menu` ([GH-87356](https://github.com/godotengine/godot/pull/87356)).
+- Fully initialize all members of structs `IdentifierActions`, `GeneratedCode` and `DefaultIdentifierActions` ([GH-88021](https://github.com/godotengine/godot/pull/88021)).
+- Change shader compiler default setting to avoid doctool error ([GH-88996](https://github.com/godotengine/godot/pull/88996)).
 
 #### XR
 

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -304,6 +304,7 @@ public:
 	EditorFileSystemDirectory *get_filesystem();
 	bool is_scanning() const;
 	bool is_importing() const { return importing; }
+	bool doing_first_scan() const { return first_scan; }
 	float get_scanning_progress() const;
 	void scan();
 	void scan_changes();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -89,6 +89,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc_data_class_path.gen.h"
 #include "editor/doc_tools.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_help.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
@@ -179,6 +180,7 @@ static OS::ProcessID editor_pid = 0;
 static bool found_project = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
+static bool wait_for_import = false;
 #ifndef DISABLE_DEPRECATED
 static int converter_max_kb_file = 4 * 1024; // 4MB
 static int converter_max_line_length = 100000;
@@ -505,6 +507,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --main-loop <main_loop_name>      Run a MainLoop specified by its global class name.\n");
 	OS::get_singleton()->print("  --check-only                      Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
+	OS::get_singleton()->print("  --import                          Starts the editor, waits for any resources to be imported, and then quits.\n");
 	OS::get_singleton()->print("  --export-release <preset> <path>  Export the project in release mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.\n");
 	OS::get_singleton()->print("                                    <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe').\n");
 	OS::get_singleton()->print("                                    The target directory must exist.\n");
@@ -1288,12 +1291,17 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing file to load argument after --validate-extension-api, aborting.");
 				goto error;
 			}
-
+		} else if (I->get() == "--import") {
+			editor = true;
+			cmdline_tool = true;
+			wait_for_import = true;
+			quit_after = 1;
 		} else if (I->get() == "--export-release" || I->get() == "--export-debug" ||
 				I->get() == "--export-pack") { // Export project
 			// Actually handling is done in start().
 			editor = true;
 			cmdline_tool = true;
+			wait_for_import = true;
 			main_args.push_back(I->get());
 #ifndef DISABLE_DEPRECATED
 		} else if (I->get() == "--export") { // For users used to 3.x syntax.
@@ -3745,6 +3753,12 @@ bool Main::iteration() {
 	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {
 		exit = true;
 	}
+
+#ifdef TOOLS_ENABLED
+	if (wait_for_import && EditorFileSystem::get_singleton()->doing_first_scan()) {
+		exit = false;
+	}
+#endif
 
 	if (fixed_fps != -1) {
 		return exit;

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -81,6 +81,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 		new_mode = RS::SHADER_FOG;
 	} else {
 		new_mode = RS::SHADER_MAX;
+		ERR_FAIL_MSG("Shader type " + mode_string + " not supported in Dummy renderer.");
 	}
 	ShaderCompiler::IdentifierActions actions;
 	actions.uniforms = &shader->uniforms;

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -77,6 +77,8 @@ public:
 
 	/* SHADER API */
 
+	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
+
 	virtual RID shader_allocate() override;
 	virtual void shader_initialize(RID p_rid) override;
 	virtual void shader_free(RID p_rid) override;

--- a/servers/rendering/dummy/storage/mesh_storage.cpp
+++ b/servers/rendering/dummy/storage/mesh_storage.cpp
@@ -63,3 +63,33 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 
 	m->surfaces.clear();
 }
+
+RID MeshStorage::multimesh_allocate() {
+	return multimesh_owner.allocate_rid();
+}
+
+void MeshStorage::multimesh_initialize(RID p_rid) {
+	multimesh_owner.initialize_rid(p_rid, DummyMultiMesh());
+}
+
+void MeshStorage::multimesh_free(RID p_rid) {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(multimesh);
+
+	multimesh_owner.free(p_rid);
+}
+
+void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_NULL(multimesh);
+	multimesh->buffer.resize(p_buffer.size());
+	float *cache_data = multimesh->buffer.ptrw();
+	memcpy(cache_data, p_buffer.ptr(), p_buffer.size() * sizeof(float));
+}
+
+Vector<float> MeshStorage::multimesh_get_buffer(RID p_multimesh) const {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_NULL_V(multimesh, Vector<float>());
+
+	return multimesh->buffer;
+}

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -138,6 +138,8 @@ public:
 
 	/* MULTIMESH API */
 
+	bool owns_multimesh(RID p_rid) { return multimesh_owner.owns(p_rid); }
+
 	virtual RID multimesh_allocate() override;
 	virtual void multimesh_initialize(RID p_rid) override;
 	virtual void multimesh_free(RID p_rid) override;

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -50,6 +50,12 @@ private:
 
 	mutable RID_Owner<DummyMesh> mesh_owner;
 
+	struct DummyMultiMesh {
+		PackedFloat32Array buffer;
+	};
+
+	mutable RID_Owner<DummyMultiMesh> multimesh_owner;
+
 public:
 	static MeshStorage *get_singleton() { return singleton; }
 
@@ -132,9 +138,9 @@ public:
 
 	/* MULTIMESH API */
 
-	virtual RID multimesh_allocate() override { return RID(); }
-	virtual void multimesh_initialize(RID p_rid) override {}
-	virtual void multimesh_free(RID p_rid) override {}
+	virtual RID multimesh_allocate() override;
+	virtual void multimesh_initialize(RID p_rid) override;
+	virtual void multimesh_free(RID p_rid) override;
 
 	virtual void multimesh_allocate_data(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false) override {}
 	virtual int multimesh_get_instance_count(RID p_multimesh) const override { return 0; }
@@ -152,8 +158,8 @@ public:
 	virtual Transform2D multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const override { return Transform2D(); }
 	virtual Color multimesh_instance_get_color(RID p_multimesh, int p_index) const override { return Color(); }
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const override { return Color(); }
-	virtual void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) override {}
-	virtual Vector<float> multimesh_get_buffer(RID p_multimesh) const override { return Vector<float>(); }
+	virtual void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) override;
+	virtual Vector<float> multimesh_get_buffer(RID p_multimesh) const override;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) override {}
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const override { return 0; }

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -31,6 +31,7 @@
 #ifndef UTILITIES_DUMMY_H
 #define UTILITIES_DUMMY_H
 
+#include "material_storage.h"
 #include "mesh_storage.h"
 #include "servers/rendering/storage/utilities.h"
 #include "texture_storage.h"
@@ -62,6 +63,12 @@ public:
 			return true;
 		} else if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
 			RendererDummy::MeshStorage::get_singleton()->mesh_free(p_rid);
+			return true;
+		} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
+			RendererDummy::MeshStorage::get_singleton()->multimesh_free(p_rid);
+			return true;
+		} else if (RendererDummy::MaterialStorage::get_singleton()->owns_shader(p_rid)) {
+			RendererDummy::MaterialStorage::get_singleton()->shader_free(p_rid);
 			return true;
 		}
 		return false;

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -53,6 +53,8 @@ public:
 	virtual RS::InstanceType get_base_type(RID p_rid) const override {
 		if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
 			return RS::INSTANCE_MESH;
+		} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
+			return RS::INSTANCE_MULTIMESH;
 		}
 		return RS::INSTANCE_NONE;
 	}

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -52,38 +52,38 @@ public:
 		HashMap<StringName, bool *> usage_flag_pointers;
 		HashMap<StringName, bool *> write_flag_pointers;
 
-		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms;
+		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms = nullptr;
 	};
 
 	struct GeneratedCode {
 		Vector<String> defines;
 		struct Texture {
 			StringName name;
-			ShaderLanguage::DataType type;
-			ShaderLanguage::ShaderNode::Uniform::Hint hint;
+			ShaderLanguage::DataType type = ShaderLanguage::DataType::TYPE_VOID;
+			ShaderLanguage::ShaderNode::Uniform::Hint hint = ShaderLanguage::ShaderNode::Uniform::Hint::HINT_NONE;
 			bool use_color = false;
-			ShaderLanguage::TextureFilter filter;
-			ShaderLanguage::TextureRepeat repeat;
-			bool global;
-			int array_size;
+			ShaderLanguage::TextureFilter filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+			ShaderLanguage::TextureRepeat repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
+			bool global = false;
+			int array_size = 0;
 		};
 
 		Vector<Texture> texture_uniforms;
 
 		Vector<uint32_t> uniform_offsets;
-		uint32_t uniform_total_size;
+		uint32_t uniform_total_size = 0;
 		String uniforms;
 		String stage_globals[STAGE_MAX];
 
 		HashMap<String, String> code;
 
-		bool uses_global_textures;
-		bool uses_fragment_time;
-		bool uses_vertex_time;
-		bool uses_screen_texture_mipmaps;
-		bool uses_screen_texture;
-		bool uses_depth_texture;
-		bool uses_normal_roughness_texture;
+		bool uses_global_textures = false;
+		bool uses_fragment_time = false;
+		bool uses_vertex_time = false;
+		bool uses_screen_texture_mipmaps = false;
+		bool uses_screen_texture = false;
+		bool uses_depth_texture = false;
+		bool uses_normal_roughness_texture = false;
 	};
 
 	struct DefaultIdentifierActions {
@@ -91,8 +91,8 @@ public:
 		HashMap<StringName, String> render_mode_defines;
 		HashMap<StringName, String> usage_defines;
 		HashMap<StringName, String> custom_samplers;
-		ShaderLanguage::TextureFilter default_filter;
-		ShaderLanguage::TextureRepeat default_repeat;
+		ShaderLanguage::TextureFilter default_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+		ShaderLanguage::TextureRepeat default_repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
 		int base_texture_binding_index = 0;
 		int texture_layout_set = 0;
 		String base_uniform_string;

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -91,8 +91,8 @@ public:
 		HashMap<StringName, String> render_mode_defines;
 		HashMap<StringName, String> usage_defines;
 		HashMap<StringName, String> custom_samplers;
-		ShaderLanguage::TextureFilter default_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
-		ShaderLanguage::TextureRepeat default_repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
+		ShaderLanguage::TextureFilter default_filter = ShaderLanguage::TextureFilter::FILTER_NEAREST;
+		ShaderLanguage::TextureRepeat default_repeat = ShaderLanguage::TextureRepeat::REPEAT_DISABLE;
 		int base_texture_binding_index = 0;
 		int texture_layout_set = 0;
 		String base_uniform_string;


### PR DESCRIPTION
`Final_final_v3-final.psd` batch for 4.2.2, to fix the critical regression in #89674.

@clayjohn evaluated what's missing from the #87392 cherry-pick, and it turns out we had missed a bunch of follow-up PRs which are also needed to really make headless shader exports reliable, and fix regressions.

The options are to:
- Cherry-pick all the remaining bits (what I've chosen to do here, on Clay's suggestion)
- Revert the #87392 cherry-pick and keep headless shader exports broken in 4.2.2, to re-evaluate in 4.2.3
- Only cherry-pick the default value init from #88996 which is enough to fix #89674, but then there are still a number of issues that wouldn't be resolved in 4.2.2

So I took the YOLO approach, and while at it, I included the much awaited #90431 which should also be pretty safe, and directly related to these changes. This should make exporting projects on CI much more reliable from 4.2.2 onwards.

Fixes #89674.