### PR TITLE
[3.x] Fix TabContainer not updating content rect after toggling tab icon

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -30,7 +30,6 @@
 
 #include "tab_container.h"
 
-#include "core/message_queue.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
@@ -874,6 +873,7 @@ void TabContainer::set_tab_icon(int p_tab, const Ref<Texture> &p_icon) {
 	Control *child = get_tab_control(p_tab);
 	ERR_FAIL_COND(!child);
 	child->set_meta("_tab_icon", p_icon);
+	_repaint();
 	update();
 }
 Ref<Texture> TabContainer::get_tab_icon(int p_tab) const {


### PR DESCRIPTION
This PR fixes the `3.x` version of #90927.

TabContainer is different under the hood between 3.x and 4.x.

p.s. Also removed an unused header include.

---

The problem: (the white rect is the actual control inside the container)

![Peek 2024-04-20 16-08](https://github.com/godotengine/godot/assets/372476/eb7ef8b4-9057-4f43-bb52-d2e5af6b4d93)

[toggle-tab-icon-3.x.zip](https://github.com/godotengine/godot/files/15047433/toggle-tab-icon-3.x.zip)
