### PR TITLE
GDScript: Add `@static_assert` annotation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="condition" type="bool" />
 			<param index="1" name="message" type="String" default="&quot;&quot;" />
 			<description>
-				Asserts that the [param condition] is [code]true[/code]. If the [param condition] is [code]false[/code], an error is generated. When running from the editor, the running project will also be paused until you resume it. This can be used as a stronger form of [method @GlobalScope.push_error] for reporting errors to project developers or add-on users.
+				Asserts that the [param condition] is [code]true[/code] [i]at runtime[/i]. If the [param condition] is [code]false[/code], an error is generated. When running from the editor, the running project will also be paused until you resume it. This can be used as a stronger form of [method @GlobalScope.push_error] for reporting errors to project developers or add-on users.
 				An optional [param message] can be shown in addition to the generic "Assertion failed" message. You can use this to provide additional details about why the assertion failed.
 				[b]Warning:[/b] For performance reasons, the code inside [method assert] is only executed in debug builds or when running the project from the editor. Don't include code that has side effects in an [method assert] call. Otherwise, the project will behave differently when exported in release mode.
 				[codeblock]
@@ -41,8 +41,9 @@
 				assert(speed &lt; 20) # True, the program will continue.
 				assert(speed &gt;= 0) # False, the program will stop.
 				assert(speed &gt;= 0 and speed &lt; 20) # You can also combine the two conditional statements in one check.
-				assert(speed &lt; 20, "the speed limit is 20") # Show a message.
+				assert(speed &lt; 20, "The speed limit is 20.") # Show a message.
 				[/codeblock]
+				See also [annotation @static_assert] for [i]compile time[/i] assertions.
 				[b]Note:[/b] [method assert] is a keyword, not a function. So you cannot access it as a [Callable] or use it inside expressions.
 			</description>
 		</method>
@@ -808,6 +809,26 @@
 				func fn_default(): pass
 				[/codeblock]
 				[b]Note:[/b] Methods annotated with [annotation @rpc] cannot receive objects which define required parameters in [method Object._init]. See [method Object._init] for more details.
+			</description>
+		</annotation>
+		<annotation name="@static_assert">
+			<return type="void" />
+			<param index="0" name="condition" type="bool" />
+			<param index="1" name="message" type="String" default="&quot;&quot;" />
+			<description>
+				Asserts that the [param condition] is [code]true[/code] [i]at compile time[/i]. If the [param condition] is [code]false[/code], an error is generated. Unlike [method assert], the check is performed once during static analysis of the script and does not affect runtime execution. Since [annotation @static_assert] is an annotation, its arguments must be constant expressions.
+				An optional [param message] can be shown in addition to the generic "Static assertion failed" message. You can use this to provide additional details about why the assertion failed.
+				[codeblock]
+				enum Element {FIRE, WATER, EARTH, WIND}
+				const ELEMENT_COLORS = [Color.RED, Color.BLUE, Color.GREEN, Color.CYAN]
+				@static_assert(len(Element) == len(ELEMENT_COLORS), "Desync detected.")
+
+				const GRAVITY = 980.0
+				const MAX_SPEED = 700.0
+				const JUMP_HEIGHT = 200.0
+				const JUMP_INITIAL_SPEED = -sqrt(2 * GRAVITY * JUMP_HEIGHT)
+				@static_assert(absf(JUMP_INITIAL_SPEED) &lt;= MAX_SPEED)
+				[/codeblock]
 			</description>
 		</annotation>
 		<annotation name="@static_unload">

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -622,8 +622,10 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 
 	// Apply annotations.
 	for (GDScriptParser::AnnotationNode *&E : p_class->annotations) {
-		resolve_annotation(E);
-		E->apply(parser, p_class, p_class->outer);
+		if (E->name != SNAME("@static_assert")) {
+			resolve_annotation(E);
+			E->apply(parser, p_class, p_class->outer);
+		}
 	}
 
 	parser->current_class = previous_class;
@@ -1564,6 +1566,14 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 			} else {
 				break;
 			}
