### PR TITLE
Allow adding custom export platforms using scripts / GDExtension.

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -11,11 +11,217 @@
 		<link title="Console support in Godot">$DOCS_URL/tutorials/platform/consoles.html</link>
 	</tutorials>
 	<methods>
+		<method name="add_message">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="EditorExportPlatform.ExportMessageType" />
+			<param index="1" name="category" type="String" />
+			<param index="2" name="message" type="String" />
+			<description>
+				Adds a message to the export log that will be displayed when exporting ends.
+			</description>
+		</method>
+		<method name="clear_messages">
+			<return type="void" />
+			<description>
+				Clears the export log.
+			</description>
+		</method>
+		<method name="create_preset">
+			<return type="EditorExportPreset" />
+			<description>
+				Create a new preset for this platform.
+			</description>
+		</method>
+		<method name="export_pack">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" default="0" />
+			<description>
+				Creates a PCK archive at [param path] for the specified [param preset].
+			</description>
+		</method>
+		<method name="export_project">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" default="0" />
+			<description>
+				Creates a full project at [param path] for the specified [param preset].
+			</description>
+		</method>
+		<method name="export_project_files">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="save_cb" type="Callable" />
+			<param index="3" name="shared_cb" type="Callable" default="Callable()" />
+			<description>
+				Exports project files for the specified preset. This method can be used to implement custom export format, other than PCK and ZIP. One of the callbacks is called for each exported file.
+				[param save_cb] is called for all exported files and have the following arguments: [code]file_path: String[/code], [code]file_data: PackedByteArray[/code], [code]file_index: int[/code], [code]file_count: int[/code], [code]encryption_include_filters: PackedStringArray[/code], [code]encryption_exclude_filters: PackedStringArray[/code], [code]encryption_key: PackedByteArray[/code].
+				[param shared_cb] is called for exported native shared/static libraries and have the following arguments: [code]file_path: String[/code], [code]tags: PackedStringArray[/code], [code]target_folder: String[/code].
+				[b]Note:[/b] [code]file_index[/code] and [code]file_count[/code] are intended for progress tracking only and aren't necesserely unique and precise.
+			</description>
+		</method>
+		<method name="export_zip">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" default="0" />
+			<description>
+				Create a ZIP archive at [param path] for the specified [param preset].
+			</description>
+		</method>
+		<method name="find_export_template" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="template_file_name" type="String" />
+			<description>
+				Locates export template for the platform, and returns [Dictionary] with the following keys: [code]path: String[/code] and [code]error: String[/code]. This method is provided for convenience and custom export platforms aren't required to use it or keep export templates stored in the same way official templates are.
+			</description>
+		</method>
+		<method name="gen_export_flags">
+			<return type="PackedStringArray" />
+			<param index="0" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
+			<description>
+				Generates array of command line arguments for the default export templates for the debug flags and editor settings.
+			</description>
+		</method>
+		<method name="get_current_presets" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns array of [EditorExportPreset]s for this platform.
+			</description>
+		</method>
+		<method name="get_forced_export_files" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns array of core file names that always should be exported regardless of preset config.
+			</description>
+		</method>
+		<method name="get_message_category" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns message category, for the message with [param index].
+			</description>
+		</method>
+		<method name="get_message_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns number of messages in the export log.
+			</description>
+		</method>
+		<method name="get_message_text" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns message text, for the message with [param index].
+			</description>
+		</method>
+		<method name="get_message_type" qualifiers="const">
+			<return type="int" enum="EditorExportPlatform.ExportMessageType" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns message type, for the message with [param index].
+			</description>
+		</method>
 		<method name="get_os_name" qualifiers="const">
 			<return type="String" />
 			<description>
 				Returns the name of the export operating system handled by this [EditorExportPlatform] class, as a friendly string. Possible return values are [code]Windows[/code], [code]Linux[/code], [code]macOS[/code], [code]Android[/code], [code]iOS[/code], and [code]Web[/code].
 			</description>
 		</method>
+		<method name="get_worst_message_type" qualifiers="const">
+			<return type="int" enum="EditorExportPlatform.ExportMessageType" />
+			<description>
+				Returns most severe message type currently present in the export log.
+			</description>
+		</method>
+		<method name="save_pack">
+			<return type="Dictionary" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="embed" type="bool" default="false" />
+			<description>
+				Saves PCK archive and returns [Dictionary] with the following keys: [code]result: Error[/code], [code]so_files: Array[/code] (array of the shared/static objects which contains dictionaries with the following keys: [code]path: String[/code], [code]tags: PackedStringArray[/code], and [code]target_folder: String[/code]).
+				If [param embed] is [code]true[/code], PCK content is appended to the end of [param path] file and return [Dictionary] additionally include following keys: [code]embedded_start: int[/code] (embedded PCK offset) and [code]embedded_size: int[/code] (embedded PCK size).
+			</description>
+		</method>
+		<method name="save_zip">
+			<return type="Dictionary" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<description>
+				Saves ZIP archive and returns [Dictionary] with the following keys: [code]result: Error[/code], [code]so_files: Array[/code] (array of the shared/static objects which contains dictionaries with the following keys: [code]path: String[/code], [code]tags: PackedStringArray[/code], and [code]target_folder: String[/code]).
+			</description>
+		</method>
+		<method name="ssh_push_to_remote" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="host" type="String" />
+			<param index="1" name="port" type="String" />
+			<param index="2" name="scp_args" type="PackedStringArray" />
+			<param index="3" name="src_file" type="String" />
+			<param index="4" name="dst_file" type="String" />
+			<description>
+				Uploads specified file over SCP protocol to the remote host.
+			</description>
+		</method>
+		<method name="ssh_run_on_remote" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="host" type="String" />
+			<param index="1" name="port" type="String" />
+			<param index="2" name="ssh_arg" type="PackedStringArray" />
+			<param index="3" name="cmd_args" type="String" />
+			<param index="4" name="output" type="Array" default="[]" />
+			<param index="5" name="port_fwd" type="int" default="-1" />
+			<description>
+				Executes specified command on the remote host via SSH protocol and returns command output in the [param output].
+			</description>
+		</method>
+		<method name="ssh_run_on_remote_no_wait" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="host" type="String" />
+			<param index="1" name="port" type="String" />
+			<param index="2" name="ssh_args" type="PackedStringArray" />
+			<param index="3" name="cmd_args" type="String" />
+			<param index="4" name="port_fwd" type="int" default="-1" />
+			<description>
+				Executes specified command on the remote host via SSH protocol and returns process ID (on the remote host) without waiting for command to finish.
+			</description>
+		</method>
 	</methods>
