### PR TITLE
fbx: Avoid name conflict with humanoid "Root" bone

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -320,7 +320,7 @@ Error FBXDocument::_parse_nodes(Ref<FBXState> p_state) {
 			node->set_name(_as_string(fbx_node->name));
 			node->set_original_name(node->get_name());
 		} else if (fbx_node->is_root) {
-			node->set_name("Root");
+			node->set_name("RootNode");
 		}
 		if (fbx_node->camera) {
 			node->camera = fbx_node->camera->typed_id;


### PR DESCRIPTION
The importer forces name uniqueness, even for the root. "RootNode" is less likely to conflict.

On a particular model whose root bone was named "Root", I was running into really confusing problems related to assigning the "Root" bone on a BoneMap, due to the FBX importer reserving the name "Root" (which puts a number after it)

I can't prove that this is actually a bug in Godot, but it sure made things far more confusing when the word "Root" is both consumed by the fbx importer, and also used for the retargeting BoneMap. After changing the name of the root node, the issue in my scripts seemed to be solved, so I'd like to propose making this change.

I'm open to changing it to something even less likely to conflict like "_rootNode". The argument in favor of "RootNode" as in this PR is this is the name used by FBX2glTF, and real world FBX files tend to refer to the root node as "RootNode", though there is no name uniqueness requirement for this.