### PR TITLE
Fix rendering transform of Y-sorted branch-root

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -332,7 +332,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			child_item_count = ci->ysort_children_count + 1;
 			child_items = (Item **)alloca(child_item_count * sizeof(Item *));
 
-			ci->ysort_xform = final_xform.affine_inverse();
+			ci->ysort_xform = ci->xform_curr.affine_inverse();
 			ci->ysort_pos = Vector2();
 			ci->ysort_modulate = Color(1, 1, 1, 1);
 			ci->ysort_index = 0;


### PR DESCRIPTION
Fixes #90739.

When Y-sorting a branch like:
```
 ┖╴A (y_sort_enabled = false)
    ┖╴B (y_sort_enabled = true)
       ┖╴C (y_sort_enabled = true)
          ┖╴D (y_sort_enabled = whatever)
```
it is flattened like:
```
 ┖╴A
    ┖╴B
       ┠╴B_copy
       ┠╴C
       ┖╴D
```
where `B_copy`, `C`, `D` are ordered/sorted according to their Y position within `B`'s coordinate space.

The issue was `B_copy.ysort_xform` was set to inverse of `B`'s final transform, hence `B_copy` would always end up being rendered at `B`'s `xform_curr` as the whole final transform would be cancelled out (and because in `RendererCanvasCull::_cull_canvas_item` called for `B_copy` the `B`'s `xform_curr` would be applied again). What needs to be cancelled out is only `B`'s `xform_curr`.