### PR TITLE
Remove experimental `constrain_avoidance` from `NavigationRegion2D`

### DIFF
--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -23,13 +23,6 @@
 				Bakes the [NavigationPolygon]. If [param on_thread] is set to [code]true[/code] (default), the baking is done on a separate thread.
 			</description>
 		</method>
-		<method name="get_avoidance_layer_value" qualifiers="const">
-			<return type="bool" />
-			<param index="0" name="layer_number" type="int" />
-			<description>
-				Returns whether or not the specified layer of the [member avoidance_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
-			</description>
-		</method>
 		<method name="get_navigation_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -61,14 +54,6 @@
 				Returns [code]true[/code] when the [NavigationPolygon] is being baked on a background thread.
 			</description>
 		</method>
-		<method name="set_avoidance_layer_value">
-			<return type="void" />
-			<param index="0" name="layer_number" type="int" />
-			<param index="1" name="value" type="bool" />
-			<description>
-				Based on [param value], enables or disables the specified layer in the [member avoidance_layers] bitmask, given a [param layer_number] between 1 and 32.
-			</description>
-		</method>
 		<method name="set_navigation_layer_value">
 			<return type="void" />
 			<param index="0" name="layer_number" type="int" />
@@ -86,12 +71,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
-			A bitfield determining all avoidance layers for the avoidance constrain.
-		</member>
-		<member name="constrain_avoidance" type="bool" setter="set_constrain_avoidance" getter="get_constrain_avoidance" default="false" experimental="When enabled, agents are known to get stuck on the navigation polygon corners and edges, especially at a high frame rate. Not recommended for use in production at this stage.">
-			If [code]true[/code] constraints avoidance agent's with an avoidance mask bit that matches with a bit of the [member avoidance_layers] to the navigation polygon. Due to each navigation polygon outline creating an obstacle and each polygon edge creating an avoidance line constrain keep the navigation polygon shape as simple as possible for performance.
-		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			Determines if the [NavigationRegion2D] is enabled or disabled.
 		</member>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -280,3 +280,16 @@ Validate extension JSON: API was removed: classes/BoneAttachment3D/methods/on_bo
 Validate extension JSON: API was removed: classes/Skeleton3D/signals/bone_pose_changed
 
 They have been replaced by a safer API due to performance concerns. Compatibility method registered.
+
+GH-90747
+--------
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/get_avoidance_layers
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/set_avoidance_layers
+Validate extension JSON: API was removed: classes/NavigationRegion2D/properties/avoidance_layers
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/get_avoidance_layer_value
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/set_avoidance_layer_value
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/set_constrain_avoidance
+Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/get_constrain_avoidance
+Validate extension JSON: API was removed: classes/NavigationRegion2D/properties/constrain_avoidance
+
+Experimental NavigationRegion2D feature "constrain_avoidance" was discontinued with no replacement.

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -46,10 +46,6 @@ class NavigationRegion2D : public Node2D {
 	real_t travel_cost = 1.0;
 	Ref<NavigationPolygon> navigation_polygon;
 
-	bool constrain_avoidance = false;
-	LocalVector<RID> constrain_avoidance_obstacles;
-	uint32_t avoidance_layers = 1;
-
 	Transform2D current_global_transform;
 
 	void _navigation_polygon_changed();
@@ -65,7 +61,6 @@ private:
 
 protected:
 	void _notification(int p_what);
-	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
@@ -106,15 +101,6 @@ public:
 	void set_navigation_polygon(const Ref<NavigationPolygon> &p_navigation_polygon);
 	Ref<NavigationPolygon> get_navigation_polygon() const;
 
-	void set_constrain_avoidance(bool p_enabled);
-	bool get_constrain_avoidance() const;
-
-	void set_avoidance_layers(uint32_t p_layers);
-	uint32_t get_avoidance_layers() const;
-
-	void set_avoidance_layer_value(int p_layer_number, bool p_value);
-	bool get_avoidance_layer_value(int p_layer_number) const;
-
 	PackedStringArray get_configuration_warnings() const override;
 
 	void bake_navigation_polygon(bool p_on_thread);
@@ -125,7 +111,6 @@ public:
 	~NavigationRegion2D();
 
 private:
-	void _update_avoidance_constrain();
 	void _region_enter_navigation_map();
 	void _region_exit_navigation_map();
 	void _region_update_transform();


### PR DESCRIPTION
Removes experimental `constrain_avoidance` feature from `NavigationRegion2D`.

This was added in Godot 4.1 with the avoidance rework in an attempt to automate the placement of static avoidance obstacles around NavigationRegion2D.

This feature already had a strong experimental tag so removing it should not come unexpected for users. It clearly told everyone to not use or rely on it for a real project because a lot of its issues where already known back then.

`experimental="When enabled, agents are known to get stuck on the navigation polygon corners and edges, especially at a high frame rate. Not recommended for use in production at this stage."`

The reason why it was even added is, at that time it looked like some of the issues could be reasonably solved in the future and that the general userbase could manage the limitations better. Both did not happen.

There are multiple reasons why this experimental  feature failed and / or why it should be removed.

- Main reason, the feature never worked, it gets agents stuck on the navmesh edges easily.
Attempting to mitigate this would require adding edge margins. Basically to implement a custom version of navmesh baking just for this feature, not at all worth the effort.

- Main reason, the feature never worked, navmesh outline order is just too brittle and unreliable.
Because the avoidance pushback was based on the (hand-drawn) navmesh outlines a single wrong interpreted outline caused the entire user world to break. Happened way to often on more complex navmeshes.

- Even if the feature worked, it could only work with a single region.
Having more than just a single region is common for nearly all projects but the constrain made it impossible for agents to cross into other regions. So basically any more evolved project had to auto-stop using this feature and / or start to juggle avoidance layers which was horrendous.

- Even if the feature worked, it had unscaleable bad performance.
The typical 2D navmesh in user projects is badly optimized and the feature added an obstacle point for every single navmesh vertex. This was just too much, a static avoidance obstacle edge is far more costly than a navmesh edge. Attempting to mitigate this would require adding an edge simplification just for this feature, again, not at all worth the effort.

- Even if the feature worked, it only existed in 2D and only on a node with no actual server support.
It also created the wrong user expectations that navmesh and avoidance are connected and violated the separation of concerns between them.

- Even if the feature worked, it makes the required refactors for the navmap and the avoidance spaces extra difficult because a region is stuck with both.

- Even if the feature worked, it adds a lot of boilerplate code and properties on the NavigationRegion2D for a niche feature.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
