### PR TITLE
Update snap value for precision in small scale models.

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -60,7 +60,9 @@ private:
 
 	bool dirty = false;
 	bool last_visible = false;
-	float snap = 0.001;
+
+	// 0.00001 meters is equal to 0.01 millimeters. Small scale models (e.g., mechanical parts, jewelry).
+	float snap = 0.00001f;
 
 	bool use_collision = false;
 	uint32_t collision_layer = 1;

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -72,7 +72,7 @@
 		<member name="operation" type="int" setter="set_operation" getter="get_operation" enum="CSGShape3D.Operation" default="0">
 			The operation that is performed on this shape. This is ignored for the first CSG child node as the operation is between this node and the previous child of this nodes parent.
 		</member>
-		<member name="snap" type="float" setter="set_snap" getter="get_snap" default="0.001">
+		<member name="snap" type="float" setter="set_snap" getter="get_snap" default="1e-05">
 			Snap makes the mesh vertices snap to a given distance so that the faces of two meshes can be perfectly aligned. A lower value results in greater precision but may be harder to adjust.
 		</member>
 		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">


### PR DESCRIPTION
Subtracting two CSG box nodes from a box can generate a floating triangle.

Not sure if this is the proper fix, so putting it out for testing.

Seems to resolve: 

* https://github.com/godotengine/godot/issues/58637
* https://github.com/godotengine/godot/issues/41140
* https://github.com/godotengine/godot/issues/86567
