### PR TITLE
Fix port cache calculation in GraphNode

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -647,6 +647,7 @@ void GraphNode::_port_pos_update() {
 	left_port_cache.clear();
 	right_port_cache.clear();
 	int vertical_ofs = titlebar_hbox->get_size().height + sb_titlebar->get_minimum_size().height + sb_panel->get_margin(SIDE_TOP);
+	int slot_index = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
 		Control *child = Object::cast_to<Control>(get_child(i, false));
@@ -656,27 +657,28 @@ void GraphNode::_port_pos_update() {
 
 		Size2i size = child->get_rect().size;
 
-		if (slot_table.has(i)) {
-			if (slot_table[i].enable_left) {
+		if (slot_table.has(slot_index)) {
+			if (slot_table[slot_index].enable_left) {
 				PortCache port_cache;
 				port_cache.pos = Point2i(edgeofs, vertical_ofs + size.height / 2);
-				port_cache.type = slot_table[i].type_left;
-				port_cache.color = slot_table[i].color_left;
-				port_cache.slot_index = child->get_index(false);
+				port_cache.type = slot_table[slot_index].type_left;
+				port_cache.color = slot_table[slot_index].color_left;
+				port_cache.slot_index = slot_index;
 				left_port_cache.push_back(port_cache);
 			}
-			if (slot_table[i].enable_right) {
+			if (slot_table[slot_index].enable_right) {
 				PortCache port_cache;
 				port_cache.pos = Point2i(get_size().width - edgeofs, vertical_ofs + size.height / 2);
-				port_cache.type = slot_table[i].type_right;
-				port_cache.color = slot_table[i].color_right;
-				port_cache.slot_index = child->get_index(false);
+				port_cache.type = slot_table[slot_index].type_right;
+				port_cache.color = slot_table[slot_index].color_right;
+				port_cache.slot_index = slot_index;
 				right_port_cache.push_back(port_cache);
 			}
 		}
 
 		vertical_ofs += separation;
 		vertical_ofs += size.height;
+		slot_index++;
 	}
 
 	port_pos_dirty = false;


### PR DESCRIPTION
Fixes #91082 by updating the `left_port_cache` & `right_port_cache` calculation in `GraphNode::_port_pos_update`.
