### PR TITLE
Check for NaN in `set_volume_db` functions

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -196,6 +196,7 @@ Ref<AudioStream> AudioStreamPlayer2D::get_stream() const {
 }
 
 void AudioStreamPlayer2D::set_volume_db(float p_volume) {
+	ERR_FAIL_COND_MSG(Math::is_nan(p_volume), "Volume can't be set to NaN.");
 	internal->volume_db = p_volume;
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -496,6 +496,7 @@ Ref<AudioStream> AudioStreamPlayer3D::get_stream() const {
 }
 
 void AudioStreamPlayer3D::set_volume_db(float p_volume) {
+	ERR_FAIL_COND_MSG(Math::is_nan(p_volume), "Volume can't be set to NaN.");
 	internal->volume_db = p_volume;
 }
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -59,6 +59,7 @@ Ref<AudioStream> AudioStreamPlayer::get_stream() const {
 }
 
 void AudioStreamPlayer::set_volume_db(float p_volume) {
+	ERR_FAIL_COND_MSG(Math::is_nan(p_volume), "Volume can't be set to NaN.");
 	internal->volume_db = p_volume;
 
 	Vector<AudioFrame> volume_vector = _get_volume_vector();


### PR DESCRIPTION
Added check in `AudioStreamPlayer`, `AudioStreamPlayer2D`, and `AudioStreamPlayer3D` `set_volume_db` functions to prevent setting volume to NaN, and give an error.  Using NaN for volume and playing the AudioStreamPlayer could prevent all audio from playing, even from other AudioStreamPlayers.

Fixes #88133

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
