### PR TITLE
Revamp autoload creation

### DIFF
--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -64,10 +64,10 @@ void SceneCreateDialog::_notification(int p_what) {
 	}
 }
 
-void SceneCreateDialog::config(const String &p_dir) {
+void SceneCreateDialog::config(const String &p_dir, const String &p_scene_name) {
 	directory = p_dir;
 	root_name_edit->set_text("");
-	scene_name_edit->set_text("");
+	scene_name_edit->set_text(p_scene_name.get_basename());
 	callable_mp((Control *)scene_name_edit, &Control::grab_focus).call_deferred(false);
 	validation_panel->update();
 
@@ -157,6 +157,10 @@ void SceneCreateDialog::update_dialog() {
 
 String SceneCreateDialog::get_scene_path() const {
 	return scene_name;
+}
+
+String SceneCreateDialog::get_root_name() const {
+	return root_name;
 }
 
 Node *SceneCreateDialog::create_scene_root() {

--- a/editor/scene/scene_create_dialog.h
+++ b/editor/scene/scene_create_dialog.h
@@ -89,9 +89,10 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void config(const String &p_dir);
+	void config(const String &p_dir, const String &p_scene_name = "");
 
 	String get_scene_path() const;
+	String get_root_name() const;
 	Node *create_scene_root();
 
 	SceneCreateDialog();

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -39,7 +39,10 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/scene/scene_create_dialog.h"
 #include "editor/settings/project_settings_editor.h"
+#include "scene/gui/button.h"
+#include "scene/gui/tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 
@@ -49,47 +52,23 @@ void EditorAutoloadSettings::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			List<String> afn;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
 			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
 
 			for (const String &E : afn) {
-				file_dialog->add_filter("*." + E);
+				scene_file_dialog->add_filter("*." + E);
 			}
 
-			browse_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
-		} break;
+			ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
 
-		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (!error_message->get_text().is_empty()) {
-				_autoload_text_changed(autoload_add_name->get_text());
+			for (const String &E : afn) {
+				autoload_file_dialog->add_filter("*." + E);
 			}
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			browse_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
-			add_autoload->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-		} break;
-
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			FileSystemDock *dock = FileSystemDock::get_singleton();
-
-			if (dock != nullptr) {
-				ScriptCreateDialog *dialog = dock->get_script_create_dialog();
-
-				if (dialog != nullptr) {
-					Callable script_created = callable_mp(this, &EditorAutoloadSettings::_script_created);
-
-					if (is_visible_in_tree()) {
-						if (!dialog->is_connected(SNAME("script_created"), script_created)) {
-							dialog->connect("script_created", script_created);
-						}
-					} else {
-						if (dialog->is_connected(SNAME("script_created"), script_created)) {
-							dialog->disconnect("script_created", script_created);
-						}
-					}
-				}
-			}
+			browse_button->set_button_icon(get_editor_theme_icon(SNAME("FileBrowse")));
+			create_script_autoload->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			create_scene_autoload->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 	}
 }
@@ -150,25 +129,6 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 	}
 
 	return true;
