### PR TITLE
Use same colors for editor and running project for collision/path debug

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -393,9 +393,6 @@
 		<member name="editors/3d_gizmos/gizmo_colors/joint" type="Color" setter="" getter="">
 			The 3D editor gizmo color for [Joint3D]s and [PhysicalBone3D]s.
 		</member>
-		<member name="editors/3d_gizmos/gizmo_colors/shape" type="Color" setter="" getter="">
-			The 3D editor gizmo color for [CollisionShape3D]s, [VehicleWheel3D]s, [RayCast3D]s and [SpringArm3D]s.
-		</member>
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -689,7 +689,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/selection_box_color", Color(1.0, 0.5, 0), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/aabb", Color(0.28, 0.8, 0.82), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// If a line is a multiple of this, it uses the primary grid color.

--- a/editor/plugins/gizmos/collision_object_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_object_3d_gizmo_plugin.cpp
@@ -38,7 +38,7 @@
 #include "scene/resources/surface_tool.h"
 
 CollisionObject3DGizmoPlugin::CollisionObject3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);

--- a/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
@@ -35,7 +35,7 @@
 #include "scene/3d/physics/collision_polygon_3d.h"
 
 CollisionPolygon3DGizmoPlugin::CollisionPolygon3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);

--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -49,7 +49,7 @@
 
 CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 	helper.instantiate();
-	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);

--- a/editor/plugins/gizmos/ray_cast_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/ray_cast_3d_gizmo_plugin.cpp
@@ -35,7 +35,7 @@
 #include "scene/3d/physics/ray_cast_3d.h"
 
 RayCast3DGizmoPlugin::RayCast3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);

--- a/editor/plugins/gizmos/shape_cast_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/shape_cast_3d_gizmo_plugin.cpp
@@ -35,7 +35,7 @@
 #include "scene/3d/physics/shape_cast_3d.h"
 
 ShapeCast3DGizmoPlugin::ShapeCast3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);

--- a/editor/plugins/gizmos/soft_body_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/soft_body_3d_gizmo_plugin.cpp
@@ -35,7 +35,7 @@
 #include "scene/3d/soft_body_3d.h"
 
 SoftBody3DGizmoPlugin::SoftBody3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 	create_handle_material("handles");
 }

--- a/editor/plugins/gizmos/spring_arm_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/spring_arm_3d_gizmo_plugin.cpp
@@ -52,7 +52,7 @@ void SpringArm3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 }
 
 SpringArm3DGizmoPlugin::SpringArm3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 }
 

--- a/editor/plugins/gizmos/vehicle_body_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/vehicle_body_3d_gizmo_plugin.cpp
@@ -35,7 +35,7 @@
 #include "scene/3d/physics/vehicle_body_3d.h"
 
 VehicleWheel3DGizmoPlugin::VehicleWheel3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();
 	create_material("shape_material", gizmo_color);
 }
 

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -1054,7 +1054,7 @@ int Path3DGizmoPlugin::get_priority() const {
 }
 
 Path3DGizmoPlugin::Path3DGizmoPlugin(float p_disk_size) {
-	Color path_color = EDITOR_DEF_RST("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.9));
+	Color path_color = SceneTree::get_singleton()->get_debug_paths_color();
 	Color path_tilt_color = EDITOR_DEF_RST("editors/3d_gizmos/gizmo_colors/path_tilt", Color(1.0, 1.0, 0.4, 0.9));
 	disk_size = p_disk_size;
 

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -144,7 +144,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 				}
 #endif
 
-				const Color stroke_color = Color(0.9, 0.2, 0.0);
+				const Color stroke_color = get_tree()->get_debug_collisions_color();
 				draw_polyline(polygon, stroke_color);
 				// Draw the last segment.
 				draw_line(polygon[polygon.size() - 1], polygon[0], stroke_color);


### PR DESCRIPTION
This harmonizes the appearance of collision shapes and paths between the editor and running project, in both 2D and 3D.

This means that in 3D, paths are now green and shapes are now cyan instead of light blue.

Editor settings for 3D path and shape gizmo colors were removed, as these colors are now set in the project settings instead (they affect both the editor and running project). This paves the way to [custom color support for CollisionShape3D](https://github.com/godotengine/godot/pull/90644), as it already works in a similar fashion in 2D.

## Preview

### Before

#### 2D

Editor | Project
-|-
![2D Editor](https://github.com/godotengine/godot/assets/180032/9201a9dd-82b6-4e81-abd6-44bde5c35d18) | ![2D Project](https://github.com/godotengine/godot/assets/180032/2bafb1d5-84ac-4a67-a05e-37e6af5c063b)

#### 3D

Editor | Project
-|-
![3D Editor](https://github.com/godotengine/godot/assets/180032/46470f1e-2fd2-4f70-a614-15649efe7045) | ![3D Project](https://github.com/godotengine/godot/assets/180032/be21c566-2737-4704-8c35-8f026b8ddf22)

### After

#### 2D

Editor | Project
-|-
![2D Editor](https://github.com/godotengine/godot/assets/180032/4615f1e0-f069-46b2-900c-e18af8edf1a6) | ![2D Project](https://github.com/godotengine/godot/assets/180032/68a18705-b61e-47e4-9326-2b5b351a2a90)


#### 3D

> [!NOTE]
>
> Colors in the editor appear more faint, as unselected gizmo drawings have lower opacity in the editor (regardless of the node or color). If the node is selected, the visual output is identical to the running project.

Editor | Project
-|-
![3D Editor](https://github.com/godotengine/godot/assets/180032/dd171664-3a71-4e12-9d77-ff465e3bb14c) | ![3D Project](https://github.com/godotengine/godot/assets/180032/24a77e3b-6ab1-44a1-afc6-57aa760a1d69)