### PR TITLE
Move avoidance from navigation map to its own avoidance space

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -32,6 +32,12 @@
 				Returns whether or not the specified mask of the [member avoidance_mask] bitmask is enabled, given a [param mask_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_avoidance_space" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the avoidance space used by this agent node.
+			</description>
+		</method>
 		<method name="get_current_navigation_path" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
@@ -63,10 +69,9 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_navigation_map" qualifiers="const">
+		<method name="get_navigation_map" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method get_avoidance_space] to get the agent&apos;s avoidance space.">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationAgent node. This function returns always the map set on the NavigationAgent node and not the map of the abstract agent on the NavigationServer. If the agent map is changed directly with the NavigationServer API the NavigationAgent node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationAgent and also update the agent on the NavigationServer.
 			</description>
 		</method>
 		<method name="get_next_path_position">
@@ -116,6 +121,13 @@
 				Based on [param value], enables or disables the specified mask in the [member avoidance_mask] bitmask, given a [param mask_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this agent node.
+			</description>
+		</method>
 		<method name="set_navigation_layer_value">
 			<return type="void" />
 			<param index="0" name="layer_number" type="int" />
@@ -124,11 +136,10 @@
 				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_navigation_map">
+		<method name="set_navigation_map" deprecated="An agent is no longer an assigned part of a navigation map. See [method set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
-				Sets the [RID] of the navigation map this NavigationAgent node should use and also updates the [code]agent[/code] on the NavigationServer.
 			</description>
 		</method>
 		<method name="set_velocity_forced">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -32,6 +32,12 @@
 				Returns whether or not the specified mask of the [member avoidance_mask] bitmask is enabled, given a [param mask_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_avoidance_space" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the avoidance space used by this agent node.
+			</description>
+		</method>
 		<method name="get_current_navigation_path" qualifiers="const">
 			<return type="PackedVector3Array" />
 			<description>
@@ -63,10 +69,9 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_navigation_map" qualifiers="const">
+		<method name="get_navigation_map" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method get_avoidance_space] to get the agent&apos;s avoidance space.">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationAgent node. This function returns always the map set on the NavigationAgent node and not the map of the abstract agent on the NavigationServer. If the agent map is changed directly with the NavigationServer API the NavigationAgent node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationAgent and also update the agent on the NavigationServer.
 			</description>
 		</method>
 		<method name="get_next_path_position">
@@ -116,6 +121,13 @@
 				Based on [param value], enables or disables the specified mask in the [member avoidance_mask] bitmask, given a [param mask_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this agent node.
+			</description>
+		</method>
 		<method name="set_navigation_layer_value">
 			<return type="void" />
 			<param index="0" name="layer_number" type="int" />
@@ -124,11 +136,10 @@
 				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_navigation_map">
+		<method name="set_navigation_map" deprecated="An agent is no longer an assigned part of a navigation map. See [method set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
-				Sets the [RID] of the navigation map this NavigationAgent node should use and also updates the [code]agent[/code] on the NavigationServer.
 			</description>
 		</method>
 		<method name="set_velocity_forced">

--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -19,10 +19,15 @@
 				Returns whether or not the specified layer of the [member avoidance_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_navigation_map" qualifiers="const">
+		<method name="get_avoidance_space" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
+				Returns the [RID] of the avoidance space used by this obstacle node.
+			</description>
+		</method>
+		<method name="get_navigation_map" qualifiers="const" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method get_avoidance_space] to get the obstacle&apos;s avoidance space.">
+			<return type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -39,11 +44,17 @@
 				Based on [param value], enables or disables the specified layer in the [member avoidance_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_navigation_map">
+		<method name="set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this obstacle node.
+			</description>
+		</method>
+		<method name="set_navigation_map" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
-				Sets the [RID] of the navigation map this NavigationObstacle node should use and also updates the [code]obstacle[/code] on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -19,10 +19,15 @@
 				Returns whether or not the specified layer of the [member avoidance_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_navigation_map" qualifiers="const">
+		<method name="get_avoidance_space" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
+				Returns the [RID] of the avoidance space used by this obstacle node.
+			</description>
+		</method>
+		<method name="get_navigation_map" qualifiers="const" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method get_avoidance_space] to get the obstacle&apos;s avoidance space.">
+			<return type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -39,11 +44,17 @@
 				Based on [param value], enables or disables the specified layer in the [member avoidance_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_navigation_map">
+		<method name="set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this obstacle node.
+			</description>
+		</method>
+		<method name="set_navigation_map" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
-				Sets the [RID] of the navigation map this NavigationObstacle node should use and also updates the [code]obstacle[/code] on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -52,11 +52,17 @@
 				Returns the [code]avoidance_priority[/code] of the specified [param agent].
 			</description>
 		</method>
-		<method name="agent_get_map" qualifiers="const">
+		<method name="agent_get_avoidance_space" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
+				Returns the [RID] of the avoidance space used by this agent.
+			</description>
+		</method>
+		<method name="agent_get_map" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method agent_get_avoidance_space] to get the agent&apos;s avoidance space.">
+			<return type="RID" />
+			<param index="0" name="agent" type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="agent_get_max_neighbors" qualifiers="const">
@@ -129,11 +135,10 @@
 				Return [code]true[/code] if the specified [param agent] has an avoidance callback.
 			</description>
 		</method>
-		<method name="agent_is_map_changed" qualifiers="const">
+		<method name="agent_is_map_changed" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method map_get_iteration_id] or connect to [signal map_changed] signal to keep track of the navigation map updates.">
 			<return type="bool" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns true if the map got changed the previous frame.
 			</description>
 		</method>
 		<method name="agent_set_avoidance_callback">
@@ -178,12 +183,19 @@
 				The specified [param agent] does not adjust the velocity for other agents that would match the [code]avoidance_mask[/code] but have a lower [code]avoidance_priority[/code]. This in turn makes the other agents with lower priority adjust their velocities even more to avoid collision with this agent.
 			</description>
 		</method>
-		<method name="agent_set_map">
+		<method name="agent_set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="agent" type="RID" />
+			<param index="1" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this agent.
+			</description>
+		</method>
+		<method name="agent_set_map" deprecated="An agent is no longer an assigned part of a navigation map. See [method agent_set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="map" type="RID" />
 			<description>
-				Puts the agent in the map.
 			</description>
 		</method>
 		<method name="agent_set_max_neighbors">
@@ -266,6 +278,48 @@
 				Replaces the internal velocity in the collision avoidance simulation with [param velocity] for the specified [param agent]. When an agent is teleported to a new position far away this function should be used in the same frame. If called frequently this function can get agents stuck.
 			</description>
 		</method>
+		<method name="avoidance_space_create">
+			<return type="RID" />
+			<description>
+				Creates a new avoidance space.
+			</description>
+		</method>
+		<method name="avoidance_space_get_agents" qualifiers="const">
+			<return type="RID[]" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns all agents [RID]s that are currently assigned to the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_get_iteration_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns the current iteration id of the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_get_obstacles" qualifiers="const">
+			<return type="RID[]" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns all obstacles [RID]s that are currently assigned to the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_is_active" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns [code]true[/code] if the requested [param avoidance_space] is active and processing.
+			</description>
+		</method>
+		<method name="avoidance_space_set_active">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<param index="1" name="active" type="bool" />
+			<description>
+				If sets to [code]true[/code] the avoidance space is active and processing.
+			</description>
+		</method>
 		<method name="bake_from_source_geometry_data">
 			<return type="void" />
 			<param index="0" name="navigation_polygon" type="NavigationPolygon" />
@@ -289,6 +343,12 @@
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Destroys the given RID.
+			</description>
+		</method>
+		<method name="get_avoidance_spaces" qualifiers="const">
+			<return type="RID[]" />
+			<description>
+				Returns all created avoidance space [RID]s on the NavigationServer. This returns both 2D and 3D created avoidance spaces.
 			</description>
 		</method>
 		<method name="get_debug_enabled" qualifiers="const">
@@ -636,11 +696,17 @@
 				Returns the [code]avoidance_layers[/code] bitmask of the specified [param obstacle].
 			</description>
 		</method>
-		<method name="obstacle_get_map" qualifiers="const">
+		<method name="obstacle_get_avoidance_space" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [param obstacle] is currently assigned to.
+				Returns the [RID] of the avoidance space used by the specified [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_get_map" qualifiers="const" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method obstacle_get_avoidance_space] to get the obstacle&apos;s avoidance space.">
+			<return type="RID" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="obstacle_get_paused" qualifiers="const">
@@ -694,12 +760,19 @@
 				Set the obstacles's [code]avoidance_layers[/code] bitmask.
 			</description>
 		</method>
-		<method name="obstacle_set_map">
+		<method name="obstacle_set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by the specified [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_set_map" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method obstacle_set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="map" type="RID" />
 			<description>
-				Sets the navigation map [RID] for the obstacle.
 			</description>
 		</method>
 		<method name="obstacle_set_paused">
@@ -975,6 +1048,11 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="avoidance_debug_changed">
+			<description>
+				Emitted when avoidance debug settings are changed. Only available in debug builds.
+			</description>
+		</signal>
 		<signal name="map_changed">
 			<param index="0" name="map" type="RID" />
 			<description>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -52,6 +52,13 @@
 				Returns the [code]avoidance_priority[/code] of the specified [param agent].
 			</description>
 		</method>
+		<method name="agent_get_avoidance_space" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [RID] of the avoidance space used by the specified [param agent].
+			</description>
+		</method>
 		<method name="agent_get_height" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="agent" type="RID" />
@@ -59,11 +66,10 @@
 				Returns the [code]height[/code] of the specified [param agent].
 			</description>
 		</method>
-		<method name="agent_get_map" qualifiers="const">
+		<method name="agent_get_map" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method agent_get_avoidance_space] to get the agent&apos;s avoidance space.">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
 			</description>
 		</method>
 		<method name="agent_get_max_neighbors" qualifiers="const">
@@ -143,11 +149,10 @@
 				Return [code]true[/code] if the specified [param agent] has an avoidance callback.
 			</description>
 		</method>
-		<method name="agent_is_map_changed" qualifiers="const">
+		<method name="agent_is_map_changed" qualifiers="const" deprecated="An agent is no longer an assigned part of a navigation map. See [method map_get_iteration_id] or connect to [signal map_changed] signal to keep track of the navigation map updates.">
 			<return type="bool" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns true if the map got changed the previous frame.
 			</description>
 		</method>
 		<method name="agent_set_avoidance_callback">
@@ -192,6 +197,14 @@
 				The specified [param agent] does not adjust the velocity for other agents that would match the [code]avoidance_mask[/code] but have a lower [code]avoidance_priority[/code]. This in turn makes the other agents with lower priority adjust their velocities even more to avoid collision with this agent.
 			</description>
 		</method>
+		<method name="agent_set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="agent" type="RID" />
+			<param index="1" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by this agent.
+			</description>
+		</method>
 		<method name="agent_set_height">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
@@ -200,12 +213,11 @@
 				Updates the provided [param agent] [param height].
 			</description>
 		</method>
-		<method name="agent_set_map">
+		<method name="agent_set_map" deprecated="An agent is no longer an assigned part of a navigation map. See [method agent_set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="map" type="RID" />
 			<description>
-				Puts the agent in the map.
 			</description>
 		</method>
 		<method name="agent_set_max_neighbors">
@@ -298,6 +310,48 @@
 				Replaces the internal velocity in the collision avoidance simulation with [param velocity] for the specified [param agent]. When an agent is teleported to a new position this function should be used in the same frame. If called frequently this function can get agents stuck.
 			</description>
 		</method>
+		<method name="avoidance_space_create">
+			<return type="RID" />
+			<description>
+				Creates a new avoidance space.
+			</description>
+		</method>
+		<method name="avoidance_space_get_agents" qualifiers="const">
+			<return type="RID[]" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns all agents [RID]s that are currently assigned to the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_get_iteration_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns the current iteration id of the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_get_obstacles" qualifiers="const">
+			<return type="RID[]" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns all obstacles [RID]s that are currently assigned to the requested [param avoidance_space].
+			</description>
+		</method>
+		<method name="avoidance_space_is_active" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<description>
+				Returns [code]true[/code] if the requested [param avoidance_space] is active and processing.
+			</description>
+		</method>
+		<method name="avoidance_space_set_active">
+			<return type="void" />
+			<param index="0" name="avoidance_space" type="RID" />
+			<param index="1" name="active" type="bool" />
+			<description>
+				If sets to [code]true[/code] the avoidance space is active and processing.
+			</description>
+		</method>
 		<method name="bake_from_source_geometry_data">
 			<return type="void" />
 			<param index="0" name="navigation_mesh" type="NavigationMesh" />
@@ -321,6 +375,12 @@
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Destroys the given RID.
+			</description>
+		</method>
+		<method name="get_avoidance_spaces" qualifiers="const">
+			<return type="RID[]" />
+			<description>
+				Returns all created avoidance space [RID]s on the NavigationServer. This returns both 2D and 3D created avoidance spaces.
 			</description>
 		</method>
 		<method name="get_debug_enabled" qualifiers="const">
@@ -738,6 +798,13 @@
 				Returns the [code]avoidance_layers[/code] bitmask of the specified [param obstacle].
 			</description>
 		</method>
+		<method name="obstacle_get_avoidance_space" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the [RID] of the avoidance space used by the specified [param obstacle].
+			</description>
+		</method>
 		<method name="obstacle_get_height" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="obstacle" type="RID" />
@@ -745,11 +812,10 @@
 				Returns the [code]height[/code] of the specified [param obstacle].
 			</description>
 		</method>
-		<method name="obstacle_get_map" qualifiers="const">
+		<method name="obstacle_get_map" qualifiers="const" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method obstacle_get_avoidance_space] to get the obstacle&apos;s avoidance space.">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [param obstacle] is currently assigned to.
 			</description>
 		</method>
 		<method name="obstacle_get_paused" qualifiers="const">
@@ -810,6 +876,14 @@
 				Set the obstacles's [code]avoidance_layers[/code] bitmask.
 			</description>
 		</method>
+		<method name="obstacle_set_avoidance_space">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="avoidance_space" type="RID" />
+			<description>
+				Sets the [RID] of the avoidance space to be used by the specified [param obstacle].
+			</description>
+		</method>
 		<method name="obstacle_set_height">
 			<return type="void" />
 			<param index="0" name="obstacle" type="RID" />
@@ -818,12 +892,11 @@
 				Sets the [param height] for the [param obstacle]. In 3D agents will ignore obstacles that are above or below them while using 2D avoidance.
 			</description>
 		</method>
-		<method name="obstacle_set_map">
+		<method name="obstacle_set_map" deprecated="An obstacle is no longer an assigned part of a navigation map. See [method obstacle_set_avoidance_space] to assigned an avoidance space.">
 			<return type="void" />
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="map" type="RID" />
 			<description>
-				Assigns the [param obstacle] to a navigation map.
 			</description>
 		</method>
 		<method name="obstacle_set_paused">

--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -10,6 +10,9 @@
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<members>
+		<member name="avoidance_space" type="RID" setter="" getter="get_avoidance_space">
+			The [RID] of this world's avoidance space. Used by the [NavigationServer2D].
+		</member>
 		<member name="canvas" type="RID" setter="" getter="get_canvas">
 			The [RID] of this world's canvas resource. Used by the [RenderingServer] for 2D drawing.
 		</member>

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -10,6 +10,9 @@
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<members>
+		<member name="avoidance_space" type="RID" setter="" getter="get_avoidance_space">
+			The [RID] of this world's avoidance space. Used by the [NavigationServer3D].
+		</member>
 		<member name="camera_attributes" type="CameraAttributes" setter="set_camera_attributes" getter="get_camera_attributes">
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -332,6 +332,30 @@ Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_circle/ar
 Optional arguments added. Compatibility methods registered.
 
 
+GH-90771
+--------
+Validate extension JSON: API was removed: classes/NavigationObstacle2D/methods/set_navigation_map
+Validate extension JSON: API was removed: classes/NavigationObstacle2D/methods/get_navigation_map
+Validate extension JSON: API was removed: classes/NavigationObstacle3D/methods/set_navigation_map
+Validate extension JSON: API was removed: classes/NavigationObstacle3D/methods/get_navigation_map
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/map_get_agents
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/map_get_obstacles
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/agent_set_map
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/agent_get_map
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/agent_is_map_changed
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/obstacle_set_map
+Validate extension JSON: API was removed: classes/NavigationServer2D/methods/obstacle_get_map
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/map_get_agents
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/map_get_obstacles
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/agent_set_map
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/agent_get_map
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/agent_is_map_changed
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/obstacle_set_map
+Validate extension JSON: API was removed: classes/NavigationServer3D/methods/obstacle_get_map
+
+NavigationServer agents and obstacles are no longer an assigned part of a navigation map. Avoidance agents and avoidance obstacles are moved to avoidance spaces.
+
+
 GH-91098
 --------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/remove_paragraph/arguments': size changed value in new API, from 1 to 2.

--- a/modules/navigation/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation/2d/godot_navigation_server_2d.cpp
@@ -238,18 +238,13 @@ GodotNavigationServer2D::GodotNavigationServer2D() {}
 GodotNavigationServer2D::~GodotNavigationServer2D() {}
 
 TypedArray<RID> FORWARD_0_C(get_maps);
+TypedArray<RID> FORWARD_0_C(get_avoidance_spaces);
 
 TypedArray<RID> FORWARD_1_C(map_get_links, RID, p_map, rid_to_rid);
 
 TypedArray<RID> FORWARD_1_C(map_get_regions, RID, p_map, rid_to_rid);
 
-TypedArray<RID> FORWARD_1_C(map_get_agents, RID, p_map, rid_to_rid);
-
-TypedArray<RID> FORWARD_1_C(map_get_obstacles, RID, p_map, rid_to_rid);
-
 RID FORWARD_1_C(region_get_map, RID, p_region, rid_to_rid);
-
-RID FORWARD_1_C(agent_get_map, RID, p_agent, rid_to_rid);
 
 RID FORWARD_0(map_create);
 
@@ -351,7 +346,6 @@ RID GodotNavigationServer2D::agent_create() {
 
 void FORWARD_2(agent_set_avoidance_enabled, RID, p_agent, bool, p_enabled, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(agent_get_avoidance_enabled, RID, p_agent, rid_to_rid);
-void FORWARD_2(agent_set_map, RID, p_agent, RID, p_map, rid_to_rid, rid_to_rid);
 void FORWARD_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_dist, rid_to_rid, real_to_real);
 real_t GodotNavigationServer2D::agent_get_neighbor_distance(RID p_agent) const {
 	return NavigationServer3D::get_singleton()->agent_get_neighbor_distance(p_agent);
@@ -385,7 +379,7 @@ void FORWARD_2(agent_set_position, RID, p_agent, Vector2, p_position, rid_to_rid
 Vector2 GodotNavigationServer2D::agent_get_position(RID p_agent) const {
 	return v3_to_v2(NavigationServer3D::get_singleton()->agent_get_position(p_agent));
 }
-bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
+
 void FORWARD_2(agent_set_paused, RID, p_agent, bool, p_paused, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(agent_get_paused, RID, p_agent, rid_to_rid);
 
@@ -416,6 +410,12 @@ void FORWARD_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority, r
 real_t GodotNavigationServer2D::agent_get_avoidance_priority(RID p_agent) const {
 	return NavigationServer3D::get_singleton()->agent_get_avoidance_priority(p_agent);
 }
+void GodotNavigationServer2D::agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) {
+	NavigationServer3D::get_singleton()->agent_set_avoidance_space(p_agent, p_avoidance_space);
+}
+RID GodotNavigationServer2D::agent_get_avoidance_space(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_avoidance_space(p_agent);
+}
 
 RID GodotNavigationServer2D::obstacle_create() {
 	RID obstacle = NavigationServer3D::get_singleton()->obstacle_create();
@@ -423,8 +423,6 @@ RID GodotNavigationServer2D::obstacle_create() {
 }
 void FORWARD_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(obstacle_get_avoidance_enabled, RID, p_obstacle, rid_to_rid);
-void FORWARD_2(obstacle_set_map, RID, p_obstacle, RID, p_map, rid_to_rid, rid_to_rid);
-RID FORWARD_1_C(obstacle_get_map, RID, p_obstacle, rid_to_rid);
 void FORWARD_2(obstacle_set_paused, RID, p_obstacle, bool, p_paused, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(obstacle_get_paused, RID, p_obstacle, rid_to_rid);
 void FORWARD_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius, rid_to_rid, real_to_real);
@@ -449,6 +447,37 @@ void GodotNavigationServer2D::obstacle_set_vertices(RID p_obstacle, const Vector
 }
 Vector<Vector2> GodotNavigationServer2D::obstacle_get_vertices(RID p_obstacle) const {
 	return vector_v3_to_v2(NavigationServer3D::get_singleton()->obstacle_get_vertices(p_obstacle));
+}
+
+void GodotNavigationServer2D::obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) {
+	NavigationServer3D::get_singleton()->obstacle_set_avoidance_space(p_obstacle, p_avoidance_space);
+}
+RID GodotNavigationServer2D::obstacle_get_avoidance_space(RID p_obstacle) const {
+	return NavigationServer3D::get_singleton()->obstacle_get_avoidance_space(p_obstacle);
+}
+
+RID GodotNavigationServer2D::avoidance_space_create() {
+	return NavigationServer3D::get_singleton()->avoidance_space_create();
+}
+
+uint32_t GodotNavigationServer2D::avoidance_space_get_iteration_id(RID p_avoidance_space) const {
+	return NavigationServer3D::get_singleton()->avoidance_space_get_iteration_id(p_avoidance_space);
+}
+
+void GodotNavigationServer2D::avoidance_space_set_active(RID p_avoidance_space, bool p_active) {
+	NavigationServer3D::get_singleton()->avoidance_space_set_active(p_avoidance_space, p_active);
+}
+
+bool GodotNavigationServer2D::avoidance_space_is_active(RID p_avoidance_space) const {
+	return NavigationServer3D::get_singleton()->avoidance_space_is_active(p_avoidance_space);
+}
+
+TypedArray<RID> GodotNavigationServer2D::avoidance_space_get_agents(RID p_avoidance_space) const {
+	return NavigationServer3D::get_singleton()->avoidance_space_get_agents(p_avoidance_space);
+}
+
+TypedArray<RID> GodotNavigationServer2D::avoidance_space_get_obstacles(RID p_avoidance_space) const {
+	return NavigationServer3D::get_singleton()->avoidance_space_get_obstacles(p_avoidance_space);
 }
 
 void GodotNavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const {
@@ -479,3 +508,15 @@ void GodotNavigationServer2D::source_geometry_parser_set_callback(RID p_parser, 
 	}
 #endif // CLIPPER2_ENABLED
 }
+
+#ifndef DISABLE_DEPRECATED
+TypedArray<RID> FORWARD_1_C(map_get_agents, RID, p_map, rid_to_rid);
+TypedArray<RID> FORWARD_1_C(map_get_obstacles, RID, p_map, rid_to_rid);
+
+void FORWARD_2(agent_set_map, RID, p_agent, RID, p_map, rid_to_rid, rid_to_rid);
+RID FORWARD_1_C(agent_get_map, RID, p_agent, rid_to_rid);
+bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
+
+void FORWARD_2(obstacle_set_map, RID, p_obstacle, RID, p_map, rid_to_rid, rid_to_rid);
+RID FORWARD_1_C(obstacle_get_map, RID, p_obstacle, rid_to_rid);
+#endif // DISABLE_DEPRECATED

--- a/modules/navigation/2d/godot_navigation_server_2d.h
+++ b/modules/navigation/2d/godot_navigation_server_2d.h
@@ -56,6 +56,7 @@ public:
 	virtual ~GodotNavigationServer2D();
 
 	virtual TypedArray<RID> get_maps() const override;
+	virtual TypedArray<RID> get_avoidance_spaces() const override;
 
 	virtual RID map_create() override;
 	virtual void map_set_active(RID p_map, bool p_active) override;
@@ -73,8 +74,6 @@ public:
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector2 &p_point) const override;
 	virtual TypedArray<RID> map_get_links(RID p_map) const override;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const override;
-	virtual TypedArray<RID> map_get_agents(RID p_map) const override;
-	virtual TypedArray<RID> map_get_obstacles(RID p_map) const override;
 	virtual void map_force_update(RID p_map) override;
 	virtual Vector2 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const override;
 	virtual uint32_t map_get_iteration_id(RID p_map) const override;
@@ -143,10 +142,6 @@ public:
 	/// Creates the agent.
 	virtual RID agent_create() override;
 
-	/// Put the agent in the map.
-	virtual void agent_set_map(RID p_agent, RID p_map) override;
-	virtual RID agent_get_map(RID p_agent) const override;
-
 	virtual void agent_set_paused(RID p_agent, bool p_paused) override;
 	virtual bool agent_get_paused(RID p_agent) const override;
 
@@ -207,9 +202,6 @@ public:
 	virtual void agent_set_position(RID p_agent, Vector2 p_position) override;
 	virtual Vector2 agent_get_position(RID p_agent) const override;
 
-	/// Returns true if the map got changed the previous frame.
-	virtual bool agent_is_map_changed(RID p_agent) const override;
-
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override;
 	virtual bool agent_has_avoidance_callback(RID p_agent) const override;
@@ -222,12 +214,12 @@ public:
 
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override;
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const override;
+	virtual void agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) override;
+	virtual RID agent_get_avoidance_space(RID p_agent) const override;
 
 	virtual RID obstacle_create() override;
 	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override;
 	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const override;
-	virtual void obstacle_set_map(RID p_obstacle, RID p_map) override;
-	virtual RID obstacle_get_map(RID p_obstacle) const override;
 	virtual void obstacle_set_paused(RID p_obstacle, bool p_paused) override;
 	virtual bool obstacle_get_paused(RID p_obstacle) const override;
 	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) override;
@@ -240,6 +232,15 @@ public:
 	virtual Vector<Vector2> obstacle_get_vertices(RID p_obstacle) const override;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override;
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override;
+	virtual void obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) override;
+	virtual RID obstacle_get_avoidance_space(RID p_obstacle) const override;
+
+	virtual RID avoidance_space_create() override;
+	virtual uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const override;
+	virtual void avoidance_space_set_active(RID p_avoidance_space, bool p_active) override;
+	virtual bool avoidance_space_is_active(RID p_avoidance_space) const override;
+	virtual TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const override;
+	virtual TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const override;
 
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const override;
 
