### PR TITLE
Make HTTPRequest 301 and 302 redirects standards-compliant

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -209,6 +209,26 @@ void HTTPRequest::cancel_request() {
 	requesting = false;
 }
 
+bool HTTPRequest::_is_content_header(const String &p_header) const {
+	return (p_header.begins_with("content-type:") || p_header.begins_with("content-length:") || p_header.begins_with("content-location:") || p_header.begins_with("content-encoding:") ||
+			p_header.begins_with("transfer-encoding:") || p_header.begins_with("connection:") || p_header.begins_with("authorization:"));
+}
+
+bool HTTPRequest::_is_method_safe() const {
+	return (method == HTTPClient::METHOD_GET || method == HTTPClient::METHOD_HEAD || method == HTTPClient::METHOD_OPTIONS || method == HTTPClient::METHOD_TRACE);
+}
+
+Error HTTPRequest::_get_redirect_headers(Vector<String> *r_headers) {
+	for (const String &E : headers) {
+		const String h = E.to_lower();
+		// We strip content headers when changing a redirect to GET.
+		if (!_is_content_header(h)) {
+			r_headers->push_back(E);
+		}
+	}
+	return OK;
+}
+
 bool HTTPRequest::_handle_response(bool *ret_value) {
 	if (!client->has_response()) {
 		_defer_done(RESULT_NO_RESPONSE, 0, PackedStringArray(), PackedByteArray());
@@ -268,6 +288,16 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 				final_body_size.set(0);
 				redirections = new_redirs;
 				*ret_value = false;
+				if (!_is_method_safe()) {
+					// 301, 302, and 303 are changed to GET for unsafe methods.
+					// See: https://www.rfc-editor.org/rfc/rfc9110#section-15.4-3.1
+					method = HTTPClient::METHOD_GET;
+					// Content headers should be dropped if changing method.
+					// See: https://www.rfc-editor.org/rfc/rfc9110#section-15.4-6.2.1
+					Vector<String> req_headers;
+					_get_redirect_headers(&req_headers);
+					headers = req_headers;
+				}
 				return true;
 			}
 		}

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -102,6 +102,10 @@ private:
 
 	void _redirect_request(const String &p_new_url);
 
+	bool _is_content_header(const String &p_header) const;
+	bool _is_method_safe() const;
+	Error _get_redirect_headers(Vector<String> *r_headers);
+
 	bool _handle_response(bool *ret_value);
 
 	Error _parse_url(const String &p_url);


### PR DESCRIPTION
The behavior of 301 and 302 redirects in the HTTPRequest node are not standards-compliant. Specifically, requests using unsafe methods were not being changed to GET and their headers were not being modified. This means that we were automatically redirecting POST, PUT, etc. requests with empty bodies and the same headers. This can pose a security risk if the server expects 301/302 responses to get changed to GET or if the user doesn't expect unsafe methods to be automatically redirected.

