### PR TITLE
Fix FBX and glTF when root nodes are skeleton bones

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1629,6 +1629,9 @@ void FBXDocument::_generate_skeleton_bone_node(Ref<FBXState> p_state, const GLTF
 
 	active_skeleton = skeleton;
 	current_node = active_skeleton;
+	if (active_skeleton) {
+		p_scene_parent = active_skeleton;
+	}
 
 	if (requires_extra_node) {
 		current_node = nullptr;
@@ -2019,8 +2022,8 @@ Node *FBXDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, bool
 	GLTFNodeIndex fbx_root = state->root_nodes.write[0];
 	Node *fbx_root_node = state->get_scene_node(fbx_root);
 	Node *root = fbx_root_node;
-	if (fbx_root_node && fbx_root_node->get_parent()) {
-		root = fbx_root_node->get_parent();
+	if (root && root->get_owner() && root->get_owner() != root) {
+		root = root->get_owner();
 	}
 	ERR_FAIL_NULL_V(root, nullptr);
 	_process_mesh_instances(state, root);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5685,6 +5685,9 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> p_state, const GL
 
 	active_skeleton = skeleton;
 	current_node = active_skeleton;
+	if (active_skeleton) {
+		p_scene_parent = active_skeleton;
+	}
 
 	if (requires_extra_node) {
 		current_node = nullptr;
@@ -7104,6 +7107,9 @@ Node *GLTFDocument::_generate_scene_node_tree(Ref<GLTFState> p_state) {
 	if (p_state->extensions_used.has("GODOT_single_root")) {
 		_generate_scene_node(p_state, 0, nullptr, nullptr);
 		single_root = p_state->scene_nodes[0];
+		if (single_root && single_root->get_owner() && single_root->get_owner() != single_root) {
+			single_root = single_root->get_owner();
+		}
 	} else {
 		single_root = memnew(Node3D);
 		for (int32_t root_i = 0; root_i < p_state->root_nodes.size(); root_i++) {


### PR DESCRIPTION
This affects some FBX models in which "Import as skeleton bones" option is used. However, it theoretically can affect glTF or models without "Import as skeleton bone" enabled, but it would need the root of the model to be something that would generate a bone attachment. I'll try to file an issue, but I'm able to reproduce it with this suzanne model: [suzanne_multimaterial.fbx.zip](https://github.com/godotengine/godot/files/15010172/suzanne_multimaterial.fbx.zip) if the Import As Skeleton Bones is selected.

Fix two issues
1. Set p_scene_parent to the skeleton to guarantee BoneAttachment3D nodes are added as a child of the active skeleton.
2. Use get_owner() to go all the way up when calculating the root node in generate_scene

After this change, such models may look like:
![image](https://github.com/godotengine/godot/assets/39946030/36aeebcc-7121-4067-92e3-9424b83dcfd2)
![image](https://github.com/godotengine/godot/assets/39946030/b0ea71ec-0b3e-403d-8174-98e6b6aabf2d)
Note how the skeleton is immediate under the root node, and contains bone attachment children.