### PR TITLE
[Web] Fix closure compiler typedef annotation

### DIFF
--- a/platform/web/js/engine/features.js
+++ b/platform/web/js/engine/features.js
@@ -72,8 +72,7 @@ const Features = { // eslint-disable-line no-unused-vars
 	 *
 	 * @returns {Array<string>} A list of human-readable missing features.
 	 * @function Engine.getMissingFeatures
-	 * @typedef {{ threads: boolean }} SupportedFeatures
-	 * @param {SupportedFeatures} supportedFeatures
+	 * @param {{threads: (boolean|undefined)}} supportedFeatures
 	 */
 	getMissingFeatures: function (supportedFeatures = {}) {
 		const {


### PR DESCRIPTION
The typedef annotation is expected to come bofre a var (or const) since it's most commonly used in externs. Use an inline definition instead.