### PR TITLE
Respect value written to DEPTH when using shadow maps.

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1515,6 +1515,12 @@ void main() {
 #CODE : FRAGMENT
 	}
 
+#ifdef DEPTH_USED
+	vec3 ndc = vec3(screen_uv * 2.0 - 1.0, gl_FragDepth);
+	vec4 view_pos = scene_data.inv_projection_matrix * vec4(ndc, 1.0);
+	vertex = view_pos.xyz / view_pos.w;
+#endif //DEPTH_USED
+
 #ifndef USE_SHADOW_TO_OPACITY
 
 #if defined(ALPHA_SCISSOR_USED)

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1517,7 +1517,7 @@ void main() {
 
 #ifdef DEPTH_USED
 	vec3 ndc = vec3(screen_uv * 2.0 - 1.0, gl_FragDepth);
-	vec4 view_pos = scene_data.inv_projection_matrix * vec4(ndc, 1.0);
+	vec4 view_pos = inv_projection_matrix * vec4(ndc, 1.0);
 	vertex = view_pos.xyz / view_pos.w;
 #endif //DEPTH_USED
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1296,6 +1296,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -646,6 +646,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -550,6 +550,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1028,6 +1028,12 @@ void fragment_shader(in SceneData scene_data) {
 #CODE : FRAGMENT
 	}
 
+#ifdef DEPTH_USED
+	vec3 ndc = vec3(screen_uv * 2.0 - 1.0, gl_FragDepth);
+	vec4 view_pos = inv_projection_matrix * vec4(ndc, 1.0);
+	vertex = view_pos.xyz / view_pos.w;
+#endif //DEPTH_USED
+
 #ifdef LIGHT_TRANSMITTANCE_USED
 	transmittance_color.a *= sss_strength;
 #endif

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -837,6 +837,12 @@ void main() {
 #CODE : FRAGMENT
 	}
 
+#ifdef DEPTH_USED
+	vec3 ndc = vec3(screen_uv * 2.0 - 1.0, gl_FragDepth);
+	vec4 view_pos = inv_projection_matrix * vec4(ndc, 1.0);
+	vertex = view_pos.xyz / view_pos.w;
+#endif //DEPTH_USED
+
 #ifdef LIGHT_TRANSMITTANCE_USED
 #ifdef SSS_MODE_SKIN
 	transmittance_color.a = sss_strength;


### PR DESCRIPTION
Responding to the comments in #65307 and possibly also closing [Proposal-1942](https://github.com/godotengine/godot-proposals/issues/1942).

This adjusts the position used to sample shadow maps to take the written DEPTH value into account. For object that both cast and receive shadows (the default), not updating the position causes the fragment to shadows itself in most cases, almost always looking horrible. Because of this it's unlikely there are any uses of depth writing shaders that receive shadows in use today.

I agree with @lyuma in that I don't understand why the other changes are necessary.  This patch only updates the position, and only when DEPTH is actually used.

Before, fragments shadow themselves:
<img width="449" alt="image" src="https://github.com/godotengine/godot/assets/671513/0565cacb-1efc-4b78-b312-158e8331ffc0">

After, they dont!
<img width="379" alt="image" src="https://github.com/godotengine/godot/assets/671513/bbf252e6-4b6a-4821-9100-b90e29997037">

Tested on Mac OS on Vulcan
