### PR TITLE
[Doc] Clarify behavior of `FileAccess.get_line`

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -190,7 +190,7 @@
 		<method name="get_line" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the next line of the file as a [String].
+				Returns the next line of the file as a [String]. The returned string doesn't include newline ([code]\n[/code]) or carriage return ([code]\r[/code]) characters, but does include any other leading or trailing whitespace.
 				Text is interpreted as being UTF-8 encoded.
 			</description>
 		</method>


### PR DESCRIPTION
Specifies that the line excludes any newline or carriage return characters.

See here for the implementation:
https://github.com/godotengine/godot/blob/658e97c93aa2533cb7b12f05e62dcf6864e7acbe/core/io/file_access.cpp#L388-L393

* Closes: https://github.com/godotengine/godot-docs/issues/9237

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
