### PR TITLE
Allow creating GDExtension plugins from inside the Godot editor

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -25,6 +25,7 @@ clangd:
   - "!**/thirdparty/**"
   - "!**/*-so_wrap.{h,c}"
   - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
+  - "!editor/settings/gdextension/cpp_scons/template/**"
   - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
   - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"

--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -20,6 +20,7 @@ clangd:
   - "!**/thirdparty/**"
   - "!**/*-so_wrap.{h,c}"
   - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
+  - "!editor/settings/gdextension/cpp_scons/template/**"
   - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
   - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,10 @@ repos:
         language: python
         entry: python misc/scripts/validate_includes.py
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc)$
+        exclude: |
+          (?x)^(
+            editor/settings/gdextension/cpp_scons/template/.*
+          )$
 
       - id: eslint
         name: eslint
@@ -176,6 +180,7 @@ repos:
         exclude: |
           (?x)^(
             core/math/bvh_.*\.inc|
+            editor/settings/gdextension/cpp_scons/template/.*|
             platform/(?!android|ios|linuxbsd|macos|web|windows)\w+/.*|
             platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView\.java|
             platform/android/java/lib/src/main/java/org/godotengine/godot/gl/EGLLogWrapper\.java|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,10 @@ repos:
         language: python
         entry: python misc/scripts/validate_includes.py
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc)$
+        exclude: |
+          (?x)^(
+            editor/settings/gdextension/cpp_scons/template/.*
+          )$
 
       - id: eslint
         name: eslint
@@ -176,6 +180,7 @@ repos:
         exclude: |
           (?x)^(
             core/math/bvh_.*\.inc|
+            editor/settings/gdextension/cpp_scons/template/.*|
             platform/(?!android|ios|linuxbsd|macos|visionos|web|windows)\w+/.*|
             platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView\.java|
             platform/android/java/lib/src/main/java/org/godotengine/godot/gl/EGLLogWrapper\.java|

--- a/editor/gui/editor_validation_panel.cpp
+++ b/editor/gui/editor_validation_panel.cpp
@@ -144,6 +144,10 @@ void EditorValidationPanel::set_message(int p_id, const String &p_text, MessageT
 	}
 }
 
+int EditorValidationPanel::get_message_count() const {
+	return valid_messages.size();
+}
+
 bool EditorValidationPanel::is_valid() const {
 	return valid;
 }

--- a/editor/gui/editor_validation_panel.h
+++ b/editor/gui/editor_validation_panel.h
@@ -79,6 +79,7 @@ public:
 
 	void update();
 	void set_message(int p_id, const String &p_text, MessageType p_type, bool p_auto_prefix = true);
+	int get_message_count() const;
 	bool is_valid() const;
 
 	EditorValidationPanel();

--- a/editor/settings/gdextension/SCsub
+++ b/editor/settings/gdextension/SCsub
@@ -4,3 +4,5 @@ from misc.utility.scons_hints import *
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")
+
+SConscript("cpp_scons/SCsub")

--- a/editor/settings/gdextension/cpp_scons/SCsub
+++ b/editor/settings/gdextension/cpp_scons/SCsub
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+import os
+
+Import("env")
+
+env.add_source_files(env.editor_sources, "*.cpp")
+
+
+def parse_template(source):
+    with open(source) as file:
+        lines = file.readlines()
+        script_template = ""
+        for line in lines:
+            script_template += line
+        if env["precision"] != "double":
+            script_template = script_template.replace('ARGUMENTS.setdefault("precision", "double")', "")
+        name = os.path.basename(source).upper().replace(".", "_")
+        return "\nconst String " + name + ' = R"<>(' + script_template.rstrip() + ')<>";\n'
+
+
+def make_templates(target, source, env):
+    dst = str(target[0])
+    with StringIO() as s:
+        s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
+        s.write("#pragma once\n\n")
+        s.write('#include "core/string/ustring.h"\n')
+        parsed_template_string = ""
+        for file in source:
+            filepath = str(file)
+            if os.path.isfile(filepath):
+                parsed_template_string += parse_template(filepath)
+        s.write(parsed_template_string)
+        s.write("\n")
+        with open(dst, "w", encoding="utf-8", newline="\n") as f:
+            f.write(s.getvalue())
+
+
+env["BUILDERS"]["MakeGDExtTemplateBuilder"] = Builder(
+    action=env.Run(make_templates),
+    suffix=".h",
+)
+
+# Template files
+templates_sources = Glob("template/*") + Glob("template/*/*") + Glob("template/*/*/*")
+
+dest_file = "gdextension_template_files.gen.h"
+env.Alias("editor_template_gdext", [env.MakeGDExtTemplateBuilder(dest_file, templates_sources)])

