### PR TITLE
Apply additional fixes to servers' threading

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2307,9 +2307,9 @@ void ObjectDB::setup() {
 }
 
 void ObjectDB::cleanup() {
-	if (slot_count > 0) {
-		spin_lock.lock();
+	spin_lock.lock();
 
+	if (slot_count > 0) {
 		WARN_PRINT("ObjectDB instances leaked at exit (run with --verbose for details).");
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			// Ensure calling the native classes because if a leaked instance has a script
@@ -2340,10 +2340,11 @@ void ObjectDB::cleanup() {
 			}
 			print_line("Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).");
 		}
-		spin_lock.unlock();
 	}
 
 	if (object_slots) {
 		memfree(object_slots);
 	}
+
+	spin_lock.unlock();
 }

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -302,7 +302,7 @@ class CommandQueueMT {
 	struct CommandBase {
 		bool sync = false;
 		virtual void call() = 0;
-		virtual ~CommandBase() = default; // Won't be called.
+		virtual ~CommandBase() = default;
 	};
 
 	struct SyncCommand : public CommandBase {
@@ -367,6 +367,10 @@ class CommandQueueMT {
 				sync_head++;
 				sync_cond_var.notify_all();
 			}
+
+			// If the command involved reallocating the buffer, the address may have changed.
+			cmd = reinterpret_cast<CommandBase *>(&command_mem[flush_read_ptr]);
+			cmd->~CommandBase();
 
 			flush_read_ptr += size;
 		}

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -388,6 +388,8 @@ class CommandQueueMT {
 		} while (sync_head != sync_head_goal); // Can't use lower-than because of wraparound.
 	}
 
+	void _no_op() {}
+
 public:
 	void lock();
 	void unlock();
@@ -409,8 +411,13 @@ public:
 			_flush();
 		}
 	}
