### PR TITLE
[RTL] Add extra argument to `remove_paragraph` to skip cache invalidation and a method for manual cache invalidation.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -249,6 +249,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="invalidate_paragraph">
+			<return type="bool" />
+			<param index="0" name="paragraph" type="int" />
+			<description>
+				Invalidates [param paragraph] and all subsequent paragraphs cache.
+			</description>
+		</method>
 		<method name="is_menu_visible" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -497,9 +504,11 @@
 		<method name="remove_paragraph">
 			<return type="bool" />
 			<param index="0" name="paragraph" type="int" />
+			<param index="1" name="no_invalidate" type="bool" default="false" />
 			<description>
 				Removes a paragraph of content from the label. Returns [code]true[/code] if the paragraph exists.
 				The [param paragraph] argument is the index of the paragraph to remove, it can take values in the interval [code][0, get_paragraph_count() - 1][/code].
+				If [param no_invalidate] is set to [code]true[/code], cache for the subsequent paragraphs is not invalidated. Use it for faster updates if deleted paragraph is fully self-contained (have no unclosed tags), or this call is part of the complex edit operation and [method invalidate_paragraph] will be called at the end of operation.
 			</description>
 		</method>
 		<method name="scroll_to_line">

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -330,3 +330,10 @@ GH-84472
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_circle/arguments': size changed value in new API, from 3 to 6.
 
 Optional arguments added. Compatibility methods registered.
+
+
+GH-91098
+--------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/remove_paragraph/arguments': size changed value in new API, from 1 to 2.
+
+Added optional argument. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -38,9 +38,14 @@ void RichTextLabel::_add_image_bind_compat_80410(const Ref<Texture2D> &p_image, 
 	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, Variant(), false, String(), false);
 }
 
+bool RichTextLabel::_remove_paragraph_bind_compat_91098(int p_paragraph) {
+	return remove_paragraph(p_paragraph, false);
+}
+
 void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89024);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));
+	ClassDB::bind_compatibility_method(D_METHOD("remove_paragraph", "paragraph"), &RichTextLabel::_remove_paragraph_bind_compat_91098);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -134,6 +134,7 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	void _push_meta_bind_compat_89024(const Variant &p_meta);
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
+	bool _remove_paragraph_bind_compat_91098(int p_paragraph);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -664,7 +665,8 @@ public:
 	void add_image(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false);
 	void update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false);
 	void add_newline();
-	bool remove_paragraph(const int p_paragraph);
+	bool remove_paragraph(int p_paragraph, bool p_no_invalidate = false);
+	bool invalidate_paragraph(int p_paragraph);
 	void push_dropcap(const String &p_string, const Ref<Font> &p_font, int p_size, const Rect2 &p_dropcap_margins = Rect2(), const Color &p_color = Color(1, 1, 1), int p_ol_size = 0, const Color &p_ol_color = Color(0, 0, 0, 0));
 	void _push_def_font(DefaultFont p_def_font);
 	void _push_def_font_var(DefaultFont p_def_font, const Ref<Font> &p_font, int p_size = -1);


### PR DESCRIPTION
Required to quickly remove paragraph for the beginning of log without full refresh, see https://github.com/godotengine/godot/pull/91012
