### PR TITLE
Correct AnimationNode documentation where it mentions multiple inputs

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -7,7 +7,7 @@
 		Base resource for [AnimationTree] nodes. In general, it's not used directly, but you can create custom ones with custom blending formulas.
 		Inherit this when creating animation nodes mainly for use in [AnimationNodeBlendTree], otherwise [AnimationRootNode] should be used instead.
 		You can access the time information as read-only parameter which is processed and stored in the previous frame for all nodes except [AnimationNodeOutput].
-		[b]Note:[/b] If more than two inputs exist in the [AnimationNode], which time information takes precedence depends on the type of [AnimationNode].
+		[b]Note:[/b] If multiple inputs exist in the [AnimationNode], which time information takes precedence depends on the type of [AnimationNode].
 		[codeblock]
 		var current_length = $AnimationTree[parameters/AnimationNodeName/current_length]
 		var current_position = $AnimationTree[parameters/AnimationNodeName/current_position]

--- a/doc/classes/AnimationNodeSync.xml
+++ b/doc/classes/AnimationNodeSync.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeSync" inherits="AnimationNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for [AnimationNode]s with more than two input ports that must be synchronized.
+		Base class for [AnimationNode]s with multiple input ports that must be synchronized.
 	</brief_description>
 	<description>
 		An animation node used to combine, mix, or blend two or more animations together while keeping them synchronized within an [AnimationTree].


### PR DESCRIPTION
As with any language, boundary value notation can be confusing. I am a Japanese speaker, so the letter `2 以上` includes `2`, but the English `more than 2` does not.

The matters to be explained here include `2`, so I change the notation so that mistakes never occur.