### PR TITLE
Display Godot version and last edited timestamp in project manager

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/time.h"
+#include "core/version.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -130,12 +132,29 @@ void ProjectListItemControl::set_project_icon(const Ref<Texture2D> &p_icon) {
 	project_icon->set_texture(p_icon);
 }
 
+void ProjectListItemControl::set_last_edited_info(const String &p_info) {
+	last_edited_info->set_text(p_info);
+}
+
+void ProjectListItemControl::set_project_version(const String &p_info) {
+	project_version->set_text(p_info);
+}
+
 void ProjectListItemControl::set_unsupported_features(PackedStringArray p_features) {
 	if (p_features.size() > 0) {
 		String tooltip_text = "";
 		for (int i = 0; i < p_features.size(); i++) {
 			if (ProjectList::project_feature_looks_like_version(p_features[i])) {
-				tooltip_text += TTR("This project was last edited in a different Godot version: ") + p_features[i] + "\n";
+				PackedStringArray project_version_split = p_features[i].split(".");
+				int project_version_major = 0, project_version_minor = 0;
+				if (project_version_split.size() >= 2) {
+					project_version_major = project_version_split[0].to_int();
+					project_version_minor = project_version_split[1].to_int();
+				}
+				if (VERSION_MAJOR != project_version_major || VERSION_MINOR <= project_version_minor) {
+					// Don't show a warning if the project was last edited in a previous minor version.
+					tooltip_text += TTR("This project was last edited in a different Godot version: ") + p_features[i] + "\n";
+				}
 				p_features.remove_at(i);
 				i--;
 			}
@@ -144,6 +163,10 @@ void ProjectListItemControl::set_unsupported_features(PackedStringArray p_featur
 			String unsupported_features_str = String(", ").join(p_features);
 			tooltip_text += TTR("This project uses features unsupported by the current build:") + "\n" + unsupported_features_str;
 		}
+		if (tooltip_text.is_empty()) {
+			return;
+		}
+		project_version->set_tooltip_text(tooltip_text);
 		project_unsupported_features->set_tooltip_text(tooltip_text);
 		project_unsupported_features->show();
 	} else {
@@ -272,11 +295,23 @@ ProjectListItemControl::ProjectListItemControl() {
 		project_path->set_modulate(Color(1, 1, 1, 0.5));
 		path_hb->add_child(project_path);
 
+		last_edited_info = memnew(Label);
+		last_edited_info->set_name("LastEditedInfo");
+		last_edited_info->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+		last_edited_info->set_tooltip_text("Last edited timestamp");
+		last_edited_info->set_modulate(Color(1, 1, 1, 0.5));
+		path_hb->add_child(last_edited_info);
+
 		project_unsupported_features = memnew(TextureRect);
 		project_unsupported_features->set_name("ProjectUnsupportedFeatures");
 		project_unsupported_features->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
 		path_hb->add_child(project_unsupported_features);
 		project_unsupported_features->hide();
+
+		project_version = memnew(Label);
+		project_version->set_name("ProjectVersion");
+		project_version->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+		path_hb->add_child(project_version);
 
 		Control *spacer = memnew(Control);
 		spacer->set_custom_minimum_size(Size2(10, 10));
@@ -409,6 +444,24 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 	PackedStringArray project_features = cf->get_value("application", "config/features", PackedStringArray());
 	PackedStringArray unsupported_features = ProjectSettings::get_unsupported_features(project_features);
 
+	String project_version = "?";
+	for (int i = 0; i < project_features.size(); i++) {
+		if (ProjectList::project_feature_looks_like_version(project_features[i])) {
+			project_version = project_features[i];
+			break;
+		}
+	}
+
+	if (config_version < ProjectSettings::CONFIG_VERSION) {
+		// Previous versions may not have unsupported features.
+		if (config_version == 4) {
+			unsupported_features.push_back("3.x");
+			project_version = "3.x";
+		} else {
+			unsupported_features.push_back("Unknown version");
+		}
+	}
+
 	uint64_t last_edited = 0;
 	if (cf_err == OK) {
 		// The modification date marks the date the project was last edited.
@@ -433,7 +486,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 		ProjectManager::get_singleton()->add_new_tag(tag);
 	}
 
-	return Item(project_name, description, tags, p_path, icon, main_scene, unsupported_features, last_edited, p_favorite, grayed, missing, config_version);
+	return Item(project_name, description, project_version, tags, p_path, icon, main_scene, unsupported_features, last_edited, p_favorite, grayed, missing, config_version);
 }
 
 void ProjectList::_update_icons_async() {
@@ -696,6 +749,8 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->set_tooltip_text(item.description);
 	hb->set_tags(item.tags, this);
 	hb->set_unsupported_features(item.unsupported_features.duplicate());
+	hb->set_project_version(item.project_version);
+	hb->set_last_edited_info(Time::get_singleton()->get_datetime_string_from_unix_time(item.last_edited, true));
 
 	hb->set_is_favorite(item.favorite);
 	hb->set_is_missing(item.missing);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -51,6 +51,8 @@ class ProjectListItemControl : public HBoxContainer {
 	TextureRect *project_icon = nullptr;
 	Label *project_title = nullptr;
 	Label *project_path = nullptr;
+	Label *last_edited_info = nullptr;
+	Label *project_version = nullptr;
 	TextureRect *project_unsupported_features = nullptr;
 	HBoxContainer *tag_container = nullptr;
 
@@ -71,6 +73,8 @@ public:
 	void set_project_path(const String &p_path);
 	void set_tags(const PackedStringArray &p_tags, ProjectList *p_parent_list);
 	void set_project_icon(const Ref<Texture2D> &p_icon);
+	void set_last_edited_info(const String &p_info);
+	void set_project_version(const String &p_version);
 	void set_unsupported_features(PackedStringArray p_features);
 
 	bool should_load_project_icon() const;
@@ -100,6 +104,7 @@ public:
 	struct Item {
 		String project_name;
 		String description;
+		String project_version;
 		PackedStringArray tags;
 		String tag_sort_string;
 		String path;
@@ -118,6 +123,7 @@ public:
 
 		Item(const String &p_name,
 				const String &p_description,
+				const String &p_project_version,
 				const PackedStringArray &p_tags,
 				const String &p_path,
 				const String &p_icon,
@@ -130,6 +136,7 @@ public:
 				int p_version) {
 			project_name = p_name;
 			description = p_description;
+			project_version = p_project_version;
 			tags = p_tags;
 			path = p_path;
 			icon = p_icon;


### PR DESCRIPTION
- closes https://github.com/godotengine/godot-proposals/issues/9384

Shows the project version and the last edited timestamp for each project. 
The version has the same tooltip as the unsupported features icon.

If the project major version is the same and the minor version is before the current version, do not show warning. (https://github.com/godotengine/godot-proposals/issues/9384#issuecomment-2020768103)
I couldn't check patches, since they aren't stored.

Adds a warning for projects edited in 3.x (config version 4). They didn't have one before since they don't have supported features.
Also adds a warning for config versions before 4 of "Unknown version".

![image](https://github.com/godotengine/godot/assets/10054226/74df063b-26d8-4273-86e4-2c483de55c3f)