### PR TITLE
Physics documentation: mention servers when mentioning `RID`s

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -130,7 +130,7 @@
 			<param index="2" name="area_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this area and the other area, respectively. [param area_rid] contains the [RID] of the other area. These values can be used with the [PhysicsServer2D].
 				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
 				[codeblocks]
@@ -150,7 +150,7 @@
 			<param index="2" name="area_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param area] exits a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param area] exits a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal area_shape_entered].
 			</description>
 		</signal>
@@ -172,7 +172,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer2D].
 				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
 				[codeblocks]
@@ -192,7 +192,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal body_shape_entered].
 			</description>
 		</signal>

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -154,7 +154,7 @@
 			<param index="2" name="area_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this area and the other area, respectively. [param area_rid] contains the [RID] of the other area. These values can be used with the [PhysicsServer3D].
 				[b]Example of getting the[/b] [CollisionShape3D] [b]node from the shape index:[/b]
 				[codeblocks]
@@ -174,7 +174,7 @@
 			<param index="2" name="area_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param area] exits a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param area] exits a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal area_shape_entered].
 			</description>
 		</signal>
@@ -196,7 +196,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer3D].
 				[b]Example of getting the[/b] [CollisionShape3D] [b]node from the shape index:[/b]
 				[codeblocks]
@@ -216,7 +216,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a collision shape of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal body_shape_entered].
 			</description>
 		</signal>

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -70,7 +70,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the object's [RID].
+				Returns the internal [RID] used by the [PhysicsServer2D] for this collision object.
 			</description>
 		</method>
 		<method name="get_shape_owner_one_way_collision_margin" qualifiers="const">

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -58,7 +58,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the object's [RID].
+				Returns the internal [RID] used by the [PhysicsServer3D] for this collision object.
 			</description>
 		</method>
 		<method name="get_shape_owners">

--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -12,7 +12,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the joint's [RID].
+				Returns the internal [RID] used by the [PhysicsServer2D] for this joint.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -13,7 +13,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the joint's [RID].
+				Returns the internal [RID] used by the [PhysicsServer3D] for this joint.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -32,7 +32,7 @@
 		<method name="get_collider_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the colliding body's [RID] used by the [PhysicsServer2D].
+				Returns the [RID] of the colliding body in the [PhysicsServer2D].
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -36,7 +36,7 @@
 			<return type="RID" />
 			<param index="0" name="collision_index" type="int" default="0" />
 			<description>
-				Returns the colliding body's [RID] used by the [PhysicsServer3D] given a collision index (the deepest collision by default).
+				Returns the [RID] of the colliding body in the [PhysicsServer3D] given a collision index (the deepest collision by default).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">

--- a/doc/classes/PhysicalBoneSimulator3D.xml
+++ b/doc/classes/PhysicalBoneSimulator3D.xml
@@ -19,16 +19,14 @@
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
-				Adds a collision exception to the physical bone.
-				Works just like the [RigidBody3D] node.
+				Adds the given [RID] to the list of [RID]s of bodies in the [PhysicsServer3D] that will be excluded from collisions with the physical bones. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 		<method name="physical_bones_remove_collision_exception">
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
-				Removes a collision exception to the physical bone.
-				Works just like the [RigidBody3D] node.
+				Removes the given [RID] from the list of [RID]s of bodies in the [PhysicsServer3D] that will be excluded from collisions with the physical bones. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 		<method name="physical_bones_start_simulation">

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -106,7 +106,7 @@
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the collider's [RID].
+				Returns the [RID] of the colliding body in the [PhysicsServer2D].
 			</description>
 		</method>
 		<method name="get_contact_collider_id" qualifiers="const">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -106,7 +106,7 @@
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the collider's [RID].
+				Returns the [RID] of the colliding body in the [PhysicsServer3D].
 			</description>
 		</method>
 		<method name="get_contact_collider_id" qualifiers="const">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -39,7 +39,7 @@
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector2]. If the object is an [Area2D], the result is [code](0, 0)[/code].
 				[code]normal[/code]: The object's surface normal at the intersection point.
 				[code]point[/code]: The intersection point.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer2D].
 				[code]shape[/code]: The shape index of the colliding shape.
 			</description>
 		</method>