+
 	void flush_all() {
 		_flush();
+	}
+
+	void sync() {
+		push_and_sync(this, &CommandQueueMT::_no_op);
 	}
 
 	void wait_and_flush() {
@@ -420,7 +427,9 @@ public:
 	}
 
 	void set_pump_task_id(WorkerThreadPool::TaskID p_task_id) {
+		lock();
 		pump_task_id = p_task_id;
+		unlock();
 	}
 
 	CommandQueueMT();

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -395,10 +395,13 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 
 	if (p_first) {
-		Size2i win_size = DisplayServer::get_singleton()->window_get_size();
 		if (p_screen_rect.position != Vector2() || p_screen_rect.size != rt->size) {
 			// Viewport doesn't cover entire window so clear window to black before blitting.
-			glViewport(0, 0, win_size.width, win_size.height);
+			// Querying the actual window size from the DisplayServer would deadlock in separate render thread mode,
+			// so let's set the biggest viewport the implementation supports, to be sure the window is fully covered.
+			GLsizei max_vp[2] = {};
+			glGetIntegerv(GL_MAX_VIEWPORT_DIMS, max_vp);
+			glViewport(0, 0, max_vp[0], max_vp[1]);
 			glClearColor(0.0, 0.0, 0.0, 1.0);
 			glClear(GL_COLOR_BUFFER_BIT);
 		}

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2312,9 +2312,11 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 
 	if (rt->backbuffer_fbo != 0) {
 		glDeleteFramebuffers(1, &rt->backbuffer_fbo);
+		rt->backbuffer_fbo = 0;
+	}
+	if (rt->backbuffer != 0) {
 		GLES3::Utilities::get_singleton()->texture_free_data(rt->backbuffer);
 		rt->backbuffer = 0;
-		rt->backbuffer_fbo = 0;
 	}
 	if (rt->backbuffer_depth != 0) {
 		GLES3::Utilities::get_singleton()->texture_free_data(rt->backbuffer_depth);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4268,6 +4268,8 @@ bool DisplayServerX11::_window_focus_check() {
 }
 
 void DisplayServerX11::process_events() {
+	ERR_FAIL_COND(!Thread::is_main_thread());
+
 	_THREAD_SAFE_LOCK_
 
 #ifdef DISPLAY_SERVER_X11_DEBUG_LOGS_ENABLED

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2985,7 +2985,7 @@ Key DisplayServerMacOS::keyboard_get_label_from_physical(Key p_keycode) const {
 }
 
 void DisplayServerMacOS::process_events() {
-	_THREAD_SAFE_LOCK_
+	ERR_FAIL_COND(!Thread::is_main_thread());
 
 	while (true) {
 		NSEvent *event = [NSApp
@@ -3018,10 +3018,10 @@ void DisplayServerMacOS::process_events() {
 
 	if (!drop_events) {
 		_process_key_events();
-		_THREAD_SAFE_UNLOCK_
 		Input::get_singleton()->flush_buffered_events();
-		_THREAD_SAFE_LOCK_
 	}
+
+	_THREAD_SAFE_LOCK_
 
 	for (KeyValue<WindowID, WindowData> &E : windows) {
 		WindowData &wd = E.value;
@@ -3051,7 +3051,7 @@ void DisplayServerMacOS::process_events() {
 }
 
 void DisplayServerMacOS::force_process_and_drop_events() {
-	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND(!Thread::is_main_thread());
 
 	drop_events = true;
 	process_events();

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -53,17 +53,14 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 
 	mutable CommandQueueMT command_queue;
 
-	void thread_loop();
-
 	Thread::ID server_thread = Thread::UNASSIGNED_ID;
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
-	Semaphore step_sem;
 	bool create_thread = false;
 
-	void thread_step(real_t p_delta);
-
-	void thread_exit();
+	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
+	void _thread_exit();
+	void _thread_loop();
 
 public:
 #define ServerName PhysicsServer2D

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -32,45 +32,37 @@
 
 #include "core/os/os.h"
 
-void PhysicsServer3DWrapMT::thread_exit() {
+void PhysicsServer3DWrapMT::_assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id) {
+	server_thread = Thread::get_caller_id();
+	server_task_id = p_pump_task_id;
+}
+
+void PhysicsServer3DWrapMT::_thread_exit() {
 	exit = true;
 }
 
-void PhysicsServer3DWrapMT::thread_step(real_t p_delta) {
-	physics_server_3d->step(p_delta);
-	step_sem.post();
-}
-
-void PhysicsServer3DWrapMT::thread_loop() {
-	server_thread = Thread::get_caller_id();
-
-	physics_server_3d->init();
-
-	command_queue.set_pump_task_id(server_task_id);
+void PhysicsServer3DWrapMT::_thread_loop() {
 	while (!exit) {
 		WorkerThreadPool::get_singleton()->yield();
 		command_queue.flush_all();
 	}
-
-	command_queue.flush_all(); // flush all
-
-	physics_server_3d->finish();
 }
 
 /* EVENT QUEUING */
 
 void PhysicsServer3DWrapMT::step(real_t p_step) {
 	if (create_thread) {
-		command_queue.push(this, &PhysicsServer3DWrapMT::thread_step, p_step);
+		command_queue.push(physics_server_3d, &PhysicsServer3D::step, p_step);
 	} else {
-		command_queue.flush_all(); // Flush all pending from other threads.
 		physics_server_3d->step(p_step);
 	}
 }
 
 void PhysicsServer3DWrapMT::sync() {
 	if (create_thread) {
-		step_sem.wait();
+		command_queue.sync();
+	} else {
+		command_queue.flush_all(); // Flush all pending from other threads.
 	}
 	physics_server_3d->sync();
 }
@@ -85,21 +77,26 @@ void PhysicsServer3DWrapMT::end_sync() {
 
 void PhysicsServer3DWrapMT::init() {
 	if (create_thread) {
-		exit = false;
-		server_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &PhysicsServer3DWrapMT::thread_loop), true);
-		step_sem.post();
+		WorkerThreadPool::TaskID tid = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &PhysicsServer3DWrapMT::_thread_loop), true);
+		command_queue.set_pump_task_id(tid);
+		command_queue.push(this, &PhysicsServer3DWrapMT::_assign_mt_ids, tid);
+		command_queue.push_and_sync(physics_server_3d, &PhysicsServer3D::init);
+		DEV_ASSERT(server_task_id == tid);
 	} else {
+		server_thread = Thread::MAIN_ID;
 		physics_server_3d->init();
 	}
 }
 
 void PhysicsServer3DWrapMT::finish() {
 	if (create_thread) {
-		command_queue.push(this, &PhysicsServer3DWrapMT::thread_exit);
+		command_queue.push(physics_server_3d, &PhysicsServer3D::finish);
+		command_queue.push(this, &PhysicsServer3DWrapMT::_thread_exit);
 		if (server_task_id != WorkerThreadPool::INVALID_TASK_ID) {
 			WorkerThreadPool::get_singleton()->wait_for_task_completion(server_task_id);
 			server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 		}
+		server_thread = Thread::MAIN_ID;
 	} else {
 		physics_server_3d->finish();
 	}
@@ -108,9 +105,6 @@ void PhysicsServer3DWrapMT::finish() {
 PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread) {
 	physics_server_3d = p_contained;
 	create_thread = p_create_thread;
-	if (!create_thread) {
-		server_thread = Thread::MAIN_ID;
-	}
 }
 
 PhysicsServer3DWrapMT::~PhysicsServer3DWrapMT() {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -52,17 +52,15 @@ class PhysicsServer3DWrapMT : public PhysicsServer3D {
 
 	mutable CommandQueueMT command_queue;
 
-	void thread_loop();
-
 	Thread::ID server_thread = Thread::UNASSIGNED_ID;
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
-	Semaphore step_sem;
 	bool create_thread = false;
 
-	void thread_step(real_t p_delta);
-
-	void thread_exit();
+	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
+	void _thread_exit();
+	void _thread_step(real_t p_delta);
+	void _thread_loop();
 
 public:
 #define ServerName PhysicsServer3D

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -678,7 +678,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 #endif // _3D_DISABLED
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		set_default_clear_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+		RSG::texture_storage->set_default_clear_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 	}
 
 	if (sorted_active_viewports_dirty) {
@@ -1519,10 +1519,6 @@ void RendererViewport::handle_timestamp(String p_timestamp, uint64_t p_cpu_time,
 		viewport->time_cpu_end = p_cpu_time;
 		viewport->time_gpu_end = p_gpu_time;
 	}
-}
-
-void RendererViewport::set_default_clear_color(const Color &p_color) {
-	RSG::texture_storage->set_default_clear_color(p_color);
 }
 
 void RendererViewport::viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_canvas_cull_mask) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -303,7 +303,6 @@ public:
 
 	void handle_timestamp(String p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time);
 
-	void set_default_clear_color(const Color &p_color);
 	void draw_viewports(bool p_swap_buffers);
 
 	bool free(RID p_rid);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -63,7 +63,7 @@ class RenderingServerDefault : public RenderingServer {
 
 	static void _changes_changed() {}
 
-	uint64_t frame_profile_frame;
+	uint64_t frame_profile_frame = 0;
 	Vector<FrameProfileArea> frame_profile;
 
 	double frame_setup_time = 0;
@@ -76,18 +76,17 @@ class RenderingServerDefault : public RenderingServer {
 
 	mutable CommandQueueMT command_queue;
 
-	void _thread_loop();
-
-	Thread::ID server_thread = Thread::UNASSIGNED_ID;
+	Thread::ID server_thread = Thread::MAIN_ID;
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
 	bool create_thread = false;
 
-	void _thread_draw(bool p_swap_buffers, double frame_step);
-
+	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
 	void _thread_exit();
+	void _thread_loop();
 
 	void _draw(bool p_swap_buffers, double frame_step);
+	void _run_post_draw_steps();
 	void _init();
 	void _finish();
 
@@ -998,9 +997,22 @@ public:
 	FUNC1(global_shader_parameters_load_settings, bool)
 	FUNC0(global_shader_parameters_clear)
 
+	/* COMPOSITOR */
+
 #undef server_name
 #undef ServerName
+#define ServerName RendererCompositor
+#define server_name RSG::rasterizer
+
+	FUNC4S(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
+
 	/* STATUS INFORMATION */
+
+#undef server_name
+#undef ServerName
+
+	/* UTILITIES */
+
 #define ServerName RendererUtilities
 #define server_name RSG::utilities
 	FUNC0RC(String, get_video_adapter_name)
@@ -1056,7 +1068,7 @@ public:
 	virtual void call_on_render_thread(const Callable &p_callable) override {
 		if (Thread::get_caller_id() == server_thread) {
 			command_queue.flush_if_pending();
-			_call_on_render_thread(p_callable);
+			p_callable.call();
 		} else {
 			command_queue.push(this, &RenderingServerDefault::_call_on_render_thread, p_callable);
 		}
@@ -1066,7 +1078,6 @@ public:
 
 	virtual double get_frame_setup_time_cpu() const override;
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override;
 	virtual Color get_default_clear_color() override;
 	virtual void set_default_clear_color(const Color &p_color) override;
 


### PR DESCRIPTION
This is a follow-up of #90268 that ties up a few loose ends of it; namely:
- Startup and teardown of physics and rendering servers is know much more consistent among them and is better integrated with the new `WorkerThreadPool`-`CommandQueueMT` collaboration infrastructure.
- The `DisplayServer` stays unlocked in more conditions, which avoids ceratin cases of deadlock when input events are delivered.
- Post-draw callbacks and signals from the `RenderingServer` are now sent from the main thread. Otherwise, you'd for sure find dragons if using separate thread.

Not directly related, and so kept in separate commits, but their need found while working on this:
- OpenGL: Avoid error due to the assumption of the lifetime of the backbuffer texture being perfectly bond to that of the backbuffer FBO.
- `ObjectDB`: Properly lock the object database for cleanup.
- `CommandQueueMT`: Fix certain leaks when using separate thread for physics or rendering (thanks to @Zylann for the investigation). Also, properly handle resize of the command buffer!

Known issues (will fix the critical ones before changing from draft to ready-for-review):
- ~Windows, OpenGL: resizing windows using separate render thread deadlocks.~ **FIXED**
- Windows, Vulkan: resizing windows seems to apply some offset to the system surface. (Present in `master`. Will have its own PR.)
- MacOS: ~Can't test anymore since there's a crash.~ Resizing with Vulkan deadlocks. Possibly a MoltenVK issue. Reported (https://github.com/KhronosGroup/MoltenVK/issues/2213). ThIs PR can be merged despite it. If it turns out to be fixable in Godot, a separate PR can address it. **UPDATE:** Seems solvable at MoltenVK; in fact, I've submitted a PR there. **UPDATE:* Fix merged upstream.

Fixed issues:
- Fixes #89585.
- Fixes #90725.
- Fixes #87382.

PS: A bit of testing on Linux with all the combos for rendering would be appreciated.
- `--render-thread safe`, `--render-thread separate`
- `--rendering-method gl_compatibility`, `--rendering-method forward_plus`