### PR TITLE
Expose unused SHADOW_MODULATE's alpha as shadow opacity for 2d lighting shadows

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -452,7 +452,7 @@ vec3 light_normal_compute(vec3 light_vec, vec3 normal, vec3 base_color, vec3 lig
 vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 #ifdef LIGHT_CODE_USED
 		,
-		vec3 shadow_modulate
+		vec4 shadow_modulate
 #endif
 ) {
 	float shadow = 0.0;
@@ -488,7 +488,8 @@ vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 
 	vec4 shadow_color = godot_unpackUnorm4x8(light_array[light_base].shadow_color);
 #ifdef LIGHT_CODE_USED
-	shadow_color.rgb *= shadow_modulate;
+	shadow_color.rgb *= shadow_modulate.rgb;
+	shadow *= shadow_modulate.a;
 #endif
 
 	shadow_color.a *= light_color.a; //respect light alpha
@@ -736,7 +737,7 @@ void main() {
 			light_color = light_shadow_compute(light_base, light_color, shadow_uv
 #ifdef LIGHT_CODE_USED
 					,
-					shadow_modulate.rgb
+					shadow_modulate
 #endif
 			);
 		}
@@ -838,7 +839,7 @@ void main() {
 			light_color = light_shadow_compute(light_base, light_color, shadow_uv
 #ifdef LIGHT_CODE_USED
 					,
-					shadow_modulate.rgb
+					shadow_modulate
 #endif
 			);
 		}

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -393,7 +393,7 @@ vec3 light_normal_compute(vec3 light_vec, vec3 normal, vec3 base_color, vec3 lig
 vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 #ifdef LIGHT_CODE_USED
 		,
-		vec3 shadow_modulate
+		vec4 shadow_modulate
 #endif
 ) {
 	float shadow;
@@ -431,7 +431,8 @@ vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 
 	vec4 shadow_color = unpackUnorm4x8(light_array.data[light_base].shadow_color);
 #ifdef LIGHT_CODE_USED
-	shadow_color.rgb *= shadow_modulate;
+	shadow_color.rgb *= shadow_modulate.rgb;
+	shadow *= shadow_modulate.a;
 #endif
 
 	shadow_color.a *= light_color.a; //respect light alpha
@@ -644,7 +645,7 @@ void main() {
 				light_color = light_shadow_compute(light_base, light_color, shadow_uv
 #ifdef LIGHT_CODE_USED
 						,
-						shadow_modulate.rgb
+						shadow_modulate
 #endif
 				);
 			}
@@ -731,7 +732,7 @@ void main() {
 				light_color = light_shadow_compute(light_base, light_color, shadow_uv
 #ifdef LIGHT_CODE_USED
 						,
-						shadow_modulate.rgb
+						shadow_modulate
 #endif
 				);
 			}


### PR DESCRIPTION
The light built-in `SHADOW_MODULATE` is a `vector4` but only first three elements of it are used for modulating the color of shadows, and the alpha channel was totally unused previously.

In this pr,  the alpha channel  of `SHADOW_MODULATE` will modulate the alpha of shadow, so users can change the opacity of received shadows when overriding `light()` function.

Maybe related to https://github.com/godotengine/godot-proposals/discussions/7136 and https://github.com/godotengine/godot-proposals/issues/9297

As `shadow_modulate` is initialized to `vec4(1.0)` before lighting compute , so the default behavior of canvas shaders should not get differences.

https://github.com/godotengine/godot/assets/33864304/62f5156a-d3c6-4fb1-b82b-04880b1f86e5

---
EDIT:  made an example Project here
[shadow_modulate.zip](https://github.com/user-attachments/files/17228800/shadow_modulate.zip)
Before:

https://github.com/user-attachments/assets/c129efa5-5178-4cd4-a27f-20f10f8c1df4

This PR:


https://github.com/user-attachments/assets/9fc8f3fd-1cf3-4f70-9fa3-66aaaeb65187



* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9541*

