### PR TITLE
Fix input map shortcuts incorrectly edited on cancel.

### DIFF
--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -587,7 +587,7 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 
 void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p_event, const String &p_current_action_name) {
 	if (p_event.is_valid()) {
-		_set_event(p_event->duplicate(), p_event);
+		_set_event(p_event->duplicate(), p_event->duplicate());
 	} else {
 		// Clear Event
 		_set_event(Ref<InputEvent>(), Ref<InputEvent>());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90833