### PR TITLE
Core: Implement `Nullable<T>` template

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -420,15 +420,15 @@ void AABB::get_edge(int p_edge, Vector3 &r_from, Vector3 &r_to) const {
 	}
 }
 
-Variant AABB::intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const {
+Nullable<Vector3> AABB::intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const {
 	Vector3 inters;
 	if (intersects_segment(p_from, p_to, &inters)) {
 		return inters;
 	}
-	return Variant();
+	return nullptr;
 }
 
-Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
+Nullable<Vector3> AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
 	Vector3 inters;
 	bool inside = false;
 
@@ -441,7 +441,7 @@ Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) c
 
 		return inters;
 	}
-	return Variant();
+	return nullptr;
 }
 
 AABB::operator String() const {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -109,8 +109,8 @@ struct [[nodiscard]] AABB {
 		return AABB(position + size.minf(0), size.abs());
 	}
 
-	Variant intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;
-	Variant intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
+	Nullable<Vector3> intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;
+	Nullable<Vector3> intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
 
 	_FORCE_INLINE_ void quantize(real_t p_unit);
 	_FORCE_INLINE_ AABB quantized(real_t p_unit) const;

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -135,31 +135,28 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	return true;
 }
 
-Variant Plane::intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const {
+Nullable<Vector3> Plane::intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const {
 	Vector3 inters;
 	if (intersect_3(p_plane1, p_plane2, &inters)) {
 		return inters;
-	} else {
-		return Variant();
 	}
+	return nullptr;
 }
 
-Variant Plane::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
+Nullable<Vector3> Plane::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
 	Vector3 inters;
 	if (intersects_ray(p_from, p_dir, &inters)) {
 		return inters;
-	} else {
-		return Variant();
 	}
+	return nullptr;
 }
 
