### PR TITLE
Relay useful PopupMenu signals through MenuButton

### DIFF
--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -49,5 +49,23 @@
 				Emitted when the [PopupMenu] of this MenuButton is about to show.
 			</description>
 		</signal>
+		<signal name="id_focused">
+			<param index="0" name="id" type="int" />
+			<description>
+				Mirrors [signal PopupMenu.id_focused].
+			</description>
+		</signal>
+		<signal name="id_pressed">
+			<param index="0" name="id" type="int" />
+			<description>
+				Mirrors [signal PopupMenu.id_pressed].
+			</description>
+		</signal>
+		<signal name="index_pressed">
+			<param index="0" name="index" type="int" />
+			<description>
+				Mirrors [signal PopupMenu.index_pressed].
+			</description>
+		</signal>
 	</signals>
 </class>

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -61,6 +61,10 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 	}
 }
 
+void MenuButton::_popup_signal_repeat(int p_id, const StringName &p_signal_name) {
+	emit_signal(p_signal_name, p_id);
+}
+
 void MenuButton::pressed() {
 	if (popup->is_visible()) {
 		popup->hide();
@@ -215,6 +219,9 @@ void MenuButton::_bind_methods() {
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");
 
 	ADD_SIGNAL(MethodInfo("about_to_popup"));
+	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
 }
 
 void MenuButton::set_disable_shortcuts(bool p_disabled) {
@@ -235,6 +242,9 @@ MenuButton::MenuButton(const String &p_text) :
 	add_child(popup, false, INTERNAL_MODE_FRONT);
 	popup->connect("about_to_popup", callable_mp(this, &MenuButton::_popup_visibility_changed).bind(true));
 	popup->connect("popup_hide", callable_mp(this, &MenuButton::_popup_visibility_changed).bind(false));
+	popup->connect("id_pressed", callable_mp(this, &MenuButton::_popup_signal_repeat).bind(SNAME("id_pressed")));
+	popup->connect("id_focused", callable_mp(this, &MenuButton::_popup_signal_repeat).bind(SNAME("id_focused")));
+	popup->connect("index_pressed", callable_mp(this, &MenuButton::_popup_signal_repeat).bind(SNAME("index_pressed")));
 }
 
 MenuButton::~MenuButton() {

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -43,6 +43,7 @@ class MenuButton : public Button {
 	PopupMenu *popup = nullptr;
 
 	void _popup_visibility_changed(bool p_visible);
+	void _popup_signal_repeat(int p_id, const StringName &p_signal_name);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Really simple relaying of the `PopupMenu` signals through `MenuButton`, just to make hooking them up through the editor simpler, I know that you can easily connect them through code by using `get_popup()` but the fact that the menu button doesn't follow the same convention as most of the UI elements where you can just connect through the editor seems to be a source of confusion for new users (see [example 1](https://forum.godotengine.org/t/how-do-i-connect-a-handler-to-buttons-in-menubutton/28123), [2](https://www.reddit.com/r/godot/comments/177rdyo/menubutton_difficult_to_use/), [3](https://forum.godotengine.org/t/cant-access-the-menubutton-items-inside-no-signal-exists-on-trying-to-access-them/9819/2)), these from just a few seconds of googling.

The one thing I'm not sure about is the documentation, I didn't want to copy-paste the PopupMenu docs so I just linked to the appropriate signal, but I'm not 100% on the wording or if that's advised.

Let me know if this needs a proposal, figured it was a small enough QOL change that it wouldn't necessarily warrant one.