### PR TITLE
Update NavigationRegion tests RID function

### DIFF
--- a/tests/scene/test_navigation_region_2d.h
+++ b/tests/scene/test_navigation_region_2d.h
@@ -41,7 +41,7 @@ namespace TestNavigationRegion2D {
 TEST_SUITE("[Navigation]") {
 	TEST_CASE("[SceneTree][NavigationRegion2D] New region should have valid RID") {
 		NavigationRegion2D *region_node = memnew(NavigationRegion2D);
-		CHECK(region_node->get_region_rid().is_valid());
+		CHECK(region_node->get_rid().is_valid());
 		memdelete(region_node);
 	}
 }

--- a/tests/scene/test_navigation_region_3d.h
+++ b/tests/scene/test_navigation_region_3d.h
@@ -43,7 +43,7 @@ namespace TestNavigationRegion3D {
 TEST_SUITE("[Navigation]") {
 	TEST_CASE("[SceneTree][NavigationRegion3D] New region should have valid RID") {
 		NavigationRegion3D *region_node = memnew(NavigationRegion3D);
-		CHECK(region_node->get_region_rid().is_valid());
+		CHECK(region_node->get_rid().is_valid());
 		memdelete(region_node);
 	}
 


### PR DESCRIPTION
Updates `NavigationRegion` test rid function from deprecated `get_region_rid()` to use newer `get_rid()`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
