### PR TITLE
Fix `PopupMenu` tooltip alignment when scrolling

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1391,7 +1391,10 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 		// Temporary solution for PopupMenus.
 		PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 		if (menu) {
-			tooltip = menu->get_tooltip(pos);
+			Vector2 corrected_pos = pos;
+			corrected_pos = p_control->get_global_transform_with_canvas().xform(corrected_pos);
+			corrected_pos *= menu->get_content_scale_factor();
+			tooltip = menu->get_tooltip(corrected_pos);
 		}
 
 		if (r_tooltip_owner) {


### PR DESCRIPTION
Call `xform()` on position before passing into `PopupMenu::get_tooltip`, to undo earlier `affine_inverse().xform()` call.  `PopupMenu` already adjusts for the control's position when checking which item is selected.  Also adjust for `PopupMenu`'s content scale factor to keep tooltips aligned if the scale factor is not 1.

Fixes #91085.

_Bugsquad edited:_ Supersedes #90922.