### PR TITLE
Fix incorrect name of internal Basis global scale getter

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -293,7 +293,7 @@ Vector3 Basis::get_scale_abs() const {
 			Vector3(rows[0][2], rows[1][2], rows[2][2]).length());
 }
 
-Vector3 Basis::get_scale_local() const {
+Vector3 Basis::get_scale_global() const {
 	real_t det_sign = SIGN(determinant());
 	return det_sign * Vector3(rows[0].length(), rows[1].length(), rows[2].length());
 }

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -103,7 +103,7 @@ struct _NO_DISCARD_ Basis {
 
 	Vector3 get_scale() const;
 	Vector3 get_scale_abs() const;
-	Vector3 get_scale_local() const;
+	Vector3 get_scale_global() const;
 
 	void set_axis_angle_scale(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale);
 	void set_euler_scale(const Vector3 &p_euler, const Vector3 &p_scale, EulerOrder p_order = EulerOrder::YXZ);

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -109,7 +109,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 
 		// Apply node transforms.
 		if (bool(p_options["retarget/rest_fixer/apply_node_transforms"])) {
-			Vector3 scl = global_transform.basis.get_scale_local();
+			Vector3 scl = global_transform.basis.get_scale_global();
 
 			Vector<int> bones_to_process = src_skeleton->get_parentless_bones();
 			for (int i = 0; i < bones_to_process.size(); i++) {
@@ -674,7 +674,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 						int bone_idx = src_skeleton->find_bone(bn);
 						if (bone_idx >= 0) {
 							Transform3D adjust_transform = src_skeleton->get_bone_global_rest(bone_idx).affine_inverse() * silhouette_diff[bone_idx].affine_inverse() * pre_silhouette_skeleton_global_rest[bone_idx];
-							adjust_transform.scale(global_transform.basis.get_scale_local());
+							adjust_transform.scale(global_transform.basis.get_scale_global());
 							skin->set_bind_pose(i, adjust_transform * skin->get_bind_pose(i));
 						}
 					}
@@ -691,7 +691,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 					}
 					ERR_CONTINUE(bone_idx < 0 || bone_idx >= src_skeleton->get_bone_count());
 					Transform3D adjust_transform = src_skeleton->get_bone_global_rest(bone_idx).affine_inverse() * silhouette_diff[bone_idx].affine_inverse() * pre_silhouette_skeleton_global_rest[bone_idx];
-					adjust_transform.scale(global_transform.basis.get_scale_local());
+					adjust_transform.scale(global_transform.basis.get_scale_global());
 
 					TypedArray<Node> child_nodes = attachment->get_children();
 					while (child_nodes.size()) {


### PR DESCRIPTION
I was looking at the Basis scale methods to double-check that my review of #90584 was correct and I noticed a problem. Basis currently has an internal-only (not exposed) method called `get_scale_local` that gets the global scale.

Fortunately the fix is very simple: Rename the method. The 3 places using the method are already correct, they are expecting the global scale as they pass it into `scale` which is global (we could rename this too, although it might be confusing because `scaled` with a "d" is exposed and is also global).

Proof: Here is what happens if I expose the method and call it from GDScript:

```gdscript
extends Node


func _ready() -> void:
	var rot_90_xy = Basis(Vector3.UP, Vector3.LEFT, Vector3.BACK)
	var b = rot_90_xy * Basis.from_scale(Vector3(1, 2, 3))
	print(b.get_scale()) # Prints (1, 2, 3) the local scale
	print(b.get_scale_local()) # Prints (2, 1, 3) the global scale, so let's rename to `get_scale_global`
```

By the way, if you are wondering whether `from_scale` is global or local, it's actually both. The difference is that `other * from_scale` will perform a local scale, while `from_scale * other` will perform a global scale.