### PR TITLE
Refactor toggling of command-line logging for import/export

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1087,9 +1087,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 		}
 
 		// Start preview thread now that it's safe.
-		if (!singleton->cmdline_export_mode) {
-			EditorResourcePreview::get_singleton()->start();
-		}
+		EditorResourcePreview::get_singleton()->start();
 	}
 }
 
@@ -1703,9 +1701,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 	save.step(TTR("Saving Scene"), 4);
 	_save_scene(p_file, p_idx);
 
-	if (!singleton->cmdline_export_mode) {
-		EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
-	}
+	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 }
 
 bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_node) {
@@ -4638,18 +4634,21 @@ bool EditorNode::is_object_of_custom_type(const Object *p_object, const StringNa
 }
 
 void EditorNode::progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {
-	if (singleton->cmdline_export_mode) {
+	if (singleton->verbose_tasks) {
 		print_line(p_task + ": begin: " + p_label + " steps: " + itos(p_steps));
-	} else if (singleton->progress_dialog) {
+	}
+
+	if (singleton->progress_dialog) {
 		singleton->progress_dialog->add_task(p_task, p_label, p_steps, p_can_cancel);
 	}
 }
 
 bool EditorNode::progress_task_step(const String &p_task, const String &p_state, int p_step, bool p_force_refresh) {
-	if (singleton->cmdline_export_mode) {
+	if (singleton->verbose_tasks) {
 		print_line("\t" + p_task + ": step " + itos(p_step) + ": " + p_state);
-		return false;
-	} else if (singleton->progress_dialog) {
+	}
+
+	if (singleton->progress_dialog) {
 		return singleton->progress_dialog->task_step(p_task, p_state, p_step, p_force_refresh);
 	} else {
 		return false;
@@ -4657,9 +4656,11 @@ bool EditorNode::progress_task_step(const String &p_task, const String &p_state,
 }
 
 void EditorNode::progress_end_task(const String &p_task) {
-	if (singleton->cmdline_export_mode) {
+	if (singleton->verbose_tasks) {
 		print_line(p_task + ": end");
-	} else if (singleton->progress_dialog) {
+	}
+
+	if (singleton->progress_dialog) {
 		singleton->progress_dialog->end_task(p_task);
 	}
 }
@@ -4864,7 +4865,6 @@ Error EditorNode::export_preset(const String &p_preset, const String &p_path, bo
 	export_defer.debug = p_debug;
 	export_defer.pack_only = p_pack_only;
 	export_defer.android_build_template = p_android_build_template;
-	cmdline_export_mode = true;
 	return OK;
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -432,7 +432,7 @@ private:
 	bool script_distraction_free = false;
 
 	bool changing_scene = false;
-	bool cmdline_export_mode = false;
+	bool verbose_tasks = false;
 	bool convert_old = false;
 	bool immediate_dialog_confirmed = false;
 	bool opening_prev = false;
@@ -895,6 +895,9 @@ public:
 	bool has_scenes_in_session();
 
 	int execute_and_show_output(const String &p_title, const String &p_path, const List<String> &p_arguments, bool p_close_on_ok = true, bool p_close_on_errors = false, String *r_output = nullptr);
+
+	void set_verbose_tasks(bool p_enabled) { verbose_tasks = p_enabled; }
+	bool are_tasks_verbose() const { return verbose_tasks; }
 
 	EditorNode();
 	~EditorNode();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3651,6 +3651,10 @@ int Main::start() {
 			editor_node = memnew(EditorNode);
 			sml->get_root()->add_child(editor_node);
 
+			if (!_export_preset.is_empty() || wait_for_import) {
+				editor_node->set_verbose_tasks(true);
+			}
+
 			if (!_export_preset.is_empty()) {
 				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only, install_android_build_template);
 				game_path = ""; // Do not load anything.


### PR DESCRIPTION
Relates to #90431.

This PR refactors `EditorNode::cmdline_export_mode` a bit, allowing the new `--import` command-line option to be able to use it as well.

The changes are as follows:

1. `cmdline_export_mode` is now called `verbose_tasks`, since it now needs to encompass importing as well, and I figured maybe something else in the future.
2. This flag is now set from `Main::start` when importing/exporting, as opposed to from `EditorNode::export_preset`.
3. The command-line logging that this flag enables is no longer mutually exclusive with the graphical progress dialog, but instead complements it. I couldn't see any reason why this shouldn't be the case. This also means the editor won't freeze up completely for a couple of minutes when doing `--export-*` without headless.
4. The checks related to `EditorResourcePreview` have been removed, since they have (from my understanding) largely been made redundant by the headless check in `EditorResourcePreview::start()` that was introduced by [#73838](https://github.com/godotengine/godot/pull/73838).