@@ -51,7 +51,7 @@
 				Checks whether a point is inside any solid shape. Position and other parameters are defined through [PhysicsPointQueryParameters2D]. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer2D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 				[b]Note:[/b] [ConcavePolygonShape2D]s and [CollisionPolygon2D]s in [code]Segments[/code] build mode are not solid shapes. Therefore, they will not be detected.
@@ -66,7 +66,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
 				[code]position[/code]: The intersection point.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer2D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
@@ -79,7 +79,7 @@
 				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. The intersected shapes are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer2D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -39,7 +39,7 @@
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector3]. If the object is an [Area3D], the result is [code](0, 0, 0)[/code].
 				[code]normal[/code]: The object's surface normal at the intersection point.
 				[code]point[/code]: The intersection point.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer3D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the shape did not intersect anything, then an empty dictionary is returned instead.
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
@@ -53,7 +53,7 @@
 				Checks whether a point is inside any solid shape. Position and other parameters are defined through [PhysicsPointQueryParameters3D]. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer3D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
@@ -69,7 +69,7 @@
 				[code]position[/code]: The intersection point.
 				[code]face_index[/code]: The face index at the intersection point.
 				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer3D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
@@ -82,7 +82,7 @@
 				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. The intersected shapes are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]rid[/code]: The intersecting object's [RID].
+				[code]rid[/code]: The [RID] of the intersecting object in the [PhysicsServer3D].
 				[code]shape[/code]: The shape index of the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.

--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -23,7 +23,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer2D] that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The position being queried for, in global coordinates.

--- a/doc/classes/PhysicsPointQueryParameters3D.xml
+++ b/doc/classes/PhysicsPointQueryParameters3D.xml
@@ -19,7 +19,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer3D] that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 		</member>
 		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
 			The position being queried for, in global coordinates.

--- a/doc/classes/PhysicsRayQueryParameters2D.xml
+++ b/doc/classes/PhysicsRayQueryParameters2D.xml
@@ -35,7 +35,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer2D] that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 		</member>
 		<member name="from" type="Vector2" setter="set_from" getter="get_from" default="Vector2(0, 0)">
 			The starting point of the ray being queried for, in global coordinates.

--- a/doc/classes/PhysicsRayQueryParameters3D.xml
+++ b/doc/classes/PhysicsRayQueryParameters3D.xml
@@ -35,7 +35,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer3D] that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 		</member>
 		<member name="from" type="Vector3" setter="set_from" getter="get_from" default="Vector3(0, 0, 0)">
 			The starting point of the ray being queried for, in global coordinates.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -10,7 +10,7 @@
 		- A [i]body[/i] is a physical object which can be in static, kinematic, or rigid mode. Its state (such as position and velocity) can be queried and updated. A force integration callback can be set to customize the body's physics.
 		- An [i]area[/i] is a region in space which can be used to detect bodies and areas entering and exiting it. A body monitoring callback can be set to report entering/exiting body shapes, and similarly an area monitoring callback can be set. Gravity and damping can be overridden within the area by setting area parameters.
 		- A [i]joint[/i] is a constraint, either between two bodies or on one body relative to a point. Parameters such as the joint bias and the rest length of a spring joint can be adjusted.
-		Physics objects in [PhysicsServer2D] may be created and manipulated independently; they do not have to be tied to nodes in the scene tree.
+		Physics objects in [PhysicsServer2D] may be created and manipulated independently using [RID]s; they do not have to be tied to nodes in the scene tree.
 		[b]Note:[/b] All the 2D physics nodes use the physics server internally. Adding a physics node to the scene tree will cause a corresponding physics object to be created in the physics server. A rigid body node registers a callback that updates the node's transform with the transform of the respective body object in the physics server (every physics update). An area node registers a callback to inform the area node about overlaps with the respective area object in the physics server. The raycast node queries the direct state of the relevant space in the physics server.
 	</description>
 	<tutorials>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -10,7 +10,7 @@
 		- A [i]body[/i] is a physical object which can be in static, kinematic, or rigid mode. Its state (such as position and velocity) can be queried and updated. A force integration callback can be set to customize the body's physics.
 		- An [i]area[/i] is a region in space which can be used to detect bodies and areas entering and exiting it. A body monitoring callback can be set to report entering/exiting body shapes, and similarly an area monitoring callback can be set. Gravity and damping can be overridden within the area by setting area parameters.
 		- A [i]joint[/i] is a constraint, either between two bodies or on one body relative to a point. Parameters such as the joint bias and the rest length of a spring joint can be adjusted.
