### PR TITLE
Don't edit current when changing docks v2

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -147,7 +147,6 @@ void EditorDockManager::_update_layout() {
 	if (!dock_context_popup->is_inside_tree() || EditorNode::get_singleton()->is_exiting()) {
 		return;
 	}
-	EditorNode::get_singleton()->edit_current();
 	dock_context_popup->docks_updated();
 	_update_docks_menu();
 	EditorNode::get_singleton()->save_editor_layout_delayed();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4019,14 +4019,16 @@ void EditorInspector::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
-			edit(nullptr); //just in case
+			if (EditorNode::get_singleton() && !EditorNode::get_singleton()->is_exiting()) {
+				// Don't need to clean up if exiting, and object may already be freed.
+				edit(nullptr);
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			if (!sub_inspector) {
 				get_tree()->disconnect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
-			edit(nullptr);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
- redo of #90816
- fixes https://github.com/godotengine/godot/issues/90654

Made the `edit(nullptr)` in `NOTIFICATION_PREDELETE` not run when exiting, since it doesn't need to clean up anything if exiting.
The object was apparently freed but not null, causing a crash on some platforms.

Needs testing on Linux and macOS to make sure https://github.com/godotengine/godot/pull/90816#issuecomment-2071069759 doesn't happen.

Edit: made sure it works when there is no EditorNode, like in dotnet glue binding.