### PR TITLE
Fix plugin wizard's generated filenames

### DIFF
--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -80,7 +80,7 @@ void PluginConfigDialog::_create_script_for_plugin(const String &p_plugin_path, 
 	ScriptLanguage *language = ScriptServer::get_language(p_script_lang_index);
 	ERR_FAIL_COND(language == nullptr);
 	String ext = language->get_extension();
-	String script_name = script_edit->get_text().is_empty() ? _get_subfolder() : script_edit->get_text();
+	String script_name = script_edit->get_text().is_empty() ? "plugin" : script_edit->get_text();
 	if (script_name.get_extension() != ext) {
 		script_name += "." + ext;
 	}
@@ -144,7 +144,7 @@ void PluginConfigDialog::_on_required_text_changed() {
 }
 
 String PluginConfigDialog::_get_subfolder() {
-	return subfolder_edit->get_text().is_empty() ? name_edit->get_text().replace(" ", "_").to_lower() : subfolder_edit->get_text();
+	return subfolder_edit->get_text().is_empty() ? name_edit->get_text().to_snake_case() : subfolder_edit->get_text();
 }
 
 String PluginConfigDialog::_to_absolute_plugin_path(const String &p_plugin_name) {


### PR DESCRIPTION
Plugin creation dialog makes certain promises for default values for filenames that aren't fulfilled:
![kuva](https://github.com/godotengine/godot/assets/1621768/251bbd68-986a-453f-9e78-83563cffa9cf)
Folder name doesn't use real snake_case, it just lowercases the text and replaces spaces to underscores. Plugin file isn't what's advertised in the tooltip (should be plugin.gd, defaults to same as folder name).

Fix automatic folder naming snake_case conversion.
Use plugin.gd as a default script name as advertised. Possible alternate is to change the tooltip to reflect the current behavior (that is, to snake_case the plugin name).
However, plugins that add custom class/es often are organized such a way:
```
addons/my_super_node/        // Plugin named after the class it adds
- plugin.gd                  // Adds the class and tools
- my_super_node.gd           // The actual class
- my_super_node_inspector.gd // Tool plugin
```
I feel that plugin.gd is appropriate name for the plugin file, since the script often does the integration of other scripts to the editor and not much more (exception being super simple one file plugins).