### PR TITLE
[MP] Fix `disconnect_peer` not doing the proper cleanup

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -425,11 +425,11 @@ void SceneMultiplayer::_del_peer(int p_id) {
 
 void SceneMultiplayer::disconnect_peer(int p_id) {
 	ERR_FAIL_COND(multiplayer_peer.is_null() || multiplayer_peer->get_connection_status() != MultiplayerPeer::CONNECTION_CONNECTED);
-	if (pending_peers.has(p_id)) {
-		pending_peers.erase(p_id);
-	} else if (connected_peers.has(p_id)) {
-		connected_peers.erase(p_id);
-	}
+	// Block signals to avoid emitting peer_disconnected.
+	bool blocking = is_blocking_signals();
+	set_block_signals(true);
+	_del_peer(p_id);
+	set_block_signals(blocking);
 	multiplayer_peer->disconnect_peer(p_id);
 }
 


### PR DESCRIPTION
Lower layers (cache, replication) were not being notified about the peer being disconnected.

Fixes #91007 (note, there's another issue, causing a different error spam in the client, which should be fixed in a separate PR as it involves different codes).

Note: In this PR I'm preserving compatibility by not emitting the signal, I wonder if we want to change that, I see that there's some inconsistency across Godot when it comes to emitting signals in response to functions being called via code.