### PR TITLE
Fix error when moving FileSystem dock

### DIFF
--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -117,23 +117,13 @@ void EditorDirDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			FileSystemDock::get_singleton()->connect("folder_color_changed", callable_mp(this, &EditorDirDialog::reload).bind(""));
-
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload).bind(""));
 			reload();
-
-			if (!tree->is_connected("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed))) {
-				tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), CONNECT_DEFERRED);
-			}
-
-			if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
-				EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload).bind(""));
-			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
-				EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
-			}
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
+			FileSystemDock::get_singleton()->disconnect("folder_color_changed", callable_mp(this, &EditorDirDialog::reload));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -229,6 +219,7 @@ EditorDirDialog::EditorDirDialog() {
 	vb->add_child(tree);
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tree->connect("item_activated", callable_mp(this, &EditorDirDialog::_item_activated));
+	tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), CONNECT_DEFERRED);
 
 	set_ok_button_text(TTR("Move"));
 


### PR DESCRIPTION
Moving the FileSystem dock between different slots produces this error:

> ERROR: Signal 'folder_color_changed' is already connected to given callable 'EditorDirDialog::reload' in that object.
>   at: connect (core/object/object.cpp:1431)

- For the `filesystem_changed` signal, it's always connected upon entering the tree and is disconnected when exiting the tree. The redundant connection check is removed.
- For the `folder_color_changed` signal, it's the same as `filesystem_changed`. This PR disconnects it when exiting the tree. So there won't be errors anymore.
- For the `item_collapsed` signal, it can be moved to the constructor.