### PR TITLE
Document AudioEffectSpectrumAnalyzerInstance, clarify relationship with AudioEffectSpectrumAnalyzer

### DIFF
--- a/doc/classes/AudioEffectSpectrumAnalyzer.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This audio effect does not affect sound output, but can be used for real-time audio visualizations.
+		This resource configures an [AudioEffectSpectrumAnalyzerInstance], which performs the actual analysis at runtime. An instance can be acquired with [method AudioServer.get_bus_effect_instance].
 		See also [AudioStreamGenerator] for procedurally generating sounds.
 	</description>
 	<tutorials>

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectSpectrumAnalyzerInstance" inherits="AudioEffectInstance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Queryable instance of an [AudioEffectSpectrumAnalyzer].
 	</brief_description>
 	<description>
+		The runtime part of an [AudioEffectSpectrumAnalyzer], which can be used to query the magnitude of a frequency range on its host bus.
+		An instance of this class can be acquired with [method AudioServer.get_bus_effect_instance].
 	</description>
 	<tutorials>
+		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<methods>
 		<method name="get_magnitude_for_frequency_range" qualifiers="const">
@@ -13,15 +17,17 @@
 			<param index="1" name="to_hz" type="float" />
 			<param index="2" name="mode" type="int" enum="AudioEffectSpectrumAnalyzerInstance.MagnitudeMode" default="1" />
 			<description>
+				Returns the magnitude of the frequencies from [param from_hz] to [param to_hz] in linear energy as a Vector2. The [code]x[/code] component of the return value represents the left stereo channel, and [code]y[/code] represents the right channel.
+				[param mode] determines how the frequency range will be processed. See [enum MagnitudeMode].
 			</description>
 		</method>
 	</methods>
 	<constants>
 		<constant name="MAGNITUDE_AVERAGE" value="0" enum="MagnitudeMode">
-			Use the average value as magnitude.
+			Use the average value across the frequency range as magnitude.
 		</constant>
 		<constant name="MAGNITUDE_MAX" value="1" enum="MagnitudeMode">
-			Use the maximum value as magnitude.
+			Use the maximum value of the frequency range as magnitude.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Fully document AudioEffectSpectrumAnalyzerInstance, including the weird return value of its sole method, and add a link to it in AudioEffectSpectrumAnalyzer to make it easier to figure out how to use.

I looked through the source code so no-one else has to.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
