### PR TITLE
Add option to force `_can_drop_data()` call

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -33,6 +33,12 @@
 				Returns the first valid [World3D] for this viewport, searching the [member world_3d] property of itself and any Viewport ancestor.
 			</description>
 		</method>
+		<method name="force_can_drop_data_check">
+			<return type="void" />
+			<description>
+				Forces [method Control._can_drop_data] to be called again. Useful to update the cursor without moving it.
+			</description>
+		</method>
 		<method name="get_audio_listener_2d" qualifiers="const">
 			<return type="AudioListener2D" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1249,6 +1249,27 @@ void Viewport::_propagate_drag_notification(Node *p_node, int p_what) {
 	}
 }
 
+void Viewport::force_can_drop_data_check() {
+	if (!gui.dragging) {
+		return;
+	}
+
+	DisplayServer::CursorShape ds_cursor_shape;
+	gui.drag_mouse_over = get_section_root_viewport()->gui.target_control;
+	if (gui.drag_mouse_over) {
+		if (!_gui_drop(gui.drag_mouse_over, gui.drag_mouse_over->get_local_mouse_position(), true)) {
+			gui.drag_mouse_over = nullptr;
+			ds_cursor_shape = DisplayServer::CURSOR_FORBIDDEN;
+		} else {
+			ds_cursor_shape = DisplayServer::CURSOR_CAN_DROP;
+		}
+
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+			DisplayServer::get_singleton()->cursor_set_shape(ds_cursor_shape);
+		}
+	}
+}
+
 Ref<World2D> Viewport::get_world_2d() const {
 	ERR_READ_THREAD_GUARD_V(Ref<World2D>());
 	return world_2d;
@@ -4545,6 +4566,7 @@ void Viewport::_propagate_world_2d_changed(Node *p_node) {
 
 void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_2d", "world_2d"), &Viewport::set_world_2d);
+	ClassDB::bind_method(D_METHOD("force_can_drop_data_check"), &Viewport::force_can_drop_data_check);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &Viewport::get_world_2d);
 	ClassDB::bind_method(D_METHOD("find_world_2d"), &Viewport::find_world_2d);
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -625,6 +625,7 @@ public:
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
 	void gui_cancel_drag();
+	void force_can_drop_data_check();
 
 	Control *gui_find_control(const Point2 &p_global);
 


### PR DESCRIPTION
## Before
Cursor drag-drop state updates only if the mouse is moving

https://github.com/godotengine/godot/assets/38570835/410887d4-9097-43be-8345-406ced028c79

## After
I fixed this by adding a new method `force_can_drop_data_check()` that will force the check to re-update the cursor state.
In this example I made a new script and called `get_viewport().force_can_drop_data_check()` whenever the state of the panel changes.
This is useful if you have custom logic dependent on whether the element can be dropped or not. This previously ran only if you are moving the mouse now you can force the check and keep the mouse still.
NOTE: As you can see the cursor is not moving at all.

https://github.com/godotengine/godot/assets/38570835/a0675575-d25b-458c-8d26-38bf276ee852

