### PR TITLE
Fix editor crash when shader has incorrect global array declaration

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -7411,6 +7411,9 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 									return ERR_PARSE_ERROR;
 								}
 								tk = _get_token();
+							} else {
+								_set_expected_error("(");
+								return ERR_PARSE_ERROR;
 							}
 						}
 					} else {
@@ -9520,6 +9523,9 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 										_set_error(RTR("Array size mismatch."));
 										return ERR_PARSE_ERROR;
 									}
+								} else {
+									_set_expected_error("(");
+									return ERR_PARSE_ERROR;
 								}
 
 								array_size = constant.array_size;


### PR DESCRIPTION
Trying to fix https://github.com/godotengine/godot/issues/90683

The crash happens around the change in `shader_compiler.cpp`, in that condition, `cnode->array_declarations[0].initializer` has size 0 and thus use `i=1` to index it will crash the editor. I leave it as a safe guard there.

Note that `const bool array[1] = bool[];;` will cause the crash but `const bool array[1] = bool[];` won't (just trigger `Expected a ',' or ';'`), the changes I made in `shader_language.cpp` prevent this by simply don't allow a global const array to be defined without initialization, I checked the doc it didn't say whether it's legal or not, so it might not be a good idea. Feel free to correct me.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
