### PR TITLE
SCons: Warn when passing unknown variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -255,6 +255,7 @@ opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))
 opts.Add("scu_limit", "Max includes per SCU file when using scu_build (determines RAM use)", "0")
 opts.Add(BoolVariable("engine_update_check", "Enable engine update checks in the Project Manager", True))
 opts.Add(BoolVariable("steamapi", "Enable minimal SteamAPI integration for usage time tracking (editor only)", False))
+opts.Add("profile", "Path to a file containing build arguments (used in addition to root `custom.py`).", "")
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_brotli", "Use the built-in Brotli library", True))
@@ -446,6 +447,14 @@ env.modules_detected = modules_detected
 # Update the environment again after all the module options are added.
 opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
 Help(opts.GenerateHelpText(env))
+
+# Detect and print a warning listing unknown SCons variables to ease troubleshooting.
+unknown = opts.UnknownVariables()
+if unknown:
+    print_warning(
+        "Unknown SCons variables were passed and will be ignored:"
+        + "".join([f"\n\t{key} = {value}" for key, value in unknown.items()])
+    )
 
 # add default include paths
 


### PR DESCRIPTION
Lifted largely from godot-cpp's implementation[^1], albeit with formatting tweaked to be more in-line with recent SConstruct adjustments.

Example output:
```
Executing task: scons dev_build=yes compiledb=yes optimize=debug verbose=no tests=yes warnings=extra d3d12=yes module_text_server_fb_enabled=yes cpp_standard=23 ninja=no 

scons: Reading SConscript files ...
Automatically detected platform: windows
WARNING: Unknown SCons variables were passed and will be ignored:
        cpp_standard = 23
Auto-detected 32 CPU cores available for build parallelism. Using 31 cores by default. You can override it with the -j argument.
```

[^1]: https://github.com/godotengine/godot-cpp/blob/e23b117ac32fdbeb0920f234e193e6d31307c0ad/SConstruct#L41-L46