@@ -257,6 +258,18 @@ public:
 	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override;
 
 	virtual Vector<Vector2> simplify_path(const Vector<Vector2> &p_path, real_t p_epsilon) override;
+
+#ifndef DISABLE_DEPRECATED
+	virtual TypedArray<RID> map_get_agents(RID p_map) const override;
+	virtual TypedArray<RID> map_get_obstacles(RID p_map) const override;
+
+	virtual void agent_set_map(RID p_agent, RID p_map) override;
+	virtual RID agent_get_map(RID p_agent) const override;
+	virtual bool agent_is_map_changed(RID p_agent) const override;
+
+	virtual void obstacle_set_map(RID p_obstacle, RID p_map) override;
+	virtual RID obstacle_get_map(RID p_obstacle) const override;
+#endif // DISABLE_DEPRECATED
 };
 
 #endif // GODOT_NAVIGATION_SERVER_2D_H

--- a/modules/navigation/3d/godot_navigation_server_3d.h
+++ b/modules/navigation/3d/godot_navigation_server_3d.h
@@ -36,6 +36,7 @@
 #include "../nav_map.h"
 #include "../nav_obstacle.h"
 #include "../nav_region.h"
+#include "nav_avoidance_space_3d.h"
 
 #include "core/templates/local_vector.h"
 #include "core/templates/rid.h"
