### PR TITLE
Extract navigation-related defaults to separate header

### DIFF
--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -36,6 +36,7 @@
 
 #include "core/math/math_defs.h"
 #include "core/object/worker_thread_pool.h"
+#include "servers/navigation/navigation_globals.h"
 
 #include <KdTree2d.h>
 #include <KdTree3d.h>
@@ -55,21 +56,21 @@ class NavMap : public NavRid {
 
 	/// To find the polygons edges the vertices are displaced in a grid where
 	/// each cell has the following cell_size and cell_height.
-	real_t cell_size = 0.25; // Must match ProjectSettings default 3D cell_size and NavigationMesh cell_size.
-	real_t cell_height = 0.25; // Must match ProjectSettings default 3D cell_height and NavigationMesh cell_height.
+	real_t cell_size = NavigationDefaults3D::navmesh_cell_size;
+	real_t cell_height = NavigationDefaults3D::navmesh_cell_height;
 
 	// For the inter-region merging to work, internal rasterization is performed.
-	float merge_rasterizer_cell_size = 0.25;
-	float merge_rasterizer_cell_height = 0.25;
+	float merge_rasterizer_cell_size = NavigationDefaults3D::navmesh_cell_size;
+	float merge_rasterizer_cell_height = NavigationDefaults3D::navmesh_cell_height;
 	// This value is used to control sensitivity of internal rasterizer.
 	float merge_rasterizer_cell_scale = 1.0;
 
 	bool use_edge_connections = true;
 	/// This value is used to detect the near edges to connect.
-	real_t edge_connection_margin = 0.25;
+	real_t edge_connection_margin = NavigationDefaults3D::edge_connection_margin;
 
 	/// This value is used to limit how far links search to find polygons to connect to.
-	real_t link_connection_radius = 1.0;
+	real_t link_connection_radius = NavigationDefaults3D::link_connection_radius;
 
 	bool regenerate_polygons = true;
 	bool regenerate_links = true;

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -957,7 +957,7 @@ void TileMapLayer::_navigation_update(bool p_force_cleanup) {
 					// Create a dedicated map for each layer.
 					RID new_layer_map = ns->map_create();
 					// Set the default NavigationPolygon cell_size on the new map as a mismatch causes an error.
-					ns->map_set_cell_size(new_layer_map, 1.0);
+					ns->map_set_cell_size(new_layer_map, NavigationDefaults2D::navmesh_cell_size);
 					ns->map_set_active(new_layer_map, true);
 					navigation_map_override = new_layer_map;
 				}

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -33,6 +33,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/navigation_mesh.h"
+#include "servers/navigation/navigation_globals.h"
 
 class NavigationPolygon : public Resource {
 	GDCLASS(NavigationPolygon, Resource);
@@ -50,7 +51,7 @@ class NavigationPolygon : public Resource {
 	// Navigation mesh
 	Ref<NavigationMesh> navigation_mesh;
 
-	real_t cell_size = 1.0f; // Must match ProjectSettings default 2D cell_size.
+	real_t cell_size = NavigationDefaults2D::navmesh_cell_size;
 	real_t border_size = 0.0f;
 
 	Rect2 baking_rect;

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -33,6 +33,7 @@
 
 #include "core/os/rw_lock.h"
 #include "scene/resources/mesh.h"
+#include "servers/navigation/navigation_globals.h"
 
 class NavigationMesh : public Resource {
 	GDCLASS(NavigationMesh, Resource);
@@ -77,8 +78,8 @@ public:
 	};
 
 protected:
-	float cell_size = 0.25f; // Must match ProjectSettings default 3D cell_size and NavigationServer NavMap cell_size.
-	float cell_height = 0.25f; // Must match ProjectSettings default 3D cell_height and NavigationServer NavMap cell_height.
+	float cell_size = NavigationDefaults3D::navmesh_cell_size;
+	float cell_height = NavigationDefaults3D::navmesh_cell_height;
 	float border_size = 0.0f;
 	float agent_height = 1.5f;
 	float agent_radius = 0.5f;

--- a/servers/navigation/navigation_globals.h
+++ b/servers/navigation/navigation_globals.h
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  navigation_globals.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NAVIGATION_GLOBALS_H
+#define NAVIGATION_GLOBALS_H
+
+namespace NavigationDefaults3D {
+
+// Rasterization.
+
+// To find the polygons edges the vertices are displaced in a grid where
+// each cell has the following cell_size and cell_height.
+constexpr float navmesh_cell_size{ 0.25f }; // Must match ProjectSettings default 3D cell_size and NavigationMesh cell_size.
+constexpr float navmesh_cell_height{ 0.25f }; // Must match ProjectSettings default 3D cell_height and NavigationMesh cell_height.
+constexpr auto navmesh_cell_size_hint{ "0.001,100,0.001,or_greater" };
+
+// Map.
+
+constexpr float edge_connection_margin{ 0.25f };
+constexpr float link_connection_radius{ 1.0f };
+
+} //namespace NavigationDefaults3D
+
+namespace NavigationDefaults2D {
+
+// Rasterization.
+
+// Same as in 3D but larger since 1px is treated as 1m.
+constexpr float navmesh_cell_size{ 1.0f }; // Must match ProjectSettings default 2D cell_size.
+constexpr auto navmesh_cell_size_hint{ "0.001,100,0.001,or_greater" };
+
+// Map.
+
+constexpr float edge_connection_margin{ 1.0f };
+constexpr float link_connection_radius{ 4.0f };
+
+} //namespace NavigationDefaults2D
+
+#endif // NAVIGATION_GLOBALS_H

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "scene/main/node.h"
+#include "servers/navigation/navigation_globals.h"
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 
@@ -227,18 +228,18 @@ NavigationServer3D::NavigationServer3D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), 1.0);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults2D::navmesh_cell_size_hint), NavigationDefaults2D::navmesh_cell_size);
 	GLOBAL_DEF("navigation/2d/use_edge_connections", true);
