### PR TITLE
Add NavigationMeshSourceGeometryData append functions

### DIFF
--- a/doc/classes/NavigationMeshSourceGeometryData2D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData2D.xml
@@ -31,6 +31,20 @@
 				Adds the outline points of a shape as traversable area.
 			</description>
 		</method>
+		<method name="append_obstruction_outlines">
+			<return type="void" />
+			<param index="0" name="obstruction_outlines" type="PackedVector2Array[]" />
+			<description>
+				Appends another array of [param obstruction_outlines] at the end of the existing obstruction outlines array.
+			</description>
+		</method>
+		<method name="append_traversable_outlines">
+			<return type="void" />
+			<param index="0" name="traversable_outlines" type="PackedVector2Array[]" />
+			<description>
+				Appends another array of [param traversable_outlines] at the end of the existing traversable outlines array.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>

--- a/doc/classes/NavigationMeshSourceGeometryData3D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData3D.xml
@@ -43,6 +43,14 @@
 				Adds a projected obstruction shape to the source geometry. The [param vertices] are considered projected on a xz-axes plane, placed at the global y-axis [param elevation] and extruded by [param height]. If [param carve] is [code]true[/code] the carved shape will not be affected by additional offsets (e.g. agent radius) of the navigation mesh baking process.
 			</description>
 		</method>
+		<method name="append_arrays">
+			<return type="void" />
+			<param index="0" name="vertices" type="PackedFloat32Array" />
+			<param index="1" name="indices" type="PackedInt32Array" />
+			<description>
+				Appends arrays of [param vertices] and [param indices] at the end of the existing arrays. Adds the existing index as an offset to the appended indices.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
@@ -97,6 +97,24 @@ TypedArray<Vector<Vector2>> NavigationMeshSourceGeometryData2D::get_obstruction_
 	return typed_array_obstruction_outlines;
 }
 
+void NavigationMeshSourceGeometryData2D::append_traversable_outlines(const TypedArray<Vector<Vector2>> &p_traversable_outlines) {
+	RWLockWrite write_lock(geometry_rwlock);
+	int traversable_outlines_size = traversable_outlines.size();
+	traversable_outlines.resize(traversable_outlines_size + p_traversable_outlines.size());
+	for (int i = traversable_outlines_size; i < p_traversable_outlines.size(); i++) {
+		traversable_outlines.write[i] = p_traversable_outlines[i];
+	}
+}
+
+void NavigationMeshSourceGeometryData2D::append_obstruction_outlines(const TypedArray<Vector<Vector2>> &p_obstruction_outlines) {
+	RWLockWrite write_lock(geometry_rwlock);
+	int obstruction_outlines_size = obstruction_outlines.size();
+	obstruction_outlines.resize(obstruction_outlines_size + p_obstruction_outlines.size());
+	for (int i = obstruction_outlines_size; i < p_obstruction_outlines.size(); i++) {
+		obstruction_outlines.write[i] = p_obstruction_outlines[i];
+	}
+}
+
 void NavigationMeshSourceGeometryData2D::add_traversable_outline(const PackedVector2Array &p_shape_outline) {
 	if (p_shape_outline.size() > 1) {
 		Vector<Vector2> traversable_outline;
@@ -239,6 +257,9 @@ void NavigationMeshSourceGeometryData2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_obstruction_outlines", "obstruction_outlines"), &NavigationMeshSourceGeometryData2D::set_obstruction_outlines);
 	ClassDB::bind_method(D_METHOD("get_obstruction_outlines"), &NavigationMeshSourceGeometryData2D::get_obstruction_outlines);
+
+	ClassDB::bind_method(D_METHOD("append_traversable_outlines", "traversable_outlines"), &NavigationMeshSourceGeometryData2D::append_traversable_outlines);
+	ClassDB::bind_method(D_METHOD("append_obstruction_outlines", "obstruction_outlines"), &NavigationMeshSourceGeometryData2D::append_obstruction_outlines);
 
 	ClassDB::bind_method(D_METHOD("add_traversable_outline", "shape_outline"), &NavigationMeshSourceGeometryData2D::add_traversable_outline);
 	ClassDB::bind_method(D_METHOD("add_obstruction_outline", "shape_outline"), &NavigationMeshSourceGeometryData2D::add_obstruction_outline);

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
@@ -82,6 +82,9 @@ public:
 	void set_obstruction_outlines(const TypedArray<Vector<Vector2>> &p_obstruction_outlines);
 	TypedArray<Vector<Vector2>> get_obstruction_outlines() const;
 
+	void append_traversable_outlines(const TypedArray<Vector<Vector2>> &p_traversable_outlines);
+	void append_obstruction_outlines(const TypedArray<Vector<Vector2>> &p_obstruction_outlines);
+
 	void add_traversable_outline(const PackedVector2Array &p_shape_outline);
 	void add_obstruction_outline(const PackedVector2Array &p_shape_outline);
 

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
@@ -80,6 +80,8 @@ public:
 	void set_indices(const Vector<int> &p_indices);
 	const Vector<int> &get_indices() const { return indices; }
 
+	void append_arrays(const Vector<float> &p_vertices, const Vector<int> &p_indices);
+
 	bool has_data() { return vertices.size() && indices.size(); };
 	void clear();
 	void clear_projected_obstructions();


### PR DESCRIPTION
Adds append functions to NavigationMeshSourceGeometryData.

With very large source geometry it is unwieldily in scripts to either append every new array one-by-one or replace the entire existing arrays.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