+	<constants>
+		<constant name="EXPORT_MESSAGE_NONE" value="0" enum="ExportMessageType">
+			Invalid message type used as the default value when no type is specified.
+		</constant>
+		<constant name="EXPORT_MESSAGE_INFO" value="1" enum="ExportMessageType">
+			Message type for informational messages that have no effect on the export.
+		</constant>
+		<constant name="EXPORT_MESSAGE_WARNING" value="2" enum="ExportMessageType">
+			Message type for warning messages that should be addressed but still allow to complete the export.
+		</constant>
+		<constant name="EXPORT_MESSAGE_ERROR" value="3" enum="ExportMessageType">
+			Message type for error messages that must be addressed and fail the export.
+		</constant>
+		<constant name="DEBUG_FLAG_DUMB_CLIENT" value="1" enum="DebugFlags" is_bitfield="true">
+			Flag is set if remotely debugged project is expected to use remote file system. If set, [method gen_export_flags] will add [code]--remove-fs[/code] and [code]--remote-fs-password[/code] (if password is set in the editor settings) command line arguments to the list.
+		</constant>
+		<constant name="DEBUG_FLAG_REMOTE_DEBUG" value="2" enum="DebugFlags" is_bitfield="true">
+			Flag is set if remote debug is enabled. If set, [method gen_export_flags] will add [code]--remote-debug[/code] and [code]--breakpoints[/code] (if breakpoints are selected in the script editor or added by the plugin) command line arguments to the list.
+		</constant>
+		<constant name="DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST" value="4" enum="DebugFlags" is_bitfield="true">
+			Flag is set if remotely debugged project is running on the localhost. If set, [method gen_export_flags] will use [code]localhost[/code] instead of [member EditorSettings.network/debug/remote_host] as remote debugger host.
+		</constant>
+		<constant name="DEBUG_FLAG_VIEW_COLLISIONS" value="8" enum="DebugFlags" is_bitfield="true">
+			Flag is set if "Visible Collision Shapes" remote debug option is enabled. If set, [method gen_export_flags] will add [code]--debug-collisions[/code] command line arguments to the list.
+		</constant>
+		<constant name="DEBUG_FLAG_VIEW_NAVIGATION" value="16" enum="DebugFlags" is_bitfield="true">
+			Flag is set if Visible Navigation" remote debug option is enabled. If set, [method gen_export_flags] will add [code]--debug-navigation[/code] command line arguments to the list.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformExtension" inherits="EditorExportPlatform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for custom [EditorExportPlatform] implementations (plugins).
+	</brief_description>
+	<description>
+		External [EditorExportPlatform] implementations should inherit from this class.
+		To use [EditorExportPlatform], register it using the [method EditorPlugin.add_export_platform] method first.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_can_export" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code], if specified [param preset] is valid and can be exported. Use [method set_config_error] and [method set_config_missing_templates] to set error details.
+				Usual implementation can call [method _has_valid_export_configuration] and [method _has_valid_project_configuration] to determine if export is possible.
+			</description>
+		</method>
+		<method name="_cleanup" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				[b]Optional.[/b]
+				Called by the editor before platform is unregistered.
+			</description>
+		</method>
+		<method name="_export_pack" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
+			<description>
+				[b]Optional.[/b]
+				Creates a PCK archive at [param path] for the specified [param preset].
+				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, and PCK is selected as a file type.
+			</description>
+		</method>
+		<method name="_export_project" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
+			<description>
+				[b]Required.[/b]
+				Creates a full project at [param path] for the specified [param preset].
+				This method is called when "Export" button is pressed in the export dialog.
+				This method implementation can call [method EditorExportPlatform.save_pack] or [method EditorExportPlatform.save_zip] to use default PCK/ZIP export process, or calls [method EditorExportPlatform.export_project_files] and implement custom callback for processing each exported file.
+			</description>
+		</method>
+		<method name="_export_zip" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
+			<description>
+				[b]Optional.[/b]
+				Create a ZIP archive at [param path] for the specified [param preset].
+				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, and ZIP is selected as a file type.
+			</description>
+		</method>
+		<method name="_get_binary_extensions" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<description>
+				[b]Required.[/b]
+				Returns array of supported binary extensions for the full project export.
+			</description>
+		</method>
+		<method name="_get_debug_protocol" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				[b]Optional.[/b]
+				Returns protocol used for remote debugging. Default implementation return [code]tcp://[/code].
+			</description>
+		</method>
+		<method name="_get_device_architecture" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="device" type="int" />
+			<description>
+				[b]Optional.[/b]
+				Returns device architecture for one-click deploy.
+			</description>
+		</method>
+		<method name="_get_export_option_visibility" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="option" type="String" />
+			<description>
+				[b]Optional.[/b]
+				Validates [param option] and returns visibility for the specified [param preset]. Default implementation return [code]true[/code] for all options.
+			</description>
+		</method>
+		<method name="_get_export_option_warning" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="option" type="StringName" />
+			<description>
+				[b]Optional.[/b]
+				Validates [param option] and returns warning message for the specified [param preset]. Default implementation return empty string for all options.
+			</description>
+		</method>
+		<method name="_get_export_options" qualifiers="virtual const">
+			<return type="Dictionary[]" />
+			<description>
+				[b]Optional.[/b]
+				Returns a property list, as an [Array] of dictionaries. Each [Dictionary] must at least contain the [code]name: StringName[/code] and [code]type: Variant.Type[/code] entries.
+				Additionally, the following keys are supported:
+				- [code]hint: PropertyHint[/code]
+				- [code]hint_string: String[/code]
+				- [code]usage: PropertyUsageFlags[/code]
+				- [code]class_name: StringName[/code]
+				- [code]default_value: Variant[/code], default value of the property.
+				- [code]update_visibility: bool[/code], if set to [code]true[/code], [method _get_export_option_visibility] is called for each property when this property is changed.
+				- [code]required: bool[/code], if set to [code]true[/code], this property warnings are critical, and should be resolved to make export possible. This value is a hint for the [method _has_valid_export_configuration] implementation, and not used by the engine directly.
+				See also [method Object._get_property_list].
+			</description>
+		</method>
+		<method name="_get_logo" qualifiers="virtual const">
+			<return type="Texture2D" />
+			<description>
+				[b]Required.[/b]
+				Returns platform logo displayed in the export dialog, logo should be 32x32 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				[b]Required.[/b]
+				Returns export platform name.
+			</description>
+		</method>
+		<method name="_get_option_icon" qualifiers="virtual const">
+			<return type="ImageTexture" />
+			<param index="0" name="device" type="int" />
+			<description>
+				[b]Optional.[/b]
+				Returns one-click deploy menu item icon for the specified [param device], icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+			</description>
+		</method>
+		<method name="_get_option_label" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="device" type="int" />
+			<description>
+				[b]Optional.[/b]
+				Returns one-click deploy menu item label for the specified [param device].
+			</description>
+		</method>
+		<method name="_get_option_tooltip" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="device" type="int" />
+			<description>
+				[b]Optional.[/b]
+				Returns one-click deploy menu item tooltip for the specified [param device].
+			</description>
+		</method>
+		<method name="_get_options_count" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				[b]Optional.[/b]
+				Returns number one-click deploy devices (or other one-click option displayed in the menu).
+			</description>
+		</method>
+		<method name="_get_options_tooltip" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				[b]Optional.[/b]
+				Returns tooltip of the one-click deploy menu button.
+			</description>
+		</method>
+		<method name="_get_os_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				[b]Required.[/b]
+				Returns target OS name.
+			</description>
+		</method>
+		<method name="_get_platform_features" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<description>
+				[b]Required.[/b]
+				Returns array of platform specific features.
+			</description>
+		</method>
+		<method name="_get_preset_features" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<description>
+				[b]Required.[/b]
+				Returns array of platform specific features for the specified [param preset].
+			</description>
+		</method>
+		<method name="_get_run_icon" qualifiers="virtual const">
+			<return type="Texture2D" />
+			<description>
+				[b]Optional.[/b]
+				Returns icon of the one-click deploy menu button, icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+			</description>
+		</method>
+		<method name="_has_valid_export_configuration" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="debug" type="bool" />
+			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if export configuration is valid.
+			</description>
+		</method>
+		<method name="_has_valid_project_configuration" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if project configuration is valid.
+			</description>
+		</method>
+		<method name="_is_executable" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if specified file is a valid executable (native executable or script) for the target platform.
+			</description>
+		</method>
+		<method name="_poll_export" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if one-click deploy options are changed and editor interface should be updated.
+			</description>
+		</method>
+		<method name="_run" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="device" type="int" />
+			<param index="2" name="debug_flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
+			<description>
+				[b]Optional.[/b]
+				This method is called when [param device] one-click deploy menu option is selected.
+				Implementation should export project to a temporary location, upload and run it on the specific [param device], or perform another action associated with the menu item.
+			</description>
+		</method>
+		<method name="_should_update_export_options" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if export options list is changed and presets should be updated.
+			</description>
+		</method>
+		<method name="get_config_error" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns current configuration error message text. This method should be called only from the [method _can_export], [method _has_valid_export_configuration], or [method _has_valid_project_configuration] implementations.
+			</description>
+		</method>
+		<method name="get_config_missing_templates" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] is export templates are missing from the current configuration. This method should be called only from the [method _can_export], [method _has_valid_export_configuration], or [method _has_valid_project_configuration] implementations.
+			</description>
+		</method>
+		<method name="set_config_error" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="error_text" type="String" />
+			<description>
+				Sets current configuration error message text. This method should be called only from the [method _can_export], [method _has_valid_export_configuration], or [method _has_valid_project_configuration] implementations.
+			</description>
+		</method>
+		<method name="set_config_missing_templates" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="missing_templates" type="bool" />
+			<description>
+				Set to [code]true[/code] is export templates are missing from the current configuration. This method should be called only from the [method _can_export], [method _has_valid_export_configuration], or [method _has_valid_project_configuration] implementations.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -305,6 +305,18 @@
 				In case of a directory code-sign will error if you place non code object in directory.
 			</description>
 		</method>