+		}
+	}
+
+	// Resolve and apply `@static_assert`s here, after all local constants have been resolved.
+	for (GDScriptParser::AnnotationNode *&E : p_class->annotations) {
+		if (E->name == SNAME("@static_assert")) {
+			resolve_annotation(E);
+			E->apply(parser, p_class, p_class->outer);
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -181,7 +181,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@export_category", PropertyInfo(Variant::STRING, "name")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_CATEGORY>);
 		register_annotation(MethodInfo("@export_group", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_GROUP>, varray(""));
 		register_annotation(MethodInfo("@export_subgroup", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_SUBGROUP>, varray(""));
-		// Warning annotations.
+		// Error and warning annotations.
+		register_annotation(MethodInfo("@static_assert", PropertyInfo(Variant::BOOL, "condition"), PropertyInfo(Variant::STRING, "message")), AnnotationInfo::STANDALONE, &GDScriptParser::static_assert_annotation, varray(""));
 		register_annotation(MethodInfo("@warning_ignore", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::CLASS_LEVEL | AnnotationInfo::STATEMENT, &GDScriptParser::warning_ignore_annotation, varray(), true);
 		register_annotation(MethodInfo("@warning_ignore_start", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::STANDALONE, &GDScriptParser::warning_ignore_region_annotations, varray(), true);
 		register_annotation(MethodInfo("@warning_ignore_restore", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::STANDALONE, &GDScriptParser::warning_ignore_region_annotations, varray(), true);
@@ -741,6 +742,10 @@ void GDScriptParser::parse_program() {
 					} else if (annotation->name == SNAME("@warning_ignore_start") || annotation->name == SNAME("@warning_ignore_restore")) {
 						// Some annotations need to be resolved and applied in the parser.
 						annotation->apply(this, nullptr, nullptr);
+					} else if (annotation->name == SNAME("@static_assert")) {
+						// We don't care about the target, but `@static_assert`s must be resolved and applied in the analyzer.
+						// Since the class context changes, it makes sense to assign `@static_assert`s to `ClassNode`s.
+						head->annotations.push_back(annotation);
 					} else {
 						push_error(R"(Unexpected standalone annotation.)");
 					}
@@ -1154,6 +1159,10 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 						} else if (annotation->name == SNAME("@warning_ignore_start") || annotation->name == SNAME("@warning_ignore_restore")) {
 							// Some annotations need to be resolved and applied in the parser.
 							annotation->apply(this, nullptr, nullptr);
+						} else if (annotation->name == SNAME("@static_assert")) {
+							// We don't care about the target, but `@static_assert`s must be resolved and applied in the analyzer.
+							// Since the class context changes, it makes sense to assign `@static_assert`s to `ClassNode`s.
+							current_class->annotations.push_back(annotation);
 						} else {
 							push_error(R"(Unexpected standalone annotation.)");
 						}
@@ -2113,6 +2122,10 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 					if (annotation->name == SNAME("@warning_ignore_start") || annotation->name == SNAME("@warning_ignore_restore")) {
 						// Some annotations need to be resolved and applied in the parser.
 						annotation->apply(this, nullptr, nullptr);
+					} else if (annotation->name == SNAME("@static_assert")) {
+						// We don't care about the target, but `@static_assert`s must be resolved and applied in the analyzer.
+						// Since the class context changes, it makes sense to assign `@static_assert`s to `ClassNode`s.
+						current_class->annotations.push_back(annotation);
 					} else {
 						push_error(R"(Unexpected standalone annotation.)");
 					}
@@ -2418,15 +2431,28 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 		}
 
 		if (match(GDScriptTokenizer::Token::ANNOTATION)) {
-			AnnotationNode *annotation = parse_annotation(AnnotationInfo::STATEMENT);
-			if (annotation == nullptr) {
-				continue;
+			AnnotationNode *annotation = parse_annotation(AnnotationInfo::STATEMENT | AnnotationInfo::STANDALONE);
+			if (annotation != nullptr) {
+				if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
+					if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
+						push_error(R"(Expected newline after a standalone annotation.)");
+					}
+					if (annotation->name == SNAME("@warning_ignore_start") || annotation->name == SNAME("@warning_ignore_restore")) {
+						// Some annotations need to be resolved and applied in the parser.
+						annotation->apply(this, nullptr, nullptr);
+					} else if (annotation->name == SNAME("@static_assert")) {
+						// We don't care about the target, but `@static_assert`s must be resolved and applied in the analyzer.
+						// Since the class context changes, it makes sense to assign `@static_assert`s to `ClassNode`s.
+						current_class->annotations.push_back(annotation);
+					} else {
+						push_error(R"(Unexpected standalone annotation.)");
+					}
+				} else if (annotation->name == SNAME("@warning_ignore")) {
+					match_branch_annotation_stack.push_back(annotation);
+				} else {
+					push_error(vformat(R"(Annotation "%s" is not allowed in this level.)", annotation->name), annotation);
+				}
 			}
-			if (annotation->name != SNAME("@warning_ignore")) {
-				push_error(vformat(R"(Annotation "%s" is not allowed in this level.)", annotation->name), annotation);
-				continue;
-			}
-			match_branch_annotation_stack.push_back(annotation);
 			continue;
 		}
 
@@ -4381,12 +4407,12 @@ bool GDScriptParser::validate_annotation_arguments(AnnotationNode *p_annotation)
 	const MethodInfo &info = valid_annotations[p_annotation->name].info;
 
 	if (((info.flags & METHOD_FLAG_VARARG) == 0) && p_annotation->arguments.size() > info.arguments.size()) {
-		push_error(vformat(R"(Annotation "%s" requires at most %d arguments, but %d were given.)", p_annotation->name, info.arguments.size(), p_annotation->arguments.size()));
+		push_error(vformat(R"(Annotation "%s" requires at most %d arguments, but %d were given.)", p_annotation->name, info.arguments.size(), p_annotation->arguments.size()), p_annotation);
 		return false;
 	}
 
 	if (p_annotation->arguments.size() < info.arguments.size() - info.default_arguments.size()) {
-		push_error(vformat(R"(Annotation "%s" requires at least %d arguments, but %d were given.)", p_annotation->name, info.arguments.size() - info.default_arguments.size(), p_annotation->arguments.size()));
+		push_error(vformat(R"(Annotation "%s" requires at least %d arguments, but %d were given.)", p_annotation->name, info.arguments.size() - info.default_arguments.size(), p_annotation->arguments.size()), p_annotation);
 		return false;
 	}
 
@@ -5086,6 +5112,22 @@ bool GDScriptParser::export_group_annotations(AnnotationNode *p_annotation, Node
 				p_annotation->export_info.hint_string = p_annotation->resolved_arguments[1];
 			}
 		} break;
+	}
+
+	return true;
+}
+
+bool GDScriptParser::static_assert_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	if (p_annotation->resolved_arguments.is_empty()) {
+		return false;
+	}
+
+	if (!p_annotation->resolved_arguments[0].booleanize()) {
+		if (p_annotation->resolved_arguments.size() >= 2) {
+			push_error("Static assertion failed: " + p_annotation->resolved_arguments[1].operator String(), p_annotation);
+		} else {
+			push_error("Static assertion failed.", p_annotation);
+		}
 	}
 
 	return true;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1564,6 +1564,7 @@ private:
 	bool export_tool_button_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyUsageFlags t_usage>
 	bool export_group_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool static_assert_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool warning_ignore_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool warning_ignore_region_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool rpc_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/failed_static_assert.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/failed_static_assert.gd
@@ -1,0 +1,7 @@
+enum MyEnum {A, B, C}
+const ARRAY = [1, 2]
+@static_assert(len(MyEnum) == len(ARRAY))
+@static_assert(len(MyEnum) == len(ARRAY), "Custom message.")
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/failed_static_assert.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/failed_static_assert.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 3: Static assertion failed.
+>> ERROR at line 4: Static assertion failed: Custom message.

--- a/modules/gdscript/tests/scripts/analyzer/features/static_assert.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/static_assert.gd
@@ -1,0 +1,19 @@
+const OtherClass = preload("./static_assert.notest.gd")
+@static_assert(len(MyEnum) == len(OtherClass.OTHER_ARRAY))
+
+class InnerClass:
+	const INNER_ARRAY = [1, 2, 3]
+	@static_assert(len(MyEnum) == len(INNER_ARRAY))
+
+	func method():
+		var _lambda = func ():
+			const LAMBDA_ARRAY = [1, 2, 3]
+			@static_assert(len(MyEnum) == len(LAMBDA_ARRAY))
+
+enum MyEnum {A, B, C}
+const ARRAY = [1, 2, 3]
+@static_assert(len(MyEnum) == len(ARRAY))
+
+func test():
+	const LOCAL_ARRAY = [1, 2, 3]
+	@static_assert(len(MyEnum) == len(LOCAL_ARRAY))

--- a/modules/gdscript/tests/scripts/analyzer/features/static_assert.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/static_assert.notest.gd
@@ -1,0 +1,1 @@
+const OTHER_ARRAY = [1, 2, 3]

--- a/modules/gdscript/tests/scripts/analyzer/features/static_assert.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/static_assert.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
* Closes godotengine/godot-proposals#6173.

This PR adds a standalone annotation `@static_assert`, which can be used for compile time assertions.

This is quite debatable since for member enums and constants you can use regular `assert`s in `_static_init()` and compile time evaluations are quite limited in GDScript (see also #81334). However, this feature can be useful for some cases (detecting desyncs and other errors in constant config) and provides several additional capabilities (detecting errors without executing code, can be used with local constants, does not require to be placed in a function body).

Example:

```gdscript
enum Element {FIRE, WATER, EARTH, WIND}
const ELEMENT_COLORS = [Color.RED, Color.BLUE, Color.GREEN, Color.CYAN]
@static_assert(len(Element) == len(ELEMENT_COLORS), "Desync detected.")

const GRAVITY = 980.0
const MAX_SPEED = 700.0
const JUMP_HEIGHT = 200.0
const JUMP_INITIAL_SPEED = -sqrt(2 * GRAVITY * JUMP_HEIGHT)
@static_assert(absf(JUMP_INITIAL_SPEED) <= MAX_SPEED)
```