### PR TITLE
[CI] [macOS] Fix CI with new GitHub runners

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: "macos-latest"
+    runs-on: "macos-12"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
New `macos-latest` run on an arm64 image instead of x86_64 breaking the editor workflow.

See, for example, my own fork:
https://github.com/AThousandShips/godot/actions/runs/8804685495/job/24165878085

This seems to be rolled out piecemeal so currently the main repo hasn't been affected, but I've seen other cases

Picked `macos-12` as it's been what's been run on the main repo in my checking

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
