### PR TITLE
Make project setting export respect to `convert_text_resources_to_binary`

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1403,7 +1403,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 	}
 
-	String config_file = "project.binary";
+	String config_file = convert_text_to_binary ? "project.binary" : "project.godot";
 	String engine_cfb = EditorPaths::get_singleton()->get_cache_dir().path_join("tmp" + config_file);
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90981

Tested locally it seems all is ok since we use `_load_settings_text_or_binary("res://project.godot", "res://project.binary")` to load the setting all the time.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
