### PR TITLE
Add Camera3D preview in Inspector

### DIFF
--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -30,8 +30,11 @@
 
 #include "camera_3d_editor_plugin.h"
 
+#include "core/config/project_settings.h"
 #include "editor/editor_node.h"
 #include "node_3d_editor_plugin.h"
+#include "scene/gui/texture_rect.h"
+#include "scene/main/viewport.h"
 
 void Camera3DEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
@@ -79,9 +82,35 @@ Camera3DEditor::Camera3DEditor() {
 	preview->connect("pressed", callable_mp(this, &Camera3DEditor::_pressed));
 }
 
+void Camera3DPreview::_update_sub_viewport_size() {
+	sub_viewport->set_size(Node3DEditor::get_camera_viewport_size(camera));
+}
+
+Camera3DPreview::Camera3DPreview(Camera3D *p_camera) :
+		TexturePreview(nullptr, false), camera(p_camera), sub_viewport(memnew(SubViewport)) {
+	RenderingServer::get_singleton()->viewport_attach_camera(sub_viewport->get_viewport_rid(), camera->get_camera());
+	add_child(sub_viewport);
+
+	TextureRect *display = get_texture_display();
+	display->set_texture(sub_viewport->get_texture());
+	sub_viewport->connect("size_changed", callable_mp((CanvasItem *)display, &CanvasItem::queue_redraw));
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_update_sub_viewport_size));
+	_update_sub_viewport_size();
+}
+
+bool EditorInspectorPluginCamera3DPreview::can_handle(Object *p_object) {
+	return Object::cast_to<Camera3D>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginCamera3DPreview::parse_begin(Object *p_object) {
+	Camera3D *camera = Object::cast_to<Camera3D>(p_object);
+	Camera3DPreview *preview = memnew(Camera3DPreview(camera));
+	add_custom_control(preview);
+}
+
 void Camera3DEditorPlugin::edit(Object *p_object) {
 	Node3DEditor::get_singleton()->set_can_preview(Object::cast_to<Camera3D>(p_object));
-	//camera_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Camera3DEditorPlugin::handles(Object *p_object) const {
@@ -89,27 +118,15 @@ bool Camera3DEditorPlugin::handles(Object *p_object) const {
 }
 
 void Camera3DEditorPlugin::make_visible(bool p_visible) {
-	if (p_visible) {
-		//Node3DEditor::get_singleton()->set_can_preview(Object::cast_to<Camera3D>(p_object));
-	} else {
+	if (!p_visible) {
 		Node3DEditor::get_singleton()->set_can_preview(nullptr);
 	}
 }
 
 Camera3DEditorPlugin::Camera3DEditorPlugin() {
-	/*	camera_editor = memnew( CameraEditor );
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(camera_editor);
-
-	camera_editor->set_anchor(SIDE_LEFT,Control::ANCHOR_END);
-	camera_editor->set_anchor(SIDE_RIGHT,Control::ANCHOR_END);
-	camera_editor->set_offset(SIDE_LEFT,60);
-	camera_editor->set_offset(SIDE_RIGHT,0);
-	camera_editor->set_offset(SIDE_TOP,0);
-	camera_editor->set_offset(SIDE_BOTTOM,10);
-
-
-	camera_editor->hide();
-*/
+	Ref<EditorInspectorPluginCamera3DPreview> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
 }
 
 Camera3DEditorPlugin::~Camera3DEditorPlugin() {

--- a/editor/plugins/camera_3d_editor_plugin.h
+++ b/editor/plugins/camera_3d_editor_plugin.h
@@ -32,7 +32,10 @@
 #define CAMERA_3D_EDITOR_PLUGIN_H
 
 #include "editor/plugins/editor_plugin.h"
-#include "scene/3d/camera_3d.h"
+#include "editor/plugins/texture_editor_plugin.h"
+
+class Camera3D;
+class SubViewport;
 
 class Camera3DEditor : public Control {
 	GDCLASS(Camera3DEditor, Control);
@@ -52,10 +55,28 @@ public:
 	Camera3DEditor();
 };
 
+class Camera3DPreview : public TexturePreview {
+	GDCLASS(Camera3DPreview, TexturePreview);
+
+	Camera3D *camera = nullptr;
+	SubViewport *sub_viewport = nullptr;
+
+	void _update_sub_viewport_size();
+
+public:
+	Camera3DPreview(Camera3D *p_camera);
+};
+
+class EditorInspectorPluginCamera3DPreview : public EditorInspectorPluginTexture {
+	GDCLASS(EditorInspectorPluginCamera3DPreview, EditorInspectorPluginTexture);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
 class Camera3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Camera3DEditorPlugin, EditorPlugin);
-
-	//CameraEditor *camera_editor;
 
 public:
 	virtual String get_name() const override { return "Camera3D"; }

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -46,24 +46,6 @@ Camera3DGizmoPlugin::Camera3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-Size2i Camera3DGizmoPlugin::_get_viewport_size(Camera3D *p_camera) {
-	Viewport *viewport = p_camera->get_viewport();
-
-	Window *window = Object::cast_to<Window>(viewport);
-	if (window) {
-		return window->get_size();
-	}
-
-	SubViewport *sub_viewport = Object::cast_to<SubViewport>(viewport);
-	ERR_FAIL_NULL_V(sub_viewport, Size2i());
-
-	if (sub_viewport == EditorNode::get_singleton()->get_scene_root()) {
-		return Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
-	}
-
-	return sub_viewport->get_size();
-}
-
 bool Camera3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Camera3D>(p_spatial) != nullptr;
 }
@@ -163,7 +145,7 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<Material> material = get_material("camera_material", p_gizmo);
 	Ref<Material> icon = get_material("camera_icon", p_gizmo);
 
-	const Size2i viewport_size = _get_viewport_size(camera);
+	const Size2i viewport_size = Node3DEditor::get_camera_viewport_size(camera);
 	const real_t viewport_aspect = viewport_size.x > 0 && viewport_size.y > 0 ? viewport_size.aspect() : 1.0;
 	const Size2 size_factor = viewport_aspect > 1.0 ? Size2(1.0, 1.0 / viewport_aspect) : Size2(viewport_aspect, 1.0);
 

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.h
@@ -37,7 +37,6 @@ class Camera3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Camera3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 private:
-	static Size2i _get_viewport_size(Camera3D *p_camera);
 	static float _find_closest_angle_to_half_pi_arc(const Vector3 &p_from, const Vector3 &p_to, float p_arc_radius, const Transform3D &p_arc_xform);
 
 public:

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8994,6 +8994,24 @@ void Node3DEditorPlugin::set_state(const Dictionary &p_state) {
 	spatial_editor->set_state(p_state);
 }
 
+Size2i Node3DEditor::get_camera_viewport_size(Camera3D *p_camera) {
+	Viewport *viewport = p_camera->get_viewport();
+
+	Window *window = Object::cast_to<Window>(viewport);
+	if (window) {
+		return window->get_size();
+	}
+
+	SubViewport *sub_viewport = Object::cast_to<SubViewport>(viewport);
+	ERR_FAIL_NULL_V(sub_viewport, Size2i());
+
+	if (sub_viewport == EditorNode::get_singleton()->get_scene_root()) {
+		return Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	}
+
+	return sub_viewport->get_size();
+}
+
 Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 	if (is_snap_enabled()) {
 		real_t snap = get_translate_snap();

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -841,6 +841,8 @@ protected:
 public:
 	static Node3DEditor *get_singleton() { return singleton; }
 
+	static Size2i get_camera_viewport_size(Camera3D *p_camera);
+
 	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
 
 	float get_znear() const { return settings_znear->get_value(); }


### PR DESCRIPTION
An alternate solution for https://github.com/godotengine/godot-proposals/issues/1017

https://github.com/godotengine/godot/assets/372476/a77cc860-ecf4-4fa5-b23e-daea809775fd

The main problem to solve is that cameras can't be transformed (inside the 3D viewport) when in preview mode. Turning split viewports on and off for a **temporary** operation is tedious.

Previewing in the inspector is almost the same as using picture-in-picture. But keeps UI the same as other texture previews.