### PR TITLE
Cleanup Android file errors

### DIFF
--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -83,7 +83,7 @@ Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mo
 				default:
 					return ERR_FILE_CANT_OPEN;
 
-				case -1:
+				case -2:
 					return ERR_FILE_NOT_FOUND;
 			}
 		}
@@ -334,10 +334,13 @@ Error FileAccessFilesystemJAndroid::resize(int64_t p_length) {
 		switch (res) {
 			case 0:
 				return OK;
-			case -3:
+			case -4:
 				return ERR_INVALID_PARAMETER;
-			case -2:
+			case -3:
 				return ERR_FILE_CANT_OPEN;
+			case -2:
+				return ERR_FILE_NOT_FOUND;
+			case -1:
 			default:
 				return FAILED;
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
@@ -52,11 +52,6 @@ internal abstract class DataAccess(private val filePath: String) {
 	companion object {
 		private val TAG = DataAccess::class.java.simpleName
 
-		private const val OK_ERROR_ID = 0;
-		private const val FAILED_ERROR_ID = -1;
-		private const val FILE_CANT_OPEN_ERROR_ID = -2;
-		private const val INVALID_PARAMETER_ERROR_ID = -3;
-
 		fun generateDataAccess(
 			storageScope: StorageScope,
 			context: Context,
@@ -145,15 +140,15 @@ internal abstract class DataAccess(private val filePath: String) {
 	fun resize(length: Long): Int {
 		return try {
 			fileChannel.truncate(length)
-			OK_ERROR_ID
+			FileErrors.OK.nativeValue
 		} catch (e: NonWritableChannelException) {
-			FILE_CANT_OPEN_ERROR_ID
+			FileErrors.FILE_CANT_OPEN.nativeValue
 		} catch (e: ClosedChannelException) {
-			FILE_CANT_OPEN_ERROR_ID
+			FileErrors.FILE_CANT_OPEN.nativeValue
 		} catch (e: IllegalArgumentException) {
-			INVALID_PARAMETER_ERROR_ID
+			FileErrors.INVALID_PARAMETER.nativeValue
 		} catch (e: IOException) {
-			FAILED_ERROR_ID
+			FileErrors.FAILED.nativeValue
 		}
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
@@ -45,8 +45,6 @@ class FileAccessHandler(val context: Context) {
 	companion object {
 		private val TAG = FileAccessHandler::class.java.simpleName
 
-		private const val FAILED_ERROR_ID = -1;
-		private const val FILE_NOT_FOUND_ERROR_ID = -1
 		internal const val INVALID_FILE_ID = 0
 		private const val STARTING_FILE_ID = 1
 
@@ -119,7 +117,7 @@ class FileAccessHandler(val context: Context) {
 				lastFileId
 			} ?: INVALID_FILE_ID
 		} catch (e: FileNotFoundException) {
-			FILE_NOT_FOUND_ERROR_ID
+			FileErrors.FILE_NOT_FOUND.nativeValue
 		} catch (e: Exception) {
 			Log.w(TAG, "Error while opening $path", e)
 			INVALID_FILE_ID
@@ -193,7 +191,7 @@ class FileAccessHandler(val context: Context) {
 
 	fun fileResize(fileId: Int, length: Long): Int {
 		if (!hasFileId(fileId)) {
-			return FAILED_ERROR_ID
+			return FileErrors.FAILED.nativeValue
 		}
 
 		return files[fileId].resize(length)

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileErrors.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileErrors.kt
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  FileErrors.kt                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.godot.io.file
+
+/**
+ * Set of errors that may occur when performing data access.
+ */
+internal enum class FileErrors(val nativeValue: Int) {
+	OK(0),
+	FAILED(-1),
+	FILE_NOT_FOUND(-2),
+	FILE_CANT_OPEN(-3),
+	INVALID_PARAMETER(-4);
+
+	companion object {
+		fun fromNativeError(error: Int): FileErrors? {
+			for (fileError in entries) {
+				if (fileError.nativeValue == error) {
+					return fileError
+				}
+			}
+			return null
+		}
+	}
+}


### PR DESCRIPTION
Consolidates all the Android expected file errors into the `FileErrors` enum class.

Follow up to https://github.com/godotengine/godot/pull/90403

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