-}
-
-void EditorAutoloadSettings::_autoload_add() {
-	if (autoload_add_path->get_text().is_empty()) {
-		ScriptCreateDialog *dialog = FileSystemDock::get_singleton()->get_script_create_dialog();
-		String fpath = path;
-		if (!fpath.ends_with("/")) {
-			fpath = fpath.get_base_dir();
-		}
-		dialog->config("Node", fpath.path_join(vformat("%s.gd", autoload_add_name->get_text())), false, false);
-		dialog->popup_centered();
-	} else {
-		if (autoload_add(autoload_add_name->get_text(), autoload_add_path->get_text())) {
-			autoload_add_path->set_text("");
-		}
-
-		autoload_add_name->set_text("");
-		add_autoload->set_disabled(true);
-	}
 }
 
 void EditorAutoloadSettings::_autoload_selected() {
@@ -287,9 +247,6 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 	switch (p_button) {
-		case BUTTON_OPEN: {
-			_autoload_open(ti->get_text(1));
-		} break;
 		case BUTTON_MOVE_UP:
 		case BUTTON_MOVE_DOWN: {
 			TreeItem *swap = nullptr;
@@ -359,36 +316,6 @@ void EditorAutoloadSettings::_autoload_open(const String &fpath) {
 	ProjectSettingsEditor::get_singleton()->hide();
 }
 
-void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
-	// Convert the file name to PascalCase, which is the convention for classes in GDScript.
-	const String class_name = p_path.get_file().get_basename().to_pascal_case();
-
-	// If the name collides with a built-in class, prefix the name to make it possible to add without having to edit the name.
-	// The prefix is subjective, but it provides better UX than leaving the Add button disabled :)
-	const String prefix = ClassDB::class_exists(class_name) ? "Global" : "";
-
-	autoload_add_name->set_text(prefix + class_name);
-	add_autoload->set_disabled(false);
-}
-
-void EditorAutoloadSettings::_autoload_text_submitted(const String &p_name) {
-	if (!autoload_add_path->get_text().is_empty() && _autoload_name_is_valid(p_name, nullptr)) {
-		_autoload_add();
-	}
-}
-
-void EditorAutoloadSettings::_autoload_path_text_changed(const String &p_path) {
-	add_autoload->set_disabled(!_autoload_name_is_valid(autoload_add_name->get_text(), nullptr));
-}
-
-void EditorAutoloadSettings::_autoload_text_changed(const String &p_name) {
-	String error_string;
-	bool is_name_valid = _autoload_name_is_valid(p_name, &error_string);
-	add_autoload->set_disabled(!is_name_valid);
-	error_message->set_text(error_string);
-	error_message->set_visible(!autoload_add_name->get_text().is_empty() && !is_name_valid);
-}
-
 Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 	Node *n = nullptr;
 	if (ResourceLoader::get_resource_type(p_path) == "PackedScene") {
@@ -426,6 +353,20 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 
 	return n;
 }
+void EditorAutoloadSettings::_create_script_autoload() {
+	if (!script_create_dialog) {
+		script_create_dialog = memnew(ScriptCreateDialog);
+		add_child(script_create_dialog);
+		script_create_dialog->connect("script_created", callable_mp(this, &EditorAutoloadSettings::_script_created));
+	}
+	script_create_dialog->config("Node", "res://new_autoload_script.gd", false, false);
+	script_create_dialog->popup_centered();
+}
+
+void EditorAutoloadSettings::_create_scene_autoload() {
+	scene_file_dialog->set_current_file("new_autoload_scene.tscn");
+	scene_file_dialog->popup_file_dialog();
+}
 
 void EditorAutoloadSettings::init_autoloads() {
 	for (AutoloadInfo &info : autoload_cache) {
@@ -456,6 +397,56 @@ void EditorAutoloadSettings::init_autoloads() {
 			get_tree()->get_root()->add_child(info.node);
 		}
 	}
+}
+
+void EditorAutoloadSettings::_autoload_file_selected(const String &p_path) {
+	_add_autoload(p_path.get_file().get_basename(), p_path);
+}
+
+void EditorAutoloadSettings::_scene_file_selected(const String &p_path) {
+	if (!scene_create_dialog) {
+		scene_create_dialog = memnew(SceneCreateDialog);
+		add_child(scene_create_dialog);
+		scene_create_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorAutoloadSettings::_scene_created));
+	}
+	scene_create_dialog->config(p_path.get_base_dir(), p_path.get_file().get_basename());
+	scene_create_dialog->popup_centered();
+}
+
+void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
+	FileSystemDock::get_singleton()->get_script_create_dialog()->hide();
+	path = p_script->get_path().get_base_dir();
+	_add_autoload(p_script->get_path().get_file().get_basename(), p_script->get_path());
+}
+
+void EditorAutoloadSettings::_scene_created() {
+	Node *root = scene_create_dialog->create_scene_root();
+
+	Ref<PackedScene> ps;
+	ps.instantiate();
+	ps->pack(root);
+
+	Error err = ResourceSaver::save(ps, scene_create_dialog->get_scene_path());
+	if (err != OK) {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Failed to create scene. Error: %d."), err));
+		return;
+	}
+
+	_add_autoload(scene_create_dialog->get_root_name(), scene_create_dialog->get_scene_path());
+}
+
+void EditorAutoloadSettings::_add_autoload(const String &p_name, const String &p_path) {
+	// Convert the file name to PascalCase, which is the convention for classes in GDScript.
+	String autoload_name = p_name.to_pascal_case();
+
+	// If the name collides with a built-in class, prefix the name to make it possible to add without having to edit the name.
+	// The prefix is subjective, but it provides better UX than throwing an error :)
+	if (ClassDB::class_exists(autoload_name)) {
+		autoload_name += "Global";
+	}
+
+	autoload_name = autoload_name.validate_ascii_identifier();
+	autoload_add(autoload_name, p_path);
 }
 
 void EditorAutoloadSettings::update_autoload() {
@@ -539,7 +530,6 @@ void EditorAutoloadSettings::update_autoload() {
 		item->set_editable(2, true);
 		item->set_text(2, TTRC("Enable"));
 		item->set_checked(2, info.is_singleton);
-		item->add_button(3, get_editor_theme_icon(SNAME("Load")), BUTTON_OPEN);
 		item->add_button(3, get_editor_theme_icon(SNAME("MoveUp")), BUTTON_MOVE_UP);
 		item->add_button(3, get_editor_theme_icon(SNAME("MoveDown")), BUTTON_MOVE_DOWN);
 		item->add_button(3, get_editor_theme_icon(SNAME("Remove")), BUTTON_DELETE);
@@ -599,17 +589,6 @@ void EditorAutoloadSettings::update_autoload() {
 	}
 
 	updating_autoload = false;
-}
-
-void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
-	FileSystemDock::get_singleton()->get_script_create_dialog()->hide();
-	path = p_script->get_path().get_base_dir();
-	autoload_add_path->set_text(p_script->get_path());
-	_autoload_add();
-}
-
-LineEdit *EditorAutoloadSettings::get_path_box() const {
-	return autoload_add_path;
 }
 
 Variant EditorAutoloadSettings::get_drag_data_fw(const Point2 &p_point, Control *p_control) {
@@ -894,58 +873,30 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	add_child(hbc);
 
-	error_message = memnew(Label);
-	error_message->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	error_message->set_focus_mode(FOCUS_ACCESSIBILITY);
-	error_message->hide();
-	error_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
-	error_message->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
-	add_child(error_message);
+	autoload_file_dialog = memnew(EditorFileDialog);
+	autoload_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
+	hbc->add_child(autoload_file_dialog);
+	autoload_file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_file_selected));
 