Per [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#name-redirection-3xx), the correct behavior is to change the method to GET for 301 and 302 redirections and remove any content headers as well as those related to security contexts like "Authorization: ".

I have not opened an issue for this, but I discussed with Networking contributors and maintainers in the contributors chat: https://chat.godotengine.org/channel/networking?msg=r74ZS86inP7SKBMpF

I have made these changes, so now the 301 and 302 redirects should change any unsafe methods to GET and remove any sensitive headers.

GET, HEAD, OPTIONS, and TRACE requests that receive a 301 or 302 are automatically forwarded unchanged since those methods are safe.

I didn't mess with any of the proxy headers since client proxy stuff seems to be set up in the raw request built by the HTTPClientTCP class like the Host and Accept headers. If we need to clear headers like "Proxy-Authorization: " as well, then I can add those to the headers that get filtered out in the _get_redirect_headers method.

Please let me know if I've missed anything related to the spec. Thanks!

Also, we don't have any automated tests for HTTPRequest that I'm aware of, so I'm working on a solution to that problem godotengine/godot-proposals#9581, but for now, I'm using the following caddy server config and GDScript test project to test these changes. All tests for the 301 code are passing on this commit. The 307 tests are for #90160, which I will be opening a separate PR for.

Caddyfile:

<details>

```
{
	http_port 8000
}


localhost:8000 {

	@get method GET
	@post method POST
	@no-content-location header !Content-Location

	redir /301-basic /redirected-from-301 301

	redir /307-basic /redirected-from-307 307

	redir /301-converts-method-to-get /redirected-from-301-get-only 301

	handle /redirected-from-301-get-only {
		respond @get 200 {
			body "Redirected from 301 method converted to GET"
		}
	}

	redir /301-strips-headers /stripped-headers 301
	redir /302-strips-headers /stripped-headers 302
	redir /307-strips-headers /stripped-headers 307
	redir /308-strips-headers /stripped-headers 308

	handle /stripped-headers {
		respond @no-content-location 200 {
			body "Redirected with headers stripped"
		}
	}

	handle /307-preserves-method {
		redir @post /redirected-from-307-post-only 307
	}

	respond /redirected-from-307 200 {
		body "Redirected from 307 basic response"
	}

	handle /redirected-from-307-post-only {
		respond @post 200 {
			body "Redirected from 307 preserved method"
		}
	}

	respond /redirected-from-301 200 {
		body "Redirected from 301 basic response"
	}
}
```

Test project script:

```
extends Node

var req: HTTPRequest = HTTPRequest.new()
var REQUESTING: bool = false
var test_count: int = 0

func _ready() -> void:
    add_child(req)

func _process(delta):
    if REQUESTING:
        return
    if test_count >= test_cases.size():
        set_process(false)
        return
    var prev_test = test_cases[test_count - 1]
    if prev_test != null:
        if req.request_completed.is_connected(prev_test.callback):
            req.request_completed.disconnect(prev_test.callback)
    var curr_test = test_cases[test_count]
    print("Test ", curr_test.callback.get_method(), "...")
    if not req.request_completed.is_connected(curr_test.callback):
        req.request_completed.connect(curr_test.callback)
    req.request(curr_test.url, curr_test.headers, curr_test.method)
    REQUESTING = true
    test_count += 1


var test_cases = [
    {
        "url": "http://localhost:8000/301-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_301_basic,
    },
    {
        "url": "http://localhost:8000/301-converts-method-to-get",
        "method": HTTPClient.METHOD_POST,
        "headers": [],
        "callback": self.redirect_301_converts_post_to_get,
    },
    {
        "url": "http://localhost:8000/301-converts-method-to-get",
        "method": HTTPClient.METHOD_PUT,
        "headers": [],
        "callback": self.redirect_301_converts_put_to_get,
    },
    {
        "url": "http://localhost:8000/301-converts-method-to-get",
        "method": HTTPClient.METHOD_DELETE,
        "headers": [],
        "callback": self.redirect_301_converts_delete_to_get,
    },
    {
        "url": "http://localhost:8000/301-strips-headers",
        "method": HTTPClient.METHOD_POST,
        "headers": ["Content-Location: /some-location"],
        "callback": self.redirect_headers_stripped,
    },
    {
        "url": "http://localhost:8000/307-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_307_basic,
    },
    {
        "url": "http://localhost:8000/307-preserves-method",
        "method": HTTPClient.METHOD_POST,
        "headers": [],
        "callback": self.redirect_307_preserves_method,
    },
]       

func debug(result, response_code, headers, body):
    print("Result: ", result)
    print("Response Code: ", response_code)
    print("Headers: ", headers)
    print("body: ", body.get_string_from_utf8())


func redirect_307_basic(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 307 basic response", "307 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_307_preserves_method(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 307 preserved method", "307 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_basic(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 basic response", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false


func redirect_301_converts_post_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_converts_put_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_converts_delete_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_headers_stripped(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 200, "Request should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected with headers stripped", "Request should give response from redirected location body")
    print("Passed!")
    REQUESTING = false
```

</details>

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
