### PR TITLE
Fix offset of node filter menu separator icon

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -57,11 +57,9 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/check_box.h"
-#include "scene/main/window.h"
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display_server.h"
-#include "servers/rendering_server.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
@@ -3636,10 +3634,7 @@ void SceneTreeDock::_filter_option_selected(int p_option) {
 
 void SceneTreeDock::_append_filter_options_to(PopupMenu *p_menu, bool p_include_separator) {
 	if (p_include_separator) {
-		p_menu->add_separator();
-
-		p_menu->set_item_text(-1, TTR("Filters"));
-		p_menu->set_item_indent(-1, -2);
+		p_menu->add_separator(TTR("Filters"));
 	}
 
 	p_menu->add_item(TTR("Filter by Type"), FILTER_BY_TYPE);


### PR DESCRIPTION
| Before | After |
|---|---|
| ![before](https://github.com/godotengine/godot/assets/372476/802b306a-13e6-46ec-bdee-546672b9a7d5) | ![after](https://github.com/godotengine/godot/assets/372476/d671d38b-fe91-4d7d-ab4a-e821752d1e42) |

I'm not sure why indent is set for the separator. It looks already like this in the PR that introduced this separator (#65932).

CC @Mickeon 

This offset issue exists in 4.2.2 and 4.1.4 as well.