### PR TITLE
Remove the Hand enum from XRHandTracker

### DIFF
--- a/doc/classes/XRHandTracker.xml
+++ b/doc/classes/XRHandTracker.xml
@@ -11,12 +11,6 @@
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_hand" qualifiers="const">
-			<return type="int" enum="XRHandTracker.Hand" />
-			<description>
-				Returns the type of hand.
-			</description>
-		</method>
 		<method name="get_hand_joint_angular_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
@@ -50,13 +44,6 @@
 			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
 			<description>
 				Returns the transform for the given hand joint.
-			</description>
-		</method>
-		<method name="set_hand">
-			<return type="void" />
-			<param index="0" name="hand" type="int" enum="XRHandTracker.Hand" />
-			<description>
-				Sets the type of hand.
 			</description>
 		</method>
 		<method name="set_hand_joint_angular_velocity">
@@ -101,6 +88,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="hand" type="int" setter="set_tracker_hand" getter="get_tracker_hand" overrides="XRPositionalTracker" enum="XRPositionalTracker.TrackerHand" default="1" />
 		<member name="hand_tracking_source" type="int" setter="set_hand_tracking_source" getter="get_hand_tracking_source" enum="XRHandTracker.HandTrackingSource" default="0">
 			The source of the hand tracking data.
 		</member>
@@ -110,15 +98,6 @@
 		<member name="type" type="int" setter="set_tracker_type" getter="get_tracker_type" overrides="XRTracker" enum="XRServer.TrackerType" default="16" />
 	</members>
 	<constants>
-		<constant name="HAND_LEFT" value="0" enum="Hand">
-			A left hand.
-		</constant>
-		<constant name="HAND_RIGHT" value="1" enum="Hand">
-			A right hand.
-		</constant>
-		<constant name="HAND_MAX" value="2" enum="Hand">
-			Represents the size of the [enum Hand] enum.
-		</constant>
 		<constant name="HAND_TRACKING_SOURCE_UNKNOWN" value="0" enum="HandTrackingSource">
 			The source of hand tracking data is unknown.
 		</constant>

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -195,7 +195,7 @@ void OpenXRHandTrackingExtension::on_process() {
 
 				Ref<XRHandTracker> godot_tracker;
 				godot_tracker.instantiate();
-				godot_tracker->set_hand(i == 0 ? XRHandTracker::HAND_LEFT : XRHandTracker::HAND_RIGHT);
+				godot_tracker->set_tracker_hand(i == 0 ? XRPositionalTracker::TRACKER_HAND_LEFT : XRPositionalTracker::TRACKER_HAND_RIGHT);
 				godot_tracker->set_tracker_name(i == 0 ? "/user/hand_tracker/left" : "/user/hand_tracker/right");
 				XRServer::get_singleton()->add_tracker(godot_tracker);
 				hand_trackers[i].godot_tracker = godot_tracker;

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -713,7 +713,7 @@ void WebXRInterfaceJS::_update_input_source(int p_input_source_id) {
 
 			if (unlikely(hand_tracker.is_null())) {
 				hand_tracker.instantiate();
-				hand_tracker->set_hand(p_input_source_id == 0 ? XRHandTracker::HAND_LEFT : XRHandTracker::HAND_RIGHT);
+				hand_tracker->set_tracker_hand(p_input_source_id == 0 ? XRPositionalTracker::TRACKER_HAND_LEFT : XRPositionalTracker::TRACKER_HAND_RIGHT);
 				hand_tracker->set_tracker_name(p_input_source_id == 0 ? "/user/hand_tracker/left" : "/user/hand_tracker/right");
 
 				// These flags always apply, since WebXR doesn't give us enough insight to be more fine grained.

--- a/servers/xr/xr_hand_tracker.cpp
+++ b/servers/xr/xr_hand_tracker.cpp
@@ -33,9 +33,6 @@
 #include "xr_body_tracker.h"
 
 void XRHandTracker::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_hand", "hand"), &XRHandTracker::set_hand);
-	ClassDB::bind_method(D_METHOD("get_hand"), &XRHandTracker::get_hand);
-
 	ClassDB::bind_method(D_METHOD("set_has_tracking_data", "has_data"), &XRHandTracker::set_has_tracking_data);
 	ClassDB::bind_method(D_METHOD("get_has_tracking_data"), &XRHandTracker::get_has_tracking_data);
 
@@ -59,10 +56,6 @@ void XRHandTracker::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_tracking_data", PROPERTY_HINT_NONE), "set_has_tracking_data", "get_has_tracking_data");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand_tracking_source", PROPERTY_HINT_ENUM, "Unknown,Unobstructed,Controller"), "set_hand_tracking_source", "get_hand_tracking_source");
-
-	BIND_ENUM_CONSTANT(HAND_LEFT);
-	BIND_ENUM_CONSTANT(HAND_RIGHT);
-	BIND_ENUM_CONSTANT(HAND_MAX);
 
 	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_UNKNOWN);
 	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_UNOBSTRUCTED);
