### PR TITLE
Expose `create_from_arrays` in SurfaceTool and cleanup some naming

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -93,7 +93,7 @@
 		<method name="commit_to_arrays">
 			<return type="Array" />
 			<description>
-				Commits the data to the same format used by [method ArrayMesh.add_surface_from_arrays]. This way you can further process the mesh data using the [ArrayMesh] API.
+				Commits the data to the same format used by [method ArrayMesh.add_surface_from_arrays], [method ImporterMesh.add_surface], and [method create_from_arrays]. This way you can further process the mesh data using the [ArrayMesh] or [ImporterMesh] APIs.
 			</description>
 		</method>
 		<method name="create_from">
@@ -102,6 +102,14 @@
 			<param index="1" name="surface" type="int" />
 			<description>
 				Creates a vertex array from an existing [Mesh].
+			</description>
+		</method>
+		<method name="create_from_arrays">
+			<return type="void" />
+			<param index="0" name="arrays" type="Array" />
+			<param index="1" name="primitive_type" type="int" enum="Mesh.PrimitiveType" default="3" />
+			<description>
+				Creates this SurfaceTool from existing vertex arrays such as returned by [method commit_to_arrays], [method Mesh.surface_get_arrays], [method Mesh.surface_get_blend_shape_arrays], [method ImporterMesh.get_surface_arrays], and [method ImporterMesh.get_surface_blend_shape_arrays]. [param primitive_type] controls the type of mesh data, defaulting to [constant Mesh.PRIMITIVE_TRIANGLES].
 			</description>
 		</method>
 		<method name="create_from_blend_shape">

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1139,7 +1139,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 		s.material = get_surface_material(i);
 		s.name = get_surface_name(i);
 
-		SurfaceTool::create_vertex_array_from_triangle_arrays(arrays, s.vertices, &s.format);
+		SurfaceTool::create_vertex_array_from_arrays(arrays, s.vertices, &s.format);
 
 		PackedVector3Array rvertices = arrays[Mesh::ARRAY_VERTEX];
 		int vc = rvertices.size();

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2086,7 +2086,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 
 		Array arrays = surface_get_arrays(i);
 		s.material = surface_get_material(i);
-		SurfaceTool::create_vertex_array_from_triangle_arrays(arrays, s.vertices, &s.format);
+		SurfaceTool::create_vertex_array_from_arrays(arrays, s.vertices, &s.format);
 
 		PackedVector3Array rvertices = arrays[Mesh::ARRAY_VERTEX];
 		int vc = rvertices.size();

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -802,7 +802,7 @@ void SurfaceTool::_create_list(const Ref<Mesh> &p_existing, int p_surface, Local
 const uint32_t SurfaceTool::custom_mask[RS::ARRAY_CUSTOM_COUNT] = { Mesh::ARRAY_FORMAT_CUSTOM0, Mesh::ARRAY_FORMAT_CUSTOM1, Mesh::ARRAY_FORMAT_CUSTOM2, Mesh::ARRAY_FORMAT_CUSTOM3 };
 const uint32_t SurfaceTool::custom_shift[RS::ARRAY_CUSTOM_COUNT] = { Mesh::ARRAY_FORMAT_CUSTOM0_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM1_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM2_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM3_SHIFT };
 
-void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<SurfaceTool::Vertex> &ret, uint64_t *r_format) {
+void SurfaceTool::create_vertex_array_from_arrays(const Array &p_arrays, LocalVector<SurfaceTool::Vertex> &ret, uint64_t *r_format) {
 	ret.clear();
 
 	Vector<Vector3> varr = p_arrays[RS::ARRAY_VERTEX];
@@ -932,7 +932,7 @@ void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays
 }
 
 void SurfaceTool::_create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
-	create_vertex_array_from_triangle_arrays(arr, *r_vertex, &lformat);
+	create_vertex_array_from_arrays(arr, *r_vertex, &lformat);
 	ERR_FAIL_COND(r_vertex->size() == 0);
 
 	//indices
@@ -949,9 +949,9 @@ void SurfaceTool::_create_list_from_arrays(Array arr, LocalVector<Vertex> *r_ver
 	}
 }
 