+		<method name="get_export_platform" qualifiers="const">
+			<return type="EditorExportPlatform" />
+			<description>
+				Returns currently used export platform.
+			</description>
+		</method>
+		<method name="get_export_preset" qualifiers="const">
+			<return type="EditorExportPreset" />
+			<description>
+				Returns currently used export preset.
+			</description>
+		</method>
 		<method name="get_option" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="name" type="StringName" />

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPreset" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Export preset configuration.
+	</brief_description>
+	<description>
+		Export preset configuration. Instances of [EditorExportPreset] by editor UI and intended to be used a read-only configuration passed to the [EditorExportPlatform] methods when exporting the project.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="are_advanced_options_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code], is "Advanced" toggle is enabled in the export dialog.
+			</description>
+		</method>
+		<method name="get_custom_features" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns string with a comma separated list of custom features.
+			</description>
+		</method>
+		<method name="get_customized_files" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns [Dictionary] of files selected in the "Resources" tab of the export dialog. Dictionary keys are file names and values are export mode - [code]"strip[/code], [code]"keep"[/code], or [code]"remove"[/code]. See also [method get_file_export_mode].
+			</description>
+		</method>
+		<method name="get_customized_files_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns number of files selected in the "Resources" tab of the export dialog.
+			</description>
+		</method>
+		<method name="get_encrypt_directory" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code], PCK directory encryption is enabled in the export dialog.
+			</description>
+		</method>
+		<method name="get_encrypt_pck" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code], PCK encryption is enabled in the export dialog.
+			</description>
+		</method>
+		<method name="get_encryption_ex_filter" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns file filters to exclude during PCK encryption.
+			</description>
+		</method>
+		<method name="get_encryption_in_filter" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns file filters to include during PCK encryption.
+			</description>
+		</method>
+		<method name="get_encryption_key" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns PCK encryption key.
+			</description>
+		</method>
+		<method name="get_exclude_filter" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns file filters to exclude during export.
+			</description>
+		</method>
+		<method name="get_export_filter" qualifiers="const">
+			<return type="int" enum="EditorExportPreset.ExportFilter" />
+			<description>
+				Returns export file filter mode selected in the "Resources" tab of the export dialog.
+			</description>
+		</method>
+		<method name="get_export_path" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns export target path.
+			</description>
+		</method>
+		<method name="get_file_export_mode" qualifiers="const">
+			<return type="int" enum="EditorExportPreset.FileExportMode" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="default" type="int" enum="EditorExportPreset.FileExportMode" default="0" />
+			<description>
+				Returns file export mode for the specified file.
+			</description>
+		</method>
+		<method name="get_files_to_export" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns array of files to export.
+			</description>
+		</method>
+		<method name="get_include_filter" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns file filters to include during export.
+			</description>
+		</method>
+		<method name="get_or_env" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="env_var" type="String" />
+			<description>
+				Returns export option value or value of environment variable if it is set.
+			</description>
+		</method>
+		<method name="get_preset_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns export preset name.
+			</description>
+		</method>
+		<method name="get_script_export_mode" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns script export mode.
+			</description>
+		</method>
+		<method name="get_version" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="windows_version" type="bool" />
+			<description>
+				Returns the preset's version number, or fall back to the [member ProjectSettings.application/config/version] project setting if set to an empty string.
+				If [param windows_version] is [code]true[/code], formats the returned version number to be compatible with Windows executable metadata.
+			</description>
+		</method>
+		<method name="has" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+				Returns [code]true[/code] if preset has specified property.
+			</description>
+		</method>
+		<method name="has_export_file">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns [code]true[/code] if specified file is exported.
+			</description>
+		</method>
+		<method name="is_dedicated_server" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if dedicated server export mode is selected in the export dialog.
+			</description>
+		</method>
+		<method name="is_runnable" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if "Runnable" toggle is enabled in the export dialog.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="EXPORT_ALL_RESOURCES" value="0" enum="ExportFilter">
+		</constant>
+		<constant name="EXPORT_SELECTED_SCENES" value="1" enum="ExportFilter">
+		</constant>
+		<constant name="EXPORT_SELECTED_RESOURCES" value="2" enum="ExportFilter">
+		</constant>
+		<constant name="EXCLUDE_SELECTED_RESOURCES" value="3" enum="ExportFilter">
+		</constant>
+		<constant name="EXPORT_CUSTOMIZED" value="4" enum="ExportFilter">
+		</constant>
+		<constant name="MODE_FILE_NOT_CUSTOMIZED" value="0" enum="FileExportMode">
+		</constant>
+		<constant name="MODE_FILE_STRIP" value="1" enum="FileExportMode">
+		</constant>
+		<constant name="MODE_FILE_KEEP" value="2" enum="FileExportMode">
+		</constant>
+		<constant name="MODE_FILE_REMOVE" value="3" enum="FileExportMode">
+		</constant>
+		<constant name="MODE_SCRIPT_TEXT" value="0" enum="ScriptExportMode">
+		</constant>
+		<constant name="MODE_SCRIPT_BINARY_TOKENS" value="1" enum="ScriptExportMode">
+		</constant>
+		<constant name="MODE_SCRIPT_BINARY_TOKENS_COMPRESSED" value="2" enum="ScriptExportMode">
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -455,6 +455,13 @@
 				Adds a [Script] as debugger plugin to the Debugger. The script must extend [EditorDebuggerPlugin].
 			</description>
 		</method>
+		<method name="add_export_platform">
+			<return type="void" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<description>
+				Registers a new [EditorExportPlatform]. Export platforms provides functionality of exporting to the specific platform.
+			</description>
+		</method>
 		<method name="add_export_plugin">
 			<return type="void" />
 			<param index="0" name="plugin" type="EditorExportPlugin" />
@@ -651,6 +658,13 @@
 			<param index="0" name="script" type="EditorDebuggerPlugin" />
 			<description>
 				Removes the debugger plugin with given script from the Debugger.
+			</description>
+		</method>
+		<method name="remove_export_platform">
+			<return type="void" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<description>
+				Removes an export platform registered by [method add_export_platform].
 			</description>
 		</method>
 		<method name="remove_export_plugin">

--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_breakpoints">
+			<return type="PackedStringArray" />
+			<description>
+				Returns array of breakpoints.
+			</description>
+		</method>
 		<method name="get_current_editor" qualifiers="const">
 			<return type="ScriptEditorBase" />
 			<description>

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -141,7 +141,7 @@ Error EditorRunNative::start_run_native(int p_id) {
 
 	emit_signal(SNAME("native_run"), preset);
 
-	int flags = 0;
+	BitField<EditorExportPlatform::DebugFlags> flags = 0;
 
 	bool deploy_debug_remote = is_deploy_debug_remote_enabled();
 	bool deploy_dumb = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
@@ -149,16 +149,16 @@ Error EditorRunNative::start_run_native(int p_id) {
 	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
 
 	if (deploy_debug_remote) {
-		flags |= EditorExportPlatform::DEBUG_FLAG_REMOTE_DEBUG;
+		flags.set_flag(EditorExportPlatform::DEBUG_FLAG_REMOTE_DEBUG);
 	}
 	if (deploy_dumb) {
-		flags |= EditorExportPlatform::DEBUG_FLAG_DUMB_CLIENT;
+		flags.set_flag(EditorExportPlatform::DEBUG_FLAG_DUMB_CLIENT);
 	}
 	if (debug_collisions) {
-		flags |= EditorExportPlatform::DEBUG_FLAG_VIEW_COLLISIONS;
+		flags.set_flag(EditorExportPlatform::DEBUG_FLAG_VIEW_COLLISIONS);
 	}
 	if (debug_navigation) {
-		flags |= EditorExportPlatform::DEBUG_FLAG_VIEW_NAVIGATION;
+		flags.set_flag(EditorExportPlatform::DEBUG_FLAG_VIEW_NAVIGATION);
 	}
 
 	eep->clear_messages();

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -124,7 +124,17 @@ void EditorExport::_bind_methods() {
 
 void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
 	export_platforms.push_back(p_platform);
+
 	should_update_presets = true;
+	should_reload_presets = true;
+}
+
+void EditorExport::remove_export_platform(const Ref<EditorExportPlatform> &p_platform) {
+	export_platforms.erase(p_platform);
+	p_platform->cleanup();
+
+	should_update_presets = true;
+	should_reload_presets = true;
 }
 
 int EditorExport::get_export_platform_count() {
@@ -244,7 +254,7 @@ void EditorExport::load_config() {
 
 		if (!preset.is_valid()) {
 			index++;
-			ERR_CONTINUE(!preset.is_valid());
+			continue; // Unknown platform, skip without error (platform might be loaded later).
 		}
 
 		preset->set_name(config->get_value(section, "name"));
@@ -342,6 +352,12 @@ void EditorExport::load_config() {
 
 void EditorExport::update_export_presets() {
 	HashMap<StringName, List<EditorExportPlatform::ExportOption>> platform_options;
+
+	if (should_reload_presets) {
+		should_reload_presets = false;
+		export_presets.clear();
+		load_config();
+	}
 
 	for (int i = 0; i < export_platforms.size(); i++) {
 		Ref<EditorExportPlatform> platform = export_platforms[i];

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -47,6 +47,7 @@ class EditorExport : public Node {
 	Timer *save_timer = nullptr;
 	bool block_save = false;
 	bool should_update_presets = false;
+	bool should_reload_presets = false;
 
 	static EditorExport *singleton;
 
@@ -66,6 +67,7 @@ public:
 	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
 	int get_export_platform_count();
 	Ref<EditorExportPlatform> get_export_platform(int p_idx);
+	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 
 	void add_export_preset(const Ref<EditorExportPreset> &p_preset, int p_at_pos = -1);
 	int get_export_preset_count() const;

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -56,6 +56,14 @@ public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 	typedef Error (*EditorExportSaveSharedObject)(void *p_userdata, const SharedObject &p_so);
 
+	enum DebugFlags {
+		DEBUG_FLAG_DUMB_CLIENT = 1,
+		DEBUG_FLAG_REMOTE_DEBUG = 2,
+		DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST = 4,
+		DEBUG_FLAG_VIEW_COLLISIONS = 8,
+		DEBUG_FLAG_VIEW_NAVIGATION = 16,
+	};
+
 	enum ExportMessageType {
 		EXPORT_MESSAGE_NONE,
 		EXPORT_MESSAGE_INFO,
@@ -92,6 +100,7 @@ private:
 	struct ZipData {
 		void *zip = nullptr;
 		EditorProgress *ep = nullptr;
+		Vector<SharedObject> *so_files = nullptr;
 	};
 
 	Vector<ExportMessage> messages;
@@ -101,12 +110,21 @@ private:
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
 	static Error _save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
+	static Error _pack_add_shared_object(void *p_userdata, const SharedObject &p_so);
+
 	static Error _save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
+	static Error _zip_add_shared_object(void *p_userdata, const SharedObject &p_so);
+
+	struct ScriptCallbackData {
+		Callable file_cb;
+		Callable so_cb;
+	};
+
+	static Error _script_save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
+	static Error _script_add_shared_object(void *p_userdata, const SharedObject &p_so);
 
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);
-
-	static Error _add_shared_object(void *p_userdata, const SharedObject &p_so);
 
 	struct FileExportCache {
 		uint64_t source_modified_time = 0;
@@ -126,18 +144,45 @@ private:
 
 protected:
 	struct ExportNotifier {
-		ExportNotifier(EditorExportPlatform &p_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags);
+		ExportNotifier(EditorExportPlatform &p_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags);
 		~ExportNotifier();
 	};
 
 	HashSet<String> get_features(const Ref<EditorExportPreset> &p_preset, bool p_debug) const;
 
-	bool exists_export_template(const String &template_file_name, String *err) const;
-	String find_export_template(const String &template_file_name, String *err = nullptr) const;
-	void gen_export_flags(Vector<String> &r_flags, int p_flags);
-	void gen_debug_flags(Vector<String> &r_flags, int p_flags);
+	Dictionary _find_export_template(const String &p_template_file_name) const {
+		Dictionary ret;
+		String err;
+
+		String path = find_export_template(p_template_file_name, &err);
+		ret["result"] = (err.is_empty() && !path.is_empty()) ? OK : FAILED;
+		ret["path"] = path;
+		ret["error_string"] = err;
+
+		return ret;
+	}
+
+	bool exists_export_template(const String &p_template_file_name, String *r_err) const;
+	String find_export_template(const String &p_template_file_name, String *r_err = nullptr) const;
+	Vector<String> gen_export_flags(BitField<EditorExportPlatform::DebugFlags> p_flags);
 
 	virtual void zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name);
+
+	Error _ssh_run_on_remote(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, Array r_output = Array(), int p_port_fwd = -1) const {
+		String pipe;
+		Error err = ssh_run_on_remote(p_host, p_port, p_ssh_args, p_cmd_args, &pipe, p_port_fwd);
+		r_output.push_back(pipe);
+		return err;
+	}
+	OS::ProcessID _ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, int p_port_fwd = -1) const {
+		OS::ProcessID pid = 0;
+		Error err = ssh_run_on_remote_no_wait(p_host, p_port, p_ssh_args, p_cmd_args, &pid, p_port_fwd);
+		if (err != OK) {
+			return -1;
+		} else {
+			return pid;
+		}
+	}
 
 	Error ssh_run_on_remote(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, String *r_out = nullptr, int p_port_fwd = -1) const;
 	Error ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, OS::ProcessID *r_pid = nullptr, int p_port_fwd = -1) const;
@@ -195,6 +240,21 @@ public:
 		return messages[p_index];
 	}
 
+	virtual ExportMessageType _get_message_type(int p_index) const {
+		ERR_FAIL_INDEX_V(p_index, messages.size(), EXPORT_MESSAGE_NONE);
+		return messages[p_index].msg_type;
+	}
+
+	virtual String _get_message_category(int p_index) const {
+		ERR_FAIL_INDEX_V(p_index, messages.size(), String());
+		return messages[p_index].category;
+	}
+
+	virtual String _get_message_text(int p_index) const {
+		ERR_FAIL_INDEX_V(p_index, messages.size(), String());
+		return messages[p_index].text;
+	}
+
 	virtual ExportMessageType get_worst_message_type() const {
 		ExportMessageType worst_type = EXPORT_MESSAGE_NONE;
 		for (int i = 0; i < messages.size(); i++) {
@@ -216,10 +276,16 @@ public:
 	virtual String get_name() const = 0;
 	virtual Ref<Texture2D> get_logo() const = 0;
 
+	Array get_current_presets() const;
+
+	Error _export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, const Callable &p_save_func, const Callable &p_so_func);
 	Error export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, EditorExportSaveFunction p_func, void *p_udata, EditorExportSaveSharedObject p_so_func = nullptr);
 
+	Dictionary _save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, bool p_embed = false);
+	Dictionary _save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
+
 	Error save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, bool p_embed = false, int64_t *r_embedded_start = nullptr, int64_t *r_embedded_size = nullptr);
-	Error save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
+	Error save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr);
 
 	virtual bool poll_export() { return false; }
 	virtual int get_options_count() const { return 0; }
@@ -229,31 +295,26 @@ public:
 	virtual String get_option_tooltip(int p_device) const { return ""; }
 	virtual String get_device_architecture(int p_device) const { return ""; }
 
-	enum DebugFlags {
-		DEBUG_FLAG_DUMB_CLIENT = 1,
-		DEBUG_FLAG_REMOTE_DEBUG = 2,
-		DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST = 4,
-		DEBUG_FLAG_VIEW_COLLISIONS = 8,
-		DEBUG_FLAG_VIEW_NAVIGATION = 16,
-	};
-
 	virtual void cleanup() {}
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) { return OK; }
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) { return OK; }
 	virtual Ref<Texture2D> get_run_icon() const { return get_logo(); }
 