@@ -77,6 +78,9 @@ class GodotNavigationServer3D : public NavigationServer3D {
 	mutable RID_Owner<NavRegion> region_owner;
 	mutable RID_Owner<NavAgent> agent_owner;
 	mutable RID_Owner<NavObstacle> obstacle_owner;
+	mutable RID_Owner<NavAvoidanceSpace3D> avoidance_space_owner;
+
+	LocalVector<NavAvoidanceSpace3D *> active_avoidance_spaces;
 
 	bool active = true;
 	LocalVector<NavMap *> active_maps;
@@ -86,9 +90,9 @@ class GodotNavigationServer3D : public NavigationServer3D {
 	NavMeshGenerator3D *navmesh_generator_3d = nullptr;
 #endif // _3D_DISABLED
 
-	// Performance Monitor
 	int pm_region_count = 0;
 	int pm_agent_count = 0;
+	int pm_obstacle_count = 0;
 	int pm_link_count = 0;
 	int pm_polygon_count = 0;
 	int pm_edge_count = 0;
@@ -103,8 +107,10 @@ public:
 	void add_command(SetCommand *command);
 
 	virtual TypedArray<RID> get_maps() const override;
+	virtual TypedArray<RID> get_avoidance_spaces() const override;
 
 	virtual RID map_create() override;
+	virtual uint32_t map_get_iteration_id(RID p_map) const override;
 	COMMAND_2(map_set_active, RID, p_map, bool, p_active);
 	virtual bool map_is_active(RID p_map) const override;
 
@@ -138,11 +144,8 @@ public:
 
 	virtual TypedArray<RID> map_get_links(RID p_map) const override;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const override;
-	virtual TypedArray<RID> map_get_agents(RID p_map) const override;
-	virtual TypedArray<RID> map_get_obstacles(RID p_map) const override;
 
 	virtual void map_force_update(RID p_map) override;
-	virtual uint32_t map_get_iteration_id(RID p_map) const override;
 
 	virtual Vector3 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const override;
 
@@ -171,9 +174,6 @@ public:
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
 	virtual Transform3D region_get_transform(RID p_region) const override;
 	COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navigation_mesh);
-#ifndef DISABLE_DEPRECATED
-	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override;
-#endif // DISABLE_DEPRECATED
 	virtual int region_get_connections_count(RID p_region) const override;
 	virtual Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override;
 	virtual Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override;
@@ -204,8 +204,6 @@ public:
 	virtual bool agent_get_avoidance_enabled(RID p_agent) const override;
 	COMMAND_2(agent_set_use_3d_avoidance, RID, p_agent, bool, p_enabled);
 	virtual bool agent_get_use_3d_avoidance(RID p_agent) const override;
-	COMMAND_2(agent_set_map, RID, p_agent, RID, p_map);
-	virtual RID agent_get_map(RID p_agent) const override;
 	COMMAND_2(agent_set_paused, RID, p_agent, bool, p_paused);
 	virtual bool agent_get_paused(RID p_agent) const override;
 	COMMAND_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_distance);
@@ -227,7 +225,6 @@ public:
 	COMMAND_2(agent_set_velocity_forced, RID, p_agent, Vector3, p_velocity);
 	COMMAND_2(agent_set_position, RID, p_agent, Vector3, p_position);
 	virtual Vector3 agent_get_position(RID p_agent) const override;
-	virtual bool agent_is_map_changed(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_callback, RID, p_agent, Callable, p_callback);
 	virtual bool agent_has_avoidance_callback(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_layers, RID, p_agent, uint32_t, p_layers);
@@ -236,14 +233,14 @@ public:
 	virtual uint32_t agent_get_avoidance_mask(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority);
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const override;
+	COMMAND_2(agent_set_avoidance_space, RID, p_agent, RID, p_avoidance_space);
+	virtual RID agent_get_avoidance_space(RID p_agent) const override;
 
 	virtual RID obstacle_create() override;
 	COMMAND_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled);
 	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_use_3d_avoidance, RID, p_obstacle, bool, p_enabled);
 	virtual bool obstacle_get_use_3d_avoidance(RID p_obstacle) const override;
-	COMMAND_2(obstacle_set_map, RID, p_obstacle, RID, p_map);
-	virtual RID obstacle_get_map(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_paused, RID, p_obstacle, bool, p_paused);
 	virtual bool obstacle_get_paused(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius);
@@ -258,6 +255,15 @@ public:
 	virtual Vector<Vector3> obstacle_get_vertices(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers);
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override;
+	COMMAND_2(obstacle_set_avoidance_space, RID, p_obstacle, RID, p_avoidance_space);
+	virtual RID obstacle_get_avoidance_space(RID p_obstacle) const override;
+
+	virtual RID avoidance_space_create() override;
+	virtual uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const override;
+	COMMAND_2(avoidance_space_set_active, RID, p_avoidance_space, bool, p_active);
+	virtual bool avoidance_space_is_active(RID p_avoidance_space) const override;
+	virtual TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const override;
+	virtual TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const override;
 
 	virtual void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override;
 	virtual void bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;
@@ -288,9 +294,24 @@ public:
 
 	int get_process_info(ProcessInfo p_info) const override;
 
+#ifndef DISABLE_DEPRECATED
+	virtual TypedArray<RID> map_get_agents(RID p_map) const override;
+	virtual TypedArray<RID> map_get_obstacles(RID p_map) const override;
+
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override;
+
+	COMMAND_2(agent_set_map, RID, p_agent, RID, p_map);
+	virtual RID agent_get_map(RID p_agent) const override;
+	virtual bool agent_is_map_changed(RID p_agent) const override;
+
+	COMMAND_2(obstacle_set_map, RID, p_obstacle, RID, p_map);
+	virtual RID obstacle_get_map(RID p_obstacle) const override;
+#endif // DISABLE_DEPRECATED
+
 private:
 	void internal_free_agent(RID p_object);
 	void internal_free_obstacle(RID p_object);
+	void internal_free_avoidance_space(RID p_object);
 };
 
 #undef COMMAND_1

