### PR TITLE
Avoid writing out of range data over valid data in CVTT decompress methods when decompressing small mip levels

### DIFF
--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -302,8 +302,6 @@ void image_decompress_cvtt(Image *p_image) {
 			int y_end = y_start + 4;
 
 			for (int x_start = 0; x_start < w; x_start += 4 * cvtt::NumParallelBlocks) {
-				int x_end = x_start + 4 * cvtt::NumParallelBlocks;
-
 				uint8_t input_blocks[16 * cvtt::NumParallelBlocks];
 				memset(input_blocks, 0, sizeof(input_blocks));
 
@@ -314,6 +312,8 @@ void image_decompress_cvtt(Image *p_image) {
 
 				memcpy(input_blocks, in_bytes, 16 * num_real_blocks);
 				in_bytes += 16 * num_real_blocks;
+
+				int x_end = x_start + 4 * num_real_blocks;
 
 				if (is_hdr) {
 					if (is_signed) {


### PR DESCRIPTION
I noticed this while debugging https://github.com/godotengine/godot/issues/90873

### Bug

When decompressing a BPTC texture, the last column of pixel for all mipmaps from levels 16x16 and lower would be black
![image](https://github.com/godotengine/godot/assets/16521339/ad378343-f96b-42fe-8fc5-1f0934a29b55)

This results in the last miplevel being totally black since it only has one column.

I can reproduce this bug in 4.3, 4.2, and 4.1. I haven't tested earlier versions.

### Problem

The problem comes from how we decompress the image. A block in BPTC is a 4x4 group of pixels. We decompress 8 blocks at a time (this isn't necessary, but it seems like it was done to allow us to trivially parallelize decompression). Which means that we decompress a 32x4 group of pixels at once. 

Once you have a mip level with a width smaller than 32 we decrease the number of blocks that we copy over into the input buffer. However, we still process the invalid blocks (they are zeroed out) **and** we still attempt to copy them over to the final image. Only the last column is affected because the logic for writing pixels greater than width is to write them out at width - 1.

### Solution

When calculating the end of the region to write pixels, we take into account the number of blocks that we are processing and we don't read back pixels from blocks that are totally zeroed out. This way we only copy back data from valid blocks


_Before:_

![Screenshot from 2024-04-19 10-22-52](https://github.com/godotengine/godot/assets/16521339/da61f7e8-4d23-4d9d-b277-7912266d2539)

_After:_
![image](https://github.com/godotengine/godot/assets/16521339/bdf425da-9132-4a0a-a552-a8e4127297e6)
