### PR TITLE
Expose global transform properties in Node2D, Node3D and Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -969,8 +969,8 @@
 			Tells Godot which node it should give focus to if the user presses [kbd]Shift + Tab[/kbd] on a keyboard by default. You can change the key by editing the [member ProjectSettings.input/ui_focus_prev] input action.
 			If this property is not set, Godot will select a "best guess" based on surrounding nodes in the scene tree.
 		</member>
-		<member name="global_position" type="Vector2" setter="_set_global_position" getter="get_global_position">
-			The node's global position, relative to the world (usually to the [CanvasLayer]).
+		<member name="global_position" type="Vector2" setter="_set_global_position" getter="get_global_position" default="Vector2(0, 0)">
+			The node's global position, relative to the [World2D] (usually to the [CanvasLayer]).
 		</member>
 		<member name="grow_horizontal" type="int" setter="set_h_grow_direction" getter="get_h_grow_direction" enum="Control.GrowDirection" default="1">
 			Controls the direction on the horizontal axis in which the control should grow if its horizontal minimum size is changed to be greater than its current size, as the control always has to be at least the minimum size.

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -37,7 +37,7 @@
 			<return type="void" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Adds the [param offset] vector to the node's global position.
+				Adds the [param offset] vector to the node's global position. See also [member global_position].
 			</description>
 		</method>
 		<method name="look_at">
@@ -93,23 +93,23 @@
 		</method>
 	</methods>
 	<members>
-		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position">
-			Global position.
+		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2(0, 0)">
+			Global position, relative to the [World2D] (usually to the [CanvasLayer]).
 		</member>
-		<member name="global_rotation" type="float" setter="set_global_rotation" getter="get_global_rotation">
-			Global rotation in radians.
+		<member name="global_rotation" type="float" setter="set_global_rotation" getter="get_global_rotation" default="0.0">
+			Global rotation in radians, relative to the [World2D].
 		</member>
 		<member name="global_rotation_degrees" type="float" setter="set_global_rotation_degrees" getter="get_global_rotation_degrees">
 			Helper property to access [member global_rotation] in degrees instead of radians.
 		</member>
-		<member name="global_scale" type="Vector2" setter="set_global_scale" getter="get_global_scale">
-			Global scale.
+		<member name="global_scale" type="Vector2" setter="set_global_scale" getter="get_global_scale" default="Vector2(1, 1)">
+			Global scale, relative to the [World2D].
 		</member>
-		<member name="global_skew" type="float" setter="set_global_skew" getter="get_global_skew">
-			Global skew in radians.
+		<member name="global_skew" type="float" setter="set_global_skew" getter="get_global_skew" default="0.0">
+			Global skew in radians, relative to the [World2D].
 		</member>
 		<member name="global_transform" type="Transform2D" setter="set_global_transform" getter="get_global_transform">
-			Global [Transform2D].
+			Global [Transform2D], relative to the [World2D].
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			Position, relative to the node's parent.

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -64,7 +64,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Rotates the global (world) transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in global coordinate system.
+				Rotates the global (world) transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in global coordinate system. See also [member global_rotation].
 			</description>
 		</method>
 		<method name="global_scale">
@@ -78,7 +78,7 @@
 			<return type="void" />
 			<param index="0" name="offset" type="Vector3" />
 			<description>
-				Moves the global (world) transformation by [Vector3] offset. The offset is in global coordinate system.
+				Moves the global (world) transformation by [Vector3] offset. The offset is in global coordinate system. See also [member global_position].
 			</description>
 		</method>
 		<method name="hide">
@@ -275,20 +275,20 @@
 			Basis of the [member transform] property. Represents the rotation, scale, and shear of this node.
 		</member>
 		<member name="global_basis" type="Basis" setter="set_global_basis" getter="get_global_basis">
-			Global basis of this node. This is equivalent to [code]global_transform.basis[/code].
+			Global basis of this node, relative to the [World3D]. This is equivalent to [code]global_transform.basis[/code].
 		</member>
-		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position">
-			Global position of this node. This is equivalent to [code]global_transform.origin[/code].
+		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position" default="Vector3(0, 0, 0)">
+			Global position of this node, relative to the [World3D]. This is equivalent to [code]global_transform.origin[/code].
 		</member>