-	GLOBAL_DEF_BASIC("navigation/2d/default_edge_connection_margin", 1.0);
-	GLOBAL_DEF_BASIC("navigation/2d/default_link_connection_radius", 4.0);
+	GLOBAL_DEF_BASIC("navigation/2d/default_edge_connection_margin", NavigationDefaults2D::edge_connection_margin);
+	GLOBAL_DEF_BASIC("navigation/2d/default_link_connection_radius", NavigationDefaults2D::link_connection_radius);
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), 0.25);
-	GLOBAL_DEF_BASIC("navigation/3d/default_cell_height", 0.25);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults3D::navmesh_cell_size_hint), NavigationDefaults3D::navmesh_cell_size);
+	GLOBAL_DEF_BASIC("navigation/3d/default_cell_height", NavigationDefaults3D::navmesh_cell_height);
 	GLOBAL_DEF("navigation/3d/default_up", Vector3(0, 1, 0));
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/3d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
 	GLOBAL_DEF("navigation/3d/use_edge_connections", true);
-	GLOBAL_DEF_BASIC("navigation/3d/default_edge_connection_margin", 0.25);
-	GLOBAL_DEF_BASIC("navigation/3d/default_link_connection_radius", 1.0);
+	GLOBAL_DEF_BASIC("navigation/3d/default_edge_connection_margin", NavigationDefaults3D::edge_connection_margin);
+	GLOBAL_DEF_BASIC("navigation/3d/default_link_connection_radius", NavigationDefaults3D::link_connection_radius);
 
 	GLOBAL_DEF("navigation/avoidance/thread_model/avoidance_use_multiple_threads", true);
 	GLOBAL_DEF("navigation/avoidance/thread_model/avoidance_use_high_priority_threads", true);


### PR DESCRIPTION
This PR introduces a new header that could ideally store all the navigation-related defaults that are scattered across the engine.

Such an approach has the following properties in my view:

- cons:
  - decreases readability - the reader needs to jump to `navigation_defaults.h` to check the value of the default each time.
- pros:
  - reduces the effort on each value change
  - removes the risk of scattered values going out-of-sync with each other by mistake
  - reduces PR sizes when defaults are changed
  - improves documentability as it introduces a single file where the default values can be commented broadly without obfuscating code elsewhere
  - makes it easier for super-users to tweak some values of the engine while working on advanced projects/experiments