-Variant Plane::intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const {
+Nullable<Vector3> Plane::intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const {
 	Vector3 inters;
 	if (intersects_segment(p_begin, p_end, &inters)) {
 		return inters;
-	} else {
-		return Variant();
 	}
+	return nullptr;
 }
 
 /* misc */

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -32,6 +32,7 @@
 #define PLANE_H
 
 #include "core/math/vector3.h"
+#include "core/templates/nullable.h"
 
 class Variant;
 
@@ -61,9 +62,9 @@ struct [[nodiscard]] Plane {
 	bool intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const;
 
 	// For Variant bindings.
-	Variant intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const;
-	Variant intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
-	Variant intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const;
+	Nullable<Vector3> intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const;
+	Nullable<Vector3> intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
+	Nullable<Vector3> intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const;
 
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_point) const {
 		return p_point - normal * distance_to(p_point);

--- a/core/templates/nullable.h
+++ b/core/templates/nullable.h
@@ -1,0 +1,209 @@
+/**************************************************************************/
+/*  nullable.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NULLABLE_H
+#define NULLABLE_H
+
+#include "core/typedefs.h"
+
+#include <type_traits>
+
+/**
+ * A template wrapper meant to allow value-types to also be assigned null. The
+ * internal value should be validated as non-null before being handled as a
+ * proper value. Includes null-coalescing operators `<<` and `<<=` that're meant
+ * to mirror C#'s `??` and `??=` respectively.
+ *
+ * Despite containing a pointer, this isn't meant to be handled as a pointer type
+ * in the traditional sense. The syntax is setup in such a way to enforce the idea
+ * that this is the type it's wrapping, if that type could also be assigned and
+ * compared against `nullptr`.
+ */
+
+template <typename T>
+class [[nodiscard]] Nullable {
+	T *value;
+	template <typename T_Other>
+	static constexpr bool is_implicitly_convertible_v = std::is_constructible_v<T, T_Other> && std::is_convertible_v<T_Other, T>;
+	template <typename T_Other>
+	static constexpr bool is_explicitly_convertible_v = std::is_constructible_v<T, T_Other> && !std::is_convertible_v<T_Other, T>;
+
+public:
+	_ALWAYS_INLINE_ Nullable() :
+			value(nullptr) {}
+
+	_ALWAYS_INLINE_ Nullable(std::nullptr_t) :
+			value(nullptr) {}
+
+	_ALWAYS_INLINE_ Nullable(const T &p_value) :
+			value(memnew(T(p_value))) {}
+
+	template <typename T_Other, std::enable_if_t<is_implicitly_convertible_v<T_Other>, int> = 0>
+	_ALWAYS_INLINE_ Nullable(const T_Other &p_value) :
+			value(memnew(T(p_value))) {}
+
+	template <typename T_Other, std::enable_if_t<is_explicitly_convertible_v<T_Other>, int> = 0>
+	_ALWAYS_INLINE_ explicit Nullable(const T_Other &p_value) :
+			value(memnew(T(p_value))) {}
+
+	_ALWAYS_INLINE_ Nullable(const Nullable &p_other) :
+			value(p_other.value) {}
+
+	template <typename T_Other, std::enable_if_t<is_implicitly_convertible_v<T_Other>, int> = 0>
+	_ALWAYS_INLINE_ Nullable(const Nullable<T_Other> &p_other) {
+		if (p_other.has_value()) {
+			operator=(*p_other);
+		}
+	}
+
+	template <typename T_Other, std::enable_if_t<is_explicitly_convertible_v<T_Other>, int> = 0>
+	_ALWAYS_INLINE_ explicit Nullable(const Nullable<T_Other> &p_other) {
+		if (p_other.has_value()) {
+			operator=((T_Other)*p_other);
+		}
+	}
+
+	_ALWAYS_INLINE_ ~Nullable() {
+		if (value != nullptr) {
+			memdelete(value);
+		}
+		value = nullptr;
+	}
+
+	_ALWAYS_INLINE_ T &operator*() const {
+		DEV_ASSERT(value != nullptr);
+		return *value;
+	}
+
+	_ALWAYS_INLINE_ void operator=(std::nullptr_t) {
+		if (value != nullptr) {
+			memdelete(value);
+		}
+		value = nullptr;
+	}
+
+	_ALWAYS_INLINE_ void operator=(const T &p_value) {
+		if (value == nullptr) {
+			value = memnew(T);
+		}
+		*value = p_value;
+	}
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ void operator=(const T_Other &p_value) {
+		if (value == nullptr) {
+			value = memnew(T);
+		}
+		*value = (T)p_value;
+	}
+
+	_ALWAYS_INLINE_ void operator=(const Nullable &p_other) {
+		if (unlikely(this == &p_other)) {
+			return;
+		} else if (p_other.value == nullptr) {
+			operator=(nullptr);
+		} else {
+			operator=(*p_other);
+		}
+	}
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ void operator=(const Nullable<T_Other> &p_other) {
+		if (unlikely(this == &p_other)) {
+			return;
+		} else if (p_other.value == nullptr) {
+			operator=(nullptr);
+		} else {
+			operator=(*p_other);
+		}
+	}
+
+	_ALWAYS_INLINE_ bool is_null() const { return value == nullptr; }
+	_ALWAYS_INLINE_ bool has_value() const { return value != nullptr; }
+
+	_ALWAYS_INLINE_ bool operator==(std::nullptr_t) const { return is_null(); }
+	_ALWAYS_INLINE_ bool operator!=(std::nullptr_t) const { return has_value(); }
+
+	_ALWAYS_INLINE_ bool operator==(const T &p_value) const { return is_null() ? false : *value == p_value; }
+	_ALWAYS_INLINE_ bool operator!=(const T &p_value) const { return is_null() ? true : *value != p_value; }
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ bool operator==(const T_Other &p_value) const { return is_null() ? false : *value == p_value; }
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ bool operator!=(const T_Other &p_value) const { return is_null() ? true : *value != p_value; }
+
+	_ALWAYS_INLINE_ bool operator==(const Nullable &p_other) const { return p_other.is_null() ? p_other.is_null() : (p_other.is_null() ? false : *value == *p_other.value); }
+	_ALWAYS_INLINE_ bool operator!=(const Nullable &p_other) const { return p_other.is_null() ? p_other.has_value() : (p_other.is_null() ? true : *value != *p_other.value); }
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ bool operator==(const Nullable &p_other) const { return p_other.is_null() ? p_other.is_null() : (p_other.is_null() ? false : *value == *p_other.value); }
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ bool operator!=(const Nullable &p_other) const { return p_other.is_null() ? p_other.has_value() : (p_other.is_null() ? true : *value != *p_other.value); }
+
+	// Null coalescing operators.
+
+	_ALWAYS_INLINE_ T operator<<(const T &p_value) const { return has_value() ? *value : p_value; }
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ T operator<<(const T_Other &p_value) const { return has_value() ? *value : T(p_value); }
+
+	_ALWAYS_INLINE_ void operator<<=(const T &p_value) {
+		if (is_null()) {
+			value = memnew(T(p_value));
+		}
+	}
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ void operator<<=(const T_Other &p_value) {
+		if (is_null()) {
+			value = memnew(T(p_value));
+		}
+	}
+
+	_ALWAYS_INLINE_ Nullable operator<<(const Nullable &p_other) const { return has_value() ? this : p_other; }
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ Nullable operator<<(const Nullable &p_other) const { return has_value() ? this : T(p_other); }
+
+	_ALWAYS_INLINE_ void operator<<=(const Nullable &p_other) {
+		if (is_null()) {
+			operator=(p_other);
+		}
+	}
+
+	template <typename T_Other, std::enable_if_t<std::is_convertible_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ void operator<<=(const Nullable &p_other) {
+		if (is_null()) {
+			operator=(p_other);
+		}
+	}
+};
+
+#endif // NULLABLE_H

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -192,6 +192,30 @@ struct PtrToArg<ObjectID> {
 	}
 };
 
+// This is for Nullable.
+
+template <typename T>
+struct PtrToArg<Nullable<T>> {
+	_FORCE_INLINE_ static const Nullable<T> &convert(const void *p_ptr) {
+		return *reinterpret_cast<const Nullable<T> *>(p_ptr);
+	}
+	typedef Nullable<T> EncodeT;
+	_FORCE_INLINE_ static void encode(const Nullable<T> &p_val, void *p_ptr) {
+		*((Nullable<T> *)p_ptr) = p_val;
+	}
+};
+
+template <typename T>
+struct PtrToArg<const Nullable<T> &> {
+	_FORCE_INLINE_ static const Nullable<T> &convert(const void *p_ptr) {
+		return *reinterpret_cast<const Nullable<T> *>(p_ptr);
+	}
+	typedef Nullable<T> EncodeT;
+	_FORCE_INLINE_ static void encode(const Nullable<T> &p_val, void *p_ptr) {
+		*((Nullable<T> *)p_ptr) = p_val;
+	}
+};
+
 // This is for the special cases used by Variant.
 
 // No EncodeT because direct pointer conversion not possible.

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -177,6 +177,25 @@ struct GetTypeInfo<const Variant &> {
 	}
 };
 
