### PR TITLE
Use TextEdit caret color for minimap highlight (fix minimap regression)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -752,16 +752,15 @@ void TextEdit::_notification(int p_what) {
 				// Draw the minimap.
 
 				// Add visual feedback when dragging or hovering the visible area rectangle.
-				float viewport_alpha;
+				Color viewport_color = theme_cache.caret_color;
 				if (dragging_minimap) {
-					viewport_alpha = 0.25;
+					viewport_color.a = 0.25;
 				} else if (hovering_minimap) {
-					viewport_alpha = 0.175;
+					viewport_color.a = 0.175;
 				} else {
-					viewport_alpha = 0.1;
+					viewport_color.a = 0.1;
 				}
 
-				const Color viewport_color = (theme_cache.background_color.get_v() < 0.5) ? Color(1, 1, 1, viewport_alpha) : Color(0, 0, 0, viewport_alpha);
 				if (rtl) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, viewport_offset_y, minimap_width, viewport_height), viewport_color);
 				} else {


### PR DESCRIPTION
Fixes the minimap highlight regression mentioned in #78311, decided to use the caret color as a base since that way it's not a hardcoded value and it's consistent across themes. Originally I attempted to get the background color but the only way to get actual one was to make a `StyleBoxFlat` from `StyleBox` and then get the bg_color and this seems much cleaner IMO but I might be missing something on that front.

Before & After:
![comparison_bug](https://github.com/godotengine/godot/assets/138269/21f7707b-88d9-4bc6-a4f4-fc8006941484)


