### PR TITLE
Fix shader crash on zero vector and negative x vector in particles processing

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -881,9 +881,9 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				case EMISSION_SHAPE_RING: {
 					real_t ring_random_angle = Math::randf() * Math_TAU;
 					real_t ring_random_radius = Math::randf() * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;
-					Vector3 axis = emission_ring_axis.normalized();
+					Vector3 axis = emission_ring_axis == Vector3(0.0, 0.0, 0.0) ? Vector3(0.0, 0.0, 1.0) : emission_ring_axis.normalized();
 					Vector3 ortho_axis;
-					if (axis == Vector3(1.0, 0.0, 0.0)) {
+					if (axis.abs() == Vector3(1.0, 0.0, 0.0)) {
 						ortho_axis = Vector3(0.0, 1.0, 0.0).cross(axis);
 					} else {
 						ortho_axis = Vector3(1.0, 0.0, 0.0).cross(axis);

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -635,9 +635,9 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "		\n";
 		code += "		float ring_spawn_angle = rand_from_seed(alt_seed) * 2.0 * pi;\n";
 		code += "		float ring_random_radius = rand_from_seed(alt_seed) * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;\n";
-		code += "		vec3 axis = normalize(emission_ring_axis);\n";
+		code += "		vec3 axis = emission_ring_axis == vec3(0.0) ? vec3(0.0, 0.0, 1.0) : normalize(emission_ring_axis);\n";
 		code += "		vec3 ortho_axis = vec3(0.0);\n";
-		code += "		if (axis == vec3(1.0, 0.0, 0.0)) {\n";
+		code += "		if (abs(axis) == vec3(1.0, 0.0, 0.0)) {\n";
 		code += "			ortho_axis = cross(axis, vec3(0.0, 1.0, 0.0));\n";
 		code += "		} else {\n";
 		code += " 			ortho_axis = cross(axis, vec3(1.0, 0.0, 0.0));\n";


### PR DESCRIPTION
This fixes issues where the GPU particles would crash if the axis vector was set to  Vector3(0.0, 0.0, 0.0) or Vector3(-1.0, 0.0, 0.0). I fixed it by defaulting to the z axis if a zero axis is entered, as that is the default in the inspector and by absoluting the axis before calculating the matrix for particle spawning.

On the CPU particles side. a zero vector would cause "The axis Vector3 must be normalized." error. So I applied the same fixes on the CPU side.

Note the -x vector issue doesn't always occur, but it crashed the particle shader on my AMD GPU. But it makes sense to avoid it as you wouldn't be able to do the cross product of Vector(1.0, 0.0, 0.0) and Vector(-1.0, 0.0, 0.0).