### PR TITLE
Optimize some project manager and extension reloading checks

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -155,12 +155,6 @@ public:
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
-
-	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {}
-	_FORCE_INLINE_ bool is_project_manager_hint() const { return false; }
-
-	_FORCE_INLINE_ void set_extension_reloading_enabled(bool p_enabled) {}
-	_FORCE_INLINE_ bool is_extension_reloading_enabled() const { return false; }
 #endif
 
 	Dictionary get_version_info() const;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1548,6 +1548,7 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 		return p_message;
 	}
 
+#ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
 		String tr_msg = TranslationServer::get_singleton()->extractable_translate(p_message, p_context);
 		if (!tr_msg.is_empty() && tr_msg != p_message) {
@@ -1556,6 +1557,7 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 
 		return TranslationServer::get_singleton()->tool_translate(p_message, p_context);
 	}
+#endif
 
 	return TranslationServer::get_singleton()->translate(p_message, p_context);
 }
@@ -1569,6 +1571,7 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 		return p_message_plural;
 	}
 
+#ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
 		String tr_msg = TranslationServer::get_singleton()->extractable_translate_plural(p_message, p_message_plural, p_n, p_context);
 		if (!tr_msg.is_empty() && tr_msg != p_message && tr_msg != p_message_plural) {
@@ -1577,6 +1580,7 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 
 		return TranslationServer::get_singleton()->tool_translate_plural(p_message, p_message_plural, p_n, p_context);
 	}
+#endif
 
 	return TranslationServer::get_singleton()->translate_plural(p_message, p_message_plural, p_n, p_context);
 }

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3815,8 +3815,12 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				case SC_MONITORPOWER: // Monitor trying to enter powersave?
 					return 0; // Prevent from happening.
 				case SC_KEYMENU:
+#ifdef TOOLS_ENABLED
 					Engine *engine = Engine::get_singleton();
 					if (((lParam >> 16) <= 0) && !engine->is_project_manager_hint() && !engine->is_editor_hint() && !GLOBAL_GET("application/run/enable_alt_space_menu")) {
+#else
+					if (((lParam >> 16) <= 0) && !GLOBAL_GET("application/run/enable_alt_space_menu")) {
+#endif
 						return 0;
 					}
 					if (!alt_mem || !(GetAsyncKeyState(VK_SPACE) & (1 << 15))) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR simply removes `project_manager_hint` and `extension_reloading_enabled` on non-editor builds and fixed some code that causes compiler errors since these are pretty much useless.