### PR TITLE
Suppress expected errors in resource unit tests

### DIFF
--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -38,6 +38,8 @@
 
 #include "thirdparty/doctest/doctest.h"
 
+#include "tests/test_macros.h"
+
 namespace TestResource {
 
 TEST_CASE("[Resource] Duplication") {
@@ -124,9 +126,12 @@ TEST_CASE("[Resource] Breaking circular references on save") {
 	const String save_path_binary = OS::get_singleton()->get_cache_path().path_join("resource.res");
 	const String save_path_text = OS::get_singleton()->get_cache_path().path_join("resource.tres");
 	ResourceSaver::save(resource_a, save_path_binary);
+	// Suppress expected errors caused by the resources above being uncached.
+	ERR_PRINT_OFF;
 	ResourceSaver::save(resource_a, save_path_text);
 
 	const Ref<Resource> &loaded_resource_a_binary = ResourceLoader::load(save_path_binary);
+	ERR_PRINT_ON;
 	CHECK_MESSAGE(
 			loaded_resource_a_binary->get_name() == "A",
 			"The loaded resource name should be equal to the expected value.");


### PR DESCRIPTION
The test "[Resource] Breaking circular references on save" produces errors 
```
ERROR: Resource was not pre cached for the resource section, bug?
   at: _write_resource (scene/resources/resource_format_text.cpp:1882)
WARNING: Couldn't load resource (no cache): local://Resource_agy4p
     at: parse_variant (core/io/resource_format_binary.cpp:412)
```
The errors are intentional because the test uses uncached internal resources and as a result of the test the circular reference is broken. I tested out the branchpath in ResourceFormatSaverBinaryInstance::_find_resources that mentions circular references and found that it skips over internal resources. 
I have only suppressed the parts that produce errors: saving to text and loading from binary. 
Fixes: #80616