### PR TITLE
Fix vague error message when trying to import a WAV file that is too large

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -148,7 +148,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 		/* chunk size */
 		uint32_t chunksize = file->get_32();
-		uint32_t file_pos = file->get_position(); //save file pos, so we can skip to next chunk safely
+		uint64_t file_pos = file->get_position(); //save file pos, so we can skip to next chunk safely
 
 		if (file->eof_reached()) {
 			//ERR_PRINT("EOF REACH");
@@ -196,6 +196,8 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 				ERR_PRINT("'data' chunk before 'format' chunk found.");
 				break;
 			}
+
+			ERR_FAIL_COND_V_MSG(chunksize > INT_MAX, ERR_INVALID_DATA, "WAV file '" + p_source_file + "' is too large (> 2 GiB of data). Try shortening or splitting it or use a compressed format such as Ogg Vorbis or MP3 instead.");
 
 			frames = chunksize;
 

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -581,10 +581,10 @@ void AudioStreamWAV::set_data(const Vector<uint8_t> &p_data) {
 		data_bytes = 0;
 	}
 
-	int datalen = p_data.size();
-	if (datalen) {
+	int64_t datalen = p_data.size();
+	if (datalen > 0 && datalen <= INT_MAX) {
 		const uint8_t *r = p_data.ptr();
-		int alloc_len = datalen + DATA_PAD * 2;
+		int64_t alloc_len = datalen + DATA_PAD * 2;
 		data = memalloc(alloc_len); //alloc with some padding for interpolation
 		memset(data, 0, alloc_len);
 		uint8_t *dataptr = (uint8_t *)data;


### PR DESCRIPTION
Fixes #90957.

This is certainly an edge case (we're talking about more than 3 hours of audio in a single stream), but I suppose the error message could be a bit nicer than "Condition "p_size < 0"".

I also fixed an edge case in AudioStreamWAV, where the size calculation would overflow when adding the padding bytes to a size that's already close to INT_MAX.

I looked into truly supporting 4 GiB WAVs, but that doesn't seem feasible, because it runs into problems with saving the binary resource later, so that would require some more fundamental changes.