### PR TITLE
Add navigation mesh source geometry parsers and callbacks

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -956,6 +956,23 @@
 				Path simplification can be helpful to mitigate various path following issues that can arise with certain agent types and script behaviors. E.g. "steering" agents or avoidance in "open fields".
 			</description>
 		</method>
+		<method name="source_geometry_parser_create">
+			<return type="RID" />
+			<description>
+				Creates a new source geometry parser. If a [Callable] is set for the parser with [method source_geometry_parser_set_callback] the callback will be called for every single node that gets parsed whenever [method parse_source_geometry_data] is used.
+			</description>
+		</method>
+		<method name="source_geometry_parser_set_callback">
+			<return type="void" />
+			<param index="0" name="parser" type="RID" />
+			<param index="1" name="callback" type="Callable" />
+			<description>
+				Sets the [param callback] [Callable] for the specific source geometry [param parser]. The [Callable] will receive a call with the following parameters:
+				- [code]navigation_mesh[/code] - The [NavigationPolygon] reference used to define the parse settings. Do NOT edit or add directly to the navigation mesh.
+				- [code]source_geometry_data[/code] - The [NavigationMeshSourceGeometryData2D] reference. Add custom source geometry for navigation mesh baking to this object.
+				- [code]node[/code] - The [Node] that is parsed.
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="map_changed">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -1103,6 +1103,23 @@
 				Path simplification can be helpful to mitigate various path following issues that can arise with certain agent types and script behaviors. E.g. "steering" agents or avoidance in "open fields".
 			</description>
 		</method>
+		<method name="source_geometry_parser_create">
+			<return type="RID" />
+			<description>
+				Creates a new source geometry parser. If a [Callable] is set for the parser with [method source_geometry_parser_set_callback] the callback will be called for every single node that gets parsed whenever [method parse_source_geometry_data] is used.
+			</description>
+		</method>
+		<method name="source_geometry_parser_set_callback">
+			<return type="void" />
+			<param index="0" name="parser" type="RID" />
+			<param index="1" name="callback" type="Callable" />
+			<description>
+				Sets the [param callback] [Callable] for the specific source geometry [param parser]. The [Callable] will receive a call with the following parameters:
+				- [code]navigation_mesh[/code] - The [NavigationMesh] reference used to define the parse settings. Do NOT edit or add directly to the navigation mesh.
+				- [code]source_geometry_data[/code] - The [NavigationMeshSourceGeometryData3D] reference. Add custom source geometry for navigation mesh baking to this object.
+				- [code]node[/code] - The [Node] that is parsed.
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="avoidance_debug_changed">

