### PR TITLE
Avoid double handling of rename in the file system dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -138,9 +138,7 @@ String FileSystemList::get_edit_text() {
 }
 
 void FileSystemList::_text_editor_popup_modal_close() {
-	if (Input::get_singleton()->is_key_pressed(Key::ESCAPE) ||
-			Input::get_singleton()->is_key_pressed(Key::KP_ENTER) ||
-			Input::get_singleton()->is_key_pressed(Key::ENTER)) {
+	if (popup_editor->get_hide_reason() == Popup::HIDE_REASON_CANCELED) {
 		return;
 	}
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -77,6 +77,9 @@ void Popup::_notification(int p_what) {
 					_initialize_visible_parents();
 				} else {
 					_deinitialize_visible_parents();
+					if (hide_reason == HIDE_REASON_NONE) {
+						hide_reason = HIDE_REASON_CANCELED;
+					}
 					emit_signal(SNAME("popup_hide"));
 					popped_up = false;
 				}
@@ -87,6 +90,7 @@ void Popup::_notification(int p_what) {
 			if (!is_in_edited_scene_root()) {
 				if (has_focus()) {
 					popped_up = true;
+					hide_reason = HIDE_REASON_NONE;
 				}
 			}
 		} break;
@@ -100,6 +104,7 @@ void Popup::_notification(int p_what) {
 
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			if (!is_in_edited_scene_root()) {
+				hide_reason = HIDE_REASON_UNFOCUSED;
 				_close_pressed();
 			}
 		} break;
@@ -114,6 +119,7 @@ void Popup::_notification(int p_what) {
 
 void Popup::_parent_focused() {
 	if (popped_up && get_flag(FLAG_POPUP)) {
+		hide_reason = HIDE_REASON_UNFOCUSED;
 		_close_pressed();
 	}
 }

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -43,6 +43,16 @@ class Popup : public Window {
 	LocalVector<Window *> visible_parents;
 	bool popped_up = false;
 
+public:
+	enum HideReason {
+		HIDE_REASON_NONE,
+		HIDE_REASON_CANCELED, // E.g., because of rupture of UI flow (app unfocused). Includes closed programmatically.
+		HIDE_REASON_UNFOCUSED, // E.g., user clicked outside.
+	};
+
+private:
+	HideReason hide_reason = HIDE_REASON_NONE;
+
 	void _initialize_visible_parents();
 	void _deinitialize_visible_parents();
 
@@ -60,6 +70,8 @@ protected:
 	virtual void _post_popup() override;
 
 public:
+	HideReason get_hide_reason() const { return hide_reason; }
+
 	Popup();
 	~Popup();
 };

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3152,9 +3152,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 }
 
 void Tree::_text_editor_popup_modal_close() {
-	if (Input::get_singleton()->is_key_pressed(Key::ESCAPE) ||
-			Input::get_singleton()->is_key_pressed(Key::KP_ENTER) ||
-			Input::get_singleton()->is_key_pressed(Key::ENTER)) {
+	if (popup_editor->get_hide_reason() == Popup::HIDE_REASON_CANCELED) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #90473.
*Bugsquad edit:* Fixes #91648

In that issue, certain change in `DisplayServerWindows` seems to be the cause of the issue on Windows. However, the report is about Linux. The fact that the issue is cross-platform makes sense if you think about what this PR does.

The floating text box used for rename can be confirmed via closing the popup containing it or via actually confirming the input. Since the latter involves the former, there's some code to avoid handling the user will twice. However, it's such a brittle deambiguation mechanism; namely, if certain keys are down, we assume the text input was already handled. It only makes sense that such a handling is subject to break with subtle changes in input event management across display servers. In fact, that's the problem: the rename operation is attempted twice because the current mechanism fails to block the second event.

This PR reimplements the involved handlers in a more robust way so the issue is gone and very unlikely to inadvertedly reappear again. That said, I'm not super happy with how _ad hoc_ this is even in the new version. Maybe `LineEdit` could have a property, such as `submit_on_parent_close` that makes the intended behavior an opt-in feature of it. This PR fixes the issue in the meantime anyway.

Lastly, `Tree` seems to have a similar deambiguation code, but that one seems to still work with the current `DisplayServer` implementations. That said, it'd warrant similar love. (CC @bruvzg, that may want to review this PR and later improve the state of affairs.)

**2024-05-01:** This is now based on #91361, which fixes the underlying issue on Windows. However, sine this issue was not Window-specific and I'd still want to have a more solid mechanism here, I've reworked this PR doing so.