### PR TITLE
Fix issue causing the `copyAndRename*` task to fail on occasions on Windows machines

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -205,36 +205,66 @@ android {
 }
 
 task copyAndRenameDebugApk(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/apk/debug/android_debug.apk"
     into getExportPath()
     rename "android_debug.apk", getExportFilename()
 }
 
 task copyAndRenameDevApk(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/apk/dev/android_dev.apk"
     into getExportPath()
     rename "android_dev.apk", getExportFilename()
 }
 
 task copyAndRenameReleaseApk(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/apk/release/android_release.apk"
     into getExportPath()
     rename "android_release.apk", getExportFilename()
 }
 
 task copyAndRenameDebugAab(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/bundle/debug/build-debug.aab"
     into getExportPath()
     rename "build-debug.aab", getExportFilename()
 }
 
 task copyAndRenameDevAab(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/bundle/dev/build-dev.aab"
     into getExportPath()
     rename "build-dev.aab", getExportFilename()
 }
 
 task copyAndRenameReleaseAab(type: Copy) {
+    // The 'doNotTrackState' is added to disable gradle's up-to-date checks for output files
+    // and directories. Otherwise this check may cause permissions access failures on Windows
+    // machines.
+    doNotTrackState("No need for up-to-date checks for the copy-and-rename operation")
+
     from "$buildDir/outputs/bundle/release/build-release.aab"
     into getExportPath()
     rename "build-release.aab", getExportFilename()


### PR DESCRIPTION
Gradle automatically handles up-to-date checks for output files and directories. This behavior sometimes causes the `copyAndRename*` task to fail on Windows machines when gradle tries to check on existing files in the output directories it doesn't have access to. 
To fix the issue, we disable this gradle behavior following the instructions in https://docs.gradle.org/8.2/userguide/incremental_build.html#sec:disable-state-tracking

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
