### PR TITLE
Fix wrong tooltip behavior in `PopupMenu`s that have styles  with top borders

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1400,6 +1400,11 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 		// Temporary solution for PopupMenus.
 		PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 		if (menu) {
+			Ref<StyleBox> sb = menu->get_theme_stylebox(SceneStringName(panel));
+			if (sb.is_valid()) {
+				pos.y += sb->get_margin(SIDE_TOP);
+			}
+
 			tooltip = menu->get_tooltip(pos);
 		}
 


### PR DESCRIPTION
Currently, when fetching the tooltip of a `PopupMenu`'s item, the top border of its style isn't take into account. This can cause the wrong tooltip (or no tooltip at all) to be fetched if said border is too big. This PR fixes that.