-		<member name="global_rotation" type="Vector3" setter="set_global_rotation" getter="get_global_rotation">
-			Rotation part of the global transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
+		<member name="global_rotation" type="Vector3" setter="set_global_rotation" getter="get_global_rotation" default="Vector3(0, 0, 0)">
+			Rotation part of the global transformation in radians, relative to the [World3D]. The angles construct a rotation in the order specified by the [member rotation_order] property.
 			[b]Note:[/b] In the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three independent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating-point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
 		</member>
 		<member name="global_rotation_degrees" type="Vector3" setter="set_global_rotation_degrees" getter="get_global_rotation_degrees">
 			Helper property to access [member global_rotation] in degrees instead of radians.
 		</member>
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
-			World3D space (global) [Transform3D] of this node.
+			Global [Transform3D] of this node, relative to the [World3D].
 		</member>
 		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
 			Local position or translation of this node relative to the parent. This is equivalent to [code]transform.origin[/code].

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -494,10 +494,12 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians_as_degrees"), "set_skew", "get_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_transform", "get_transform");
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation", PROPERTY_HINT_NONE, "radians_as_degrees", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
+	// Global position/rotation/scale is shown in the editor for convenience, but isn't stored as it can always be recalculated on-the-fly.
+	ADD_SUBGROUP("Global Transform", "global_");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_RANGE, "-99999,99999,0.001,or_less,or_greater,hide_slider,suffix:px", PROPERTY_USAGE_EDITOR), "set_global_position", "get_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians_as_degrees", PROPERTY_USAGE_EDITOR), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation_degrees", "get_global_rotation_degrees");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_scale", "get_global_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_skew", PROPERTY_HINT_NONE, "radians_as_degrees", PROPERTY_USAGE_NONE), "set_global_skew", "get_global_skew");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_scale", PROPERTY_HINT_LINK, "", PROPERTY_USAGE_EDITOR), "set_global_scale", "get_global_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians_as_degrees", PROPERTY_USAGE_EDITOR), "set_global_skew", "get_global_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
 }

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1034,7 +1034,7 @@ NodePath Node3D::get_visibility_parent() const {
 }
 
 void Node3D::_validate_property(PropertyInfo &p_property) const {
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && p_property.name == "basis") {
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && (p_property.name == "basis" || p_property.name == "global_basis")) {
 		p_property.usage = 0;
 	}
 	if (data.rotation_edit_mode == ROTATION_EDIT_MODE_BASIS && p_property.name == "scale") {
@@ -1043,7 +1043,7 @@ void Node3D::_validate_property(PropertyInfo &p_property) const {
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_QUATERNION && p_property.name == "quaternion") {
 		p_property.usage = 0;
 	}
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && p_property.name == "rotation") {
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && (p_property.name == "rotation" || p_property.name == "global_rotation")) {
 		p_property.usage = 0;
 	}
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && p_property.name == "rotation_order") {
@@ -1052,15 +1052,15 @@ void Node3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 bool Node3D::_property_can_revert(const StringName &p_name) const {
-	if (p_name == "basis") {
+	if (p_name == "basis" || p_name == "global_basis") {
 		return true;
 	} else if (p_name == "scale") {
 		return true;
 	} else if (p_name == "quaternion") {
 		return true;
-	} else if (p_name == "rotation") {
+	} else if (p_name == "rotation" || p_name == "global_rotation") {
 		return true;
-	} else if (p_name == "position") {
+	} else if (p_name == "position" || p_name == "global_position") {
 		return true;
 	}
 	return false;
@@ -1071,6 +1071,13 @@ bool Node3D::_property_get_revert(const StringName &p_name, Variant &r_property)
 
 	if (p_name == "basis") {
 		Variant variant = PropertyUtils::get_property_default_value(this, "transform", &valid);
+		if (valid && variant.get_type() == Variant::Type::TRANSFORM3D) {
+			r_property = Transform3D(variant).get_basis();
+		} else {
+			r_property = Basis();
+		}
+	} else if (p_name == "global_basis") {
+		Variant variant = PropertyUtils::get_property_default_value(this, "global_transform", &valid);
 		if (valid && variant.get_type() == Variant::Type::TRANSFORM3D) {
 			r_property = Transform3D(variant).get_basis();
 		} else {
@@ -1097,8 +1104,22 @@ bool Node3D::_property_get_revert(const StringName &p_name, Variant &r_property)
 		} else {
 			r_property = Vector3();
 		}
+	} else if (p_name == "global_rotation") {
+		Variant variant = PropertyUtils::get_property_default_value(this, "global_transform", &valid);
+		if (valid && variant.get_type() == Variant::Type::TRANSFORM3D) {
+			r_property = Transform3D(variant).get_basis().get_euler_normalized(data.euler_rotation_order);
+		} else {
+			r_property = Vector3();
+		}
 	} else if (p_name == "position") {
 		Variant variant = PropertyUtils::get_property_default_value(this, "transform", &valid);
+		if (valid) {
+			r_property = Transform3D(variant).get_origin();
+		} else {
+			r_property = Vector3();
+		}
+	} else if (p_name == "global_position") {
+		Variant variant = PropertyUtils::get_property_default_value(this, "global_transform", &valid);
 		if (valid) {
 			r_property = Transform3D(variant).get_origin();
 		} else {
@@ -1205,7 +1226,8 @@ void Node3D::_bind_methods() {
 
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR), "set_transform", "get_transform");
-	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "global_transform", PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
+
+	// Global position/rotation/basis is shown in the editor for convenience, but isn't stored as it can always be recalculated on-the-fly.
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position", PROPERTY_HINT_RANGE, "-99999,99999,0.001,or_greater,or_less,hide_slider,suffix:m", PROPERTY_USAGE_EDITOR), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians_as_degrees", PROPERTY_USAGE_EDITOR), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_rotation_degrees", "get_rotation_degrees");
@@ -1216,10 +1238,13 @@ void Node3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_order", PROPERTY_HINT_ENUM, "XYZ,XZY,YXZ,YZX,ZXY,ZYX"), "set_rotation_order", "get_rotation_order");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
-	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "global_basis", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_basis", "get_global_basis");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
+	ADD_SUBGROUP("Global Transform", "global_");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_RANGE, "-99999,99999,0.001,or_greater,or_less,hide_slider,suffix:m", PROPERTY_USAGE_EDITOR), "set_global_position", "get_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians_as_degrees", PROPERTY_USAGE_EDITOR), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation_degrees", "get_global_rotation_degrees");
+	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "global_basis", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_global_basis", "get_global_basis");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "global_transform", PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
+
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "visibility_parent", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GeometryInstance3D"), "set_visibility_parent", "get_visibility_parent");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3532,13 +3532,16 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_vertical", PROPERTY_HINT_ENUM, "Top,Bottom,Both"), "set_v_grow_direction", "get_v_grow_direction");
 
 	ADD_SUBGROUP("Transform", "");
