### PR TITLE
Strip ANSI escape codes from file logging

### DIFF
--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -34,6 +34,10 @@
 #include "core/io/file_access.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
+#include "modules/modules_enabled.gen.h" // For regex.
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif // MODULE_REGEX_ENABLED
 
 #include <stdarg.h>
 
@@ -85,6 +89,10 @@ class RotatedFileLogger : public Logger {
 
 	void clear_old_backups();
 	void rotate_file();
+
+#ifdef MODULE_REGEX_ENABLED
+	Ref<RegEx> strip_ansi_regex;
+#endif // MODULE_REGEX_ENABLED
 
 public:
 	explicit RotatedFileLogger(const String &p_base_path, int p_max_files = 10);


### PR DESCRIPTION
Text editors cannot display ANSI escape codes, so these should be stripped from log files to ensure readability.

Since this uses a regex, this works both for `print_rich()` and manually inserted ANSI escape codes.

This has a slight performance impact: starting Godot, printing 200,000 lines then exiting Godot now takes 1.85 seconds instead of 1.75 seconds on an i9-13900K with a Linux x86_64 optimized (LTO) editor build. It may be possible to have a slightly faster solution using manual string handling, but handling all ANSI escape codes in a robust manner can be nontrivial. I've tried to use `strstr()` to check for the presence of an ANSI escape code in the log message before applying the regex on it, but it made no difference in performance.

- This closes https://github.com/godotengine/godot/issues/79508.

## Preview

stdout appearance for reference:

![image](https://github.com/godotengine/godot/assets/180032/8b89f94d-9e14-42ba-87b8-9273e30ad106)

### Before

Log file contents:

```
raw string0
[1mte[91mst[39m[22m[0m
1
[1mte[91mst[39m[22m[0m
2
[1mte[91mst[39m[22m[0m
3
[1mte[91mst[39m[22m[0m
4
```

### After

Log file contents:

```
test
1
test
2
test
3
test
4
```