### PR TITLE
[CI] [macOS] Build for both `arm64` and `x86_64`

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: "macos-12"
+    runs-on: "macos-latest"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -24,7 +24,7 @@ jobs:
             cache-name: macos-editor
             target: editor
             tests: true
-            bin: "./bin/godot.macos.editor.x86_64"
+            bin: "./bin/godot.macos.editor.universal"
 
           - name: Template (target=template_release)
             cache-name: macos-template
@@ -50,16 +50,26 @@ jobs:
         run: |
           sh misc/scripts/install_vulkan_sdk_macos.sh
 
-      - name: Compilation
+      - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }}
+          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+          platform: macos
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Compilation (arm64)
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
 
       - name: Prepare artifact
         run: |
+          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal
+          rm ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64
           strip bin/godot.*
           chmod +x bin/godot.*
 


### PR DESCRIPTION
Creates a universal build, to catch discrepancies on different architectures

Follow-up to:
* https://github.com/godotengine/godot/pull/91074

See https://github.com/godotengine/godot/pull/91074#issuecomment-2074514049

The build times will naturally increase on large changes, but ensuring general code compliance should be worth it, using a universal build to make testing easier without having to wrangle CI commands to test which version to use

Switched back to using the latest image, can switch back to using any specific image to perhaps ensure stability, unsure if mixing images slows down CI due to needing a different runner available

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
