### PR TITLE
Change order of operation for C# types reloading

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -941,6 +941,31 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		to_reload_state.push_back(scr);
 	}
 
+	// Deserialize managed callables.
+	// This is done before reloading script's internal state, so potential callables invoked in properties work.
+	{
+		MutexLock lock(ManagedCallable::instances_mutex);
+
+		for (const KeyValue<ManagedCallable *, Array> &elem : ManagedCallable::instances_pending_reload) {
+			ManagedCallable *managed_callable = elem.key;
+			const Array &serialized_data = elem.value;
+
+			GCHandleIntPtr delegate = { nullptr };
+
+			bool success = GDMonoCache::managed_callbacks.DelegateUtils_TryDeserializeDelegateWithGCHandle(
+					&serialized_data, &delegate);
+
+			if (success) {
+				ERR_CONTINUE(delegate.value == nullptr);
+				managed_callable->delegate_handle = delegate;
+			} else if (OS::get_singleton()->is_stdout_verbose()) {
+				OS::get_singleton()->print("Failed to deserialize delegate\n");
+			}
+		}
+
+		ManagedCallable::instances_pending_reload.clear();
+	}
+
 	for (Ref<CSharpScript> &scr : to_reload_state) {
 		for (const ObjectID &obj_id : scr->pending_reload_instances) {
 			Object *obj = ObjectDB::get_instance(obj_id);
@@ -963,7 +988,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 					properties[G.first] = G.second;
 				}
 
-				// Restore serialized state and call OnAfterDeserialization
+				// Restore serialized state and call OnAfterDeserialize.
 				GDMonoCache::managed_callbacks.CSharpInstanceBridge_DeserializeState(
 						csi->get_gchandle_intptr(), &properties, &state_backup.event_signals);
 			}
@@ -971,30 +996,6 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 		scr->pending_reload_instances.clear();
 		scr->pending_reload_state.clear();
-	}
-
-	// Deserialize managed callables
-	{
-		MutexLock lock(ManagedCallable::instances_mutex);
-
-		for (const KeyValue<ManagedCallable *, Array> &elem : ManagedCallable::instances_pending_reload) {
-			ManagedCallable *managed_callable = elem.key;
-			const Array &serialized_data = elem.value;
-
-			GCHandleIntPtr delegate = { nullptr };
-
-			bool success = GDMonoCache::managed_callbacks.DelegateUtils_TryDeserializeDelegateWithGCHandle(
-					&serialized_data, &delegate);
-
-			if (success) {
-				ERR_CONTINUE(delegate.value == nullptr);
-				managed_callable->delegate_handle = delegate;
-			} else if (OS::get_singleton()->is_stdout_verbose()) {
-				OS::get_singleton()->print("Failed to deserialize delegate\n");
-			}
-		}
-
-		ManagedCallable::instances_pending_reload.clear();
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
- Relates to #78513

## The issue

With the following classes (granted they are used in a scene opened in editor), the reload process would trigger an error when restoring the value of `RadialPatternResolver.RadialPattern`. This happens because at the time the value is restored, we have not yet deserialized the managed callable associated with `_radialPattern.Changed`. Ultimately, our reload process would consider this a fail, and the infamous `.NET: Failed to unload assemblies` would show. Basically bricking the engine until we quit/restart.

```cs
[GlobalClass, Tool]
public partial class RadialPattern : Resource
{
    private bool _someToggle;

    [Export]
    public bool SomeToggle
    {
        get => _someToggle;
        private set
        {
            _someToggle = value;
            EmitChanged();
        }
    }
}

[Tool]
public partial class RadialPatternResolver : Node
{
    private RadialPattern _radialPattern;

    [Export]
    public RadialPattern RadialPattern
    {
        get => _radialPattern;
        private set
        {
            GD.Print($"RadialPattern setter (value={value}).");

            if (_radialPattern is not null)
            {
                _radialPattern.Changed -= OnRadialPatternChanged;
            }

            _radialPattern = value;

            if (_radialPattern is not null)
            {
                _radialPattern.Changed += OnRadialPatternChanged;
            }
        }
    }

    private void OnRadialPatternChanged()
    {
        GD.Print("OnRadialPatternChanged");
    }
}
```

## The fix

We now deserialize callables before reloading property states, in case a property is doing anything with the callable in its getter and/or setter.

## PSA

This should not change the behaviour currently implemented (apart from fixing the actual error), but it should be noted that said behaviour might be counter-intuitive to some users. In the example used above, after the reload, `_radialPattern.Changed` would be subscribed to twice (one is from before the reload, that we now properly restore, the other from during the reload, when the property's state is restored). We can see this is the currently implemented behaviour by connecting the signal with the deferred flag (this basically bypasses the original timing issue). I included this in the provided MRP.

This is probably not ideal, but we probably don't want to widely change the behaviour here. Users can implement the `ISerializationListener` if they need finer control.

## Minimal reproduction

- [MRP.zip](https://github.com/godotengine/godot/files/15021672/MRP.zip)
