### PR TITLE
Fix wrong Tree column title position

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4344,7 +4344,7 @@ void Tree::_notification(int p_what) {
 						}
 
 						default: {
-							text_pos.x += sb->get_offset().x + (tbrect.size.width - columns[i].text_buf->get_size().x) / 2;
+							text_pos.x += (tbrect.size.width - columns[i].text_buf->get_size().x) / 2;
 							break;
 						}
 					}
@@ -4726,7 +4726,8 @@ int Tree::get_column_minimum_width(int p_column) const {
 
 		// Check if the visible title of the column is wider.
 		if (show_column_titles) {
-			min_width = MAX(theme_cache.font->get_string_size(columns[p_column].xl_title, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width + theme_cache.panel_style->get_margin(SIDE_LEFT) + theme_cache.panel_style->get_margin(SIDE_RIGHT), min_width);
+			const float padding = theme_cache.title_button->get_margin(SIDE_LEFT) + theme_cache.title_button->get_margin(SIDE_RIGHT);
+			min_width = MAX(theme_cache.font->get_string_size(columns[p_column].xl_title, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width + padding, min_width);
 		}
 
 		if (!columns[p_column].clip_content) {


### PR DESCRIPTION
<table>
<tr><th>Before</th><td>

![before](https://github.com/godotengine/godot/assets/372476/5fa7d369-b7cf-4d4b-ab29-2c0b3f3e4719)
</td></tr>
<tr><th>After</th><td>

![after](https://github.com/godotengine/godot/assets/372476/b47dd5ab-c67f-48df-943f-d6bb04bbbd7b)
</td></tr>
</table>

- Removes extra spacing on the left side of the centered column title
- When calculating minimum size of a column, the padding of column title should come from `title_button` (background of title buttons) instead of `panel_style` (background of the tree)