### PR TITLE
Disable creating RD projects in project manager if RD is not supported

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -428,6 +428,8 @@ void ProjectDialog::_renderer_selected() {
 
 	String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
 
+	bool rd_error = false;
+
 	if (renderer_type == "forward_plus") {
 		renderer_info->set_text(
 				String::utf8("•  ") + TTR("Supports desktop platforms only.") +
@@ -435,6 +437,7 @@ void ProjectDialog::_renderer_selected() {
 				String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
 				String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
 				String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
+		rd_error = !rendering_device_supported;
 	} else if (renderer_type == "mobile") {
 		renderer_info->set_text(
 				String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
@@ -442,15 +445,23 @@ void ProjectDialog::_renderer_selected() {
 				String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
 				String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
 				String::utf8("\n•  ") + TTR("Fast rendering of simple scenes."));
+		rd_error = !rendering_device_supported;
 	} else if (renderer_type == "gl_compatibility") {
 		renderer_info->set_text(
 				String::utf8("•  ") + TTR("Supports desktop, mobile + web platforms.") +
-				String::utf8("\n•  ") + TTR("Least advanced 3D graphics (currently work-in-progress).") +
+				String::utf8("\n•  ") + TTR("Least advanced 3D graphics.") +
 				String::utf8("\n•  ") + TTR("Intended for low-end/older devices.") +
 				String::utf8("\n•  ") + TTR("Uses OpenGL 3 backend (OpenGL 3.3/ES 3.0/WebGL2).") +
 				String::utf8("\n•  ") + TTR("Fastest rendering of simple scenes."));
 	} else {
 		WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
+	}
+
+	rd_not_supported->set_visible(rd_error);
+	get_ok_button()->set_disabled(rd_error);
+	if (rd_error) {
+		// Needs to be set here since theme colors aren't available at startup.
+		rd_not_supported->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 	}
 }
 
@@ -903,10 +914,16 @@ ProjectDialog::ProjectDialog() {
 		default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
 	}
 
+	rendering_device_supported = DisplayServer::can_create_rendering_device();
+
+	if (!rendering_device_supported) {
+		default_renderer_type = "gl_compatibility";
+	}
+
 	Button *rs_button = memnew(CheckBox);
 	rs_button->set_button_group(renderer_button_group);
 	rs_button->set_text(TTR("Forward+"));
-#if defined(WEB_ENABLED)
+#ifndef RD_ENABLED
 	rs_button->set_disabled(true);
 #endif
 	rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
@@ -918,7 +935,7 @@ ProjectDialog::ProjectDialog() {
 	rs_button = memnew(CheckBox);
 	rs_button->set_button_group(renderer_button_group);
 	rs_button->set_text(TTR("Mobile"));
-#if defined(WEB_ENABLED)
+#ifndef RD_ENABLED
 	rs_button->set_disabled(true);
 #endif
 	rs_button->set_meta(SNAME("rendering_method"), "mobile");
@@ -950,6 +967,15 @@ ProjectDialog::ProjectDialog() {
 	renderer_info = memnew(Label);
 	renderer_info->set_modulate(Color(1, 1, 1, 0.7));
 	rvb->add_child(renderer_info);
+
+	rd_not_supported = memnew(Label);
+	rd_not_supported->set_text(TTR("Rendering Device backend not available. Please use the Compatibility renderer."));
+	rd_not_supported->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	rd_not_supported->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	rd_not_supported->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	rd_not_supported->set_visible(false);
+	renderer_container->add_child(rd_not_supported);
+
 	_renderer_selected();
 
 	l = memnew(Label);

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -77,6 +77,8 @@ private:
 	Label *renderer_info = nullptr;
 	HBoxContainer *default_files_container = nullptr;
 	Ref<ButtonGroup> renderer_button_group;
+	bool rendering_device_supported = false;
+	Label *rd_not_supported = nullptr;
 
 	Label *msg = nullptr;
 	LineEdit *project_name = nullptr;

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -594,6 +594,8 @@ public:
 	static Vector<String> get_create_function_rendering_drivers(int p_index);
 	static DisplayServer *create(int p_index, const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error);
 
+	static bool can_create_rendering_device();
+
 	DisplayServer();
 	~DisplayServer();
 };


### PR DESCRIPTION
This alleviates the problem for new users with devices that don't support Vulkan/D3D12/Metal. Now when creating a new project, we default to selecting the Compatibility renderer and we don't allow users to create new RD projects if Vulkan/D3D12 aren't supported (Metal will need to be added to this once merged).

Now that this detection code is in place, we can use it in other places when users attempt to switch to an RD renderer (project settings or the top right dropdown menu in editor). But I will leave that for a follow up PR

_Screenshot of what this looks like to a user who doesn't have RD support_
<img width="536" alt="Screenshot 2024-08-02 at 10 55 11 AM" src="https://github.com/user-attachments/assets/3d4d1e2b-154a-40a4-b11e-fbb28b7388de">

_Out of date comments_
This works as a stopgap measure if we want. But I think it would be better to address a couple of things before merging:
~1. Is disabling the button really an appropriate UX? Or should we hide the buttons altogether with a message to the user?~ 

Done, disabled "Create & Edit" button and display a warning instead. This matches the other UX in the popup better

~2. This will attempt to create an RD context every time the ProjectManager is opened which will significantly slow down project opening on some devices. We should avoid doing this unless we need to.~ 

Measured cost on an M2 MBP is 5ms. This may need more checking later, but if others are similar than there is nothing to worry about.

~3. Should we abstract the RD checking functionality into another place? This code will fail on macOS once the Metal renderer is added. A helper function could be used in other places like https://github.com/godotengine/godot/pull/91150 and in the lightmapper~ 

Abstracted into the DisplayServer.