--- a/editor/settings/gdextension/cpp_scons/cpp_scons_gdext_creator.cpp
+++ b/editor/settings/gdextension/cpp_scons/cpp_scons_gdext_creator.cpp
@@ -1,0 +1,253 @@
+/**************************************************************************/
+/*  cpp_scons_gdext_creator.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "cpp_scons_gdext_creator.h"
+
+#include "core/io/dir_access.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "core/string/string_builder.h"
+#include "core/version.h"
+#include "editor/editor_node.h"
+#include "editor/settings/gdextension/cpp_scons/gdextension_template_files.gen.h"
+
+void CppSconsGDExtensionCreator::_git_clone_godot_cpp(const String &p_parent_path, bool p_compile) {
+	EditorProgress ep("Preparing GDExtension C++ plugin", "Preparing GDExtension C++ plugin", 3);
+	List<String> args = { "clone", "--single-branch", "--branch", VERSION_BRANCH, "https://github.com/godotengine/godot-cpp" };
+	const String godot_cpp_path = p_parent_path.trim_prefix("res://").path_join("godot-cpp");
+	args.push_back(godot_cpp_path);
+	ep.step(TTR("Cloning godot-cpp..."), 1);
+	String output = "";
+	int result = OS::get_singleton()->execute("git", args, &output);
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	if (result != 0 || !dir->dir_exists(godot_cpp_path)) {
+		args.get(3) = "master";
+		output = "";
+		result = OS::get_singleton()->execute("git", args, &output);
+	}
+	ERR_FAIL_COND_MSG(result != 0 || !dir->dir_exists(godot_cpp_path), "Failed to clone godot-cpp. Please clone godot-cpp manually in order to have a working GDExtension plugin.");
+	if (p_compile) {
+		ep.step(TTR("Performing initial compile... (this may take several minutes)"), 2);
+		result = OS::get_singleton()->execute("scons", List<String>());
+		ERR_FAIL_COND_MSG(result != 0, "Failed to compile godot-cpp. Please ensure SCons is installed, then run the `scons` command in your project.");
+	}
+	ep.step(TTR("Done!"), 3);
+}
+
+String CppSconsGDExtensionCreator::_process_template(const String &p_contents) {
+	String ret;
+	if (strip_module_defines) {
+		StringBuilder builder;
+		bool keep = true;
+		PackedStringArray lines = p_contents.split("\n");
+		for (const String &line : lines) {
+			if (line == "#if GDEXTENSION" || line == "#else") {
+				continue;
+			} else if (line == "#elif GODOT_MODULE") {
+				keep = false;
+				continue;
+			} else if (line == "#endif") {
+				keep = true;
+				continue;
+			}
+			if (keep) {
+				builder += line;
+				builder += "\n";
+			}
+		}
+		ret = builder.as_string();
+	} else {
+		ret = p_contents;
+	}
+	if (ClassDB::class_exists("ExampleNode")) {
+		ret = ret.replace("ExampleNode", example_node_name);
+	}
+	ret = ret.replace("__BASE_NAME__", base_name);
+	ret = ret.replace("__BASE_NAME_UPPER__", base_name.to_upper());
+	ret = ret.replace("__LIBRARY_NAME__", library_name);
+	ret = ret.replace("__LIBRARY_NAME_UPPER__", library_name.to_upper());
+	ret = ret.replace("__GODOT_VERSION__", VERSION_BRANCH);
+	ret = ret.replace("__BASE_PATH__", res_path.trim_prefix("res://"));
+	ret = ret.replace("__UPDIR_DOTS__", updir_dots);
+	if (!ret.ends_with("\n")) {
+		ret = ret + "\n";
+	}
+	return ret;
+}
+
+void CppSconsGDExtensionCreator::_write_file(const String &p_file_path, const String &p_contents) {
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_file_path, FileAccess::WRITE, &err);
+	ERR_FAIL_COND_MSG(err != OK, "Couldn't write file at path: " + p_file_path + ".");
+	file->store_string(_process_template(p_contents));
+	file->close();
+}
+
+void CppSconsGDExtensionCreator::_ensure_file_contains(const String &p_file_path, const String &p_new_contents) {
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_file_path, FileAccess::READ_WRITE, &err);
+	if (err != OK) {
+		_write_file(p_file_path, p_new_contents);
+		return;
+	}
+	String new_contents = _process_template(p_new_contents);
+	String existing_contents = file->get_as_text();
+	if (existing_contents.is_empty()) {
+		file->store_string(new_contents);
+	} else {
+		file->seek_end();
+		PackedStringArray lines = new_contents.split("\n", false);
+		for (const String &line : lines) {
+			if (!existing_contents.contains(line)) {
+				file->store_string(line + "\n");
+			}
+		}
+	}
+	file->close();
+}
+
+void CppSconsGDExtensionCreator::_write_common_files_and_dirs() {
+	DirAccess::make_dir_recursive_absolute(res_path.path_join("doc_classes"));
+	DirAccess::make_dir_recursive_absolute(res_path.path_join("icons"));
+	DirAccess::make_dir_recursive_absolute(res_path.path_join("src"));
+	_ensure_file_contains("res://SConstruct", SCONSTRUCT_TOP_LEVEL);
+	_write_file(res_path.path_join("doc_classes/" + example_node_name + ".xml"), EXAMPLENODE_XML);
+	_write_file(res_path.path_join("icons/" + example_node_name + ".svg"), EXAMPLENODE_SVG);
+	_write_file(res_path.path_join("icons/" + example_node_name + ".svg.import"), EXAMPLENODE_SVG_IMPORT);
+	_write_file(res_path.path_join("src/.gdignore"), "");
+	_write_file(res_path.path_join(".gitignore"), GDEXT_GITIGNORE + "\n*.obj");
+	_write_file(res_path.path_join(library_name + ".gdextension"), LIBRARY_NAME_GDEXTENSION);
+}
+
+void CppSconsGDExtensionCreator::_write_gdext_only_files() {
+	_ensure_file_contains("res://.gitignore", "*.dblite");
+	_write_file(res_path.path_join("src/example_node.cpp"), EXAMPLE_NODE_CPP);
+	_write_file(res_path.path_join("src/example_node.h"), EXAMPLE_NODE_H);
+	_write_file(res_path.path_join("src/register_types.cpp"), REGISTER_TYPES_CPP);
+	_write_file(res_path.path_join("src/register_types.h"), REGISTER_TYPES_H);
+	_write_file(res_path.path_join("src/" + library_name + "_defines.h"), GDEXT_DEFINES_H);
+	_write_file(res_path.path_join("src/initialize_gdextension.cpp"), INITIALIZE_GDEXTENSION_CPP.replace("#include \"__UPDIR_DOTS__/../", "#include \""));
+	_write_file(res_path.path_join("SConstruct"), SCONSTRUCT_ADDON.replace(" + Glob(\"__UPDIR_DOTS__/*.cpp\")", "").replace(", \"__UPDIR_DOTS__/\"", "").replace("__UPDIR_DOTS__/editor", "src/editor"));
+}
+
+void CppSconsGDExtensionCreator::_write_gdext_module_files() {
+	_ensure_file_contains("res://.gitignore", GDEXT_GITIGNORE);
+	DirAccess::make_dir_recursive_absolute("res://tests/nodes");
+	_write_file("res://SCsub", SCSUB);
+	_write_file("res://config.py", CONFIG_PY);
+	_write_file("res://example_node.cpp", EXAMPLE_NODE_CPP);
+	_write_file("res://example_node.h", EXAMPLE_NODE_H);
+	_write_file("res://register_types.cpp", REGISTER_TYPES_CPP);
+	_write_file("res://register_types.h", REGISTER_TYPES_H);
+	_write_file("res://" + library_name + "_defines.h", SHARED_DEFINES_H);
+	_write_file("res://tests/test_" + base_name + ".h", TEST_BASE_NAME_H);
+	_write_file("res://tests/nodes/test_example_node.h", TEST_EXAMPLE_NODE_H);
+	_write_file(res_path.path_join("src/initialize_gdextension.cpp"), INITIALIZE_GDEXTENSION_CPP);
+	_write_file(res_path.path_join("SConstruct"), SCONSTRUCT_ADDON);
+}
+
+void CppSconsGDExtensionCreator::create_gdextension(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) {
+	res_path = p_path;
+	base_name = p_base_name;
+	library_name = p_library_name;
+	updir_dots = String("../").repeat(p_path.count("/", 6)) + "..";
+	strip_module_defines = p_variation_index == LANG_VAR_GDEXT_ONLY;
+	if (ClassDB::class_exists("ExampleNode")) {
+		int discriminator = 2;
+		example_node_name = "ExampleNode2";
+		while (ClassDB::class_exists(example_node_name)) {
+			discriminator++;
+			example_node_name = "ExampleNode" + itos(discriminator);
+		}
+	}
+	_write_common_files_and_dirs();
+	if (p_variation_index == LANG_VAR_GDEXT_ONLY) {
+		_write_gdext_only_files();
+	} else {
+		_write_gdext_module_files();
+	}
+	if (does_git_exist) {
+		_git_clone_godot_cpp(p_path.path_join("src"), p_compile);
+	}
+}
+
+void CppSconsGDExtensionCreator::setup_creator() {
+	// Check for Git and SCons.
+	List<String> args;
+	args.push_back("--version");
+	String output;
+	OS::get_singleton()->execute("git", args, &output);
+	if (output.is_empty()) {
+		does_git_exist = false;
+	} else {
+		does_git_exist = true;
+		output = "";
+		OS::get_singleton()->execute("scons", args, &output);
+		does_scons_exist = !output.is_empty();
+	}
+}
+
+PackedStringArray CppSconsGDExtensionCreator::get_language_variations() const {
+	PackedStringArray variants;
+	// Keep this in sync with enum LanguageVariation.
+	variants.push_back("C++ with SCons, GDExtension only");
+	variants.push_back("C++ with SCons, GDExtension and engine module");
+	return variants;
+}
+
+Dictionary CppSconsGDExtensionCreator::get_validation_messages(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) {
+	Dictionary messages;
+	// Check for Git and SCons.
+	MessageType compile_consequence = p_compile ? MSG_ERROR : MSG_WARNING;
+	if (does_git_exist) {
+		if (does_scons_exist) {
+#ifdef WINDOWS_ENABLED
+			messages[TTR("Both Git and SCons were found. You also need a C++17-compatible compiler, such as GCC, Clang/LLVM, or MSVC from Visual Studio.")] = MSG_OK;
+#else
+			messages[TTR("Both Git and SCons were found. You also need a C++17-compatible compiler, such as GCC or Clang/LLVM.")] = MSG_OK;
+#endif
+		} else {
+			messages[TTR("Cannot compile now, SCons was not found.")] = compile_consequence;
+		}
+	} else {
+		messages[TTR("Cannot compile now, Git was not found.")] = compile_consequence;
+	}
+	// Check for existing engine module.
+	if (p_variation_index == LANG_VAR_GDEXT_MODULE) {
+		Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		if (dir->file_exists("SCsub")) {
+			messages[TTR("This project already contains a C++ engine module.")] = MSG_ERROR;
+		} else {
+			messages[TTR("Able to create engine module in this Godot project. Note that the base name should match the project's folder name when used as a module.")] = MSG_OK;
+			messages[TTR("Warning: This will turn the root of your project into an engine module!")] = MSG_WARNING;
+		}
+	}
+	return messages;
+}

--- a/editor/settings/gdextension/cpp_scons/cpp_scons_gdext_creator.h
+++ b/editor/settings/gdextension/cpp_scons/cpp_scons_gdext_creator.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  project_settings_gdextension.h                                        */
+/*  cpp_scons_gdext_creator.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,34 +30,37 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
+#include "editor/settings/gdextension/gdextension_creator_plugin.h"
 
-class GDExtensionCreateDialog;
-class Tree;
-
-class ProjectSettingsGDExtension : public VBoxContainer {
-	GDCLASS(ProjectSettingsGDExtension, VBoxContainer);
-
-	enum {
-		COLUMN_PATH,
-		COLUMN_MIN_VERSION,
-		COLUMN_MAX_VERSION,
-		COLUMN_RELOAD,
-		COLUMN_MAX,
+class CppSconsGDExtensionCreator : public GDExtensionCreatorPlugin {
+	// Keep this in sync with get_language_variations().
+	enum LanguageVariation {
+		LANG_VAR_GDEXT_ONLY,
+		LANG_VAR_GDEXT_MODULE,
 	};
 
-	GDExtensionCreateDialog *create_dialog = nullptr;
-	Tree *extension_list = nullptr;
+	// Used by _process_template.
+	String base_name;
+	String library_name;
+	String example_node_name = "ExampleNode";
+	String res_path;
+	String updir_dots;
+	bool strip_module_defines = false;
 
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _on_create_gdextension_pressed();
-	void _on_gdextension_created();
-	void _on_item_activated();
-	void _update_extension_tree();
+	bool does_git_exist = false;
+	bool does_scons_exist = false;
 
-protected:
-	void _notification(int p_what);
+	void _git_clone_godot_cpp(const String &p_parent_path, bool p_compile);
+	String _process_template(const String &p_contents);
+	void _write_common_files_and_dirs();
+	void _write_gdext_only_files();
+	void _write_gdext_module_files();
+	void _write_file(const String &p_file_path, const String &p_contents);
+	void _ensure_file_contains(const String &p_file_path, const String &p_new_contents);
 
 public:
-	ProjectSettingsGDExtension();
+	void create_gdextension(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) override;
+	void setup_creator() override;
+	PackedStringArray get_language_variations() const override;
+	Dictionary get_validation_messages(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) override;
 };

--- a/editor/settings/gdextension/cpp_scons/template/SConstruct_top_level
+++ b/editor/settings/gdextension/cpp_scons/template/SConstruct_top_level
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+# This file is for building as a Godot GDExtension.
+SConscript("__BASE_PATH__/SConstruct")

--- a/editor/settings/gdextension/cpp_scons/template/SCsub
+++ b/editor/settings/gdextension/cpp_scons/template/SCsub
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+# This file is for building as a Godot engine module.
+
+Import("env")
+Import("env_modules")
+
+env_modules.Append(CPPDEFINES=["GODOT_MODULE"])
+
+env___BASE_NAME__ = env_modules.Clone()
+
+env___BASE_NAME__.add_source_files(env.modules_sources, "*.cpp")
+
+if env.editor_build:
+    # If your module has editor-specific code, you can add it here.
+    # env___BASE_NAME__.add_source_files(env.modules_sources, "editor/*.cpp")
+    pass

--- a/editor/settings/gdextension/cpp_scons/template/addon/SConstruct_addon
+++ b/editor/settings/gdextension/cpp_scons/template/addon/SConstruct_addon
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# This file is for building as a Godot GDExtension.
+ARGUMENTS.setdefault("precision", "double")
+env = SConscript("src/godot-cpp/SConstruct")
+
+# Add source files.
+env.Append(CPPPATH=["src/", "__UPDIR_DOTS__/"])
+sources = Glob("src/*.cpp") + Glob("__UPDIR_DOTS__/*.cpp")
+
+env.Append(CPPDEFINES=["GDEXTENSION"])
+
+bin_path = "bin/"
+extension_name = "__LIBRARY_NAME__"
+debug_or_release = "release" if env["target"] == "template_release" else "debug"
+
+if not "arch_suffix" in env:
+    env["arch_suffix"] = env["arch"]
+
+if env["target"] in ["editor", "template_debug"]:
+    # GDExtension has editor classes available in debug templates, which allows editor code to compile.
+    # If you don't want to compile editor stuff in templates, move these 2 lines to a separate "if" block.
+    env.Append(CPPPATH=["__UPDIR_DOTS__/editor/"])
+    sources += Glob("__UPDIR_DOTS__/editor/*.cpp")
+    # Add documentation XML files as a generated cpp file. Only works in Godot 4.3+.
+    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+    sources.append(doc_data)
+
+# Create the library target (e.g. lib__LIBRARY_NAME__.linux.debug.x86_64.so).
+if env["platform"] == "macos":
+    library = env.SharedLibrary(
+        "{0}/lib{1}.{2}.{3}.framework/{1}.{2}.{3}".format(
+            bin_path,
+            extension_name,
+            env["platform"],
+            debug_or_release,
+        ),
+        source=sources,
+    )
+else:
+    library = env.SharedLibrary(
+        "{}/{}{}.{}.{}.{}{}".format(
+            bin_path,
+            env.subst('$SHLIBPREFIX'),
+            extension_name,
+            env["platform"],
+            debug_or_release,
+            env["arch_suffix"],
+            env["SHLIBSUFFIX"],
+        ),
+        source=sources,
+    )
+
+Default(library)

--- a/editor/settings/gdextension/cpp_scons/template/addon/doc_classes/ExampleNode.xml
+++ b/editor/settings/gdextension/cpp_scons/template/addon/doc_classes/ExampleNode.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ExampleNode" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		GDExtension example node.
+	</brief_description>
+	<description>
+		An example node that demonstrates how to create a node in [GDExtension], which can be compiled and loaded by [GDExtensionManager]. This example node can also be compiled as an engine module, if that option was selected in the editor when creating the GDExtension.
+	</description>
+	<tutorials>
+		<link title="The GDExtension system">$DOCS_URL/tutorials/scripting/gdextension/index.html</link>
+		<link title="GDExtension C++ (godot-cpp)">$DOCS_URL/tutorials/scripting/cpp/index.html</link>
+	</tutorials>
+	<methods>
+		<method name="print_hello" qualifiers="const">
+			<return type="void" />
+			<description>
+				Prints either [code]"Hello, World! From GDExtension."[/code] if compiled as GDExtension or [code]"Hello, World! From a module."[/code] if compiled as a module, determined by the [code]#if[/code] directives in the C++ code. If neither a module nor extension, the code does not compile.
+			</description>
+		</method>
+		<method name="return_hello" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns either [code]"Hello, World! From GDExtension."[/code] if compiled as GDExtension or [code]"Hello, World! From a module."[/code] if compiled as a module, determined by the [code]#if[/code] directives in the C++ code. If neither a module nor extension, the code does not compile.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/settings/gdextension/cpp_scons/template/addon/gdext.gitignore
+++ b/editor/settings/gdextension/cpp_scons/template/addon/gdext.gitignore
@@ -1,0 +1,23 @@
+# GDExtension generated files
+*.gen.*
+.sconsign*.dblite
+__pycache__/
+bin/
+compile_commands.json
+src/gen/
+
+# Compiled files
+*.bc
+*.creator
+*.creator.user
+*.dblite
+*.exp
+*.files
+*.idb
+*.includes
+*.lib
+*.o
+*.os
+*.pdb
+*.pyc
+*.so

--- a/editor/settings/gdextension/cpp_scons/template/addon/icons/ExampleNode.svg
+++ b/editor/settings/gdextension/cpp_scons/template/addon/icons/ExampleNode.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="5" fill="none" stroke="#b0b" stroke-width="2"/></svg>

--- a/editor/settings/gdextension/cpp_scons/template/addon/icons/ExampleNode.svg.import
+++ b/editor/settings/gdextension/cpp_scons/template/addon/icons/ExampleNode.svg.import
@@ -1,0 +1,3 @@
+[params]
+
+svg/scale=4.0

--- a/editor/settings/gdextension/cpp_scons/template/addon/library_name.gdextension
+++ b/editor/settings/gdextension/cpp_scons/template/addon/library_name.gdextension
@@ -1,0 +1,32 @@
+[configuration]
+
+entry_symbol = "__LIBRARY_NAME___library_init"
+compatibility_minimum = __GODOT_VERSION__
+reloadable = true
+
+[libraries]
+
+android.debug.arm64 = "./bin/lib__LIBRARY_NAME__.android.debug.arm64.so"
+android.release.arm64 = "./bin/lib__LIBRARY_NAME__.android.release.arm64.so"
+ios.debug = "./bin/lib__LIBRARY_NAME__.ios.debug.universal.dylib"
+ios.release = "./bin/lib__LIBRARY_NAME__.ios.release.universal.dylib"
+linux.debug.x86_64 = "./bin/lib__LIBRARY_NAME__.linux.debug.x86_64.so"
+linux.release.x86_64 = "./bin/lib__LIBRARY_NAME__.linux.release.x86_64.so"
+linux.debug.arm64 = "./bin/lib__LIBRARY_NAME__.linux.debug.arm64.so"
+linux.release.arm64 = "./bin/lib__LIBRARY_NAME__.linux.release.arm64.so"
+linux.debug.rv64 = "./bin/lib__LIBRARY_NAME__.linux.debug.rv64.so"
+linux.release.rv64 = "./bin/lib__LIBRARY_NAME__.linux.release.rv64.so"
+macos.debug = "./bin/lib__LIBRARY_NAME__.macos.debug.framework"
+macos.release = "./bin/lib__LIBRARY_NAME__.macos.release.framework"
+web.debug.wasm32.nothreads = "./bin/lib__LIBRARY_NAME__.web.debug.wasm32.nothreads.wasm"
+web.release.wasm32.nothreads = "./bin/lib__LIBRARY_NAME__.web.release.wasm32.nothreads.wasm"
+web.debug.wasm32.threads = "./bin/lib__LIBRARY_NAME__.web.debug.wasm32.wasm"
+web.release.wasm32.threads = "./bin/lib__LIBRARY_NAME__.web.release.wasm32.wasm"
+windows.debug.x86_64 = "./bin/__LIBRARY_NAME__.windows.debug.x86_64.dll"
+windows.release.x86_64 = "./bin/__LIBRARY_NAME__.windows.release.x86_64.dll"
+windows.debug.arm64 = "./bin/__LIBRARY_NAME__.windows.debug.arm64.dll"
+windows.release.arm64 = "./bin/__LIBRARY_NAME__.windows.release.arm64.dll"
+
+[icons]
+
+ExampleNode = "icons/ExampleNode.svg"

--- a/editor/settings/gdextension/cpp_scons/template/addon/src/gdext_defines.h
+++ b/editor/settings/gdextension/cpp_scons/template/addon/src/gdext_defines.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// This file should be included before any other files.
+
+// The build system already defines GDEXTENSION, but this helps IDEs detect the build mode.
+#define GDEXTENSION 1
+
+// Extremely common classes used by most files. Customize for your extension as needed.
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/version.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace CoreBind = godot;
+// Including the namespace helps make GDExtension code more similar to module code.
+// Remove this if you prefer to use the `godot::` namespace explicitly.
+using namespace godot;

--- a/editor/settings/gdextension/cpp_scons/template/addon/src/initialize_gdextension.cpp
+++ b/editor/settings/gdextension/cpp_scons/template/addon/src/initialize_gdextension.cpp
@@ -1,0 +1,16 @@
+#include "__UPDIR_DOTS__/../register_types.h"
+
+#include <gdextension_interface.h>
+
+extern "C" {
+// Initialization.
+GDExtensionBool GDE_EXPORT __LIBRARY_NAME___library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
+
+	init_obj.register_initializer(initialize___BASE_NAME___module);
+	init_obj.register_terminator(uninitialize___BASE_NAME___module);
+	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+
+	return init_obj.init();
+}
+} // extern "C"

--- a/editor/settings/gdextension/cpp_scons/template/addon/src/initialize_gdextension.cpp
+++ b/editor/settings/gdextension/cpp_scons/template/addon/src/initialize_gdextension.cpp
@@ -1,0 +1,18 @@
+#include "__UPDIR_DOTS__/../register_types.h"
+
+#include <gdextension_interface.h>
+
+extern "C" {
+// Initialization.
+GDExtensionBool GDE_EXPORT __LIBRARY_NAME___library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
+
+	init_obj.register_initializer(initialize___BASE_NAME___module);
+	init_obj.register_terminator(uninitialize___BASE_NAME___module);
+	// Setting this to SCENE enables reloading, but prevents using CORE or SERVERS initialization levels.
+	// Reloading will only actually occur if `reloadable = true` is set in the .gdextension file.
+	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+
+	return init_obj.init();
+}
+} // extern "C"

--- a/editor/settings/gdextension/cpp_scons/template/config.py
+++ b/editor/settings/gdextension/cpp_scons/template/config.py
@@ -1,0 +1,21 @@
+# This file is for building as a Godot engine module.
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "ExampleNode",
+    ]
+
+
+def get_doc_path():
+    return "__BASE_PATH__/doc_classes"
+
+
+def get_icons_path():
+    return "__BASE_PATH__/icons"

--- a/editor/settings/gdextension/cpp_scons/template/example_node.cpp
+++ b/editor/settings/gdextension/cpp_scons/template/example_node.cpp
@@ -1,0 +1,36 @@
+#include "example_node.h"
+
+void ExampleNode::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+#if GDEXTENSION
+			print_line("The example GDExtension node has been added to the scene tree and is now ready!");
+#elif GODOT_MODULE
+			print_line("The example engine module node has been added to the scene tree and is now ready!");
+#else
+#error "Must build as Godot GDExtension or Godot module."
+#endif
+		} break;
+	}
+}
+
+void ExampleNode::print_hello() const {
+#if GDEXTENSION
+	print_line("Hello, World! From GDExtension.");
+#elif GODOT_MODULE
+	print_line("Hello, World! From a module.");
+#endif
+}
+
+String ExampleNode::return_hello() const {
+#if GDEXTENSION
+	return "Hello, World! From GDExtension.";
+#elif GODOT_MODULE
+	return "Hello, World! From a module.";
+#endif
+}
+
+void ExampleNode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("print_hello"), &ExampleNode::print_hello);
+	ClassDB::bind_method(D_METHOD("return_hello"), &ExampleNode::return_hello);
+}

--- a/editor/settings/gdextension/cpp_scons/template/example_node.h
+++ b/editor/settings/gdextension/cpp_scons/template/example_node.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "__LIBRARY_NAME___defines.h"
+
+#if GDEXTENSION
+#include <godot_cpp/classes/node.hpp>
+#elif GODOT_MODULE
+#include "scene/main/node.h"
+#endif
+
+class ExampleNode : public Node {
+	GDCLASS(ExampleNode, Node);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	void print_hello() const;
+	String return_hello() const;
+};

--- a/editor/settings/gdextension/cpp_scons/template/register_types.cpp
+++ b/editor/settings/gdextension/cpp_scons/template/register_types.cpp
@@ -1,0 +1,34 @@
+#include "register_types.h"
+
+#if GDEXTENSION
+#include <godot_cpp/classes/engine.hpp>
+#elif GODOT_MODULE
+#include "core/config/engine.h"
+#include "core/core_bind.h"
+#endif
+
+#include "example_node.h"
+
+inline void add_godot_singleton(const StringName &p_singleton_name, Object *p_object) {
+	CoreBind::Engine::get_singleton()->register_singleton(p_singleton_name, p_object);
+}
+
+inline void remove_godot_singleton(const StringName &p_singleton_name) {
+	CoreBind::Engine::get_singleton()->unregister_singleton(p_singleton_name);
+}
+
+void initialize___BASE_NAME___module(ModuleInitializationLevel p_level) {
+	// Note: Classes MUST be registered in inheritance order.
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		// Register node classes here.
+		// You can add singletons using add_godot_singleton().
+		GDREGISTER_CLASS(ExampleNode);
+	}
+}
+
+void uninitialize___BASE_NAME___module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		// Perform cleanup here.
+		// You can remove singletons using remove_godot_singleton().
+	}
+}

--- a/editor/settings/gdextension/cpp_scons/template/register_types.cpp
+++ b/editor/settings/gdextension/cpp_scons/template/register_types.cpp
@@ -1,0 +1,34 @@
+#include "register_types.h"
+
+#if GDEXTENSION
+#include <godot_cpp/classes/engine.hpp>
+#elif GODOT_MODULE
+#include "core/config/engine.h"
+#include "core/core_bind.h"
+#endif
+
+#include "example_node.h"
+
+inline void add_godot_singleton(const StringName &p_singleton_name, Object *p_object) {
+	CoreBind::Engine::get_singleton()->register_singleton(p_singleton_name, p_object);
+}
+
+inline void remove_godot_singleton(const StringName &p_singleton_name) {
+	CoreBind::Engine::get_singleton()->unregister_singleton(p_singleton_name);
+}
+
+void initialize___BASE_NAME___module(ModuleInitializationLevel p_level) {
+	// Classes MUST be registered in inheritance order, then dependency order.
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		// Register node classes here.
+		// You can add singletons using add_godot_singleton().
+		GDREGISTER_CLASS(ExampleNode);
+	}
+}
+
+void uninitialize___BASE_NAME___module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		// Perform cleanup here.
+		// You can remove singletons using remove_godot_singleton().
+	}
+}

--- a/editor/settings/gdextension/cpp_scons/template/register_types.h
+++ b/editor/settings/gdextension/cpp_scons/template/register_types.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "__LIBRARY_NAME___defines.h"
+
+#if GDEXTENSION
+#include <godot_cpp/core/class_db.hpp>
+#elif GODOT_MODULE
+#include "modules/register_module_types.h"
+#else
+#error "Must build as Godot GDExtension or Godot module."
+#endif
+
+void initialize___BASE_NAME___module(ModuleInitializationLevel p_level);
+void uninitialize___BASE_NAME___module(ModuleInitializationLevel p_level);

--- a/editor/settings/gdextension/cpp_scons/template/shared_defines.h
+++ b/editor/settings/gdextension/cpp_scons/template/shared_defines.h
@@ -1,0 +1,34 @@
+#pragma once
+// This file should be included before any other files.
+
+// Uncomment one of these to help IDEs detect the build mode.
+// The build system already defines one of these, so keep them
+// commented out when committing.
+#ifndef GDEXTENSION
+//#define GDEXTENSION 1
+#endif // GDEXTENSION
+
+#ifndef GODOT_MODULE
+//#define GODOT_MODULE 1
+#endif // GODOT_MODULE
+
+#if GDEXTENSION
+// Extremely common classes used by most files. Customize for your extension as needed.
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/version.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace CoreBind = godot;
+// Including the namespace helps make GDExtension code more similar to module code.
+using namespace godot;
+
+#elif GODOT_MODULE
+#include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
+#include "core/string/ustring.h"
+#include "core/version.h"
+
+#else
+#error "Must build as Godot GDExtension or Godot module."
+#endif

--- a/editor/settings/gdextension/cpp_scons/template/tests/test_base_name.h
+++ b/editor/settings/gdextension/cpp_scons/template/tests/test_base_name.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define GODOT_MODULE 1
+
+#include "nodes/test_example_node.h"

--- a/editor/settings/gdextension/cpp_scons/template/tests/test_example_node.h
+++ b/editor/settings/gdextension/cpp_scons/template/tests/test_example_node.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../example_node.h"
+
+#include "tests/test_macros.h"
+
+namespace TestExampleNode {
+TEST_CASE("[ExampleNode] Hello") {
+	ExampleNode test = ExampleNode();
+	const String hello_text = test.return_hello();
+	REQUIRE(hello_text == "Hello, World! From a module.");
+}
+} // namespace TestExampleNode

--- a/editor/settings/gdextension/gdextension_create_dialog.cpp
+++ b/editor/settings/gdextension/gdextension_create_dialog.cpp
@@ -1,0 +1,265 @@
+/**************************************************************************/
+/*  gdextension_create_dialog.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdextension_create_dialog.h"
+
+#include "core/io/dir_access.h"
+#include "core/object/callable_mp.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "editor/settings/gdextension/gdextension_creator_plugin.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+
+void GDExtensionCreateDialog::load_plugin_creators(const Vector<Ref<GDExtensionCreatorPlugin>> &p_plugin_creators) {
+	plugin_creators = p_plugin_creators;
+	language_option->clear();
+	language_option_index_map.clear();
+	for (int i = 0; i < plugin_creators.size(); i++) {
+		const Ref<GDExtensionCreatorPlugin> plugin_creator = plugin_creators[i];
+		plugin_creator->setup_creator();
+		const Vector<String> lang_variations = plugin_creator->get_language_variations();
+		for (int j = 0; j < lang_variations.size(); j++) {
+			language_option->add_item(lang_variations[j]);
+			language_option_index_map.push_back(Vector2i(i, j));
+		}
+	}
+	language_option->select(0);
+}
+
+void GDExtensionCreateDialog::_clear_fields() {
+	base_name_edit->clear();
+	library_name_edit->clear();
+	path_edit->clear();
+	library_name_edit->set_placeholder("my_extension");
+	path_edit->set_placeholder("res://addons/my_extension");
+}
+
+void GDExtensionCreateDialog::_on_canceled() {
+	_clear_fields();
+}
+
+void GDExtensionCreateDialog::_on_confirmed() {
+	const String valid_base_name = _get_valid_base_name();
+	const String valid_library_name = _get_valid_library_name(valid_base_name);
+	const String valid_path = _get_valid_path(valid_base_name);
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	dir->make_dir_recursive(valid_path);
+	Vector2i selected_indices = language_option_index_map[language_option->get_selected_id()];
+	Ref<GDExtensionCreatorPlugin> plugin_creator = plugin_creators[selected_indices.x];
+	plugin_creator->create_gdextension(valid_path, valid_base_name, valid_library_name, selected_indices.y, compile_checkbox->is_pressed());
+	_clear_fields();
+	emit_signal("gdextension_created");
+}
+
+void GDExtensionCreateDialog::_on_required_text_changed() {
+	// Erase existing messages.
+	const int start_message_count = validation_panel->get_message_count();
+	for (int i = 1; i < start_message_count; i++) {
+		validation_panel->set_message(i, "", EditorValidationPanel::MSG_INFO);
+	}
+	if (base_name_edit->get_text().is_empty()) {
+		validation_panel->set_message(MSG_ID_BASE_NAME, TTR("Please specify a base name."), EditorValidationPanel::MSG_ERROR);
+		library_name_edit->set_placeholder("my_extension");
+		path_edit->set_placeholder("res://addons/my_extension");
+		return;
+	}
+	// Update included messages for the text boxes.
+	const String valid_base_name = _get_valid_base_name();
+	const String valid_library_name = _get_valid_library_name(valid_base_name);
+	const String valid_path = _get_valid_path(valid_base_name);
+	library_name_edit->set_placeholder(valid_library_name);
+	path_edit->set_placeholder(valid_path);
+	validation_panel->set_message(MSG_ID_BASE_NAME, TTR("Base name will be: ") + valid_base_name, EditorValidationPanel::MSG_OK);
+	validation_panel->set_message(MSG_ID_LIBRARY_NAME, TTR("Library name will be: ") + valid_library_name, EditorValidationPanel::MSG_OK);
+	validation_panel->set_message(MSG_ID_PATH, TTR("Path will be: ") + valid_path, EditorValidationPanel::MSG_OK);
+	// Write new custom messages.
+	Vector2i selected_indices = language_option_index_map[language_option->get_selected_id()];
+	Ref<GDExtensionCreatorPlugin> plugin_creator = plugin_creators[selected_indices.x];
+	Dictionary validation_messages = plugin_creator->get_validation_messages(valid_base_name, valid_library_name, valid_path, selected_indices.y, compile_checkbox->is_pressed());
+	Array messages = validation_messages.keys();
+	for (int i = 0; i < messages.size(); i++) {
+		const String message = messages[i];
+		const int status = validation_messages[message];
+		const int index = i + MSG_ID_MAX;
+		if (index >= start_message_count) {
+			validation_panel->add_line(index, "");
+		}
+		validation_panel->set_message(index, message, (EditorValidationPanel::MessageType)status);
+	}
+}
+
+String GDExtensionCreateDialog::_get_valid_base_name() {
+	String text = base_name_edit->get_text().strip_edges().validate_ascii_identifier();
+	if (text.begins_with("_")) {
+		return text.substr(1);
+	}
+	return text;
+}
+
+String GDExtensionCreateDialog::_get_valid_library_name(const String &p_valid_base_name) {
+	String text = library_name_edit->get_text().strip_edges();
+	if (text.is_empty()) {
+		text = p_valid_base_name;
+	}
+	if (is_digit(text[0])) {
+		text = "godot_" + text;
+	}
+	return text.validate_ascii_identifier();
+}
+
+String GDExtensionCreateDialog::_get_valid_path(const String &p_valid_base_name) {
+	String text = path_edit->get_text().strip_edges();
+	if (text.is_empty()) {
+		text = p_valid_base_name;
+	}
+	if (!text.begins_with("res://")) {
+		if (text.contains("/")) {
+			return "res://" + text;
+		} else {
+			return "res://addons/" + text;
+		}
+	}
+	return text;
+}
+
+void GDExtensionCreateDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("gdextension_created"));
+}
+
+void GDExtensionCreateDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				base_name_edit->grab_focus();
+			}
+		} break;
+
+		case NOTIFICATION_READY: {
+			connect(SceneStringName(confirmed), callable_mp(this, &GDExtensionCreateDialog::_on_confirmed));
+			get_cancel_button()->connect(SceneStringName(pressed), callable_mp(this, &GDExtensionCreateDialog::_on_canceled));
+		} break;
+	}
+}
+
+GDExtensionCreateDialog::GDExtensionCreateDialog() {
+	get_ok_button()->set_disabled(true);
+	get_ok_button()->set_text(TTR("Create"));
+	set_hide_on_ok(true);
+	set_title(TTR("Create GDExtension"));
+
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(vbox);
+
+	GridContainer *grid = memnew(GridContainer);
+	grid->set_columns(2);
+	grid->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vbox->add_child(grid);
+
+	// Base name line edit.
+	Label *base_name_label = memnew(Label);
+	base_name_label->set_text(TTR("Base Name:"));
+	base_name_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(base_name_label);
+
+	base_name_edit = memnew(LineEdit);
+	base_name_edit->set_placeholder("my_extension");
+	base_name_edit->set_tooltip_text(TTR("Required. The base name of the extension. Must be valid as an identifier continuation in a programming language (alphanumeric and underscores).\nThis will be used to determine the library and folder names, if unspecified.\nFor engine modules, this must match the module's folder name."));
+	base_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(base_name_edit);
+
+	// Library name line edit.
+	Label *library_name_label = memnew(Label);
+	library_name_label->set_text(TTR("Library Name:"));
+	library_name_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(library_name_label);
+
+	library_name_edit = memnew(LineEdit);
+	library_name_edit->set_placeholder("my_extension");
+	library_name_edit->set_tooltip_text(TTR("This should be similar to the base name, but must on its own be a valid identifier in a programming language.\nThis is used for the defines header, the init function, and the compiled library file.\nAs a good practice, this should be a superset of the base name."));
+	library_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(library_name_edit);
+
+	// Path line edit.
+	Label *path_label = memnew(Label);
+	path_label->set_text(TTR("Path:"));
+	path_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(path_label);
+
+	path_edit = memnew(LineEdit);
+	path_edit->set_placeholder("res://addons/my_extension");
+	path_edit->set_tooltip_text(TTR("The path to the extension (relative to the project root). If you type this manually, res:// will be added for you."));
+	path_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(path_edit);
+
+	// Language dropdown.
+	Label *language_label = memnew(Label);
+	language_label->set_text(TTR("Language:"));
+	language_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(language_label);
+
+	language_option = memnew(OptionButton);
+	language_option->set_tooltip_text(TTR("The programming language to use for the extension."));
+	grid->add_child(language_option);
+
+	// Compile now checkbox.
+	Label *compile_label = memnew(Label);
+	compile_label->set_text(TTR("Compile now?"));
+	compile_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(compile_label);
+
+	compile_checkbox = memnew(CheckBox);
+	compile_checkbox->set_pressed(true);
+	grid->add_child(compile_checkbox);
+
+	Control *spacing = memnew(Control);
+	vbox->add_child(spacing);
+	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+
+	validation_panel = memnew(EditorValidationPanel);
+	validation_panel->set_custom_minimum_size(Size2(500, 200) * EDSCALE);
+	validation_panel->add_line(MSG_ID_BASE_NAME, TTR("Please specify a base name."));
+	validation_panel->add_line(MSG_ID_LIBRARY_NAME, TTR("Please specify a library name."));
+	validation_panel->add_line(MSG_ID_PATH, TTR("Please specify a path."));
+	validation_panel->set_update_callback(callable_mp(this, &GDExtensionCreateDialog::_on_required_text_changed));
+	validation_panel->set_accept_button(get_ok_button());
+	vbox->add_child(validation_panel);
+	validation_panel->update();
+
+	base_name_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	library_name_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	path_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	language_option->connect(SceneStringName(item_selected), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	compile_checkbox->connect(SceneStringName(pressed), callable_mp(validation_panel, &EditorValidationPanel::update));
+}

--- a/editor/settings/gdextension/gdextension_create_dialog.h
+++ b/editor/settings/gdextension/gdextension_create_dialog.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  project_settings_gdextension.h                                        */
+/*  gdextension_create_dialog.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,34 +30,48 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
+#include "scene/gui/dialogs.h"
 
-class GDExtensionCreateDialog;
-class Tree;
+class CheckBox;
+class EditorValidationPanel;
+class GDExtensionCreatorPlugin;
+class OptionButton;
 
-class ProjectSettingsGDExtension : public VBoxContainer {
-	GDCLASS(ProjectSettingsGDExtension, VBoxContainer);
+class GDExtensionCreateDialog : public ConfirmationDialog {
+	GDCLASS(GDExtensionCreateDialog, ConfirmationDialog);
 
+	// Unbounded enum. Individual GDExtension creators may add more message IDs.
 	enum {
-		COLUMN_PATH,
-		COLUMN_MIN_VERSION,
-		COLUMN_MAX_VERSION,
-		COLUMN_RELOAD,
-		COLUMN_MAX,
+		MSG_ID_BASE_NAME,
+		MSG_ID_LIBRARY_NAME,
+		MSG_ID_PATH,
+		MSG_ID_MAX,
 	};
 
-	GDExtensionCreateDialog *create_dialog = nullptr;
-	Tree *extension_list = nullptr;
+	LineEdit *base_name_edit = nullptr;
+	LineEdit *library_name_edit = nullptr;
+	LineEdit *path_edit = nullptr;
+	OptionButton *language_option = nullptr;
+	CheckBox *compile_checkbox = nullptr;
 
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _on_create_gdextension_pressed();
-	void _on_gdextension_created();
-	void _on_item_activated();
-	void _update_extension_tree();
+	EditorValidationPanel *validation_panel = nullptr;
+	Vector<Ref<GDExtensionCreatorPlugin>> plugin_creators;
+	Vector<Vector2i> language_option_index_map;
+
+	void _clear_fields();
+	void _on_canceled();
+	void _on_confirmed();
+	void _on_required_text_changed();
+
+	String _get_valid_base_name();
+	String _get_valid_library_name(const String &p_valid_base_name);
+	String _get_valid_path(const String &p_valid_base_name);
 
 protected:
+	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
-	ProjectSettingsGDExtension();
+	void load_plugin_creators(const Vector<Ref<GDExtensionCreatorPlugin>> &p_plugin_creators);
+	GDExtensionCreateDialog();
 };

--- a/editor/settings/gdextension/gdextension_creator_plugin.h
+++ b/editor/settings/gdextension/gdextension_creator_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  project_settings_gdextension.h                                        */
+/*  gdextension_creator_plugin.h                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,34 +30,22 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
+#include "core/object/ref_counted.h"
 
-class GDExtensionCreateDialog;
-class Tree;
-
-class ProjectSettingsGDExtension : public VBoxContainer {
-	GDCLASS(ProjectSettingsGDExtension, VBoxContainer);
-
-	enum {
-		COLUMN_PATH,
-		COLUMN_MIN_VERSION,
-		COLUMN_MAX_VERSION,
-		COLUMN_RELOAD,
-		COLUMN_MAX,
-	};
-
-	GDExtensionCreateDialog *create_dialog = nullptr;
-	Tree *extension_list = nullptr;
-
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _on_create_gdextension_pressed();
-	void _on_gdextension_created();
-	void _on_item_activated();
-	void _update_extension_tree();
+class GDExtensionCreatorPlugin : public RefCounted {
+	GDCLASS(GDExtensionCreatorPlugin, RefCounted);
 
 protected:
-	void _notification(int p_what);
+	enum MessageType {
+		MSG_OK,
+		MSG_WARNING,
+		MSG_ERROR,
+		MSG_INFO,
+	};
 
 public:
-	ProjectSettingsGDExtension();
+	virtual void create_gdextension(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) = 0;
+	virtual void setup_creator() = 0;
+	virtual PackedStringArray get_language_variations() const = 0;
+	virtual Dictionary get_validation_messages(const String &p_path, const String &p_base_name, const String &p_library_name, int p_variation_index, bool p_compile) = 0;
 };

--- a/editor/settings/gdextension/project_settings_gdextension.cpp
+++ b/editor/settings/gdextension/project_settings_gdextension.cpp
@@ -35,6 +35,10 @@
 #include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
+#include "editor/file_system/editor_file_system.h"
+#include "editor/settings/gdextension/cpp_scons/cpp_scons_gdext_creator.h"
+#include "editor/settings/gdextension/gdextension_create_dialog.h"
+#include "editor/settings/gdextension/gdextension_creator_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/label.h"
 #include "scene/gui/tree.h"
@@ -71,6 +75,18 @@ void ProjectSettingsGDExtension::_cell_button_pressed(Object *p_item, int p_colu
 	}
 }
 
+void ProjectSettingsGDExtension::_on_create_gdextension_pressed() {
+	Vector<Ref<GDExtensionCreatorPlugin>> creators;
+	creators.append(memnew(CppSconsGDExtensionCreator));
+	create_dialog->load_plugin_creators(creators);
+	create_dialog->popup_centered(Size2(400, 300) * EDSCALE);
+}
+
+void ProjectSettingsGDExtension::_on_gdextension_created() {
+	EditorFileSystem::get_singleton()->scan();
+	_update_extension_tree();
+}
+
 void ProjectSettingsGDExtension::_on_item_activated() {
 	TreeItem *item = extension_list->get_selected();
 	if (item == nullptr) {
@@ -104,12 +120,19 @@ void ProjectSettingsGDExtension::_update_extension_tree() {
 }
 
 ProjectSettingsGDExtension::ProjectSettingsGDExtension() {
+	create_dialog = memnew(GDExtensionCreateDialog);
+	add_child(create_dialog);
+	create_dialog->connect("gdextension_created", callable_mp(this, &ProjectSettingsGDExtension::_on_gdextension_created));
 	// Create the title label.
 	HBoxContainer *title_hb = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTRC("Installed GDExtensions:")));
 	label->set_theme_type_variation("HeaderSmall");
 	title_hb->add_child(label);
 	title_hb->add_spacer();
+	// Create the "Create GDExtension" button.
+	Button *create_plugin_button = memnew(Button(TTR("Create GDExtension")));
+	create_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsGDExtension::_on_create_gdextension_pressed));
+	title_hb->add_child(create_plugin_button);
 	add_child(title_hb);
 	// Create the tree.
 	extension_list = memnew(Tree);

--- a/misc/scripts/header_guards.py
+++ b/misc/scripts/header_guards.py
@@ -10,6 +10,8 @@ changed = []
 invalid = []
 
 for file in sys.argv[1:]:
+    if file.startswith("editor/settings/gdextension/cpp_scons/template/"):
+        continue
     header_start = -1
     header_end = -1
 


### PR DESCRIPTION
This PR implements https://github.com/godotengine/godot-proposals/issues/3367 and https://github.com/godotengine/godot-proposals/issues/9306 (not exactly as the proposals describe, but solves the same problem).

The status quo for GDExtension development is really unfortunate. For the most part the only easy way to get started is to edit the [GDExtension template project](https://github.com/godotengine/godot-cpp-template), or copy-paste an existing GDExtension project and use it as a template. If you don't do this, you'd need to follow the documentation, which is a [massive behemoth](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html) that manually explains to the user how to create each file from scratch, and it would take a user hours to follow this guide.

Really, I believe it should be as simple as making a GDScript plugin:
- Click a button to open a wizard to make an extension.
- Give your extension a name.
- Select a language from the dropdown menu.
- Click Create.

This is what this PR implements. Just go into Project Settings -> GDExtension:

<img width="940" alt="Screenshot 2024-05-27 at 12 02 11 AM" src="https://github.com/godotengine/godot/assets/1646875/c51091fa-fa7d-4d08-a668-f07e5bb95c48">

Next, click Create GDExtension, type in a base name, click "Create", and then it will create and compile an extension.

<img width="480" alt="Screenshot 2024-05-27 at 1 30 48 AM" src="https://github.com/godotengine/godot/assets/1646875/dfc3533a-3e54-4a0a-a3bf-006b1df63e41">

The library name and path are optional. If you do not specify these, they will be determined automatically.

The dialog includes hover tooltips if you hover over the boxes, which explain what each field is and what the values you write in it should be.

The language system is designed to be completely language-agnostic. The dialogs have no clue about the existence of C++ or SCons. All of the C++ and SCons specific code is isolated in one class, and in the future we can allow editor plugins to extend this. It's not exposed as of this PR in case we want to iterate on the internal code first, but we can expose it whenever, preferably in a future PR to avoid this one becoming too big.

As mentioned by proposal https://github.com/godotengine/godot-proposals/issues/3367, this sets up the build system with a build command (`scons`), the `.gitignore` files, the `.gdextension` file, the type registration boilerplate, and it even `git clone`s `godot-cpp`. By default, it will also initiate `scons` to compile the extension, but this does take awhile, so you can skip this step by unchecking the "Compile now?" box.

Note that this PR does not include setting up system-level dependencies, such as installing a C++ compiler, installing Git, installing SCons, etc. This varies widely by operating system and it would be a slippery slope to try and have that. This PR is purely focused on the files that go in your project, not the system-wide dependencies. This PR does not try to detect a C++ compiler, but it will warn the user if either Git or SCons is not found on their system.

When you create a GDExtension plugin with this PR, one example node is provided called `ExampleNode`. Like the Blender default cube, this is expected to be replaced by users as soon as possible. However, its existence is useful to both new and experienced users, since it serves 2 functions: 1) As a reference for how to make a node type, including the code, registration, docs, icon, etc, and 2) A minimal test to check if your GDExtension plugin works (don't see it in the editor? It's not working).

Assuming you have the system-wide dependencies installed, and you leave the "Compile now?" checkbox enabled, and you wait for it to finish, the extension **immediately** works. No fuss, the example node is just there.

<img width="250" alt="Screenshot 2024-05-27 at 1 27 30 AM" src="https://github.com/godotengine/godot/assets/1646875/f8e99333-28ef-4cce-b483-5d0b23170ea8">

Assuming it was compiled, it will show up in a list of GDExtensions. This list will contain every loaded GDExtension, regardless of whether it was been created by the create dialog. It gets this list from GDExtensionManager, so it will not include any non-compiled or otherwise broken extensions.

<img width="940" alt="Screenshot 2024-05-27 at 12 08 11 AM" src="https://github.com/godotengine/godot/assets/1646875/529af8aa-0ce0-47b9-af4b-ffb058e15579">

If you change the code, you just need to run `scons` in either the extension folder or the project root. A future idea would be to detect this in projects and provide a "Build" button in the editor UI like we already do for C#, but that is technically separate from what this PR does.

The files look like this:

<img width="460" alt="Screenshot 2024-04-21 at 4 25 19 AM" src="https://github.com/godotengine/godot/assets/1646875/bc0bd3c5-62b6-4140-a8a8-339e974881fc">

The `SConstruct` at the project root is extremely barebones, it is only one line to call into another SConstruct. It is designed to be simple enough so that more GDExtension plugins can be added to the same Godot project with no manual work. The `_ensure_file_contains` helper function in this PR completely handles the merging of more calls into this file. You can just make 2 plugins back-to-back with no conflicts. If you want to have 20 GDExtension plugins, this PR will let you do that just fine, with one call to `scons` in the root folder able to compile all of them at once.

This PR provides 2 options for making a GDExtension plugin: "C++ with SCons, GDExtension only" or "C++ with SCons, GDExtension and engine module". The former creates a standalone GDExtension C++ plugin, with the only files stored in the root of the project being a `.gitignore` and barebones `SConstruct`.

The engine module option provides a few more files like `SCsub` and `config.py`, provides lots of `#ifdef` directives to support both GDExtensions and modules, and places most of the C++ code in the root of the folder, which is more suitable for making a Godot engine module. This way if users want to target both GDExtension and modules with one codebase, they can do this as easily as selecting it from the dropdown. This option turns the project's root folder into a module, so only one module is allowed per project.

<img width="464" alt="Screenshot 2024-05-27 at 12 10 59 AM" src="https://github.com/godotengine/godot/assets/1646875/ddb26aa7-9ff8-43a6-8b70-c36a3890f37e">

When in this mode, you can either compile for GDExtension the same as with the "only" option, or you can copy-paste the entire Godot project into the engine modules folder, naming the folder the same as the addon folder name, and it works.

The source files are designed to handle the extension+module case, but are automatically simplified by this PR's project generator when making a non-module extension, including by looking at the `#if` preprocessor directives to determine which lines of code to exclude. "Yo dawg, I heard you like preprocessors, so I preprocessed your preprocessor directives so there are fewer preprocessor directives to direct your preprocessor."
