### PR TITLE
Fix `SubViewport`/`AudioStreamPlayer2D` crash

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5048,6 +5048,9 @@ Viewport::~Viewport() {
 	for (ViewportTexture *E : viewport_textures) {
 		E->vp = nullptr;
 	}
+	if (world_2d.is_valid()) {
+		world_2d->remove_viewport(this);
+	}
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(viewport);
 }


### PR DESCRIPTION
Updated `Viewport` destructor to remove itself from `World2D`, to avoid `World2D` keeping invalid pointers.

Fixes #89212

Fixes #91796

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
