### PR TITLE
Increase width of project settings window.

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -54,7 +54,7 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
-		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
+		popup_centered_clamped(Size2(1200, 700) * EDSCALE, 0.8);
 	}
 
 	_add_feature_overrides();


### PR DESCRIPTION
Edits project_settings_editor.cpp

When creating a new project and opening the project settings window for the first time, it will automatically be set to a specific dimension (900 x 700). However, when using other languages (i.e. Polish), some of the taps at the top would be longer than the window, hiding some of the tabs, making the user click the arrows to see the rest of them.

By increasing the default window size to 1000 x 700, it guarantees that all tabs will be visible when the project window is first opened. I considered implementing a feature that changed the default size depending on the language, but decided that keeping the size consistent no matter the language would be better. 

Fixes #91009 