-		Physics objects in [PhysicsServer3D] may be created and manipulated independently; they do not have to be tied to nodes in the scene tree.
+		Physics objects in [PhysicsServer3D] may be created and manipulated independently using [RID]s; they do not have to be tied to nodes in the scene tree.
 		[b]Note:[/b] All the 3D physics nodes use the physics server internally. Adding a physics node to the scene tree will cause a corresponding physics object to be created in the physics server. A rigid body node registers a callback that updates the node's transform with the transform of the respective body object in the physics server (every physics update). An area node registers a callback to inform the area node about overlaps with the respective area object in the physics server. The raycast node queries the direct state of the relevant space in the physics server.
 	</description>
 	<tutorials>

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -19,7 +19,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer2D] that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
@@ -31,7 +31,7 @@
 			The [Shape2D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
-			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
+			The [RID] of the shape in the [PhysicsServer2D] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
 				[codeblocks]
 				[gdscript]
 				var shape_rid = PhysicsServer2D.circle_shape_create()

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -19,7 +19,7 @@
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
-			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
+			The list of [RID]s of objects in the [PhysicsServer3D] that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
@@ -31,7 +31,7 @@
 			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
-			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
+			The [RID] of the shape in the [PhysicsServer3D] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
 				[codeblocks]
 				[gdscript]
 				var shape_rid = PhysicsServer3D.shape_create(PhysicsServer3D.SHAPE_SPHERE)

--- a/doc/classes/PhysicsTestMotionParameters2D.xml
+++ b/doc/classes/PhysicsTestMotionParameters2D.xml
@@ -14,7 +14,7 @@
 			If set to [code]false[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
 		</member>
 		<member name="exclude_bodies" type="RID[]" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
-			Optional array of body [RID] to exclude from collision. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
+			Optional array of [RID]s of bodies in the [PhysicsServer2D] to exclude from collision. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 		</member>
 		<member name="exclude_objects" type="int[]" setter="set_exclude_objects" getter="get_exclude_objects" default="[]">
 			Optional array of object unique instance ID to exclude from collision. See [method Object.get_instance_id].

--- a/doc/classes/PhysicsTestMotionParameters3D.xml
+++ b/doc/classes/PhysicsTestMotionParameters3D.xml
@@ -14,7 +14,7 @@
 			If set to [code]false[/code], shapes of type [constant PhysicsServer3D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
 		</member>
 		<member name="exclude_bodies" type="RID[]" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
-			Optional array of body [RID] to exclude from collision. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
+			Optional array [RID]s of bodies in the [PhysicsServer3D] to exclude from collision. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 		</member>
 		<member name="exclude_objects" type="int[]" setter="set_exclude_objects" getter="get_exclude_objects" default="[]">
 			Optional array of object unique instance ID to exclude from collision. See [method Object.get_instance_id].

--- a/doc/classes/PhysicsTestMotionResult2D.xml
+++ b/doc/classes/PhysicsTestMotionResult2D.xml
@@ -24,7 +24,7 @@
 		<method name="get_collider_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the colliding body's [RID] used by the [PhysicsServer2D], if a collision occurred.
+				Returns the [RID] of the colliding body in the [PhysicsServer2D], if a collision occurred.
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">

--- a/doc/classes/PhysicsTestMotionResult3D.xml
+++ b/doc/classes/PhysicsTestMotionResult3D.xml
@@ -27,7 +27,7 @@
 			<return type="RID" />
 			<param index="0" name="collision_index" type="int" default="0" />
 			<description>
-				Returns the colliding body's [RID] used by the [PhysicsServer3D] given a collision index (the deepest collision by default), if a collision occurred.
+				Returns the [RID] of the colliding body in the [PhysicsServer3D] given a collision index (the deepest collision by default), if a collision occurred.
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -24,7 +24,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Adds a collision exception so the ray does not report collisions with the specified [RID].
+				Adds a collision exception so the ray does not report collisions with the object in the [PhysicsServer2D] with the given [RID].
 			</description>
 		</method>
 		<method name="clear_exceptions">
@@ -49,7 +49,7 @@
 		<method name="get_collider_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the first object that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the [RID] of the first object (in the [PhysicsServer3D]) that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -111,7 +111,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Removes a collision exception so the ray does report collisions with the specified [RID].
+				Removes a collision exception so the ray does report collisions with the object in the [PhysicsServer2D] with the given [RID].
 			</description>
 		</method>
 		<method name="set_collision_mask_value">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -25,7 +25,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Adds a collision exception so the ray does not report collisions with the specified [RID].
+				Adds a collision exception so the ray does not report collisions with the object in the [PhysicsServer3D] with the given [RID].
 			</description>
 		</method>
 		<method name="clear_exceptions">
@@ -50,7 +50,7 @@
 		<method name="get_collider_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the first object that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the [RID] of the first object (in the [PhysicsServer3D]) that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -118,7 +118,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Removes a collision exception so the ray does report collisions with the specified [RID].
+				Removes a collision exception so the ray does report collisions with the object in the [PhysicsServer3D] with the given [RID].
 			</description>
 		</method>
 		<method name="set_collision_mask_value">

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -249,8 +249,8 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when one of this RigidBody2D's [Shape2D]s collides with another [PhysicsBody2D] or [TileMap]'s [Shape2D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				Emitted when one of this RigidBody2D's collision shapes collides with another [PhysicsBody2D] or [TileMap]'s collision shape. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has collision shapes.
+				[param body_rid] the [RID] of the other body in the [PhysicsServer2D].
 				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape2D] of this RigidBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
@@ -262,8 +262,8 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when the collision between one of this RigidBody2D's [Shape2D]s and another [PhysicsBody2D] or [TileMap]'s [Shape2D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				Emitted when the collision between one of this RigidBody2D's collision shapes and another [PhysicsBody2D] or [TileMap]'s collision shape ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has collision shapes.
+				[param body_rid] the [RID] of the other body in the [PhysicsServer2D].
 				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape2D] of this RigidBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -256,8 +256,8 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when one of this RigidBody3D's [Shape3D]s collides with another [PhysicsBody3D] or [GridMap]'s [Shape3D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[param body_rid] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
+				Emitted when one of this RigidBody3D's collision shapes collides with another [PhysicsBody3D] or [GridMap]'s collision shape. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has collision shapes.
+				[param body_rid] the [RID] of the other body in the [PhysicsServer3D].
 				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 				[param body_shape_index] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape3D] of this RigidBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
@@ -269,8 +269,8 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when the collision between one of this RigidBody3D's [Shape3D]s and another [PhysicsBody3D] or [GridMap]'s [Shape3D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[param body_rid] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D]. [GridMap]s are detected if the Meshes have [Shape3D]s.
+				Emitted when the collision between one of this RigidBody3D's collision shapes and another [PhysicsBody3D] or [GridMap]'s collision shape ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has collision shapes.
+				[param body_rid] the [RID] of the other body in the [PhysicsServer3D].
 				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 				[param body_shape_index] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape3D] of this RigidBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].

--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -22,7 +22,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Adds a collision exception so the shape does not report collisions with the specified [RID].
+				Adds a collision exception so the shape does not report collisions with the object in the [PhysicsServer2D] with the given [RID].
 			</description>
 		</method>
 		<method name="clear_exceptions">
@@ -62,7 +62,7 @@
 			<return type="RID" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the [RID] of the collided object of one of the multiple collisions at [param index].
+				Returns the [RID] of the collided object (in the [PhysicsServer2D]) of one of the multiple collisions at [param index].
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -117,7 +117,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Removes a collision exception so the shape does report collisions with the specified [RID].
+				Removes a collision exception so the shape does report collisions with the object in the [PhysicsServer2D] with the given [RID].
 			</description>
 		</method>
 		<method name="set_collision_mask_value">

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -22,7 +22,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Adds a collision exception so the shape does not report collisions with the specified [RID].
+				Adds a collision exception so the shape does not report collisions with the object in the [PhysicsServer3D] with the given [RID].
 			</description>
 		</method>
 		<method name="clear_exceptions">
@@ -62,7 +62,7 @@
 			<return type="RID" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the [RID] of the collided object of one of the multiple collisions at [param index].
+				Returns the [RID] of the collided object (in the [PhysicsServer3D]) of one of the multiple collisions at [param index].
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -117,7 +117,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Removes a collision exception so the shape does report collisions with the specified [RID].
+				Removes a collision exception so the shape does report collisions with the object in the [PhysicsServer3D] with the given [RID].
 			</description>
 		</method>
 		<method name="resource_changed" deprecated="Use [signal Resource.changed] instead.">

--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -48,7 +48,7 @@
 		<method name="get_skeleton" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of a Skeleton2D instance.
+				Returns the internal [RID] used by the [RenderingServer] for this skeleton.
 			</description>
 		</method>
 		<method name="set_bone_local_pose_override">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -186,16 +186,14 @@
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
-				Adds a collision exception to the physical bone.
-				Works just like the [RigidBody3D] node.
+				Adds the given [RID] to the list of [RID]s of bodies in the [PhysicsServer3D] that will be excluded from collisions with the physical bones. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 		<method name="physical_bones_remove_collision_exception" deprecated="">
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
-				Removes a collision exception to the physical bone.
-				Works just like the [RigidBody3D] node.
+				Removes the given [RID] from the list of [RID]s of bodies in the [PhysicsServer3D] that will be excluded from collisions with the physical bones. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 		<method name="physical_bones_start_simulation" deprecated="">

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -42,7 +42,7 @@
 		<method name="get_physics_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the internal [RID] used by the [PhysicsServer3D] for this body.
+				Returns the internal [RID] used by the [PhysicsServer3D] for this soft body.
 			</description>
 		</method>
 		<method name="get_point_transform">

--- a/doc/classes/SpringArm3D.xml
+++ b/doc/classes/SpringArm3D.xml
@@ -13,13 +13,13 @@
 			<return type="void" />
 			<param index="0" name="RID" type="RID" />
 			<description>
-				Adds the [PhysicsBody3D] object with the given [RID] to the list of [PhysicsBody3D] objects excluded from the collision check.
+				Adds the given [RID] of an object in the [PhysicsServer3D] to the list of [RID]s excluded from the collision check. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 		<method name="clear_excluded_objects">
 			<return type="void" />
 			<description>
-				Clears the list of [PhysicsBody3D] objects excluded from the collision check.
+				Clears the list of objects excluded from the collision check.
 			</description>
 		</method>
 		<method name="get_hit_length">
@@ -32,7 +32,7 @@
 			<return type="bool" />
 			<param index="0" name="RID" type="RID" />
 			<description>
-				Removes the given [RID] from the list of [PhysicsBody3D] objects excluded from the collision check.
+				Removes the given [RID] from the list of [RID]s of objects in the [PhysicsServer3D] excluded from the collision check. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -140,14 +140,14 @@
 			<return type="Vector2i" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the coordinates of the tile for given physics body RID. Such RID can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
+				Returns the coordinates of the tile that contains the body with the given [RID] from the [PhysicsServer2D]. Such an [RID] can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
 			</description>
 		</method>
 		<method name="get_layer_for_body_rid">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the tilemap layer of the tile for given physics body RID. Such RID can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
+				Returns the tilemap layer of the tile that contains the body with the given [RID] from the [PhysicsServer2D]. Such an [RID] can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
 			</description>
 		</method>
 		<method name="get_layer_modulate" qualifiers="const">

--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -91,7 +91,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the coordinates of the tile for given physics body [RID]. Such an [RID] can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
+				Returns the coordinates of the tile that contains the body with the given [RID] from the [PhysicsServer2D]. Such an [RID] can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
 			</description>
 		</method>
 		<method name="get_navigation_map" qualifiers="const">
@@ -150,7 +150,7 @@
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns whether the provided [param body] [RID] belongs to one of this [TileMapLayer]'s cells.
+				Returns whether the provided [RID] of a body from the [PhysicsServer2D] belongs to one of this [TileMapLayer]'s cells.
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -29,7 +29,7 @@
 			The World3D's visual scenario.
 		</member>
 		<member name="space" type="RID" setter="" getter="get_space">
-			The World3D's physics space.
+			The [RID] of this world's physics space resource. Used by the [PhysicsServer3D] for 3D physics.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Also mention `RID`s in the top description of servers.

Also fix some mistakes in affected lines. For example, bodies and areas have (collision) shapes with a transform, so it is incorrect/incomplete to refer to these as `Shape2D`'s, which are resources without a transform.