### PR TITLE
Fix `Path3D` tilt gizmo raycasting against local plane

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -169,21 +169,17 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 			const Basis posture = c->get_point_baked_posture(idx);
 			const Vector3 tangent = -posture.get_column(2);
 			const Vector3 up = posture.get_column(1);
-			const Plane p_tilt = Plane(tangent, position);
+			const Plane tilt_plane_global = gt.xform(Plane(tangent, position));
 
 			Vector3 intersection;
 
-			if (p_tilt.intersects_ray(ray_from, ray_dir, &intersection)) {
-				Vector3 direction = intersection - position;
-				direction.normalize(); // FIXME: redundant?
+			if (tilt_plane_global.intersects_ray(ray_from, ray_dir, &intersection)) {
+				Vector3 direction = gi.xform(intersection) - position;
 				real_t tilt_angle = up.signed_angle_to(direction, tangent);
 
 				if (Node3DEditor::get_singleton()->is_snap_enabled()) {
-					real_t snap = Node3DEditor::get_singleton()->get_rotate_snap();
-
-					tilt_angle = Math::rad_to_deg(tilt_angle) + snap * 0.5; // Else it won't reach +180.
-					tilt_angle -= Math::fmod(tilt_angle, snap);
-					tilt_angle = Math::deg_to_rad(tilt_angle);
+					real_t snap_degrees = Node3DEditor::get_singleton()->get_rotate_snap();
+					tilt_angle = Math::deg_to_rad(Math::snapped(Math::rad_to_deg(tilt_angle), snap_degrees));
 				}
 
 				c->set_point_tilt(idx, tilt_angle);


### PR DESCRIPTION
Fixes #91088.

| Before<br>(v4.3.dev5.official [89f70e98d])| After<br>(this PR)|
|--------|--------|
|![Ty5KWfHDQe](https://github.com/godotengine/godot/assets/9283098/f8d09b84-e2a2-46bf-9dd2-8dcc624c5434)|![htVOHeFql1](https://github.com/godotengine/godot/assets/9283098/fa61ccbd-c496-44e6-9201-f02149a83176)|

Also fixes incorrect tilt snapping for negative angles (just like in #84049):
| Before<br>(v4.3.dev5.official [89f70e98d])| After<br>(this PR)|
|--------|--------|
|![vfnxfbcraS](https://github.com/godotengine/godot/assets/9283098/0c9d65a2-e118-4c4d-b2c5-dd9694b2f8d3)|![0z5HsIQc8g](https://github.com/godotengine/godot/assets/9283098/589f9a4c-6567-4d11-8d97-2d80e12c6e66)|
