### PR TITLE
Defer call to `set_break_language`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -51,7 +51,7 @@ void Script::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
 			if (EngineDebugger::is_active()) {
-				EngineDebugger::get_script_debugger()->set_break_language(get_language());
+				callable_mp(this, &Script::_set_debugger_break_language).call_deferred();
 			}
 		} break;
 	}
@@ -101,6 +101,12 @@ Dictionary Script::_get_script_constant_map() {
 		ret[E.key] = E.value;
 	}
 	return ret;
+}
+
+void Script::_set_debugger_break_language() {
+	if (EngineDebugger::is_active()) {
+		EngineDebugger::get_script_debugger()->set_break_language(get_language());
+	}
 }
 
 int Script::get_script_method_argument_count(const StringName &p_method, bool *r_is_valid) const {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -124,6 +124,8 @@ protected:
 	TypedArray<Dictionary> _get_script_signal_list();
 	Dictionary _get_script_constant_map();
 
+	void _set_debugger_break_language();
+
 public:
 	virtual void reload_from_file() override;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86816

As `ScriptExtension` objects are not yet set up when this is called to invoke virtuals, by using `call_deferred`, we avoid this error:

```
ERROR: Required virtual method ScriptExtension::_get_language must be overridden before calling.
   at: _gdvirtual__get_language_call (./core/object/script_language_extension.h:106)
```