### PR TITLE
Expose access to 3D color buffer through ViewportTexture

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -106,6 +106,7 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) override{};
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override{};
 	virtual void set_use_debanding(bool p_use_debanding) override{};
+	virtual RID get_color_buffer() override { return render_target; }
 
 	void free_render_buffer_data();
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -197,6 +197,9 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 	emit_changed();
 }
 
+void ViewportTexture::_update_rid_from_vp() {
+}
+
 void ViewportTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_viewport_path_in_scene", "path"), &ViewportTexture::set_viewport_path_in_scene);
 	ClassDB::bind_method(D_METHOD("get_viewport_path_in_scene"), &ViewportTexture::get_viewport_path_in_scene);
@@ -981,7 +984,7 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 	stretch_transform = stretch_transform_new;
 
 #ifndef _3D_DISABLED
-	if (!use_xr) {
+	if (viewport_mode != VIEWPORT_MODE_XR) {
 #endif
 
 		if (p_allocated) {
@@ -1019,7 +1022,7 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 
 Size2i Viewport::_get_size() const {
 #ifndef _3D_DISABLED
-	if (use_xr) {
+	if (viewport_mode == VIEWPORT_MODE_XR) {
 		if (XRServer::get_singleton() != nullptr) {
 			Ref<XRInterface> xr_interface = XRServer::get_singleton()->get_primary_interface();
 			if (xr_interface.is_valid() && xr_interface->is_initialized()) {
@@ -4473,14 +4476,15 @@ void Viewport::_propagate_exit_world_3d(Node *p_node) {
 	}
 }
 
-void Viewport::set_use_xr(bool p_use_xr) {
+void Viewport::set_viewport_mode(ViewportMode p_viewport_mode) {
 	ERR_MAIN_THREAD_GUARD;
-	if (use_xr != p_use_xr) {
-		use_xr = p_use_xr;
+	bool was_using_xr = is_using_xr();
+	if (p_viewport_mode != viewport_mode) {
+		viewport_mode = p_viewport_mode;
 
-		RS::get_singleton()->viewport_set_use_xr(viewport, use_xr);
+		RS::get_singleton()->viewport_set_viewport_mode(viewport, (RS::ViewportMode)(int)p_viewport_mode);
 
-		if (!use_xr) {
+		if (was_using_xr) {
 			// Set viewport to previous size when exiting XR.
 			if (size_allocated) {
 				RS::get_singleton()->viewport_set_size(viewport, size.width, size.height);
@@ -4492,12 +4496,29 @@ void Viewport::set_use_xr(bool p_use_xr) {
 			RID rt = RS::get_singleton()->viewport_get_render_target(viewport);
 			RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID());
 		}
+
+		texture_rid = RenderingServer::get_singleton()->viewport_get_texture(viewport);
+		// Will need a new RID (i.e. switching from 2D render target to 3D buffer).
+		for (ViewportTexture *E : viewport_textures) {
+			RS::get_singleton()->texture_proxy_update(E->get_rid(), texture_rid);
+			E->emit_changed();
+		}
 	}
+}
+
+Viewport::ViewportMode Viewport::get_viewport_mode() const {
+	ERR_READ_THREAD_GUARD_V(VIEWPORT_MODE_2D_AND_3D);
+	return viewport_mode;
+}
+
+void Viewport::set_use_xr(bool p_use_xr) {
+	ERR_MAIN_THREAD_GUARD;
+	set_viewport_mode(p_use_xr ? VIEWPORT_MODE_XR : VIEWPORT_MODE_2D_AND_3D);
 }
 
 bool Viewport::is_using_xr() {
 	ERR_READ_THREAD_GUARD_V(false);
-	return use_xr;
+	return viewport_mode == VIEWPORT_MODE_XR;
 }
 
 void Viewport::set_scaling_3d_mode(Scaling3DMode p_scaling_3d_mode) {
@@ -4733,6 +4754,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_xr", "use"), &Viewport::set_use_xr);
 	ClassDB::bind_method(D_METHOD("is_using_xr"), &Viewport::is_using_xr);
 
+	ClassDB::bind_method(D_METHOD("set_viewport_mode", "mode"), &Viewport::set_viewport_mode);
+	ClassDB::bind_method(D_METHOD("get_viewport_mode"), &Viewport::get_viewport_mode);
+
 	ClassDB::bind_method(D_METHOD("set_scaling_3d_mode", "scaling_3d_mode"), &Viewport::set_scaling_3d_mode);
 	ClassDB::bind_method(D_METHOD("get_scaling_3d_mode"), &Viewport::get_scaling_3d_mode);
 
@@ -4752,7 +4776,8 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vrs_texture"), &Viewport::get_vrs_texture);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
+	//ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "viewport_mode", PROPERTY_HINT_ENUM, "2D and 3D,3D,XR"), "set_viewport_mode", "get_viewport_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_3d", PROPERTY_HINT_RESOURCE_TYPE, "World3D"), "set_world_3d", "get_world_3d");
 #endif // _3D_DISABLED

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -63,6 +63,7 @@ class ViewportTexture : public Texture2D {
 	bool vp_changed = false;
 
 	void _setup_local_to_scene(const Node *p_loc_scene);
+	void _update_rid_from_vp();
 
 	mutable RID proxy_ph;
 	mutable RID proxy;
@@ -211,6 +212,13 @@ public:
 		VRS_TEXTURE,
 		VRS_XR,
 		VRS_MAX
+	};
+
+	enum ViewportMode {
+		VIEWPORT_MODE_2D_AND_3D,
+		VIEWPORT_MODE_3D,
+		VIEWPORT_MODE_XR,
+		VIEWPORT_MODE_MAX
 	};
 
 private:
@@ -698,7 +706,7 @@ public:
 #ifndef _3D_DISABLED
 private:
 	// 3D audio, camera, physics, and world.
-	bool use_xr = false;
+	ViewportMode viewport_mode = VIEWPORT_MODE_2D_AND_3D;
 	friend class AudioListener3D;
 	AudioListener3D *audio_listener_3d = nullptr;
 	HashSet<AudioListener3D *> audio_listener_3d_set;
@@ -772,6 +780,9 @@ public:
 
 	void set_use_xr(bool p_use_xr);
 	bool is_using_xr();
+
+	void set_viewport_mode(ViewportMode p_viewport_mode);
+	ViewportMode get_viewport_mode() const;
 #endif // _3D_DISABLED
 
 	Viewport();
@@ -849,5 +860,6 @@ VARIANT_ENUM_CAST(Viewport::RenderInfo);
 VARIANT_ENUM_CAST(Viewport::RenderInfoType);
 VARIANT_ENUM_CAST(Viewport::DefaultCanvasItemTextureFilter);
 VARIANT_ENUM_CAST(Viewport::DefaultCanvasItemTextureRepeat);
+VARIANT_ENUM_CAST(Viewport::ViewportMode);
 
 #endif // VIEWPORT_H

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -129,6 +129,11 @@ void RenderSceneBuffersRD::cleanup() {
 	}
 	named_textures.clear();
 
+	if (color_texture_rs.is_valid()) {
+		RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
+		texture_storage->texture_2d_for_3d_free(color_texture_rs);
+	}
+
 	// Clear weight_buffer / blur textures.
 	for (const WeightBuffers &weight_buffer : weight_buffers) {
 		if (weight_buffer.weight.is_valid()) {
@@ -199,6 +204,7 @@ void RenderSceneBuffersRD::configure(const RenderSceneBuffersConfiguration *p_co
 		}
 
 		create_texture(RB_SCOPE_BUFFERS, RB_TEX_DEPTH, format, usage_bits);
+		color_texture_rs = texture_storage->texture_2d_init_for_3d(_get_color_texture(false), internal_size.width, internal_size.height);
 	}
 
 	// Create our MSAA buffers
@@ -275,6 +281,10 @@ void RenderSceneBuffersRD::set_texture_mipmap_bias(float p_texture_mipmap_bias) 
 
 void RenderSceneBuffersRD::set_use_debanding(bool p_use_debanding) {
 	use_debanding = p_use_debanding;
+}
+
+RID RenderSceneBuffersRD::get_color_buffer() {
+	return color_texture_rs;
 }
 
 // Named textures

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -73,6 +73,8 @@ private:
 
 	// Our render target represents our final destination that we display on screen.
 	RID render_target;
+	// A proxy RS::Texture to be used with VIEWPORT_MODE_3D.
+	RID color_texture_rs;
 	Size2i target_size = Size2i(0, 0);
 	uint32_t view_count = 1;
 
@@ -190,6 +192,8 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) override;
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override;
 	virtual void set_use_debanding(bool p_use_debanding) override;
+
+	virtual RID get_color_buffer() override;
 
 	// Named Textures
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -558,6 +558,30 @@ public:
 		return Size2i(tex->width_2d, tex->height_2d);
 	}
 
+	RID texture_2d_init_for_3d(RID p_rid, int p_width, int p_height) {
+		Texture texture;
+
+		texture.rd_texture = p_rid;
+		texture.is_render_target = true;
+		texture.width = p_width;
+		texture.height = p_height;
+		texture.rd_format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+		texture.rd_format_srgb = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+		texture.format = Image::FORMAT_RGBAH;
+		texture.validated_format = Image::FORMAT_RGBAH;
+		texture.is_proxy = false;
+
+		return texture_owner.make_rid(texture);
+	}
+
+	void texture_2d_for_3d_free(RID p_texture) {
+		Texture *t = texture_owner.get_or_null(p_texture);
+		ERR_FAIL_NULL(t);
+
+		t->is_render_target = false;
+		texture_free(p_texture);
+	}
+
 	/* DECAL API */
 
 	void update_decal_atlas();

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -52,8 +52,7 @@ public:
 		RID self;
 		RID parent;
 
-		// use xr interface to override camera positioning and projection matrices and control output
-		bool use_xr = false;
+		RS::ViewportMode viewport_mode = RS::VIEWPORT_MODE_2D_AND_3D;
 
 		Size2i internal_size;
 		Size2i size;
@@ -177,7 +176,7 @@ public:
 			snap_2d_transforms_to_pixel = false;
 			snap_2d_vertices_to_pixel = false;
 
-			use_xr = false;
+			viewport_mode = RS::VIEWPORT_MODE_2D_AND_3D;
 			sdf_active = false;
 
 			time_cpu_begin = 0;
@@ -221,6 +220,7 @@ public:
 	void viewport_initialize(RID p_rid);
 
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
+	void viewport_set_viewport_mode(RID p_viewport, RS::ViewportMode p_viewport_mode);
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -609,6 +609,7 @@ public:
 	FUNCRIDSPLIT(viewport)
 
 	FUNC2(viewport_set_use_xr, RID, bool)
+	FUNC2(viewport_set_viewport_mode, RID, ViewportMode)
 	FUNC3(viewport_set_size, RID, int, int)
 
 	FUNC2(viewport_set_active, RID, bool)

--- a/servers/rendering/storage/render_scene_buffers.h
+++ b/servers/rendering/storage/render_scene_buffers.h
@@ -110,6 +110,9 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) = 0;
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) = 0;
 	virtual void set_use_debanding(bool p_use_debanding) = 0;
+
+	virtual RID get_color_buffer() = 0;
+	//virtual RID get_depth_buffer() = 0;
 };
 
 class RenderSceneBuffersExtension : public RenderSceneBuffers {
@@ -131,6 +134,7 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) override;
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override;
 	virtual void set_use_debanding(bool p_use_debanding) override;
+	virtual RID get_color_buffer() override { return RID(); }
 };
 
 #endif // RENDER_SCENE_BUFFERS_H

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2771,6 +2771,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
+	ClassDB::bind_method(D_METHOD("viewport_set_viewport_mode", "viewport", "mode"), &RenderingServer::viewport_set_viewport_mode);
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -850,7 +850,15 @@ public:
 		VIEWPORT_SCALING_3D_MODE_OFF = 255, // for internal use only
 	};
 
+	enum ViewportMode {
+		VIEWPORT_MODE_2D_AND_3D,
+		VIEWPORT_MODE_3D,
+		VIEWPORT_MODE_XR,
+		VIEWPORT_MODE_MAX
+	};
+
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
+	virtual void viewport_set_viewport_mode(RID p_viewport, ViewportMode p_viewport_mode) = 0;
 	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
@@ -1788,6 +1796,7 @@ VARIANT_ENUM_CAST(RenderingServer::ViewportOcclusionCullingBuildQuality);
 VARIANT_ENUM_CAST(RenderingServer::ViewportSDFOversize);
 VARIANT_ENUM_CAST(RenderingServer::ViewportSDFScale);
 VARIANT_ENUM_CAST(RenderingServer::ViewportVRSMode);
+VARIANT_ENUM_CAST(RenderingServer::ViewportMode);
 VARIANT_ENUM_CAST(RenderingServer::SkyMode);
 VARIANT_ENUM_CAST(RenderingServer::CompositorEffectCallbackType);
 VARIANT_ENUM_CAST(RenderingServer::CompositorEffectFlags);


### PR DESCRIPTION
Proper fix for: https://github.com/godotengine/godot/issues/54122
Supersedes: https://github.com/godotengine/godot/pull/61667 and https://github.com/godotengine/godot/pull/70970

This PR does a few things:
1. Replaces the "use_xr" property of viewports with the enum "ViewportMode"
2. Allows viewports to be tagged as used for "2D and 3D", "3D", or "XR"
3. When tagged as "3D" 2D rendering is not performed and ViewportTextures will display the raw 3D buffer (before post processing/tonemapping/EOTF) which is in linear space and has the full dynamic range

### Open Questions
1. When using "3D" mode, should writing to the swapchain be disabled (i.e. the texture can only be used by ViewportTexture) or should tonemapping happen directly into the swapchain (i.e. 2D is simply skipped)? My feeling is that "3D" mode should imply
2. Right now alpha is cleared to 0 for the 3D buffers. This is because it is used for SSS. For VR passthrough, we most likely need to start always using alpha for actual alpha and put SSS in a separate texture. Should we make that change before this one as it will impact all reads from the color buffer?
3. How will this interact with exposing the depth/normal buffers through ViewportTexture? Perhaps this functionality is better exposed through the ViewportTexture anyway.

### Alternative approach

Building on question 3 above, we could change this PR to instead expose a similar set of options in the ViewportTexture itself: "2D and 3D", 3D, Depth, Normal-Roughness. Then users can use the ViewportTexture with whatever buffer they want. 

In the Viewport API, we already have options to disable 2D if we want. So we could leave the questions of disabling 2D/3D in the Viewport and the question of what texture to expose to the ViewportTexture. To me, exposing these through ViewportTexture seems a bit cleaner and it doesn't carry implications for what rendering/processing is done. Further, users could also access multiple buffers from the same Viewport which I think is very important.

### Example
In the below scene, the mesh has a red emission with a strength of 10. As expected, when dividing by 10 in "2D and 3D" mode, the color ends up quite dark as the color range is clipped to 0-1. When using the "3D" mode, the color is not clipped, so dividing by 10 restores it to the expected color
_"2D and 3D" mode (same as current master)_
![Screenshot from 2024-04-17 09-46-20](https://github.com/godotengine/godot/assets/16521339/c9ee091c-b7bb-40e4-b4cd-fa514af1197f)

_New "3D" mode_
![Screenshot from 2024-04-17 09-46-25](https://github.com/godotengine/godot/assets/16521339/b8ce9b73-a0a3-4b0d-ad70-a9989d00343e)


