### PR TITLE
Core: Utilize initializer lists in Variant constructors

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2373,184 +2373,183 @@ Variant::operator IPAddress() const {
 	return IPAddress(operator String());
 }
 
-Variant::Variant(bool p_bool) {
-	type = BOOL;
+Variant::Variant(bool p_bool) :
+		type(BOOL) {
 	_data._bool = p_bool;
 }
 
-Variant::Variant(int64_t p_int64) {
-	type = INT;
+Variant::Variant(int64_t p_int64) :
+		type(INT) {
 	_data._int = p_int64;
 }
 
-Variant::Variant(int32_t p_int32) {
-	type = INT;
+Variant::Variant(int32_t p_int32) :
+		type(INT) {
 	_data._int = p_int32;
 }
 
-Variant::Variant(int16_t p_int16) {
-	type = INT;
+Variant::Variant(int16_t p_int16) :
+		type(INT) {
 	_data._int = p_int16;
 }
 
-Variant::Variant(int8_t p_int8) {
-	type = INT;
+Variant::Variant(int8_t p_int8) :
+		type(INT) {
 	_data._int = p_int8;
 }
 
-Variant::Variant(uint64_t p_uint64) {
-	type = INT;
+Variant::Variant(uint64_t p_uint64) :
+		type(INT) {
 	_data._int = p_uint64;
 }
 
-Variant::Variant(uint32_t p_uint32) {
-	type = INT;
+Variant::Variant(uint32_t p_uint32) :
+		type(INT) {
 	_data._int = p_uint32;
 }
 
-Variant::Variant(uint16_t p_uint16) {
-	type = INT;
+Variant::Variant(uint16_t p_uint16) :
+		type(INT) {
 	_data._int = p_uint16;
 }
 
-Variant::Variant(uint8_t p_uint8) {
-	type = INT;
+Variant::Variant(uint8_t p_uint8) :
+		type(INT) {
 	_data._int = p_uint8;
 }
 
-Variant::Variant(float p_float) {
-	type = FLOAT;
+Variant::Variant(float p_float) :
+		type(FLOAT) {
 	_data._float = p_float;
 }
 
-Variant::Variant(double p_double) {
-	type = FLOAT;
+Variant::Variant(double p_double) :
+		type(FLOAT) {
 	_data._float = p_double;
 }
 
-Variant::Variant(const ObjectID &p_id) {
-	type = INT;
+Variant::Variant(const ObjectID &p_id) :
+		type(INT) {
 	_data._int = p_id;
 }
 
-Variant::Variant(const StringName &p_string) {
-	type = STRING_NAME;
+Variant::Variant(const StringName &p_string) :
+		type(STRING_NAME) {
 	memnew_placement(_data._mem, StringName(p_string));
 }
 
-Variant::Variant(const String &p_string) {
-	type = STRING;
+Variant::Variant(const String &p_string) :
+		type(STRING) {
 	memnew_placement(_data._mem, String(p_string));
 }
 
-Variant::Variant(const char *const p_cstring) {
-	type = STRING;
+Variant::Variant(const char *const p_cstring) :
+		type(STRING) {
 	memnew_placement(_data._mem, String((const char *)p_cstring));
 }
 
-Variant::Variant(const char32_t *p_wstring) {
-	type = STRING;
+Variant::Variant(const char32_t *p_wstring) :
+		type(STRING) {
 	memnew_placement(_data._mem, String(p_wstring));
 }
 
-Variant::Variant(const Vector3 &p_vector3) {
-	type = VECTOR3;
+Variant::Variant(const Vector3 &p_vector3) :
+		type(VECTOR3) {
 	memnew_placement(_data._mem, Vector3(p_vector3));
 }
 
-Variant::Variant(const Vector3i &p_vector3i) {
-	type = VECTOR3I;
+Variant::Variant(const Vector3i &p_vector3i) :
+		type(VECTOR3I) {
 	memnew_placement(_data._mem, Vector3i(p_vector3i));
 }
 
-Variant::Variant(const Vector4 &p_vector4) {
-	type = VECTOR4;
+Variant::Variant(const Vector4 &p_vector4) :
+		type(VECTOR4) {
 	memnew_placement(_data._mem, Vector4(p_vector4));
 }
 
-Variant::Variant(const Vector4i &p_vector4i) {
-	type = VECTOR4I;
+Variant::Variant(const Vector4i &p_vector4i) :
+		type(VECTOR4I) {
 	memnew_placement(_data._mem, Vector4i(p_vector4i));
 }
 
-Variant::Variant(const Vector2 &p_vector2) {
-	type = VECTOR2;
+Variant::Variant(const Vector2 &p_vector2) :
+		type(VECTOR2) {
 	memnew_placement(_data._mem, Vector2(p_vector2));
 }
 
-Variant::Variant(const Vector2i &p_vector2i) {
-	type = VECTOR2I;
+Variant::Variant(const Vector2i &p_vector2i) :
+		type(VECTOR2I) {
 	memnew_placement(_data._mem, Vector2i(p_vector2i));
 }
 
-Variant::Variant(const Rect2 &p_rect2) {
-	type = RECT2;
+Variant::Variant(const Rect2 &p_rect2) :
+		type(RECT2) {
 	memnew_placement(_data._mem, Rect2(p_rect2));
 }
 
-Variant::Variant(const Rect2i &p_rect2i) {
-	type = RECT2I;
+Variant::Variant(const Rect2i &p_rect2i) :
+		type(RECT2I) {
 	memnew_placement(_data._mem, Rect2i(p_rect2i));
 }
 
-Variant::Variant(const Plane &p_plane) {
-	type = PLANE;
+Variant::Variant(const Plane &p_plane) :
+		type(PLANE) {
 	memnew_placement(_data._mem, Plane(p_plane));
 }
 
-Variant::Variant(const ::AABB &p_aabb) {
-	type = AABB;
+Variant::Variant(const ::AABB &p_aabb) :
+		type(AABB) {
 	_data._aabb = (::AABB *)Pools::_bucket_small.alloc();
 	memnew_placement(_data._aabb, ::AABB(p_aabb));
 }
 
-Variant::Variant(const Basis &p_matrix) {
-	type = BASIS;
+Variant::Variant(const Basis &p_matrix) :
+		type(BASIS) {
 	_data._basis = (Basis *)Pools::_bucket_medium.alloc();
 	memnew_placement(_data._basis, Basis(p_matrix));
 }
 
-Variant::Variant(const Quaternion &p_quaternion) {
-	type = QUATERNION;
+Variant::Variant(const Quaternion &p_quaternion) :
+		type(QUATERNION) {
 	memnew_placement(_data._mem, Quaternion(p_quaternion));
 }
 
-Variant::Variant(const Transform3D &p_transform) {
-	type = TRANSFORM3D;
+Variant::Variant(const Transform3D &p_transform) :
+		type(TRANSFORM3D) {
 	_data._transform3d = (Transform3D *)Pools::_bucket_medium.alloc();
 	memnew_placement(_data._transform3d, Transform3D(p_transform));
 }
 
-Variant::Variant(const Projection &pp_projection) {
-	type = PROJECTION;
+Variant::Variant(const Projection &pp_projection) :
+		type(PROJECTION) {
 	_data._projection = (Projection *)Pools::_bucket_large.alloc();
 	memnew_placement(_data._projection, Projection(pp_projection));
 }
 
-Variant::Variant(const Transform2D &p_transform) {
-	type = TRANSFORM2D;
+Variant::Variant(const Transform2D &p_transform) :
+		type(TRANSFORM2D) {
 	_data._transform2d = (Transform2D *)Pools::_bucket_small.alloc();
 	memnew_placement(_data._transform2d, Transform2D(p_transform));
 }
 
-Variant::Variant(const Color &p_color) {
-	type = COLOR;
+Variant::Variant(const Color &p_color) :
+		type(COLOR) {
 	memnew_placement(_data._mem, Color(p_color));
 }
 
-Variant::Variant(const NodePath &p_node_path) {
-	type = NODE_PATH;
+Variant::Variant(const NodePath &p_node_path) :
+		type(NODE_PATH) {
 	memnew_placement(_data._mem, NodePath(p_node_path));
 }
 
-Variant::Variant(const ::RID &p_rid) {
-	type = RID;
+Variant::Variant(const ::RID &p_rid) :
+		type(RID) {
 	memnew_placement(_data._mem, ::RID(p_rid));
 }
 
-Variant::Variant(const Object *p_object) {
-	type = OBJECT;
-
+Variant::Variant(const Object *p_object) :
+		type(OBJECT) {
 	memnew_placement(_data._mem, ObjData);
 
 	if (p_object) {
@@ -2571,76 +2570,74 @@ Variant::Variant(const Object *p_object) {
 	}
 }
 
-Variant::Variant(const Callable &p_callable) {
-	type = CALLABLE;
+Variant::Variant(const Callable &p_callable) :
+		type(CALLABLE) {
 	memnew_placement(_data._mem, Callable(p_callable));
 }
 
-Variant::Variant(const Signal &p_callable) {
-	type = SIGNAL;
+Variant::Variant(const Signal &p_callable) :
+		type(SIGNAL) {
 	memnew_placement(_data._mem, Signal(p_callable));
 }
 
-Variant::Variant(const Dictionary &p_dictionary) {
-	type = DICTIONARY;
+Variant::Variant(const Dictionary &p_dictionary) :
+		type(DICTIONARY) {
 	memnew_placement(_data._mem, Dictionary(p_dictionary));
 }
 
-Variant::Variant(const Array &p_array) {
-	type = ARRAY;
+Variant::Variant(const Array &p_array) :
+		type(ARRAY) {
 	memnew_placement(_data._mem, Array(p_array));
 }
 
-Variant::Variant(const PackedByteArray &p_byte_array) {
-	type = PACKED_BYTE_ARRAY;
-
+Variant::Variant(const PackedByteArray &p_byte_array) :
+		type(PACKED_BYTE_ARRAY) {
 	_data.packed_array = PackedArrayRef<uint8_t>::create(p_byte_array);
 }
 
-Variant::Variant(const PackedInt32Array &p_int32_array) {
-	type = PACKED_INT32_ARRAY;
+Variant::Variant(const PackedInt32Array &p_int32_array) :
+		type(PACKED_INT32_ARRAY) {
 	_data.packed_array = PackedArrayRef<int32_t>::create(p_int32_array);
 }
 
-Variant::Variant(const PackedInt64Array &p_int64_array) {
-	type = PACKED_INT64_ARRAY;
+Variant::Variant(const PackedInt64Array &p_int64_array) :
+		type(PACKED_INT64_ARRAY) {
 	_data.packed_array = PackedArrayRef<int64_t>::create(p_int64_array);
 }
 
-Variant::Variant(const PackedFloat32Array &p_float32_array) {
-	type = PACKED_FLOAT32_ARRAY;
+Variant::Variant(const PackedFloat32Array &p_float32_array) :
+		type(PACKED_FLOAT32_ARRAY) {
 	_data.packed_array = PackedArrayRef<float>::create(p_float32_array);
 }
 
-Variant::Variant(const PackedFloat64Array &p_float64_array) {
-	type = PACKED_FLOAT64_ARRAY;
+Variant::Variant(const PackedFloat64Array &p_float64_array) :
+		type(PACKED_FLOAT64_ARRAY) {
 	_data.packed_array = PackedArrayRef<double>::create(p_float64_array);
 }
 
-Variant::Variant(const PackedStringArray &p_string_array) {
-	type = PACKED_STRING_ARRAY;
+Variant::Variant(const PackedStringArray &p_string_array) :
+		type(PACKED_STRING_ARRAY) {
 	_data.packed_array = PackedArrayRef<String>::create(p_string_array);
 }
 
-Variant::Variant(const PackedVector2Array &p_vector2_array) {
-	type = PACKED_VECTOR2_ARRAY;
+Variant::Variant(const PackedVector2Array &p_vector2_array) :
+		type(PACKED_VECTOR2_ARRAY) {
 	_data.packed_array = PackedArrayRef<Vector2>::create(p_vector2_array);
 }
 
-Variant::Variant(const PackedVector3Array &p_vector3_array) {
-	type = PACKED_VECTOR3_ARRAY;
+Variant::Variant(const PackedVector3Array &p_vector3_array) :
+		type(PACKED_VECTOR3_ARRAY) {
 	_data.packed_array = PackedArrayRef<Vector3>::create(p_vector3_array);
 }
 
-Variant::Variant(const PackedColorArray &p_color_array) {
-	type = PACKED_COLOR_ARRAY;
+Variant::Variant(const PackedColorArray &p_color_array) :
+		type(PACKED_COLOR_ARRAY) {
 	_data.packed_array = PackedArrayRef<Color>::create(p_color_array);
 }
 
 /* helpers */
-Variant::Variant(const Vector<::RID> &p_array) {
-	type = ARRAY;
-
+Variant::Variant(const Vector<::RID> &p_array) :
+		type(ARRAY) {
 	Array *rid_array = memnew_placement(_data._mem, Array);
 
 	rid_array->resize(p_array.size());
@@ -2650,9 +2647,8 @@ Variant::Variant(const Vector<::RID> &p_array) {
 	}
 }
 
-Variant::Variant(const Vector<Plane> &p_array) {
-	type = ARRAY;
-
+Variant::Variant(const Vector<Plane> &p_array) :
+		type(ARRAY) {
 	Array *plane_array = memnew_placement(_data._mem, Array);
 
 	plane_array->resize(p_array.size());
@@ -2662,7 +2658,8 @@ Variant::Variant(const Vector<Plane> &p_array) {
 	}
 }
 
-Variant::Variant(const Vector<Face3> &p_face_array) {
+Variant::Variant(const Vector<Face3> &p_face_array) :
+		type(NIL) {
 	PackedVector3Array vertices;
 	int face_count = p_face_array.size();
 	vertices.resize(face_count * 3);
@@ -2678,13 +2675,11 @@ Variant::Variant(const Vector<Face3> &p_face_array) {
 		}
 	}
 
-	type = NIL;
-
 	*this = vertices;
 }
 
-Variant::Variant(const Vector<Variant> &p_array) {
-	type = NIL;
+Variant::Variant(const Vector<Variant> &p_array) :
+		type(NIL) {
 	Array arr;
 	arr.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
@@ -2693,8 +2688,8 @@ Variant::Variant(const Vector<Variant> &p_array) {
 	*this = arr;
 }
 
-Variant::Variant(const Vector<StringName> &p_array) {
-	type = NIL;
+Variant::Variant(const Vector<StringName> &p_array) :
+		type(NIL) {
 	PackedStringArray v;
 	int len = p_array.size();
 	v.resize(len);
@@ -2863,12 +2858,13 @@ void Variant::operator=(const Variant &p_variant) {
 	}
 }
 
-Variant::Variant(const IPAddress &p_address) {
-	type = STRING;
+Variant::Variant(const IPAddress &p_address) :
+		type(STRING) {
 	memnew_placement(_data._mem, String(p_address));
 }
 
-Variant::Variant(const Variant &p_variant) {
+Variant::Variant(const Variant &p_variant) :
+		type(NIL) {
 	reference(p_variant);
 }
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -165,7 +165,7 @@ private:
 	// Variant takes 20 bytes when real_t is float, and 36 if double
 	// it only allocates extra memory for aabb/matrix.
 
-	Type type = NIL;
+	Type type;
 
 	struct ObjData {
 		ObjectID id;
@@ -483,8 +483,8 @@ public:
 	Variant(const IPAddress &p_address);
 
 #define VARIANT_ENUM_CLASS_CONSTRUCTOR(m_enum) \
-	Variant(m_enum p_value) {                  \
-		type = INT;                            \
+	Variant(m_enum p_value) :                  \
+			type(INT) {                        \
 		_data._int = (int64_t)p_value;         \
 	}
 
@@ -788,7 +788,8 @@ public:
 	static void unregister_types();
 
 	Variant(const Variant &p_variant);
-	_FORCE_INLINE_ Variant() {}
+	_FORCE_INLINE_ Variant() :
+			type(NIL) {}
 	_FORCE_INLINE_ ~Variant() {
 		clear();
 	}


### PR DESCRIPTION
Inspired by a conversation in #core[^1], this makes all Variant constructors set `type` via initalizer lists. I'm unsure what the *actual* performance benefits of this will be, but this style of constuction is good practice either way.

[^1]: https://chat.godotengine.org/channel/core?msg=TExpzJdiHN526Xd7f