### PR TITLE
Handle Vector4 default input values in visual shaders

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2116,6 +2116,10 @@ Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringB
 				Vector3 val = defval;
 				inputs[i] = "n_in" + itos(p_node) + "p" + itos(i);
 				node_code += "	vec3 " + inputs[i] + " = " + vformat("vec3(%.5f, %.5f, %.5f);\n", val.x, val.y, val.z);
+			} else if (defval.get_type() == Variant::VECTOR4) {
+				Vector4 val = defval;
+				inputs[i] = "n_in" + itos(p_node) + "p" + itos(i);
+				node_code += "	vec4 " + inputs[i] + " = " + vformat("vec4(%.5f, %.5f, %.5f, %.5f);\n", val.x, val.y, val.z, val.w);
 			} else if (defval.get_type() == Variant::QUATERNION) {
 				Quaternion val = defval;
 				inputs[i] = "n_in" + itos(p_node) + "p" + itos(i);


### PR DESCRIPTION
When `set_input_port_default_value` in a `VisualShaderNodeCustom` is called with a `Vector4` as the second parameter and nothing is connected to the input, shader code generator inserts empty space instead of the default value.

This PR should fix this by making code generator handle 4d vectors the same way as 3d and 2d.

~~I don't yet have an environment set up to properly build and test this, so the changes may be not valid.~~

UPD: Tested the build from github actions. Seems to work fine.
