### PR TITLE
GDScript: Fix test `reset_uninit_local_vars.gd` failure

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/reset_uninit_local_vars.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/reset_uninit_local_vars.gd
@@ -10,12 +10,12 @@ func test():
 		var c := 1
 
 	if true:
-		@warning_ignore("unassigned_variable")
 		var a
+		@warning_ignore("unassigned_variable")
 		print(a)
-		@warning_ignore("unassigned_variable")
 		var b
-		print(b)
 		@warning_ignore("unassigned_variable")
+		print(b)
 		var c: Object
+		@warning_ignore("unassigned_variable")
 		print(c)


### PR DESCRIPTION
* Fix test failure due to #89990 not being rebased before merging (conflict with #90442).