### PR TITLE
Set animation step from importers. Increase default step from 10 to 30FPS

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -602,7 +602,7 @@
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="Animation.LoopMode" default="0">
 			Determines the behavior of both ends of the animation timeline during animation playback. This is used for correct interpolation of animation cycles, and for hinting the player that it must restart the animation.
 		</member>
-		<member name="step" type="float" setter="set_step" getter="get_step" default="0.1">
+		<member name="step" type="float" setter="set_step" getter="get_step" default="0.0333333">
 			The animation step value.
 		</member>
 	</members>

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1556,6 +1556,7 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 	}
 
 	animation->set_length(anim_length);
+	animation->set_step(snapshot_interval);
 
 	bool tracks_found = false;
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1908,6 +1908,7 @@ void ResourceImporterScene::_create_slices(AnimationPlayer *ap, Ref<Animation> a
 
 		new_anim->set_loop_mode(loop_mode);
 		new_anim->set_length(to - from);
+		new_anim->set_step(anim->get_step());
 
 		al->add_animation(name, new_anim);
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -548,8 +548,13 @@ void AnimationPlayerEditor::_animation_name_edited() {
 		} break;
 
 		case TOOL_NEW_ANIM: {
+			String current = animation->get_item_text(animation->get_selected());
+			Ref<Animation> current_anim = player->get_animation(current);
 			Ref<Animation> new_anim = Ref<Animation>(memnew(Animation));
 			new_anim->set_name(new_name);
+			if (current_anim.is_valid()) {
+				new_anim->set_step(current_anim->get_step());
+			}
 			String library_name;
 			Ref<AnimationLibrary> al;
 			library_name = library->get_item_metadata(library->get_selected());

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1699,6 +1699,7 @@ void FBXDocument::_import_animation(Ref<FBXState> p_state, AnimationPlayer *p_an
 	Ref<Animation> animation;
 	animation.instantiate();
 	animation->set_name(anim_name);
+	animation->set_step(1.0 / p_bake_fps);
 
 	if (anim->get_loop()) {
 		animation->set_loop_mode(Animation::LOOP_LINEAR);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5881,6 +5881,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 	Ref<Animation> animation;
 	animation.instantiate();
 	animation->set_name(anim_name);
+	animation->set_step(1.0 / p_bake_fps);
 
 	if (anim->get_loop()) {
 		animation->set_loop_mode(Animation::LOOP_LINEAR);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -266,7 +266,7 @@ private:
 	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
 
 	double length = 1.0;
-	real_t step = 0.1;
+	real_t step = 1.0 / 30;
 	LoopMode loop_mode = LOOP_NONE;
 
 	void _track_update_hash(int p_track);

--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -41,7 +41,7 @@ TEST_CASE("[Animation] Empty animation getters") {
 	const Ref<Animation> animation = memnew(Animation);
 
 	CHECK(animation->get_length() == doctest::Approx(real_t(1.0)));
-	CHECK(animation->get_step() == doctest::Approx(real_t(0.1)));
+	CHECK(animation->get_step() == doctest::Approx(real_t(1.0 / 30)));
 }
 
 TEST_CASE("[Animation] Create value track") {


### PR DESCRIPTION
Most framerates are a multiple of 30, and most animations also use 30 or 60 as a basis.

However, imported animations did not have a step assigned, leading editing imported animations to be extremely clunky since snap is on by default and the default step interval is at 10 fps.

This PR makes the default step in the Animation resource 1/30 (30 fps) and also uses the correct bake_fps value as step during import. Finally, the new button in the animation track editor will reuse the current animation step if one is loaded.

In a pedantic sense, this is compatibility breaking because I am changing the default value of an existing resource property: almost all existing animations will likely be increased to 30 FPS. I don't see this as a problem for these reasons:
1. The `step` value is currently only used in editor tooling. The exception would be cases where this value is used by a game script and that game uses 10 FPS animations that have not changed from the default value.
2. Almost all imported assets were incorrectly imported as 10 FPS step, since the value was never assigned during import. Changing the value in the Animation resource will retroactively "fix" the timestamp from most imported animations.
3. For the purposes of editing, a step of 1/30 is still compatible with 10 FPS animations: It is possible to ignore the in between keyframes and snap cleanly to 1/10 if desired.

If there is pushback to changing the Animation resource or the default FPS for new animations, I can remove those changes.

Finally, there was a comment in chat that it will look weird to have the Snap field default to 0.03333 since it doesn't look like a round number. My rebuttal is this is a consequence of being in the real world. We can't change that 30 FPS is a popular framerate, and we can't change the infinitely repeating decimal nature of 1/30. There is a FPS dropdown in the animation track editor and I'd be open to changing the default dropdown to be FPS, but this affects how the timeline looks and my goal is to not change the UX significantly. If I could do FPS just for the textbox but keep the track editor in seconds then maybe...