### PR TITLE
Improve `Array.pick_random()`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -343,7 +343,7 @@ Variant Array::back() const {
 
 Variant Array::pick_random() const {
 	ERR_FAIL_COND_V_MSG(_p->array.is_empty(), Variant(), "Can't take value from empty array.");
-	return operator[](Math::rand() % _p->array.size());
+	return operator[](Math::rand(_p->array.size() - 1));
 }
 
 int Array::find(const Variant &p_value, int p_from) const {


### PR DESCRIPTION
Closes #82117

Replaces modulo in `pick_random()` with ranged `rand()`, same as in `randi_range()`. I did some tests and, as already noted in the issue, there is not much difference in uniformity. But there is not much difference in performance either, so it's like free improvement.