### PR TITLE
Deprecate unused parameter `angular_limit/softness` in `HingeJoint3D`

### DIFF
--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -53,7 +53,7 @@
 		<member name="angular_limit/relaxation" type="float" setter="set_param" getter="get_param" default="1.0">
 			The lower this value, the more the rotation gets slowed down.
 		</member>
-		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="0.9">
+		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="0.9" deprecated="This property is never set by the engine and is kept for compatibility purposes.">
 		</member>
 		<member name="angular_limit/upper" type="float" setter="set_param" getter="get_param" default="1.5708">
 			The maximum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
@@ -84,7 +84,7 @@
 		<constant name="PARAM_LIMIT_BIAS" value="3" enum="Param">
 			The speed with which the rotation across the axis perpendicular to the hinge gets corrected.
 		</constant>
-		<constant name="PARAM_LIMIT_SOFTNESS" value="4" enum="Param">
+		<constant name="PARAM_LIMIT_SOFTNESS" value="4" enum="Param" deprecated="This property is never used by the engine and is kept for compatibility purpose.">
 		</constant>
 		<constant name="PARAM_LIMIT_RELAXATION" value="5" enum="Param">
 			The lower this value, the more the rotation gets slowed down.


### PR DESCRIPTION
It appears that the parameter was never used and its probably left code from the Bullet days.