-	Label *l = memnew(Label);
-	l->set_text(TTRC("Path:"));
-	hbc->add_child(l);
-
-	autoload_add_path = memnew(LineEdit);
-	hbc->add_child(autoload_add_path);
-	autoload_add_path->set_accessibility_name(TTRC("Autoload Path"));
-	autoload_add_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	autoload_add_path->set_clear_button_enabled(true);
-	autoload_add_path->set_placeholder(TTRC("Set path or press \"Add\" to create a script."));
-	autoload_add_path->connect(SceneStringName(text_changed), callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
+	scene_file_dialog = memnew(EditorFileDialog);
+	scene_file_dialog->set_file_mode(FileDialog::FILE_MODE_SAVE_FILE);
+	hbc->add_child(scene_file_dialog);
+	scene_file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_scene_file_selected));
 
 	browse_button = memnew(Button);
+	browse_button->set_text(TTRC("Select Script/Scene"));
 	hbc->add_child(browse_button);
-	browse_button->set_accessibility_name(TTRC("Select Autoload Path"));
-	browse_button->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_browse_autoload_add_path));
+	browse_button->connect(SceneStringName(pressed), callable_mp(autoload_file_dialog, &FileDialog::popup_file_dialog));
 
-	file_dialog = memnew(EditorFileDialog);
-	hbc->add_child(file_dialog);
-	file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_set_autoload_add_path));
-	file_dialog->connect("dir_selected", callable_mp(this, &EditorAutoloadSettings::_set_autoload_add_path));
-	file_dialog->connect("files_selected", callable_mp(this, &EditorAutoloadSettings::_set_autoload_add_path));
+	create_script_autoload = memnew(Button);
+	create_script_autoload->set_text(TTRC("Create Script"));
+	hbc->add_child(create_script_autoload);
+	create_script_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_create_script_autoload));
 
