### PR TITLE
Core: Utilize initalizer lists in Math constructors

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -124,11 +124,11 @@ struct _NO_DISCARD_ AABB {
 
 	operator String() const;
 
-	_FORCE_INLINE_ AABB() {}
-	inline AABB(const Vector3 &p_pos, const Vector3 &p_size) :
+	constexpr AABB() {}
+
+	constexpr AABB(const Vector3 &p_pos, const Vector3 &p_size) :
 			position(p_pos),
-			size(p_size) {
-	}
+			size(p_size) {}
 };
 
 inline bool AABB::intersects(const AABB &p_aabb) const {

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -35,11 +35,7 @@
 #include "core/math/vector3.h"
 
 struct _NO_DISCARD_ Basis {
-	Vector3 rows[3] = {
-		Vector3(1, 0, 0),
-		Vector3(0, 1, 0),
-		Vector3(0, 0, 1)
-	};
+	Vector3 rows[3];
 
 	_FORCE_INLINE_ const Vector3 &operator[](int p_axis) const {
 		return rows[p_axis];
@@ -204,9 +200,6 @@ struct _NO_DISCARD_ Basis {
 				rows[0].z * p_m[0].y + rows[1].z * p_m[1].y + rows[2].z * p_m[2].y,
 				rows[0].z * p_m[0].z + rows[1].z * p_m[1].z + rows[2].z * p_m[2].z);
 	}
-	Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) {
-		set(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	}
 
 	void orthonormalize();
 	Basis orthonormalized() const;
@@ -230,11 +223,26 @@ struct _NO_DISCARD_ Basis {
 	Basis(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_angle, p_scale); }
 	static Basis from_scale(const Vector3 &p_scale);
 
-	_FORCE_INLINE_ Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) {
-		set_columns(p_x_axis, p_y_axis, p_z_axis);
-	}
+	constexpr Basis() :
+			rows{
+				{ 1, 0, 0 },
+				{ 0, 1, 0 },
+				{ 0, 0, 1 },
+			} {}
 
-	_FORCE_INLINE_ Basis() {}
+	constexpr Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) :
+			rows{
+				{ p_xx, p_xy, p_xz },
+				{ p_yx, p_yy, p_yz },
+				{ p_zx, p_zy, p_zz },
+			} {}
+
+	constexpr Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) :
+			rows{
+				{ p_x_axis.x, p_y_axis.x, p_z_axis.x },
+				{ p_x_axis.y, p_y_axis.y, p_z_axis.y },
+				{ p_x_axis.z, p_y_axis.z, p_z_axis.z },
+			} {}
 
 private:
 	// Helper method.

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -435,8 +435,6 @@ private:
 			return;
 		}
 
-		BOUNDS bb;
-
 		typename BVHTREE_CLASS::CullParams params;
 
 		params.result_count_overall = 0;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -43,7 +43,8 @@ struct _NO_DISCARD_ Color {
 			float b;
 			float a;
 		};
-		float components[4] = { 0, 0, 0, 1.0 };
+
+		float components[4] = { 0, 0, 0, 1 };
 	};
 
 	uint32_t to_rgba32() const;
