### PR TITLE
NavigationRegion test suppress warning about visual meshes

### DIFF
--- a/tests/scene/test_navigation_region_3d.h
+++ b/tests/scene/test_navigation_region_3d.h
@@ -65,7 +65,9 @@ TEST_SUITE("[Navigation]") {
 		CHECK_EQ(navigation_mesh->get_vertices().size(), 0);
 
 		SUBCASE("Synchronous bake should have immediate effects") {
+			ERR_PRINT_OFF; // Suppress warning about baking from visual meshes as source geometry.
 			navigation_region->bake_navigation_mesh(false);
+			ERR_PRINT_ON;
 			CHECK_FALSE(navigation_region->is_baking());
 			CHECK_NE(navigation_mesh->get_polygon_count(), 0);
 			CHECK_NE(navigation_mesh->get_vertices().size(), 0);


### PR DESCRIPTION
Suppresses warning about source geometry parsing from visual meshes in NavigationRegion test.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