@@ -110,48 +103,8 @@ void XRHandTracker::set_tracker_type(XRServer::TrackerType p_type) {
 }
 
 void XRHandTracker::set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand) {
-	ERR_FAIL_INDEX(p_hand, TRACKER_HAND_MAX);
-
-	switch (p_hand) {
-		case TRACKER_HAND_LEFT:
-			tracker_hand = TRACKER_HAND_LEFT;
-			hand = HAND_LEFT;
-			break;
-
-		case TRACKER_HAND_RIGHT:
-			tracker_hand = TRACKER_HAND_RIGHT;
-			hand = HAND_RIGHT;
-			break;
-
-		case TRACKER_HAND_UNKNOWN:
-		default:
-			ERR_FAIL_MSG("XRHandTracker must specify hand");
-			break;
-	}
-}
-
-void XRHandTracker::set_hand(XRHandTracker::Hand p_hand) {
-	ERR_FAIL_INDEX(p_hand, HAND_MAX);
-
-	switch (p_hand) {
-		case HAND_LEFT:
-			tracker_hand = TRACKER_HAND_LEFT;
-			hand = HAND_LEFT;
-			break;
-
-		case HAND_RIGHT:
-			tracker_hand = TRACKER_HAND_RIGHT;
-			hand = HAND_RIGHT;
-			break;
-
-		default:
-			ERR_FAIL_MSG("XRHandTracker must specify hand");
-			break;
-	}
-}
-
-XRHandTracker::Hand XRHandTracker::get_hand() const {
-	return hand;
+	ERR_FAIL_COND_MSG(p_hand != TRACKER_HAND_LEFT && p_hand != TRACKER_HAND_RIGHT, "XRHandTracker must specify hand.");
+	tracker_hand = p_hand;
 }
 
 void XRHandTracker::set_has_tracking_data(bool p_has_tracking_data) {
@@ -222,4 +175,5 @@ Vector3 XRHandTracker::get_hand_joint_angular_velocity(XRHandTracker::HandJoint 
 
 XRHandTracker::XRHandTracker() {
 	type = XRServer::TRACKER_HAND;
+	tracker_hand = TRACKER_HAND_LEFT;
 }

--- a/servers/xr/xr_hand_tracker.h
+++ b/servers/xr/xr_hand_tracker.h
@@ -38,12 +38,6 @@ class XRHandTracker : public XRPositionalTracker {
 	_THREAD_SAFE_CLASS_
 
 public:
-	enum Hand {
-		HAND_LEFT,
-		HAND_RIGHT,
-		HAND_MAX,
-	};
-
 	enum HandTrackingSource {
 		HAND_TRACKING_SOURCE_UNKNOWN,
 		HAND_TRACKING_SOURCE_UNOBSTRUCTED,
@@ -93,9 +87,6 @@ public:
 	void set_tracker_type(XRServer::TrackerType p_type) override;
 	void set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand) override;
 
-	void set_hand(Hand p_hand);
-	Hand get_hand() const;
-
 	void set_has_tracking_data(bool p_has_tracking_data);
 	bool get_has_tracking_data() const;
 
@@ -123,7 +114,6 @@ protected:
 	static void _bind_methods();
 
 private:
-	Hand hand = HAND_LEFT;
 	bool has_tracking_data = false;
 	HandTrackingSource hand_tracking_source = HAND_TRACKING_SOURCE_UNKNOWN;
 
@@ -134,7 +124,6 @@ private:
 	Vector3 hand_joint_angular_velocities[HAND_JOINT_MAX];
 };
 
-VARIANT_ENUM_CAST(XRHandTracker::Hand)
 VARIANT_ENUM_CAST(XRHandTracker::HandTrackingSource)
 VARIANT_ENUM_CAST(XRHandTracker::HandJoint)
 VARIANT_BITFIELD_CAST(XRHandTracker::HandJointFlags)


### PR DESCRIPTION
## History
When initially introduced for Godot 4.3, the new `XRHandTracker` resource was written with a `Hand` enum _[Left=0, Right=1]_ and a `hand` property describing the hand being tracked.

When the XR-Trackers were subsequently reorganized into an inheritance-tree, the `XRHandTracker` was modified to extend from `XRPositionalTracker` which already has a `hand` property _[Unknown=0, Left=1, Right=2]_ relaying identical information.

At the time of the XR-Tracker refactoring, the decision was made to keep the `XRHandTracker::Hand` enum and getter/setter methods, but to drop the property as this was causing a direct name-collision.

## Problem
What was missed was that for C#/.Net, properties are converted to PascalCase, and so the `XRPositionalTracker` hand property is renamed to `Hand`, causing a direct name collision with the `XRHandTracker::Hand` enum.

## Change
This PR completely removes the `XRHandTracker::Hand` enum and getter/setter methods, as they are simply duplicate information for the existing `XRPositionalTracker` hand property.

The `XRHandTracker` type has not been released yet, and so cleaning it of duplicate/confusing accessors for the same information is preferred - and has the benefit of fixing the C#/.Net name collision.
