### PR TITLE
Subscribe to correct tracker signals

### DIFF
--- a/scene/3d/xr_body_modifier_3d.cpp
+++ b/scene/3d/xr_body_modifier_3d.cpp
@@ -312,7 +312,7 @@ void XRBodyModifier3D::_process_modification() {
 	}
 }
 
-void XRBodyModifier3D::_tracker_changed(const StringName &p_tracker_name, const Ref<XRBodyTracker> &p_tracker) {
+void XRBodyModifier3D::_tracker_changed(const StringName &p_tracker_name, XRServer::TrackerType p_tracker_type) {
 	if (tracker_name == p_tracker_name) {
 		_get_joint_data();
 	}
@@ -327,18 +327,18 @@ void XRBodyModifier3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			XRServer *xr_server = XRServer::get_singleton();
 			if (xr_server) {
-				xr_server->connect("body_tracker_added", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
-				xr_server->connect("body_tracker_updated", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
-				xr_server->connect("body_tracker_removed", callable_mp(this, &XRBodyModifier3D::_tracker_changed).bind(Ref<XRBodyTracker>()));
+				xr_server->connect("tracker_added", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
+				xr_server->connect("tracker_updated", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
+				xr_server->connect("tracker_removed", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
 			}
 			_get_joint_data();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			XRServer *xr_server = XRServer::get_singleton();
 			if (xr_server) {
-				xr_server->disconnect("body_tracker_added", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
-				xr_server->disconnect("body_tracker_updated", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
-				xr_server->disconnect("body_tracker_removed", callable_mp(this, &XRBodyModifier3D::_tracker_changed).bind(Ref<XRBodyTracker>()));
+				xr_server->disconnect("tracker_added", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
+				xr_server->disconnect("tracker_updated", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
+				xr_server->disconnect("tracker_removed", callable_mp(this, &XRBodyModifier3D::_tracker_changed));
 			}
 			for (int i = 0; i < XRBodyTracker::JOINT_MAX; i++) {
 				joints[i].bone = -1;

--- a/scene/3d/xr_body_modifier_3d.h
+++ b/scene/3d/xr_body_modifier_3d.h
@@ -86,7 +86,7 @@ private:
 	JointData joints[XRBodyTracker::JOINT_MAX];
 
 	void _get_joint_data();
-	void _tracker_changed(const StringName &p_tracker_name, const Ref<XRBodyTracker> &p_tracker);
+	void _tracker_changed(const StringName &p_tracker_name, XRServer::TrackerType p_tracker_type);
 };
 
 VARIANT_BITFIELD_CAST(XRBodyModifier3D::BodyUpdate)


### PR DESCRIPTION
This PR modifies XRBodyModifier3D so it subscribes to the correct signals:
- Correct: `tracker_added` / `tracker_updated` / `tracker_removed`
- Incorrect: `body_tracker_added` / `body_tracker_updated` / `body_tracker_removed` (experimental + removed)

The body-specific signals were experimental, and ended up being unnecessary and deleted by the XRTracker unification PR.
