### PR TITLE
Increase size of WorldBoundaryShape to be much larger

### DIFF
--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -123,7 +123,7 @@ void GodotWorldBoundaryShape2D::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(arr.size() != 2);
 	normal = arr[0];
 	d = arr[1];
-	configure(Rect2(Vector2(-1e4, -1e4), Vector2(1e4 * 2, 1e4 * 2)));
+	configure(Rect2(Vector2(-1e15, -1e15), Vector2(1e15 * 2, 1e15 * 2)));
 }
 
 Variant GodotWorldBoundaryShape2D::get_data() const {

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -152,7 +152,7 @@ Vector3 GodotWorldBoundaryShape3D::get_moment_of_inertia(real_t p_mass) const {
 
 void GodotWorldBoundaryShape3D::_setup(const Plane &p_plane) {
 	plane = p_plane;
-	configure(AABB(Vector3(-1e4, -1e4, -1e4), Vector3(1e4 * 2, 1e4 * 2, 1e4 * 2)));
+	configure(AABB(Vector3(-1e15, -1e15, -1e15), Vector3(1e15 * 2, 1e15 * 2, 1e15 * 2)));
 }
 
 void GodotWorldBoundaryShape3D::set_data(const Variant &p_data) {


### PR DESCRIPTION
The size was previously 20,000 pixels or units, which could be easily reached in many projects. It is now 2,000,000,000,000,000 pixels or units[^1], which is larger than the supported coordinate space with a single-precision build, and still very large in a double precision build.

I've tested this in 2D and 3D, and it works well even when far away from the world origin, even if the WorldBoundaryShape3D is being continuously moved or rotated. No precision issues occur as a result of this change (if there are precision issues, they were already present in `master`).

[^1]: It might be possible to use `FLT_MAX` if we want to cover the full range of floating-point numbers, but I don't know if using `FLT_MAX * 0.5` in the rect/AABB calculation is particularly safe in terms of precision.

- This closes https://github.com/godotengine/godot/issues/76917.

**Testing project:** [test_worldboundaryshape3d.zip](https://github.com/godotengine/godot/files/14999818/test_worldboundaryshape3d.zip)