### PR TITLE
Revert "Correctly display tooltips for buttons in Tree when they overlap cell content

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2459,7 +2459,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (rtl) {
 					button_ofs.x = get_size().width - button_ofs.x - button_texture->get_width();
 				}
-				p_item->cells.write[i].buttons.write[j].rect = Rect2i(button_ofs, button_size);
 				button_texture->draw(ci, button_ofs, p_item->cells[i].buttons[j].disabled ? Color(1, 1, 1, 0.5) : p_item->cells[i].buttons[j].color);
 				item_width_with_buttons -= button_size.width + theme_cache.button_margin;
 			}
@@ -5400,7 +5399,6 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 			return Control::get_tooltip(p_pos);
 		}
 
-		Point2 button_pos = pos;
 		if (h_scroll->is_visible_in_tree()) {
 			pos.x += h_scroll->get_value();
 		}
@@ -5413,13 +5411,22 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 
 		if (it) {
 			const TreeItem::Cell &c = it->cells[col];
+			int col_width = get_column_width(col);
+
+			for (int i = 0; i < col; i++) {
+				pos.x -= get_column_width(i);
+			}
+
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
-				if (c.buttons[j].rect.has_point(button_pos)) {
+				Ref<Texture2D> b = c.buttons[j].texture;
+				Size2 size = b->get_size() + theme_cache.button_pressed->get_minimum_size();
+				if (pos.x > col_width - size.width) {
 					String tooltip = c.buttons[j].tooltip;
 					if (!tooltip.is_empty()) {
 						return tooltip;
 					}
 				}
+				col_width -= size.width;
 			}
 			String ret;
 			if (it->get_tooltip_text(col) == "") {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -108,7 +108,6 @@ private:
 			Ref<Texture2D> texture;
 			Color color = Color(1, 1, 1, 1);
 			String tooltip;
-			Rect2i rect;
 		};
 
 		Vector<Button> buttons;


### PR DESCRIPTION
#79792 caches button rect when drawing, and uses that rect to determine the tooltip. However, the rectangle used for processing mouse input is not the same as the rectangle used for drawing. The tooltip is still missing in some edge cases. So I think it's not the correct fix for #79629.

It also caused a regression (#86497) making tree buttons' tooltips missing / wrong if the Tree has column titles visible which is impossible for users to workaround.

*Bugsquad edit:*
- Fixes #86497
- Reopens #79629