### PR TITLE
Fix error when saving nested non-persistent resource

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1931,17 +1931,8 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 						npk.base = res;
 						npk.property = pi.name;
 						non_persistent_map[npk] = v;
-
-						Ref<Resource> sres = v;
-						if (sres.is_valid()) {
-							resource_set.insert(sres);
-							saved_resources.push_back(sres);
-						} else {
-							_find_resources(v);
-						}
-					} else {
-						_find_resources(v);
 					}
+					_find_resources(v);
 				}
 
 				I = I->next();


### PR DESCRIPTION
Found this bug when tweaking the resource format saver.

If a property is `PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT` and is a resource containing another new resource, saving the scene / resource will fail:

> Resource was not pre cached for the resource section, bug?

In the engine, only `ImageTexture*` has `PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT` properties. And those properties don't have nested resource, thus won't trigger this bug.

Fixes #92820

---

To reproduce this bug, use this MRP ([test-4.zip](https://github.com/godotengine/godot/files/15042046/test-4.zip)).

1. Open `new_resource.tres` in the inspector.
2. Click "Generate" property (it won't change, just to set temporary value for the actual non-persistent property)
3. Click save.