### PR TITLE
Don't show scene group progress for 1 scene

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1664,7 +1664,10 @@ void EditorFileSystem::_queue_update_script_class(const String &p_path) {
 }
 
 void EditorFileSystem::_update_scene_groups() {
-	EditorProgress ep("update_scene_groups", TTR("Update Scene Groups"), update_scene_paths.size());
+	EditorProgress *ep = nullptr;
+	if (update_scene_paths.size() > 1) {
+		ep = memnew(EditorProgress("update_scene_groups", TTR("Update Scene Groups"), update_scene_paths.size()));
+	}
 	int step_count = 0;
 
 	update_scene_mutex.lock();
@@ -1684,9 +1687,12 @@ void EditorFileSystem::_update_scene_groups() {
 			ProjectSettings::get_singleton()->add_scene_groups_cache(path, scene_groups);
 		}
 
-		ep.step(TTR("Updating Scene Groups..."), step_count++);
+		if (ep) {
+			ep->step(TTR("Updating Scene Groups..."), step_count++);
+		}
 	}
 
+	memdelete_notnull(ep);
 	update_scene_paths.clear();
 	update_scene_mutex.unlock();
 


### PR DESCRIPTION
The new progress bar for updating scene groups (#89739) appears too often. It shows when you open project and every time you save a scene (in which case 2 progress bards appear).
![image](https://github.com/godotengine/godot/assets/2223172/58b18a91-0731-40de-8787-40245a0a2b6b)
This PR makes it appear only when updating more than 1 scene, so it's less annoying.