--- a/modules/navigation/3d/nav_avoidance_space_3d.cpp
+++ b/modules/navigation/3d/nav_avoidance_space_3d.cpp
@@ -1,0 +1,323 @@
+/**************************************************************************/
+/*  nav_avoidance_space_3d.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "nav_avoidance_space_3d.h"
+
+#include "core/config/project_settings.h"
+#include "core/object/worker_thread_pool.h"
+
+#include <Obstacle2d.h>
+
+bool NavAvoidanceSpace3D::use_threads = true;
+bool NavAvoidanceSpace3D::avoidance_use_multiple_threads = true;
+bool NavAvoidanceSpace3D::avoidance_use_high_priority_threads = true;
+
+bool NavAvoidanceSpace3D::has_agent(NavAgent *agent) const {
+	return agents.find(agent) >= 0;
+}
+
+void NavAvoidanceSpace3D::add_agent(NavAgent *agent) {
+	if (agent->get_paused()) {
+		// No point in adding a paused agent, it will add itself when unpaused again.
+		return;
+	}
+
+	if (!has_agent(agent)) {
+		agents.push_back(agent);
+		agents_dirty = true;
+	}
+
+	if (agent->get_use_3d_avoidance()) {
+		int64_t agent_3d_index = active_3d_avoidance_agents.find(agent);
+		if (agent_3d_index < 0) {
+			active_3d_avoidance_agents.push_back(agent);
+			agents_dirty = true;
+		}
+	} else {
+		int64_t agent_2d_index = active_2d_avoidance_agents.find(agent);
+		if (agent_2d_index < 0) {
+			active_2d_avoidance_agents.push_back(agent);
+			agents_dirty = true;
+		}
+	}
+}
+
+void NavAvoidanceSpace3D::remove_agent(NavAgent *agent) {
+	int64_t agent_index = agents.find(agent);
+	if (agent_index >= 0) {
+		agents.remove_at_unordered(agent_index);
+		agents_dirty = true;
+	}
+
+	int64_t agent_3d_index = active_3d_avoidance_agents.find(agent);
+	if (agent_3d_index >= 0) {
+		active_3d_avoidance_agents.remove_at_unordered(agent_3d_index);
+		agents_dirty = true;
+	}
+	int64_t agent_2d_index = active_2d_avoidance_agents.find(agent);
+	if (agent_2d_index >= 0) {
+		active_2d_avoidance_agents.remove_at_unordered(agent_2d_index);
+		agents_dirty = true;
+	}
+}
+
+bool NavAvoidanceSpace3D::has_obstacle(NavObstacle *obstacle) const {
+	return obstacles.find(obstacle) >= 0;
+}
+
+void NavAvoidanceSpace3D::add_obstacle(NavObstacle *obstacle) {
+	if (obstacle->get_paused()) {
+		// No point in adding a paused obstacle, it will add itself when unpaused again.
+		return;
+	}
+
+	if (!has_obstacle(obstacle)) {
+		obstacles.push_back(obstacle);
+		obstacles_dirty = true;
+	}
+}
+
+void NavAvoidanceSpace3D::remove_obstacle(NavObstacle *obstacle) {
+	int64_t obstacle_index = obstacles.find(obstacle);
+	if (obstacle_index >= 0) {
+		obstacles.remove_at_unordered(obstacle_index);
+		obstacles_dirty = true;
+	}
+}
+
+void NavAvoidanceSpace3D::sync() {
+	RWLockWrite write_lock(space_rwlock);
+
+	int _new_pm_agent_count = agents.size();
+	int _new_pm_obstacle_count = obstacles.size();
+
+	for (NavObstacle *obstacle : obstacles) {
+		if (obstacle->check_dirty()) {
+			obstacles_dirty = true;
+		}
+	}
+
+	for (NavAgent *agent : agents) {
+		if (agent->check_dirty()) {
+			agents_dirty = true;
+		}
+	}
+
+	if (obstacles_dirty || agents_dirty) {
+		_update_rvo_simulation();
+	}
+
+	agents_dirty = false;
+	obstacles_dirty = false;
+
+	pm_agent_count = _new_pm_agent_count;
+	pm_obstacle_count = _new_pm_obstacle_count;
+}
+
+void NavAvoidanceSpace3D::_update_rvo_obstacles_tree_2d() {
+	int obstacle_vertex_count = 0;
+	for (NavObstacle *obstacle : obstacles) {
+		obstacle_vertex_count += obstacle->get_vertices().size();
+	}
+
+	// Cleaning old obstacles.
+	for (size_t i = 0; i < rvo_simulation_2d.obstacles_.size(); ++i) {
+		delete rvo_simulation_2d.obstacles_[i];
+	}
+	rvo_simulation_2d.obstacles_.clear();
+
+	// Cannot use LocalVector here as RVO library expects std::vector to build KdTree
+	std::vector<RVO2D::Obstacle2D *> &raw_obstacles = rvo_simulation_2d.obstacles_;
+	raw_obstacles.reserve(obstacle_vertex_count);
+
+	// The following block is modified copy from RVO2D::AddObstacle()
+	// Obstacles are linked and depend on all other obstacles.
+	for (NavObstacle *obstacle : obstacles) {
+		const Vector3 &_obstacle_position = obstacle->get_position();
+		const Vector<Vector3> &_obstacle_vertices = obstacle->get_vertices();
+
+		if (_obstacle_vertices.size() < 2) {
+			continue;
+		}
+
+		std::vector<RVO2D::Vector2> rvo_2d_vertices;
+		rvo_2d_vertices.reserve(_obstacle_vertices.size());
+
+		uint32_t _obstacle_avoidance_layers = obstacle->get_avoidance_layers();
+		real_t _obstacle_height = obstacle->get_height();
+
+		for (const Vector3 &_obstacle_vertex : _obstacle_vertices) {
+#ifdef TOOLS_ENABLED
+			if (_obstacle_vertex.y != 0) {
+				WARN_PRINT_ONCE("Y coordinates of static obstacle vertices are ignored. Please use obstacle position Y to change elevation of obstacle.");
+			}
+#endif
+			rvo_2d_vertices.push_back(RVO2D::Vector2(_obstacle_vertex.x + _obstacle_position.x, _obstacle_vertex.z + _obstacle_position.z));
+		}
+
+		const size_t obstacleNo = raw_obstacles.size();
+
+		for (size_t i = 0; i < rvo_2d_vertices.size(); i++) {
+			RVO2D::Obstacle2D *rvo_2d_obstacle = new RVO2D::Obstacle2D();
+			rvo_2d_obstacle->point_ = rvo_2d_vertices[i];
+			rvo_2d_obstacle->height_ = _obstacle_height;
+			rvo_2d_obstacle->elevation_ = _obstacle_position.y;
+
+			rvo_2d_obstacle->avoidance_layers_ = _obstacle_avoidance_layers;
+
+			if (i != 0) {
+				rvo_2d_obstacle->prevObstacle_ = raw_obstacles.back();
+				rvo_2d_obstacle->prevObstacle_->nextObstacle_ = rvo_2d_obstacle;
+			}
+
+			if (i == rvo_2d_vertices.size() - 1) {
+				rvo_2d_obstacle->nextObstacle_ = raw_obstacles[obstacleNo];
+				rvo_2d_obstacle->nextObstacle_->prevObstacle_ = rvo_2d_obstacle;
+			}
+
+			rvo_2d_obstacle->unitDir_ = normalize(rvo_2d_vertices[(i == rvo_2d_vertices.size() - 1 ? 0 : i + 1)] - rvo_2d_vertices[i]);
+
+			if (rvo_2d_vertices.size() == 2) {
+				rvo_2d_obstacle->isConvex_ = true;
+			} else {
+				rvo_2d_obstacle->isConvex_ = (leftOf(rvo_2d_vertices[(i == 0 ? rvo_2d_vertices.size() - 1 : i - 1)], rvo_2d_vertices[i], rvo_2d_vertices[(i == rvo_2d_vertices.size() - 1 ? 0 : i + 1)]) >= 0.0f);
+			}
+
+			rvo_2d_obstacle->id_ = raw_obstacles.size();
+
+			raw_obstacles.push_back(rvo_2d_obstacle);
+		}
+	}
+
+	rvo_simulation_2d.kdTree_->buildObstacleTree(raw_obstacles);
+}
+
+void NavAvoidanceSpace3D::_update_rvo_agents_tree_2d() {
+	// Cannot use LocalVector here as RVO library expects std::vector to build KdTree.
+	std::vector<RVO2D::Agent2D *> raw_agents;
+	raw_agents.reserve(active_2d_avoidance_agents.size());
+	for (NavAgent *agent : active_2d_avoidance_agents) {
+		raw_agents.push_back(agent->get_rvo_agent_2d());
+	}
+	rvo_simulation_2d.kdTree_->buildAgentTree(raw_agents);
+}
+
+void NavAvoidanceSpace3D::_update_rvo_agents_tree_3d() {
+	// Cannot use LocalVector here as RVO library expects std::vector to build KdTree.
+	std::vector<RVO3D::Agent3D *> raw_agents;
+	raw_agents.reserve(active_3d_avoidance_agents.size());
+	for (NavAgent *agent : active_3d_avoidance_agents) {
+		raw_agents.push_back(agent->get_rvo_agent_3d());
+	}
+	rvo_simulation_3d.kdTree_->buildAgentTree(raw_agents);
+}
+
+void NavAvoidanceSpace3D::_update_rvo_simulation() {
+	if (obstacles_dirty) {
+		_update_rvo_obstacles_tree_2d();
+	}
+	if (agents_dirty) {
+		_update_rvo_agents_tree_2d();
+		_update_rvo_agents_tree_3d();
+	}
+}
+
+void NavAvoidanceSpace3D::compute_single_avoidance_step_2d(uint32_t index, NavAgent **agent) {
+	NavAgent *nav_agent = (*(agent + index));
+	nav_agent->get_rvo_agent_2d()->computeNeighbors(&rvo_simulation_2d);
+	nav_agent->get_rvo_agent_2d()->computeNewVelocity(&rvo_simulation_2d);
+	nav_agent->get_rvo_agent_2d()->update(&rvo_simulation_2d);
+	nav_agent->update();
+}
+
+void NavAvoidanceSpace3D::compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent) {
+	NavAgent *nav_agent = (*(agent + index));
+	nav_agent->get_rvo_agent_3d()->computeNeighbors(&rvo_simulation_3d);
+	nav_agent->get_rvo_agent_3d()->computeNewVelocity(&rvo_simulation_3d);
+	nav_agent->get_rvo_agent_3d()->update(&rvo_simulation_3d);
+	nav_agent->update();
+}
+
+void NavAvoidanceSpace3D::step(real_t p_deltatime) {
+	RWLockWrite write_lock(space_rwlock);
+
+	deltatime = p_deltatime;
+
+	rvo_simulation_2d.setTimeStep(float(deltatime));
+	rvo_simulation_3d.setTimeStep(float(deltatime));
+
+	if (active_2d_avoidance_agents.size() > 0) {
+		if (use_threads && avoidance_use_multiple_threads) {
+			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavAvoidanceSpace3D::compute_single_avoidance_step_2d, active_2d_avoidance_agents.ptr(), active_2d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents2D"));
+			WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+		} else {
+			for (NavAgent *agent : active_2d_avoidance_agents) {
+				agent->get_rvo_agent_2d()->computeNeighbors(&rvo_simulation_2d);
+				agent->get_rvo_agent_2d()->computeNewVelocity(&rvo_simulation_2d);
+				agent->get_rvo_agent_2d()->update(&rvo_simulation_2d);
+				agent->update();
+			}
+		}
+	}
+
+	if (active_3d_avoidance_agents.size() > 0) {
+		if (use_threads && avoidance_use_multiple_threads) {
+			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavAvoidanceSpace3D::compute_single_avoidance_step_3d, active_3d_avoidance_agents.ptr(), active_3d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents3D"));
+			WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+		} else {
+			for (NavAgent *agent : active_3d_avoidance_agents) {
+				agent->get_rvo_agent_3d()->computeNeighbors(&rvo_simulation_3d);
+				agent->get_rvo_agent_3d()->computeNewVelocity(&rvo_simulation_3d);
+				agent->get_rvo_agent_3d()->update(&rvo_simulation_3d);
+				agent->update();
+			}
+		}
+	}
+
+	iteration_id = iteration_id % UINT32_MAX + 1;
+}
+
+void NavAvoidanceSpace3D::dispatch_callbacks() {
+	for (NavAgent *agent : active_2d_avoidance_agents) {
+		agent->dispatch_avoidance_callback();
+	}
+
+	for (NavAgent *agent : active_3d_avoidance_agents) {
+		agent->dispatch_avoidance_callback();
+	}
+}
+
+NavAvoidanceSpace3D::NavAvoidanceSpace3D() {
+	avoidance_use_multiple_threads = GLOBAL_GET("navigation/avoidance/thread_model/avoidance_use_multiple_threads");
+	avoidance_use_high_priority_threads = GLOBAL_GET("navigation/avoidance/thread_model/avoidance_use_high_priority_threads");
+}
+
+NavAvoidanceSpace3D::~NavAvoidanceSpace3D() {
+}

--- a/modules/navigation/3d/nav_avoidance_space_3d.h
+++ b/modules/navigation/3d/nav_avoidance_space_3d.h
@@ -1,0 +1,107 @@
+/**************************************************************************/
+/*  nav_avoidance_space_3d.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NAV_AVOIDANCE_SPACE_3D_H
+#define NAV_AVOIDANCE_SPACE_3D_H
+
+#include "../nav_agent.h"
+#include "../nav_obstacle.h"
+#include "../nav_rid.h"
+#include "../nav_utils.h"
+
+#include "core/math/math_defs.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/rw_lock.h"
+
+#include "servers/navigation_server_3d.h"
+
+#include <KdTree2d.h>
+#include <KdTree3d.h>
+#include <RVOSimulator2d.h>
+#include <RVOSimulator3d.h>
+
+class NavAvoidanceSpace3D : public NavRid {
+	RWLock space_rwlock;
+
+	bool obstacles_dirty = false;
+	bool agents_dirty = false;
+
+	uint32_t iteration_id = 0;
+
+	RVO2D::RVOSimulator2D rvo_simulation_2d;
+	RVO3D::RVOSimulator3D rvo_simulation_3d;
+
+	LocalVector<NavAgent *> active_2d_avoidance_agents;
+	LocalVector<NavAgent *> active_3d_avoidance_agents;
+
+	LocalVector<NavAgent *> agents;
+	LocalVector<NavObstacle *> obstacles;
+	real_t deltatime = 0.0;
+
+	static bool use_threads;
+	static bool avoidance_use_multiple_threads;
+	static bool avoidance_use_high_priority_threads;
+
+	int pm_agent_count = 0;
+	int pm_obstacle_count = 0;
+
+	void compute_single_step(uint32_t index, NavAgent **agent);
+	void compute_single_avoidance_step_2d(uint32_t index, NavAgent **agent);
+	void compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent);
+	void _update_rvo_simulation();
+	void _update_rvo_obstacles_tree_2d();
+	void _update_rvo_agents_tree_2d();
+	void _update_rvo_agents_tree_3d();
+
+public:
+	uint32_t get_iteration_id() { return iteration_id; };
+
+	bool has_agent(NavAgent *agent) const;
+	void add_agent(NavAgent *agent);
+	void remove_agent(NavAgent *agent);
+	const LocalVector<NavAgent *> &get_agents() const { return agents; }
+
+	bool has_obstacle(NavObstacle *obstacle) const;
+	void add_obstacle(NavObstacle *obstacle);
+	void remove_obstacle(NavObstacle *obstacle);
+	const LocalVector<NavObstacle *> &get_obstacles() const { return obstacles; }
+
+	void sync();
+	void step(real_t p_deltatime);
+	void dispatch_callbacks();
+
+	int get_pm_agent_count() const { return pm_agent_count; }
+	int get_pm_obstacle_count() const { return pm_obstacle_count; }
+
+	NavAvoidanceSpace3D();
+	~NavAvoidanceSpace3D();
+};
+
+#endif // NAV_AVOIDANCE_SPACE_3D_H

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -77,6 +77,7 @@ env_navigation.add_source_files(module_obj, "*.cpp")
 env_navigation.add_source_files(module_obj, "2d/*.cpp")
 if not env["disable_3d"]:
     env_navigation.add_source_files(module_obj, "3d/*.cpp")
+env_navigation.add_source_files(module_obj, "avoidance/*.cpp")
 if env.editor_build:
     env_navigation.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj

--- a/modules/navigation/nav_agent.h
+++ b/modules/navigation/nav_agent.h
@@ -40,6 +40,7 @@
 #include <Agent3d.h>
 
 class NavMap;
+class NavAvoidanceSpace3D;
 
 class NavAgent : public NavRid {
 	Vector3 position;
@@ -56,7 +57,7 @@ class NavAgent : public NavRid {
 	Vector3 safe_velocity;
 	bool clamp_speed = true; // Experimental, clamps velocity to max_speed.
 
-	NavMap *map = nullptr;
+	NavAvoidanceSpace3D *avoidance_space = nullptr;
 
 	RVO2D::Agent2D rvo_agent_2d;
 	RVO3D::Agent3D rvo_agent_3d;
@@ -71,7 +72,6 @@ class NavAgent : public NavRid {
 
 	bool agent_dirty = true;
 
-	uint32_t last_map_iteration_id = 0;
 	bool paused = false;
 
 public:
@@ -83,10 +83,8 @@ public:
 	void set_use_3d_avoidance(bool p_enabled);
 	bool get_use_3d_avoidance() { return use_3d_avoidance; }
 
-	void set_map(NavMap *p_map);
-	NavMap *get_map() { return map; }
-
-	bool is_map_changed();
+	void set_avoidance_space(NavAvoidanceSpace3D *p_avoidance_space);
+	NavAvoidanceSpace3D *get_avoidance_space() { return avoidance_space; }
 
 	RVO2D::Agent2D *get_rvo_agent_2d() { return &rvo_agent_2d; }
 	RVO3D::Agent3D *get_rvo_agent_3d() { return &rvo_agent_3d; }

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -37,15 +37,8 @@
 #include "core/math/math_defs.h"
 #include "core/object/worker_thread_pool.h"
 
-#include <KdTree2d.h>
-#include <KdTree3d.h>
-#include <RVOSimulator2d.h>
-#include <RVOSimulator3d.h>
-
 class NavLink;
 class NavRegion;
-class NavAgent;
-class NavObstacle;
 
 class NavMap : public NavRid {
 	RWLock map_rwlock;
@@ -84,39 +77,11 @@ class NavMap : public NavRid {
 	/// Map polygons
 	LocalVector<gd::Polygon> polygons;
 
-	/// RVO avoidance worlds
-	RVO2D::RVOSimulator2D rvo_simulation_2d;
-	RVO3D::RVOSimulator3D rvo_simulation_3d;
-
-	/// avoidance controlled agents
-	LocalVector<NavAgent *> active_2d_avoidance_agents;
-	LocalVector<NavAgent *> active_3d_avoidance_agents;
-
-	/// dirty flag when one of the agent's arrays are modified
-	bool agents_dirty = true;
-
-	/// All the Agents (even the controlled one)
-	LocalVector<NavAgent *> agents;
-
-	/// All the avoidance obstacles (both static and dynamic)
-	LocalVector<NavObstacle *> obstacles;
-
-	/// Are rvo obstacles modified?
-	bool obstacles_dirty = true;
-
-	/// Physics delta time
-	real_t deltatime = 0.0;
-
 	/// Change the id each time the map is updated.
 	uint32_t iteration_id = 0;
 
-	bool use_threads = true;
-	bool avoidance_use_multiple_threads = true;
-	bool avoidance_use_high_priority_threads = true;
-
 	// Performance Monitor
 	int pm_region_count = 0;
-	int pm_agent_count = 0;
 	int pm_link_count = 0;
 	int pm_polygon_count = 0;
 	int pm_edge_count = 0;
@@ -127,8 +92,6 @@ class NavMap : public NavRid {
 public:
 	NavMap();
 	~NavMap();
-
-	uint32_t get_iteration_id() const { return iteration_id; }
 
 	void set_up(Vector3 p_up);
 	Vector3 get_up() const {
@@ -184,32 +147,15 @@ public:
 		return links;
 	}
 
-	bool has_agent(NavAgent *agent) const;
-	void add_agent(NavAgent *agent);
-	void remove_agent(NavAgent *agent);
-	const LocalVector<NavAgent *> &get_agents() const {
-		return agents;
-	}
-
-	void set_agent_as_controlled(NavAgent *agent);
-	void remove_agent_as_controlled(NavAgent *agent);
-
-	bool has_obstacle(NavObstacle *obstacle) const;
-	void add_obstacle(NavObstacle *obstacle);
-	void remove_obstacle(NavObstacle *obstacle);
-	const LocalVector<NavObstacle *> &get_obstacles() const {
-		return obstacles;
-	}
+	uint32_t get_iteration_id() const { return iteration_id; }
 
 	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
 	void sync();
-	void step(real_t p_deltatime);
 	void dispatch_callbacks();
 
 	// Performance Monitor
 	int get_pm_region_count() const { return pm_region_count; }
-	int get_pm_agent_count() const { return pm_agent_count; }
 	int get_pm_link_count() const { return pm_link_count; }
 	int get_pm_polygon_count() const { return pm_polygon_count; }
 	int get_pm_edge_count() const { return pm_edge_count; }
@@ -218,16 +164,7 @@ public:
 	int get_pm_edge_free_count() const { return pm_edge_free_count; }
 
 private:
-	void compute_single_step(uint32_t index, NavAgent **agent);
-
-	void compute_single_avoidance_step_2d(uint32_t index, NavAgent **agent);
-	void compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent);
-
 	void clip_path(const LocalVector<gd::NavigationPoly> &p_navigation_polys, Vector<Vector3> &path, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly, Vector<int32_t> *r_path_types, TypedArray<RID> *r_path_rids, Vector<int64_t> *r_path_owners) const;
-	void _update_rvo_simulation();
-	void _update_rvo_obstacles_tree_2d();
-	void _update_rvo_agents_tree_2d();
-	void _update_rvo_agents_tree_3d();
 
 	void _update_merge_rasterizer_cell_dimensions();
 };

--- a/modules/navigation/nav_obstacle.cpp
+++ b/modules/navigation/nav_obstacle.cpp
@@ -30,6 +30,7 @@
 
 #include "nav_obstacle.h"
 
+#include "3d/nav_avoidance_space_3d.h"
 #include "nav_agent.h"
 #include "nav_map.h"
 
@@ -71,23 +72,23 @@ void NavObstacle::set_use_3d_avoidance(bool p_enabled) {
 	}
 }
 
-void NavObstacle::set_map(NavMap *p_map) {
-	if (map == p_map) {
+void NavObstacle::set_avoidance_space(NavAvoidanceSpace3D *p_avoidance_space) {
+	if (avoidance_space == p_avoidance_space) {
 		return;
 	}
 
-	if (map) {
-		map->remove_obstacle(this);
+	if (avoidance_space) {
+		avoidance_space->remove_obstacle(this);
 		if (agent) {
-			agent->set_map(nullptr);
+			agent->set_avoidance_space(nullptr);
 		}
 	}
 
-	map = p_map;
+	avoidance_space = p_avoidance_space;
 	obstacle_dirty = true;
 
-	if (map) {
-		map->add_obstacle(this);
+	if (avoidance_space) {
+		avoidance_space->add_obstacle(this);
 		internal_update_agent();
 	}
 }
@@ -147,16 +148,6 @@ void NavObstacle::set_vertices(const Vector<Vector3> &p_vertices) {
 	obstacle_dirty = true;
 }
 
-bool NavObstacle::is_map_changed() {
-	if (map) {
-		bool is_changed = map->get_iteration_id() != last_map_iteration_id;
-		last_map_iteration_id = map->get_iteration_id();
-		return is_changed;
-	} else {
-		return false;
-	}
-}
-
 void NavObstacle::set_avoidance_layers(uint32_t p_layers) {
 	if (avoidance_layers == p_layers) {
 		return;
@@ -185,7 +176,7 @@ void NavObstacle::internal_update_agent() {
 		agent->set_avoidance_mask(0.0);
 		agent->set_neighbor_distance(0.0);
 		agent->set_avoidance_priority(1.0);
-		agent->set_map(map);
+		agent->set_avoidance_space(avoidance_space);
 		agent->set_paused(paused);
 		agent->set_radius(radius);
 		agent->set_height(height);
@@ -203,11 +194,11 @@ void NavObstacle::set_paused(bool p_paused) {
 
 	paused = p_paused;
 
-	if (map) {
+	if (avoidance_space) {
 		if (paused) {
-			map->remove_obstacle(this);
+			avoidance_space->remove_obstacle(this);
 		} else {
-			map->add_obstacle(this);
+			avoidance_space->add_obstacle(this);
 		}
 	}
 	internal_update_agent();

--- a/modules/navigation/nav_obstacle.h
+++ b/modules/navigation/nav_obstacle.h
@@ -38,10 +38,11 @@
 
 class NavAgent;
 class NavMap;
+class NavAvoidanceSpace3D;
 
 class NavObstacle : public NavRid {
 	NavAgent *agent = nullptr;
-	NavMap *map = nullptr;
+	NavAvoidanceSpace3D *avoidance_space = nullptr;
 	Vector3 velocity;
 	Vector3 position;
 	Vector<Vector3> vertices;
@@ -55,7 +56,6 @@ class NavObstacle : public NavRid {
 
 	bool obstacle_dirty = true;
 
-	uint32_t last_map_iteration_id = 0;
 	bool paused = false;
 
 public:
@@ -67,9 +67,6 @@ public:
 
 	void set_use_3d_avoidance(bool p_enabled);
 	bool get_use_3d_avoidance() { return use_3d_avoidance; }
-
-	void set_map(NavMap *p_map);
-	NavMap *get_map() { return map; }
 
 	void set_agent(NavAgent *p_agent);
 	NavAgent *get_agent() { return agent; }
@@ -89,8 +86,6 @@ public:
 	void set_vertices(const Vector<Vector3> &p_vertices);
 	const Vector<Vector3> &get_vertices() const { return vertices; }
 
-	bool is_map_changed();
-
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const { return avoidance_layers; };
 
@@ -98,6 +93,9 @@ public:
 	bool get_paused() const;
 
 	bool check_dirty();
+
+	void set_avoidance_space(NavAvoidanceSpace3D *p_avoidance_space);
+	NavAvoidanceSpace3D *get_avoidance_space() { return avoidance_space; }
 
 private:
 	void internal_update_agent();

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -44,6 +44,7 @@ class NavigationAgent2D : public Node {
 
 	RID agent;
 	RID map_override;
+	RID avoidance_space_override;
 
 	bool avoidance_enabled = false;
 	uint32_t avoidance_layers = 1;
@@ -93,6 +94,7 @@ class NavigationAgent2D : public Node {
 	bool last_waypoint_reached = false;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	uint32_t last_map_iteration_id = 0;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;
@@ -209,6 +211,9 @@ public:
 	void _avoidance_done(Vector3 p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
+
+	void set_avoidance_space(RID p_avoidance_space);
+	RID get_avoidance_space() const;
 
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const;

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -41,8 +41,10 @@ void NavigationObstacle2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_avoidance_enabled", "enabled"), &NavigationObstacle2D::set_avoidance_enabled);
 	ClassDB::bind_method(D_METHOD("get_avoidance_enabled"), &NavigationObstacle2D::get_avoidance_enabled);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &NavigationObstacle2D::set_navigation_map);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &NavigationObstacle2D::get_navigation_map);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &NavigationObstacle2D::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &NavigationObstacle2D::get_radius);
@@ -65,6 +67,9 @@ void NavigationObstacle2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_carve_navigation_mesh", "enabled"), &NavigationObstacle2D::set_carve_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_carve_navigation_mesh"), &NavigationObstacle2D::get_carve_navigation_mesh);
 
+	ClassDB::bind_method(D_METHOD("set_avoidance_space", "avoidance_space"), &NavigationObstacle2D::set_avoidance_space);
+	ClassDB::bind_method(D_METHOD("get_avoidance_space"), &NavigationObstacle2D::get_avoidance_space);
+
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.0,500,0.01,suffix:px"), "set_radius", "get_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
 	ADD_GROUP("NavigationMesh", "");
@@ -79,121 +84,63 @@ void NavigationObstacle2D::_bind_methods() {
 void NavigationObstacle2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
-			if (map_override.is_valid()) {
-				_update_map(map_override);
-			} else if (is_inside_tree()) {
-				_update_map(get_world_2d()->get_navigation_map());
-			} else {
-				_update_map(RID());
-			}
-			previous_transform = get_global_transform();
-			// need to trigger map controlled agent assignment somehow for the fake_agent since obstacles use no callback like regular agents
-			NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
-			_update_position(get_global_position());
-			set_physics_process_internal(true);
-#ifdef DEBUG_ENABLED
-			RS::get_singleton()->canvas_item_set_parent(debug_canvas_item, get_world_2d()->get_canvas());
-#endif // DEBUG_ENABLED
+			_obstacle_enter_tree();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			set_physics_process_internal(false);
-			_update_map(RID());
-#ifdef DEBUG_ENABLED
-			RS::get_singleton()->canvas_item_set_parent(debug_canvas_item, RID());
-#endif // DEBUG_ENABLED
+			_obstacle_exit_tree();
 		} break;
 
-		case NOTIFICATION_PAUSED: {
-			if (!can_process()) {
-				map_before_pause = map_current;
-				_update_map(RID());
-			} else if (can_process() && !(map_before_pause == RID())) {
-				_update_map(map_before_pause);
-				map_before_pause = RID();
-			}
-			NavigationServer2D::get_singleton()->obstacle_set_paused(obstacle, !can_process());
-		} break;
-
+		case NOTIFICATION_PAUSED:
 		case NOTIFICATION_UNPAUSED: {
-			if (!can_process()) {
-				map_before_pause = map_current;
-				_update_map(RID());
-			} else if (can_process() && !(map_before_pause == RID())) {
-				_update_map(map_before_pause);
-				map_before_pause = RID();
-			}
 			NavigationServer2D::get_singleton()->obstacle_set_paused(obstacle, !can_process());
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 #ifdef DEBUG_ENABLED
-			RS::get_singleton()->canvas_item_set_visible(debug_canvas_item, is_visible_in_tree());
+			if (debug_canvas_item.is_valid()) {
+				RS::get_singleton()->canvas_item_set_visible(debug_canvas_item, is_visible_in_tree());
+			}
 #endif // DEBUG_ENABLED
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (is_inside_tree()) {
-				_update_position(get_global_position());
-
-				if (velocity_submitted) {
-					velocity_submitted = false;
-					// only update if there is a noticeable change, else the rvo agent preferred velocity stays the same
-					if (!previous_velocity.is_equal_approx(velocity)) {
-						NavigationServer2D::get_singleton()->obstacle_set_velocity(obstacle, velocity);
-					}
-					previous_velocity = velocity;
-				}
-			}
+			_obstacle_physics_process();
 		} break;
 
 		case NOTIFICATION_DRAW: {
 #ifdef DEBUG_ENABLED
-			if (is_inside_tree()) {
-				bool is_debug_enabled = false;
-				if (Engine::get_singleton()->is_editor_hint()) {
-					is_debug_enabled = true;
-				} else if (NavigationServer2D::get_singleton()->get_debug_enabled() && NavigationServer2D::get_singleton()->get_debug_avoidance_enabled()) {
-					is_debug_enabled = true;
-				}
-
-				if (is_debug_enabled) {
-					RS::get_singleton()->canvas_item_clear(debug_canvas_item);
-					Transform2D debug_transform = Transform2D(0.0, get_global_position());
-					RS::get_singleton()->canvas_item_set_transform(debug_canvas_item, debug_transform);
-					_update_fake_agent_radius_debug();
-					_update_static_obstacle_debug();
-				}
-			}
+			_obstacle_debug_update();
 #endif // DEBUG_ENABLED
 		} break;
 	}
 }
 
 NavigationObstacle2D::NavigationObstacle2D() {
-	obstacle = NavigationServer2D::get_singleton()->obstacle_create();
+	NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
 
-	NavigationServer2D::get_singleton()->obstacle_set_radius(obstacle, radius);
-	NavigationServer2D::get_singleton()->obstacle_set_vertices(obstacle, vertices);
-	NavigationServer2D::get_singleton()->obstacle_set_avoidance_layers(obstacle, avoidance_layers);
-	NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
+	obstacle = ns2d->obstacle_create();
+
+	ns2d->obstacle_set_radius(obstacle, radius);
+	ns2d->obstacle_set_vertices(obstacle, vertices);
+	ns2d->obstacle_set_avoidance_layers(obstacle, avoidance_layers);
+	ns2d->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
 
 #ifdef DEBUG_ENABLED
-	debug_canvas_item = RenderingServer::get_singleton()->canvas_item_create();
+	ns2d->connect("avoidance_debug_changed", callable_mp((CanvasItem *)this, &NavigationObstacle2D::queue_redraw));
 #endif // DEBUG_ENABLED
 }
 
 NavigationObstacle2D::~NavigationObstacle2D() {
-	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
+	NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
+	ERR_FAIL_NULL(ns2d);
 
-	NavigationServer2D::get_singleton()->free(obstacle);
+	ns2d->free(obstacle);
 	obstacle = RID();
 
 #ifdef DEBUG_ENABLED
-	if (debug_canvas_item.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_canvas_item);
-		debug_canvas_item = RID();
-	}
+	ns2d->disconnect("avoidance_debug_changed", callable_mp((CanvasItem *)this, &NavigationObstacle2D::queue_redraw));
+	_obstacle_debug_free();
 #endif // DEBUG_ENABLED
 }
 
@@ -205,19 +152,24 @@ void NavigationObstacle2D::set_vertices(const Vector<Vector2> &p_vertices) {
 #endif // DEBUG_ENABLED
 }
 
-void NavigationObstacle2D::set_navigation_map(RID p_navigation_map) {
-	if (map_override == p_navigation_map) {
+void NavigationObstacle2D::set_avoidance_space(RID p_avoidance_space) {
+	if (avoidance_space_override == p_avoidance_space) {
 		return;
 	}
-	map_override = p_navigation_map;
-	_update_map(map_override);
+
+	avoidance_space_override = p_avoidance_space;
+
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_space(obstacle, get_avoidance_space());
 }
 
-RID NavigationObstacle2D::get_navigation_map() const {
-	if (map_override.is_valid()) {
-		return map_override;
+RID NavigationObstacle2D::get_avoidance_space() const {
+	if (!avoidance_enabled) {
+		return RID();
+	}
+	if (avoidance_space_override.is_valid()) {
+		return avoidance_space_override;
 	} else if (is_inside_tree()) {
-		return get_world_2d()->get_navigation_map();
+		return get_world_2d()->get_avoidance_space();
 	}
 	return RID();
 }
@@ -303,39 +255,121 @@ bool NavigationObstacle2D::get_carve_navigation_mesh() const {
 	return carve_navigation_mesh;
 }
 
-void NavigationObstacle2D::_update_map(RID p_map) {
-	map_current = p_map;
-	NavigationServer2D::get_singleton()->obstacle_set_map(obstacle, p_map);
-}
-
 void NavigationObstacle2D::_update_position(const Vector2 p_position) {
 	NavigationServer2D::get_singleton()->obstacle_set_position(obstacle, p_position);
+#ifdef DEBUG_ENABLED
+	if (debug_canvas_item.is_valid()) {
+		Transform2D debug_transform = Transform2D(0.0, get_global_position());
+		RenderingServer::get_singleton()->canvas_item_set_transform(debug_canvas_item, debug_transform);
+	}
+#endif // DEBUG_ENABLED
+}
+
+void NavigationObstacle2D::_update_avoidance_space(RID p_avoidance_space) {
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_space(obstacle, get_avoidance_space());
+}
+
+void NavigationObstacle2D::_obstacle_enter_tree() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	previous_transform = get_global_transform();
+
+	// Need to trigger map controlled agent assignment somehow for the fake_agent since obstacles use no callback like regular agents.
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_space(obstacle, get_avoidance_space());
+
+	_update_position(get_global_position());
+	set_physics_process_internal(true);
+#ifdef DEBUG_ENABLED
+	queue_redraw();
+#endif // DEBUG_ENABLED
+}
+
+void NavigationObstacle2D::_obstacle_exit_tree() {
+	set_physics_process_internal(false);
+	_update_avoidance_space(RID());
+#ifdef DEBUG_ENABLED
+	_obstacle_debug_free();
+#endif // DEBUG_ENABLED
+}
+
+void NavigationObstacle2D::_obstacle_physics_process() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	_update_position(get_global_position());
+
+	if (velocity_submitted) {
+		velocity_submitted = false;
+		// Only update if there is a noticeable change, else the rvo agent preferred velocity stays the same.
+		if (!previous_velocity.is_equal_approx(velocity)) {
+			NavigationServer2D::get_singleton()->obstacle_set_velocity(obstacle, velocity);
+		}
+		previous_velocity = velocity;
+	}
+
 #ifdef DEBUG_ENABLED
 	queue_redraw();
 #endif // DEBUG_ENABLED
 }
 
 #ifdef DEBUG_ENABLED
-void NavigationObstacle2D::_update_fake_agent_radius_debug() {
-	if (radius > 0.0 && NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_radius()) {
-		Color debug_radius_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_color();
+void NavigationObstacle2D::_obstacle_debug_update() {
+	NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
+	bool is_debug_enabled = false;
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		is_debug_enabled = true;
+	} else if (ns2d->get_debug_enabled() && ns2d->get_debug_avoidance_enabled()) {
+		is_debug_enabled = true;
+	}
+
+	RenderingServer *rs = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rs);
+
+	if (debug_canvas_item.is_null()) {
+		debug_canvas_item = rs->canvas_item_create();
+	}
+
+	rs->canvas_item_clear(debug_canvas_item);
+
+	if (!is_debug_enabled) {
+		if (debug_canvas_item.is_valid()) {
+			rs->free(debug_canvas_item);
+			debug_canvas_item = RID();
+		}
+		return;
+	}
+
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	rs->canvas_item_set_parent(debug_canvas_item, get_canvas());
+	rs->canvas_item_set_z_index(debug_canvas_item, RS::CANVAS_ITEM_Z_MAX - 1);
+	rs->canvas_item_set_visible(debug_canvas_item, is_visible_in_tree());
+
+	Transform2D debug_transform = Transform2D(0.0, get_global_position());
+	rs->canvas_item_set_transform(debug_canvas_item, debug_transform);
+
+	if (radius > 0.0 && ns2d->get_debug_navigation_avoidance_enable_obstacles_radius()) {
+		Color debug_radius_color = ns2d->get_debug_navigation_avoidance_obstacles_radius_color();
 
 		RS::get_singleton()->canvas_item_add_circle(debug_canvas_item, Vector2(), radius, debug_radius_color);
 	}
-}
-#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_ENABLED
-void NavigationObstacle2D::_update_static_obstacle_debug() {
-	if (get_vertices().size() > 2 && NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_static()) {
+	if (get_vertices().size() > 2 && ns2d->get_debug_navigation_avoidance_enable_obstacles_static()) {
 		bool obstacle_pushes_inward = Geometry2D::is_polygon_clockwise(get_vertices());
 
 		Color debug_static_obstacle_face_color;
 
 		if (obstacle_pushes_inward) {
-			debug_static_obstacle_face_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushin_face_color();
+			debug_static_obstacle_face_color = ns2d->get_debug_navigation_avoidance_static_obstacle_pushin_face_color();
 		} else {
-			debug_static_obstacle_face_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushout_face_color();
+			debug_static_obstacle_face_color = ns2d->get_debug_navigation_avoidance_static_obstacle_pushout_face_color();
 		}
 
 		Vector<Vector2> debug_obstacle_polygon_vertices = get_vertices();
@@ -349,9 +383,9 @@ void NavigationObstacle2D::_update_static_obstacle_debug() {
 		Color debug_static_obstacle_edge_color;
 
 		if (obstacle_pushes_inward) {
-			debug_static_obstacle_edge_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color();
+			debug_static_obstacle_edge_color = ns2d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color();
 		} else {
-			debug_static_obstacle_edge_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color();
+			debug_static_obstacle_edge_color = ns2d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color();
 		}
 
 		Vector<Vector2> debug_obstacle_line_vertices = get_vertices();
@@ -366,3 +400,25 @@ void NavigationObstacle2D::_update_static_obstacle_debug() {
 	}
 }
 #endif // DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+void NavigationObstacle2D::_obstacle_debug_free() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rs);
+
+	if (debug_canvas_item.is_valid()) {
+		rs->free(debug_canvas_item);
+		debug_canvas_item = RID();
+	}
+}
+#endif // DEBUG_ENABLED
+
+#ifndef DISABLE_DEPRECATED
+void NavigationObstacle2D::set_navigation_map(RID p_navigation_map) {
+	WARN_PRINT_ONCE("An Obstacle is no longer an assigned part of a navigation map. See 'set_avoidance_space()' to set the obstacle's avoidance space.");
+};
+RID NavigationObstacle2D::get_navigation_map() const {
+	WARN_PRINT_ONCE("An Obstacle is no longer an assigned part of a navigation map. See 'get_avoidance_space()' to get the obstacle's avoidance space.");
+	return RID();
+};
+#endif // DISABLE_DEPRECATED

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -37,9 +37,9 @@ class NavigationObstacle2D : public Node2D {
 	GDCLASS(NavigationObstacle2D, Node2D);
 
 	RID obstacle;
-	RID map_before_pause;
 	RID map_override;
-	RID map_current;
+
+	RID avoidance_space_override;
 
 	real_t radius = 0.0;
 
@@ -60,9 +60,12 @@ class NavigationObstacle2D : public Node2D {
 #ifdef DEBUG_ENABLED
 private:
 	RID debug_canvas_item;
-	void _update_fake_agent_radius_debug();
-	void _update_static_obstacle_debug();
+	void _obstacle_debug_update();
+	void _obstacle_debug_free();
 #endif // DEBUG_ENABLED
+	void _obstacle_enter_tree();
+	void _obstacle_exit_tree();
+	void _obstacle_physics_process();
 
 protected:
 	static void _bind_methods();
@@ -77,8 +80,13 @@ public:
 	void set_avoidance_enabled(bool p_enabled);
 	bool get_avoidance_enabled() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;
+#endif // DISABLE_DEPRECATED
+
+	void set_avoidance_space(RID p_avoidance_space);
+	RID get_avoidance_space() const;
 
 	void set_radius(real_t p_radius);
 	real_t get_radius() const { return radius; }
@@ -107,8 +115,8 @@ public:
 	bool get_carve_navigation_mesh() const;
 
 private:
-	void _update_map(RID p_map);
 	void _update_position(const Vector2 p_position);
+	void _update_avoidance_space(RID p_avoidance_space);
 };
 
 #endif // NAVIGATION_OBSTACLE_2D_H

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -138,9 +138,11 @@ real_t NavigationRegion2D::get_travel_cost() const {
 	return travel_cost;
 }
 
+#ifndef DISABLE_DEPRECATED
 RID NavigationRegion2D::get_region_rid() const {
 	return get_rid();
 }
+#endif // DISABLE_DEPRECATED
 
 #ifdef TOOLS_ENABLED
 Rect2 NavigationRegion2D::_edit_get_rect() const {
@@ -310,7 +312,9 @@ void NavigationRegion2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_navigation_layer_value", "layer_number", "value"), &NavigationRegion2D::set_navigation_layer_value);
 	ClassDB::bind_method(D_METHOD("get_navigation_layer_value", "layer_number"), &NavigationRegion2D::get_navigation_layer_value);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion2D::get_region_rid);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_enter_cost", "enter_cost"), &NavigationRegion2D::set_enter_cost);
 	ClassDB::bind_method(D_METHOD("get_enter_cost"), &NavigationRegion2D::get_enter_cost);

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -90,7 +90,9 @@ public:
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
 
+#ifndef DISABLE_DEPRECATED
 	RID get_region_rid() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_enter_cost(real_t p_enter_cost);
 	real_t get_enter_cost() const;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -44,6 +44,7 @@ class NavigationAgent3D : public Node {
 
 	RID agent;
 	RID map_override;
+	RID avoidance_space_override;
 
 	bool avoidance_enabled = false;
 	bool use_3d_avoidance = false;
@@ -100,6 +101,7 @@ class NavigationAgent3D : public Node {
 	bool last_waypoint_reached = false;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	uint32_t last_map_iteration_id = 0;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;
@@ -174,6 +176,9 @@ public:
 
 	void set_path_height_offset(real_t p_path_height_offset);
 	real_t get_path_height_offset() const { return path_height_offset; }
+
+	void set_avoidance_space(RID p_avoidance_space);
+	RID get_avoidance_space() const;
 
 	void set_use_3d_avoidance(bool p_use_3d_avoidance);
 	bool get_use_3d_avoidance() const { return use_3d_avoidance; }

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -37,9 +37,9 @@ class NavigationObstacle3D : public Node3D {
 	GDCLASS(NavigationObstacle3D, Node3D);
 
 	RID obstacle;
-	RID map_before_pause;
 	RID map_override;
-	RID map_current;
+
+	RID avoidance_space_override;
 
 	real_t height = 1.0;
 	real_t radius = 0.0;
@@ -67,10 +67,14 @@ class NavigationObstacle3D : public Node3D {
 	RID static_obstacle_debug_instance;
 	Ref<ArrayMesh> static_obstacle_debug_mesh;
 
-private:
 	void _update_fake_agent_radius_debug();
 	void _update_static_obstacle_debug();
+	void _obstacle_debug_update();
+	void _obstacle_debug_free();
 #endif // DEBUG_ENABLED
+	void _obstacle_enter_tree();
+	void _obstacle_exit_tree();
+	void _obstacle_physics_process();
 
 protected:
 	static void _bind_methods();
@@ -85,8 +89,13 @@ public:
 	void set_avoidance_enabled(bool p_enabled);
 	bool get_avoidance_enabled() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;
+#endif // DISABLE_DEPRECATED
+
+	void set_avoidance_space(RID p_avoidance_space);
+	RID get_avoidance_space() const;
 
 	void set_radius(real_t p_radius);
 	real_t get_radius() const { return radius; }
@@ -118,9 +127,9 @@ public:
 	bool get_carve_navigation_mesh() const;
 
 private:
-	void _update_map(RID p_map);
 	void _update_position(const Vector3 p_position);
 	void _update_use_3d_avoidance(bool p_use_3d_avoidance);
+	void _update_avoidance_space(RID p_avoidance_space);
 };
 
 #endif // NAVIGATION_OBSTACLE_3D_H

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -73,6 +73,14 @@ RID World3D::get_navigation_map() const {
 	return navigation_map;
 }
 
+RID World3D::get_avoidance_space() const {
+	if (avoidance_space.is_null()) {
+		avoidance_space = NavigationServer3D::get_singleton()->avoidance_space_create();
+		NavigationServer3D::get_singleton()->avoidance_space_set_active(avoidance_space, true);
+	}
+	return avoidance_space;
+}
+
 RID World3D::get_scenario() const {
 	return scenario;
 }
@@ -148,6 +156,7 @@ PhysicsDirectSpaceState3D *World3D::get_direct_space_state() {
 void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_space"), &World3D::get_space);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World3D::get_navigation_map);
+	ClassDB::bind_method(D_METHOD("get_avoidance_space"), &World3D::get_avoidance_space);
 	ClassDB::bind_method(D_METHOD("get_scenario"), &World3D::get_scenario);
 	ClassDB::bind_method(D_METHOD("set_environment", "env"), &World3D::set_environment);
 	ClassDB::bind_method(D_METHOD("get_environment"), &World3D::get_environment);
@@ -161,6 +170,7 @@ void World3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "avoidance_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_avoidance_space");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState3D", PROPERTY_USAGE_NONE), "", "get_direct_space_state");
 }
@@ -180,5 +190,8 @@ World3D::~World3D() {
 	}
 	if (navigation_map.is_valid()) {
 		NavigationServer3D::get_singleton()->free(navigation_map);
+	}
+	if (avoidance_space.is_valid()) {
+		NavigationServer3D::get_singleton()->free(avoidance_space);
 	}
 }

--- a/scene/resources/3d/world_3d.h
+++ b/scene/resources/3d/world_3d.h
@@ -49,6 +49,7 @@ private:
 	RID scenario;
 	mutable RID space;
 	mutable RID navigation_map;
+	mutable RID avoidance_space;
 
 	Ref<Environment> environment;
 	Ref<Environment> fallback_environment;
@@ -68,6 +69,7 @@ protected:
 public:
 	RID get_space() const;
 	RID get_navigation_map() const;
+	RID get_avoidance_space() const;
 	RID get_scenario() const;
 
 	void set_environment(const Ref<Environment> &p_environment);

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -70,16 +70,26 @@ PhysicsDirectSpaceState2D *World2D::get_direct_space_state() {
 	return PhysicsServer2D::get_singleton()->space_get_direct_state(get_space());
 }
 
+RID World2D::get_avoidance_space() const {
+	if (avoidance_space.is_null()) {
+		avoidance_space = NavigationServer2D::get_singleton()->avoidance_space_create();
+		NavigationServer2D::get_singleton()->avoidance_space_set_active(avoidance_space, true);
+	}
+	return avoidance_space;
+}
+
 void World2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_canvas"), &World2D::get_canvas);
 	ClassDB::bind_method(D_METHOD("get_space"), &World2D::get_space);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World2D::get_navigation_map);
+	ClassDB::bind_method(D_METHOD("get_avoidance_space"), &World2D::get_avoidance_space);
 
 	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World2D::get_direct_space_state);
 
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "canvas", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_canvas");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "avoidance_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_avoidance_space");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState2D", PROPERTY_USAGE_NONE), "", "get_direct_space_state");
 }
 
@@ -105,5 +115,8 @@ World2D::~World2D() {
 	}
 	if (navigation_map.is_valid()) {
 		NavigationServer2D::get_singleton()->free(navigation_map);
+	}
+	if (avoidance_space.is_valid()) {
+		NavigationServer2D::get_singleton()->free(avoidance_space);
 	}
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -44,6 +44,7 @@ class World2D : public Resource {
 	RID canvas;
 	mutable RID space;
 	mutable RID navigation_map;
+	mutable RID avoidance_space;
 
 	HashSet<Viewport *> viewports;
 
@@ -55,6 +56,7 @@ public:
 	RID get_canvas() const;
 	RID get_space() const;
 	RID get_navigation_map() const;
+	RID get_avoidance_space() const;
 
 	PhysicsDirectSpaceState2D *get_direct_space_state();
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -36,6 +36,7 @@ NavigationServer2D *NavigationServer2D::singleton = nullptr;
 
 void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_maps"), &NavigationServer2D::get_maps);
+	ClassDB::bind_method(D_METHOD("get_avoidance_spaces"), &NavigationServer2D::get_avoidance_spaces);
 
 	ClassDB::bind_method(D_METHOD("map_create"), &NavigationServer2D::map_create);
 	ClassDB::bind_method(D_METHOD("map_set_active", "map", "active"), &NavigationServer2D::map_set_active);
@@ -54,9 +55,6 @@ void NavigationServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("map_get_links", "map"), &NavigationServer2D::map_get_links);
 	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer2D::map_get_regions);
-	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer2D::map_get_agents);
-	ClassDB::bind_method(D_METHOD("map_get_obstacles", "map"), &NavigationServer2D::map_get_obstacles);
-
 	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer2D::map_force_update);
 	ClassDB::bind_method(D_METHOD("map_get_iteration_id", "map"), &NavigationServer2D::map_get_iteration_id);
 
@@ -111,8 +109,6 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_create"), &NavigationServer2D::agent_create);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_enabled", "agent", "enabled"), &NavigationServer2D::agent_set_avoidance_enabled);
 	ClassDB::bind_method(D_METHOD("agent_get_avoidance_enabled", "agent"), &NavigationServer2D::agent_get_avoidance_enabled);
-	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer2D::agent_set_map);
-	ClassDB::bind_method(D_METHOD("agent_get_map", "agent"), &NavigationServer2D::agent_get_map);
 	ClassDB::bind_method(D_METHOD("agent_set_paused", "agent", "paused"), &NavigationServer2D::agent_set_paused);
 	ClassDB::bind_method(D_METHOD("agent_get_paused", "agent"), &NavigationServer2D::agent_get_paused);
 	ClassDB::bind_method(D_METHOD("agent_set_neighbor_distance", "agent", "distance"), &NavigationServer2D::agent_set_neighbor_distance);
@@ -132,7 +128,6 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_get_velocity", "agent"), &NavigationServer2D::agent_get_velocity);
 	ClassDB::bind_method(D_METHOD("agent_set_position", "agent", "position"), &NavigationServer2D::agent_set_position);
 	ClassDB::bind_method(D_METHOD("agent_get_position", "agent"), &NavigationServer2D::agent_get_position);
-	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer2D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_callback", "agent", "callback"), &NavigationServer2D::agent_set_avoidance_callback);
 	ClassDB::bind_method(D_METHOD("agent_has_avoidance_callback", "agent"), &NavigationServer2D::agent_has_avoidance_callback);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_layers", "agent", "layers"), &NavigationServer2D::agent_set_avoidance_layers);
@@ -141,12 +136,12 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_get_avoidance_mask", "agent"), &NavigationServer2D::agent_get_avoidance_mask);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_priority", "agent", "priority"), &NavigationServer2D::agent_set_avoidance_priority);
 	ClassDB::bind_method(D_METHOD("agent_get_avoidance_priority", "agent"), &NavigationServer2D::agent_get_avoidance_priority);
+	ClassDB::bind_method(D_METHOD("agent_set_avoidance_space", "agent", "avoidance_space"), &NavigationServer2D::agent_set_avoidance_space);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_space", "agent"), &NavigationServer2D::agent_get_avoidance_space);
 
 	ClassDB::bind_method(D_METHOD("obstacle_create"), &NavigationServer2D::obstacle_create);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_enabled", "obstacle", "enabled"), &NavigationServer2D::obstacle_set_avoidance_enabled);
 	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_enabled", "obstacle"), &NavigationServer2D::obstacle_get_avoidance_enabled);
-	ClassDB::bind_method(D_METHOD("obstacle_set_map", "obstacle", "map"), &NavigationServer2D::obstacle_set_map);
-	ClassDB::bind_method(D_METHOD("obstacle_get_map", "obstacle"), &NavigationServer2D::obstacle_get_map);
 	ClassDB::bind_method(D_METHOD("obstacle_set_paused", "obstacle", "paused"), &NavigationServer2D::obstacle_set_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_get_paused", "obstacle"), &NavigationServer2D::obstacle_get_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_set_radius", "obstacle", "radius"), &NavigationServer2D::obstacle_set_radius);
@@ -159,6 +154,15 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("obstacle_get_vertices", "obstacle"), &NavigationServer2D::obstacle_get_vertices);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_layers", "obstacle", "layers"), &NavigationServer2D::obstacle_set_avoidance_layers);
 	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_layers", "obstacle"), &NavigationServer2D::obstacle_get_avoidance_layers);
+	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_space", "obstacle", "avoidance_space"), &NavigationServer2D::obstacle_set_avoidance_space);
+	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_space", "obstacle"), &NavigationServer2D::obstacle_get_avoidance_space);
+
+	ClassDB::bind_method(D_METHOD("avoidance_space_create"), &NavigationServer2D::avoidance_space_create);
+	ClassDB::bind_method(D_METHOD("avoidance_space_get_iteration_id", "avoidance_space"), &NavigationServer2D::avoidance_space_get_iteration_id);
+	ClassDB::bind_method(D_METHOD("avoidance_space_set_active", "avoidance_space", "active"), &NavigationServer2D::avoidance_space_set_active);
+	ClassDB::bind_method(D_METHOD("avoidance_space_is_active", "avoidance_space"), &NavigationServer2D::avoidance_space_is_active);
+	ClassDB::bind_method(D_METHOD("avoidance_space_get_agents", "avoidance_space"), &NavigationServer2D::avoidance_space_get_agents);
+	ClassDB::bind_method(D_METHOD("avoidance_space_get_obstacles", "avoidance_space"), &NavigationServer2D::avoidance_space_get_obstacles);
 
 	ClassDB::bind_method(D_METHOD("parse_source_geometry_data", "navigation_polygon", "source_geometry_data", "root_node", "callback"), &NavigationServer2D::parse_source_geometry_data, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("bake_from_source_geometry_data", "navigation_polygon", "source_geometry_data", "callback"), &NavigationServer2D::bake_from_source_geometry_data, DEFVAL(Callable()));
@@ -175,9 +179,22 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationServer2D::set_debug_enabled);
 	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationServer2D::get_debug_enabled);
 
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer2D::map_get_agents);
+	ClassDB::bind_method(D_METHOD("map_get_obstacles", "map"), &NavigationServer2D::map_get_obstacles);
+
+	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer2D::agent_set_map);
+	ClassDB::bind_method(D_METHOD("agent_get_map", "agent"), &NavigationServer2D::agent_get_map);
+	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer2D::agent_is_map_changed);
+
+	ClassDB::bind_method(D_METHOD("obstacle_set_map", "obstacle", "map"), &NavigationServer2D::obstacle_set_map);
+	ClassDB::bind_method(D_METHOD("obstacle_get_map", "obstacle"), &NavigationServer2D::obstacle_get_map);
+#endif // DISABLE_DEPRECATED
+
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
 
 	ADD_SIGNAL(MethodInfo("navigation_debug_changed"));
+	ADD_SIGNAL(MethodInfo("avoidance_debug_changed"));
 }
 
 NavigationServer2D *NavigationServer2D::get_singleton() {
@@ -192,12 +209,19 @@ NavigationServer2D::NavigationServer2D() {
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->connect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal));
+	NavigationServer3D::get_singleton()->connect(SNAME("avoidance_debug_changed"), callable_mp(this, &NavigationServer2D::_emit_avoidance_debug_changed_signal));
 #endif // DEBUG_ENABLED
 }
 
 #ifdef DEBUG_ENABLED
 void NavigationServer2D::_emit_navigation_debug_changed_signal() {
 	emit_signal(SNAME("navigation_debug_changed"));
+}
+#endif // DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+void NavigationServer2D::_emit_avoidance_debug_changed_signal() {
+	emit_signal(SNAME("avoidance_debug_changed"));
 }
 #endif // DEBUG_ENABLED
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -59,6 +59,7 @@ public:
 	static NavigationServer2D *get_singleton();
 
 	virtual TypedArray<RID> get_maps() const = 0;
+	virtual TypedArray<RID> get_avoidance_spaces() const = 0;
 
 	/// Create a new map.
 	virtual RID map_create() = 0;
@@ -98,9 +99,6 @@ public:
 
 	virtual TypedArray<RID> map_get_links(RID p_map) const = 0;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const = 0;
-	virtual TypedArray<RID> map_get_agents(RID p_map) const = 0;
-	virtual TypedArray<RID> map_get_obstacles(RID p_map) const = 0;
-
 	virtual void map_force_update(RID p_map) = 0;
 	virtual uint32_t map_get_iteration_id(RID p_map) const = 0;
 
@@ -192,10 +190,6 @@ public:
 	/// Creates the agent.
 	virtual RID agent_create() = 0;
 
-	/// Put the agent in the map.
-	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
-	virtual RID agent_get_map(RID p_agent) const = 0;
-
 	virtual void agent_set_paused(RID p_agent, bool p_paused) = 0;
 	virtual bool agent_get_paused(RID p_agent) const = 0;
 
@@ -256,9 +250,6 @@ public:
 	virtual void agent_set_position(RID p_agent, Vector2 p_position) = 0;
 	virtual Vector2 agent_get_position(RID p_agent) const = 0;
 
-	/// Returns true if the map got changed the previous frame.
-	virtual bool agent_is_map_changed(RID p_agent) const = 0;
-
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
 	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
@@ -272,12 +263,13 @@ public:
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
+	virtual void agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) = 0;
+	virtual RID agent_get_avoidance_space(RID p_agent) const = 0;
+
 	/// Creates the obstacle.
 	virtual RID obstacle_create() = 0;
 	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) = 0;
 	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const = 0;
-	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
-	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
 	virtual void obstacle_set_paused(RID p_obstacle, bool p_paused) = 0;
 	virtual bool obstacle_get_paused(RID p_obstacle) const = 0;
 	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) = 0;
@@ -290,6 +282,15 @@ public:
 	virtual Vector<Vector2> obstacle_get_vertices(RID p_obstacle) const = 0;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
+	virtual void obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) = 0;
+	virtual RID obstacle_get_avoidance_space(RID p_obstacle) const = 0;
+
+	virtual RID avoidance_space_create() = 0;
+	virtual uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const = 0;
+	virtual void avoidance_space_set_active(RID p_avoidance_space, bool p_active) = 0;
+	virtual bool avoidance_space_is_active(RID p_avoidance_space) const = 0;
+	virtual TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const = 0;
+	virtual TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const = 0;
 
 	/// Returns a customized navigation path using a query parameters object
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const = 0;
@@ -316,6 +317,18 @@ public:
 
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
+
+#ifndef DISABLE_DEPRECATED
+	virtual TypedArray<RID> map_get_agents(RID p_map) const = 0;
+	virtual TypedArray<RID> map_get_obstacles(RID p_map) const = 0;
+
+	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
+	virtual RID agent_get_map(RID p_agent) const = 0;
+	virtual bool agent_is_map_changed(RID p_agent) const = 0;
+
+	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
+	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
+#endif // DISABLE_DEPRECATED
 
 #ifdef DEBUG_ENABLED
 	void set_debug_navigation_enabled(bool p_enabled);
@@ -394,6 +407,7 @@ public:
 #ifdef DEBUG_ENABLED
 private:
 	void _emit_navigation_debug_changed_signal();
+	void _emit_avoidance_debug_changed_signal();
 #endif // DEBUG_ENABLED
 };
 

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -38,6 +38,7 @@ class NavigationServer2DDummy : public NavigationServer2D {
 
 public:
 	TypedArray<RID> get_maps() const override { return TypedArray<RID>(); }
+	TypedArray<RID> get_avoidance_spaces() const override { return TypedArray<RID>(); }
 
 	RID map_create() override { return RID(); }
 	void map_set_active(RID p_map, bool p_active) override {}
@@ -55,8 +56,6 @@ public:
 	RID map_get_closest_point_owner(RID p_map, const Vector2 &p_point) const override { return RID(); }
 	TypedArray<RID> map_get_links(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_regions(RID p_map) const override { return TypedArray<RID>(); }
-	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
-	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
 	void map_force_update(RID p_map) override {}
 	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); };
 	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
@@ -106,8 +105,6 @@ public:
 	ObjectID link_get_owner_id(RID p_link) const override { return ObjectID(); }
 
 	RID agent_create() override { return RID(); }
-	void agent_set_map(RID p_agent, RID p_map) override {}
-	RID agent_get_map(RID p_agent) const override { return RID(); }
 	void agent_set_paused(RID p_agent, bool p_paused) override {}
 	bool agent_get_paused(RID p_agent) const override { return false; }
 	void agent_set_avoidance_enabled(RID p_agent, bool p_enabled) override {}
@@ -129,7 +126,6 @@ public:
 	Vector2 agent_get_velocity(RID p_agent) const override { return Vector2(); }
 	void agent_set_position(RID p_agent, Vector2 p_position) override {}
 	Vector2 agent_get_position(RID p_agent) const override { return Vector2(); }
-	bool agent_is_map_changed(RID p_agent) const override { return false; }
 	void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override {}
 	bool agent_has_avoidance_callback(RID p_agent) const override { return false; }
 	void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) override {}
@@ -138,12 +134,12 @@ public:
 	uint32_t agent_get_avoidance_mask(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override {}
 	real_t agent_get_avoidance_priority(RID p_agent) const override { return 0; }
+	void agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) override {}
+	RID agent_get_avoidance_space(RID p_agent) const override { return RID(); }
 
 	RID obstacle_create() override { return RID(); }
 	void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override {}
 	bool obstacle_get_avoidance_enabled(RID p_obstacle) const override { return false; }
-	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
-	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
 	void obstacle_set_paused(RID p_obstacle, bool p_paused) override {}
 	bool obstacle_get_paused(RID p_obstacle) const override { return false; }
 	void obstacle_set_radius(RID p_obstacle, real_t p_radius) override {}
@@ -156,6 +152,15 @@ public:
 	Vector<Vector2> obstacle_get_vertices(RID p_agent) const override { return Vector<Vector2>(); }
 	void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override {}
 	uint32_t obstacle_get_avoidance_layers(RID p_agent) const override { return 0; }
+	void obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) override {}
+	RID obstacle_get_avoidance_space(RID p_obstacle) const override { return RID(); }
+
+	RID avoidance_space_create() override { return RID(); }
+	uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const override { return 0; }
+	void avoidance_space_set_active(RID p_avoidance_space, bool p_active) override {}
+	bool avoidance_space_is_active(RID p_avoidance_space) const override { return false; }
+	TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const override { return TypedArray<RID>(); }
+	TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const override { return TypedArray<RID>(); }
 
 	void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const override {}
 
@@ -177,6 +182,18 @@ public:
 
 	void set_debug_enabled(bool p_enabled) {}
 	bool get_debug_enabled() const { return false; }
+
+#ifndef DISABLE_DEPRECATED
+	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
+	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
+
+	void agent_set_map(RID p_agent, RID p_map) override {}
+	RID agent_get_map(RID p_agent) const override { return RID(); }
+	bool agent_is_map_changed(RID p_agent) const override { return false; }
+
+	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
+	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
+#endif // DISABLE_DEPRECATED
 };
 
 #endif // NAVIGATION_SERVER_2D_DUMMY_H

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -59,6 +59,7 @@ public:
 	static NavigationServer3D *get_singleton();
 
 	virtual TypedArray<RID> get_maps() const = 0;
+	virtual TypedArray<RID> get_avoidance_spaces() const = 0;
 
 	/// Create a new map.
 	virtual RID map_create() = 0;
@@ -112,8 +113,6 @@ public:
 
 	virtual TypedArray<RID> map_get_links(RID p_map) const = 0;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const = 0;
-	virtual TypedArray<RID> map_get_agents(RID p_map) const = 0;
-	virtual TypedArray<RID> map_get_obstacles(RID p_map) const = 0;
 
 	virtual void map_force_update(RID p_map) = 0;
 	virtual uint32_t map_get_iteration_id(RID p_map) const = 0;
@@ -157,11 +156,6 @@ public:
 
 	/// Set the navigation mesh of this region.
 	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) = 0;
-
-#ifndef DISABLE_DEPRECATED
-	/// Bake the navigation mesh.
-	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) = 0;
-#endif // DISABLE_DEPRECATED
 
 	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const = 0;
@@ -210,11 +204,6 @@ public:
 
 	/// Creates the agent.
 	virtual RID agent_create() = 0;
-
-	/// Put the agent in the map.
-	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
-	virtual RID agent_get_map(RID p_agent) const = 0;
-
 	virtual void agent_set_paused(RID p_agent, bool p_paused) = 0;
 	virtual bool agent_get_paused(RID p_agent) const = 0;
 
@@ -280,9 +269,6 @@ public:
 	virtual void agent_set_position(RID p_agent, Vector3 p_position) = 0;
 	virtual Vector3 agent_get_position(RID p_agent) const = 0;
 
-	/// Returns true if the map got changed the previous frame.
-	virtual bool agent_is_map_changed(RID p_agent) const = 0;
-
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
 	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
@@ -296,12 +282,11 @@ public:
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
+	virtual void agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) = 0;
+	virtual RID agent_get_avoidance_space(RID p_agent) const = 0;
+
 	/// Creates the obstacle.
 	virtual RID obstacle_create() = 0;
-
-	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
-	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
-
 	virtual void obstacle_set_paused(RID p_obstacle, bool p_paused) = 0;
 	virtual bool obstacle_get_paused(RID p_obstacle) const = 0;
 
@@ -324,16 +309,22 @@ public:
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
 
+	virtual void obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) = 0;
+	virtual RID obstacle_get_avoidance_space(RID p_obstacle) const = 0;
+
+	virtual RID avoidance_space_create() = 0;
+	virtual uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const = 0;
+	virtual void avoidance_space_set_active(RID p_avoidance_space, bool p_active) = 0;
+	virtual bool avoidance_space_is_active(RID p_avoidance_space) const = 0;
+	virtual TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const = 0;
+	virtual TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const = 0;
+
 	/// Destroy the `RID`
 	virtual void free(RID p_object) = 0;
 
 	/// Control activation of this server.
 	virtual void set_active(bool p_active) = 0;
 
-	/// Process the collision avoidance agents.
-	/// The result of this process is needed by the physics server,
-	/// so this must be called in the main thread.
-	/// Note: This function is not thread safe.
 	virtual void process(real_t delta_time) = 0;
 	virtual void init() = 0;
 	virtual void sync() = 0;
@@ -375,6 +366,20 @@ public:
 
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
+
+#ifndef DISABLE_DEPRECATED
+	virtual TypedArray<RID> map_get_agents(RID p_map) const = 0;
+	virtual TypedArray<RID> map_get_obstacles(RID p_map) const = 0;
+
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) = 0;
+
+	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
+	virtual RID agent_get_map(RID p_agent) const = 0;
+	virtual bool agent_is_map_changed(RID p_agent) const = 0;
+
+	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
+	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
+#endif // DISABLE_DEPRECATED
 
 private:
 	bool debug_enabled = false;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -38,7 +38,10 @@ class NavigationServer3DDummy : public NavigationServer3D {
 
 public:
 	TypedArray<RID> get_maps() const override { return TypedArray<RID>(); }
+	TypedArray<RID> get_avoidance_spaces() const override { return TypedArray<RID>(); }
+
 	RID map_create() override { return RID(); }
+	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
 	void map_set_active(RID p_map, bool p_active) override {}
 	bool map_is_active(RID p_map) const override { return false; }
 	void map_set_up(RID p_map, Vector3 p_up) override {}
@@ -63,10 +66,7 @@ public:
 	Vector3 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const override { return Vector3(); }
 	TypedArray<RID> map_get_links(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_regions(RID p_map) const override { return TypedArray<RID>(); }
-	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
-	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
 	void map_force_update(RID p_map) override {}
-	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
 
 	RID region_create() override { return RID(); }
 	void region_set_enabled(RID p_region, bool p_enabled) override {}
@@ -87,9 +87,6 @@ public:
 	void region_set_transform(RID p_region, Transform3D p_transform) override {}
 	Transform3D region_get_transform(RID p_region) const override { return Transform3D(); }
 	void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) override {}
-#ifndef DISABLE_DEPRECATED
-	void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override {}
-#endif // DISABLE_DEPRECATED
 	int region_get_connections_count(RID p_region) const override { return 0; }
 	Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override { return Vector3(); }
 	Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override { return Vector3(); }
@@ -116,8 +113,6 @@ public:
 	ObjectID link_get_owner_id(RID p_link) const override { return ObjectID(); }
 
 	RID agent_create() override { return RID(); }
-	void agent_set_map(RID p_agent, RID p_map) override {}
-	RID agent_get_map(RID p_agent) const override { return RID(); }
 	void agent_set_paused(RID p_agent, bool p_paused) override {}
 	bool agent_get_paused(RID p_agent) const override { return false; }
 	void agent_set_avoidance_enabled(RID p_agent, bool p_enabled) override {}
@@ -143,7 +138,6 @@ public:
 	Vector3 agent_get_velocity(RID p_agent) const override { return Vector3(); }
 	void agent_set_position(RID p_agent, Vector3 p_position) override {}
 	Vector3 agent_get_position(RID p_agent) const override { return Vector3(); }
-	bool agent_is_map_changed(RID p_agent) const override { return false; }
 	void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override {}
 	bool agent_has_avoidance_callback(RID p_agent) const override { return false; }
 	void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) override {}
@@ -152,10 +146,10 @@ public:
 	uint32_t agent_get_avoidance_mask(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override {}
 	real_t agent_get_avoidance_priority(RID p_agent) const override { return 0; }
+	void agent_set_avoidance_space(RID p_agent, RID p_avoidance_space) override {}
+	RID agent_get_avoidance_space(RID p_agent) const override { return RID(); }
 
 	RID obstacle_create() override { return RID(); }
-	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
-	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
 	void obstacle_set_paused(RID p_obstacle, bool p_paused) override {}
 	bool obstacle_get_paused(RID p_obstacle) const override { return false; }
 	void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override {}
@@ -174,6 +168,15 @@ public:
 	Vector<Vector3> obstacle_get_vertices(RID p_obstacle) const override { return Vector<Vector3>(); }
 	void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override {}
 	uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override { return 0; }
+	void obstacle_set_avoidance_space(RID p_obstacle, RID p_avoidance_space) override {}
+	RID obstacle_get_avoidance_space(RID p_obstacle) const override { return RID(); }
+
+	RID avoidance_space_create() override { return RID(); }
+	uint32_t avoidance_space_get_iteration_id(RID p_avoidance_space) const override { return 0; }
+	void avoidance_space_set_active(RID p_avoidance_space, bool p_active) override {}
+	bool avoidance_space_is_active(RID p_avoidance_space) const override { return false; }
+	TypedArray<RID> avoidance_space_get_agents(RID p_avoidance_space) const override { return TypedArray<RID>(); }
+	TypedArray<RID> avoidance_space_get_obstacles(RID p_avoidance_space) const override { return TypedArray<RID>(); }
 
 #ifndef _3D_DISABLED
 	void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override {}
@@ -189,7 +192,7 @@ public:
 
 	void free(RID p_object) override {}
 	void set_active(bool p_active) override {}
-	void process(real_t delta_time) override {}
+	void process(real_t p_delta_time) override {}
 	void init() override {}
 	void sync() override {}
 	void finish() override {}
@@ -199,6 +202,20 @@ public:
 
 	void set_debug_enabled(bool p_enabled) {}
 	bool get_debug_enabled() const { return false; }
+
+#ifndef DISABLE_DEPRECATED
+	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
+	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
+
+	void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override {}
+
+	void agent_set_map(RID p_agent, RID p_map) override {}
+	RID agent_get_map(RID p_agent) const override { return RID(); }
+	bool agent_is_map_changed(RID p_agent) const override { return false; }
+
+	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
+	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
+#endif // DISABLE_DEPRECATED
 };
 
 #endif // NAVIGATION_SERVER_3D_DUMMY_H

--- a/tests/scene/test_navigation_agent_2d.h
+++ b/tests/scene/test_navigation_agent_2d.h
@@ -65,6 +65,26 @@ TEST_SUITE("[Navigation]") {
 		memdelete(agent_node);
 		memdelete(node_2d);
 	}
+
+	TEST_CASE("[SceneTree][NavigationAgent2D] New agent should attach to default avoidance space") {
+		Node2D *node_2d = memnew(Node2D);
+		SceneTree::get_singleton()->get_root()->add_child(node_2d);
+
+		NavigationAgent2D *agent_node = memnew(NavigationAgent2D);
+
+		// agent should not be attached to any avoidance space when outside of tree
+		CHECK_FALSE(agent_node->get_avoidance_space().is_valid());
+
+		SUBCASE("Agent should attach to default avoidance space when it enters the tree with avoidance enabled") {
+			agent_node->set_avoidance_enabled(true);
+			node_2d->add_child(agent_node);
+			CHECK(agent_node->get_avoidance_space().is_valid());
+			CHECK(agent_node->get_avoidance_space() == node_2d->get_world_2d()->get_avoidance_space());
+		}
+
+		memdelete(agent_node);
+		memdelete(node_2d);
+	}
 }
 
 } //namespace TestNavigationAgent2D

--- a/tests/scene/test_navigation_agent_3d.h
+++ b/tests/scene/test_navigation_agent_3d.h
@@ -64,6 +64,26 @@ TEST_SUITE("[Navigation]") {
 		memdelete(agent_node);
 		memdelete(node_3d);
 	}
+
+	TEST_CASE("[SceneTree][NavigationAgent3D] New agent should attach to default avoidance space") {
+		Node3D *node_3d = memnew(Node3D);
+		SceneTree::get_singleton()->get_root()->add_child(node_3d);
+
+		NavigationAgent3D *agent_node = memnew(NavigationAgent3D);
+
+		// agent should not be attached to any avoidance space when outside of tree
+		CHECK_FALSE(agent_node->get_avoidance_space().is_valid());
+
+		SUBCASE("Agent should attach to default avoidance space when it enters the tree with avoidance enabled") {
+			agent_node->set_avoidance_enabled(true);
+			node_3d->add_child(agent_node);
+			CHECK(agent_node->get_avoidance_space().is_valid());
+			CHECK(agent_node->get_avoidance_space() == node_3d->get_world_3d()->get_avoidance_space());
+		}
+
+		memdelete(agent_node);
+		memdelete(node_3d);
+	}
 }
 
 } //namespace TestNavigationAgent3D

--- a/tests/scene/test_navigation_obstacle_2d.h
+++ b/tests/scene/test_navigation_obstacle_2d.h
@@ -45,18 +45,18 @@ TEST_SUITE("[Navigation]") {
 		memdelete(obstacle_node);
 	}
 
-	TEST_CASE("[SceneTree][NavigationObstacle2D] New obstacle should attach to default map") {
+	TEST_CASE("[SceneTree][NavigationObstacle2D] New obstacle should attach to default avoidance space") {
 		Node2D *node_2d = memnew(Node2D);
 		SceneTree::get_singleton()->get_root()->add_child(node_2d);
 
 		NavigationObstacle2D *obstacle_node = memnew(NavigationObstacle2D);
-		// obstacle should not be attached to any map when outside of tree
-		CHECK_FALSE(obstacle_node->get_navigation_map().is_valid());
+		// obstacle should not be attached to any avoidance space when outside of tree
+		CHECK_FALSE(obstacle_node->get_avoidance_space().is_valid());
 
-		SUBCASE("Obstacle should attach to default map when it enters the tree") {
+		SUBCASE("Obstacle should attach to default avoidance space when it enters the tree") {
 			node_2d->add_child(obstacle_node);
-			CHECK(obstacle_node->get_navigation_map().is_valid());
-			CHECK(obstacle_node->get_navigation_map() == node_2d->get_world_2d()->get_navigation_map());
+			CHECK(obstacle_node->get_avoidance_space().is_valid());
+			CHECK(obstacle_node->get_avoidance_space() == node_2d->get_world_2d()->get_avoidance_space());
 		}
 
 		memdelete(obstacle_node);

--- a/tests/scene/test_navigation_obstacle_3d.h
+++ b/tests/scene/test_navigation_obstacle_3d.h
@@ -45,18 +45,18 @@ TEST_SUITE("[Navigation]") {
 		memdelete(obstacle_node);
 	}
 
-	TEST_CASE("[SceneTree][NavigationObstacle3D] New obstacle should attach to default map") {
+	TEST_CASE("[SceneTree][NavigationObstacle3D] New obstacle should attach to default avoidance space") {
 		Node3D *node_3d = memnew(Node3D);
 		SceneTree::get_singleton()->get_root()->add_child(node_3d);
 
 		NavigationObstacle3D *obstacle_node = memnew(NavigationObstacle3D);
-		// obstacle should not be attached to any map when outside of tree
-		CHECK_FALSE(obstacle_node->get_navigation_map().is_valid());
+		// obstacle should not be attached to any avoidance space when outside of tree
+		CHECK_FALSE(obstacle_node->get_avoidance_space().is_valid());
 
-		SUBCASE("Obstacle should attach to default map when it enters the tree") {
+		SUBCASE("Obstacle should attach to default avoidance space when it enters the tree") {
 			node_3d->add_child(obstacle_node);
-			CHECK(obstacle_node->get_navigation_map().is_valid());
-			CHECK(obstacle_node->get_navigation_map() == node_3d->get_world_3d()->get_navigation_map());
+			CHECK(obstacle_node->get_avoidance_space().is_valid());
+			CHECK(obstacle_node->get_avoidance_space() == node_3d->get_world_3d()->get_avoidance_space());
 		}
 
 		memdelete(obstacle_node);


### PR DESCRIPTION
Moves avoidance from navigation map to its own avoidance space.

Proposal https://github.com/godotengine/godot-proposals/issues/8939

Looks like a lot of code changes but what this PR primarly does is.
- Move everything avoidance related from navigation maps to new avoidance spaces.
- Change the API from avoidance agents and avoidance obstacles to use those new avoidance spaces.
- Removes the navigiation map assigments for server agents and obstacles as they become dead code.
- Updates and syncs some debug code on the NavigationObstacle2D/3D nodes.
- Moved depr API functions to the end because having so many lines with DISABLE_DEPRECATED was too much.

The removal of the agent and obstacle navigation map assignment will make even more sense with other PRs planned. Having the agents and obstacles as part of a navigation map was always problematic. Outside of avoidance there was no real use for this especially since it was never needed to query a path.

On more complex games an agent regularly uses multiple different maps at the same time depending on state and context. Having an agent only able to subscribe to a single navigation map was counterproductive. 

The problem with keeping all this API alive is that it creates a lot of problems for the synchronisation rework to fix all the runtime performance issues with the navigation map. It also violates the separation of concerns between avoidance and navmesh pathfinding which are two very different systems.

There are also feature requests to manually step the avoidance or take and apply snapshots of the avoidance state for e.g. rollbacks. Those are near impossible to add in reasonable capacity while everything is glued together in the navigation map.

- [x] Move avoidance API from navigation maps to new avoidance spaces.
- [x] Update agent and obstacle API, depr old.


Things for follow-up PRs:
- Add API to change processing mode for avoidance, e.g. process, physics, manual.
- Add API to manually step avoidance space with custom delta.
- Add API for missing agent and obstacle properties, e.g. to collect and set values for roll backs.
- Rework all the test cases that will inevitably fail with the changes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