@@ -221,40 +222,42 @@ struct _NO_DISCARD_ Color {
 	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
 
-	_FORCE_INLINE_ Color() {}
+	constexpr Color() :
+			r(0),
+			g(0),
+			b(0),
+			a(1) {}
 
 	/**
 	 * RGBA construct parameters.
 	 * Alpha is not optional as otherwise we can't bind the RGB version for scripting.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b, float p_a) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = p_a;
-	}
+	constexpr Color(float p_r, float p_g, float p_b, float p_a) :
+			r(p_r),
+			g(p_g),
+			b(p_b),
+			a(p_a) {}
 
 	/**
 	 * RGB construct parameters.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = 1.0f;
-	}
+	constexpr Color(float p_r, float p_g, float p_b) :
+			r(p_r),
+			g(p_g),
+			b(p_b),
+			a(1) {}
 
 	/**
 	 * Construct a Color from another Color, but with the specified alpha value.
 	 */
-	_FORCE_INLINE_ Color(const Color &p_c, float p_a) {
-		r = p_c.r;
-		g = p_c.g;
-		b = p_c.b;
-		a = p_a;
-	}
+	constexpr Color(const Color &p_c, float p_a) :
+			r(p_c.r),
+			g(p_c.g),
+			b(p_c.b),
+			a(p_a) {}
 
-	Color(const String &p_code) {
+	Color(const String &p_code) :
+			Color() {
 		if (html_is_valid(p_code)) {
 			*this = html(p_code);
 		} else {
@@ -262,7 +265,8 @@ struct _NO_DISCARD_ Color {
 		}
 	}
 
-	Color(const String &p_code, float p_a) {
+	Color(const String &p_code, float p_a) :
+			Color() {
 		*this = Color(p_code);
 		a = p_a;
 	}

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -79,12 +79,14 @@ struct _NO_DISCARD_ Face3 {
 	_FORCE_INLINE_ bool intersects_aabb2(const AABB &p_aabb) const;
 	operator String() const;
 
-	inline Face3() {}
-	inline Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) {
-		vertex[0] = p_v1;
-		vertex[1] = p_v2;
-		vertex[2] = p_v3;
-	}
+	constexpr Face3() {}
+
+	constexpr Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) :
+			vertex{
+				p_v1,
+				p_v2,
+				p_v3,
+			} {}
 };
 
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -80,12 +80,9 @@ struct _NO_DISCARD_ Plane {
 	_FORCE_INLINE_ bool operator!=(const Plane &p_plane) const;
 	operator String() const;
 
-	_FORCE_INLINE_ Plane() {}
-	_FORCE_INLINE_ Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
-			normal(p_a, p_b, p_c),
-			d(p_d) {}
-
-	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d = 0.0);
+	constexpr Plane() {}
+	constexpr Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d);
+	constexpr Plane(const Vector3 &p_normal, real_t p_d = 0);
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
@@ -102,11 +99,6 @@ bool Plane::has_point(const Vector3 &p_point, real_t p_tolerance) const {
 	real_t dist = normal.dot(p_point) - d;
 	dist = ABS(dist);
 	return (dist <= p_tolerance);
-}
-
-Plane::Plane(const Vector3 &p_normal, real_t p_d) :
-		normal(p_normal),
-		d(p_d) {
 }
 
 Plane::Plane(const Vector3 &p_normal, const Vector3 &p_point) :
@@ -132,5 +124,13 @@ bool Plane::operator==(const Plane &p_plane) const {
 bool Plane::operator!=(const Plane &p_plane) const {
 	return normal != p_plane.normal || d != p_plane.d;
 }
+
+constexpr Plane::Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
+		normal(p_a, p_b, p_c),
+		d(p_d) {}
+
+constexpr Plane::Plane(const Vector3 &p_normal, real_t p_d) :
+		normal(p_normal),
+		d(p_d) {}
 
 #endif // PLANE_H

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -699,10 +699,6 @@ void Projection::flip_y() {
 	}
 }
 
-Projection::Projection() {
-	set_identity();
-}
-
 Projection Projection::operator*(const Projection &p_matrix) const {
 	Projection new_matrix;
 
@@ -902,13 +898,6 @@ Projection::operator Transform3D() const {
 	tr.origin.z = m[14];
 
 	return tr;
-}
-
-Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) {
-	columns[0] = p_x;
-	columns[1] = p_y;
-	columns[2] = p_z;
-	columns[3] = p_w;
 }
 
 Projection::Projection(const Transform3D &p_transform) {

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -150,8 +150,8 @@ struct _NO_DISCARD_ Projection {
 
 	real_t get_lod_multiplier() const;
 
-	Projection();
-	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
+	constexpr Projection();
+	constexpr Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
 	Projection(const Transform3D &p_transform);
 	~Projection();
 };
@@ -164,5 +164,21 @@ Vector3 Projection::xform(const Vector3 &p_vec3) const {
 	real_t w = columns[0][3] * p_vec3.x + columns[1][3] * p_vec3.y + columns[2][3] * p_vec3.z + columns[3][3];
 	return ret / w;
 }
+
+constexpr Projection::Projection() :
+		columns{
+			{ 1, 0, 0, 0 },
+			{ 0, 1, 0, 0 },
+			{ 0, 0, 1, 0 },
+			{ 0, 0, 0, 1 },
+		} {}
+
+constexpr Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) :
+		columns{
+			p_x,
+			p_y,
+			p_z,
+			p_w,
+		} {}
 
 #endif // PROJECTION_H

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -43,7 +43,7 @@ struct _NO_DISCARD_ Quaternion {
 			real_t z;
 			real_t w;
 		};
-		real_t components[4] = { 0, 0, 0, 1.0 };
+		real_t components[4] = { 0, 0, 0, 1 };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_idx) {
@@ -115,23 +115,25 @@ struct _NO_DISCARD_ Quaternion {
 
 	operator String() const;
 
-	_FORCE_INLINE_ Quaternion() {}
+	constexpr Quaternion() :
+			x(0),
+			y(0),
+			z(0),
+			w(1) {}
 
-	_FORCE_INLINE_ Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+	constexpr Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x),
 			y(p_y),
 			z(p_z),
-			w(p_w) {
-	}
+			w(p_w) {}
 
 	Quaternion(const Vector3 &p_axis, real_t p_angle);
 
-	Quaternion(const Quaternion &p_q) :
+	constexpr Quaternion(const Quaternion &p_q) :
 			x(p_q.x),
 			y(p_q.y),
 			z(p_q.z),
-			w(p_q.w) {
-	}
+			w(p_q.w) {}
 
 	void operator=(const Quaternion &p_q) {
 		x = p_q.x;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -359,15 +359,15 @@ struct _NO_DISCARD_ Rect2 {
 	operator String() const;
 	operator Rect2i() const;
 
-	Rect2() {}
-	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
+	constexpr Rect2() {}
+
+	constexpr Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
 			position(Point2(p_x, p_y)),
-			size(Size2(p_width, p_height)) {
-	}
-	Rect2(const Point2 &p_pos, const Size2 &p_size) :
+			size(Size2(p_width, p_height)) {}
+
+	constexpr Rect2(const Point2 &p_pos, const Size2 &p_size) :
 			position(p_pos),
-			size(p_size) {
-	}
+			size(p_size) {}
 };
 
 #endif // RECT2_H

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -227,15 +227,15 @@ struct _NO_DISCARD_ Rect2i {
 	operator String() const;
 	operator Rect2() const;
 
-	Rect2i() {}
-	Rect2i(int p_x, int p_y, int p_width, int p_height) :
+	constexpr Rect2i() {}
+
+	constexpr Rect2i(int p_x, int p_y, int p_width, int p_height) :
 			position(Point2i(p_x, p_y)),
-			size(Size2i(p_width, p_height)) {
-	}
-	Rect2i(const Point2i &p_pos, const Size2i &p_size) :
+			size(Size2i(p_width, p_height)) {}
+
+	constexpr Rect2i(const Point2i &p_pos, const Size2i &p_size) :
 			position(p_pos),
-			size(p_size) {
-	}
+			size(p_size) {}
 };
 
 #endif // RECT2I_H

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -125,29 +125,30 @@ struct _NO_DISCARD_ Transform2D {
 
 	operator String() const;
 
-	Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) {
-		columns[0][0] = p_xx;
-		columns[0][1] = p_xy;
-		columns[1][0] = p_yx;
-		columns[1][1] = p_yy;
-		columns[2][0] = p_ox;
-		columns[2][1] = p_oy;
-	}
+	constexpr Transform2D() :
+			columns{
+				{ 1, 0 },
+				{ 0, 1 },
+				{ 0, 0 },
+			} {}
 
-	Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) {
-		columns[0] = p_x;
-		columns[1] = p_y;
-		columns[2] = p_origin;
-	}
+	constexpr Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) :
+			columns{
+				{ p_xx, p_xy },
+				{ p_yx, p_yy },
+				{ p_ox, p_oy },
+			} {}
+
+	constexpr Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) :
+			columns{
+				p_x,
+				p_y,
+				p_origin,
+			} {}
 
 	Transform2D(real_t p_rot, const Vector2 &p_pos);
 
 	Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos);
