### PR TITLE
Fix `RID` cannot be string formatted

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -465,6 +465,7 @@ void Variant::_register_variant_operators() {
 	register_string_modulo_op(Color, Variant::COLOR);
 	register_string_modulo_op(StringName, Variant::STRING_NAME);
 	register_string_modulo_op(NodePath, Variant::NODE_PATH);
+	register_string_modulo_op(::RID, Variant::RID);
 	register_string_modulo_op(Object, Variant::OBJECT);
 	register_string_modulo_op(Callable, Variant::CALLABLE);
 	register_string_modulo_op(Signal, Variant::SIGNAL);


### PR DESCRIPTION
Fixes #90855

Added a missing operator registration, so that `"%s" % RID()` will work as intended.
I guess this is merely an oversight.

