### PR TITLE
Fix `TabContainer` regressions related to switching tabs in certain cases

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -147,9 +147,7 @@ void TabContainer::_notification(int p_what) {
 			if (get_tab_count() > 0) {
 				_refresh_tab_names();
 			}
-		} break;
 
-		case NOTIFICATION_POST_ENTER_TREE: {
 			if (setup_current_tab >= -1) {
 				set_current_tab(setup_current_tab);
 				setup_current_tab = -2;
@@ -189,6 +187,25 @@ void TabContainer::_notification(int p_what) {
 					theme_cache.menu_icon->draw(get_canvas_item(), Point2(x, header_voffset + (header_height - theme_cache.menu_icon->get_height()) / 2));
 				}
 			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible() || setup_current_tab > -2) {
+				return;
+			}
+
+			updating_visibility = true;
+
+			// As the visibility change notification will be triggered for all children soon after,
+			// beat it to the punch and make sure that the correct node is the only one visible first.
+			// Otherwise, it can prevent a tab change done right before this container was made visible.
+			Vector<Control *> controls = _get_tab_controls();
+			int current = get_current_tab();
+			for (int i = 0; i < controls.size(); i++) {
+				controls[i]->set_visible(i == current);
+			}
+
+			updating_visibility = false;
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -611,6 +628,7 @@ void TabContainer::set_current_tab(int p_current) {
 		setup_current_tab = p_current;
 		return;
 	}
+
 	tab_bar->set_current_tab(p_current);
 }
 


### PR DESCRIPTION
Fixes #91135.

- Fix regression caused by #83893, where setting the current tab right after entering the tree would make the value be reset to 0.

- The other one is bit more complicated (caused by #87194). It happens because the tab visibility change is also triggered if it becomes visible in the tree (even if it was already set to `visible`), ~and I'm not sure how to fix this without some ugly hackiness.~ Alright, did the cleanest attempt I could, suggestions are welcomed.

Thanks to @jsjtxietian for pointing me in the right direction and saving me time.