### PR TITLE
Docs: Fix FileAccess example conflicting with global scope `load`

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -8,23 +8,23 @@
 		Here's a sample on how to write and read from a file:
 		[codeblocks]
 		[gdscript]
-		func save(content):
+		func save_to_file(content):
 		    var file = FileAccess.open("user://save_game.dat", FileAccess.WRITE)
 		    file.store_string(content)
 
-		func load():
+		func load_from_file():
 		    var file = FileAccess.open("user://save_game.dat", FileAccess.READ)
 		    var content = file.get_as_text()
 		    return content
 		[/gdscript]
 		[csharp]
-		public void Save(string content)
+		public void SaveToFile(string content)
 		{
 		    using var file = FileAccess.Open("user://save_game.dat", FileAccess.ModeFlags.Write);
 		    file.StoreString(content);
 		}
 
-		public string Load()
+		public string LoadFromFile()
 		{
 		    using var file = FileAccess.Open("user://save_game.dat", FileAccess.ModeFlags.Read);
 		    string content = file.GetAsText();


### PR DESCRIPTION
In the example code the declared load() function conflicts with global scope load(). so if you copy pasted the GDScript example it in godot 4.2.2 you would get a "Too few arguments for "load()" call. Expected at least 1 but received 0." error since it doesn't override global scope load(). 

So i only renamed the functions into to: save_to_file() and load_from_file() for GDScript; and for C# to SaveToFile() and LoadFromFile().
to avoid overriding global scope load().

## Heres what the *current* example code looks like in engine:
![image](https://github.com/godotengine/godot/assets/16447282/a3502a8c-6969-4fec-8511-0430d372b6ab)
## Here my proposal
![image](https://github.com/godotengine/godot/assets/16447282/e0b3cabc-713c-4165-9dd5-edb60144f979)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