+	// Global position is shown in the editor for convenience, but isn't stored as it can always be recalculated on-the-fly.
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_EDITOR), "_set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_EDITOR), "_set_position", "get_position");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "_set_global_position", "get_global_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians_as_degrees"), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_pivot_offset", "get_pivot_offset");
+
+	ADD_SUBGROUP("Global Transform", "global_");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_EDITOR), "_set_global_position", "get_global_position");
 
 	ADD_SUBGROUP("Container Sizing", "size_flags_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_horizontal", PROPERTY_HINT_FLAGS, "Fill:1,Expand:2,Shrink Center:4,Shrink End:8"), "set_h_size_flags", "get_h_size_flags");


### PR DESCRIPTION
This can be used to view and assign global transform in the inspector. This is useful to quickly move a node back to the origin regardless of its node hierarchy, or view its current global transform in the live scene debugger.

The following properties are now exposed:

- **Node2D:**
  - Global Position
  - Global Rotation
  - Global Scale
  - Global Skew
- **Node3D:**
  - Global Position
  - Global Rotation
  - Global Basis
- **Control:**
  - Global Position

The basic functionality seems to work OK from my testing. However, there's an issue with this error being spammed about 162 times when you open the editor, or even when you use `--doctool`:

```
ERROR: Condition "!is_inside_tree()" is true. Returning: Transform3D()
   at: get_global_transform (./scene/3d/node_3d.cpp:346)
```

This does not occur with Node2D and Control.

## Preview

*Subgroups are collapsed by default. Here, I expanded them to take the screenshot.*

Node2D | Node3D | Control
-|-|-
![Screenshot_20240417_154403](https://github.com/godotengine/godot/assets/180032/3d835403-f82d-4ddb-8fe6-b90ecfb70df6) | ![image](https://github.com/godotengine/godot/assets/180032/87496147-0068-41fa-8049-bcda5cbd4b21) | ![Screenshot_20240417_154534](https://github.com/godotengine/godot/assets/180032/2a08ccc9-ceda-4581-ab57-e077b81c27d7)

___

- This closes https://github.com/godotengine/godot-proposals/issues/1657.
