### PR TITLE
Exit light calculation early when pixel outside of light bounding rectangle

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -776,6 +776,12 @@ void main() {
 
 		vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array[light_base].texture_matrix[0], light_array[light_base].texture_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
 		vec2 tex_uv_atlas = tex_uv * light_array[light_base].atlas_rect.zw + light_array[light_base].atlas_rect.xy;
+
+		if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
+			//if outside the light texture, light color is zero
+			continue;
+		}
+
 		vec4 light_color = textureLod(atlas_texture, tex_uv_atlas, 0.0);
 		vec4 light_base_color = light_array[light_base].color;
 
@@ -800,10 +806,6 @@ void main() {
 			light_color.rgb *= base_color.rgb;
 		}
 #endif
-		if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
-			//if outside the light texture, light color is zero
-			light_color.a = 0.0;
-		}
 
 		if (bool(light_array[light_base].flags & LIGHT_FLAGS_HAS_SHADOW)) {
 			vec2 shadow_pos = (vec4(shadow_vertex, 0.0, 1.0) * mat4(light_array[light_base].shadow_matrix[0], light_array[light_base].shadow_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -665,6 +665,12 @@ void main() {
 
 		vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array.data[light_base].texture_matrix[0], light_array.data[light_base].texture_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
 		vec2 tex_uv_atlas = tex_uv * light_array.data[light_base].atlas_rect.zw + light_array.data[light_base].atlas_rect.xy;
+
+		if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
+			//if outside the light texture, light color is zero
+			continue;
+		}
+
 		vec4 light_color = textureLod(sampler2D(atlas_texture, texture_sampler), tex_uv_atlas, 0.0);
 		vec4 light_base_color = light_array.data[light_base].color;
 
@@ -689,10 +695,6 @@ void main() {
 			light_color.rgb *= base_color.rgb;
 		}
 #endif
-		if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
-			//if outside the light texture, light color is zero
-			light_color.a = 0.0;
-		}
 
 		if (bool(light_array.data[light_base].flags & LIGHT_FLAGS_HAS_SHADOW)) {
 			vec2 shadow_pos = (vec4(shadow_vertex, 0.0, 1.0) * mat4(light_array.data[light_base].shadow_matrix[0], light_array.data[light_base].shadow_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.


### PR DESCRIPTION
Potential fix for https://github.com/godotengine/godot/issues/81152
Fixes: https://github.com/godotengine/godot/issues/90905

Right now when rendering a CanvasItem for each pixel in the fragment shader we loop over all lights that intersect that CanvasItem and calculate their contribution to the pixel. If the pixel is outside of the light's texture, we set the alpha value of the final result to 0 which results in that light not contributing to the pixel. 

Unfortunately, this means that we read from the light's texture still and run the light shader for that light, even though it won't have any effect. 

Normally, using a continue op in a loop is not a good idea is it can stop the compiler from doing certain beneficial optimizations. But in this case, the compiler can't optimize this loop for many other reasons, so this ends up being a net win. 

**Performance testing**
|        | iGPU RD | iGPU compatibility | Pixel 4 RD      | Pixel 4 compatibility |
|--------|---------|--------------------|-----------------|-----------------------|
| Before | 240 FPS | 140 FPS            | 42 FPS          | 50 FPS                |
| After  | 370 FPS | 275 FPS            | 60 FPS (locked) | 60 FPS (locked)       |
* Note the Pixel 4 does not support not using VSync, so it is unclear what the actual performance gain is as the device caps at 60 FPS.

**Further testing**

This PR would benefit from being tested on even lower end mobile, on web export, ~and on a desktop device with a dedicated GPU~ (done)

[Light2DTestUpdated.zip](https://github.com/godotengine/godot/files/15046194/Light2DTestUpdated.zip)