+// For Nullable. Pretends bindings are Variant to not break compatibility with bindings.
+template <typename T>
+struct GetTypeInfo<Nullable<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::NIL;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(VARIANT_TYPE, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
+	}
+};
+
+template <typename T>
+struct GetTypeInfo<const Nullable<T> &> {
+	static const Variant::Type VARIANT_TYPE = Variant::NIL;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(VARIANT_TYPE, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
+	}
+};
+
 #define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
 	template <>                                                                       \
 	struct GetTypeInfo<m_template<m_type>> {                                          \

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -55,6 +55,7 @@
 #include "core/os/keyboard.h"
 #include "core/string/node_path.h"
 #include "core/string/ustring.h"
+#include "core/templates/nullable.h"
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rid.h"
 #include "core/variant/array.h"
@@ -428,6 +429,11 @@ public:
 
 	operator IPAddress() const;
 
+	template <typename T>
+	operator Nullable<T>() const {
+		return type == NIL ? Nullable<T>() : Nullable<T>(operator T());
+	}
+
 	Object *get_validated_object() const;
 	Object *get_validated_object_with_check(bool &r_previously_freed) const;
 
@@ -489,6 +495,13 @@ public:
 	Variant(const Vector<StringName> &p_array);
 
 	Variant(const IPAddress &p_address);
+
+	template <typename T>
+	Variant(const Nullable<T> &p_nullable) {
+		if (p_nullable.has_value()) {
+			*this = Variant(*p_nullable);
+		}
+	}
 
 #define VARIANT_ENUM_CLASS_CONSTRUCTOR(m_enum) \
 	Variant(m_enum p_value) :                  \

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1113,6 +1113,24 @@ struct VariantInternalAccessor<Vector<Variant>> {
 };
 
 template <typename T>
+struct VariantInternalAccessor<Nullable<T>> {
+	static _FORCE_INLINE_ const Nullable<T> &get(const Variant *v) {
+		if (v->get_type() != Variant::Type::NIL) {
+			return VariantInternalAccessor<T>::get(v);
+		} else {
+			return nullptr;
+		}
+	}
+	static _FORCE_INLINE_ void set(Variant *v, const Nullable<T> &p_value) {
+		if (p_value.has_value()) {
+			VariantInternalAccessor<T>::set(v, *p_value);
+		} else {
+			*v = Variant();
+		}
+	}
+};
+
+template <typename T>
 struct VariantInitializer {
 };
 

--- a/tests/core/templates/test_nullable.h
+++ b/tests/core/templates/test_nullable.h
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  test_nullable.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_NULLABLE_H
+#define TEST_NULLABLE_H
+
+#include "core/templates/nullable.h"
+
+#include "tests/test_macros.h"
+
+namespace TestNullable {
+
+TEST_CASE("[Nullable] Initialize") {
+	Nullable<int> nullable;
+	CHECK(nullable.is_null());
+	CHECK(nullable == nullptr);
+
+	nullable = 0;
+	CHECK(nullable.has_value());
+	CHECK(nullable == 0);
+
+	nullable = nullptr;
+	CHECK(nullable.is_null());
+	CHECK(nullable == nullptr);
+}
+
+TEST_CASE("[Nullable] Coalesse") {
+	Nullable<int> nullable;
+	CHECK(nullable.is_null());
+	CHECK(nullable == nullptr);
+
+	nullable <<= nullptr;
+	CHECK(nullable.is_null());
+	CHECK(nullable == nullptr);
+
+	nullable <<= 123;
+	CHECK(nullable.has_value());
+	CHECK(nullable == 123);
+
+	nullable <<= nullptr;
+	CHECK(nullable.has_value());
+	CHECK(nullable == 123);
+
+	nullable <<= 999;
+	CHECK(nullable.has_value());
+	CHECK(nullable == 123);
+}
+
+TEST_CASE("[Nullable] Equality operators") {
+	Nullable<int> nullable = 123;
+	CHECK(nullable == 123.0);
+	CHECK_FALSE(nullable == nullptr);
+
+	Nullable<Vector2> nullable_v2 = Vector2(1, 1);
+	CHECK(nullable_v2 == Vector2i(1, 1));
+	CHECK_FALSE(nullable_v2 == nullptr);
+
+	Nullable<Vector3> nullable_v3 = Vector3(1, 1, 1);
+	CHECK(nullable_v3 == Vector3i(1, 1, 1));
+	CHECK_FALSE(nullable_v3 == nullptr);
+}
+
+} // namespace TestNullable
+
+#endif // TEST_NULLABLE_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -89,6 +89,7 @@
 #include "tests/core/templates/test_list.h"
 #include "tests/core/templates/test_local_vector.h"
 #include "tests/core/templates/test_lru.h"
+#include "tests/core/templates/test_nullable.h"
 #include "tests/core/templates/test_oa_hash_map.h"
 #include "tests/core/templates/test_paged_array.h"
 #include "tests/core/templates/test_rid.h"


### PR DESCRIPTION
Preliminary work for handling value-types as nullable in a manner that can be recognized more explicitly than `Variant`. The bindable versions of the aabb/plane functions had their return value changed from `Variant` to `Nullable<Vector3>` to demonstrate this capability without breaking compatability (bindings see `Nullable` *as* `Variant` atm).

Doesn't attempt to overhaul current bindings nor the type system; this is strictly for introducing this concept at its most basic level. The only exception is letting `Nullable` get bound in the same way as `Variant`, albeit specialized to its return type; that is, any bound `Variant` return type that represents specifically `T` and null can be 1-1 replaced with `Nullable<T>`.