### PR TITLE
Don't use vscroll when fit to content height in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7491,7 +7491,7 @@ void TextEdit::_update_scrollbars() {
 
 	updating_scrolls = true;
 
-	if (total_rows > visible_rows) {
+	if (!fit_content_height && total_rows > visible_rows) {
 		v_scroll->show();
 		v_scroll->set_max(total_rows + _get_visible_lines_offset());
 		v_scroll->set_page(visible_rows + _get_visible_lines_offset());


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/81764

The horizontal scrollbar part was fixed in https://github.com/godotengine/godot/pull/83286

This makes sure that the vertical scroll bar won't be shown when fit to content height.
This fixes the crash mentioned in the issue. https://github.com/godotengine/godot/issues/80546 had a slightly different cause for the crash, which was fixed. This crash only happens at certain sizes depending on the text and is rarer.
This fixes it since in `_update_wrap_at_column`, the v_scroll size is used, which is then removed next time it is updated, causing an infinite loop.