### PR TITLE
Add symlink API support for Windows, expose symlink methods.

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -582,6 +582,10 @@ void DirAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove", "path"), &DirAccess::remove);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("remove_absolute", "path"), &DirAccess::remove_absolute);
 
+	ClassDB::bind_method(D_METHOD("is_link", "path"), &DirAccess::is_link);
+	ClassDB::bind_method(D_METHOD("read_link", "path"), &DirAccess::read_link);
+	ClassDB::bind_method(D_METHOD("create_link", "source", "target"), &DirAccess::create_link);
+
 	ClassDB::bind_method(D_METHOD("set_include_navigational", "enable"), &DirAccess::set_include_navigational);
 	ClassDB::bind_method(D_METHOD("get_include_navigational"), &DirAccess::get_include_navigational);
 	ClassDB::bind_method(D_METHOD("set_include_hidden", "enable"), &DirAccess::set_include_hidden);

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -94,6 +94,16 @@
 				Static version of [method copy]. Supports only absolute paths.
 			</description>
 		</method>
+		<method name="create_link">
+			<return type="int" enum="Error" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="target" type="String" />
+			<description>
+				Creates symbolic link between files or folders.
+				[b]Note:[/b] On Windows, this method works only if the application is running with elevated privileges or Developer Mode is enabled.
+				[b]Note:[/b] This method is implemented on macOS, Linux, and Windows.
+			</description>
+		</method>
 		<method name="current_is_dir" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -212,6 +222,14 @@
 				[b]Note:[/b] This method is implemented on macOS, Linux (for EXT4 and F2FS filesystems only) and Windows. On other platforms, it always returns [code]true[/code].
 			</description>
 		</method>
+		<method name="is_link">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns [code]true[/code] if the file or directory is a symbolic link, directory junction, or other reparse point.
+				[b]Note:[/b] This method is implemented on macOS, Linux, and Windows.
+			</description>
+		</method>
 		<method name="list_dir_begin">
 			<return type="int" enum="Error" />
 			<description>
@@ -262,6 +280,14 @@
 			<description>
 				Creates a new [DirAccess] object and opens an existing directory of the filesystem. The [param path] argument can be within the project tree ([code]res://folder[/code]), the user directory ([code]user://folder[/code]) or an absolute path of the user filesystem (e.g. [code]/tmp/folder[/code] or [code]C:\tmp\folder[/code]).
 				Returns [code]null[/code] if opening the directory failed. You can use [method get_open_error] to check the error that occurred.
+			</description>
+		</method>
+		<method name="read_link">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns target of the symbolic link.
+				[b]Note:[/b] This method is implemented on macOS, Linux, and Windows.
 			</description>
 		</method>
 		<method name="remove">

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -77,9 +77,9 @@ public:
 	virtual Error rename(String p_path, String p_new_path) override;
 	virtual Error remove(String p_path) override;
 
-	virtual bool is_link(String p_file) override { return false; };
-	virtual String read_link(String p_file) override { return p_file; };
-	virtual Error create_link(String p_source, String p_target) override { return FAILED; };
+	virtual bool is_link(String p_file) override;
+	virtual String read_link(String p_file) override;
+	virtual Error create_link(String p_source, String p_target) override;
 
 	uint64_t get_space_left() override;
 


### PR DESCRIPTION
Note: `create_link` require evelated privilegies or [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) enabled.