### PR TITLE
Fix incorrect C# in `OS.get_cmdline_args` docs

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -189,26 +189,26 @@
 				for argument in OS.get_cmdline_args():
 				    if argument.contains("="):
 				        var key_value = argument.split("=")
-				        arguments[key_value[0].lstrip("--")] = key_value[1]
+				        arguments[key_value[0].trim_prefix("--")] = key_value[1]
 				    else:
 				        # Options without an argument will be present in the dictionary,
 				        # with the value set to an empty string.
-				        arguments[argument.lstrip("--")] = ""
+				        arguments[argument.trim_prefix("--")] = ""
 				[/gdscript]
 				[csharp]
-				var arguments = new Godot.Collections.Dictionary();
+				var arguments = new Dictionary&lt;string, string&gt;();
 				foreach (var argument in OS.GetCmdlineArgs())
 				{
 				    if (argument.Contains('='))
 				    {
 				        string[] keyValue = argument.Split("=");
-				        arguments[keyValue[0].LStrip("--")] = keyValue[1];
+				        arguments[keyValue[0].TrimPrefix("--")] = keyValue[1];
 				    }
 				    else
 				    {
 				        // Options without an argument will be present in the dictionary,
 				        // with the value set to an empty string.
-				        arguments[keyValue[0].LStrip("--")] = "";
+				        arguments[argument.TrimPrefix("--")] = "";
 				    }
 				}
 				[/csharp]


### PR DESCRIPTION
Fixes incorrect C# example for the documentation of [OS.get_cmdline_args](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-cmdline-args)