### PR TITLE
Expose several resource/resource-saver functions

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -181,6 +181,10 @@ void ResourceSaver::remove_resource_format_saver(Ref<ResourceFormatSaver> p_form
 	::ResourceSaver::remove_resource_format_saver(p_format_saver);
 }
 
+ResourceUID::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
+	return ::ResourceSaver::get_resource_id_for_path(p_path, p_generate);
+}
+
 ResourceSaver *ResourceSaver::singleton = nullptr;
 
 void ResourceSaver::_bind_methods() {
@@ -188,6 +192,7 @@ void ResourceSaver::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &ResourceSaver::get_recognized_extensions);
 	ClassDB::bind_method(D_METHOD("add_resource_format_saver", "format_saver", "at_front"), &ResourceSaver::add_resource_format_saver, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_resource_format_saver", "format_saver"), &ResourceSaver::remove_resource_format_saver);
+	ClassDB::bind_method(D_METHOD("get_resource_id_for_path", "path", "generate"), &ResourceSaver::get_resource_id_for_path, DEFVAL(false));
 
 	BIND_BITFIELD_FLAG(FLAG_NONE);
 	BIND_BITFIELD_FLAG(FLAG_RELATIVE_PATHS);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -116,6 +116,8 @@ public:
 	void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front);
 	void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 
+	ResourceUID::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
+
 	ResourceSaver() { singleton = this; }
 };
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -89,6 +89,9 @@ protected:
 
 	GDVIRTUAL0RC(RID, _get_rid);
 
+	GDVIRTUAL1C(_set_path_cache, String);
+	GDVIRTUAL0(_reset_state);
+
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor
 	static void (*_update_configuration_warning)(); //used by editor
@@ -144,11 +147,9 @@ public:
 
 	virtual RID get_rid() const; // some resources may offer conversion to RID
 
-#ifdef TOOLS_ENABLED
 	//helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 	void set_id_for_path(const String &p_path, const String &p_id);
 	String get_id_for_path(const String &p_path) const;
-#endif
 
 	Resource();
 	~Resource();

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -20,6 +20,19 @@
 				Override this method to return a custom [RID] when [method get_rid] is called.
 			</description>
 		</method>
+		<method name="_reset_state" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				For resources that use a variable number of properties, either via [method Object._validate_property] or [method Object._get_property_list], this method should be implemented to correctly clear the resource's state.
+			</description>
+		</method>
+		<method name="_set_path_cache" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Sets the resource's path to [param path] without involving the resource cache.
+			</description>
+		</method>
 		<method name="_setup_local_to_scene" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -68,6 +81,14 @@
 				Generates a unique identifier for a resource to be contained inside a [PackedScene], based on the current date, time, and a random value. The returned string is only composed of letters ([code]a[/code] to [code]y[/code]) and numbers ([code]0[/code] to [code]8[/code]). See also [member resource_scene_unique_id].
 			</description>
 		</method>
+		<method name="get_id_for_path" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the unique identifier for the resource with the given [param path] from the resource cache. If the resource is not loaded and cached, an empty string is returned.
+				[b]Note:[/b] This method is only implemented when running in an editor context. At runtime, it returns an empty string.
+			</description>
+		</method>
 		<method name="get_local_scene" qualifiers="const">
 			<return type="Node" />
 			<description>
@@ -78,6 +99,34 @@
 			<return type="RID" />
 			<description>
 				Returns the [RID] of this resource (or an empty RID). Many resources (such as [Texture2D], [Mesh], and so on) are high-level abstractions of resources stored in a specialized server ([DisplayServer], [RenderingServer], etc.), so this function will return the original [RID].
+			</description>
+		</method>
+		<method name="is_built_in" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the resource is built-in (from the engine) or [code]false[/code] if it is user-defined.
+			</description>
+		</method>
+		<method name="reset_state">
+			<return type="void" />
+			<description>
+				For resources that use a variable number of properties, either via [method Object._validate_property] or [method Object._get_property_list], override [method _reset_state] to correctly clear the resource's state.
+			</description>
+		</method>
+		<method name="set_id_for_path">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="id" type="String" />
+			<description>
+				Sets the unique identifier to [param id] for the resource with the given [param path] in the resource cache. If the unique identifier is empty, the cache entry using [param path] is removed if it exists.
+				[b]Note:[/b] This method is only implemented when running in an editor context.
+			</description>
+		</method>
+		<method name="set_path_cache">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Sets the resource's path to [param path] without involving the resource cache.
 			</description>
 		</method>
 		<method name="setup_local_to_scene" deprecated="This method should only be called internally.">

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -26,6 +26,14 @@
 				Returns the list of extensions available for saving a resource of a given type.
 			</description>
 		</method>
+		<method name="get_resource_id_for_path">
+			<return type="int" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="generate" type="bool" default="false" />
+			<description>
+				Returns the resource ID for the given path. If [param generate] is [code]true[/code], a new resource ID will be generated if one for the path is not found. If [param generate] is [code]false[/code] and the path is not found, [constant ResourceUID.INVALID_ID] is returned.
+			</description>
+		</method>
 		<method name="remove_resource_format_saver">
 			<return type="void" />
 			<param index="0" name="format_saver" type="ResourceFormatSaver" />


### PR DESCRIPTION
Exposes several methods for GDExtension and script languages related to `Resource`, `ResourceUID`, and `ResourceSaver`.

*Bugsquad edit:* The methods are Resource `get_id_for_path`, `is_built_in`, `reset_state`, `set_id_for_path`, `set_path_cache`, and ResourceSaver `get_resource_id_for_path`.