-	hbc->set_h_size_flags(SIZE_EXPAND_FILL);
-	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-	file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_file_callback));
-
-	l = memnew(Label);
-	l->set_text(TTRC("Node Name:"));
-	hbc->add_child(l);
-
-	autoload_add_name = memnew(LineEdit);
-	autoload_add_name->set_accessibility_name(TTRC("Node Name:"));
-	autoload_add_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	autoload_add_name->connect(SceneStringName(text_submitted), callable_mp(this, &EditorAutoloadSettings::_autoload_text_submitted));
-	autoload_add_name->connect(SceneStringName(text_changed), callable_mp(this, &EditorAutoloadSettings::_autoload_text_changed));
-	hbc->add_child(autoload_add_name);
-
-	add_autoload = memnew(Button);
-	add_autoload->set_text(TTRC("Add"));
-	add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add));
-	// The button will be enabled once a valid name is entered (either automatically or manually).
-	add_autoload->set_disabled(true);
-	hbc->add_child(add_autoload);
+	create_scene_autoload = memnew(Button);
+	create_scene_autoload->set_text(TTRC("Create Scene"));
+	hbc->add_child(create_scene_autoload);
+	create_scene_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_create_scene_autoload));
 
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -966,17 +917,20 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_column_titles_visible(true);
 
 	tree->set_column_title(0, TTRC("Name"));
+	tree->set_column_title_tooltip_text(0, TTRC("Name of the autoload. Double-click to rename."));
 	tree->set_column_title_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 	tree->set_column_expand(0, true);
 	tree->set_column_expand_ratio(0, 1);
 
 	tree->set_column_title(1, TTRC("Path"));
+	tree->set_column_title_tooltip_text(1, TTRC("Path to the autoload file. Double-click to open it."));
 	tree->set_column_title_alignment(1, HORIZONTAL_ALIGNMENT_LEFT);
 	tree->set_column_expand(1, true);
 	tree->set_column_clip_content(1, true);
 	tree->set_column_expand_ratio(1, 2);
 
 	tree->set_column_title(2, TTRC("Global Variable"));
+	tree->set_column_title_tooltip_text(2, TTRC("If enabled, this autoload can be accessed in scripts using its name."));
 	tree->set_column_expand(2, false);
 
 	tree->set_column_expand(3, false);
@@ -995,13 +949,4 @@ EditorAutoloadSettings::~EditorAutoloadSettings() {
 			memdelete(info.node);
 		}
 	}
-}
-
-void EditorAutoloadSettings::_set_autoload_add_path(const String &p_text) {
-	autoload_add_path->set_text(p_text);
-	autoload_add_path->emit_signal(SceneStringName(text_submitted), p_text);
-}
-
-void EditorAutoloadSettings::_browse_autoload_add_path() {
-	file_dialog->popup_file_dialog();
 }

--- a/editor/settings/editor_autoload_settings.h
+++ b/editor/settings/editor_autoload_settings.h
@@ -31,19 +31,20 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
-#include "scene/gui/tree.h"
 
