### PR TITLE
Implement hidden class in core to replace "EditorX" class being hidden.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2134,6 +2134,14 @@ bool ClassDB::is_class_exposed(const StringName &p_class) {
 	return ti->exposed;
 }
 
+bool ClassDB::is_class_hidden(const StringName &p_class) {
+	OBJTYPE_RLOCK;
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
+	return ti->hidden;
+}
+
 bool ClassDB::is_class_reloadable(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -132,6 +132,7 @@ public:
 		StringName name;
 		bool disabled = false;
 		bool exposed = false;
+		bool hidden = false;
 		bool reloadable = false;
 		bool is_virtual = false;
 		bool is_runtime = false;
@@ -205,7 +206,7 @@ public:
 	}
 
 	template <typename T>
-	static void register_class(bool p_virtual = false) {
+	static void register_class(bool p_virtual = false, bool p_hidden = false) {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
@@ -213,6 +214,7 @@ public:
 		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
 		t->exposed = true;
+		t->hidden = p_hidden;
 		t->is_virtual = p_virtual;
 		t->class_ptr = T::get_class_ptr_static();
 		t->api = current_api;
@@ -477,6 +479,7 @@ public:
 	static bool is_class_enabled(const StringName &p_class);
 
 	static bool is_class_exposed(const StringName &p_class);
+	static bool is_class_hidden(const StringName &p_class);
 	static bool is_class_reloadable(const StringName &p_class);
 	static bool is_class_runtime(const StringName &p_class);
 
@@ -546,6 +549,10 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 #define GDREGISTER_VIRTUAL_CLASS(m_class)         \
 	if (m_class::_class_is_enabled) {             \
 		::ClassDB::register_class<m_class>(true); \
+	}
+#define GDREGISTER_HIDDEN_CLASS(m_class)                 \
+	if (m_class::_class_is_enabled) {                    \
+		::ClassDB::register_class<m_class>(false, true); \
 	}
 #define GDREGISTER_ABSTRACT_CLASS(m_class)             \
 	if (m_class::_class_is_enabled) {                  \

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -140,10 +140,6 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true;
 	}
 
-	if (is_base_type_node && p_type.operator String().begins_with("Editor")) {
-		return true; // Do not show editor nodes.
-	}
-
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.
@@ -154,6 +150,10 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		}
 
 		if (!ClassDB::is_class_exposed(p_type)) {
+			return true; // Unexposed types.
+		}
+
+		if (ClassDB::is_class_hidden(p_type)) {
 			return true; // Unexposed types.
 		}
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -139,28 +139,28 @@ void register_editor_types() {
 
 	EditorStringNames::create();
 
-	GDREGISTER_CLASS(EditorPaths);
-	GDREGISTER_CLASS(EditorPlugin);
-	GDREGISTER_CLASS(EditorTranslationParserPlugin);
-	GDREGISTER_CLASS(EditorImportPlugin);
-	GDREGISTER_CLASS(EditorScript);
-	GDREGISTER_CLASS(EditorSelection);
-	GDREGISTER_CLASS(EditorFileDialog);
-	GDREGISTER_CLASS(EditorSettings);
+	GDREGISTER_HIDDEN_CLASS(EditorPaths);
+	GDREGISTER_HIDDEN_CLASS(EditorPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorTranslationParserPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorImportPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorScript);
+	GDREGISTER_HIDDEN_CLASS(EditorSelection);
+	GDREGISTER_HIDDEN_CLASS(EditorFileDialog);
+	GDREGISTER_HIDDEN_CLASS(EditorSettings);
 	GDREGISTER_ABSTRACT_CLASS(EditorToaster);
-	GDREGISTER_CLASS(EditorNode3DGizmo);
-	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorNode3DGizmo);
+	GDREGISTER_HIDDEN_CLASS(EditorNode3DGizmoPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);
-	GDREGISTER_CLASS(EditorResourcePreviewGenerator);
-	GDREGISTER_CLASS(EditorResourceTooltipPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorResourcePreviewGenerator);
+	GDREGISTER_HIDDEN_CLASS(EditorResourceTooltipPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorFileSystem);
-	GDREGISTER_CLASS(EditorFileSystemDirectory);
-	GDREGISTER_CLASS(EditorVCSInterface);
+	GDREGISTER_HIDDEN_CLASS(EditorFileSystemDirectory);
+	GDREGISTER_HIDDEN_CLASS(EditorVCSInterface);
 	GDREGISTER_ABSTRACT_CLASS(ScriptEditor);
 	GDREGISTER_ABSTRACT_CLASS(ScriptEditorBase);
-	GDREGISTER_CLASS(EditorSyntaxHighlighter);
+	GDREGISTER_HIDDEN_CLASS(EditorSyntaxHighlighter);
 	GDREGISTER_ABSTRACT_CLASS(EditorInterface);
-	GDREGISTER_CLASS(EditorExportPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorExportPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformPC);
 	GDREGISTER_CLASS(EditorExportPlatformExtension);
@@ -168,26 +168,26 @@ void register_editor_types() {
 
 	register_exporter_types();
 
-	GDREGISTER_CLASS(EditorResourceConversionPlugin);
-	GDREGISTER_CLASS(EditorSceneFormatImporter);
-	GDREGISTER_CLASS(EditorScenePostImportPlugin);
-	GDREGISTER_CLASS(EditorInspector);
-	GDREGISTER_CLASS(EditorInspectorPlugin);
-	GDREGISTER_CLASS(EditorProperty);
+	GDREGISTER_HIDDEN_CLASS(EditorResourceConversionPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorSceneFormatImporter);
+	GDREGISTER_HIDDEN_CLASS(EditorScenePostImportPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorInspector);
+	GDREGISTER_HIDDEN_CLASS(EditorInspectorPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorProperty);
 	GDREGISTER_CLASS(ScriptCreateDialog);
-	GDREGISTER_CLASS(EditorFeatureProfile);
-	GDREGISTER_CLASS(EditorSpinSlider);
-	GDREGISTER_CLASS(EditorResourcePicker);
-	GDREGISTER_CLASS(EditorScriptPicker);
+	GDREGISTER_HIDDEN_CLASS(EditorFeatureProfile);
+	GDREGISTER_HIDDEN_CLASS(EditorSpinSlider);
+	GDREGISTER_HIDDEN_CLASS(EditorResourcePicker);
+	GDREGISTER_HIDDEN_CLASS(EditorScriptPicker);
 	GDREGISTER_ABSTRACT_CLASS(EditorUndoRedoManager);
 	GDREGISTER_CLASS(EditorContextMenuPlugin);
 
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);
 
-	GDREGISTER_CLASS(EditorScenePostImport);
-	GDREGISTER_CLASS(EditorCommandPalette);
-	GDREGISTER_CLASS(EditorDebuggerPlugin);
+	GDREGISTER_HIDDEN_CLASS(EditorScenePostImport);
+	GDREGISTER_HIDDEN_CLASS(EditorCommandPalette);
+	GDREGISTER_HIDDEN_CLASS(EditorDebuggerPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorDebuggerSession);
 
 	// Required to document import options in the class reference.

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -61,10 +61,10 @@ void initialize_fbx_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		GDREGISTER_CLASS(EditorSceneFormatImporterUFBX);
+		GDREGISTER_HIDDEN_CLASS(EditorSceneFormatImporterUFBX);
 
 		GLOBAL_DEF_RST_BASIC("filesystem/import/fbx2gltf/enabled", true);
-		GDREGISTER_CLASS(EditorSceneFormatImporterFBX2GLTF);
+		GDREGISTER_HIDDEN_CLASS(EditorSceneFormatImporterFBX2GLTF);
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.android", false);
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.web", false);
 

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -135,12 +135,12 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		GDREGISTER_CLASS(EditorSceneFormatImporterGLTF);
+		GDREGISTER_HIDDEN_CLASS(EditorSceneFormatImporterGLTF);
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 
 		// Project settings defined here so doctool finds them.
 		GLOBAL_DEF_RST_BASIC("filesystem/import/blender/enabled", true);
-		GDREGISTER_CLASS(EditorSceneFormatImporterBlend);
+		GDREGISTER_HIDDEN_CLASS(EditorSceneFormatImporterBlend);
 		// Can't (a priori) run external app on these platforms.
 		GLOBAL_DEF_RST("filesystem/import/blender/enabled.android", false);
 		GLOBAL_DEF_RST("filesystem/import/blender/enabled.web", false);


### PR DESCRIPTION
Fixes #88601

This create a way in `ClassDB` to mark a class as hidden. This value is then used by Create Dialog to skip those class. All Classes that started with `Editor` were marked as hidden to match previous behavior. 
The goal would be to add a similar thing in ScriptServer to enable a `@hide` annotation to do the same for a script which would help for godotengine/godot-proposals#1047 
I would wait for the ScriptServer counterpart which I am already working on before merging because this in fact remove the posibillity to hide nodes even if it was never really considered a feature. 

This should make hiding nodes available to GDExtension at least I think.
