### PR TITLE
Fix issue with copy shader not working in multiview

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -57,7 +57,7 @@ void main() {
 	}
 
 	if (bool(params.flags & FLAG_USE_SRC_SECTION)) {
-		uv_interp = params.section.xy + uv_interp * params.section.zw;
+		uv_interp.xy = params.section.xy + uv_interp.xy * params.section.zw;
 	}
 }
 


### PR DESCRIPTION
This should fix this error reported by @Malcolmnixon :

![image](https://github.com/godotengine/godot/assets/1945449/5fbe46d6-9e32-4ba3-bffc-4b2d08cff384)

In multiview `uv_interp` is a vec3 variable, we need to swizzle it to allow this multiplication.