### PR TITLE
Modify allocation process of the PhysicalBoneSimulator in Skeleton3D

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -271,16 +271,15 @@ void Skeleton3D::_update_process_order() {
 
 #ifndef DISABLE_DEPRECATED
 void Skeleton3D::setup_simulator() {
+	if (simulator && simulator->get_parent() == this) {
+		remove_child(simulator);
+		simulator->queue_free();
+	}
 	PhysicalBoneSimulator3D *sim = memnew(PhysicalBoneSimulator3D);
 	simulator = sim;
 	sim->is_compat = true;
 	sim->set_active(false); // Don't run unneeded process.
-	add_child(sim);
-}
-
-void Skeleton3D::remove_simulator() {
-	remove_child(simulator);
-	memdelete(simulator);
+	add_child(simulator);
 }
 #endif // _DISABLE_DEPRECATED
 
@@ -294,11 +293,6 @@ void Skeleton3D::_notification(int p_what) {
 			setup_simulator();
 #endif // _DISABLE_DEPRECATED
 		} break;
-#ifndef DISABLE_DEPRECATED
-		case NOTIFICATION_EXIT_TREE: {
-			remove_simulator();
-		} break;
-#endif // _DISABLE_DEPRECATED
 		case NOTIFICATION_UPDATE_SKELETON: {
 			// Update bone transforms to apply unprocessed poses.
 			force_update_all_dirty_bones();

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -69,7 +69,6 @@ class Skeleton3D : public Node3D {
 #ifndef DISABLE_DEPRECATED
 	Node *simulator = nullptr;
 	void setup_simulator();
-	void remove_simulator();
 #endif // _DISABLE_DEPRECATED
 
 public:


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/91063
- Fixes #91211

Fixed an issue with the allocation process with PhysicalBoneSimulator as virtual children that was occurring when Skeleton3D was added to or removed from scenes in the editor, such as ImportScene.
