### PR TITLE
Don't store TileMapLayer data if empty

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -268,7 +268,7 @@
 			The quadrant size does not apply on a Y-sorted [TileMapLayer], as tiles are be grouped by Y position instead in that case.
 			[b]Note:[/b] As quadrants are created according to the map's coordinate system, the quadrant's "square shape" might not look like square in the [TileMapLayer]'s local coordinate system.
 		</member>
-		<member name="tile_map_data" type="PackedByteArray" setter="set_tile_map_data_from_array" getter="get_tile_map_data_as_array" default="PackedByteArray(&quot;AAA=&quot;)">
+		<member name="tile_map_data" type="PackedByteArray" setter="set_tile_map_data_from_array" getter="get_tile_map_data_as_array" default="PackedByteArray()">
 			The raw tile map data as a byte array.
 		</member>
 		<member name="tile_set" type="TileSet" setter="set_tile_set" getter="get_tile_set">

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2588,6 +2588,11 @@ TileMapLayer::HighlightMode TileMapLayer::get_highlight_mode() const {
 }
 
 void TileMapLayer::set_tile_map_data_from_array(const Vector<uint8_t> &p_data) {
+	if (p_data.is_empty()) {
+		clear();
+		return;
+	}
+
 	const int cell_data_struct_size = 12;
 
 	int size = p_data.size();
@@ -2630,6 +2635,10 @@ Vector<uint8_t> TileMapLayer::get_tile_map_data_as_array() const {
 	const int cell_data_struct_size = 12;
 
 	Vector<uint8_t> tile_map_data_array;
+	if (tile_map_layer_data.is_empty()) {
+		return tile_map_data_array;
+	}
+
 	tile_map_data_array.resize(2 + tile_map_layer_data.size() * cell_data_struct_size);
 	uint8_t *ptr = tile_map_data_array.ptrw();
 


### PR DESCRIPTION
TileMapLayer will store tile data even if it's empty. When there are no tiles, format version is saved for no reason, leading to potential pointless compatibility problems and documentation noise.

This PR changes it, so with no tiles nothing is saved.