### PR TITLE
Tweak appearance of 3D editor gizmo icons

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -912,7 +912,9 @@ void EditorNode3DGizmoPlugin::create_icon_material(const String &p_name, const R
 		Color color = instantiated ? instantiated_color : p_albedo;
 
 		if (!selected) {
-			color.a *= 0.85;
+			color.r *= 0.6;
+			color.g *= 0.6;
+			color.b *= 0.6;
 		}
 
 		icon->set_albedo(color);
@@ -921,9 +923,8 @@ void EditorNode3DGizmoPlugin::create_icon_material(const String &p_name, const R
 		icon->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 		icon->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
 		icon->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-		icon->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-		icon->set_depth_draw_mode(StandardMaterial3D::DEPTH_DRAW_DISABLED);
-		icon->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+		icon->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA_SCISSOR);
+		icon->set_alpha_scissor_threshold(0.1);
 		icon->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, p_texture);
 		icon->set_flag(StandardMaterial3D::FLAG_FIXED_SIZE, true);
 		icon->set_billboard_mode(StandardMaterial3D::BILLBOARD_ENABLED);


### PR DESCRIPTION
- Use alpha scissor to resolve transparency sorting issues with gizmo icons relative to other transparent materials in the scene. This also makes gizmos visible in `screen_texture`, which means gizmos can now be seen through refractive materials. Lastly, this reduces the amount of artifacts visible around gizmo outlines (although they are still present at times).
- Make icons darker when not selected to be less intrusive (and easier to distinguish when selected).
  - It's possible that the darkening effect is too strong, so this can be revisited later.

This isn't a perfect solution to all gizmo rendering problems by any means, but it should provide an usability upgrade already.

- This closes https://github.com/godotengine/godot/issues/24069.
See https://github.com/godotengine/godot/issues/9935
and https://github.com/godotengine/godot/issues/82579.

## Preview

*All screenshots/videos performed with a 1920×1080 editor window. At higher resolutions, gizmos look better (both before and after this PR).*

### All gizmos

*The RGB stripes are located behind the gizmos' position, and they use a transparent (Alpha) material.*

Before | After
-|-
![Screenshot_20240425_202528](https://github.com/godotengine/godot/assets/180032/43feee24-f3c1-4bf0-bf7f-2940f5f8a924) | ![Screenshot_20240425_202455](https://github.com/godotengine/godot/assets/180032/3497aca5-29be-4c04-a234-5a91749681ce)

### Selected gizmo comparison

Before | After
-|-
![Screenshot_20240425_202538](https://github.com/godotengine/godot/assets/180032/7045baea-0e9c-4c2f-bcbf-dc76aa960e24) | ![Screenshot_20240425_202602](https://github.com/godotengine/godot/assets/180032/82447abd-3586-4365-8d43-014b35bb955a)

### Gizmo visible behind refractive material

*Gizmos are still refracted (as they are part of the screen texture), but it's better than nothing.*

![Screenshot_20240425_202904](https://github.com/godotengine/godot/assets/180032/26dc17a9-a649-4c60-ab38-73f1b7cc5ac3)

### Transparency sorting

#### Before (incorrect)

*The decal and camera gizmos appear behind the red toruses that are far away in the background, but they shouldn't.*

https://github.com/godotengine/godot/assets/180032/5d3d764d-9295-4976-b44c-68af49813e1b

#### After (correct)

https://github.com/godotengine/godot/assets/180032/4336d291-b109-4dba-9318-8dd8467def80