### PR TITLE
Enforce using .NET SDK >= 8

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -151,7 +151,7 @@ def find_any_msbuild_tool(mono_prefix):
     return None
 
 
-def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: Optional[List[str]] = None):
+def run_msbuild(tools: ToolsLocation, sln: str, chdir_to: str, msbuild_args: Optional[List[str]] = None):
     using_msbuild_mono = False
 
     # Preference order: dotnet CLI > Standalone MSBuild > Mono's MSBuild
@@ -190,7 +190,8 @@ def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: Optional[List[str]
             }
         )
 
-    return subprocess.call(args, env=msbuild_env)
+    # We want to control cwd when running msbuild, because that's where the search for global.json begins.
+    return subprocess.call(args, env=msbuild_env, cwd=chdir_to)
 
 
 def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, precision):
@@ -218,11 +219,7 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
             args += ["/p:GodotFloat64=true"]
 
         sln = os.path.join(module_dir, "glue/GodotSharp/GodotSharp.sln")
-        exit_code = run_msbuild(
-            msbuild_tool,
-            sln=sln,
-            msbuild_args=args,
-        )
+        exit_code = run_msbuild(msbuild_tool, sln=sln, chdir_to=module_dir, msbuild_args=args)
         if exit_code != 0:
             return exit_code
 
@@ -361,7 +358,7 @@ def build_all(msbuild_tool, module_dir, output_dir, godot_platform, dev_debug, p
         args += ["/p:ClearNuGetLocalCache=true", "/p:PushNuGetToLocalSource=" + push_nupkgs_local]
     if precision == "double":
         args += ["/p:GodotFloat64=true"]
-    exit_code = run_msbuild(msbuild_tool, sln=sln, msbuild_args=args)
+    exit_code = run_msbuild(msbuild_tool, sln=sln, chdir_to=module_dir, msbuild_args=args)
     if exit_code != 0:
         return exit_code
 
@@ -372,7 +369,7 @@ def build_all(msbuild_tool, module_dir, output_dir, godot_platform, dev_debug, p
     if precision == "double":
         args += ["/p:GodotFloat64=true"]
     sln = os.path.join(module_dir, "editor/Godot.NET.Sdk/Godot.NET.Sdk.sln")
-    exit_code = run_msbuild(msbuild_tool, sln=sln, msbuild_args=args)
+    exit_code = run_msbuild(msbuild_tool, sln=sln, chdir_to=module_dir, msbuild_args=args)
     if exit_code != 0:
         return exit_code
 

--- a/modules/mono/global.json
+++ b/modules/mono/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
As discussed on 🚀 

Officially enforce that we are building the .NET projects with SDK 8.
- I believe we are already building with this on CI since we're running `ubuntu-20.04`.
- The [build container](https://github.com/godotengine/build-containers/blob/41400a892229e1bcf27b22bd1693ca09a0ed577b/Dockerfile.base#L10) already uses this SDK too.
- The required SDK version on the [*Compiling with .NET* documentation page](https://github.com/godotengine/godot-docs/blob/eb9931594e6909a87fcc2204a53f96dd10798ff5/contributing/development/compiling/compiling_with_dotnet.rst?plain=1#L11) will need to be edited to reflect this change.
- This should not impact anything since we do not change any TFM, nor any C# version used.
- This will however close #89386 by not allowing to build with SDK 6 any more.

Since the lookup for `global.json` starts in the current working directory (and not in the project directory), I had to modify our Python script to make sure we run our MSBuild commands from the `modules/mono/` folder. 
