### PR TITLE
[Experimental] Add Betsy GPU texture compressor

### DIFF
--- a/core/io/image.h
+++ b/core/io/image.h
@@ -159,6 +159,12 @@ public:
 	static void (*_image_compress_etc2_func)(Image *, UsedChannels p_channels);
 	static void (*_image_compress_astc_func)(Image *, ASTCFormat p_format);
 
+	static void (*_image_compress_bc_rd_func)(Image *, UsedChannels p_channels);
+	static void (*_image_compress_bptc_rd_func)(Image *, UsedChannels p_channels);
+	static void (*_image_compress_etc1_rd_func)(Image *);
+	static void (*_image_compress_etc2_rd_func)(Image *, UsedChannels p_channels);
+	//static void (*_image_compress_astc_rd_func)(Image *, ASTCFormat p_format);
+
 	static void (*_image_decompress_bc)(Image *);
 	static void (*_image_decompress_bptc)(Image *);
 	static void (*_image_decompress_etc1)(Image *);

--- a/modules/betsy/CrossPlatformSettings_piece_all.glsl
+++ b/modules/betsy/CrossPlatformSettings_piece_all.glsl
@@ -1,0 +1,76 @@
+
+#define min3(a, b, c) min(a, min(b, c))
+#define max3(a, b, c) max(a, max(b, c))
+
+#define float2 vec2
+#define float3 vec3
+#define float4 vec4
+
+#define int2 ivec2
+#define int3 ivec3
+#define int4 ivec4
+
+#define uint2 uvec2
+#define uint3 uvec3
+#define uint4 uvec4
+
+#define float2x2 mat2
+#define float3x3 mat3
+#define float4x4 mat4
+#define ogre_float4x3 mat3x4
+
+#define ushort uint
+#define ushort3 uint3
+#define ushort4 uint4
+
+//Short used for read operations. It's an int in GLSL & HLSL. An ushort in Metal
+#define rshort int
+#define rshort2 int2
+#define rint int
+//Short used for write operations. It's an int in GLSL. An ushort in HLSL & Metal
+#define wshort2 int2
+#define wshort3 int3
+
+#define toFloat3x3(x) mat3(x)
+#define buildFloat3x3(row0, row1, row2) mat3(row0, row1, row2)
+
+#define mul(x, y) ((x) * (y))
+#define saturate(x) clamp((x), 0.0, 1.0)
+#define lerp mix
+#define rsqrt inversesqrt
+#define INLINE
+#define NO_INTERPOLATION_PREFIX flat
+#define NO_INTERPOLATION_SUFFIX
+
+#define PARAMS_ARG_DECL
+#define PARAMS_ARG
+
+#define reversebits bitfieldReverse
+
+#define OGRE_Sample(tex, sampler, uv) texture(tex, uv)
+#define OGRE_SampleLevel(tex, sampler, uv, lod) textureLod(tex, uv, lod)
+#define OGRE_SampleArray2D(tex, sampler, uv, arrayIdx) texture(tex, vec3(uv, arrayIdx))
+#define OGRE_SampleArray2DLevel(tex, sampler, uv, arrayIdx, lod) textureLod(tex, vec3(uv, arrayIdx), lod)
+#define OGRE_SampleArrayCubeLevel(tex, sampler, uv, arrayIdx, lod) textureLod(tex, vec4(uv, arrayIdx), lod)
+#define OGRE_SampleGrad(tex, sampler, uv, ddx, ddy) textureGrad(tex, uv, ddx, ddy)
+#define OGRE_SampleArray2DGrad(tex, sampler, uv, arrayIdx, ddx, ddy) textureGrad(tex, vec3(uv, arrayIdx), ddx, ddy)
+#define OGRE_ddx(val) dFdx(val)
+#define OGRE_ddy(val) dFdy(val)
+#define OGRE_Load2D(tex, iuv, lod) texelFetch(tex, iuv, lod)
+#define OGRE_LoadArray2D(tex, iuv, arrayIdx, lod) texelFetch(tex, ivec3(iuv, arrayIdx), lod)
+#define OGRE_Load2DMS(tex, iuv, subsample) texelFetch(tex, iuv, subsample)
+
+#define OGRE_Load3D(tex, iuv, lod) texelFetch(tex, ivec3(iuv), lod)
+
+#define OGRE_GatherRed(tex, sampler, uv) textureGather(tex, uv, 0)
+#define OGRE_GatherGreen(tex, sampler, uv) textureGather(tex, uv, 1)
+#define OGRE_GatherBlue(tex, sampler, uv) textureGather(tex, uv, 2)
+
+#define bufferFetch1(buffer, idx) texelFetch(buffer, idx).x
+
+#define OGRE_SAMPLER_ARG_DECL(samplerName)
+#define OGRE_SAMPLER_ARG(samplerName)
+
+#define OGRE_Texture3D_float4 sampler3D
+#define OGRE_OUT_REF(declType, variableName) out declType variableName
+#define OGRE_INOUT_REF(declType, variableName) inout declType variableName

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_betsy = env_modules.Clone()
+env_betsy.GLSL_HEADER("bc6h.glsl")
+env_betsy.GLSL_HEADER("bc1.glsl")
+env_betsy.GLSL_HEADER("bc4.glsl")
+env_betsy.GLSL_HEADER("format_converter.glsl")
+env_betsy.Depends(Glob("*.glsl.gen.h"), ["#glsl_builders.py"])
+
+# Thirdparty source files
+
+thirdparty_obj = []
+
+thirdparty_dir = "#thirdparty/betsy/"
+# thirdparty_sources = [
+# ]
+# thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
+env_betsy.Prepend(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_betsy.Clone()
+env_thirdparty.disable_warnings()
+# env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
+
+# Godot source files
+
+module_obj = []
+
+env_betsy.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/betsy/UavCrossPlatform_piece_all.glsl
+++ b/modules/betsy/UavCrossPlatform_piece_all.glsl
@@ -1,0 +1,17 @@
+
+#define OGRE_imageLoad2D(inImage, iuv) imageLoad(inImage, int2(iuv))
+#define OGRE_imageLoad2DArray(inImage, iuvw) imageLoad(inImage, int3(iuvw))
+
+#define OGRE_imageWrite2D1(outImage, iuv, value) imageStore(outImage, int2(iuv), float4(value, 0, 0, 0))
+#define OGRE_imageWrite2D2(outImage, iuv, value) imageStore(outImage, int2(iuv), float4(value, 0, 0))
+#define OGRE_imageWrite2D4(outImage, iuv, value) imageStore(outImage, int2(iuv), value)
+
+#define OGRE_imageLoad3D(inImage, iuv) imageLoad(inImage, int3(iuv))
+
+#define OGRE_imageWrite3D1(outImage, iuv, value) imageStore(outImage, int3(iuv), value)
+#define OGRE_imageWrite3D4(outImage, iuv, value) imageStore(outImage, int3(iuv), value)
+
+#define OGRE_imageWrite2DArray1(outImage, iuvw, value) imageStore(outImage, int3(iuvw), value)
+#define OGRE_imageWrite2DArray4(outImage, iuvw, value) imageStore(outImage, int3(iuvw), value)
+
+//#define sharedOnlyBarrier memoryBarrierShared();barrier();

--- a/modules/betsy/bc1.glsl
+++ b/modules/betsy/bc1.glsl
@@ -1,0 +1,480 @@
+#[compute]
+
+#version 450
+
+#include "CrossPlatformSettings_piece_all.glsl"
+#include "UavCrossPlatform_piece_all.glsl"
+
+#define FLT_MAX 340282346638528859811704183484516925440.0f
+
+layout(binding = 0) uniform sampler2D srcTex;
+
+layout(rg32ui, binding = 1) uniform restrict writeonly uimage2D dstTexture;
+
+layout(std430, binding = 2) readonly restrict buffer globalBuffer {
+	float2 c_oMatch5[256];
+	float2 c_oMatch6[256];
+};
+
+layout(push_constant, std430) uniform Params {
+	uint p_numRefinements;
+	uint p_padding[3];
+}
+params;
+
+layout(local_size_x = 8, //
+		local_size_y = 8, //
+		local_size_z = 1) in;
+
+float3 rgb565to888(float rgb565) {
+	float3 retVal;
+	retVal.x = floor(rgb565 / 2048.0f);
+	retVal.y = floor(mod(rgb565, 2048.0f) / 32.0f);
+	retVal.z = floor(mod(rgb565, 32.0f));
+
+	// This is the correct 565 to 888 conversion:
+	//		rgb = floor( rgb * ( 255.0f / float3( 31.0f, 63.0f, 31.0f ) ) + 0.5f )
+	//
+	// However stb_dxt follows a different one:
+	//		rb = floor( rb * ( 256 / 32 + 8 / 32 ) );
+	//		g  = floor( g  * ( 256 / 64 + 4 / 64 ) );
+	//
+	// I'm not sure exactly why but it's possible this is how the S3TC specifies it should be decoded
+	// It's quite possible this is the reason:
+	//		http://www.ludicon.com/castano/blog/2009/03/gpu-dxt-decompression/
+	//
+	// Or maybe it's just because it's cheap to do with integer shifts.
+	// Anyway, we follow stb_dxt's conversion just in case
+	// (gives almost the same result, with 1 or -1 of difference for a very few values)
+	//
+	// Perhaps when we make 888 -> 565 -> 888 it doesn't matter
+	// because they end up mapping to the original number
+
+	return floor(retVal * float3(8.25f, 4.0625f, 8.25f));
+}
+
+float rgb888to565(float3 rgbValue) {
+	rgbValue.rb = floor(rgbValue.rb * 31.0f / 255.0f + 0.5f);
+	rgbValue.g = floor(rgbValue.g * 63.0f / 255.0f + 0.5f);
+
+	return rgbValue.r * 2048.0f + rgbValue.g * 32.0f + rgbValue.b;
+}
+
+// linear interpolation at 1/3 point between a and b, using desired rounding type
+float3 lerp13(float3 a, float3 b) {
+#ifdef STB_DXT_USE_ROUNDING_BIAS
+	// with rounding bias
+	return a + floor((b - a) * (1.0f / 3.0f) + 0.5f);
+#else
+	// without rounding bias
+	return floor((2.0f * a + b) / 3.0f);
+#endif
+}
+
+/// Unpacks a block of 4 colours from two 16-bit endpoints
+void EvalColors(out float3 colours[4], float c0, float c1) {
+	colours[0] = rgb565to888(c0);
+	colours[1] = rgb565to888(c1);
+	colours[2] = lerp13(colours[0], colours[1]);
+	colours[3] = lerp13(colours[1], colours[0]);
+}
+
+/** The color optimization function. (Clever code, part 1)
+@param outMinEndp16 [out]
+	Minimum endpoint, in RGB565
+@param outMaxEndp16 [out]
+	Maximum endpoint, in RGB565
+*/
+void OptimizeColorsBlock(const uint srcPixelsBlock[16], out float outMinEndp16, out float outMaxEndp16) {
+	// determine color distribution
+	float3 avgColour;
+	float3 minColour;
+	float3 maxColour;
+
+	avgColour = minColour = maxColour = unpackUnorm4x8(srcPixelsBlock[0]).xyz;
+	for (int i = 1; i < 16; ++i) {
+		const float3 currColourUnorm = unpackUnorm4x8(srcPixelsBlock[i]).xyz;
+		avgColour += currColourUnorm;
+		minColour = min(minColour, currColourUnorm);
+		maxColour = max(maxColour, currColourUnorm);
+	}
+
+	avgColour = round(avgColour * 255.0f / 16.0f);
+	maxColour *= 255.0f;
+	minColour *= 255.0f;
+
+	// determine covariance matrix
+	float cov[6];
+	for (int i = 0; i < 6; ++i)
+		cov[i] = 0;
+
+	for (int i = 0; i < 16; ++i) {
+		const float3 currColour = unpackUnorm4x8(srcPixelsBlock[i]).xyz * 255.0f;
+		float3 rgbDiff = currColour - avgColour;
+
+		cov[0] += rgbDiff.r * rgbDiff.r;
+		cov[1] += rgbDiff.r * rgbDiff.g;
+		cov[2] += rgbDiff.r * rgbDiff.b;
+		cov[3] += rgbDiff.g * rgbDiff.g;
+		cov[4] += rgbDiff.g * rgbDiff.b;
+		cov[5] += rgbDiff.b * rgbDiff.b;
+	}
+
+	// convert covariance matrix to float, find principal axis via power iter
+	for (int i = 0; i < 6; ++i)
+		cov[i] /= 255.0f;
+
+	float3 vF = maxColour - minColour;
+
+	const int nIterPower = 4;
+	for (int iter = 0; iter < nIterPower; ++iter) {
+		const float r = vF.r * cov[0] + vF.g * cov[1] + vF.b * cov[2];
+		const float g = vF.r * cov[1] + vF.g * cov[3] + vF.b * cov[4];
+		const float b = vF.r * cov[2] + vF.g * cov[4] + vF.b * cov[5];
+
+		vF.r = r;
+		vF.g = g;
+		vF.b = b;
+	}
+
+	float magn = max3(abs(vF.r), abs(vF.g), abs(vF.b));
+	float3 v;
+
+	if (magn < 4.0f) { // too small, default to luminance
+		v.r = 299.0f; // JPEG YCbCr luma coefs, scaled by 1000.
+		v.g = 587.0f;
+		v.b = 114.0f;
+	} else {
+		v = trunc(vF * (512.0f / magn));
+	}
+
+	// Pick colors at extreme points
+	float3 minEndpoint, maxEndpoint;
+	float minDot = FLT_MAX;
+	float maxDot = -FLT_MAX;
+	for (int i = 0; i < 16; ++i) {
+		const float3 currColour = unpackUnorm4x8(srcPixelsBlock[i]).xyz * 255.0f;
+		const float dotValue = dot(currColour, v);
+
+		if (dotValue < minDot) {
+			minDot = dotValue;
+			minEndpoint = currColour;
+		}
+
+		if (dotValue > maxDot) {
+			maxDot = dotValue;
+			maxEndpoint = currColour;
+		}
+	}
+
+	outMinEndp16 = rgb888to565(minEndpoint);
+	outMaxEndp16 = rgb888to565(maxEndpoint);
+}
+
+// The color matching function
+uint MatchColorsBlock(const uint srcPixelsBlock[16], float3 colour[4]) {
+	uint mask = 0u;
+	float3 dir = colour[0] - colour[1];
+	float stops[4];
+
+	for (int i = 0; i < 4; ++i)
+		stops[i] = dot(colour[i], dir);
+
+	// think of the colors as arranged on a line; project point onto that line, then choose
+	// next color out of available ones. we compute the crossover points for "best color in top
+	// half"/"best in bottom half" and then the same inside that subinterval.
+	//
+	// relying on this 1d approximation isn't always optimal in terms of euclidean distance,
+	// but it's very close and a lot faster.
+	// http://cbloomrants.blogspot.com/2008/12/12-08-08-dxtc-summary.html
+
+	float c0Point = trunc((stops[1] + stops[3]) * 0.5f);
+	float halfPoint = trunc((stops[3] + stops[2]) * 0.5f);
+	float c3Point = trunc((stops[2] + stops[0]) * 0.5f);
+
+#ifndef BC1_DITHER
+	// the version without dithering is straightforward
+	for (uint i = 16u; i-- > 0u;) {
+		const float3 currColour = unpackUnorm4x8(srcPixelsBlock[i]).xyz * 255.0f;
+
+		const float dotValue = dot(currColour, dir);
+		mask <<= 2u;
+
+		if (dotValue < halfPoint)
+			mask |= ((dotValue < c0Point) ? 1u : 3u);
+		else
+			mask |= ((dotValue < c3Point) ? 2u : 0u);
+	}
+#else
+	// with floyd-steinberg dithering
+	float4 ep1 = float4(0, 0, 0, 0);
+	float4 ep2 = float4(0, 0, 0, 0);
+
+	c0Point *= 16.0f;
+	halfPoint *= 16.0f;
+	c3Point *= 16.0f;
+
+	for (uint y = 0u; y < 4u; ++y) {
+		float ditherDot;
+		uint lmask, step;
+
+		float3 currColour;
+		float dotValue;
+
+		currColour = unpackUnorm4x8(srcPixelsBlock[y * 4 + 0]).xyz * 255.0f;
+		dotValue = dot(currColour, dir);
+
+		ditherDot = (dotValue * 16.0f) + (3 * ep2[1] + 5 * ep2[0]);
+		if (ditherDot < halfPoint)
+			step = (ditherDot < c0Point) ? 1u : 3u;
+		else
+			step = (ditherDot < c3Point) ? 2u : 0u;
+		ep1[0] = dotValue - stops[step];
+		lmask = step;
+
+		currColour = unpackUnorm4x8(srcPixelsBlock[y * 4 + 1]).xyz * 255.0f;
+		dotValue = dot(currColour, dir);
+
+		ditherDot = (dotValue * 16.0f) + (7 * ep1[0] + 3 * ep2[2] + 5 * ep2[1] + ep2[0]);
+		if (ditherDot < halfPoint)
+			step = (ditherDot < c0Point) ? 1u : 3u;
+		else
+			step = (ditherDot < c3Point) ? 2u : 0u;
+		ep1[1] = dotValue - stops[step];
+		lmask |= step << 2u;
+
+		currColour = unpackUnorm4x8(srcPixelsBlock[y * 4 + 2]).xyz * 255.0f;
+		dotValue = dot(currColour, dir);
+
+		ditherDot = (dotValue * 16.0f) + (7 * ep1[1] + 3 * ep2[3] + 5 * ep2[2] + ep2[1]);
+		if (ditherDot < halfPoint)
+			step = (ditherDot < c0Point) ? 1u : 3u;
+		else
+			step = (ditherDot < c3Point) ? 2u : 0u;
+		ep1[2] = dotValue - stops[step];
+		lmask |= step << 4u;
+
+		currColour = unpackUnorm4x8(srcPixelsBlock[y * 4 + 2]).xyz * 255.0f;
+		dotValue = dot(currColour, dir);
+
+		ditherDot = (dotValue * 16.0f) + (7 * ep1[2] + 5 * ep2[3] + ep2[2]);
+		if (ditherDot < halfPoint)
+			step = (ditherDot < c0Point) ? 1u : 3u;
+		else
+			step = (ditherDot < c3Point) ? 2u : 0u;
+		ep1[3] = dotValue - stops[step];
+		lmask |= step << 6u;
+
+		mask |= lmask << (y * 8u);
+		{
+			float4 tmp = ep1;
+			ep1 = ep2;
+			ep2 = tmp;
+		} // swap
+	}
+#endif
+
+	return mask;
+}
+
+// The refinement function. (Clever code, part 2)
+// Tries to optimize colors to suit block contents better.
+// (By solving a least squares system via normal equations+Cramer's rule)
+bool RefineBlock(const uint srcPixelsBlock[16], uint mask, inout float inOutMinEndp16,
+		inout float inOutMaxEndp16) {
+	float newMin16, newMax16;
+	const float oldMin = inOutMinEndp16;
+	const float oldMax = inOutMaxEndp16;
+
+	if ((mask ^ (mask << 2u)) < 4u) // all pixels have the same index?
+	{
+		// yes, linear system would be singular; solve using optimal
+		// single-color match on average color
+		float3 rgbVal = float3(8.0f / 255.0f, 8.0f / 255.0f, 8.0f / 255.0f);
+		for (int i = 0; i < 16; ++i)
+			rgbVal += unpackUnorm4x8(srcPixelsBlock[i]).xyz;
+
+		rgbVal = floor(rgbVal * (255.0f / 16.0f));
+
+		newMax16 = c_oMatch5[uint(rgbVal.r)][0] * 2048.0f + //
+				c_oMatch6[uint(rgbVal.g)][0] * 32.0f + //
+				c_oMatch5[uint(rgbVal.b)][0];
+		newMin16 = c_oMatch5[uint(rgbVal.r)][1] * 2048.0f + //
+				c_oMatch6[uint(rgbVal.g)][1] * 32.0f + //
+				c_oMatch5[uint(rgbVal.b)][1];
+	} else {
+		const float w1Tab[4] = { 3, 0, 2, 1 };
+		const float prods[4] = { 589824.0f, 2304.0f, 262402.0f, 66562.0f };
+		// ^some magic to save a lot of multiplies in the accumulating loop...
+		// (precomputed products of weights for least squares system, accumulated inside one 32-bit
+		// register)
+
+		float akku = 0.0f;
+		uint cm = mask;
+		float3 at1 = float3(0, 0, 0);
+		float3 at2 = float3(0, 0, 0);
+		for (int i = 0; i < 16; ++i, cm >>= 2u) {
+			const float3 currColour = unpackUnorm4x8(srcPixelsBlock[i]).xyz * 255.0f;
+
+			const uint step = cm & 3u;
+			const float w1 = w1Tab[step];
+			akku += prods[step];
+			at1 += currColour * w1;
+			at2 += currColour;
+		}
+
+		at2 = 3.0f * at2 - at1;
+
+		// extract solutions and decide solvability
+		const float xx = floor(akku / 65535.0f);
+		const float yy = floor(mod(akku, 65535.0f) / 256.0f);
+		const float xy = mod(akku, 256.0f);
+
+		float2 f_rb_g;
+		f_rb_g.x = 3.0f * 31.0f / 255.0f / (xx * yy - xy * xy);
+		f_rb_g.y = f_rb_g.x * 63.0f / 31.0f;
+
+		// solve.
+		const float3 newMaxVal = clamp(floor((at1 * yy - at2 * xy) * f_rb_g.xyx + 0.5f),
+				float3(0.0f, 0.0f, 0.0f), float3(31, 63, 31));
+		newMax16 = newMaxVal.x * 2048.0f + newMaxVal.y * 32.0f + newMaxVal.z;
+
+		const float3 newMinVal = clamp(floor((at2 * xx - at1 * xy) * f_rb_g.xyx + 0.5f),
+				float3(0.0f, 0.0f, 0.0f), float3(31, 63, 31));
+		newMin16 = newMinVal.x * 2048.0f + newMinVal.y * 32.0f + newMinVal.z;
+	}
+
+	inOutMinEndp16 = newMin16;
+	inOutMaxEndp16 = newMax16;
+
+	return oldMin != newMin16 || oldMax != newMax16;
+}
+
+#ifdef BC1_DITHER
+/// Quantizes 'srcValue' which is originally in 888 (full range),
+/// converting it to 565 and then back to 888 (quantized)
+float3 quant(float3 srcValue) {
+	srcValue = clamp(srcValue, 0.0f, 255.0f);
+	// Convert 888 -> 565
+	srcValue = floor(srcValue * float3(31.0f / 255.0f, 63.0f / 255.0f, 31.0f / 255.0f) + 0.5f);
+	// Convert 565 -> 888 back
+	srcValue = floor(srcValue * float3(8.25f, 4.0625f, 8.25f));
+
+	return srcValue;
+}
+
+void DitherBlock(const uint srcPixBlck[16], out uint dthPixBlck[16]) {
+	float3 ep1[4] = { float3(0, 0, 0), float3(0, 0, 0), float3(0, 0, 0), float3(0, 0, 0) };
+	float3 ep2[4] = { float3(0, 0, 0), float3(0, 0, 0), float3(0, 0, 0), float3(0, 0, 0) };
+
+	for (uint y = 0u; y < 16u; y += 4u) {
+		float3 srcPixel, dithPixel;
+
+		srcPixel = unpackUnorm4x8(srcPixBlck[y + 0u]).xyz * 255.0f;
+		dithPixel = quant(srcPixel + trunc((3 * ep2[1] + 5 * ep2[0]) * (1.0f / 16.0f)));
+		ep1[0] = srcPixel - dithPixel;
+		dthPixBlck[y + 0u] = packUnorm4x8(float4(dithPixel * (1.0f / 255.0f), 1.0f));
+
+		srcPixel = unpackUnorm4x8(srcPixBlck[y + 1u]).xyz * 255.0f;
+		dithPixel = quant(
+				srcPixel + trunc((7 * ep1[0] + 3 * ep2[2] + 5 * ep2[1] + ep2[0]) * (1.0f / 16.0f)));
+		ep1[1] = srcPixel - dithPixel;
+		dthPixBlck[y + 1u] = packUnorm4x8(float4(dithPixel * (1.0f / 255.0f), 1.0f));
+
+		srcPixel = unpackUnorm4x8(srcPixBlck[y + 2u]).xyz * 255.0f;
+		dithPixel = quant(
+				srcPixel + trunc((7 * ep1[1] + 3 * ep2[3] + 5 * ep2[2] + ep2[1]) * (1.0f / 16.0f)));
+		ep1[2] = srcPixel - dithPixel;
+		dthPixBlck[y + 2u] = packUnorm4x8(float4(dithPixel * (1.0f / 255.0f), 1.0f));
+
+		srcPixel = unpackUnorm4x8(srcPixBlck[y + 3u]).xyz * 255.0f;
+		dithPixel = quant(srcPixel + trunc((7 * ep1[2] + 5 * ep2[3] + ep2[2]) * (1.0f / 16.0f)));
+		ep1[3] = srcPixel - dithPixel;
+		dthPixBlck[y + 3u] = packUnorm4x8(float4(dithPixel * (1.0f / 255.0f), 1.0f));
+
+		// swap( ep1, ep2 )
+		for (uint i = 0u; i < 4u; ++i) {
+			float3 tmp = ep1[i];
+			ep1[i] = ep2[i];
+			ep2[i] = tmp;
+		}
+	}
+}
+#endif
+
+void main() {
+	uint srcPixelsBlock[16];
+
+	bool bAllColoursEqual = true;
+
+	// Load the whole 4x4 block
+	const uint2 pixelsToLoadBase = gl_GlobalInvocationID.xy << 2u;
+	for (uint i = 0u; i < 16u; ++i) {
+		const uint2 pixelsToLoad = pixelsToLoadBase + uint2(i & 0x03u, i >> 2u);
+		const float3 srcPixels0 = OGRE_Load2D(srcTex, int2(pixelsToLoad), 0).xyz;
+		srcPixelsBlock[i] = packUnorm4x8(float4(srcPixels0, 1.0f));
+		bAllColoursEqual = bAllColoursEqual && srcPixelsBlock[0] == srcPixelsBlock[i];
+	}
+
+	float maxEndp16, minEndp16;
+	uint mask = 0u;
+
+	if (bAllColoursEqual) {
+		const uint3 rgbVal = uint3(unpackUnorm4x8(srcPixelsBlock[0]).xyz * 255.0f);
+		mask = 0xAAAAAAAAu;
+		maxEndp16 =
+				c_oMatch5[rgbVal.r][0] * 2048.0f + c_oMatch6[rgbVal.g][0] * 32.0f + c_oMatch5[rgbVal.b][0];
+		minEndp16 =
+				c_oMatch5[rgbVal.r][1] * 2048.0f + c_oMatch6[rgbVal.g][1] * 32.0f + c_oMatch5[rgbVal.b][1];
+	} else {
+#ifdef BC1_DITHER
+		uint ditherPixelsBlock[16];
+		// first step: compute dithered version for PCA if desired
+		DitherBlock(srcPixelsBlock, ditherPixelsBlock);
+#else
+#define ditherPixelsBlock srcPixelsBlock
+#endif
+
+		// second step: pca+map along principal axis
+		OptimizeColorsBlock(ditherPixelsBlock, minEndp16, maxEndp16);
+		if (minEndp16 != maxEndp16) {
+			float3 colours[4];
+			EvalColors(colours, maxEndp16, minEndp16); // Note min/max are inverted
+			mask = MatchColorsBlock(srcPixelsBlock, colours);
+		}
+
+		// third step: refine (multiple times if requested)
+		bool bStopRefinement = false;
+		for (uint i = 0u; i < params.p_numRefinements && !bStopRefinement; ++i) {
+			const uint lastMask = mask;
+
+			if (RefineBlock(ditherPixelsBlock, mask, minEndp16, maxEndp16)) {
+				if (minEndp16 != maxEndp16) {
+					float3 colours[4];
+					EvalColors(colours, maxEndp16, minEndp16); // Note min/max are inverted
+					mask = MatchColorsBlock(srcPixelsBlock, colours);
+				} else {
+					mask = 0u;
+					bStopRefinement = true;
+				}
+			}
+
+			bStopRefinement = mask == lastMask || bStopRefinement;
+		}
+	}
+
+	// write the color block
+	if (maxEndp16 < minEndp16) {
+		const float tmpValue = minEndp16;
+		minEndp16 = maxEndp16;
+		maxEndp16 = tmpValue;
+		mask ^= 0x55555555u;
+	}
+
+	uint2 outputBytes;
+	outputBytes.x = uint(maxEndp16) | (uint(minEndp16) << 16u);
+	outputBytes.y = mask;
+
+	uint2 dstUV = gl_GlobalInvocationID.xy;
+	imageStore(dstTexture, int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
+}

--- a/modules/betsy/bc4.glsl
+++ b/modules/betsy/bc4.glsl
@@ -1,0 +1,154 @@
+#[compute]
+
+#version 450
+
+#include "CrossPlatformSettings_piece_all.glsl"
+#include "UavCrossPlatform_piece_all.glsl"
+
+shared float2 g_minMaxValues[4u * 4u * 4u];
+shared uint2 g_mask[4u * 4u];
+
+//layout( location = 0 ) uniform float2 params;
+
+layout(binding = 0) uniform sampler2D srcTex;
+
+layout(rg32ui, binding = 1) uniform restrict writeonly uimage2D dstTexture;
+
+layout(local_size_x = 4, //
+		local_size_y = 4, //
+		local_size_z = 4) in;
+
+layout(push_constant, std430) uniform Params {
+	uint p_channelIdx;
+	uint p_useSNorm;
+	uint2 p_padding;
+}
+params;
+
+//#define p_channelIdx params.x
+//#define p_useSNorm params.y
+
+/// Each block is 16 pixels
+/// Each thread works on 4 pixels
+/// Therefore each block needs 4 threads, generating 8 masks
+/// At the end these 8 masks get merged into 2 and results written to output
+///
+/// **Q: Why 4 pixels per thread? Why not 1 pixel per thread? Why not 2? Why not 16?**
+///
+/// A: It's a sweetspot.
+///  - Very short threads cannot fill expensive GPUs with enough work (dispatch bound)
+///  - Lots of threads means lots of synchronization (e.g. evaluating min/max, merging masks)
+///    overhead, and also more LDS usage which reduces occupancy.
+///  - Long threads (e.g. 1 thread per block) misses parallelism opportunities
+void main() {
+	float minVal, maxVal;
+	float4 srcPixel;
+
+	const uint blockThreadId = gl_LocalInvocationID.x;
+
+	const uint2 pixelsToLoadBase = gl_GlobalInvocationID.yz << 2u;
+
+	for (uint i = 0u; i < 4u; ++i) {
+		const uint2 pixelsToLoad = pixelsToLoadBase + uint2(i, blockThreadId);
+
+		const float4 value = OGRE_Load2D(srcTex, int2(pixelsToLoad), 0).xyzw;
+		srcPixel[i] = params.p_channelIdx == 0 ? value.x : (params.p_channelIdx == 1 ? value.y : value.w);
+		srcPixel[i] *= 255.0f;
+	}
+
+	minVal = min3(srcPixel.x, srcPixel.y, srcPixel.z);
+	maxVal = max3(srcPixel.x, srcPixel.y, srcPixel.z);
+	minVal = min(minVal, srcPixel.w);
+	maxVal = max(maxVal, srcPixel.w);
+
+	const uint minMaxIdxBase = (gl_LocalInvocationID.z << 4u) + (gl_LocalInvocationID.y << 2u);
+	const uint maskIdxBase = (gl_LocalInvocationID.z << 2u) + gl_LocalInvocationID.y;
+
+	g_minMaxValues[minMaxIdxBase + blockThreadId] = float2(minVal, maxVal);
+	g_mask[maskIdxBase] = uint2(0u, 0u);
+
+	//__sharedOnlyBarrier;
+	memoryBarrierShared();
+	barrier();
+
+	// Have all 4 threads in the block grab the min/max value by comparing what all 4 threads uploaded
+	for (uint i = 0u; i < 4u; ++i) {
+		minVal = min(g_minMaxValues[minMaxIdxBase + i].x, minVal);
+		maxVal = max(g_minMaxValues[minMaxIdxBase + i].y, maxVal);
+	}
+
+	// determine bias and emit color indices
+	// given the choice of maxVal/minVal, these indices are optimal:
+	// http://fgiesen.wordpress.com/2009/12/15/dxt5-alpha-block-index-determination/
+	float dist = maxVal - minVal;
+	float dist4 = dist * 4.0f;
+	float dist2 = dist * 2.0f;
+	float bias = (dist < 8) ? (dist - 1) : (trunc(dist * 0.5f) + 2);
+	bias -= minVal * 7;
+
+	uint mask0 = 0u, mask1 = 0u;
+
+	for (uint i = 0u; i < 4u; ++i) {
+		float a = srcPixel[i] * 7.0f + bias;
+
+		int ind = 0;
+
+		// select index. this is a "linear scale" lerp factor between 0 (val=min) and 7 (val=max).
+		if (a >= dist4) {
+			ind = 4;
+			a -= dist4;
+		}
+
+		if (a >= dist2) {
+			ind += 2;
+			a -= dist2;
+		}
+
+		if (a >= dist)
+			ind += 1;
+
+		// turn linear scale into DXT index (0/1 are extremal pts)
+		ind = -ind & 7;
+		ind ^= (2 > ind) ? 1 : 0;
+
+		// write index
+		const uint bits = 16u + ((blockThreadId << 2u) + i) * 3u;
+		if (bits < 32u) {
+			mask0 |= uint(ind) << bits;
+			if (bits + 3u > 32u) {
+				mask1 |= uint(ind) >> (32u - bits);
+			}
+		} else {
+			mask1 |= uint(ind) << (bits - 32u);
+		}
+	}
+
+	if (mask0 != 0u)
+		atomicOr(g_mask[maskIdxBase].x, mask0);
+	if (mask1 != 0u)
+		atomicOr(g_mask[maskIdxBase].y, mask1);
+
+	//__sharedOnlyBarrier;
+	memoryBarrierShared();
+	barrier();
+
+	if (blockThreadId == 0u) {
+		// Save data
+		uint2 outputBytes;
+
+		if (params.p_useSNorm != 0) {
+			outputBytes.x =
+					packSnorm4x8(float4(maxVal * (1.0f / 255.0f) * 2.0f - 1.0f,
+							minVal * (1.0f / 255.0f) * 2.0f - 1.0f, 0.0f, 0.0f));
+		} else {
+			outputBytes.x = packUnorm4x8(
+					float4(maxVal * (1.0f / 255.0f), minVal * (1.0f / 255.0f), 0.0f, 0.0f));
+		}
+		outputBytes.x |= g_mask[maskIdxBase].x;
+		outputBytes.y = g_mask[maskIdxBase].y;
+
+		uint2 dstUV = gl_GlobalInvocationID.yz;
+
+		imageAtomicOr(dstTexture, int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
+	}
+}

--- a/modules/betsy/bc6h.glsl
+++ b/modules/betsy/bc6h.glsl
@@ -1,0 +1,595 @@
+#[compute]
+#version 450
+
+#include "CrossPlatformSettings_piece_all.glsl"
+#include "UavCrossPlatform_piece_all.glsl"
+
+#define QUALITY
+
+//SIGNED macro is WIP
+//#define SIGNED
+
+float3 f32tof16(float3 value) {
+	return float3(packHalf2x16(float2(value.x, 0.0)),
+			packHalf2x16(float2(value.y, 0.0)),
+			packHalf2x16(float2(value.z, 0.0)));
+}
+
+float3 f16tof32(uint3 value) {
+	return float3(unpackHalf2x16(value.x).x,
+			unpackHalf2x16(value.y).x,
+			unpackHalf2x16(value.z).x);
+}
+
+float f32tof16(float value) {
+	return packHalf2x16(float2(value.x, 0.0));
+}
+
+float f16tof32(uint value) {
+	return unpackHalf2x16(value.x).x;
+}
+
+layout(binding = 0) uniform sampler2D srcTexture;
+layout(binding = 1, rgba32ui) uniform restrict writeonly uimage2D dstTexture;
+
+layout(push_constant, std430) uniform Params {
+	float2 p_textureSizeRcp;
+	float2 p_padding;
+}
+params;
+
+const float HALF_MAX = 65504.0f;
+const uint PATTERN_NUM = 32u;
+
+float CalcMSLE(float3 a, float3 b) {
+	float3 err = log2((b + 1.0f) / (a + 1.0f));
+	;
+	err = err * err;
+	return err.x + err.y + err.z;
+}
+
+uint PatternFixupID(uint i) {
+	uint ret = 15u;
+	ret = ((3441033216u >> i) & 0x1u) != 0 ? 2u : ret;
+	ret = ((845414400u >> i) & 0x1u) != 0 ? 8u : ret;
+	return ret;
+}
+
+uint Pattern(uint p, uint i) {
+	uint p2 = p / 2u;
+	uint p3 = p - p2 * 2u;
+
+	uint enc = 0u;
+	enc = p2 == 0u ? 2290666700u : enc;
+	enc = p2 == 1u ? 3972591342u : enc;
+	enc = p2 == 2u ? 4276930688u : enc;
+	enc = p2 == 3u ? 3967876808u : enc;
+	enc = p2 == 4u ? 4293707776u : enc;
+	enc = p2 == 5u ? 3892379264u : enc;
+	enc = p2 == 6u ? 4278255592u : enc;
+	enc = p2 == 7u ? 4026597360u : enc;
+	enc = p2 == 8u ? 9369360u : enc;
+	enc = p2 == 9u ? 147747072u : enc;
+	enc = p2 == 10u ? 1930428556u : enc;
+	enc = p2 == 11u ? 2362323200u : enc;
+	enc = p2 == 12u ? 823134348u : enc;
+	enc = p2 == 13u ? 913073766u : enc;
+	enc = p2 == 14u ? 267393000u : enc;
+	enc = p2 == 15u ? 966553998u : enc;
+
+	enc = p3 != 0u ? enc >> 16u : enc;
+	uint ret = (enc >> i) & 0x1u;
+	return ret;
+}
+
+#ifndef SIGNED
+//UF
+float3 Quantize7(float3 x) {
+	return (f32tof16(x) * 128.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize9(float3 x) {
+	return (f32tof16(x) * 512.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize10(float3 x) {
+	return (f32tof16(x) * 1024.0f) / (0x7bff + 1.0f);
+}
+
+float3 Unquantize7(float3 x) {
+	return (x * 65536.0f + 0x8000) / 128.0f;
+}
+
+float3 Unquantize9(float3 x) {
+	return (x * 65536.0f + 0x8000) / 512.0f;
+}
+
+float3 Unquantize10(float3 x) {
+	return (x * 65536.0f + 0x8000) / 1024.0f;
+}
+
+float3 FinishUnquantize(float3 endpoint0Unq, float3 endpoint1Unq, float weight) {
+	float3 comp = (endpoint0Unq * (64.0f - weight) + endpoint1Unq * weight + 32.0f) * (31.0f / 4096.0f);
+	return f16tof32(uint3(comp));
+}
+#else
+//SF
+
+float3 cmpSign(float3 value) {
+	float3 signVal;
+	signVal.x = value.x >= 0.0f ? 1.0f : -1.0f;
+	signVal.y = value.y >= 0.0f ? 1.0f : -1.0f;
+	signVal.z = value.z >= 0.0f ? 1.0f : -1.0f;
+	return signVal;
+}
+
+float3 Quantize7(float3 x) {
+	float3 signVal = cmpSign(x);
+	return signVal * (f32tof16(abs(x)) * 64.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize9(float3 x) {
+	float3 signVal = cmpSign(x);
+	return signVal * (f32tof16(abs(x)) * 256.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize10(float3 x) {
+	float3 signVal = cmpSign(x);
+	return signVal * (f32tof16(abs(x)) * 512.0f) / (0x7bff + 1.0f);
+}
+
+float3 Unquantize7(float3 x) {
+	float3 signVal = sign(x);
+	x = abs(x);
+	float3 finalVal = signVal * (x * 32768.0f + 0x4000) / 64.0f;
+	finalVal.x = x.x >= 64.0f ? 32767.0 : finalVal.x;
+	finalVal.y = x.y >= 64.0f ? 32767.0 : finalVal.y;
+	finalVal.z = x.z >= 64.0f ? 32767.0 : finalVal.z;
+	return finalVal;
+}
+
+float3 Unquantize9(float3 x) {
+	float3 signVal = sign(x);
+	x = abs(x);
+	float3 finalVal = signVal * (x * 32768.0f + 0x4000) / 256.0f;
+	finalVal.x = x.x >= 256.0f ? 32767.0 : finalVal.x;
+	finalVal.y = x.y >= 256.0f ? 32767.0 : finalVal.y;
+	finalVal.z = x.z >= 256.0f ? 32767.0 : finalVal.z;
+	return finalVal;
+}
+
+float3 Unquantize10(float3 x) {
+	float3 signVal = sign(x);
+	x = abs(x);
+	float3 finalVal = signVal * (x * 32768.0f + 0x4000) / 512.0f;
+	finalVal.x = x.x >= 512.0f ? 32767.0 : finalVal.x;
+	finalVal.y = x.y >= 512.0f ? 32767.0 : finalVal.y;
+	finalVal.z = x.z >= 512.0f ? 32767.0 : finalVal.z;
+	return finalVal;
+}
+
+float3 FinishUnquantize(float3 endpoint0Unq, float3 endpoint1Unq, float weight) {
+	float3 comp = (endpoint0Unq * (64.0f - weight) + endpoint1Unq * weight + 32.0f) * (31.0f / 2048.0f);
+	/*float3 signVal;
+	signVal.x = comp.x >= 0.0f ? 0.0f : 0x8000;
+	signVal.y = comp.y >= 0.0f ? 0.0f : 0x8000;
+	signVal.z = comp.z >= 0.0f ? 0.0f : 0x8000;*/
+	//return f16tof32( uint3( signVal + abs( comp ) ) );
+	return f16tof32(uint3(comp));
+}
+#endif
+
+void Swap(inout float3 a, inout float3 b) {
+	float3 tmp = a;
+	a = b;
+	b = tmp;
+}
+
+void Swap(inout float a, inout float b) {
+	float tmp = a;
+	a = b;
+	b = tmp;
+}
+
+uint ComputeIndex3(float texelPos, float endPoint0Pos, float endPoint1Pos) {
+	float r = (texelPos - endPoint0Pos) / (endPoint1Pos - endPoint0Pos);
+	return uint(clamp(r * 6.98182f + 0.00909f + 0.5f, 0.0f, 7.0f));
+}
+
+uint ComputeIndex4(float texelPos, float endPoint0Pos, float endPoint1Pos) {
+	float r = (texelPos - endPoint0Pos) / (endPoint1Pos - endPoint0Pos);
+	return uint(clamp(r * 14.93333f + 0.03333f + 0.5f, 0.0f, 15.0f));
+}
+
+void SignExtend(inout float3 v1, uint mask, uint signFlag) {
+	int3 v = int3(v1);
+	v.x = (v.x & int(mask)) | (v.x < 0 ? int(signFlag) : 0);
+	v.y = (v.y & int(mask)) | (v.y < 0 ? int(signFlag) : 0);
+	v.z = (v.z & int(mask)) | (v.z < 0 ? int(signFlag) : 0);
+	v1 = v;
+}
+
+void EncodeP1(inout uint4 block, inout float blockMSLE, float3 texels[16]) {
+	// compute endpoints (min/max RGB bbox)
+	float3 blockMin = texels[0];
+	float3 blockMax = texels[0];
+	for (uint i = 1u; i < 16u; ++i) {
+		blockMin = min(blockMin, texels[i]);
+		blockMax = max(blockMax, texels[i]);
+	}
+
+	// refine endpoints in log2 RGB space
+	float3 refinedBlockMin = blockMax;
+	float3 refinedBlockMax = blockMin;
+	for (uint i = 0u; i < 16u; ++i) {
+		refinedBlockMin = min(refinedBlockMin, texels[i] == blockMin ? refinedBlockMin : texels[i]);
+		refinedBlockMax = max(refinedBlockMax, texels[i] == blockMax ? refinedBlockMax : texels[i]);
+	}
+
+	float3 logBlockMax = log2(blockMax + 1.0f);
+	float3 logBlockMin = log2(blockMin + 1.0f);
+	float3 logRefinedBlockMax = log2(refinedBlockMax + 1.0f);
+	float3 logRefinedBlockMin = log2(refinedBlockMin + 1.0f);
+	float3 logBlockMaxExt = (logBlockMax - logBlockMin) * (1.0f / 32.0f);
+	logBlockMin += min(logRefinedBlockMin - logBlockMin, logBlockMaxExt);
+	logBlockMax -= min(logBlockMax - logRefinedBlockMax, logBlockMaxExt);
+	blockMin = exp2(logBlockMin) - 1.0f;
+	blockMax = exp2(logBlockMax) - 1.0f;
+
+	float3 blockDir = blockMax - blockMin;
+	blockDir = blockDir / (blockDir.x + blockDir.y + blockDir.z);
+
+	float3 endpoint0 = Quantize10(blockMin);
+	float3 endpoint1 = Quantize10(blockMax);
+	float endPoint0Pos = f32tof16(dot(blockMin, blockDir));
+	float endPoint1Pos = f32tof16(dot(blockMax, blockDir));
+
+	// check if endpoint swap is required
+	float fixupTexelPos = f32tof16(dot(texels[0], blockDir));
+	uint fixupIndex = ComputeIndex4(fixupTexelPos, endPoint0Pos, endPoint1Pos);
+	if (fixupIndex > 7) {
+		Swap(endPoint0Pos, endPoint1Pos);
+		Swap(endpoint0, endpoint1);
+	}
+
+	// compute indices
+	uint indices[16] = { 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
+	for (uint i = 0u; i < 16u; ++i) {
+		float texelPos = f32tof16(dot(texels[i], blockDir));
+		indices[i] = ComputeIndex4(texelPos, endPoint0Pos, endPoint1Pos);
+	}
+
+	// compute compression error (MSLE)
+	float3 endpoint0Unq = Unquantize10(endpoint0);
+	float3 endpoint1Unq = Unquantize10(endpoint1);
+	float msle = 0.0f;
+	for (uint i = 0u; i < 16u; ++i) {
+		float weight = floor((indices[i] * 64.0f) / 15.0f + 0.5f);
+		float3 texelUnc = FinishUnquantize(endpoint0Unq, endpoint1Unq, weight);
+
+		msle += CalcMSLE(texels[i], texelUnc);
+	}
+
+	// encode block for mode 11
+	blockMSLE = msle;
+	block.x = 0x03;
+
+	// endpoints
+	block.x |= uint(endpoint0.x) << 5u;
+	block.x |= uint(endpoint0.y) << 15u;
+	block.x |= uint(endpoint0.z) << 25u;
+	block.y |= uint(endpoint0.z) >> 7u;
+	block.y |= uint(endpoint1.x) << 3u;
+	block.y |= uint(endpoint1.y) << 13u;
+	block.y |= uint(endpoint1.z) << 23u;
+	block.z |= uint(endpoint1.z) >> 9u;
+
+	// indices
+	block.z |= indices[0] << 1u;
+	block.z |= indices[1] << 4u;
+	block.z |= indices[2] << 8u;
+	block.z |= indices[3] << 12u;
+	block.z |= indices[4] << 16u;
+	block.z |= indices[5] << 20u;
+	block.z |= indices[6] << 24u;
+	block.z |= indices[7] << 28u;
+	block.w |= indices[8] << 0u;
+	block.w |= indices[9] << 4u;
+	block.w |= indices[10] << 8u;
+	block.w |= indices[11] << 12u;
+	block.w |= indices[12] << 16u;
+	block.w |= indices[13] << 20u;
+	block.w |= indices[14] << 24u;
+	block.w |= indices[15] << 28u;
+}
+
+void EncodeP2Pattern(inout uint4 block, inout float blockMSLE, uint pattern, float3 texels[16]) {
+	float3 p0BlockMin = float3(HALF_MAX, HALF_MAX, HALF_MAX);
+	float3 p0BlockMax = float3(0.0f, 0.0f, 0.0f);
+	float3 p1BlockMin = float3(HALF_MAX, HALF_MAX, HALF_MAX);
+	float3 p1BlockMax = float3(0.0f, 0.0f, 0.0f);
+
+	for (uint i = 0u; i < 16u; ++i) {
+		uint paletteID = Pattern(pattern, i);
+		if (paletteID == 0) {
+			p0BlockMin = min(p0BlockMin, texels[i]);
+			p0BlockMax = max(p0BlockMax, texels[i]);
+		} else {
+			p1BlockMin = min(p1BlockMin, texels[i]);
+			p1BlockMax = max(p1BlockMax, texels[i]);
+		}
+	}
+
+	float3 p0BlockDir = p0BlockMax - p0BlockMin;
+	float3 p1BlockDir = p1BlockMax - p1BlockMin;
+	p0BlockDir = p0BlockDir / (p0BlockDir.x + p0BlockDir.y + p0BlockDir.z);
+	p1BlockDir = p1BlockDir / (p1BlockDir.x + p1BlockDir.y + p1BlockDir.z);
+
+	float p0Endpoint0Pos = f32tof16(dot(p0BlockMin, p0BlockDir));
+	float p0Endpoint1Pos = f32tof16(dot(p0BlockMax, p0BlockDir));
+	float p1Endpoint0Pos = f32tof16(dot(p1BlockMin, p1BlockDir));
+	float p1Endpoint1Pos = f32tof16(dot(p1BlockMax, p1BlockDir));
+
+	uint fixupID = PatternFixupID(pattern);
+	float p0FixupTexelPos = f32tof16(dot(texels[0], p0BlockDir));
+	float p1FixupTexelPos = f32tof16(dot(texels[fixupID], p1BlockDir));
+	uint p0FixupIndex = ComputeIndex3(p0FixupTexelPos, p0Endpoint0Pos, p0Endpoint1Pos);
+	uint p1FixupIndex = ComputeIndex3(p1FixupTexelPos, p1Endpoint0Pos, p1Endpoint1Pos);
+	if (p0FixupIndex > 3u) {
+		Swap(p0Endpoint0Pos, p0Endpoint1Pos);
+		Swap(p0BlockMin, p0BlockMax);
+	}
+	if (p1FixupIndex > 3u) {
+		Swap(p1Endpoint0Pos, p1Endpoint1Pos);
+		Swap(p1BlockMin, p1BlockMax);
+	}
+
+	uint indices[16] = { 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
+	for (uint i = 0u; i < 16u; ++i) {
+		float p0TexelPos = f32tof16(dot(texels[i], p0BlockDir));
+		float p1TexelPos = f32tof16(dot(texels[i], p1BlockDir));
+		uint p0Index = ComputeIndex3(p0TexelPos, p0Endpoint0Pos, p0Endpoint1Pos);
+		uint p1Index = ComputeIndex3(p1TexelPos, p1Endpoint0Pos, p1Endpoint1Pos);
+
+		uint paletteID = Pattern(pattern, i);
+		indices[i] = paletteID == 0u ? p0Index : p1Index;
+	}
+
+	float3 endpoint760 = floor(Quantize7(p0BlockMin));
+	float3 endpoint761 = floor(Quantize7(p0BlockMax));
+	float3 endpoint762 = floor(Quantize7(p1BlockMin));
+	float3 endpoint763 = floor(Quantize7(p1BlockMax));
+
+	float3 endpoint950 = floor(Quantize9(p0BlockMin));
+	float3 endpoint951 = floor(Quantize9(p0BlockMax));
+	float3 endpoint952 = floor(Quantize9(p1BlockMin));
+	float3 endpoint953 = floor(Quantize9(p1BlockMax));
+
+	endpoint761 = endpoint761 - endpoint760;
+	endpoint762 = endpoint762 - endpoint760;
+	endpoint763 = endpoint763 - endpoint760;
+
+	endpoint951 = endpoint951 - endpoint950;
+	endpoint952 = endpoint952 - endpoint950;
+	endpoint953 = endpoint953 - endpoint950;
+
+	int maxVal76 = 0x1F;
+	endpoint761 = clamp(endpoint761, -maxVal76, maxVal76);
+	endpoint762 = clamp(endpoint762, -maxVal76, maxVal76);
+	endpoint763 = clamp(endpoint763, -maxVal76, maxVal76);
+
+	int maxVal95 = 0xF;
+	endpoint951 = clamp(endpoint951, -maxVal95, maxVal95);
+	endpoint952 = clamp(endpoint952, -maxVal95, maxVal95);
+	endpoint953 = clamp(endpoint953, -maxVal95, maxVal95);
+
+	float3 endpoint760Unq = Unquantize7(endpoint760);
+	float3 endpoint761Unq = Unquantize7(endpoint760 + endpoint761);
+	float3 endpoint762Unq = Unquantize7(endpoint760 + endpoint762);
+	float3 endpoint763Unq = Unquantize7(endpoint760 + endpoint763);
+	float3 endpoint950Unq = Unquantize9(endpoint950);
+	float3 endpoint951Unq = Unquantize9(endpoint950 + endpoint951);
+	float3 endpoint952Unq = Unquantize9(endpoint950 + endpoint952);
+	float3 endpoint953Unq = Unquantize9(endpoint950 + endpoint953);
+
+	float msle76 = 0.0f;
+	float msle95 = 0.0f;
+	for (uint i = 0u; i < 16u; ++i) {
+		uint paletteID = Pattern(pattern, i);
+
+		float3 tmp760Unq = paletteID == 0u ? endpoint760Unq : endpoint762Unq;
+		float3 tmp761Unq = paletteID == 0u ? endpoint761Unq : endpoint763Unq;
+		float3 tmp950Unq = paletteID == 0u ? endpoint950Unq : endpoint952Unq;
+		float3 tmp951Unq = paletteID == 0u ? endpoint951Unq : endpoint953Unq;
+
+		float weight = floor((indices[i] * 64.0f) / 7.0f + 0.5f);
+		float3 texelUnc76 = FinishUnquantize(tmp760Unq, tmp761Unq, weight);
+		float3 texelUnc95 = FinishUnquantize(tmp950Unq, tmp951Unq, weight);
+
+		msle76 += CalcMSLE(texels[i], texelUnc76);
+		msle95 += CalcMSLE(texels[i], texelUnc95);
+	}
+
+	SignExtend(endpoint761, 0x1F, 0x20);
+	SignExtend(endpoint762, 0x1F, 0x20);
+	SignExtend(endpoint763, 0x1F, 0x20);
+
+	SignExtend(endpoint951, 0xF, 0x10);
+	SignExtend(endpoint952, 0xF, 0x10);
+	SignExtend(endpoint953, 0xF, 0x10);
+
+	// encode block
+	float p2MSLE = min(msle76, msle95);
+	if (p2MSLE < blockMSLE) {
+		blockMSLE = p2MSLE;
+		block = uint4(0u, 0u, 0u, 0u);
+
+		if (p2MSLE == msle76) {
+			// 7.6
+			block.x = 0x1u;
+			block.x |= (uint(endpoint762.y) & 0x20u) >> 3u;
+			block.x |= (uint(endpoint763.y) & 0x10u) >> 1u;
+			block.x |= (uint(endpoint763.y) & 0x20u) >> 1u;
+			block.x |= uint(endpoint760.x) << 5u;
+			block.x |= (uint(endpoint763.z) & 0x01u) << 12u;
+			block.x |= (uint(endpoint763.z) & 0x02u) << 12u;
+			block.x |= (uint(endpoint762.z) & 0x10u) << 10u;
+			block.x |= uint(endpoint760.y) << 15u;
+			block.x |= (uint(endpoint762.z) & 0x20u) << 17u;
+			block.x |= (uint(endpoint763.z) & 0x04u) << 21u;
+			block.x |= (uint(endpoint762.y) & 0x10u) << 20u;
+			block.x |= uint(endpoint760.z) << 25u;
+			block.y |= (uint(endpoint763.z) & 0x08u) >> 3u;
+			block.y |= (uint(endpoint763.z) & 0x20u) >> 4u;
+			block.y |= (uint(endpoint763.z) & 0x10u) >> 2u;
+			block.y |= uint(endpoint761.x) << 3u;
+			block.y |= (uint(endpoint762.y) & 0x0Fu) << 9u;
+			block.y |= uint(endpoint761.y) << 13u;
+			block.y |= (uint(endpoint763.y) & 0x0Fu) << 19u;
+			block.y |= uint(endpoint761.z) << 23u;
+			block.y |= (uint(endpoint762.z) & 0x07u) << 29u;
+			block.z |= (uint(endpoint762.z) & 0x08u) >> 3u;
+			block.z |= uint(endpoint762.x) << 1u;
+			block.z |= uint(endpoint763.x) << 7u;
+		} else {
+			// 9.5
+			block.x = 0xEu;
+			block.x |= uint(endpoint950.x) << 5u;
+			block.x |= (uint(endpoint952.z) & 0x10u) << 10u;
+			block.x |= uint(endpoint950.y) << 15u;
+			block.x |= (uint(endpoint952.y) & 0x10u) << 20u;
+			block.x |= uint(endpoint950.z) << 25u;
+			block.y |= uint(endpoint950.z) >> 7u;
+			block.y |= (uint(endpoint953.z) & 0x10u) >> 2u;
+			block.y |= uint(endpoint951.x) << 3u;
+			block.y |= (uint(endpoint953.y) & 0x10u) << 4u;
+			block.y |= (uint(endpoint952.y) & 0x0Fu) << 9u;
+			block.y |= uint(endpoint951.y) << 13u;
+			block.y |= (uint(endpoint953.z) & 0x01u) << 18u;
+			block.y |= (uint(endpoint953.y) & 0x0Fu) << 19u;
+			block.y |= uint(endpoint951.z) << 23u;
+			block.y |= (uint(endpoint953.z) & 0x02u) << 27u;
+			block.y |= uint(endpoint952.z) << 29u;
+			block.z |= (uint(endpoint952.z) & 0x08u) >> 3u;
+			block.z |= uint(endpoint952.x) << 1u;
+			block.z |= (uint(endpoint953.z) & 0x04u) << 4u;
+			block.z |= uint(endpoint953.x) << 7u;
+			block.z |= (uint(endpoint953.z) & 0x08u) << 9u;
+		}
+
+		block.z |= pattern << 13u;
+		uint blockFixupID = PatternFixupID(pattern);
+		if (blockFixupID == 15u) {
+			block.z |= indices[0] << 18u;
+			block.z |= indices[1] << 20u;
+			block.z |= indices[2] << 23u;
+			block.z |= indices[3] << 26u;
+			block.z |= indices[4] << 29u;
+			block.w |= indices[5] << 0u;
+			block.w |= indices[6] << 3u;
+			block.w |= indices[7] << 6u;
+			block.w |= indices[8] << 9u;
+			block.w |= indices[9] << 12u;
+			block.w |= indices[10] << 15u;
+			block.w |= indices[11] << 18u;
+			block.w |= indices[12] << 21u;
+			block.w |= indices[13] << 24u;
+			block.w |= indices[14] << 27u;
+			block.w |= indices[15] << 30u;
+		} else if (blockFixupID == 2u) {
+			block.z |= indices[0] << 18u;
+			block.z |= indices[1] << 20u;
+			block.z |= indices[2] << 23u;
+			block.z |= indices[3] << 25u;
+			block.z |= indices[4] << 28u;
+			block.z |= indices[5] << 31u;
+			block.w |= indices[5] >> 1u;
+			block.w |= indices[6] << 2u;
+			block.w |= indices[7] << 5u;
+			block.w |= indices[8] << 8u;
+			block.w |= indices[9] << 11u;
+			block.w |= indices[10] << 14u;
+			block.w |= indices[11] << 17u;
+			block.w |= indices[12] << 20u;
+			block.w |= indices[13] << 23u;
+			block.w |= indices[14] << 26u;
+			block.w |= indices[15] << 29u;
+		} else {
+			block.z |= indices[0] << 18u;
+			block.z |= indices[1] << 20u;
+			block.z |= indices[2] << 23u;
+			block.z |= indices[3] << 26u;
+			block.z |= indices[4] << 29u;
+			block.w |= indices[5] << 0u;
+			block.w |= indices[6] << 3u;
+			block.w |= indices[7] << 6u;
+			block.w |= indices[8] << 9u;
+			block.w |= indices[9] << 11u;
+			block.w |= indices[10] << 14u;
+			block.w |= indices[11] << 17u;
+			block.w |= indices[12] << 20u;
+			block.w |= indices[13] << 23u;
+			block.w |= indices[14] << 26u;
+			block.w |= indices[15] << 29u;
+		}
+	}
+}
+
+layout(local_size_x = 8,
+		local_size_y = 8,
+		local_size_z = 1) in;
+
+void main() {
+	// gather texels for current 4x4 block
+	// 0 1 2 3
+	// 4 5 6 7
+	// 8 9 10 11
+	// 12 13 14 15
+	float2 uv = gl_GlobalInvocationID.xy * params.p_textureSizeRcp * 4.0f + params.p_textureSizeRcp;
+	float2 block0UV = uv;
+	float2 block1UV = uv + float2(2.0f * params.p_textureSizeRcp.x, 0.0f);
+	float2 block2UV = uv + float2(0.0f, 2.0f * params.p_textureSizeRcp.y);
+	float2 block3UV = uv + float2(2.0f * params.p_textureSizeRcp.x, 2.0f * params.p_textureSizeRcp.y);
+	float4 block0X = OGRE_GatherRed(srcTexture, pointSampler, block0UV);
+	float4 block1X = OGRE_GatherRed(srcTexture, pointSampler, block1UV);
+	float4 block2X = OGRE_GatherRed(srcTexture, pointSampler, block2UV);
+	float4 block3X = OGRE_GatherRed(srcTexture, pointSampler, block3UV);
+	float4 block0Y = OGRE_GatherGreen(srcTexture, pointSampler, block0UV);
+	float4 block1Y = OGRE_GatherGreen(srcTexture, pointSampler, block1UV);
+	float4 block2Y = OGRE_GatherGreen(srcTexture, pointSampler, block2UV);
+	float4 block3Y = OGRE_GatherGreen(srcTexture, pointSampler, block3UV);
+	float4 block0Z = OGRE_GatherBlue(srcTexture, pointSampler, block0UV);
+	float4 block1Z = OGRE_GatherBlue(srcTexture, pointSampler, block1UV);
+	float4 block2Z = OGRE_GatherBlue(srcTexture, pointSampler, block2UV);
+	float4 block3Z = OGRE_GatherBlue(srcTexture, pointSampler, block3UV);
+
+	float3 texels[16];
+	texels[0] = float3(block0X.w, block0Y.w, block0Z.w);
+	texels[1] = float3(block0X.z, block0Y.z, block0Z.z);
+	texels[2] = float3(block1X.w, block1Y.w, block1Z.w);
+	texels[3] = float3(block1X.z, block1Y.z, block1Z.z);
+	texels[4] = float3(block0X.x, block0Y.x, block0Z.x);
+	texels[5] = float3(block0X.y, block0Y.y, block0Z.y);
+	texels[6] = float3(block1X.x, block1Y.x, block1Z.x);
+	texels[7] = float3(block1X.y, block1Y.y, block1Z.y);
+	texels[8] = float3(block2X.w, block2Y.w, block2Z.w);
+	texels[9] = float3(block2X.z, block2Y.z, block2Z.z);
+	texels[10] = float3(block3X.w, block3Y.w, block3Z.w);
+	texels[11] = float3(block3X.z, block3Y.z, block3Z.z);
+	texels[12] = float3(block2X.x, block2Y.x, block2Z.x);
+	texels[13] = float3(block2X.y, block2Y.y, block2Z.y);
+	texels[14] = float3(block3X.x, block3Y.x, block3Z.x);
+	texels[15] = float3(block3X.y, block3Y.y, block3Z.y);
+
+	uint4 block = uint4(0u, 0u, 0u, 0u);
+	float blockMSLE = 0.0f;
+
+	EncodeP1(block, blockMSLE, texels);
+#ifdef QUALITY
+	for (uint i = 0u; i < 32u; ++i) {
+		EncodeP2Pattern(block, blockMSLE, i, texels);
+	}
+#endif
+
+	imageStore(dstTexture, int2(gl_GlobalInvocationID.xy), block);
+}

--- a/modules/betsy/config.py
+++ b/modules/betsy/config.py
@@ -1,0 +1,6 @@
+def can_build(env, platform):
+    return env.editor_build
+
+
+def configure(env):
+    pass

--- a/modules/betsy/format_converter.glsl
+++ b/modules/betsy/format_converter.glsl
@@ -1,0 +1,15 @@
+#[compute]
+
+#version 450
+
+layout(binding = 0) uniform restrict readonly image2D srcTexture;
+layout(rg32ui, binding = 1) uniform restrict writeonly image2D dstTexture;
+
+layout(local_size_x = 8, //
+		local_size_y = 8, //
+		local_size_z = 1) in;
+
+void main() {
+	vec4 src = imageLoad(srcTexture, gl_GlobalInvocationID.xy);
+	imageStore(dstTexture, gl_GlobalInvocationID.xy, src);
+}

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -1,0 +1,1523 @@
+/**************************************************************************/
+/*  image_compress_betsy.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "image_compress_betsy.h"
+
+#include "bc1.glsl.gen.h"
+#include "bc4.glsl.gen.h"
+#include "bc6h.glsl.gen.h"
+#include "format_converter.glsl.gen.h"
+
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+#include "servers/rendering/rendering_device_binds.h"
+
+static const float dxt1_encoding_table[1024] = {
+	0,
+	0,
+	0,
+	0,
+	0,
+	1,
+	0,
+	1,
+	1,
+	0,
+	1,
+	0,
+	1,
+	0,
+	1,
+	1,
+	1,
+	1,
+	2,
+	0,
+	2,
+	0,
+	0,
+	4,
+	2,
+	1,
+	2,
+	1,
+	2,
+	1,
+	3,
+	0,
+	3,
+	0,
+	3,
+	0,
+	3,
+	1,
+	1,
+	5,
+	3,
+	2,
+	3,
+	2,
+	4,
+	0,
+	4,
+	0,
+	4,
+	1,
+	4,
+	1,
+	4,
+	2,
+	4,
+	2,
+	4,
+	2,
+	3,
+	5,
+	5,
+	1,
+	5,
+	1,
+	5,
+	2,
+	4,
+	4,
+	5,
+	3,
+	5,
+	3,
+	5,
+	3,
+	6,
+	2,
+	6,
+	2,
+	6,
+	2,
+	6,
+	3,
+	5,
+	5,
+	6,
+	4,
+	6,
+	4,
+	4,
+	8,
+	7,
+	3,
+	7,
+	3,
+	7,
+	3,
+	7,
+	4,
+	7,
+	4,
+	7,
+	4,
+	7,
+	5,
+	5,
+	9,
+	7,
+	6,
+	7,
+	6,
+	8,
+	4,
+	8,
+	4,
+	8,
+	5,
+	8,
+	5,
+	8,
+	6,
+	8,
+	6,
+	8,
+	6,
+	7,
+	9,
+	9,
+	5,
+	9,
+	5,
+	9,
+	6,
+	8,
+	8,
+	9,
+	7,
+	9,
+	7,
+	9,
+	7,
+	10,
+	6,
+	10,
+	6,
+	10,
+	6,
+	10,
+	7,
+	9,
+	9,
+	10,
+	8,
+	10,
+	8,
+	8,
+	12,
+	11,
+	7,
+	11,
+	7,
+	11,
+	7,
+	11,
+	8,
+	11,
+	8,
+	11,
+	8,
+	11,
+	9,
+	9,
+	13,
+	11,
+	10,
+	11,
+	10,
+	12,
+	8,
+	12,
+	8,
+	12,
+	9,
+	12,
+	9,
+	12,
+	10,
+	12,
+	10,
+	12,
+	10,
+	11,
+	13,
+	13,
+	9,
+	13,
+	9,
+	13,
+	10,
+	12,
+	12,
+	13,
+	11,
+	13,
+	11,
+	13,
+	11,
+	14,
+	10,
+	14,
+	10,
+	14,
+	10,
+	14,
+	11,
+	13,
+	13,
+	14,
+	12,
+	14,
+	12,
+	12,
+	16,
+	15,
+	11,
+	15,
+	11,
+	15,
+	11,
+	15,
+	12,
+	15,
+	12,
+	15,
+	12,
+	15,
+	13,
+	13,
+	17,
+	15,
+	14,
+	15,
+	14,
+	16,
+	12,
+	16,
+	12,
+	16,
+	13,
+	16,
+	13,
+	16,
+	14,
+	16,
+	14,
+	16,
+	14,
+	15,
+	17,
+	17,
+	13,
+	17,
+	13,
+	17,
+	14,
+	16,
+	16,
+	17,
+	15,
+	17,
+	15,
+	17,
+	15,
+	18,
+	14,
+	18,
+	14,
+	18,
+	14,
+	18,
+	15,
+	17,
+	17,
+	18,
+	16,
+	18,
+	16,
+	16,
+	20,
+	19,
+	15,
+	19,
+	15,
+	19,
+	15,
+	19,
+	16,
+	19,
+	16,
+	19,
+	16,
+	19,
+	17,
+	17,
+	21,
+	19,
+	18,
+	19,
+	18,
+	20,
+	16,
+	20,
+	16,
+	20,
+	17,
+	20,
+	17,
+	20,
+	18,
+	20,
+	18,
+	20,
+	18,
+	19,
+	21,
+	21,
+	17,
+	21,
+	17,
+	21,
+	18,
+	20,
+	20,
+	21,
+	19,
+	21,
+	19,
+	21,
+	19,
+	22,
+	18,
+	22,
+	18,
+	22,
+	18,
+	22,
+	19,
+	21,
+	21,
+	22,
+	20,
+	22,
+	20,
+	20,
+	24,
+	23,
+	19,
+	23,
+	19,
+	23,
+	19,
+	23,
+	20,
+	23,
+	20,
+	23,
+	20,
+	23,
+	21,
+	21,
+	25,
+	23,
+	22,
+	23,
+	22,
+	24,
+	20,
+	24,
+	20,
+	24,
+	21,
+	24,
+	21,
+	24,
+	22,
+	24,
+	22,
+	24,
+	22,
+	23,
+	25,
+	25,
+	21,
+	25,
+	21,
+	25,
+	22,
+	24,
+	24,
+	25,
+	23,
+	25,
+	23,
+	25,
+	23,
+	26,
+	22,
+	26,
+	22,
+	26,
+	22,
+	26,
+	23,
+	25,
+	25,
+	26,
+	24,
+	26,
+	24,
+	24,
+	28,
+	27,
+	23,
+	27,
+	23,
+	27,
+	23,
+	27,
+	24,
+	27,
+	24,
+	27,
+	24,
+	27,
+	25,
+	25,
+	29,
+	27,
+	26,
+	27,
+	26,
+	28,
+	24,
+	28,
+	24,
+	28,
+	25,
+	28,
+	25,
+	28,
+	26,
+	28,
+	26,
+	28,
+	26,
+	27,
+	29,
+	29,
+	25,
+	29,
+	25,
+	29,
+	26,
+	28,
+	28,
+	29,
+	27,
+	29,
+	27,
+	29,
+	27,
+	30,
+	26,
+	30,
+	26,
+	30,
+	26,
+	30,
+	27,
+	29,
+	29,
+	30,
+	28,
+	30,
+	28,
+	30,
+	28,
+	31,
+	27,
+	31,
+	27,
+	31,
+	27,
+	31,
+	28,
+	31,
+	28,
+	31,
+	28,
+	31,
+	29,
+	31,
+	29,
+	31,
+	30,
+	31,
+	30,
+	31,
+	30,
+	31,
+	31,
+	31,
+	31,
+	0,
+	0,
+	0,
+	1,
+	1,
+	0,
+	1,
+	0,
+	1,
+	1,
+	2,
+	0,
+	2,
+	1,
+	3,
+	0,
+	3,
+	0,
+	3,
+	1,
+	4,
+	0,
+	4,
+	0,
+	4,
+	1,
+	5,
+	0,
+	5,
+	1,
+	6,
+	0,
+	6,
+	0,
+	6,
+	1,
+	7,
+	0,
+	7,
+	0,
+	7,
+	1,
+	8,
+	0,
+	8,
+	1,
+	8,
+	1,
+	8,
+	2,
+	9,
+	1,
+	9,
+	2,
+	9,
+	2,
+	9,
+	3,
+	10,
+	2,
+	10,
+	3,
+	10,
+	3,
+	10,
+	4,
+	11,
+	3,
+	11,
+	4,
+	11,
+	4,
+	11,
+	5,
+	12,
+	4,
+	12,
+	5,
+	12,
+	5,
+	12,
+	6,
+	13,
+	5,
+	13,
+	6,
+	8,
+	16,
+	13,
+	7,
+	14,
+	6,
+	14,
+	7,
+	9,
+	17,
+	14,
+	8,
+	15,
+	7,
+	15,
+	8,
+	11,
+	16,
+	15,
+	9,
+	15,
+	10,
+	16,
+	8,
+	16,
+	9,
+	16,
+	10,
+	15,
+	13,
+	17,
+	9,
+	17,
+	10,
+	17,
+	11,
+	15,
+	16,
+	18,
+	10,
+	18,
+	11,
+	18,
+	12,
+	16,
+	16,
+	19,
+	11,
+	19,
+	12,
+	19,
+	13,
+	17,
+	17,
+	20,
+	12,
+	20,
+	13,
+	20,
+	14,
+	19,
+	16,
+	21,
+	13,
+	21,
+	14,
+	21,
+	15,
+	20,
+	17,
+	22,
+	14,
+	22,
+	15,
+	25,
+	10,
+	22,
+	16,
+	23,
+	15,
+	23,
+	16,
+	26,
+	11,
+	23,
+	17,
+	24,
+	16,
+	24,
+	17,
+	27,
+	12,
+	24,
+	18,
+	25,
+	17,
+	25,
+	18,
+	28,
+	13,
+	25,
+	19,
+	26,
+	18,
+	26,
+	19,
+	29,
+	14,
+	26,
+	20,
+	27,
+	19,
+	27,
+	20,
+	30,
+	15,
+	27,
+	21,
+	28,
+	20,
+	28,
+	21,
+	28,
+	21,
+	28,
+	22,
+	29,
+	21,
+	29,
+	22,
+	24,
+	32,
+	29,
+	23,
+	30,
+	22,
+	30,
+	23,
+	25,
+	33,
+	30,
+	24,
+	31,
+	23,
+	31,
+	24,
+	27,
+	32,
+	31,
+	25,
+	31,
+	26,
+	32,
+	24,
+	32,
+	25,
+	32,
+	26,
+	31,
+	29,
+	33,
+	25,
+	33,
+	26,
+	33,
+	27,
+	31,
+	32,
+	34,
+	26,
+	34,
+	27,
+	34,
+	28,
+	32,
+	32,
+	35,
+	27,
+	35,
+	28,
+	35,
+	29,
+	33,
+	33,
+	36,
+	28,
+	36,
+	29,
+	36,
+	30,
+	35,
+	32,
+	37,
+	29,
+	37,
+	30,
+	37,
+	31,
+	36,
+	33,
+	38,
+	30,
+	38,
+	31,
+	41,
+	26,
+	38,
+	32,
+	39,
+	31,
+	39,
+	32,
+	42,
+	27,
+	39,
+	33,
+	40,
+	32,
+	40,
+	33,
+	43,
+	28,
+	40,
+	34,
+	41,
+	33,
+	41,
+	34,
+	44,
+	29,
+	41,
+	35,
+	42,
+	34,
+	42,
+	35,
+	45,
+	30,
+	42,
+	36,
+	43,
+	35,
+	43,
+	36,
+	46,
+	31,
+	43,
+	37,
+	44,
+	36,
+	44,
+	37,
+	44,
+	37,
+	44,
+	38,
+	45,
+	37,
+	45,
+	38,
+	40,
+	48,
+	45,
+	39,
+	46,
+	38,
+	46,
+	39,
+	41,
+	49,
+	46,
+	40,
+	47,
+	39,
+	47,
+	40,
+	43,
+	48,
+	47,
+	41,
+	47,
+	42,
+	48,
+	40,
+	48,
+	41,
+	48,
+	42,
+	47,
+	45,
+	49,
+	41,
+	49,
+	42,
+	49,
+	43,
+	47,
+	48,
+	50,
+	42,
+	50,
+	43,
+	50,
+	44,
+	48,
+	48,
+	51,
+	43,
+	51,
+	44,
+	51,
+	45,
+	49,
+	49,
+	52,
+	44,
+	52,
+	45,
+	52,
+	46,
+	51,
+	48,
+	53,
+	45,
+	53,
+	46,
+	53,
+	47,
+	52,
+	49,
+	54,
+	46,
+	54,
+	47,
+	57,
+	42,
+	54,
+	48,
+	55,
+	47,
+	55,
+	48,
+	58,
+	43,
+	55,
+	49,
+	56,
+	48,
+	56,
+	49,
+	59,
+	44,
+	56,
+	50,
+	57,
+	49,
+	57,
+	50,
+	60,
+	45,
+	57,
+	51,
+	58,
+	50,
+	58,
+	51,
+	61,
+	46,
+	58,
+	52,
+	59,
+	51,
+	59,
+	52,
+	62,
+	47,
+	59,
+	53,
+	60,
+	52,
+	60,
+	53,
+	60,
+	53,
+	60,
+	54,
+	61,
+	53,
+	61,
+	54,
+	61,
+	54,
+	61,
+	55,
+	62,
+	54,
+	62,
+	55,
+	62,
+	55,
+	62,
+	56,
+	63,
+	55,
+	63,
+	56,
+	63,
+	56,
+	63,
+	57,
+	63,
+	58,
+	63,
+	59,
+	63,
+	59,
+	63,
+	60,
+	63,
+	61,
+	63,
+	62,
+	63,
+	62,
+	63,
+	63,
+};
+
+static int get_next_multiple(int n, int m) {
+	return n + (m - (n % m));
+}
+
+void _compress_betsy(BetsyFormat p_format, Image *r_img) {
+	ERR_FAIL_COND_MSG(r_img->is_compressed(), "Image is already compressed.");
+
+	Ref<Image> img_clone = memnew(Image);
+	img_clone->copy_from(r_img);
+
+	// Create local RD.
+	RenderingDevice *rd = RenderingDevice::get_singleton()->create_local_device();
+
+	Ref<RDShaderFile> compute_shader;
+	compute_shader.instantiate();
+
+	// Destination format.
+	Image::Format dest_format = Image::FORMAT_MAX;
+
+	Error err = OK;
+	switch (p_format) {
+		case BETSY_FORMAT_BC6UF:
+			err = compute_shader->parse_versions_from_text(bc6h_shader_glsl);
+			dest_format = Image::FORMAT_BPTC_RGBFU;
+			break;
+
+		case BETSY_FORMAT_BC6SF:
+			err = compute_shader->parse_versions_from_text(bc6h_shader_glsl, "#define SIGNED");
+			dest_format = Image::FORMAT_BPTC_RGBF;
+			break;
+
+		case BETSY_FORMAT_BC1:
+			err = compute_shader->parse_versions_from_text(bc1_shader_glsl);
+			dest_format = Image::FORMAT_DXT1;
+			break;
+
+		case BETSY_FORMAT_BC4U:
+			err = compute_shader->parse_versions_from_text(bc4_shader_glsl);
+			dest_format = Image::FORMAT_RGTC_R;
+			break;
+
+		case BETSY_FORMAT_BC5U:
+			err = compute_shader->parse_versions_from_text(bc4_shader_glsl);
+			dest_format = Image::FORMAT_RGTC_RG;
+			break;
+
+		default:
+			return;
+	}
+
+	ERR_FAIL_COND(err != OK);
+
+	// Compile the shader, return early if invalid.
+	RID shader = rd->shader_create_from_spirv(compute_shader->get_spirv_stages());
+	ERR_FAIL_COND(shader.is_null());
+
+	RID pipeline = rd->compute_pipeline_create(shader);
+
+	//RID dst_texture;
+	//RID src_texture;
+	RID src_sampler;
+	RID encoding_table_buffer; // Encoding table only for BC1/ETC2
+
+	bool uses_encoding_table = false;
+
+	// src_texture format information.
+	RD::TextureFormat src_texture_format;
+	{
+		src_texture_format.array_layers = 1;
+		src_texture_format.depth = 1;
+		src_texture_format.mipmaps = 1;
+		src_texture_format.texture_type = RD::TEXTURE_TYPE_2D;
+		src_texture_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+	}
+
+	if (img_clone->get_format() >= Image::FORMAT_L8 && img_clone->get_format() <= Image::FORMAT_RGB565) {
+		// RGBA8.
+		src_texture_format.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+		img_clone->convert(Image::FORMAT_RGBA8);
+	} else if (img_clone->get_format() >= Image::FORMAT_RF && img_clone->get_format() <= Image::FORMAT_RGBAF) {
+		// RGBAF.
+		src_texture_format.format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
+		img_clone->convert(Image::FORMAT_RGBAF);
+	} else if (img_clone->get_format() >= Image::FORMAT_RH && img_clone->get_format() <= Image::FORMAT_RGBE9995) {
+		// RGBAH.
+		src_texture_format.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+		img_clone->convert(Image::FORMAT_RGBAH);
+	}
+
+	/*
+	// Convert the image to a format which can be sampled.
+	if (img_clone->get_format() != Image::FORMAT_RGBA8 || img_clone->get_format() != Image::FORMAT_RGBAH || img_clone->get_format() != Image::FORMAT_RGBAF) {
+		Ref<RDShaderFile> convert_shader;
+		convert_shader.instantiate();
+
+		err = convert_shader->parse_versions_from_text(format_converter_glsl);
+		ERR_FAIL_COND(err != OK);
+
+		// Compile the shader, return early if invalid.
+		RID convert_shader_rid = rd->shader_create_from_spirv(convert_shader->get_spirv_stages());
+		ERR_FAIL_COND(convert_shader_rid.is_null());
+
+		RID convert_pipeline = rd->compute_pipeline_create(convert_shader_rid);
+
+		Vector<RD::Uniform> uniforms;
+		{
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 0;
+				u.append_id(src_sampler);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 1;
+				u.append_id(dst_textures_ptr[i]);
+				uniforms.push_back(u);
+			}
+		}
+
+		RID uniform_set = rd->uniform_set_create(uniforms, convert_shader_rid, 0);
+		RD::ComputeListID compute_list = rd->compute_list_begin();
+
+		rd->compute_list_bind_compute_pipeline(compute_list, convert_pipeline);
+		rd->compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+		rd->compute_list_dispatch(compute_list, get_next_multiple(img_clone->get_width(), 32) / 32, get_next_multiple(img_clone->get_height(), 32) / 32, 1);
+		rd->compute_list_end();
+	}*/
+
+	// For the destination format just copy the source format and change the usage bits.
+	RD::TextureFormat dst_texture_format = src_texture_format;
+	dst_texture_format.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+
+	RD::SamplerState src_sampler_state;
+	{
+		src_sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
+		src_sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
+		src_sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
+		src_sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
+		src_sampler_state.mip_filter = RD::SAMPLER_FILTER_NEAREST;
+	}
+
+	src_sampler = rd->sampler_create(src_sampler_state);
+
+	// Set the destination texture format to match the compressed block size.
+	switch (dest_format) {
+		case Image::FORMAT_DXT1:
+		case Image::FORMAT_RGTC_R:
+		case Image::FORMAT_ETC2_R11:
+		case Image::FORMAT_ETC2_R11S:
+		case Image::FORMAT_ETC2_RGB8:
+		case Image::FORMAT_ETC2_RGB8A1:
+			dst_texture_format.format = RD::DATA_FORMAT_R32G32_UINT;
+			break;
+
+		case Image::FORMAT_DXT5:
+		case Image::FORMAT_RGTC_RG:
+		case Image::FORMAT_BPTC_RGBA:
+		case Image::FORMAT_BPTC_RGBF:
+		case Image::FORMAT_BPTC_RGBFU:
+		case Image::FORMAT_ETC2_RG11:
+		case Image::FORMAT_ETC2_RG11S:
+		case Image::FORMAT_ETC2_RGBA8:
+			dst_texture_format.format = RD::DATA_FORMAT_R32G32B32A32_UINT;
+			break;
+
+		default:
+			break;
+	}
+
+	const int mip_count = img_clone->get_mipmap_count() + 1;
+
+	// Encoding table setup.
+	if (dest_format == Image::FORMAT_DXT1) {
+		Vector<uint8_t> data;
+		data.resize(1024 * 4);
+		memcpy(data.ptrw(), dxt1_encoding_table, 1024 * 4);
+
+		encoding_table_buffer = rd->storage_buffer_create(1024 * 4, data);
+		uses_encoding_table = true;
+	}
+
+	Vector<RID> src_textures;
+	src_textures.resize(mip_count);
+	RID *src_textures_ptr = src_textures.ptrw();
+
+	Vector<RID> dst_textures;
+	dst_textures.resize(mip_count);
+	RID *dst_textures_ptr = dst_textures.ptrw();
+
+	for (int i = 0; i < mip_count; i++) {
+		int ofs, size, width, height;
+		img_clone->get_mipmap_offset_size_and_dimensions(i, ofs, size, width, height);
+
+		// Set the source texture width and size.
+		src_texture_format.height = height;
+		src_texture_format.width = width;
+
+		// Set the destination texture width and size.
+		dst_texture_format.height = (height + 3) >> 2;
+		dst_texture_format.width = (width + 3) >> 2;
+
+		Vector<Vector<uint8_t>> src_images;
+		src_images.push_back(Vector<uint8_t>());
+		src_images.ptrw()[0].resize(size);
+		memcpy(src_images.ptrw()[0].ptrw(), img_clone->get_data().ptr() + ofs, size);
+
+		src_textures_ptr[i] = rd->texture_create(src_texture_format, RD::TextureView(), src_images);
+		dst_textures_ptr[i] = rd->texture_create(dst_texture_format, RD::TextureView());
+		rd->texture_clear(dst_textures_ptr[i], Color(0, 0, 0, 0), 0, 1, 0, 1);
+
+		if (dest_format == Image::FORMAT_DXT1) {
+			Vector<uint32_t> push_constant;
+			push_constant.push_back(2);
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+
+			Vector<RD::Uniform> uniforms;
+			{
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+					u.binding = 0;
+					u.append_id(src_sampler);
+					u.append_id(src_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+					u.binding = 1;
+					u.append_id(dst_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.binding = 2;
+					u.append_id(encoding_table_buffer);
+					uniforms.push_back(u);
+				}
+			}
+
+			RID uniform_set = rd->uniform_set_create(uniforms, shader, 0);
+			RD::ComputeListID compute_list = rd->compute_list_begin();
+
+			rd->compute_list_bind_compute_pipeline(compute_list, pipeline);
+			rd->compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+			rd->compute_list_set_push_constant(compute_list, push_constant.ptr(), push_constant.size() * 4);
+			rd->compute_list_dispatch(compute_list, get_next_multiple(width, 32) / 32, get_next_multiple(height, 32) / 32, 1);
+			rd->compute_list_end();
+
+		} else if (dest_format == Image::FORMAT_RGTC_R) {
+			Vector<uint32_t> push_constant;
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+
+			Vector<RD::Uniform> uniforms;
+			{
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+					u.binding = 0;
+					u.append_id(src_sampler);
+					u.append_id(src_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+					u.binding = 1;
+					u.append_id(dst_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+			}
+
+			RID uniform_set = rd->uniform_set_create(uniforms, shader, 0);
+			RD::ComputeListID compute_list = rd->compute_list_begin();
+
+			rd->compute_list_bind_compute_pipeline(compute_list, pipeline);
+			rd->compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+			rd->compute_list_set_push_constant(compute_list, push_constant.ptr(), push_constant.size() * 4);
+			rd->compute_list_dispatch(compute_list, 1, get_next_multiple(width, 16) / 16, get_next_multiple(height, 16) / 16);
+			rd->compute_list_end();
+
+		} else if (dest_format == Image::FORMAT_RGTC_RG) {
+			Vector<RD::Uniform> uniforms;
+			{
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+					u.binding = 0;
+					u.append_id(src_sampler);
+					u.append_id(src_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+					u.binding = 1;
+					u.append_id(dst_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+			}
+
+			RID uniform_set = rd->uniform_set_create(uniforms, shader, 0);
+			RD::ComputeListID compute_list = rd->compute_list_begin();
+
+			for (size_t j = 0; j < 2; j++) {
+				Vector<uint32_t> push_constant;
+				push_constant.push_back(j);
+				push_constant.push_back(0);
+				push_constant.push_back(0);
+				push_constant.push_back(0);
+
+				rd->compute_list_bind_compute_pipeline(compute_list, pipeline);
+				rd->compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+				rd->compute_list_set_push_constant(compute_list, push_constant.ptr(), push_constant.size() * 4);
+				rd->compute_list_dispatch(compute_list, 1, get_next_multiple(width, 16) / 16, get_next_multiple(height, 16) / 16);
+			}
+
+			rd->compute_list_end();
+
+		} else if (dest_format == Image::FORMAT_BPTC_RGBFU || dest_format == Image::FORMAT_BPTC_RGBF) {
+			PackedFloat32Array push_constant;
+			push_constant.push_back(1.0f / width);
+			push_constant.push_back(1.0f / height);
+			push_constant.push_back(0);
+			push_constant.push_back(0);
+
+			Vector<RD::Uniform> uniforms;
+			{
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+					u.binding = 0;
+					u.append_id(src_sampler);
+					u.append_id(src_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+					u.binding = 1;
+					u.append_id(dst_textures_ptr[i]);
+					uniforms.push_back(u);
+				}
+			}
+
+			RID uniform_set = rd->uniform_set_create(uniforms, shader, 0);
+			RD::ComputeListID compute_list = rd->compute_list_begin();
+
+			rd->compute_list_bind_compute_pipeline(compute_list, pipeline);
+			rd->compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+			rd->compute_list_set_push_constant(compute_list, push_constant.ptr(), push_constant.size() * 4);
+			rd->compute_list_dispatch(compute_list, get_next_multiple(width, 32) / 32, get_next_multiple(height, 32) / 32, 1);
+			rd->compute_list_end();
+		}
+
+		rd->submit();
+		rd->sync();
+	}
+
+	//rd->sync();
+
+	// Container for the compressed data.
+	Vector<uint8_t> dst_data;
+	dst_data.resize(Image::get_image_data_size(img_clone->get_width(), img_clone->get_height(), dest_format, img_clone->has_mipmaps()));
+	uint8_t *dst_data_ptr = dst_data.ptrw();
+
+	// Copy data from the GPU to the buffer.
+	for (int i = 0; i < mip_count; i++) {
+		const Vector<uint8_t> &texture_data = rd->texture_get_data(dst_textures_ptr[i], 0);
+		int ofs = Image::get_image_mipmap_offset(img_clone->get_width(), img_clone->get_height(), dest_format, i);
+
+		memcpy(dst_data_ptr + ofs, texture_data.ptr(), texture_data.size());
+
+		// Free the source and dest texture.
+		rd->free(dst_textures_ptr[i]);
+		rd->free(src_textures_ptr[i]);
+	}
+
+	// Set the compressed data to the image.
+	r_img->set_data(img_clone->get_width(), img_clone->get_height(), img_clone->has_mipmaps(), dest_format, dst_data);
+
+	// Free the shader (dependencies will be cleared automatically).
+	rd->free(src_sampler);
+	rd->free(shader);
+
+	// Free the encoding table.
+	if (uses_encoding_table) {
+		rd->free(encoding_table_buffer);
+	}
+}
+
+void _betsy_compress_bptc(Image *r_img, Image::UsedChannels p_channels) {
+	Image::Format format = r_img->get_format();
+
+	if (format >= Image::FORMAT_RH && format <= Image::FORMAT_RGBAH) {
+		_compress_betsy(BETSY_FORMAT_BC6UF, r_img);
+	}
+}
+
+void _betsy_compress_etc1(Image *r_img) {
+	_compress_betsy(BETSY_FORMAT_ETC1, r_img);
+}
+
+void _betsy_compress_etc2(Image *r_img, Image::UsedChannels p_channels) {
+	switch (p_channels) {
+		case Image::USED_CHANNELS_R:
+			//	_compress_betsy(BETSY_FORMAT_ETC2_R11, r_img);
+			//	break;
+
+		case Image::USED_CHANNELS_RG:
+			//	_compress_betsy(BETSY_FORMAT_ETC2_RG11, r_img);
+			//	break;
+
+		case Image::USED_CHANNELS_RGB:
+		case Image::USED_CHANNELS_L:
+			_compress_betsy(BETSY_FORMAT_ETC2_RGB8, r_img);
+			break;
+
+		case Image::USED_CHANNELS_RGBA:
+		case Image::USED_CHANNELS_LA:
+			_compress_betsy(BETSY_FORMAT_ETC2_RGBA8, r_img);
+			break;
+	}
+}
+
+void _betsy_compress_bc(Image *r_img, Image::UsedChannels p_channels) {
+	switch (p_channels) {
+		case Image::USED_CHANNELS_R:
+			//	_compress_betsy(BETSY_FORMAT_BC4U, r_img);
+			//	break;
+
+		case Image::USED_CHANNELS_RG:
+			//	_compress_betsy(BETSY_FORMAT_BC5U, r_img);
+			//	break;
+
+		case Image::USED_CHANNELS_RGB:
+		case Image::USED_CHANNELS_L:
+			_compress_betsy(BETSY_FORMAT_BC1, r_img);
+			break;
+
+		case Image::USED_CHANNELS_RGBA:
+		case Image::USED_CHANNELS_LA:
+			_compress_betsy(BETSY_FORMAT_BC3, r_img);
+			break;
+	}
+}

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  image_compress_betsy.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef IMAGE_COMPRESS_BETSY_H
+#define IMAGE_COMPRESS_BETSY_H
+
+#include "core/io/image.h"
+
+enum BetsyFormat {
+	BETSY_FORMAT_BC1,
+	BETSY_FORMAT_BC3,
+	BETSY_FORMAT_BC4U,
+	BETSY_FORMAT_BC5U,
+	BETSY_FORMAT_BC6UF,
+	BETSY_FORMAT_BC6SF,
+	//BETSY_FORMAT_BC7,
+	BETSY_FORMAT_ETC1,
+	BETSY_FORMAT_ETC2_RGB8,
+	BETSY_FORMAT_ETC2_RGBA8,
+	BETSY_FORMAT_ETC2_R11,
+	BETSY_FORMAT_ETC2_RG11,
+	//BETSY_FORMAT_ASTC_4,
+	//BETSY_FORMAT_ASTC_4_HDR,
+	//BETSY_FORMAT_ASTC_8,
+	//BETSY_FORMAT_ASTC_8_HDR,
+};
+
+void _compress_betsy(BetsyFormat p_format, Image *r_img);
+
+void _betsy_compress_bptc(Image *r_img, Image::UsedChannels p_channels);
+void _betsy_compress_bc(Image *r_img, Image::UsedChannels p_channels);
+void _betsy_compress_etc1(Image *r_img);
+void _betsy_compress_etc2(Image *r_img, Image::UsedChannels p_channels);
+
+#endif // IMAGE_COMPRESS_BETSY_H

--- a/modules/betsy/register_types.cpp
+++ b/modules/betsy/register_types.cpp
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "image_compress_betsy.h"
+
+void initialize_betsy_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	Image::_image_compress_bptc_rd_func = _betsy_compress_bptc;
+	Image::_image_compress_bc_rd_func = _betsy_compress_bc;
+	Image::_image_compress_etc1_rd_func = _betsy_compress_etc1;
+	Image::_image_compress_etc2_rd_func = _betsy_compress_etc2;
+}
+
+void uninitialize_betsy_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}

--- a/modules/betsy/register_types.h
+++ b/modules/betsy/register_types.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BETSY_REGISTER_TYPES_H
+#define BETSY_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void initialize_betsy_module(ModuleInitializationLevel p_level);
+void uninitialize_betsy_module(ModuleInitializationLevel p_level);
+
+#endif // BETSY_REGISTER_TYPES_H

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -70,6 +70,17 @@ Files extracted from upstream source:
 Applied upstream PR https://github.com/BinomialLLC/basis_universal/pull/344 to
 fix build with our own copy of zstd (patch in `patches`).
 
+## betsy
+
+- Upstream: https://github.com/darksylinc/betsy
+- Version: git (cc723dcae9a6783ae572f64d12a90d60ef8d631a, 2022)
+- License: MIT
+
+Files extracted from upstream source:
+
+- `bc6h.glsl`, `bc4.glsl`, `bc1.glsl`, `CrossPlatformSettings_piece_all.glsl` and `UavCrossPlatform_piece_all.glsl`.
+- `LICENSE.md`
+
 
 ## brotli
 

--- a/thirdparty/betsy/LICENSE.md
+++ b/thirdparty/betsy/LICENSE.md
@@ -1,0 +1,18 @@
+Copyright 2020-2022 Matias N. Goldberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+This software uses code from:
+
+* [GPURealTimeBC6H](https://github.com/knarkowicz/GPURealTimeBC6H), under public domain. Modifications by Matias N. Goldberg
+* [rg-etc1](https://github.com/richgel999/rg-etc1/), Copyright (c) 2012 Rich Geldreich, zlib license. Extensive modifications by Matias N. Goldberg to adapt it as a compute shader
+* [stb_dxt](https://github.com/nothings/stb/blob/master/stb_dxt.h), under dual-license: A. MIT License
+Copyright (c) 2017 Sean Barrett, B. Public Domain (www.unlicense.org). Original by fabian "ryg" giesen - ported to C by stb. Modifications by Matias N. Goldberg to adapt it as a compute shader
+* EAC loosely inspired on [etc2_encoder](https://github.com/titilambert/packaging-efl/blob/master/src/static_libs/rg_etc/etc2_encoder.c), Copyright (C) 2014 Jean-Philippe ANDRE, 2-clause BSD license
+* ETC2 T & H modes based on [etc2_encoder](https://github.com/titilambert/packaging-efl/blob/master/src/static_libs/rg_etc/etc2_encoder.c), Copyright (C) 2014 Jean-Philippe ANDRE, 2-clause BSD license. A couple minor bugfixes applied by Matias N. Goldberg. Modifications made by Matias N. Goldberg to adapt it as a compute shader
+* ETC2 P very loosely based on [etc2_encoder](https://github.com/titilambert/packaging-efl/blob/master/src/static_libs/rg_etc/etc2_encoder.c), Copyright (C) 2014 Jean-Philippe ANDRE, 2-clause BSD license. Considerable rewrite by Matias N. Goldberg to enhance its quality.


### PR DESCRIPTION
A proof-of-concept implementation of the <a href=https://github.com/darksylinc/betsy>Betsy GPU texture compressor</a>. Currently, the only supported formats are BC1 and BC6. 

In terms of performance it is comparable to etcpak, albeit the results are significantly higher-quality, especially with BC1. 

TODO:
- [ ] Add all other formats currently supported by Betsy,
- [ ] Look into BC7 and ASTC,
- [ ] Improve the parallelization of the process. Currently each mip map is compressed one after another, ideally they should all be compressed concurrently and combined at the end,
- [ ] Clean up the code,
- [ ] Get some insight from someone with more knowledge about compute shaders whether I'm doing this correctly,
- [ ] Find a way to speed up RGB to RGBA texture conversion (RGB formats cannot be sampled directly),
- [ ] Use the default static methods in `Image` instead of rd-specific variants,
- [ ] Some of the shader code was modified, ideally it should be reverted to how it is in upstream,
- [ ] Test on a lot of different GPUs,
- [ ] Move the thirdparty files into the thirdparty directory,
- [ ] Fix memory leaks.