### PR TITLE
[Windows] Improve console IO redirection.

### DIFF
--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -136,6 +136,10 @@ int main(int argc, char *argv[]) {
 	STARTUPINFOW si;
 	ZeroMemory(&si, sizeof(si));
 	si.cb = sizeof(si);
+	si.dwFlags = STARTF_USESTDHANDLES;
+	si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+	si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+	si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
 
 	WCHAR new_command_line[32767];
 	_snwprintf_s(new_command_line, 32767, _TRUNCATE, L"%ls %ls", exe_name, PathGetArgsW(GetCommandLineW()));

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -53,26 +53,12 @@ void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_er
 	}
 	buf[len] = 0;
 
-	int wlen = MultiByteToWideChar(CP_UTF8, 0, buf, len, nullptr, 0);
-	if (wlen < 0) {
-		return;
-	}
-
-	wchar_t *wbuf = (wchar_t *)memalloc((len + 1) * sizeof(wchar_t));
-	ERR_FAIL_NULL_MSG(wbuf, "Out of memory.");
-	MultiByteToWideChar(CP_UTF8, 0, buf, len, wbuf, wlen);
-	wbuf[wlen] = 0;
-
-	if (p_err) {
-		fwprintf(stderr, L"%ls", wbuf);
-	} else {
-		wprintf(L"%ls", wbuf);
-	}
-
-	memfree(wbuf);
+	DWORD written = 0;
+	HANDLE h = p_err ? GetStdHandle(STD_ERROR_HANDLE) : GetStdHandle(STD_OUTPUT_HANDLE);
+	WriteFile(h, &buf[0], len, &written, nullptr);
 
 #ifdef DEBUG_ENABLED
-	fflush(stdout);
+	FlushFileBuffers(h);
 #endif
 }
 


### PR DESCRIPTION
Improves console IO redirection and Unicode handling.

| Operation | Console Wrapper | subsystem=windows | subsystem=console | Comments |
| - | - | - | - | - |
| Godot `print` to console | ✅ | ✅ | ✅ | |
| Godot `print` to file/pipe | ✅ | ✅ | ✅ | Rich print write escape sequences to the file. |
| Godot `get_stdin_string` from console | ✅ | ❌ | ✅ | Hangs waiting for input, probably not fixable. |
| Godot `get_stdin_string` from file/pipe | ✅ | ✅ | ✅ | |
| C `printf`/`std::cout` to console | ✅ | ✅ | ✅ | |
| C `printf`/`std::cout` to file/pipe | ✅ | ✅ | ✅ | |
| C `printf`/`std::cout` in GDExtension to console | ✅ | ✅ | ✅ | Tested both MinGW and MSVC |
| C `printf`/`std::cout` in GDExtension to file/pipe | ✅ | ✅ | ✅ | |
| C# `Console.WriteLine` to console | ✅ | ✅ | ✅ | |
| C# `Console.WriteLine` to file/pipe | ✅ | ✅ | ✅ | |
| C# `GD.Print` to console | ✅ | ✅ | ✅ | |
| C# `GD.Print` to file/pipe | ✅ | ✅ | ✅ | |

Unicode characters seems to be working in all tested cases (both input and output), IO redirected to/from file/pipe expect and write text as UTF-8 without BOM (same as other platforms).

Note: using `>` to redirect in PowerShell seems to be broken (not sure if it supposed to work), but `Start-Process ... -RedirectStandardOutput` works fine. In `cmd` `>` and `<` works fine.

Fixes https://github.com/godotengine/godot/issues/87591
Fixes https://github.com/godotengine/godot/issues/91002