### PR TITLE
Add BitMap methods for bitwise boolean operations

### DIFF
--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -9,6 +9,33 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="bitwise_and">
+			<return type="void" />
+			<param index="0" name="other" type="BitMap" />
+			<description>
+				Performs the boolean AND operation with this bitmap and [param other]. This method fails if the two bitmaps are not exactly the same size.
+			</description>
+		</method>
+		<method name="bitwise_not">
+			<return type="void" />
+			<description>
+				Performs the boolean NOT operation on this bitmap. This causes every bit to flip from [code]true[/code] to [code]false[/code], and from [code]false[/code] to [code]true[/code].
+			</description>
+		</method>
+		<method name="bitwise_or">
+			<return type="void" />
+			<param index="0" name="other" type="BitMap" />
+			<description>
+				Performs the boolean OR operation with this bitmap and [param other]. This method fails if the two bitmaps are not exactly the same size.
+			</description>
+		</method>
+		<method name="bitwise_xor">
+			<return type="void" />
+			<param index="0" name="other" type="BitMap" />
+			<description>
+				Performs the boolean XOR operation with this bitmap and [param other]. This method fails if the two bitmaps are not exactly the same size.
+			</description>
+		</method>
 		<method name="convert_to_image" qualifiers="const">
 			<return type="Image" />
 			<description>

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -704,6 +704,87 @@ void BitMap::blit(const Vector2i &p_pos, const Ref<BitMap> &p_bitmap) {
 	}
 }
 
+void BitMap::bitwise_and(const Ref<BitMap> &p_other) {
+	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+
+	int ds = bitmask.size();
+	uint8_t *d = bitmask.ptrw();
+	const uint8_t *d2 = p_other->bitmask.ptr();
+
+	uint64_t *d_u64 = (uint64_t *)d;
+	const uint64_t *d2_u64 = (uint64_t *)d2;
+
+	for (int i = 0; i < (ds >> 3); i++) {
+		d_u64[i] &= d2_u64[i];
+	}
+
+	for (int i = ds & ~0b111; i < ds; i++) {
+		d[i] &= d2[i];
+	}
+}
+
+void BitMap::bitwise_not() {
+	int ds = bitmask.size();
+	uint8_t *d = bitmask.ptrw();
+
+	uint64_t *d_u64 = (uint64_t *)d;
+
+	for (int i = 0; i < (ds >> 3); i++) {
+		d_u64[i] = ~d_u64[i];
+	}
+
+	for (int i = ds & ~0b111; i < ds; i++) {
+		d[i] = ~d[i];
+	}
+
+	// mask "hidden" bits for true bit count
+	int hidden_count = (ds << 3) - (width * height);
+	if (hidden_count > 0) {
+		d[ds - 1] &= 0xFF << hidden_count;
+	}
+}
+
+void BitMap::bitwise_or(const Ref<BitMap> &p_other) {
+	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+
+	int ds = bitmask.size();
+	uint8_t *d = bitmask.ptrw();
+	const uint8_t *d2 = p_other->bitmask.ptr();
+
+	uint64_t *d_u64 = (uint64_t *)d;
+	const uint64_t *d2_u64 = (uint64_t *)d2;
+
+	for (int i = 0; i < (ds >> 3); i++) {
+		d_u64[i] |= d2_u64[i];
+	}
+
+	for (int i = ds & ~0b111; i < ds; i++) {
+		d[i] |= d2[i];
+	}
+}
+
+void BitMap::bitwise_xor(const Ref<BitMap> &p_other) {
+	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+
+	int ds = bitmask.size();
+	uint8_t *d = bitmask.ptrw();
+	const uint8_t *d2 = p_other->bitmask.ptr();
+
+	uint64_t *d_u64 = (uint64_t *)d;
+	const uint64_t *d2_u64 = (uint64_t *)d2;
+
+	for (int i = 0; i < (ds >> 3); i++) {
+		d_u64[i] ^= d2_u64[i];
+	}
+
+	for (int i = ds & ~0b111; i < ds; i++) {
+		d[i] ^= d2[i];
+	}
+}
+
 void BitMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create", "size"), &BitMap::create);
 	ClassDB::bind_method(D_METHOD("create_from_image_alpha", "image", "threshold"), &BitMap::create_from_image_alpha, DEFVAL(0.1));