-	bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const;
+	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const;
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const = 0;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const = 0;
 
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const = 0;
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
-	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
-	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) = 0;
+	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
+	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) const = 0;
-	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) = 0;
+	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features){};
 	virtual String get_debug_protocol() const { return "tcp://"; }
 
 	EditorExportPlatform();
 };
+
+VARIANT_ENUM_CAST(EditorExportPlatform::ExportMessageType)
+VARIANT_BITFIELD_CAST(EditorExportPlatform::DebugFlags);
 
 #endif // EDITOR_EXPORT_PLATFORM_H

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -1,0 +1,317 @@
+/**************************************************************************/
+/*  editor_export_platform_extension.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_export_platform_extension.h"
+
+void EditorExportPlatformExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_config_error", "error_text"), &EditorExportPlatformExtension::set_config_error);
+	ClassDB::bind_method(D_METHOD("get_config_error"), &EditorExportPlatformExtension::get_config_error);
+
+	ClassDB::bind_method(D_METHOD("set_config_missing_templates", "missing_templates"), &EditorExportPlatformExtension::set_config_missing_templates);
+	ClassDB::bind_method(D_METHOD("get_config_missing_templates"), &EditorExportPlatformExtension::get_config_missing_templates);
+
+	GDVIRTUAL_BIND(_get_preset_features, "preset");
+	GDVIRTUAL_BIND(_is_executable, "path");
+	GDVIRTUAL_BIND(_get_export_options);
+	GDVIRTUAL_BIND(_should_update_export_options);
+	GDVIRTUAL_BIND(_get_export_option_visibility, "preset", "option");
+	GDVIRTUAL_BIND(_get_export_option_warning, "preset", "option");
+
+	GDVIRTUAL_BIND(_get_os_name);
+	GDVIRTUAL_BIND(_get_name);
+	GDVIRTUAL_BIND(_get_logo);
+
+	GDVIRTUAL_BIND(_poll_export);
+	GDVIRTUAL_BIND(_get_options_count);
+	GDVIRTUAL_BIND(_get_options_tooltip);
+
+	GDVIRTUAL_BIND(_get_option_icon, "device");
+	GDVIRTUAL_BIND(_get_option_label, "device");
+	GDVIRTUAL_BIND(_get_option_tooltip, "device");
+	GDVIRTUAL_BIND(_get_device_architecture, "device");
+
+	GDVIRTUAL_BIND(_cleanup);
+
+	GDVIRTUAL_BIND(_run, "preset", "device", "debug_flags");
+	GDVIRTUAL_BIND(_get_run_icon);
+
+	GDVIRTUAL_BIND(_can_export, "preset", "debug");
+	GDVIRTUAL_BIND(_has_valid_export_configuration, "preset", "debug");
+	GDVIRTUAL_BIND(_has_valid_project_configuration, "preset");
+
+	GDVIRTUAL_BIND(_get_binary_extensions, "preset");
+
+	GDVIRTUAL_BIND(_export_project, "preset", "debug", "path", "flags");
+	GDVIRTUAL_BIND(_export_pack, "preset", "debug", "path", "flags");
+	GDVIRTUAL_BIND(_export_zip, "preset", "debug", "path", "flags");
+
+	GDVIRTUAL_BIND(_get_platform_features);
+
+	GDVIRTUAL_BIND(_get_debug_protocol);
+}
+
+void EditorExportPlatformExtension::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+	Vector<String> ret;
+	if (GDVIRTUAL_REQUIRED_CALL(_get_preset_features, p_preset, ret) && r_features) {
+		for (const String &E : ret) {
+			r_features->push_back(E);
+		}
+	}
+}
+
+bool EditorExportPlatformExtension::is_executable(const String &p_path) const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_executable, p_path, ret);
+	return ret;
+}
+
+void EditorExportPlatformExtension::get_export_options(List<ExportOption> *r_options) const {
+	TypedArray<Dictionary> ret;
+	if (GDVIRTUAL_CALL(_get_export_options, ret) && r_options) {
+		for (const Variant &var : ret) {
+			const Dictionary &d = var;
+			ERR_CONTINUE(!d.has("name"));
+			ERR_CONTINUE(!d.has("type"));
+
+			PropertyInfo pinfo = PropertyInfo::from_dict(d);
+			ERR_CONTINUE(pinfo.name.is_empty() && (pinfo.usage & PROPERTY_USAGE_STORAGE));
+			ERR_CONTINUE(pinfo.type < 0 || pinfo.type >= Variant::VARIANT_MAX);
+
+			Variant default_value;
+			if (d.has("default_value")) {
+				default_value = d["default_value"];
+			}
+			bool update_visibility = false;
+			if (d.has("update_visibility")) {
+				update_visibility = d["update_visibility"];
+			}
+			bool required = false;
+			if (d.has("required")) {
+				required = d["required"];
+			}
+
+			r_options->push_back(ExportOption(pinfo, default_value, update_visibility, required));
+		}
+	}
+}
+
+bool EditorExportPlatformExtension::should_update_export_options() {
+	bool ret = false;
+	GDVIRTUAL_CALL(_should_update_export_options, ret);
+	return ret;
+}
+
+bool EditorExportPlatformExtension::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
+	bool ret = true;
+	GDVIRTUAL_CALL(_get_export_option_visibility, Ref<EditorExportPreset>(p_preset), p_option, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {
+	String ret;
+	GDVIRTUAL_CALL(_get_export_option_warning, Ref<EditorExportPreset>(p_preset), p_name, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_os_name() const {
+	String ret;
+	GDVIRTUAL_REQUIRED_CALL(_get_os_name, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_name() const {
+	String ret;
+	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+	return ret;
+}
+
+Ref<Texture2D> EditorExportPlatformExtension::get_logo() const {
+	Ref<Texture2D> ret;
+	GDVIRTUAL_REQUIRED_CALL(_get_logo, ret);
+	return ret;
+}
+
+bool EditorExportPlatformExtension::poll_export() {
+	bool ret = false;
+	GDVIRTUAL_CALL(_poll_export, ret);
+	return ret;
+}
+
+int EditorExportPlatformExtension::get_options_count() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_options_count, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_options_tooltip() const {
+	String ret;
+	GDVIRTUAL_CALL(_get_options_tooltip, ret);
+	return ret;
+}
+
+Ref<ImageTexture> EditorExportPlatformExtension::get_option_icon(int p_index) const {
+	Ref<ImageTexture> ret;
+	if (GDVIRTUAL_CALL(_get_option_icon, p_index, ret)) {
+		return ret;
+	}
+	return EditorExportPlatform::get_option_icon(p_index);
+}
+
+String EditorExportPlatformExtension::get_option_label(int p_device) const {
+	String ret;
+	GDVIRTUAL_CALL(_get_option_label, p_device, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_option_tooltip(int p_device) const {
+	String ret;
+	GDVIRTUAL_CALL(_get_option_tooltip, p_device, ret);
+	return ret;
+}
+
+String EditorExportPlatformExtension::get_device_architecture(int p_device) const {
+	String ret;
+	GDVIRTUAL_CALL(_get_device_architecture, p_device, ret);
+	return ret;
+}
+
+void EditorExportPlatformExtension::cleanup() {
+	GDVIRTUAL_CALL(_cleanup);
+}
+
+Error EditorExportPlatformExtension::run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
+	Error ret = OK;
+	GDVIRTUAL_CALL(_run, p_preset, p_device, p_debug_flags, ret);
+	return ret;
+}
+
+Ref<Texture2D> EditorExportPlatformExtension::get_run_icon() const {
+	Ref<Texture2D> ret;
+	if (GDVIRTUAL_CALL(_get_run_icon, ret)) {
+		return ret;
+	}
+	return EditorExportPlatform::get_run_icon();
+}
+
+bool EditorExportPlatformExtension::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	bool ret = false;
+	config_error = r_error;
+	config_missing_templates = r_missing_templates;
+	if (GDVIRTUAL_CALL(_can_export, p_preset, p_debug, ret)) {
+		r_error = config_error;
+		r_missing_templates = config_missing_templates;
+		return ret;
+	}
+	return EditorExportPlatform::can_export(p_preset, r_error, r_missing_templates, p_debug);
+}
+
+bool EditorExportPlatformExtension::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	bool ret = false;
+	config_error = r_error;
+	config_missing_templates = r_missing_templates;
+	if (GDVIRTUAL_REQUIRED_CALL(_has_valid_export_configuration, p_preset, p_debug, ret)) {
+		r_error = config_error;
+		r_missing_templates = config_missing_templates;
+	}
+	return ret;
+}
+
+bool EditorExportPlatformExtension::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
+	bool ret = false;
+	config_error = r_error;
+	if (GDVIRTUAL_REQUIRED_CALL(_has_valid_project_configuration, p_preset, ret)) {
+		r_error = config_error;
+	}
+	return ret;
+}
+
+List<String> EditorExportPlatformExtension::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> ret_list;
+	Vector<String> ret;
+	if (GDVIRTUAL_REQUIRED_CALL(_get_binary_extensions, p_preset, ret)) {
+		for (const String &E : ret) {
+			ret_list.push_back(E);
+		}
+	}
+	return ret_list;
+}
+
+Error EditorExportPlatformExtension::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
+	Error ret = FAILED;
+	GDVIRTUAL_REQUIRED_CALL(_export_project, p_preset, p_debug, p_path, p_flags, ret);
+	return ret;
+}
+
+Error EditorExportPlatformExtension::export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
+	Error ret = FAILED;
+	if (GDVIRTUAL_CALL(_export_pack, p_preset, p_debug, p_path, p_flags, ret)) {
+		return ret;
+	}
+	return save_pack(p_preset, p_debug, p_path);
+}
+
+Error EditorExportPlatformExtension::export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
+	Error ret = FAILED;
+	if (GDVIRTUAL_CALL(_export_zip, p_preset, p_debug, p_path, p_flags, ret)) {
+		return ret;
+	}
+	return save_zip(p_preset, p_debug, p_path);
+}
+
+void EditorExportPlatformExtension::get_platform_features(List<String> *r_features) const {
+	Vector<String> ret;
+	if (GDVIRTUAL_REQUIRED_CALL(_get_platform_features, ret) && r_features) {
+		for (const String &E : ret) {
+			r_features->push_back(E);
+		}
+	}
+}
+
+String EditorExportPlatformExtension::get_debug_protocol() const {
+	String ret;
+	if (GDVIRTUAL_CALL(_get_debug_protocol, ret)) {
+		return ret;
+	}
+	return EditorExportPlatform::get_debug_protocol();
+}
+
+EditorExportPlatformExtension::EditorExportPlatformExtension() {
+	//NOP
+}
+
+EditorExportPlatformExtension::~EditorExportPlatformExtension() {
+	//NOP
+}

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -1,0 +1,149 @@
+/**************************************************************************/
+/*  editor_export_platform_extension.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_EXPORT_PLATFORM_EXTENSION_H
+#define EDITOR_EXPORT_PLATFORM_EXTENSION_H
+
+#include "editor_export_platform.h"
+#include "editor_export_preset.h"
+
+class EditorExportPlatformExtension : public EditorExportPlatform {
+	GDCLASS(EditorExportPlatformExtension, EditorExportPlatform);
+
+	mutable String config_error;
+	mutable bool config_missing_templates = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	GDVIRTUAL1RC(Vector<String>, _get_preset_features, Ref<EditorExportPreset>);
+
+	virtual bool is_executable(const String &p_path) const override;
+	GDVIRTUAL1RC(bool, _is_executable, const String &);
+
+	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_export_options);
+
+	virtual bool should_update_export_options() override;
+	GDVIRTUAL0R(bool, _should_update_export_options);
+
+	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
+	GDVIRTUAL2RC(bool, _get_export_option_visibility, Ref<EditorExportPreset>, const String &);
+
+	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
+	GDVIRTUAL2RC(String, _get_export_option_warning, Ref<EditorExportPreset>, const StringName &);
+
+	virtual String get_os_name() const override;
+	GDVIRTUAL0RC(String, _get_os_name);
+
+	virtual String get_name() const override;
+	GDVIRTUAL0RC(String, _get_name);
+
+	virtual Ref<Texture2D> get_logo() const override;
+	GDVIRTUAL0RC(Ref<Texture2D>, _get_logo);
+
+	virtual bool poll_export() override;
+	GDVIRTUAL0R(bool, _poll_export);
+
+	virtual int get_options_count() const override;
+	GDVIRTUAL0RC(int, _get_options_count);
+
+	virtual String get_options_tooltip() const override;
+	GDVIRTUAL0RC(String, _get_options_tooltip);
+
+	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	GDVIRTUAL1RC(Ref<ImageTexture>, _get_option_icon, int);
+
+	virtual String get_option_label(int p_device) const override;
+	GDVIRTUAL1RC(String, _get_option_label, int);
+
+	virtual String get_option_tooltip(int p_device) const override;
+	GDVIRTUAL1RC(String, _get_option_tooltip, int);
+
+	virtual String get_device_architecture(int p_device) const override;
+	GDVIRTUAL1RC(String, _get_device_architecture, int);
+
+	virtual void cleanup() override;
+	GDVIRTUAL0(_cleanup);
+
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
+	GDVIRTUAL3R(Error, _run, Ref<EditorExportPreset>, int, BitField<EditorExportPlatform::DebugFlags>);
+
+	virtual Ref<Texture2D> get_run_icon() const override;
+	GDVIRTUAL0RC(Ref<Texture2D>, _get_run_icon);
+
+	void set_config_error(const String &p_error) const {
+		config_error = p_error;
+	}
+	String get_config_error() const {
+		return config_error;
+	}
+
+	void set_config_missing_templates(bool p_missing_templates) const {
+		config_missing_templates = p_missing_templates;
+	}
+	bool get_config_missing_templates() const {
+		return config_missing_templates;
+	}
+
+	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	GDVIRTUAL2RC(bool, _can_export, Ref<EditorExportPreset>, bool);
+
+	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	GDVIRTUAL2RC(bool, _has_valid_export_configuration, Ref<EditorExportPreset>, bool);
+
+	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
+	GDVIRTUAL1RC(bool, _has_valid_project_configuration, Ref<EditorExportPreset>);
+
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	GDVIRTUAL1RC(Vector<String>, _get_binary_extensions, Ref<EditorExportPreset>);
+
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+	GDVIRTUAL4R(Error, _export_project, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
+
+	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+	GDVIRTUAL4R(Error, _export_pack, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
+
+	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+	GDVIRTUAL4R(Error, _export_zip, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
+
+	virtual void get_platform_features(List<String> *r_features) const override;
+	GDVIRTUAL0RC(Vector<String>, _get_platform_features);
+
+	virtual String get_debug_protocol() const override;
+	GDVIRTUAL0RC(String, _get_debug_protocol);
+
+	EditorExportPlatformExtension();
+	~EditorExportPlatformExtension();
+};
+
+#endif // EDITOR_EXPORT_PLATFORM_EXTENSION_H

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -115,7 +115,7 @@ bool EditorExportPlatformPC::has_valid_project_configuration(const Ref<EditorExp
 	return true;
 }
 
-Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
 	Error err = prepare_template(p_preset, p_debug, p_path, p_flags);
@@ -129,7 +129,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 	return err;
 }
 
-Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	if (!DirAccess::exists(p_path.get_base_dir())) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Template"), TTR("The given export path doesn't exist."));
 		return ERR_FILE_BAD_PATH;
@@ -182,7 +182,7 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 	return err;
 }
 
-Error EditorExportPlatformPC::export_project_data(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformPC::export_project_data(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	String pck_path;
 	if (p_preset->get("binary_format/embed_pck")) {
 		pck_path = p_path;

--- a/editor/export/editor_export_platform_pc.h
+++ b/editor/export/editor_export_platform_pc.h
@@ -54,13 +54,13 @@ public:
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const = 0;
 
-	virtual Error prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags);
-	virtual Error modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) { return OK; };
-	virtual Error export_project_data(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags);
+	virtual Error prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags);
+	virtual Error modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) { return OK; }
+	virtual Error export_project_data(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags);
 
 	void set_name(const String &p_name);
 	void set_os_name(const String &p_name);

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -48,6 +48,14 @@ Ref<EditorExportPreset> EditorExportPlugin::get_export_preset() const {
 	return export_preset;
 }
 
+Ref<EditorExportPlatform> EditorExportPlugin::get_export_platform() const {
+	if (export_preset.is_valid()) {
+		return export_preset->get_platform();
+	} else {
+		return Ref<EditorExportPlatform>();
+	}
+}
+
 void EditorExportPlugin::add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap) {
 	ExtraFile ef;
 	ef.data = p_file;
@@ -320,6 +328,9 @@ void EditorExportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_macos_plugin_file", "path"), &EditorExportPlugin::add_macos_plugin_file);
 	ClassDB::bind_method(D_METHOD("skip"), &EditorExportPlugin::skip);
 	ClassDB::bind_method(D_METHOD("get_option", "name"), &EditorExportPlugin::get_option);
+
+	ClassDB::bind_method(D_METHOD("get_export_preset"), &EditorExportPlugin::get_export_preset);
+	ClassDB::bind_method(D_METHOD("get_export_platform"), &EditorExportPlugin::get_export_platform);
 
 	GDVIRTUAL_BIND(_export_file, "path", "type", "features");
 	GDVIRTUAL_BIND(_export_begin, "features", "is_debug", "path", "flags");

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -91,6 +91,7 @@ class EditorExportPlugin : public RefCounted {
 protected:
 	void set_export_preset(const Ref<EditorExportPreset> &p_preset);
 	Ref<EditorExportPreset> get_export_preset() const;
+	Ref<EditorExportPlatform> get_export_platform() const;
 
 	void add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap);
 	void add_shared_object(const String &p_path, const Vector<String> &tags, const String &p_target = String());

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -62,6 +62,48 @@ bool EditorExportPreset::_get(const StringName &p_name, Variant &r_ret) const {
 
 void EditorExportPreset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &EditorExportPreset::_get_property_warning);
+
+	ClassDB::bind_method(D_METHOD("has", "property"), &EditorExportPreset::has);
+
+	ClassDB::bind_method(D_METHOD("get_files_to_export"), &EditorExportPreset::get_files_to_export);
+	ClassDB::bind_method(D_METHOD("get_customized_files"), &EditorExportPreset::get_customized_files);
+	ClassDB::bind_method(D_METHOD("get_customized_files_count"), &EditorExportPreset::get_customized_files_count);
+	ClassDB::bind_method(D_METHOD("has_export_file", "path"), &EditorExportPreset::has_export_file);
+	ClassDB::bind_method(D_METHOD("get_file_export_mode", "path", "default"), &EditorExportPreset::get_file_export_mode, DEFVAL(MODE_FILE_NOT_CUSTOMIZED));
+
+	ClassDB::bind_method(D_METHOD("get_preset_name"), &EditorExportPreset::get_name);
+	ClassDB::bind_method(D_METHOD("is_runnable"), &EditorExportPreset::is_runnable);
+	ClassDB::bind_method(D_METHOD("are_advanced_options_enabled"), &EditorExportPreset::are_advanced_options_enabled);
+	ClassDB::bind_method(D_METHOD("is_dedicated_server"), &EditorExportPreset::is_dedicated_server);
+	ClassDB::bind_method(D_METHOD("get_export_filter"), &EditorExportPreset::get_export_filter);
+	ClassDB::bind_method(D_METHOD("get_include_filter"), &EditorExportPreset::get_include_filter);
+	ClassDB::bind_method(D_METHOD("get_exclude_filter"), &EditorExportPreset::get_exclude_filter);
+	ClassDB::bind_method(D_METHOD("get_custom_features"), &EditorExportPreset::get_custom_features);
+	ClassDB::bind_method(D_METHOD("get_export_path"), &EditorExportPreset::get_export_path);
+	ClassDB::bind_method(D_METHOD("get_encryption_in_filter"), &EditorExportPreset::get_enc_in_filter);
+	ClassDB::bind_method(D_METHOD("get_encryption_ex_filter"), &EditorExportPreset::get_enc_ex_filter);
+	ClassDB::bind_method(D_METHOD("get_encrypt_pck"), &EditorExportPreset::get_enc_pck);
+	ClassDB::bind_method(D_METHOD("get_encrypt_directory"), &EditorExportPreset::get_enc_directory);
+	ClassDB::bind_method(D_METHOD("get_encryption_key"), &EditorExportPreset::get_script_encryption_key);
+	ClassDB::bind_method(D_METHOD("get_script_export_mode"), &EditorExportPreset::get_script_export_mode);
+
+	ClassDB::bind_method(D_METHOD("get_or_env", "name", "env_var"), &EditorExportPreset::_get_or_env);
+	ClassDB::bind_method(D_METHOD("get_version", "name", "windows_version"), &EditorExportPreset::get_version);
+
+	BIND_ENUM_CONSTANT(EXPORT_ALL_RESOURCES);
+	BIND_ENUM_CONSTANT(EXPORT_SELECTED_SCENES);
+	BIND_ENUM_CONSTANT(EXPORT_SELECTED_RESOURCES);
+	BIND_ENUM_CONSTANT(EXCLUDE_SELECTED_RESOURCES);
+	BIND_ENUM_CONSTANT(EXPORT_CUSTOMIZED);
+
+	BIND_ENUM_CONSTANT(MODE_FILE_NOT_CUSTOMIZED);
+	BIND_ENUM_CONSTANT(MODE_FILE_STRIP);
+	BIND_ENUM_CONSTANT(MODE_FILE_KEEP);
+	BIND_ENUM_CONSTANT(MODE_FILE_REMOVE);
+
+	BIND_ENUM_CONSTANT(MODE_SCRIPT_TEXT);
+	BIND_ENUM_CONSTANT(MODE_SCRIPT_BINARY_TOKENS);
+	BIND_ENUM_CONSTANT(MODE_SCRIPT_BINARY_TOKENS_COMPRESSED);
 }
 
 String EditorExportPreset::_get_property_warning(const StringName &p_name) const {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -168,6 +168,9 @@ public:
 	void set_script_export_mode(int p_mode);
 	int get_script_export_mode() const;
 
+	Variant _get_or_env(const StringName &p_name, const String &p_env_var) const {
+		return get_or_env(p_name, p_env_var);
+	}
 	Variant get_or_env(const StringName &p_name, const String &p_env_var, bool *r_valid = nullptr) const;
 
 	// Return the preset's version number, or fall back to the
@@ -182,5 +185,9 @@ public:
 
 	EditorExportPreset();
 };
+
+VARIANT_ENUM_CAST(EditorExportPreset::ExportFilter);
+VARIANT_ENUM_CAST(EditorExportPreset::FileExportMode);
+VARIANT_ENUM_CAST(EditorExportPreset::ScriptExportMode);
 
 #endif // EDITOR_EXPORT_PRESET_H

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_translation_parser.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/export/editor_export.h"
+#include "editor/export/editor_export_platform.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_title_bar.h"
 #include "editor/import/3d/resource_importer_scene.h"
@@ -441,6 +442,16 @@ void EditorPlugin::remove_export_plugin(const Ref<EditorExportPlugin> &p_exporte
 	EditorExport::get_singleton()->remove_export_plugin(p_exporter);
 }
 
+void EditorPlugin::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
+	ERR_FAIL_COND(p_platform.is_null());
+	EditorExport::get_singleton()->add_export_platform(p_platform);
+}
+
+void EditorPlugin::remove_export_platform(const Ref<EditorExportPlatform> &p_platform) {
+	ERR_FAIL_COND(p_platform.is_null());
+	EditorExport::get_singleton()->remove_export_platform(p_platform);
+}
+
 void EditorPlugin::add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
 	ERR_FAIL_COND(!p_gizmo_plugin.is_valid());
 	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
@@ -608,6 +619,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::remove_scene_post_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
 	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);
+	ClassDB::bind_method(D_METHOD("add_export_platform", "platform"), &EditorPlugin::add_export_platform);
+	ClassDB::bind_method(D_METHOD("remove_export_platform", "platform"), &EditorPlugin::remove_export_platform);
 	ClassDB::bind_method(D_METHOD("add_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::add_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPlugin::add_inspector_plugin);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -41,6 +41,7 @@ class PopupMenu;
 class EditorDebuggerPlugin;
 class EditorExport;
 class EditorExportPlugin;
+class EditorExportPlatform;
 class EditorImportPlugin;
 class EditorInspectorPlugin;
 class EditorInterface;
@@ -223,6 +224,9 @@ public:
 
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
+
+	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
+	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 
 	void add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
 	void remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -578,8 +578,8 @@ void ScriptEditor::_clear_breakpoints() {
 	script_editor_cache->get_sections(&cached_editors);
 	for (const String &E : cached_editors) {
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
-		for (int i = 0; i < breakpoints.size(); i++) {
-			EditorDebuggerNode::get_singleton()->set_breakpoint(E, (int)breakpoints[i] + 1, false);
+		for (int breakpoint : breakpoints) {
+			EditorDebuggerNode::get_singleton()->set_breakpoint(E, (int)breakpoint + 1, false);
 		}
 
 		if (breakpoints.size() > 0) {
@@ -1820,7 +1820,8 @@ void ScriptEditor::notify_script_changed(const Ref<Script> &p_script) {
 	emit_signal(SNAME("editor_script_changed"), p_script);
 }
 
-void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
+Vector<String> ScriptEditor::_get_breakpoints() {
+	Vector<String> ret;
 	HashSet<String> loaded_scripts;
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
@@ -1829,19 +1830,19 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 		}
 
 		Ref<Script> scr = se->get_edited_resource();
-		if (scr == nullptr) {
+		if (scr.is_null()) {
 			continue;
 		}
 
 		String base = scr->get_path();
 		loaded_scripts.insert(base);
-		if (base.begins_with("local://") || base.is_empty()) {
+		if (base.is_empty() || base.begins_with("local://")) {
 			continue;
 		}
 
 		PackedInt32Array bpoints = se->get_breakpoints();
-		for (int j = 0; j < bpoints.size(); j++) {
-			p_breakpoints->push_back(base + ":" + itos((int)bpoints[j] + 1));
+		for (int32_t bpoint : bpoints) {
+			ret.push_back(base + ":" + itos((int)bpoint + 1));
 		}
 	}
 
@@ -1854,8 +1855,49 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 		}
 
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
-		for (int i = 0; i < breakpoints.size(); i++) {
-			p_breakpoints->push_back(E + ":" + itos((int)breakpoints[i] + 1));
+		for (int breakpoint : breakpoints) {
+			ret.push_back(E + ":" + itos((int)breakpoint + 1));
+		}
+	}
+	return ret;
+}
+
+void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
+	HashSet<String> loaded_scripts;
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
+		if (!se) {
+			continue;
+		}
+
+		Ref<Script> scr = se->get_edited_resource();
+		if (scr.is_null()) {
+			continue;
+		}
+
+		String base = scr->get_path();
+		loaded_scripts.insert(base);
+		if (base.is_empty() || base.begins_with("local://")) {
+			continue;
+		}
+
+		PackedInt32Array bpoints = se->get_breakpoints();
+		for (int32_t bpoint : bpoints) {
+			p_breakpoints->push_back(base + ":" + itos((int)bpoint + 1));
+		}
+	}
+
+	// Load breakpoints that are in closed scripts.
+	List<String> cached_editors;
+	script_editor_cache->get_sections(&cached_editors);
+	for (const String &E : cached_editors) {
+		if (loaded_scripts.has(E)) {
+			continue;
+		}
+
+		Array breakpoints = _get_cached_breakpoints_for_script(E);
+		for (int breakpoint : breakpoints) {
+			p_breakpoints->push_back(E + ":" + itos((int)breakpoint + 1));
 		}
 	}
 }
@@ -2944,8 +2986,8 @@ void ScriptEditor::_files_moved(const String &p_old_file, const String &p_new_fi
 
 	// If Script, update breakpoints with debugger.
 	Array breakpoints = _get_cached_breakpoints_for_script(p_new_file);
-	for (int i = 0; i < breakpoints.size(); i++) {
-		int line = (int)breakpoints[i] + 1;
+	for (int breakpoint : breakpoints) {
+		int line = (int)breakpoint + 1;
 		EditorDebuggerNode::get_singleton()->set_breakpoint(p_old_file, line, false);
 		if (!p_new_file.begins_with("local://") && ResourceLoader::exists(p_new_file, "Script")) {
 			EditorDebuggerNode::get_singleton()->set_breakpoint(p_new_file, line, true);
@@ -2969,8 +3011,8 @@ void ScriptEditor::_file_removed(const String &p_removed_file) {
 	// Check closed.
 	if (script_editor_cache->has_section(p_removed_file)) {
 		Array breakpoints = _get_cached_breakpoints_for_script(p_removed_file);
-		for (int i = 0; i < breakpoints.size(); i++) {
-			EditorDebuggerNode::get_singleton()->set_breakpoint(p_removed_file, (int)breakpoints[i] + 1, false);
+		for (int breakpoint : breakpoints) {
+			EditorDebuggerNode::get_singleton()->set_breakpoint(p_removed_file, (int)breakpoint + 1, false);
 		}
 		script_editor_cache->erase_section(p_removed_file);
 	}
@@ -3425,8 +3467,8 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 		}
 
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
-		for (int i = 0; i < breakpoints.size(); i++) {
-			EditorDebuggerNode::get_singleton()->set_breakpoint(E, (int)breakpoints[i] + 1, true);
+		for (int breakpoint : breakpoints) {
+			EditorDebuggerNode::get_singleton()->set_breakpoint(E, (int)breakpoint + 1, true);
 		}
 	}
 
@@ -3972,6 +4014,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_help_tab_goto", &ScriptEditor::_help_tab_goto);
 	ClassDB::bind_method("get_current_editor", &ScriptEditor::_get_current_editor);
 	ClassDB::bind_method("get_open_script_editors", &ScriptEditor::_get_open_script_editors);
+	ClassDB::bind_method("get_breakpoints", &ScriptEditor::_get_breakpoints);
 
 	ClassDB::bind_method(D_METHOD("register_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::register_syntax_highlighter);
 	ClassDB::bind_method(D_METHOD("unregister_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::unregister_syntax_highlighter);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -539,6 +539,7 @@ public:
 	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
 	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);
 
+	Vector<String> _get_breakpoints();
 	void get_breakpoints(List<String> *p_breakpoints);
 
 	PackedStringArray get_unsaved_scripts() const;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -46,6 +46,7 @@
 #include "editor/editor_translation_parser.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/export/editor_export_platform.h"
+#include "editor/export/editor_export_platform_extension.h"
 #include "editor/export/editor_export_platform_pc.h"
 #include "editor/export/editor_export_plugin.h"
 #include "editor/filesystem_dock.h"
@@ -161,6 +162,8 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorExportPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformPC);
+	GDREGISTER_CLASS(EditorExportPlatformExtension);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPreset);
 
 	register_exporter_types();
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -214,7 +214,7 @@ public:
 
 	virtual String get_device_architecture(int p_index) const override;
 
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 
 	virtual Ref<Texture2D> get_run_icon() const override;
 
@@ -242,7 +242,7 @@ public:
 
 	Error save_apk_expansion_file(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 
-	void get_command_line_flags(const Ref<EditorExportPreset> &p_preset, const String &p_path, int p_flags, Vector<uint8_t> &r_command_line_flags);
+	void get_command_line_flags(const Ref<EditorExportPreset> &p_preset, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, Vector<uint8_t> &r_command_line_flags);
 
 	Error sign_apk(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &export_path, EditorProgress &ep);
 
@@ -253,9 +253,9 @@ public:
 	static String join_list(const List<String> &p_parts, const String &p_separator);
 	static String join_abis(const Vector<ABI> &p_parts, const String &p_separator, bool p_use_arch);
 
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 
-	Error export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, int p_flags);
+	Error export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, BitField<EditorExportPlatform::DebugFlags> p_flags);
 
 	virtual void get_platform_features(List<String> *r_features) const override;
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -2017,11 +2017,11 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 	return OK;
 }
 
-Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	return _export_project_helper(p_preset, p_debug, p_path, p_flags, false, false);
 }
 
-Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags, bool p_simulator, bool p_oneclick) {
+Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_simulator, bool p_oneclick) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
 	const String dest_dir = p_path.get_base_dir() + "/";
@@ -2983,7 +2983,7 @@ void EditorExportPlatformIOS::_update_preset_status() {
 }
 #endif
 
-Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
+Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
 #ifdef MACOS_ENABLED
 	ERR_FAIL_INDEX_V(p_device, devices.size(), ERR_INVALID_PARAMETER);
 
@@ -3029,11 +3029,11 @@ Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int 
 	String host = EDITOR_GET("network/debug/remote_host");
 	int remote_port = (int)EDITOR_GET("network/debug/remote_port");
 
-	if (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST) {
+	if (p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)) {
 		host = "localhost";
 	}
 
-	if (p_debug_flags & DEBUG_FLAG_DUMB_CLIENT) {
+	if (p_debug_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT)) {
 		int port = EDITOR_GET("filesystem/file_server/port");
 		String passwd = EDITOR_GET("filesystem/file_server/password");
 		cmd_args_list.push_back("--remote-fs");
@@ -3044,7 +3044,7 @@ Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int 
 		}
 	}
 
-	if (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG) {
+	if (p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG)) {
 		cmd_args_list.push_back("--remote-debug");
 
 		cmd_args_list.push_back(get_debug_protocol() + host + ":" + String::num(remote_port));
@@ -3066,11 +3066,11 @@ Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int 
 		}
 	}
 
-	if (p_debug_flags & DEBUG_FLAG_VIEW_COLLISIONS) {
+	if (p_debug_flags.has_flag(DEBUG_FLAG_VIEW_COLLISIONS)) {
 		cmd_args_list.push_back("--debug-collisions");
 	}
 
-	if (p_debug_flags & DEBUG_FLAG_VIEW_NAVIGATION) {
+	if (p_debug_flags.has_flag(DEBUG_FLAG_VIEW_NAVIGATION)) {
 		cmd_args_list.push_back("--debug-navigation");
 	}
 

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -146,7 +146,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	Error _export_additional_assets(const Ref<EditorExportPreset> &p_preset, const String &p_out_dir, const Vector<SharedObject> &p_libraries, Vector<IOSExportAsset> &r_exported_assets);
 	Error _export_ios_plugins(const Ref<EditorExportPreset> &p_preset, IOSConfigData &p_config_data, const String &dest_dir, Vector<IOSExportAsset> &r_exported_assets, bool p_debug);
 
-	Error _export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags, bool p_simulator, bool p_oneclick);
+	Error _export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_simulator, bool p_oneclick);
 
 	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
 
@@ -169,7 +169,7 @@ public:
 	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 
 	virtual bool poll_export() override {
 		bool dc = devices_changed.is_set();
@@ -202,7 +202,7 @@ public:
 		return list;
 	}
 
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -60,7 +60,7 @@ Error EditorExportPlatformLinuxBSD::_export_debug_script(const Ref<EditorExportP
 	return OK;
 }
 
-Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	String custom_debug = p_preset->get("custom_template/debug");
 	String custom_release = p_preset->get("custom_template/release");
 	String arch = p_preset->get("binary_format/architecture");
@@ -458,7 +458,7 @@ void EditorExportPlatformLinuxBSD::cleanup() {
 	cleanup_commands.clear();
 }
 
-Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
+Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
 	cleanup();
 	if (p_device) { // Stop command, cleanup only.
 		return OK;
@@ -512,8 +512,7 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 
 	String cmd_args;
 	{
-		Vector<String> cmd_args_list;
-		gen_debug_flags(cmd_args_list, p_debug_flags);
+		Vector<String> cmd_args_list = gen_export_flags(p_debug_flags);
 		for (int i = 0; i < cmd_args_list.size(); i++) {
 			if (i != 0) {
 				cmd_args += " ";
@@ -522,7 +521,7 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 		}
 	}
 
-	const bool use_remote = (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG) || (p_debug_flags & DEBUG_FLAG_DUMB_CLIENT);
+	const bool use_remote = p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG) || p_debug_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT);
 	int dbg_port = EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	print_line("Creating temporary directory...");

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -76,7 +76,7 @@ public:
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 	virtual bool is_executable(const String &p_path) const override;
@@ -87,7 +87,7 @@ public:
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
 	EditorExportPlatformLinuxBSD();

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1505,7 +1505,7 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 	return OK;
 }
 
-Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
 	const String base_dir = p_path.get_base_dir();
@@ -2511,7 +2511,7 @@ void EditorExportPlatformMacOS::cleanup() {
 	cleanup_commands.clear();
 }
 
-Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
+Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
 	cleanup();
 	if (p_device) { // Stop command, cleanup only.
 		return OK;
@@ -2573,8 +2573,7 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 
 	String cmd_args;
 	{
-		Vector<String> cmd_args_list;
-		gen_debug_flags(cmd_args_list, p_debug_flags);
+		Vector<String> cmd_args_list = gen_export_flags(p_debug_flags);
 		for (int i = 0; i < cmd_args_list.size(); i++) {
 			if (i != 0) {
 				cmd_args += " ";
@@ -2583,7 +2582,7 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 		}
 	}
 
-	const bool use_remote = (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG) || (p_debug_flags & DEBUG_FLAG_DUMB_CLIENT);
+	const bool use_remote = p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG) || p_debug_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT);
 	int dbg_port = EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	print_line("Creating temporary directory...");

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -147,7 +147,7 @@ public:
 
 	virtual bool is_executable(const String &p_path) const override;
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
@@ -167,7 +167,7 @@ public:
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
 	EditorExportPlatformMacOS();

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -130,15 +130,14 @@ void EditorExportPlatformWeb::_replace_strings(const HashMap<String, String> &p_
 	}
 }
 
-void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes) {
+void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes) {
 	// Engine.js config
 	Dictionary config;
 	Array libs;
 	for (int i = 0; i < p_shared_objects.size(); i++) {
 		libs.push_back(p_shared_objects[i].path.get_file());
 	}
-	Vector<String> flags;
-	gen_export_flags(flags, p_flags & (~DEBUG_FLAG_DUMB_CLIENT));
+	Vector<String> flags = gen_export_flags(p_flags & (~DEBUG_FLAG_DUMB_CLIENT));
 	Array args;
 	for (int i = 0; i < flags.size(); i++) {
 		args.push_back(flags[i]);
@@ -450,7 +449,7 @@ List<String> EditorExportPlatformWeb::get_binary_extensions(const Ref<EditorExpo
 	return list;
 }
 
-Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
 	const String custom_debug = p_preset->get("custom_template/debug");
@@ -744,7 +743,7 @@ String EditorExportPlatformWeb::get_option_tooltip(int p_index) const {
 	return "";
 }
 
-Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int p_option, int p_debug_flags) {
+Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int p_option, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
 	const uint16_t bind_port = EDITOR_GET("export/web/http_port");
 	// Resolve host if needed.
 	const String bind_host = EDITOR_GET("export/web/http_host");

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -98,7 +98,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 
 	Error _extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa);
 	void _replace_strings(const HashMap<String, String> &p_replaces, Vector<uint8_t> &r_template);
-	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes);
+	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes);
 	Error _add_manifest_icon(const String &p_path, const String &p_icon, int p_size, Array &r_arr);
 	Error _build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects);
 	Error _write_or_error(const uint8_t *p_content, int p_len, String p_path);
@@ -120,14 +120,14 @@ public:
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 
 	virtual bool poll_export() override;
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
 	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_option, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_option, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual Ref<Texture2D> get_run_icon() const override;
 
 	virtual void get_platform_features(List<String> *r_features) const override {

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -167,7 +167,7 @@ Error EditorExportPlatformWindows::sign_shared_object(const Ref<EditorExportPres
 	}
 }
 
-Error EditorExportPlatformWindows::modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformWindows::modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	if (p_preset->get("application/modify_resources")) {
 		_rcedit_add_data(p_preset, p_path, false);
 		String wrapper_path = p_path.get_basename() + ".console.exe";
@@ -178,7 +178,7 @@ Error EditorExportPlatformWindows::modify_template(const Ref<EditorExportPreset>
 	return OK;
 }
 
-Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	String custom_debug = p_preset->get("custom_template/debug");
 	String custom_release = p_preset->get("custom_template/release");
 	String arch = p_preset->get("binary_format/architecture");
@@ -996,7 +996,7 @@ void EditorExportPlatformWindows::cleanup() {
 	cleanup_commands.clear();
 }
 
-Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
+Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) {
 	cleanup();
 	if (p_device) { // Stop command, cleanup only.
 		return OK;
@@ -1050,8 +1050,7 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 
 	String cmd_args;
 	{
-		Vector<String> cmd_args_list;
-		gen_debug_flags(cmd_args_list, p_debug_flags);
+		Vector<String> cmd_args_list = gen_export_flags(p_debug_flags);
 		for (int i = 0; i < cmd_args_list.size(); i++) {
 			if (i != 0) {
 				cmd_args += " ";
@@ -1060,7 +1059,7 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 		}
 	}
 
-	const bool use_remote = (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG) || (p_debug_flags & DEBUG_FLAG_DUMB_CLIENT);
+	const bool use_remote = p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG) || p_debug_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT);
 	int dbg_port = EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	print_line("Creating temporary directory...");

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -76,8 +76,8 @@ class EditorExportPlatformWindows : public EditorExportPlatformPC {
 	String _get_exe_arch(const String &p_path) const;
 
 public:
-	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
-	virtual Error modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+	virtual Error modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) override;
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) override;
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
@@ -95,7 +95,7 @@ public:
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
-	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
+	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
 	EditorExportPlatformWindows();


### PR DESCRIPTION
Adds option to make custom export platforms using scripts or GDExtension without editor rebuild.

TODO:

- [x] Docs.
- [x] GDExtension sample project - https://github.com/bruvzg/gdextension_editor_export_platform_template
- [x] Testing.
- [x] Expose optional helper methods from base `EditorExportPlatform` (zip / pck creation, finding export template, ssh/scp methods).
- [x] Expose generic `ExportPreset` properties.