-void SurfaceTool::create_from_triangle_arrays(const Array &p_arrays) {
+void SurfaceTool::create_from_arrays(const Array &p_arrays, Mesh::PrimitiveType p_primitive_type) {
 	clear();
-	primitive = Mesh::PRIMITIVE_TRIANGLES;
+	primitive = p_primitive_type;
 	_create_list_from_arrays(p_arrays, &vertex_array, &index_array, format);
 
 	for (int j = 0; j < RS::ARRAY_CUSTOM_COUNT; j++) {
@@ -959,6 +959,10 @@ void SurfaceTool::create_from_triangle_arrays(const Array &p_arrays) {
 			last_custom_format[j] = (CustomFormat)((format >> custom_shift[j]) & RS::ARRAY_FORMAT_CUSTOM_MASK);
 		}
 	}
+}
+
+void SurfaceTool::create_from_triangle_arrays(const Array &p_arrays) {
+	create_from_arrays(p_arrays, Mesh::PRIMITIVE_TRIANGLES);
 }
 
 void SurfaceTool::create_from(const Ref<Mesh> &p_existing, int p_surface) {
@@ -1377,6 +1381,7 @@ void SurfaceTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &SurfaceTool::clear);
 
 	ClassDB::bind_method(D_METHOD("create_from", "existing", "surface"), &SurfaceTool::create_from);
+	ClassDB::bind_method(D_METHOD("create_from_arrays", "arrays", "primitive_type"), &SurfaceTool::create_from_arrays, DEFVAL(Mesh::PRIMITIVE_TRIANGLES));
 	ClassDB::bind_method(D_METHOD("create_from_blend_shape", "existing", "surface", "blend_shape"), &SurfaceTool::create_from_blend_shape);
 	ClassDB::bind_method(D_METHOD("append_from", "existing", "surface", "transform"), &SurfaceTool::append_from);
 	ClassDB::bind_method(D_METHOD("commit", "existing", "flags"), &SurfaceTool::commit, DEFVAL(Variant()), DEFVAL(0));

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -219,7 +219,8 @@ public:
 	LocalVector<Vertex> &get_vertex_array() { return vertex_array; }
 
 	void create_from_triangle_arrays(const Array &p_arrays);
-	static void create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<Vertex> &ret, uint64_t *r_format = nullptr);
+	void create_from_arrays(const Array &p_arrays, Mesh::PrimitiveType p_primitive_type = Mesh::PRIMITIVE_TRIANGLES);
+	static void create_vertex_array_from_arrays(const Array &p_arrays, LocalVector<Vertex> &ret, uint64_t *r_format = nullptr);
 	Array commit_to_arrays();
 	void create_from(const Ref<Mesh> &p_existing, int p_surface);
 	void create_from_blend_shape(const Ref<Mesh> &p_existing, int p_surface, const String &p_blend_shape_name);


### PR DESCRIPTION
Currently, the only user-facing API to SurfaceTool is by using `ArrayMesh`, which requires copying CPU -> GPU -> CPU.

The function for in-memory creation already existed internally `SurfaceTool::create_from_triangle_arrays`, since this is used by ImporterMesh and other import tooling, but this function was not exposed.

Furthermore, when reviewing how this function was implemented, the code sets primitive to `PRIMITIVE_TRIANGLES`, yet does not depend on this assumption. I believe this was caused by the fact that it calls an erroneously-named internal `static SurfaceTool::create_vertex_array_from_triangle_arrays` function, which is actually used internally for all types of meshes and makes no assumption about the primitive type.

In summary, I'm renaming `create_vertex_array_from_triangle_arrays` to `create_vertex_array_from_arrays` and adding a wrapper function for triangles so that `SurfaceTool::create_from_arrays` can be exposed.