### PR TITLE
[3.x] Fix `spatial_editor_plugin` enum

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -184,6 +184,10 @@ class SpatialEditorViewport : public Control {
 	friend class SpatialEditor;
 	friend class ViewportNavigationControl;
 	friend class ViewportRotationControl;
+
+	// These values are serialized, so if adding new values
+	// add to the bottom to preserve compatibility between
+	// editor versions.
 	enum {
 
 		VIEW_TOP,
@@ -204,7 +208,6 @@ class SpatialEditorViewport : public Control {
 		VIEW_AUDIO_DOPPLER,
 		VIEW_GIZMOS,
 		VIEW_INFORMATION,
-		VIEW_SELECTED_INFO,
 		VIEW_FPS,
 		VIEW_DISPLAY_NORMAL,
 		VIEW_DISPLAY_WIREFRAME,
@@ -214,6 +217,7 @@ class SpatialEditorViewport : public Control {
 		VIEW_CINEMATIC_PREVIEW,
 		VIEW_AUTO_ORTHOGONAL,
 		VIEW_PORTAL_CULLING,
+		VIEW_SELECTED_INFO,
 	};
 
 	enum ViewType {


### PR DESCRIPTION
* The `view_mesh_stats` feature introduced a new enum value `VIEW_SLECTED_INFO` within the unnamed `VIEW` enum.
* This turns out to be saved somehow, which means the view settings can get out of sync when reloading the project in an older version of the editor.
* The solution is simply to move the new value to the end of the enum so there are no conflicts.

Fixes regression from #88207

## Notes
* This normally exhibits as saving the editor after choosing `view_selected_info`, and reloading into old version starts in wireframe.
* I had seen this a couple of times during development but didn't twig that it was due to the PR, sorry my bad.
* It wasn't obvious during development that this enum was saved in any way (I had thought it used strings from examining the files).
* I've added a comment to help prevent this happening again, as it was non-obvious.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