--- a/modules/navigation/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation/2d/godot_navigation_server_2d.cpp
@@ -389,7 +389,16 @@ bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
 void FORWARD_2(agent_set_paused, RID, p_agent, bool, p_paused, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(agent_get_paused, RID, p_agent, rid_to_rid);
 
-void FORWARD_1(free, RID, p_object, rid_to_rid);
+void GodotNavigationServer2D::free(RID p_object) {
+#ifdef CLIPPER2_ENABLED
+	if (navmesh_generator_2d && navmesh_generator_2d->owns(p_object)) {
+		navmesh_generator_2d->free(p_object);
+		return;
+	}
+#endif // CLIPPER2_ENABLED
+	NavigationServer3D::get_singleton()->free(p_object);
+}
+
 void FORWARD_2(agent_set_avoidance_callback, RID, p_agent, Callable, p_callback, rid_to_rid, callable_to_callable);
 bool GodotNavigationServer2D::agent_has_avoidance_callback(RID p_agent) const {
 	return NavigationServer3D::get_singleton()->agent_has_avoidance_callback(p_agent);
@@ -452,4 +461,21 @@ void GodotNavigationServer2D::query_path(const Ref<NavigationPathQueryParameters
 	p_query_result->set_path_types(_query_result.path_types);
 	p_query_result->set_path_rids(_query_result.path_rids);
 	p_query_result->set_path_owner_ids(_query_result.path_owner_ids);
+}
+
+RID GodotNavigationServer2D::source_geometry_parser_create() {
+#ifdef CLIPPER2_ENABLED
+	if (navmesh_generator_2d) {
+		return navmesh_generator_2d->source_geometry_parser_create();
+	}
+#endif // CLIPPER2_ENABLED
+	return RID();
+}
+
+void GodotNavigationServer2D::source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) {
+#ifdef CLIPPER2_ENABLED
+	if (navmesh_generator_2d) {
+		navmesh_generator_2d->source_geometry_parser_set_callback(p_parser, p_callback);
+	}
+#endif // CLIPPER2_ENABLED
 }

--- a/modules/navigation/2d/godot_navigation_server_2d.h
+++ b/modules/navigation/2d/godot_navigation_server_2d.h
@@ -253,6 +253,9 @@ public:
 	virtual void bake_from_source_geometry_data_async(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;
 	virtual bool is_baking_navigation_polygon(Ref<NavigationPolygon> p_navigation_polygon) const override;
 
+	virtual RID source_geometry_parser_create() override;
+	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override;
+
 	virtual Vector<Vector2> simplify_path(const Vector<Vector2> &p_path, real_t p_epsilon) override;
 };
 

--- a/modules/navigation/2d/nav_mesh_generator_2d.h
+++ b/modules/navigation/2d/nav_mesh_generator_2d.h
@@ -35,6 +35,7 @@
 
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/templates/rid_owner.h"
 
 class Node;
 class NavigationPolygon;
@@ -45,6 +46,14 @@ class NavMeshGenerator2D : public Object {
 
 	static Mutex baking_navmesh_mutex;
 	static Mutex generator_task_mutex;
+
+	static RWLock generator_rid_rwlock;
+	struct NavMeshGeometryParser2D {
+		RID self;
+		Callable callback;
+	};
+	static RID_Owner<NavMeshGeometryParser2D> generator_parser_owner;
+	static LocalVector<NavMeshGeometryParser2D *> generator_parsers;
 
 	static bool use_threads;
 	static bool baking_use_multiple_threads;
@@ -96,6 +105,12 @@ public:
 	static void bake_from_source_geometry_data(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback = Callable());
 	static void bake_from_source_geometry_data_async(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback = Callable());
 	static bool is_baking(Ref<NavigationPolygon> p_navigation_polygon);
+
+	static RID source_geometry_parser_create();
+	static void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback);
+
+	static bool owns(RID p_object);
+	static void free(RID p_object);
 
 	NavMeshGenerator2D();
 	~NavMeshGenerator2D();

--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -1202,6 +1202,11 @@ COMMAND_1(free, RID, p_object) {
 	} else if (obstacle_owner.owns(p_object)) {
 		internal_free_obstacle(p_object);
 
+#ifndef _3D_DISABLED
+	} else if (navmesh_generator_3d && navmesh_generator_3d->owns(p_object)) {
+		navmesh_generator_3d->free(p_object);
+#endif // _3D_DISABLED
+
 	} else {
 		ERR_PRINT("Attempted to free a NavigationServer RID that did not exist (or was already freed).");
 	}
@@ -1426,6 +1431,23 @@ PathQueryResult GodotNavigationServer3D::_query_path(const PathQueryParameters &
 	// add path stats
 
 	return r_query_result;
+}
+
+RID GodotNavigationServer3D::source_geometry_parser_create() {
+#ifndef _3D_DISABLED
+	if (navmesh_generator_3d) {
+		return navmesh_generator_3d->source_geometry_parser_create();
+	}
+#endif // _3D_DISABLED
+	return RID();
+}
+
+void GodotNavigationServer3D::source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) {
+#ifndef _3D_DISABLED
+	if (navmesh_generator_3d) {
+		navmesh_generator_3d->source_geometry_parser_set_callback(p_parser, p_callback);
+	}
+#endif // _3D_DISABLED
 }
 
 Vector<Vector3> GodotNavigationServer3D::simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) {

--- a/modules/navigation/3d/godot_navigation_server_3d.h
+++ b/modules/navigation/3d/godot_navigation_server_3d.h
@@ -264,6 +264,9 @@ public:
 	virtual void bake_from_source_geometry_data_async(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;
 	virtual bool is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const override;
 
+	virtual RID source_geometry_parser_create() override;
+	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override;
+
 	virtual Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) override;
 
 private:

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -66,11 +66,14 @@
 NavMeshGenerator3D *NavMeshGenerator3D::singleton = nullptr;
 Mutex NavMeshGenerator3D::baking_navmesh_mutex;
 Mutex NavMeshGenerator3D::generator_task_mutex;
+RWLock NavMeshGenerator3D::generator_rid_rwlock;
 bool NavMeshGenerator3D::use_threads = true;
 bool NavMeshGenerator3D::baking_use_multiple_threads = true;
 bool NavMeshGenerator3D::baking_use_high_priority_threads = true;
 HashSet<Ref<NavigationMesh>> NavMeshGenerator3D::baking_navmeshes;
 HashMap<WorkerThreadPool::TaskID, NavMeshGenerator3D::NavMeshGeneratorTask3D *> NavMeshGenerator3D::generator_tasks;
+RID_Owner<NavMeshGenerator3D::NavMeshGeometryParser3D> NavMeshGenerator3D::generator_parser_owner;
+LocalVector<NavMeshGenerator3D::NavMeshGeometryParser3D *> NavMeshGenerator3D::generator_parsers;
 
 NavMeshGenerator3D *NavMeshGenerator3D::get_singleton() {
 	return singleton;
@@ -138,6 +141,13 @@ void NavMeshGenerator3D::cleanup() {
 		memdelete(generator_task);
 	}
 	generator_tasks.clear();
+
+	generator_rid_rwlock.write_lock();
+	for (NavMeshGeometryParser3D *parser : generator_parsers) {
+		generator_parser_owner.free(parser->self);
+	}
+	generator_parsers.clear();
+	generator_rid_rwlock.write_unlock();
 
 	generator_task_mutex.unlock();
 	baking_navmesh_mutex.unlock();
@@ -253,6 +263,15 @@ void NavMeshGenerator3D::generator_parse_geometry_node(const Ref<NavigationMesh>
 	generator_parse_gridmap_node(p_navigation_mesh, p_source_geometry_data, p_node);
 #endif
 	generator_parse_navigationobstacle_node(p_navigation_mesh, p_source_geometry_data, p_node);
+
+	generator_rid_rwlock.read_lock();
+	for (const NavMeshGeometryParser3D *parser : generator_parsers) {
+		if (!parser->callback.is_valid()) {
+			continue;
+		}
+		parser->callback.call(p_navigation_mesh, p_source_geometry_data, p_node);
+	}
+	generator_rid_rwlock.read_unlock();
 
 	if (p_recurse_children) {
 		for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -918,6 +937,47 @@ bool NavMeshGenerator3D::generator_emit_callback(const Callable &p_callback) {
 	p_callback.callp(nullptr, 0, result, ce);
 
 	return ce.error == Callable::CallError::CALL_OK;
+}
+
+RID NavMeshGenerator3D::source_geometry_parser_create() {
+	RWLockWrite write_lock(generator_rid_rwlock);
+
+	RID rid = generator_parser_owner.make_rid();
+
+	NavMeshGeometryParser3D *parser = generator_parser_owner.get_or_null(rid);
+	parser->self = rid;
+
+	generator_parsers.push_back(parser);
+
+	return rid;
+}
+
+void NavMeshGenerator3D::source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) {
+	RWLockWrite write_lock(generator_rid_rwlock);
+
+	NavMeshGeometryParser3D *parser = generator_parser_owner.get_or_null(p_parser);
+	ERR_FAIL_NULL(parser);
+
+	parser->callback = p_callback;
+}
+
+bool NavMeshGenerator3D::owns(RID p_object) {
+	RWLockRead read_lock(generator_rid_rwlock);
+	return generator_parser_owner.owns(p_object);
+}
+
+void NavMeshGenerator3D::free(RID p_object) {
+	RWLockWrite write_lock(generator_rid_rwlock);
+
+	if (generator_parser_owner.owns(p_object)) {
+		NavMeshGeometryParser3D *parser = generator_parser_owner.get_or_null(p_object);
+
+		generator_parsers.erase(parser);
+
+		generator_parser_owner.free(p_object);
+	} else {
+		ERR_PRINT("Attempted to free a NavMeshGenerator3D RID that did not exist (or was already freed).");
+	}
 }
 
 #endif // _3D_DISABLED

--- a/modules/navigation/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation/3d/nav_mesh_generator_3d.h
@@ -35,6 +35,7 @@
 
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/templates/rid_owner.h"
 #include "modules/modules_enabled.gen.h" // For csg, gridmap.
 
 class Node;
@@ -46,6 +47,14 @@ class NavMeshGenerator3D : public Object {
 
 	static Mutex baking_navmesh_mutex;
 	static Mutex generator_task_mutex;
+
+	static RWLock generator_rid_rwlock;
+	struct NavMeshGeometryParser3D {
+		RID self;
+		Callable callback;
+	};
+	static RID_Owner<NavMeshGeometryParser3D> generator_parser_owner;
+	static LocalVector<NavMeshGeometryParser3D *> generator_parsers;
 
 	static bool use_threads;
 	static bool baking_use_multiple_threads;
@@ -101,6 +110,12 @@ public:
 	static void bake_from_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback = Callable());
 	static void bake_from_source_geometry_data_async(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback = Callable());
 	static bool is_baking(Ref<NavigationMesh> p_navigation_mesh);
+
+	static RID source_geometry_parser_create();
+	static void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback);
+
+	static bool owns(RID p_object);
+	static void free(RID p_object);
 
 	NavMeshGenerator3D();
 	~NavMeshGenerator3D();

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -165,6 +165,9 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bake_from_source_geometry_data_async", "navigation_polygon", "source_geometry_data", "callback"), &NavigationServer2D::bake_from_source_geometry_data_async, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("is_baking_navigation_polygon", "navigation_polygon"), &NavigationServer2D::is_baking_navigation_polygon);
 
+	ClassDB::bind_method(D_METHOD("source_geometry_parser_create"), &NavigationServer2D::source_geometry_parser_create);
+	ClassDB::bind_method(D_METHOD("source_geometry_parser_set_callback", "parser", "callback"), &NavigationServer2D::source_geometry_parser_set_callback);
+
 	ClassDB::bind_method(D_METHOD("simplify_path", "path", "epsilon"), &NavigationServer2D::simplify_path);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -306,6 +306,9 @@ public:
 	virtual void bake_from_source_geometry_data_async(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback = Callable()) = 0;
 	virtual bool is_baking_navigation_polygon(Ref<NavigationPolygon> p_navigation_polygon) const = 0;
 
+	virtual RID source_geometry_parser_create() = 0;
+	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) = 0;
+
 	virtual Vector<Vector2> simplify_path(const Vector<Vector2> &p_path, real_t p_epsilon) = 0;
 
 	NavigationServer2D();

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -170,6 +170,9 @@ public:
 	void bake_from_source_geometry_data_async(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback = Callable()) override {}
 	bool is_baking_navigation_polygon(Ref<NavigationPolygon> p_navigation_polygon) const override { return false; }
 
+	RID source_geometry_parser_create() override { return RID(); }
+	void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override {}
+
 	Vector<Vector2> simplify_path(const Vector<Vector2> &p_path, real_t p_epsilon) override { return Vector<Vector2>(); }
 
 	void set_debug_enabled(bool p_enabled) {}

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -188,6 +188,9 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_baking_navigation_mesh", "navigation_mesh"), &NavigationServer3D::is_baking_navigation_mesh);
 #endif // _3D_DISABLED
 
+	ClassDB::bind_method(D_METHOD("source_geometry_parser_create"), &NavigationServer3D::source_geometry_parser_create);
+	ClassDB::bind_method(D_METHOD("source_geometry_parser_set_callback", "parser", "callback"), &NavigationServer3D::source_geometry_parser_set_callback);
+
 	ClassDB::bind_method(D_METHOD("simplify_path", "path", "epsilon"), &NavigationServer3D::simplify_path);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -351,6 +351,9 @@ public:
 	virtual bool is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const = 0;
 #endif // _3D_DISABLED
 
+	virtual RID source_geometry_parser_create() = 0;
+	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) = 0;
+
 	virtual Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) = 0;
 
 	NavigationServer3D();

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -182,6 +182,9 @@ public:
 	bool is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const override { return false; }
 #endif // _3D_DISABLED
 