-
-	Transform2D() {
-		columns[0][0] = 1.0;
-		columns[1][1] = 1.0;
-	}
 };
 
 Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -225,20 +225,3 @@ Transform3D::operator String() const {
 			", Z: " + basis.get_column(2).operator String() +
 			", O: " + origin.operator String() + "]";
 }
-
-Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :
-		basis(p_basis),
-		origin(p_origin) {
-}
-
-Transform3D::Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
-		origin(p_origin) {
-	basis.set_column(0, p_x);
-	basis.set_column(1, p_y);
-	basis.set_column(2, p_z);
-}
-
-Transform3D::Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) {
-	basis = Basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	origin = Vector3(p_ox, p_oy, p_oz);
-}

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -124,10 +124,19 @@ struct _NO_DISCARD_ Transform3D {
 
 	operator String() const;
 
-	Transform3D() {}
-	Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3());
-	Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin);
-	Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz);
+	constexpr Transform3D() {}
+
+	constexpr Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3()) :
+			basis(p_basis),
+			origin(p_origin) {}
+
+	constexpr Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
+			basis(p_x, p_y, p_z),
+			origin(p_origin) {}
+
+	constexpr Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) :
+			basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz),
+			origin(p_ox, p_oy, p_oz) {}
 };
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -57,7 +57,7 @@ struct _NO_DISCARD_ Vector2 {
 			};
 		};
 