@@ -725,6 +806,11 @@ void BitMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("grow_mask", "pixels", "rect"), &BitMap::grow_mask);
 	ClassDB::bind_method(D_METHOD("convert_to_image"), &BitMap::convert_to_image);
 	ClassDB::bind_method(D_METHOD("opaque_to_polygons", "rect", "epsilon"), &BitMap::_opaque_to_polygons_bind, DEFVAL(2.0));
+
+	ClassDB::bind_method(D_METHOD("bitwise_and", "other"), &BitMap::bitwise_and);
+	ClassDB::bind_method(D_METHOD("bitwise_not"), &BitMap::bitwise_not);
+	ClassDB::bind_method(D_METHOD("bitwise_or", "other"), &BitMap::bitwise_or);
+	ClassDB::bind_method(D_METHOD("bitwise_xor", "other"), &BitMap::bitwise_xor);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 }

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -746,8 +746,8 @@ void BitMap::bitwise_not() {
 }
 
 void BitMap::bitwise_or(const Ref<BitMap> &p_other) {
-	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
-	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+	ERR_FAIL_COND_MSG(p_other.is_null(), "The BitMap passed as the \"other\" parameter is null.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "Both bitmaps need to have the same size.");
 
 	int ds = bitmask.size();
 	uint8_t *d = bitmask.ptrw();
@@ -766,8 +766,8 @@ void BitMap::bitwise_or(const Ref<BitMap> &p_other) {
 }
 
 void BitMap::bitwise_xor(const Ref<BitMap> &p_other) {
-	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
-	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+	ERR_FAIL_COND_MSG(p_other.is_null(), "The BitMap passed as the \"other\" parameter is null.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "Both bitmaps need to have the same size.");
 
 	int ds = bitmask.size();
 	uint8_t *d = bitmask.ptrw();

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -705,8 +705,8 @@ void BitMap::blit(const Vector2i &p_pos, const Ref<BitMap> &p_bitmap) {
 }
 
 void BitMap::bitwise_and(const Ref<BitMap> &p_other) {
-	ERR_FAIL_COND_MSG(p_other.is_null(), "Null reference to supplied BitMap other.");
-	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "The given bitmap is not the expected size for the specified operation.");
+	ERR_FAIL_COND_MSG(p_other.is_null(), "The BitMap passed as the \"other\" parameter is null.");
+	ERR_FAIL_COND_MSG(get_size() != p_other->get_size(), "Both bitmaps need to have the same size.");
 
 	int ds = bitmask.size();
 	uint8_t *d = bitmask.ptrw();
@@ -738,7 +738,7 @@ void BitMap::bitwise_not() {
 		d[i] = ~d[i];
 	}
 
-	// mask "hidden" bits for true bit count
+	// Reset extraneous trailing bits we may have accidentally set during the previous loops.
 	int hidden_count = (ds << 3) - (width * height);
 	if (hidden_count > 0) {
 		d[ds - 1] &= 0xFF << hidden_count;

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -79,6 +79,11 @@ public:
 
 	Vector<Vector<Vector2>> clip_opaque_to_polygons(const Rect2i &p_rect, float p_epsilon = 2.0) const;
 
+	void bitwise_and(const Ref<BitMap> &p_other);
+	void bitwise_not();
+	void bitwise_or(const Ref<BitMap> &p_other);
+	void bitwise_xor(const Ref<BitMap> &p_other);
+
 	BitMap();
 };
 


### PR DESCRIPTION
Created methods for BitMap for boolean operators AND, OR, XOR, and NOT.  

The methods for the binary operators (AND, OR, XOR) all have a parameter "other" for the secondary bitmap (the one being compared to).  ~~Additionally, there is a BitwiseSizeMode enum which controls the size of the new bitmap being made, in the case that the bitmaps are not the same size.~~ (Edit: For performance reasons, this proposed size mode implementation was scrapped.)  The method bitwise_not is unary, and thus does not have any parameters.

This is an uninstrusive QOL change for handling bitmaps.  Combining and operating on bitmaps is a common operation in many games that use them.  I, for one, am working on a puzzle game where geometry is generated from bitmaps you edit.  Ordinarily, comparing two bitmaps can be tedious, usually involving some sort of nested double for loop.  This can obviously bloat your game's codebase.  The new methods in this PR will make combining bitmaps much simpler for developers.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9609*