### PR TITLE
Create extension owner without postinitialization.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1473,9 +1473,16 @@ static GDExtensionMethodBindPtr gdextension_classdb_get_method_bind(GDExtensionC
 	return (GDExtensionMethodBindPtr)mb;
 }
 
+#ifndef DISABLE_DEPRECATED
 static GDExtensionObjectPtr gdextension_classdb_construct_object(GDExtensionConstStringNamePtr p_classname) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	return (GDExtensionObjectPtr)ClassDB::instantiate_no_placeholders(classname);
+}
+#endif
+
+static GDExtensionObjectPtr gdextension_classdb_construct_object2(GDExtensionConstStringNamePtr p_classname) {
+	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
+	return (GDExtensionObjectPtr)ClassDB::instantiate_without_postinitialization(classname);
 }
 
 static void *gdextension_classdb_get_class_tag(GDExtensionConstStringNamePtr p_classname) {
@@ -1655,7 +1662,10 @@ void gdextension_setup_interface() {
 #endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(callable_custom_create2);
 	REGISTER_INTERFACE_FUNC(callable_custom_get_userdata);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(classdb_construct_object);
+#endif // DISABLE_DEPRECATED
+	REGISTER_INTERFACE_FUNC(classdb_construct_object2);
 	REGISTER_INTERFACE_FUNC(classdb_get_method_bind);
 	REGISTER_INTERFACE_FUNC(classdb_get_class_tag);
 	REGISTER_INTERFACE_FUNC(editor_add_plugin);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2592,6 +2592,7 @@ typedef void *(*GDExtensionInterfaceCallableCustomGetUserData)(GDExtensionConstT
 /**
  * @name classdb_construct_object
  * @since 4.1
+ * @deprecated in Godot 4.3. Use `classdb_construct_object2` instead.
  *
  * Constructs an Object of the requested class.
  *
@@ -2602,6 +2603,22 @@ typedef void *(*GDExtensionInterfaceCallableCustomGetUserData)(GDExtensionConstT
  * @return A pointer to the newly created Object.
  */
 typedef GDExtensionObjectPtr (*GDExtensionInterfaceClassdbConstructObject)(GDExtensionConstStringNamePtr p_classname);
+
+/**
+ * @name classdb_construct_object2
+ * @since 4.3
+ *
+ * Constructs an Object of the requested class.
+ *
+ * The passed class must be a built-in godot class, or an already-registered extension class. In both cases, object_set_instance() should be called to fully initialize the object.
+ *
+ * "NOTIFICATION_POSTINITIALIZE" must be sent after construction.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer to the newly created Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceClassdbConstructObject2)(GDExtensionConstStringNamePtr p_classname);
 
 /**
  * @name classdb_get_method_bind

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -491,7 +491,7 @@ StringName ClassDB::get_compatibility_class(const StringName &p_class) {
 	return StringName();
 }
 
-Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require_real_class) {
+Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require_real_class, bool p_skip_post_initialize) {
 	ClassInfo *ti;
 	{
 		OBJTYPE_RLOCK;
@@ -530,8 +530,12 @@ Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require
 			}
 		}
 #endif
-
-		return ti->creation_func();
+		if (p_skip_post_initialize) {
+			// If creating an extension owner, should not postinitialize here.
+			return ti->creation_without_postinitialization_func();
+		} else {
+			return ti->creation_func();
+		}
 	}
 }
 
@@ -541,6 +545,10 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 
 Object *ClassDB::instantiate_no_placeholders(const StringName &p_class) {
 	return _instantiate_internal(p_class, true);
+}
+
+Object *ClassDB::instantiate_without_postinitialization(const StringName &p_class) {
+	return _instantiate_internal(p_class, true, true);
 }
 
 #ifdef TOOLS_ENABLED

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -208,10 +208,13 @@ void Object::cancel_free() {
 	_predelete_ok = false;
 }
 
-void Object::_postinitialize() {
+void Object::_initialize() {
 	_class_name_ptr = _get_class_namev(); // Set the direct pointer, which is much faster to obtain, but can only happen after postinitialize.
 	_initialize_classv();
 	_class_name_ptr = nullptr; // May have been called from a constructor.
+}
+
+void Object::_postinitialize() {
 	notification(NOTIFICATION_POSTINITIALIZE);
 }
 
@@ -2155,6 +2158,7 @@ bool predelete_handler(Object *p_object) {
 }
 
 void postinitialize_handler(Object *p_object) {
+	p_object->_initialize();
 	p_object->_postinitialize();
 }
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -632,6 +632,7 @@ private:
 	int _predelete_ok = 0;
 	ObjectID _instance_id;
 	bool _predelete();
+	void _initialize();
 	void _postinitialize();
 	bool _can_translate = true;
 	bool _emitting = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

An alternative of [#91018](https://github.com/godotengine/godot/pull/91018).

This pr reduce changes (no need to change GodotSharp), but a new pointer field “creation_without_postinitialization_func” needs to be introduced, it will increase memory usage (in my [eos plugin](https://github.com/Daylily-Zeleen/GD-EOS), it will add hundreds of classes, 8 bytes per class look like expensive).

-----------------------------
Fix [#91023](https://github.com/godotengine/godot/issues/91023).