### PR TITLE
MacOS: headless mode UX improvements

### DIFF
--- a/misc/dist/macos_tools.app/Contents/Info.plist
+++ b/misc/dist/macos_tools.app/Contents/Info.plist
@@ -45,6 +45,8 @@
 		<key>x86_64</key>
 		<string>10.12</string>
 	</dict>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleDocumentTypes</key>

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3469,6 +3469,9 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 
 	CGEventSourceSetLocalEventsSuppressionInterval(event_source, 0.0);
 
+	// Now that we are sure we're not headless, display our icon in the dock/task switcher.
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
 	int screen_count = get_screen_count();
 	for (int i = 0; i < screen_count; i++) {
 		display_max_scale = fmax(display_max_scale, screen_get_scale(i));

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -177,6 +177,9 @@ String OS_MacOS::get_version() const {
 }
 
 void OS_MacOS::alert(const String &p_alert, const String &p_title) {
+	// Make sure we are shown in the dock/task switcher now (even if we were headless).
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
 	NSAlert *window = [[NSAlert alloc] init];
 	NSString *ns_title = [NSString stringWithUTF8String:p_title.utf8().get_data()];
 	NSString *ns_alert = [NSString stringWithUTF8String:p_alert.utf8().get_data()];
@@ -819,9 +822,6 @@ OS_MacOS::OS_MacOS() {
 
 	// Implicitly create shared NSApplication instance.
 	[GodotApplication sharedApplication];
-
-	// In case we are unbundled, make us a proper UI application.
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
 	// Menu bar setup must go between sharedApplication above and
 	// finishLaunching below, in order to properly emulate the behavior


### PR DESCRIPTION
Don't show the application in the dock or task switcher unless one of the following is true:
- we create a non-headless display driver or
- an alert must be shown

This is generally best practice, but also greatly improves the UX of `godotTools.lsp.headless` mode. Without this fix, enabling headless mode for the GodotTools language server (which is quite nice) causes a phantom Godot application (no icon) to appear to be running in the dock / task switcher whenever VSCode is open.

git history shows this call used to be in display_server_macos and was moved to os_macos when alert was moved to OS. Because if this I think it should be a fairly safe change. 