### PR TITLE
Fix GDExtension documentation disappearing after hot-reload

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -456,6 +456,9 @@ void EditorNode::_update_from_settings() {
 void EditorNode::_gdextensions_reloaded() {
 	// In case the developer is inspecting an object that will be changed by the reload.
 	InspectorDock::get_inspector_singleton()->update_tree();
+
+	// Regenerate documentation.
+	EditorHelp::generate_doc();
 }
 
 void EditorNode::_select_default_main_screen_plugin() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76796

Currently, unless a GDExtension provides its own documentation by submitting XML data, its classes will be removed from the editors docs on a successful hot-reload.

This PR fixes that, by re-generating the docs after any extensions have been hot-reloaded.

Works in my testing, both with GDExtensions that provide XML docs data, and those that don't!