+	RID source_geometry_parser_create() override { return RID(); }
+	void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override {}
+
 	Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) override { return Vector<Vector3>(); }
 
 	void free(RID p_object) override {}


### PR DESCRIPTION
Add navigation mesh source geometry parsers and callbacks so that externals can hook their own geometry into the internal navigation mesh baking process.

Proposal https://github.com/godotengine/godot-proposals/issues/5138

This can be used to hook addons, modules and extensions into the navigation mesh baking process.

E.g. Terrain3D or VoxelTool to name some examples. What all those extensions have currently in common is that they need to use suboptimal processes to add their geometry for navmesh baking and can't work frictionless with the default baking.

![nav_baking](https://github.com/godotengine/godot/assets/52464204/bf162229-9e3e-480d-bc79-dad9dd9a0c35)


If a parser with callback is registered the `Callable` will be called for every single node that gets parsed when the NavigationServer `parse_source_geometry_data()` is used by something.

The Callable will get called with 3 args, the navigation mesh for the parse and bake properties, the source geometry object to add geometry to, and the actual node that gets parsed.

If the parser is no longer needed, e.g. because addon gets disabled, free the parser RID with the NavigationServer.

### 2D

```gdscript
var source_geometry_parser: RID
var source_geometry_parser_callback: Callable

func _ready() -> void:
	source_geometry_parser_callback = Callable(self, "_on_source_geometry_parser_callback")
	source_geometry_parser = NavigationServer2D.source_geometry_parser_create()
	NavigationServer2D.source_geometry_parser_set_callback(source_geometry_parser, source_geometry_parser_callback)

func _on_source_geometry_parser_callback(
	p_navigation_mesh: NavigationPolygon,
	p_source_geometry_data: NavigationMeshSourceGeometryData2D,
	p_parsed_node: Node) -> void:
	pass
	# Add custom source geometry to p_source_geometry_data.
	# The p_navigation_mesh holds the parse settings. Do NOT edit or add directly to p_navigation_mesh.
	# The p_parsed_node is the currently parsed node.

func delete_parser() -> void:
	NavigationServer2D.free_rid(source_geometry_parser)
	source_geometry_parser = RID()
```

### 3D

```gdscript
var source_geometry_parser: RID
var source_geometry_parser_callback: Callable

func _ready() -> void:
	source_geometry_parser_callback = Callable(self, "_on_source_geometry_parser_callback")
	source_geometry_parser = NavigationServer3D.source_geometry_parser_create()
	NavigationServer3D.source_geometry_parser_set_callback(source_geometry_parser, source_geometry_parser_callback)

func _on_source_geometry_parser_callback(
	p_navigation_mesh: NavigationMesh,
	p_source_geometry_data: NavigationMeshSourceGeometryData3D,
	p_parsed_node: Node) -> void:
	pass
	# Add custom source geometry to p_source_geometry_data.
	# The p_navigation_mesh holds the parse settings. Do NOT edit or add directly to p_navigation_mesh.
	# The p_parsed_node is the currently parsed node.

func delete_parser() -> void:
	NavigationServer3D.free_rid(source_geometry_parser)
	source_geometry_parser = RID()
```


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
