### PR TITLE
Fix errors/crashes related to skipped imports

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -200,7 +200,8 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	params->update();
 	_update_preset_menu();
 
-	if (params->importer.is_valid() && params->paths.size() == 1 && params->importer->has_advanced_options()) {
+	bool was_imported = p_config.is_valid() && p_config->get_value("remap", "importer") != "skip" && p_config->get_value("remap", "importer") != "keep";
+	if (was_imported && params->importer.is_valid() && params->paths.size() == 1 && params->importer->has_advanced_options()) {
 		advanced->show();
 		advanced_spacer->show();
 	} else {
@@ -508,6 +509,18 @@ static bool _find_owners(EditorFileSystemDirectory *efsd, const String &p_path) 
 	return false;
 }
 
+void ImportDock::_reimport_pressed() {
+	_reimport_attempt();
+
+	if (params->importer.is_valid() && params->paths.size() == 1 && params->importer->has_advanced_options()) {
+		advanced->show();
+		advanced_spacer->show();
+	} else {
+		advanced->hide();
+		advanced_spacer->hide();
+	}
+}
+
 void ImportDock::_reimport_attempt() {
 	bool used_in_resources = false;
 
@@ -528,7 +541,7 @@ void ImportDock::_reimport_attempt() {
 		ERR_CONTINUE(err != OK);
 
 		String imported_with = config->get_value("remap", "importer");
-		if (imported_with != importer_name) {
+		if (imported_with != importer_name && imported_with != "keep" && imported_with != "skip") {
 			Ref<Resource> resource = ResourceLoader::load(params->paths[i]);
 			if (resource.is_valid()) {
 				need_cleanup.push_back(params->paths[i]);
@@ -575,7 +588,10 @@ void ImportDock::_reimport_and_cleanup() {
 
 	for (const String &path : need_cleanup) {
 		Ref<Resource> old_res = old_resources[path];
-		Ref<Resource> new_res = ResourceLoader::load(path);
+		Ref<Resource> new_res;
+		if (params->importer.is_valid()) {
+			new_res = ResourceLoader::load(path);
+		}
 
 		for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
 			Node *edited_scene_root = EditorNode::get_editor_data().get_edited_scene_root(i);
@@ -782,7 +798,7 @@ ImportDock::ImportDock() {
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
-	import->connect("pressed", callable_mp(this, &ImportDock::_reimport_attempt));
+	import->connect("pressed", callable_mp(this, &ImportDock::_reimport_pressed));
 	if (!DisplayServer::get_singleton()->get_swap_cancel_ok()) {
 		advanced_spacer = hb->add_spacer();
 		advanced = memnew(Button);

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -76,6 +76,7 @@ class ImportDock : public VBoxContainer {
 	void _property_edited(const StringName &p_prop);
 	void _property_toggled(const StringName &p_prop, bool p_checked);
 	void _set_dirty(bool p_dirty);
+	void _reimport_pressed();
 	void _reimport_attempt();
 	void _reimport_and_cleanup();
 	void _reimport();

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -298,6 +298,7 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		}
 		return nullptr;
 	}
+	ERR_FAIL_COND_V(!p_options.has("animation/fps"), nullptr);
 
 #ifndef DISABLE_DEPRECATED
 	bool trimming = p_options.has("animation/trimming") ? (bool)p_options["animation/trimming"] : false;


### PR DESCRIPTION
- Added check for "animation/fps" key before attempting to use it in `EditorSceneFormatImporterBlend::import_scene`, to give error instead of crashing

- Don't show "Advanced..." button if last import used "Keep File" or "Skip File"

- Don't try to call `ResourceLoader::load` on kept/skipped file when changing importer, which would give an error

Fixes #90324

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
