### PR TITLE
Only define `ENGINE_UPDATE_CHECK_ENABLED` in editor builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -475,7 +475,7 @@ if methods.get_cmdline_bool("fast_unsafe", env_base.dev_build):
 if env_base["use_precise_math_checks"]:
     env_base.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])
 
-if env_base["engine_update_check"]:
+if env_base.editor_build and env_base["engine_update_check"]:
     env_base.Append(CPPDEFINES=["ENGINE_UPDATE_CHECK_ENABLED"])
 
 if not env_base.File("#main/splash_editor.png").exists():


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR simply makes the piece of code only compile for editor builds, thus reducing tiny bit of binary size from template builds since they don't need to update/upgrade the engine unless they want.