### PR TITLE
Register text enter for script base class

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -883,6 +883,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	parent_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_parent_name_changed));
 	parent_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
+	register_text_enter(parent_name);
 	parent_search_button = memnew(Button);
 	parent_search_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_class_in_tree));
 	hb->add_child(parent_search_button);


### PR DESCRIPTION
When creating a script file, the script name is automatically focused and by pressing Enter you can accept the creation. This is nice when you create the script from scene, but not from filesystem dock, where you want to change the base type in 99% cases. This PR allows pressing Enter to create script after changing base type.

https://github.com/godotengine/godot/assets/2223172/e9e04355-c896-46cd-b763-59b2d64b3674

