### PR TITLE
Fix Android build failure due to spaces in `ANDROID_HOME` or `ANDROID_NDK_ROOT` environment variable paths

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -893,7 +893,7 @@ def is_vanilla_clang(env):
     if not using_clang(env):
         return False
     try:
-        version = subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip().decode("utf-8")
+        version = subprocess.check_output(f'{env.subst(env["CXX"])} --version').strip().decode("utf-8")
     except (subprocess.CalledProcessError, OSError):
         print("Couldn't parse CXX environment variable to infer compiler version.")
         return False
@@ -927,7 +927,7 @@ def get_compiler_version(env):
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         try:
             version = (
-                subprocess.check_output([env.subst(env["CXX"]), "--version"], shell=(os.name == "nt"))
+                subprocess.check_output(f'{env.subst(env["CXX"])} --version', shell=(os.name == "nt"))
                 .strip()
                 .decode("utf-8")
             )

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -80,7 +80,7 @@ def install_ndk_if_needed(env: "SConsEnvironment"):
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
-        sdkmanager = sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension
+        sdkmanager = f'"{sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension}"'
         if os.path.exists(sdkmanager):
             # Install the Android NDK
             print("Installing Android NDK...")
@@ -166,11 +166,11 @@ def configure(env: "SConsEnvironment"):
     toolchain_path = ndk_root + "/toolchains/llvm/prebuilt/" + host_subpath
     compiler_path = toolchain_path + "/bin"
 
-    env["CC"] = compiler_path + "/clang"
-    env["CXX"] = compiler_path + "/clang++"
-    env["AR"] = compiler_path + "/llvm-ar"
-    env["RANLIB"] = compiler_path + "/llvm-ranlib"
-    env["AS"] = compiler_path + "/clang"
+    env["CC"] = f'"{compiler_path + "/clang"}"'
+    env["CXX"] = f'"{compiler_path + "/clang++"}"'
+    env["AR"] = f'"{compiler_path + "/llvm-ar"}"'
+    env["RANLIB"] = f'"{compiler_path + "/llvm-ranlib"}"'
+    env["AS"] = f'"{compiler_path + "/clang"}"'
 
     env.Append(
         CCFLAGS=(

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -80,7 +80,8 @@ def install_ndk_if_needed(env: "SConsEnvironment"):
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
-        sdkmanager = f'"{sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension}"'
+        sdkmanager = sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension
+        sdkmanager = f'"{sdkmanager}"' if os.name == "nt" else sdkmanager
         if os.path.exists(sdkmanager):
             # Install the Android NDK
             print("Installing Android NDK...")


### PR DESCRIPTION
Issue:
Android builds failed for users with spaces in their paths for ANDROID_HOME or ANDROID_NDK_ROOT environment variables.

Solution:
Escaped spaces in paths to ensure successful Android builds.

Fixes: https://github.com/godotengine/godot/issues/19211 fixes: https://github.com/godotengine/godot/issues/17710

Recreating this PR, because of issues with the last PR.
Please review and let me know if there are any further changes required.
