### PR TITLE
Add line limit to Output Log in Editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -924,6 +924,9 @@
 		<member name="run/output/font_size" type="int" setter="" getter="">
 			The size of the font in the [b]Output[/b] panel at the bottom of the editor. This setting does not impact the font size of the script editor (see [member interface/editor/code_font_size]).
 		</member>
+		<member name="run/output/max_lines" type="int" setter="" getter="">
+			Maximum number of lines to show at any one time in the Output panel.
+		</member>
 		<member name="run/platforms/linuxbsd/prefer_wayland" type="bool" setter="" getter="">
 			If [code]true[/code], on Linux/BSD, the editor will check for Wayland first instead of X11 (if available).
 		</member>

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -127,6 +127,14 @@ void EditorLog::_update_theme() {
 	theme_cache.message_color = get_theme_color(SNAME("font_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.6);
 }
 
+void EditorLog::_editor_settings_changed() {
+	int new_line_limit = int(EDITOR_GET("run/output/max_lines"));
+	if (new_line_limit != line_limit) {
+		line_limit = new_line_limit;
+		_rebuild_log();
+	}
+}
+
 void EditorLog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -267,7 +275,35 @@ void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
 void EditorLog::_rebuild_log() {
 	log->clear();
 
-	for (int msg_idx = 0; msg_idx < messages.size(); msg_idx++) {
+	int line_count = 0;
+	int start_message_index = 0;
+	int initial_skip = 0;
+
+	// Search backward for starting place.
+	for (start_message_index = messages.size() - 1; start_message_index >= 0; start_message_index--) {
+		LogMessage msg = messages[start_message_index];
+		if (collapse) {
+			if (_check_display_message(msg)) {
+				line_count++;
+			}
+		} else {
+			// If not collapsing, log each instance on a line.
+			for (int i = 0; i < msg.count; i++) {
+				if (_check_display_message(msg)) {
+					line_count++;
+				}
+			}
+		}
+		if (line_count >= line_limit) {
+			initial_skip = line_count - line_limit;
+			break;
+		}
+		if (start_message_index == 0) {
+			break;
+		}
+	}
+
+	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
 
 		if (collapse) {
@@ -275,11 +311,19 @@ void EditorLog::_rebuild_log() {
 			_add_log_line(msg);
 		} else {
 			// If not collapsing, log each instance on a line.
-			for (int i = 0; i < msg.count; i++) {
+			for (int i = initial_skip; i < msg.count; i++) {
+				initial_skip = 0;
 				_add_log_line(msg);
 			}
 		}
 	}
+}
+
+bool EditorLog::_check_display_message(LogMessage &p_message) {
+	bool filter_active = type_filter_map[p_message.type]->is_active();
+	String search_text = search_box->get_text();
+	bool search_match = search_text.is_empty() || p_message.text.findn(search_text) > -1;
+	return filter_active && search_match;
 }
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
@@ -294,11 +338,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	// Only add the message to the log if it passes the filters.
-	bool filter_active = type_filter_map[p_message.type]->is_active();
-	String search_text = search_box->get_text();
-	bool search_match = search_text.is_empty() || p_message.text.findn(search_text) > -1;
-
-	if (!filter_active || !search_match) {
+	if (!_check_display_message(p_message)) {
 		return;
 	}
 
@@ -359,6 +399,10 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 			}
 		}
 	}
+
+	while (log->get_paragraph_count() > line_limit + 1) {
+		log->remove_paragraph(0, true);
+	}
 }
 
 void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
@@ -391,6 +435,9 @@ EditorLog::EditorLog() {
 	save_state_timer->set_one_shot(true);
 	save_state_timer->connect("timeout", callable_mp(this, &EditorLog::_save_state));
 	add_child(save_state_timer);
+
+	line_limit = int(EDITOR_GET("run/output/max_lines"));
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorLog::_editor_settings_changed));
 
 	HBoxContainer *hb = this;
 

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -128,6 +128,8 @@ private:
 		}
 	};
 
+	int line_limit = 10000;
+
 	Vector<LogMessage> messages;
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	HashMap<MessageType, LogFilter *> type_filter_map;
@@ -164,6 +166,7 @@ private:
 
 	void _rebuild_log();
 	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
+	bool _check_display_message(LogMessage &p_message);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _set_search_visible(bool p_visible);
@@ -179,6 +182,7 @@ private:
 	void _load_state();
 
 	void _update_theme();
+	void _editor_settings_changed();
 
 protected:
 	void _notification(int p_what);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -821,6 +821,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("run/output/always_open_output_on_play", true);
 	_initial_set("run/output/always_close_output_on_stop", false);
 
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "run/output/max_lines", 10000, "100,100000,1")
+
 	// Platform
 	_initial_set("run/platforms/linuxbsd/prefer_wayland", false);
 	set_restart_if_changed("run/platforms/linuxbsd/prefer_wayland", true);


### PR DESCRIPTION
Fixes  #84718

Currently the Output Log in the Editor has no limit on the amount of lines. This can lead to slowdown if a lot of text is sent to it.

This fix adds an editor setting `run/output/max_lines` that sets the max amount of lines the Output Log can currently display. It's set to `10000` by default.

The Log still remembers all the messages (so it can switch from Collapse to Un-Collapsed, or filter or search for messages no longer displayed), but the amount of lines/paragraphs displayed are limited to whatever the Editor setting is.