### PR TITLE
Add SkeletonIK3D `get`/`set_interpolation` compat from #87888

### DIFF
--- a/doc/classes/SkeletonIK3D.xml
+++ b/doc/classes/SkeletonIK3D.xml
@@ -55,6 +55,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="interpolation" type="float" setter="set_interpolation" getter="get_interpolation" deprecated="Use [member SkeletonModifier3D.influence] instead.">
+			Interpolation value for how much the IK results are applied to the current skeleton bone chain. A value of [code]1.0[/code] will overwrite all skeleton bone transforms completely while a value of [code]0.0[/code] will visually disable the SkeletonIK.
+		</member>
 		<member name="magnet" type="Vector3" setter="set_magnet_position" getter="get_magnet_position" default="Vector3(0, 0, 0)">
 			Secondary target position (first is [member target] property or [member target_node]) for the IK chain. Use magnet position (pole target) to control the bending of the IK chain. Only works if the bone chain has more than 2 bones. The middle chain bone position will be linearly interpolated with the magnet position.
 		</member>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -264,9 +264,6 @@ Removed VisualShaderNodeComment, which is replaced by VisualShaderNodeFrame.
 GH-87888
 --------
 Validate extension JSON: API was removed: classes/Skeleton3D/properties/animate_physical_bones
-Validate extension JSON: API was removed: classes/SkeletonIK3D/methods/get_interpolation
-Validate extension JSON: API was removed: classes/SkeletonIK3D/methods/set_interpolation
-Validate extension JSON: API was removed: classes/SkeletonIK3D/properties/interpolation
 
 These base class is changed to SkeletonModifier3D which is processed by Skeleton3D with the assumption that it is Skeleton3D's child.
 

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -366,6 +366,12 @@ void SkeletonIK3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "target_node"), "set_target_node", "get_target_node");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_min_distance", "get_min_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_iterations"), "set_max_iterations", "get_max_iterations");
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("set_interpolation", "interpolation"), &SkeletonIK3D::_set_interpolation);
+	ClassDB::bind_method(D_METHOD("get_interpolation"), &SkeletonIK3D::_get_interpolation);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "interpolation", PROPERTY_HINT_RANGE, "0,1,0.001", PROPERTY_USAGE_NONE), "set_interpolation", "get_interpolation");
+#endif
 }
 
 void SkeletonIK3D::_process_modification() {
@@ -414,6 +420,16 @@ void SkeletonIK3D::set_tip_bone(const StringName &p_tip_bone) {
 StringName SkeletonIK3D::get_tip_bone() const {
 	return tip_bone;
 }
+
+#ifndef DISABLE_DEPRECATED
+void SkeletonIK3D::_set_interpolation(real_t p_interpolation) {
+	set_influence(p_interpolation);
+}
+
+real_t SkeletonIK3D::_get_interpolation() const {
+	return get_influence();
+}
+#endif
 
 void SkeletonIK3D::set_target_transform(const Transform3D &p_target) {
 	target = p_target;

--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -134,6 +134,11 @@ class SkeletonIK3D : public SkeletonModifier3D {
 	Variant target_node_override_ref = Variant();
 	FabrikInverseKinematic::Task *task = nullptr;
 
+#ifndef DISABLE_DEPRECATED
+	void _set_interpolation(real_t p_interpolation);
+	real_t _get_interpolation() const;
+#endif // DISABLE_DEPRECATED
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 


### PR DESCRIPTION
Adds both SkeletonIK3D functions mentioned in issue #90303

interpolation was moved to influence, so the compat methods forward to the influence getter/setter.