### PR TITLE
Ask confirmation before saving scene to new format

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -81,6 +81,15 @@ bool ResourceFormatLoader::handles_type(const String &p_type) const {
 	return success;
 }
 
+int ResourceFormatLoader::get_format_version(const String &p_path) const {
+	int ret;
+	if (GDVIRTUAL_CALL(_get_format_version, p_path, ret)) {
+		return ret;
+	}
+
+	return 0;
+}
+
 void ResourceFormatLoader::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
 	Vector<String> ret;
 	if (GDVIRTUAL_CALL(_get_classes_used, p_path, ret)) {
@@ -194,6 +203,7 @@ void ResourceFormatLoader::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions);
 	GDVIRTUAL_BIND(_recognize_path, "path", "type");
 	GDVIRTUAL_BIND(_handles_type, "type");
+	GDVIRTUAL_BIND(_get_format_version, "path");
 	GDVIRTUAL_BIND(_get_resource_type, "path");
 	GDVIRTUAL_BIND(_get_resource_script_class, "path");
 	GDVIRTUAL_BIND(_get_resource_uid, "path");
@@ -851,6 +861,18 @@ Error ResourceLoader::rename_dependencies(const String &p_path, const HashMap<St
 	}
 
 	return OK; // ??
+}
+
+int ResourceLoader::get_format_version(const String &p_path) {
+	String local_path = _validate_local_path(p_path);
+
+	for (int i = 0; i < loader_count; i++) {
+		if (!loader[i]->recognize_path(local_path)) {
+			continue;
+		}
+
+		return loader[i]->get_format_version(p_path);
+	}
 }
 
 void ResourceLoader::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -60,6 +60,7 @@ protected:
 	GDVIRTUAL0RC(Vector<String>, _get_recognized_extensions)
 	GDVIRTUAL2RC(bool, _recognize_path, String, StringName)
 	GDVIRTUAL1RC(bool, _handles_type, StringName)
+	GDVIRTUAL1RC(int, _get_format_version, String)
 	GDVIRTUAL1RC(String, _get_resource_type, String)
 	GDVIRTUAL1RC(String, _get_resource_script_class, String)
 	GDVIRTUAL1RC(ResourceUID::ID, _get_resource_uid, String)
@@ -77,6 +78,7 @@ public:
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const;
 	virtual bool handles_type(const String &p_type) const;
+	virtual int get_format_version(const String &p_path) const;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	virtual String get_resource_type(const String &p_path) const;
 	virtual String get_resource_script_class(const String &p_path) const;
@@ -209,6 +211,7 @@ public:
 	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);
 	static void add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front = false);
 	static void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
+	static int get_format_version(const String &p_path);
 	static void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	static String get_resource_type(const String &p_path);
 	static String get_resource_script_class(const String &p_path);

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -45,6 +45,7 @@ protected:
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
+	GDVIRTUAL2RC(int, _get_current_format_version, Ref<Resource>, String)
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
@@ -52,6 +53,7 @@ public:
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
+	virtual int get_current_format_version(const Ref<Resource> &p_resource, const String &p_path) const;
 
 	virtual ~ResourceFormatSaver() {}
 };
@@ -70,6 +72,7 @@ class ResourceSaver {
 	static ResourceSavedCallback save_callback;
 	static ResourceSaverGetResourceIDForPath save_get_id_for_path;
 
+	static Ref<ResourceFormatSaver> _find_resource_format_saver_for_resource(const Ref<Resource> &p_resource, const String &p_path);
 	static Ref<ResourceFormatSaver> _find_custom_resource_format_saver(const String &path);
 
 public:
@@ -85,6 +88,7 @@ public:
 	};
 
 	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static int get_current_format_version(const Ref<Resource> &p_resource, const String &p_path = "");
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -372,8 +372,10 @@ private:
 	ConfirmationDialog *import_confirmation = nullptr;
 	ConfirmationDialog *pick_main_scene = nullptr;
 	Button *select_current_scene_button = nullptr;
-	AcceptDialog *accept = nullptr;
-	AcceptDialog *save_accept = nullptr;
+	AcceptDialog *accept_dialog = nullptr;
+	Callable accept_dialog_action;
+	ConfirmationDialog *confirm_dialog = nullptr;
+	Callable confirm_dialog_action;
 	EditorAbout *about = nullptr;
 	AcceptDialog *warning = nullptr;
 	EditorPlugin *plugin_to_save = nullptr;
@@ -566,7 +568,7 @@ private:
 	void _set_current_scene(int p_idx);
 	void _set_current_scene_nocheck(int p_idx);
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
-	void _save_scene(String p_file, int idx = -1);
+	void _save_scene(String p_file, int idx = -1, bool p_force_save_to_new_format = false);
 	void _save_all_scenes();
 	int _next_unsaved_scene(bool p_valid_filename, int p_start = 0);
 	void _discard_changes(const String &p_str = String());
@@ -838,8 +840,8 @@ public:
 
 	bool is_object_of_custom_type(const Object *p_object, const StringName &p_class);
 
-	void show_accept(const String &p_text, const String &p_title);
-	void show_save_accept(const String &p_text, const String &p_title);
+	void show_accept(const String &p_text, const String &p_title, Callable p_confirm_action = Callable());
+	void show_confirm(const String &p_text, const String &p_title, Callable p_confirm_action);
 	void show_warning(const String &p_text, const String &p_title = TTR("Warning!"));
 
 	void _copy_warning(const String &p_str);

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -87,6 +87,12 @@ class ProgressDialog : public PopupPanel {
 	void _cancel_pressed();
 	bool canceled = false;
 
+	void _check_should_hide();
+
+protected:
+	virtual void add_child_notify(Node *p_child) override;
+	virtual void remove_child_notify(Node *p_child) override;
+
 public:
 	static ProgressDialog *get_singleton() { return singleton; }
 	void add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -127,6 +127,7 @@ public:
 	void open(Ref<FileAccess> p_f, bool p_skip_first_tag = false);
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
+	int get_format_version(Ref<FileAccess> p_f);
 	ResourceUID::ID get_uid(Ref<FileAccess> p_f);
 	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
 	Error rename_dependencies(Ref<FileAccess> p_f, const String &p_path, const HashMap<String, String> &p_map);
@@ -143,6 +144,7 @@ public:
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
+	virtual int get_format_version(const String &p_path) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 
 	virtual String get_resource_type(const String &p_path) const override;
@@ -203,6 +205,7 @@ public:
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual int get_current_format_version(const Ref<Resource> &p_resource, const String &p_path) const override;
 
 	ResourceFormatSaverText();
 };


### PR DESCRIPTION
This does ask for confirmation when saving a scene to a newer format. It's more changes than I expected, but it required implementing a way to retrieve the format version of a resource via ResourceLoader/ResourceFormatLoader and a way to retrieve the latest format version from ResourceSaver/ResourceFormatSaver.

It does also fixes a bug in the editor where error dialogs wouldn't show up. This was due to "exclusive popups" being spawned as children of the ProgressDialog used by scene saving. To workaround this issue, I made `ProgressDialog::end_task()` only hide if there's no visible child window. This could be made optional I guess (to avoid any compat-breaking change), but  I am not sure there's really a point for that.

Setting the PR as draft for now, as we probably need to implement the save thing for resources too.