### PR TITLE
Fix empty string variable not shown in script debug tooltip

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -280,7 +280,28 @@ String EditorDebuggerInspector::get_stack_variable(const String &p_var) {
 	for (KeyValue<StringName, Variant> &E : variables->prop_values) {
 		String v = E.key.operator String();
 		if (v.get_slice("/", 1) == p_var) {
-			return variables->get_variant(v);
+			Variant var = variables->get_variant(v);
+
+			String prefix;
+			String literal = String(var);
+
+			switch (var.get_type()) {
+				case Variant::STRING:
+					literal = literal.quote("\"");
+					break;
+				case Variant::STRING_NAME:
+					prefix = "&";
+					literal = literal.quote("\"");
+					break;
+				case Variant::NODE_PATH:
+					prefix = "^";
+					literal = literal.quote("\"");
+					break;
+				default:
+					break;
+			}
+
+			return prefix + literal;
 		}
 	}
 	return String();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91162

I tried with showing `<empty>` or `""` , but it may cause some confusion as in that case we'd better change the stack variable's display to match the tooltip, like in the image below. Right now it just shows nothing, feel free to correct me.

![image](https://github.com/godotengine/godot/assets/8315986/a8192fc1-8432-4b2e-85df-4fd57bc0cb4a)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
