### PR TITLE
Fix `move_and_slide` wall slide acceleration (3D)

### DIFF
--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -232,7 +232,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 							} else {
 								// Travel is too high to be safely canceled, we take it into account.
 								result.travel = result.travel.slide(up_direction);
-								motion = motion.normalized() * result.travel.length();
+								motion = result.remainder;
 							}
 							set_global_transform(gt);
 							// Determines if you are on the ground, and limits the possibility of climbing on the walls because of the approximations.


### PR DESCRIPTION
When `travel` is high enough, keep the global position resulting from the `move_and_collide` call, and set the `motion` to the `remainder` from the `move_and_collide` call. This ensures `travel` is taken into account once, rather than twice.

This is also consistent with the other branch:

https://github.com/godotengine/godot/blob/2efbc6bfb3b4f49a6bc75b3d367cfe81eeddbf3a/scene/3d/physics/character_body_3d.cpp#L241-L242

Thanks to @Calinou for extra testing.

- Fixes https://github.com/godotengine/godot/issues/66249
- Fixes https://github.com/godotengine/godot/issues/74553
- Fixes https://github.com/godotengine/godot/issues/90410