### PR TITLE
Fix TreeItem button handling

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -645,6 +645,8 @@ private:
 
 	TreeItem *_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_column, int &h, int &section) const;
 
+	void _find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_column, int &r_index) const;
+
 	/*	float drag_speed;
 	float drag_accum;
 


### PR DESCRIPTION
Fixes #79629

This PR mainly fixes `get_tooltip()` and `get_button_id_at_position()`:

- They did not work when the control is too narrow and when RTL layout is used.
- They did not take `button_margin`, `h_separation`, and `item_margin` into account.

---

[TestProject.zip](https://github.com/godotengine/godot/files/15021885/test.zip)
