### PR TITLE
Don't edit current when changing docks (reverted)

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -147,7 +147,6 @@ void EditorDockManager::_update_layout() {
 	if (!dock_context_popup->is_inside_tree() || EditorNode::get_singleton()->is_exiting()) {
 		return;
 	}
-	EditorNode::get_singleton()->edit_current();
 	dock_context_popup->docks_updated();
 	_update_docks_menu();
 	EditorNode::get_singleton()->save_editor_layout_delayed();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3468,7 +3468,9 @@ void EditorInspector::edit(Object *p_object) {
 	next_object = p_object; // Some plugins need to know the next edited object when clearing the inspector.
 	if (object) {
 		_clear();
-		object->disconnect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
+		if (object->is_connected("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback))) {
+			object->disconnect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
+		}
 	}
 	per_array_page.clear();
 
@@ -4010,14 +4012,13 @@ void EditorInspector::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
-			edit(nullptr); //just in case
+			edit(nullptr);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			if (!sub_inspector) {
 				get_tree()->disconnect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
-			edit(nullptr);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/90654

- Before #88003, 
edit_current was called in move dock left/right, make/close window, move to/from bottom, and dock select click.
But not in drag and drop, changing dock tab, distraction free, load layout, or feature profiles.

In that PR I unified them to all call edit_current, but I don't think they need to call it at all. If any of them do, let me know.