### PR TITLE
Fix `Node.duplicate()` crash when duplicating a node that cannot be instantiated.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2783,9 +2783,11 @@ Node *Node::duplicate(int p_flags) const {
 	ERR_THREAD_GUARD_V(nullptr);
 	Node *dupe = _duplicate(p_flags);
 
+	ERR_FAIL_NULL_V_MSG(dupe, nullptr, "Failed to duplicate node.");
+
 	_duplicate_properties(this, this, dupe, p_flags);
 
-	if (dupe && (p_flags & DUPLICATE_SIGNALS)) {
+	if (p_flags & DUPLICATE_SIGNALS) {
 		_duplicate_signals(this, dupe);
 	}
 
@@ -2800,6 +2802,8 @@ Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap) con
 Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap, const HashMap<Ref<Resource>, Ref<Resource>> &p_resource_remap) const {
 	int flags = DUPLICATE_SIGNALS | DUPLICATE_GROUPS | DUPLICATE_SCRIPTS | DUPLICATE_USE_INSTANTIATION | DUPLICATE_FROM_EDITOR;
 	Node *dupe = _duplicate(flags, &r_duplimap);
+
+	ERR_FAIL_NULL_V_MSG(dupe, nullptr, "Failed to duplicate node.");
 
 	_duplicate_properties(this, this, dupe, flags);
 


### PR DESCRIPTION
closes #90991 