### PR TITLE
Make seeking animation playback track consider internal seeking

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1617,7 +1617,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 					if (seeked) {
 						// Seek.
-						int idx = a->track_find_key(i, time, is_external_seeking ? Animation::FIND_MODE_NEAREST : Animation::FIND_MODE_EXACT, true);
+						int idx = a->track_find_key(i, time, Animation::FIND_MODE_NEAREST, true);
 						if (idx < 0) {
 							continue;
 						}
@@ -1630,6 +1630,9 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						double at_anim_pos = 0.0;
 						switch (anim->get_loop_mode()) {
 							case Animation::LOOP_NONE: {
+								if (!is_external_seeking && ((!backward && time >= pos + (double)anim->get_length()) || (backward && time <= pos))) {
+									continue; // Do nothing if current time is outside of length when started.
+								}
 								at_anim_pos = MIN((double)anim->get_length(), time - pos); // Seek to end.
 							} break;
 							case Animation::LOOP_LINEAR: {
@@ -1641,7 +1644,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							default:
 								break;
 						}
-						if (player2->is_playing()) {
+						if (player2->is_playing() || !is_external_seeking) {
 							player2->seek(at_anim_pos, false, p_update_only);
 							player2->play(anim_name);
 							t->playing = true;


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/89794
- Fixes https://github.com/godotengine/godot/issues/90864

Also, this fixes a problem where playback from the middle of an AnimationPlaybackTrack was not being played that has not worked since 4.0. However, this is not guaranteed to work with AnimationTree, to accomplish that, we need to more rework as I have said some times. For now, it is expected that this PR will make the behavior of AnimationPlaybackTrack the same as in 3.x.

To backport to 4.1 or earlier, a slightly different modification would be required. So this PR code is valid until 4.2.


