### PR TITLE
[DBus] Process file dialog callback in the main event loop instead of using deferred call.

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -56,8 +56,6 @@ private:
 	static void append_dbus_dict_bool(DBusMessageIter *p_iter, const String &p_key, bool p_value);
 	static bool file_chooser_parse_response(DBusMessageIter *p_iter, const Vector<String> &p_names, bool &r_cancel, Vector<String> &r_urls, int &r_index, Dictionary &r_options);
 
-	void _file_dialog_callback(const Callable &p_callable, const Variant &p_status, const Variant &p_list, const Variant &p_index, const Variant &p_options, bool p_opt_in_cb);
-
 	struct FileDialogData {
 		Vector<String> filter_names;
 		DisplayServer::WindowID prev_focus = DisplayServer::INVALID_WINDOW_ID;
@@ -66,6 +64,16 @@ private:
 		String path;
 		bool opt_in_cb = false;
 	};
+
+	struct FileDialogCallback {
+		Callable callback;
+		Variant status;
+		Variant files;
+		Variant index;
+		Variant options;
+		bool opt_in_cb = false;
+	};
+	List<FileDialogCallback> pending_cbs;
 
 	Mutex file_dialog_mutex;
 	Vector<FileDialogData> file_dialogs;
@@ -86,6 +94,7 @@ public:
 	bool is_supported() { return !unsupported; }
 
 	Error file_dialog_show(DisplayServer::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServer::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);
+	void process_file_dialog_callbacks();
 
 	// Retrieve the system's preferred color scheme.
 	// 0: No preference or unknown.

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1161,6 +1161,12 @@ void DisplayServerWayland::process_events() {
 		}
 	}
 
+#ifdef DBUS_ENABLED
+	if (portal_desktop) {
+		portal_desktop->process_file_dialog_callbacks();
+	}
+#endif
+
 	wayland_thread.mutex.unlock();
 
 	Input::get_singleton()->flush_buffered_events();

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5097,6 +5097,12 @@ void DisplayServerX11::process_events() {
 		*/
 	}
 
+#ifdef DBUS_ENABLED
+	if (portal_desktop) {
+		portal_desktop->process_file_dialog_callbacks();
+	}
+#endif
+
 	_THREAD_SAFE_UNLOCK_
 
 	Input::get_singleton()->flush_buffered_events();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90947

Behavior should be similar to macOS (callback deferred by OS and called during event processing), and help to avoid issues with hacky `ProgressDialog`.
