### PR TITLE
[Web] Fix building for web on Windows

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -926,7 +926,11 @@ def get_compiler_version(env):
         # Not using -dumpversion as some GCC distros only return major, and
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         try:
-            version = subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip().decode("utf-8")
+            version = (
+                subprocess.check_output([env.subst(env["CXX"]), "--version"], shell=(os.name == "nt"))
+                .strip()
+                .decode("utf-8")
+            )
         except (subprocess.CalledProcessError, OSError):
             print("Couldn't parse CXX environment variable to infer compiler version.")
             return ret


### PR DESCRIPTION
On Windows the command for emscripten are provided as `.bat` files, which causes the compiler version check to fail without `shell=True`

Shell version of the command works on Windows only, hence the check

If run on Windows without this change you get:
```
Couldn't parse CXX environment variable to infer compiler version.
```
And the version is set to just `(-1, -1, -1)`, breaking any adjustments and fixes for the compiler

* Fixes: https://github.com/godotengine/godot/issues/90983

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
