### PR TITLE
Fix TabContainer not redrawing after toggling tab icon

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -30,9 +30,6 @@
 
 #include "tab_container.h"
 
-#include "scene/gui/box_container.h"
-#include "scene/gui/label.h"
-#include "scene/gui/texture_rect.h"
 #include "scene/theme/theme_db.h"
 
 int TabContainer::_get_tab_height() const {
@@ -782,6 +779,7 @@ void TabContainer::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 
 	_update_margins();
 	_repaint();
+	queue_redraw();
 }
 
 Ref<Texture2D> TabContainer::get_tab_icon(int p_tab) const {


### PR DESCRIPTION
Fixes #90927

It turns out that the 4.x bug is exactly the opposite of the 3.x bug 🤣 That one is TabContainer updating background but not resizing child controls, while this one is TabContainer resizing child controls but not redrawing its background.

p.s. Also removed unused header includes.