### PR TITLE
WorkerThreadPool: Polish yielding (fix corner case, remove misleading warning)

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -491,12 +491,10 @@ void WorkerThreadPool::notify_yield_over(TaskID p_task_id) {
 		ERR_FAIL_MSG("Invalid Task ID.");
 	}
 	Task *task = *taskp;
-
-#ifdef DEBUG_ENABLED
-	if (task->pool_thread_index == get_thread_index()) {
-		WARN_PRINT("A worker thread is attempting to notify itself. That makes no sense.");
+	if (task->completed) {
+		task_mutex.unlock();
+		return;
 	}
-#endif
 
 	ThreadData &td = threads[task->pool_thread_index];
 	td.yield_is_over = true;


### PR DESCRIPTION
Intended to avoid a crash when a daemon task has already finished but it still exists and, before its awaited so it gets erased, `notify_yield_over()` is called with its id. The `pool_thread_index` would be `-1`. This PR handles such a situation gracefully.

Oh, and the warning is removed because it can legitly happen that a task notifies itself to stop yielding. A case of that is that a daemon task started yielding and thus started a collaborative wait in which it can run other tasks on top of its stack frame. Its correct that such an additional task wants to awake the underlying daemon.