### PR TITLE
Misc code cleanup

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -63,7 +63,6 @@ void EditorAbout::_notification(int p_what) {
 
 			_logo->set_texture(get_editor_theme_icon(SNAME("Logo")));
 
-			Ref<StyleBoxEmpty> empty_stylebox = memnew(StyleBoxEmpty);
 			for (ItemList *il : name_lists) {
 				for (int i = 0; i < il->get_item_count(); i++) {
 					if (il->get_item_metadata(i)) {

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -494,7 +494,7 @@ void TextureProgressBar::_notification(int p_what) {
 								Rect2 source = Rect2(Point2(), progress->get_size());
 								draw_texture_rect_region(progress, region, source, tint_progress);
 							} else if (val != 0) {
-								Array pts;
+								LocalVector<float> pts;
 								float direction = mode == FILL_COUNTER_CLOCKWISE ? -1 : 1;
 								float start;
 
@@ -507,11 +507,11 @@ void TextureProgressBar::_notification(int p_what) {
 								float end = start + direction * val;
 								float from = MIN(start, end);
 								float to = MAX(start, end);
-								pts.append(from);
+								pts.push_back(from);
 								for (float corner = Math::floor(from * 4 + 0.5) * 0.25 + 0.125; corner < to; corner += 0.25) {
-									pts.append(corner);
+									pts.push_back(corner);
 								}
-								pts.append(to);
+								pts.push_back(to);
 
 								Ref<AtlasTexture> atlas_progress = progress;
 								bool valid_atlas_progress = atlas_progress.is_valid() && atlas_progress->get_atlas().is_valid();
@@ -524,8 +524,8 @@ void TextureProgressBar::_notification(int p_what) {
 
 								Vector<Point2> uvs;
 								Vector<Point2> points;
-								for (int i = 0; i < pts.size(); i++) {
-									Point2 uv = unit_val_to_uv(pts[i]);
+								for (const float &f : pts) {
+									Point2 uv = unit_val_to_uv(f);
 									if (uvs.find(uv) >= 0) {
 										continue;
 									}

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -105,10 +105,6 @@ public:
 		_changes_changed();
 	}
 
-#define DISPLAY_CHANGED \
-	changes++;          \
-	_changes_changed();
-
 #else
 	_FORCE_INLINE_ static void redraw_request() {
 		changes++;


### PR DESCRIPTION
Some random things I spotted.
- Remove unused `empty_stylebox` from EditorAbout
- Remove unused `DISPLAY_CHANGED` macro from RenderingServerDefault
- Change `pts` variable in TextureProgressBar from `Array` to float array