### PR TITLE
Fix missing return in `StreamPeerTCP::poll` when connection is `STATUS_CONNECTED`

### DIFF
--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -51,6 +51,7 @@ Error StreamPeerTCP::poll() {
 			status = STATUS_ERROR;
 			return err;
 		}
+		return OK;
 	} else if (status != STATUS_CONNECTING) {
 		return OK;
 	}


### PR DESCRIPTION
If the `StreamPeerTCP` is polled and the TCP connection is `STATUS_CONNECTED` it should return after polling netsocket for events. Without `return` poll keeps calling `_sock->connect_to_host` and `connect()`. Calling `connect()` on a TCP socket is unspecified behaviour, and likely wrong.
