### PR TITLE
Fix buttons offset to the right when dialog is at minsize

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -264,12 +264,6 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 		content_minsize = child_minsize.max(content_minsize);
 	}
 
-	// Then we take the background panel as it provides the offsets,
-	// which are always added to the minimum size.
-	if (theme_cache.panel_style.is_valid()) {
-		content_minsize += theme_cache.panel_style->get_minimum_size();
-	}
-
 	// Then we add buttons. Horizontally we're interested in whichever
 	// value is the biggest. Vertically buttons add to the overall size.
 	Size2 buttons_minsize = buttons_hbox->get_combined_minimum_size();
@@ -277,6 +271,12 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 	content_minsize.y += buttons_minsize.y;
 	// Plus there is a separation size added on top.
 	content_minsize.y += theme_cache.buttons_separation;
+
+	// Then we take the background panel as it provides the offsets,
+	// which are always added to the minimum size.
+	if (theme_cache.panel_style.is_valid()) {
+		content_minsize += theme_cache.panel_style->get_minimum_size();
+	}
 
 	return content_minsize;
 }


### PR DESCRIPTION
The command palette window at its minsize:

| Before | After |
|----|----|
| ![ksnip_20240418-212027](https://github.com/godotengine/godot/assets/372476/2954f2e2-244b-49d9-9c98-1564fbbda366) | ![ksnip_20240418-212028](https://github.com/godotengine/godot/assets/372476/681fc13f-8847-4497-b5dc-4e6a8c95f35a) |



When determining window minimum width, panel padding should be applied after `max(buttons_width, child_width)`.

https://github.com/godotengine/godot/blob/2543d192c3f74640393f245e48fdf70e241dbe37/scene/gui/dialogs.cpp#L223-L227