### PR TITLE
Fix crash when GraphFrame `sb_to_draw_panel` is not a StyleBoxFlat

### DIFF
--- a/scene/gui/graph_frame.cpp
+++ b/scene/gui/graph_frame.cpp
@@ -118,7 +118,7 @@ void GraphFrame::_notification(int p_what) {
 					sb_panel_flat->set_border_color(selected ? original_border_color : tint_color.lightened(0.3));
 					draw_style_box(sb_panel_flat, body_rect);
 				} else if (sb_panel_texture.is_valid()) {
-					sb_panel_texture = sb_panel_flat->duplicate();
+					sb_panel_texture = sb_panel_texture->duplicate();
 					sb_panel_texture->set_modulate(tint_color);
 					draw_style_box(sb_panel_texture, body_rect);
 				}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/88014#pullrequestreview-1981165537

This was flagged by GCC as a warning treated as error on my CI (not sure why Godot CI didnt catch it?).
```
scene/gui/graph_frame.cpp:121:84: error: 'this' pointer is null [-Werror=nonnull]
  121 |                                         sb_panel_texture = sb_panel_flat->duplicate();
      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~^~
```
