### PR TITLE
GDExtension: Fix missing library path breaking hot reloading

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -736,6 +736,8 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 		// If temporary files are generated, let's change the library path to point at the original,
 		// because that's what we want to check to see if it's changed.
 		library_path = actual_lib_path.get_base_dir().path_join(p_path.get_file());
+	} else {
+		library_path = p_path;
 	}
 
 	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, "GDExtension dynamic library not found: " + abs_path);


### PR DESCRIPTION
`GDExtension::open_library` was forgetting to set `library_path` for the extension, which was causing `has_library_changed()` to always return true (reading the modification time of the root directory instead of the library path) and reloading libraries every time the editor focus changed even if the file was not modified, causing huge slowdowns. 