-class EditorFileDialog;
+class Button;
+class FileDialog;
+class SceneCreateDialog;
+class ScriptCreateDialog;
+class Tree;
 
 class EditorAutoloadSettings : public VBoxContainer {
 	GDCLASS(EditorAutoloadSettings, VBoxContainer);
 
 	enum {
-		BUTTON_OPEN,
 		BUTTON_MOVE_UP,
 		BUTTON_MOVE_DOWN,
-		BUTTON_DELETE
+		BUTTON_DELETE,
 	};
 
 	String path = "res://";
@@ -68,35 +69,35 @@ class EditorAutoloadSettings : public VBoxContainer {
 	String selected_autoload;
 
 	Tree *tree = nullptr;
-	LineEdit *autoload_add_name = nullptr;
-	Button *add_autoload = nullptr;
-	LineEdit *autoload_add_path = nullptr;
-	Label *error_message = nullptr;
 	Button *browse_button = nullptr;
-	EditorFileDialog *file_dialog = nullptr;
+	Button *create_script_autoload = nullptr;
+	Button *create_scene_autoload = nullptr;
+	FileDialog *autoload_file_dialog = nullptr;
+	FileDialog *scene_file_dialog = nullptr;
+	ScriptCreateDialog *script_create_dialog = nullptr;
+	SceneCreateDialog *scene_create_dialog = nullptr;
 
 	bool _autoload_name_is_valid(const String &p_name, String *r_error = nullptr);
 
-	void _autoload_add();
 	void _autoload_selected();
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _autoload_activated();
-	void _autoload_path_text_changed(const String &p_path);
-	void _autoload_text_submitted(const String &p_name);
-	void _autoload_text_changed(const String &p_name);
 	void _autoload_open(const String &fpath);
-	void _autoload_file_callback(const String &p_path);
 	Node *_create_autoload(const String &p_path);
 
+	void _create_script_autoload();
+	void _create_scene_autoload();
+	void _autoload_file_selected(const String &p_path);
+	void _scene_file_selected(const String &p_path);
+
 	void _script_created(Ref<Script> p_script);
+	void _scene_created();
+	void _add_autoload(const String &p_name, const String &p_path);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_control);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control);
-
-	void _set_autoload_add_path(const String &p_text);
-	void _browse_autoload_add_path();
 
 protected:
 	void _notification(int p_what);
@@ -107,8 +108,6 @@ public:
 	void update_autoload();
 	bool autoload_add(const String &p_name, const String &p_path);
 	void autoload_remove(const String &p_name);
-
-	LineEdit *get_path_box() const;
 
 	EditorAutoloadSettings();
 	~EditorAutoloadSettings();

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -413,8 +413,6 @@ void ProjectSettingsEditor::_focus_current_path_box() {
 		current_path_box = property_box;
 	} else if (tab == action_map_editor) {
 		current_path_box = action_map_editor->get_path_box();
-	} else if (tab == autoload_settings) {
-		current_path_box = autoload_settings->get_path_box();
 	} else if (tab == shaders_global_shader_uniforms_editor) {
 		current_path_box = shaders_global_shader_uniforms_editor->get_name_box();
 	} else if (tab == group_settings) {


### PR DESCRIPTION
Closes #17110
Closes https://github.com/godotengine/godot-proposals/issues/10691
- Text fields are replaced with buttons:
  - Select Existing Script/Scene - select a scene or script that will be added as autoload. This is the previous browse option, except the autoload is added immediately
  - Create Script Autoload - creates a new script and adds as autoload. This already existed btw, the script dialog was opening when you tried to Add autoload without a path
  - Create Scene Autoload - same as above, but creates a scene. The UX is a bit awkward, because you need to go through 2 dialogs, but maybe it's fine

Autoload name is assigned automatically from file name (or root name in case of scene) and there is basic validation to create valid identifier, as otherwise you'll be met with an error dialog. Hopefully it won't be a big problem. If you don't like auto-generated name, you can rename the autoload by double-clicking it in Tree (although the default name is fine in most cases, hence the text inputs were mostly useless).

https://github.com/godotengine/godot/assets/2223172/b9876b15-8e4e-42f3-a6f4-41c3b667ef2b

I'm getting some errors about exclusive children™, though they already existed with the script dialog. Not sure how to fix.