### PR TITLE
SCons: Disable `show_progress` with Ninja

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -990,6 +990,10 @@ def using_emcc(env):
 
 
 def show_progress(env):
+    if env["ninja"]:
+        # Has its own progress/tracking tool that clashes with ours
+        return
+
     import sys
     from SCons.Script import Progress, Command, AlwaysBuild
 


### PR DESCRIPTION
Ninja already has its own builtin tools for tracking progress & jobcount; these tools are mutually exclusive with ours & warrant separation.

The fact that ninja can accurately detect how many jobs will need to be done *before* building anything is an indication that our current system is likely outdated. Changing it to something "smarter" is well beyond the scope of this PR, but it's something to keep in mind if/when this bit of code gets refactored in the future.