### PR TITLE
Warn that navigation mesh baking from Meshes is bad for runtime performance

### DIFF
--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -158,6 +158,15 @@ void NavigationMeshSourceGeometryData3D::_add_faces(const PackedVector3Array &p_
 
 void NavigationMeshSourceGeometryData3D::add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform) {
 	ERR_FAIL_COND(!p_mesh.is_valid());
+
+#ifdef DEBUG_ENABLED
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		WARN_PRINT_ONCE("Source geometry parsing for navigation mesh baking had to parse RenderingServer meshes at runtime.\n\
+		This poses a significant performance issues as visual meshes store geometry data on the GPU and transferring this data back to the CPU blocks the rendering.\n\
+		For runtime (re)baking navigation meshes use and parse collision shapes as source geometry or create geometry data procedurally in scripts.");
+	}
+#endif
+
 	_add_mesh(p_mesh, root_node_transform * p_xform);
 }
 


### PR DESCRIPTION
Adds a one-time warning when a visual Mesh is added to the source geometry at runtime to make users more aware about this problem.

Resolves https://github.com/godotengine/godot/issues/90607

At runtime this poses a significant performance issues as visual meshes store geometry data on the GPU and transferring this data back to the CPU blocks the rendering.

So baking navigation mesh when parsing from e.g. MeshInstance3D or MultiMeshInstance3D  nodes is really only viable inside the Editor where frame rate is less of an issue.

For runtime (re)baking navigation meshes use and parse collision shapes as source geometry or create geometry data procedural in scripts.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