-		real_t coord[2] = { 0 };
+		real_t coord[2] = { 0, 0 };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
@@ -174,11 +174,13 @@ struct _NO_DISCARD_ Vector2 {
 	operator String() const;
 	operator Vector2i() const;
 
-	_FORCE_INLINE_ Vector2() {}
-	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	constexpr Vector2() :
+			x(0),
+			y(0) {}
+
+	constexpr Vector2(real_t p_x, real_t p_y) :
+			x(p_x),
+			y(p_y) {}
 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -57,7 +57,7 @@ struct _NO_DISCARD_ Vector2i {
 			};
 		};
 
-		int32_t coord[2] = { 0 };
+		int32_t coord[2] = { 0, 0 };
 	};
 
 	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
@@ -132,11 +132,13 @@ struct _NO_DISCARD_ Vector2i {
 	operator String() const;
 	operator Vector2() const;
 
-	inline Vector2i() {}
-	inline Vector2i(int32_t p_x, int32_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	constexpr Vector2i() :
+			x(0),
+			y(0) {}
+
+	constexpr Vector2i(int32_t p_x, int32_t p_y) :
+			x(p_x),
+			y(p_y) {}
 };
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -55,7 +55,7 @@ struct _NO_DISCARD_ Vector3 {
 			real_t z;
 		};
 
-		real_t coord[3] = { 0 };
+		real_t coord[3] = { 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
@@ -175,12 +175,15 @@ struct _NO_DISCARD_ Vector3 {
 	operator String() const;
 	operator Vector3i() const;
 
-	_FORCE_INLINE_ Vector3() {}
-	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3() :
+			x(0),
+			y(0),
+			z(0) {}
+
+	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :
+			x(p_x),
+			y(p_y),
+			z(p_z) {}
 };
 
 Vector3 Vector3::cross(const Vector3 &p_with) const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -53,7 +53,7 @@ struct _NO_DISCARD_ Vector3i {
 			int32_t z;
 		};
 
-		int32_t coord[3] = { 0 };
+		int32_t coord[3] = { 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
@@ -122,12 +122,15 @@ struct _NO_DISCARD_ Vector3i {
 	operator String() const;
 	operator Vector3() const;
 
-	_FORCE_INLINE_ Vector3i() {}
-	_FORCE_INLINE_ Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3i() :
+			x(0),
+			y(0),
+			z(0) {}
+
+	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
+			x(p_x),
+			y(p_y),
+			z(p_z) {}
 };
 
 int64_t Vector3i::length_squared() const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -130,21 +130,23 @@ struct _NO_DISCARD_ Vector4 {
 
 	operator String() const;
 
-	_FORCE_INLINE_ Vector4() {}
+	constexpr Vector4() :
+			x(0),
+			y(0),
+			z(0),
+			w(0) {}
 
-	_FORCE_INLINE_ Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+	constexpr Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x),
 			y(p_y),
 			z(p_z),
-			w(p_w) {
-	}
+			w(p_w) {}
 
-	Vector4(const Vector4 &p_vec4) :
+	constexpr Vector4(const Vector4 &p_vec4) :
 			x(p_vec4.x),
 			y(p_vec4.y),
 			z(p_vec4.z),
-			w(p_vec4.w) {
-	}
+			w(p_vec4.w) {}
 
 	void operator=(const Vector4 &p_vec4) {
 		x = p_vec4.x;

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -55,7 +55,7 @@ struct _NO_DISCARD_ Vector4i {
 			int32_t w;
 		};
 
-		int32_t coord[4] = { 0 };
+		int32_t coord[4] = { 0, 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
@@ -124,14 +124,19 @@ struct _NO_DISCARD_ Vector4i {
 	operator String() const;
 	operator Vector4() const;
 
-	_FORCE_INLINE_ Vector4i() {}
+	constexpr Vector4i() :
+			x(0),
+			y(0),
+			z(0),
+			w(0) {}
+
+	constexpr Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) :
+			x(p_x),
+			y(p_y),
+			z(p_z),
+			w(p_w) {}
+
 	Vector4i(const Vector4 &p_vec4);
-	_FORCE_INLINE_ Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
 };
 
 int64_t Vector4i::length_squared() const {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -165,7 +165,7 @@ private:
 	// Variant takes 20 bytes when real_t is float, and 36 if double
 	// it only allocates extra memory for aabb/matrix.
 
-	Type type;
+	Type type = NIL;
 
 	struct ObjData {
 		ObjectID id;

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -208,7 +208,6 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) const {
 
 				Vector<float> ret;
 				ret.resize(16);
-				Transform3D tr;
 				// i wonder why collada matrices are transposed, given that's opposed to opengl..
 				ret.write[0] = interp.basis.rows[0][0];
 				ret.write[1] = interp.basis.rows[0][1];

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4702,7 +4702,6 @@ void CanvasItemEditor::_set_owner_for_node_and_children(Node *p_node, Node *p_ow
 }
 
 void CanvasItemEditor::_focus_selection(int p_op) {
-	Vector2 center(0.f, 0.f);
 	Rect2 rect;
 	int count = 0;
 

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -219,7 +219,6 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector3 right(hsize * size_factor.x, 0, 0);
 			Vector3 up(0, hsize * size_factor.y, 0);
 			Vector3 back(0, 0, -1.0);
-			Vector3 front(0, 0, 0);
 
 			ADD_QUAD(-up - right, -up + right, up + right, up - right);
 			ADD_QUAD(-up - right + back, -up + right + back, up + right + back, up - right + back);

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -475,7 +475,6 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 
 	for (int i = 0; i < poly.size(); i++) {
 		Vector2 point_2d;
-		Vector2 p2;
 
 		if (i == edited_point) {
 			point_2d = edited_point_pos;

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -479,7 +479,7 @@ void Polygon3DEditor::_polygon_draw() {
 		va.resize(poly.size());
 		Vector3 *w = va.ptrw();
 		for (int i = 0; i < poly.size(); i++) {
-			Vector2 p, p2;
+			Vector2 p;
 			p = i == edited_point ? edited_point_pos : poly[i];
 
 			Vector3 point = Vector3(p.x, p.y, depth);

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -135,7 +135,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	// few things we need
 	Input *input = Input::get_singleton();
 	Vector3 down(0.0, -1.0, 0.0); // Down is Y negative
-	Vector3 north(0.0, 0.0, 1.0); // North is Z positive
+	//Vector3 north(0.0, 0.0, 1.0); // North is Z positive
 
 	// make copies of our inputs
 	bool has_grav = false;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2457,8 +2457,6 @@ Transform3D OpenXRAPI::transform_from_pose(const XrPosef &p_pose) {
 
 template <typename T>
 XRPose::TrackingConfidence _transform_from_location(const T &p_location, Transform3D &r_transform) {
-	Basis basis;
-	Vector3 origin;
 	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
 	const XrPosef &pose = p_location.pose;
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -68,7 +68,6 @@ static GodotIOJavaWrapper *godot_io_java = nullptr;
 
 static SafeNumeric<int> step; // Shared between UI and render threads
 
-static Size2 new_size;
 static Vector3 accelerometer;
 static Vector3 gravity;
 static Vector3 magnetometer;

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -424,7 +424,6 @@ void Label::_notification(int p_what) {
 
 			bool has_settings = settings.is_valid();
 
-			Size2 string_size;
 			Size2 size = get_size();
 			Ref<StyleBox> style = theme_cache.normal_style;
 			Ref<Font> font = (has_settings && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -524,7 +524,6 @@ static void fill_bits(const BitMap *p_src, Ref<BitMap> &p_map, const Point2i &p_
 Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2i &p_rect, float p_epsilon) const {
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 
-	Point2i from;
 	Ref<BitMap> fill;
 	fill.instantiate();
 	fill->create(get_size());

--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -112,7 +112,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	}
 
 	Vector3 b1Axis1, b1Axis2, b1Axis3;
-	Vector3 b2Axis1, b2Axis2;
+	Vector3 b2Axis1;
 
 	b1Axis1 = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(0));
 	b2Axis1 = B->get_transform().basis.xform(m_rbBFrame.basis.get_column(0));


### PR DESCRIPTION
The Math equivalent of #90866, whereby the bulk of math constructors set their properties via initalizer lists. Differs from Variant in two main ways:
1. Not all constructors got this treatment, as some had more advanced logic that was outside the scope of this conversion.
2. Due to using exclusively primitive types, the changed constructors are all able to safely use `constexpr`. (Possible groundwork for constexpr math types? 🤔)