### PR TITLE
Fix TabContainer using wrong content rect after tab title update

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -760,10 +760,8 @@ void TabContainer::set_tab_title(int p_tab, const String &p_title) {
 		child->set_meta("_tab_name", p_title);
 	}
 
-	_update_margins();
-	if (!get_clip_tabs()) {
-		update_minimum_size();
-	}
+	_repaint();
+	queue_redraw();
 }
 
 String TabContainer::get_tab_title(int p_tab) const {


### PR DESCRIPTION
Continuation of #90942.

This PR fixes a bug that only happens when you update tab title *after* updating tab icon. Updating tab icon before updating tab title is fine. `3.x` does not have this bug.

Tab title can affect minimum size even when clipping tabs (e.g. changing from using empty title to some visible text).

| Before | After |
|---|---|
| ![before](https://github.com/godotengine/godot/assets/372476/f069f656-cd32-488a-80d8-cee33ae20a88) | ![after](https://github.com/godotengine/godot/assets/372476/0b152768-2791-4b1b-8356-0a6f7662f7de) |

_The magenta rect is the tab content._

Test project: [tab-container.zip](https://github.com/godotengine/godot/files/15070342/tab-container.zip)