### PR TITLE
Rename internal `is_ascii_char` to `is_ascii_alphabet_char`

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -344,10 +344,10 @@ Error JSON::_get_token(const char32_t *p_str, int &index, int p_len, Token &r_to
 					r_token.value = number;
 					return OK;
 
-				} else if (is_ascii_char(p_str[index])) {
+				} else if (is_ascii_alphabet_char(p_str[index])) {
 					String id;
 
-					while (is_ascii_char(p_str[index])) {
+					while (is_ascii_alphabet_char(p_str[index])) {
 						id += p_str[index];
 						index++;
 					}

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -92,7 +92,7 @@ static _FORCE_INLINE_ bool is_binary_digit(char32_t c) {
 	return (c == '0' || c == '1');
 }
 
-static _FORCE_INLINE_ bool is_ascii_char(char32_t c) {
+static _FORCE_INLINE_ bool is_ascii_alphabet_char(char32_t c) {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -993,7 +993,7 @@ String TranslationServer::add_padding(const String &p_message, int p_length) con
 }
 
 const char32_t *TranslationServer::get_accented_version(char32_t p_character) const {
-	if (!is_ascii_char(p_character)) {
+	if (!is_ascii_alphabet_char(p_character)) {
 		return nullptr;
 	}
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -489,11 +489,11 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 						r_token.value = num.as_int();
 					}
 					return OK;
-				} else if (is_ascii_char(cchar) || is_underscore(cchar)) {
+				} else if (is_ascii_alphabet_char(cchar) || is_underscore(cchar)) {
 					StringBuffer<> id;
 					bool first = true;
 
-					while (is_ascii_char(cchar) || is_underscore(cchar) || (!first && is_digit(cchar))) {
+					while (is_ascii_alphabet_char(cchar) || is_underscore(cchar) || (!first && is_digit(cchar))) {
 						id += cchar;
 						cchar = p_stream->get_char();
 						first = false;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1187,7 +1187,7 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					if (!clipped && lookup_symbol_word.length() != 0) { // Highlight word
-						if (is_ascii_char(lookup_symbol_word[0]) || lookup_symbol_word[0] == '_' || lookup_symbol_word[0] == '.') {
+						if (is_ascii_alphabet_char(lookup_symbol_word[0]) || lookup_symbol_word[0] == '_' || lookup_symbol_word[0] == '.') {
 							int lookup_symbol_word_col = _get_column_pos_of_word(lookup_symbol_word, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 							int lookup_symbol_word_len = lookup_symbol_word.length();
 							while (lookup_symbol_word_col != -1) {

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -313,7 +313,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 			}
 		}
 
-		if (!in_word && (is_ascii_char(str[j]) || is_underscore(str[j])) && !is_number) {
+		if (!in_word && (is_ascii_alphabet_char(str[j]) || is_underscore(str[j])) && !is_number) {
 			in_word = true;
 		}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1463,7 +1463,7 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 		return String();
 	}
 
-	while (port_name.length() && !is_ascii_char(port_name[0])) {
+	while (port_name.length() && !is_ascii_alphabet_char(port_name[0])) {
 		port_name = port_name.substr(1, port_name.length() - 1);
 	}
 
@@ -1508,7 +1508,7 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 
 String VisualShader::validate_parameter_name(const String &p_name, const Ref<VisualShaderNodeParameter> &p_parameter) const {
 	String param_name = p_name; //validate name first
-	while (param_name.length() && !is_ascii_char(param_name[0])) {
+	while (param_name.length() && !is_ascii_alphabet_char(param_name[0])) {
 		param_name = param_name.substr(1, param_name.length() - 1);
 	}
 	if (!param_name.is_empty()) {


### PR DESCRIPTION
```cpp
static _FORCE_INLINE_ bool is_ascii_alphabet_char(char32_t c) {
	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
}
```

Reasoning: This is the non-numeric version of `is_ascii_alphanumeric_char`. `is_ascii_char` can be misleading because it could imply all ASCII characters, including numbers, symbols, and control characters. Since this method explicitly only checks for alphabetical characters, it should be called `is_ascii_alphabet_char` (or similar).