### PR TITLE
Remove rect from Path2D

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -447,8 +447,13 @@ void Path2DEditor::edit(Node *p_path2d) {
 		canvas_item_editor = CanvasItemEditor::get_singleton();
 	}
 
+	if (node) {
+		node->set_selected(false);
+	}
+
 	if (p_path2d) {
 		node = Object::cast_to<Path2D>(p_path2d);
+		node->set_selected(true);
 
 		if (!node->is_connected("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed))) {
 			node->connect("visibility_changed", callable_mp(this, &Path2DEditor::_node_visibility_changed));

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -38,26 +38,10 @@
 #endif
 
 #ifdef TOOLS_ENABLED
-Rect2 Path2D::_edit_get_rect() const {
-	if (!curve.is_valid() || curve->get_point_count() == 0) {
-		return Rect2(0, 0, 0, 0);
-	}
 
-	Rect2 aabb = Rect2(curve->get_point_position(0), Vector2(0, 0));
-
-	for (int i = 0; i < curve->get_point_count(); i++) {
-		for (int j = 0; j <= 8; j++) {
-			real_t frac = j / 8.0;
-			Vector2 p = curve->sample(i, frac);
-			aabb.expand_to(p);
-		}
-	}
-
-	return aabb;
-}
-
-bool Path2D::_edit_use_rect() const {
-	return curve.is_valid() && curve->get_point_count() != 0;
+void Path2D::set_selected(bool p_selected) {
+	selected = p_selected;
+	queue_redraw();
 }
 
 bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
@@ -102,8 +86,13 @@ void Path2D::_notification(int p_what) {
 				return;
 			}
 
+			Color draw_color = get_tree()->get_debug_paths_color();
+
 #ifdef TOOLS_ENABLED
 			const real_t line_width = get_tree()->get_debug_paths_width() * EDSCALE;
+			if (selected) {
+				draw_color = Color(1, 0.6, 0.4, 0.7); // Same color as 2D editor selected node's box.
+			}
 #else
 			const real_t line_width = get_tree()->get_debug_paths_width();
 #endif
@@ -135,7 +124,7 @@ void Path2D::_notification(int p_what) {
 					for (int i = 0; i < sample_count; i++) {
 						w[i] = r[i].get_origin();
 					}
-					draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width, false);
+					draw_polyline(v2p, draw_color, line_width, false);
 				}
 
 				// Draw fish bones
@@ -154,7 +143,7 @@ void Path2D::_notification(int p_what) {
 						w[1] = p;
 						w[2] = p + (-side - forward) * 5;
 
-						draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width * 0.5, false);
+						draw_polyline(v2p, draw_color, line_width * 0.5, false);
 					}
 				}
 			}

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -49,8 +49,8 @@ protected:
 
 public:
 #ifdef TOOLS_ENABLED
-	virtual Rect2 _edit_get_rect() const override;
-	virtual bool _edit_use_rect() const override;
+	bool selected = false;
+	void set_selected(bool p_selected);
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 #endif
 


### PR DESCRIPTION
When Path2D is selected, it shows the standard orange rectangle with scale handles. The handles can be confused for path points and lead to accidental scaling. Also scaling Path2D is not very useful in general.

This PR removes the rect.
Before:
![image](https://github.com/godotengine/godot/assets/2223172/fcdc86e4-09f5-4916-a366-997dcd8b26c0)
After:
![image](https://github.com/godotengine/godot/assets/2223172/520096ee-c715-4d20-919c-3d2c3c1a9fd7)
You can still select the path by clicking on its curve.

Removing rect completely has potential drawbacks. The path is not obviously "selected" and you don't see its bounds. While this is a minor problem, an alternative of showing the rect without handles is possible too.