### PR TITLE
Mark `OpenXRCompositionLayer` and its children as experimental

### DIFF
--- a/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OpenXRCompositionLayer" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="OpenXRCompositionLayer" inherits="Node3D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		The parent class of all OpenXR composition layer nodes.
 	</brief_description>

--- a/modules/openxr/doc_classes/OpenXRCompositionLayerCylinder.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayerCylinder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OpenXRCompositionLayerCylinder" inherits="OpenXRCompositionLayer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="OpenXRCompositionLayerCylinder" inherits="OpenXRCompositionLayer" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		An OpenXR composition layer that is rendered as an internal slice of a cylinder.
 	</brief_description>

--- a/modules/openxr/doc_classes/OpenXRCompositionLayerEquirect.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayerEquirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OpenXRCompositionLayerEquirect" inherits="OpenXRCompositionLayer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="OpenXRCompositionLayerEquirect" inherits="OpenXRCompositionLayer" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		An OpenXR composition layer that is rendered as an internal slice of a sphere.
 	</brief_description>

--- a/modules/openxr/doc_classes/OpenXRCompositionLayerQuad.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayerQuad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OpenXRCompositionLayerQuad" inherits="OpenXRCompositionLayer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="OpenXRCompositionLayerQuad" inherits="OpenXRCompositionLayer" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		An OpenXR composition layer that is rendered as a quad.
 	</brief_description>


### PR DESCRIPTION
This is a follow-up to https://github.com/godotengine/godot/pull/89880

I had always intended to mark `OpenXRCompositionLayer` and its children as experimental, but I guess I forgot to do it in the original PR.

These nodes are new and we don't have much experience with them, so I think they should be experimental in Godot 4.3, in case we find some fundamental issue with them after developer start using them in practice. In a minor version or two, we can remove the experimental flag.