### PR TITLE
SCons: Colorize warnings/errors during generation

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -29,8 +29,8 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
                 ec_valid = False
             txt += txts
     if not ec_valid:
-        print("Error: Invalid AES256 encryption key, not 64 hexadecimal characters: '" + key + "'.")
-        print(
+        methods.print_error(
+            f'Invalid AES256 encryption key, not 64 hexadecimal characters: "{key}".\n'
             "Unset 'SCRIPT_AES256_ENCRYPTION_KEY' in your environment "
             "or make sure that it contains exactly 64 hexadecimal characters."
         )

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import uuid
 import zlib
+from methods import print_warning
 
 
 def make_doc_header(target, source, env):
@@ -57,7 +58,7 @@ def make_translations_header(target, source, env, category):
         msgfmt_available = shutil.which("msgfmt") is not None
 
         if not msgfmt_available:
-            print("WARNING: msgfmt is not found, using .po files instead of .mo")
+            print_warning("msgfmt is not found, using .po files instead of .mo")
 
         xl_names = []
         for i in range(len(sorted_paths)):
@@ -71,8 +72,8 @@ def make_translations_header(target, source, env, category):
                     with open(mo_path, "rb") as f:
                         buf = f.read()
                 except OSError as e:
-                    print(
-                        "WARNING: msgfmt execution failed, using .po file instead of .mo: path=%r; [%s] %s"
+                    print_warning(
+                        "msgfmt execution failed, using .po file instead of .mo: path=%r; [%s] %s"
                         % (sorted_paths[i], e.__class__.__name__, e)
                     )
                     with open(sorted_paths[i], "rb") as f:
@@ -82,9 +83,8 @@ def make_translations_header(target, source, env, category):
                         os.remove(mo_path)
                     except OSError as e:
                         # Do not fail the entire build if it cannot delete a temporary file.
-                        print(
-                            "WARNING: Could not delete temporary .mo file: path=%r; [%s] %s"
-                            % (mo_path, e.__class__.__name__, e)
+                        print_warning(
+                            "Could not delete temporary .mo file: path=%r; [%s] %s" % (mo_path, e.__class__.__name__, e)
                         )
             else:
                 with open(sorted_paths[i], "rb") as f:

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -1,7 +1,7 @@
 """Functions used to generate source files during build time"""
 
 import os.path
-
+from methods import print_error
 from typing import Optional
 
 
@@ -94,11 +94,11 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
                 if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
                     header_data.vertex_included_files += [included_file]
                     if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
-                        print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                        print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif not included_file in header_data.fragment_included_files and header_data.reading == "fragment":
                     header_data.fragment_included_files += [included_file]
                     if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
-                        print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                        print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
 
                 line = fs.readline()
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -1,6 +1,7 @@
 """Functions used to generate source files during build time"""
 
 import os.path
+from methods import print_error
 from typing import Optional, Iterable
 
 
@@ -79,15 +80,15 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
                 if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
                     header_data.vertex_included_files += [included_file]
                     if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
-                        print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                        print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif not included_file in header_data.fragment_included_files and header_data.reading == "fragment":
                     header_data.fragment_included_files += [included_file]
                     if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
-                        print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                        print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif not included_file in header_data.compute_included_files and header_data.reading == "compute":
                     header_data.compute_included_files += [included_file]
                     if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
-                        print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
+                        print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
 
                 line = fs.readline()
 

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -1,9 +1,19 @@
 #!/usr/bin/env python
 import atexit
-import os
 import sys
 import methods
 import time
+
+# Enable ANSI escape code support on Windows 10 and later (for colored console output).
+# <https://github.com/python/cpython/issues/73245>
+if sys.platform == "win32":
+    from ctypes import windll, c_int, byref
+
+    stdout_handle = windll.kernel32.GetStdHandle(c_int(-11))
+    mode = c_int(0)
+    windll.kernel32.GetConsoleMode(c_int(stdout_handle), byref(mode))
+    mode = c_int(mode.value | 4)
+    windll.kernel32.SetConsoleMode(c_int(stdout_handle), mode)
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++
@@ -30,7 +40,7 @@ opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", Fa
 opts.Update(env)
 
 if not env["verbose"]:
-    methods.no_verbose(sys, env)
+    methods.no_verbose(env)
 
 if env["platform"] == "windows" and not env["use_mingw"]:
     env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
@@ -764,9 +774,16 @@ Default(library)
 
 
 def print_elapsed_time():
-    elapsed_time_sec = round(time.time() - time_at_start, 3)
-    time_ms = round((elapsed_time_sec % 1) * 1000)
-    print("[Time elapsed: {}.{:03}]".format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)), time_ms))
+    elapsed_time_sec = round(time.time() - time_at_start, 2)
+    time_centiseconds = round((elapsed_time_sec % 1) * 100)
+    print(
+        "{}[Time elapsed: {}.{:02}]{}".format(
+            methods.ANSI.GRAY,
+            time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)),
+            time_centiseconds,
+            methods.ANSI.RESET,
+        )
+    )
 
 
 atexit.register(print_elapsed_time)

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -1,66 +1,73 @@
 import os
 import sys
+from enum import Enum
+
+# Colors are disabled in non-TTY environments such as pipes. This means
+# that if output is redirected to a file, it won't contain color codes.
+# Colors are always enabled on continuous integration.
+_colorize = bool(sys.stdout.isatty() or os.environ.get("CI"))
 
 
-def no_verbose(sys, env):
-    colors = {}
+class ANSI(Enum):
+    """
+    Enum class for adding ansi colorcodes directly into strings.
+    Automatically converts values to strings representing their
+    internal value, or an empty string in a non-colorized scope.
+    """
 
-    # Colors are disabled in non-TTY environments such as pipes. This means
-    # that if output is redirected to a file, it will not contain color codes
-    if sys.stdout.isatty():
-        colors["blue"] = "\033[0;94m"
-        colors["bold_blue"] = "\033[1;94m"
-        colors["reset"] = "\033[0m"
-    else:
-        colors["blue"] = ""
-        colors["bold_blue"] = ""
-        colors["reset"] = ""
+    GRAY = "\x1b[0;30m"
+    RED = "\x1b[0;31m"
+    GREEN = "\x1b[0;32m"
+    YELLOW = "\x1b[0;33m"
+    BLUE = "\x1b[0;34m"
+    PURPLE = "\x1b[0;35m"
+    CYAN = "\x1b[0;36m"
+    WHITE = "\x1b[0;37m"
+
+    BOLD_GRAY = "\x1b[1;90m"
+    BOLD_RED = "\x1b[1;91m"
+    BOLD_GREEN = "\x1b[1;92m"
+    BOLD_YELLOW = "\x1b[1;93m"
+    BOLD_BLUE = "\x1b[1;94m"
+    BOLD_PURPLE = "\x1b[1;95m"
+    BOLD_CYAN = "\x1b[1;96m"
+    BOLD_WHITE = "\x1b[1;97m"
+
+    RESET = "\x1b[0m"
+
+    def __str__(self):
+        global _colorize
+        return self.value if _colorize else ""
+
+
+def no_verbose(env):
+    colors = [ANSI.BLUE, ANSI.BOLD_BLUE, ANSI.RESET]
 
     # There is a space before "..." to ensure that source file names can be
     # Ctrl + clicked in the VS Code terminal.
-    compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    java_compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    compile_shared_source_message = "{}Compiling shared {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_program_message = "{}Linking Program {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_library_message = "{}Linking Static Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    ranlib_library_message = "{}Ranlib Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_shared_library_message = "{}Linking Shared Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
+    compile_source_message = "{0}Compiling {1}$SOURCE{0} ...{2}".format(*colors)
+    java_compile_source_message = "{0}Compiling {1}$SOURCE{0} ...{2}".format(*colors)
+    compile_shared_source_message = "{0}Compiling shared {1}$SOURCE{0} ...{2}".format(*colors)
+    link_program_message = "{0}Linking Program {1}$TARGET{0} ...{2}".format(*colors)
+    link_library_message = "{0}Linking Static Library {1}$TARGET{0} ...{2}".format(*colors)
+    ranlib_library_message = "{0}Ranlib Library {1}$TARGET{0} ...{2}".format(*colors)
+    link_shared_library_message = "{0}Linking Shared Library {1}$TARGET{0} ...{2}".format(*colors)
+    java_library_message = "{0}Creating Java Archive {1}$TARGET{0} ...{2}".format(*colors)
+    compiled_resource_message = "{0}Creating Compiled Resource {1}$TARGET{0} ...{2}".format(*colors)
+    generated_file_message = "{0}Generating {1}$TARGET{0} ...{2}".format(*colors)
 
-    env.Append(CXXCOMSTR=[compile_source_message])
-    env.Append(CCCOMSTR=[compile_source_message])
-    env.Append(SHCCCOMSTR=[compile_shared_source_message])
-    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
-    env.Append(ARCOMSTR=[link_library_message])
-    env.Append(RANLIBCOMSTR=[ranlib_library_message])
-    env.Append(SHLINKCOMSTR=[link_shared_library_message])
-    env.Append(LINKCOMSTR=[link_program_message])
-    env.Append(JARCOMSTR=[java_library_message])
-    env.Append(JAVACCOMSTR=[java_compile_source_message])
-    env.Append(RCCOMSTR=[compiled_resource_message])
-    env.Append(GENCOMSTR=[generated_file_message])
+    env.Append(CXXCOMSTR=compile_source_message)
+    env.Append(CCCOMSTR=compile_source_message)
+    env.Append(SHCCCOMSTR=compile_shared_source_message)
+    env.Append(SHCXXCOMSTR=compile_shared_source_message)
+    env.Append(ARCOMSTR=link_library_message)
+    env.Append(RANLIBCOMSTR=ranlib_library_message)
+    env.Append(SHLINKCOMSTR=link_shared_library_message)
+    env.Append(LINKCOMSTR=link_program_message)
+    env.Append(JARCOMSTR=java_library_message)
+    env.Append(JAVACCOMSTR=java_compile_source_message)
+    env.Append(RCCOMSTR=compiled_resource_message)
+    env.Append(GENCOMSTR=generated_file_message)
 
 
 def disable_warnings(self):

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -1,9 +1,19 @@
 #!/usr/bin/env python
 import atexit
-import os
 import sys
 import methods
 import time
+
+# Enable ANSI escape code support on Windows 10 and later (for colored console output).
+# <https://github.com/python/cpython/issues/73245>
+if sys.platform == "win32":
+    from ctypes import windll, c_int, byref
+
+    stdout_handle = windll.kernel32.GetStdHandle(c_int(-11))
+    mode = c_int(0)
+    windll.kernel32.GetConsoleMode(c_int(stdout_handle), byref(mode))
+    mode = c_int(mode.value | 4)
+    windll.kernel32.SetConsoleMode(c_int(stdout_handle), mode)
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++
@@ -28,7 +38,7 @@ opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", Fa
 opts.Update(env)
 
 if not env["verbose"]:
-    methods.no_verbose(sys, env)
+    methods.no_verbose(env)
 
 # ThorVG
 if env["thorvg_enabled"] and env["freetype_enabled"]:
@@ -311,9 +321,16 @@ Default(library)
 
 
 def print_elapsed_time():
-    elapsed_time_sec = round(time.time() - time_at_start, 3)
-    time_ms = round((elapsed_time_sec % 1) * 1000)
-    print("[Time elapsed: {}.{:03}]".format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)), time_ms))
+    elapsed_time_sec = round(time.time() - time_at_start, 2)
+    time_centiseconds = round((elapsed_time_sec % 1) * 100)
+    print(
+        "{}[Time elapsed: {}.{:02}]{}".format(
+            methods.ANSI.GRAY,
+            time.strftime("%H:%M:%S", time.gmtime(elapsed_time_sec)),
+            time_centiseconds,
+            methods.ANSI.RESET,
+        )
+    )
 
 
 atexit.register(print_elapsed_time)

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -1,66 +1,73 @@
 import os
 import sys
+from enum import Enum
+
+# Colors are disabled in non-TTY environments such as pipes. This means
+# that if output is redirected to a file, it won't contain color codes.
+# Colors are always enabled on continuous integration.
+_colorize = bool(sys.stdout.isatty() or os.environ.get("CI"))
 
 
-def no_verbose(sys, env):
-    colors = {}
+class ANSI(Enum):
+    """
+    Enum class for adding ansi colorcodes directly into strings.
+    Automatically converts values to strings representing their
+    internal value, or an empty string in a non-colorized scope.
+    """
 
-    # Colors are disabled in non-TTY environments such as pipes. This means
-    # that if output is redirected to a file, it will not contain color codes
-    if sys.stdout.isatty():
-        colors["blue"] = "\033[0;94m"
-        colors["bold_blue"] = "\033[1;94m"
-        colors["reset"] = "\033[0m"
-    else:
-        colors["blue"] = ""
-        colors["bold_blue"] = ""
-        colors["reset"] = ""
+    GRAY = "\x1b[0;30m"
+    RED = "\x1b[0;31m"
+    GREEN = "\x1b[0;32m"
+    YELLOW = "\x1b[0;33m"
+    BLUE = "\x1b[0;34m"
+    PURPLE = "\x1b[0;35m"
+    CYAN = "\x1b[0;36m"
+    WHITE = "\x1b[0;37m"
+
+    BOLD_GRAY = "\x1b[1;90m"
+    BOLD_RED = "\x1b[1;91m"
+    BOLD_GREEN = "\x1b[1;92m"
+    BOLD_YELLOW = "\x1b[1;93m"
+    BOLD_BLUE = "\x1b[1;94m"
+    BOLD_PURPLE = "\x1b[1;95m"
+    BOLD_CYAN = "\x1b[1;96m"
+    BOLD_WHITE = "\x1b[1;97m"
+
+    RESET = "\x1b[0m"
+
+    def __str__(self):
+        global _colorize
+        return self.value if _colorize else ""
+
+
+def no_verbose(env):
+    colors = [ANSI.BLUE, ANSI.BOLD_BLUE, ANSI.RESET]
 
     # There is a space before "..." to ensure that source file names can be
     # Ctrl + clicked in the VS Code terminal.
-    compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    java_compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    compile_shared_source_message = "{}Compiling shared {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_program_message = "{}Linking Program {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_library_message = "{}Linking Static Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    ranlib_library_message = "{}Ranlib Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    link_shared_library_message = "{}Linking Shared Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
-    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
-    )
+    compile_source_message = "{0}Compiling {1}$SOURCE{0} ...{2}".format(*colors)
+    java_compile_source_message = "{0}Compiling {1}$SOURCE{0} ...{2}".format(*colors)
+    compile_shared_source_message = "{0}Compiling shared {1}$SOURCE{0} ...{2}".format(*colors)
+    link_program_message = "{0}Linking Program {1}$TARGET{0} ...{2}".format(*colors)
+    link_library_message = "{0}Linking Static Library {1}$TARGET{0} ...{2}".format(*colors)
+    ranlib_library_message = "{0}Ranlib Library {1}$TARGET{0} ...{2}".format(*colors)
+    link_shared_library_message = "{0}Linking Shared Library {1}$TARGET{0} ...{2}".format(*colors)
+    java_library_message = "{0}Creating Java Archive {1}$TARGET{0} ...{2}".format(*colors)
+    compiled_resource_message = "{0}Creating Compiled Resource {1}$TARGET{0} ...{2}".format(*colors)
+    generated_file_message = "{0}Generating {1}$TARGET{0} ...{2}".format(*colors)
 
-    env.Append(CXXCOMSTR=[compile_source_message])
-    env.Append(CCCOMSTR=[compile_source_message])
-    env.Append(SHCCCOMSTR=[compile_shared_source_message])
-    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
-    env.Append(ARCOMSTR=[link_library_message])
-    env.Append(RANLIBCOMSTR=[ranlib_library_message])
-    env.Append(SHLINKCOMSTR=[link_shared_library_message])
-    env.Append(LINKCOMSTR=[link_program_message])
-    env.Append(JARCOMSTR=[java_library_message])
-    env.Append(JAVACCOMSTR=[java_compile_source_message])
-    env.Append(RCCOMSTR=[compiled_resource_message])
-    env.Append(GENCOMSTR=[generated_file_message])
+    env.Append(CXXCOMSTR=compile_source_message)
+    env.Append(CCCOMSTR=compile_source_message)
+    env.Append(SHCCCOMSTR=compile_shared_source_message)
+    env.Append(SHCXXCOMSTR=compile_shared_source_message)
+    env.Append(ARCOMSTR=link_library_message)
+    env.Append(RANLIBCOMSTR=ranlib_library_message)
+    env.Append(SHLINKCOMSTR=link_shared_library_message)
+    env.Append(LINKCOMSTR=link_program_message)
+    env.Append(JARCOMSTR=java_library_message)
+    env.Append(JAVACCOMSTR=java_compile_source_message)
+    env.Append(RCCOMSTR=compiled_resource_message)
+    env.Append(GENCOMSTR=generated_file_message)
 
 
 def disable_warnings(self):

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import subprocess
+from methods import print_warning
 
 Import("env")
 
@@ -52,7 +53,7 @@ elif env["arch"] == "x86_32":
 elif env["arch"] == "x86_64":
     lib_arch_dir = "x86_64"
 else:
-    print("WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin")
+    print_warning("Architecture not suitable for embedding into APK; keeping .so at \\bin")
 
 if lib_arch_dir != "":
     if env.dev_build:

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -2,7 +2,7 @@ import os
 import sys
 import platform
 import subprocess
-
+from methods import print_warning, print_error
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -76,7 +76,6 @@ def get_flags():
 # Check if Android NDK version is installed
 # If not, install it.
 def install_ndk_if_needed(env: "SConsEnvironment"):
-    print("Checking for Android NDK...")
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
@@ -87,13 +86,11 @@ def install_ndk_if_needed(env: "SConsEnvironment"):
             ndk_download_args = "ndk;" + get_ndk_version()
             subprocess.check_call([sdkmanager, ndk_download_args])
         else:
-            print("Cannot find " + sdkmanager)
-            print(
-                "Please ensure ANDROID_HOME is correct and cmdline-tools are installed, or install NDK version "
-                + get_ndk_version()
-                + " manually."
+            print_error(
+                f'Cannot find "{sdkmanager}". Please ensure ANDROID_HOME is correct and cmdline-tools'
+                f'are installed, or install NDK version "{get_ndk_version()}" manually.'
             )
-            sys.exit()
+            sys.exit(255)
     env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
@@ -101,15 +98,15 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for Android. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     if get_min_sdk_version(env["ndk_platform"]) < get_min_target_api():
-        print(
-            "WARNING: minimum supported Android target api is %d. Forcing target api %d."
+        print_warning(
+            "Minimum supported Android target api is %d. Forcing target api %d."
             % (get_min_target_api(), get_min_target_api())
         )
         env["ndk_platform"] = "android-" + str(get_min_target_api())

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from methods import detect_darwin_sdk_path
+from methods import print_error, detect_darwin_sdk_path
 
 from typing import TYPE_CHECKING
 
@@ -60,11 +60,11 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for iOS. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     ## LTO
 
@@ -118,7 +118,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["arch"] == "x86_64":
         if not env["ios_simulator"]:
-            print("ERROR: Building for iOS with 'arch=x86_64' requires 'ios_simulator=yes'.")
+            print_error("Building for iOS with 'arch=x86_64' requires 'ios_simulator=yes'.")
             sys.exit(255)
 
         env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.9"

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import sys
-from methods import get_compiler_version, using_gcc
+from methods import print_warning, print_error, get_compiler_version, using_gcc
 from platform_methods import detect_arch
 
 from typing import TYPE_CHECKING
@@ -20,7 +20,7 @@ def can_build():
 
     pkgconf_error = os.system("pkg-config --version > /dev/null")
     if pkgconf_error:
-        print("Error: pkg-config not found. Aborting.")
+        print_error("pkg-config not found. Aborting.")
         return False
 
     return True
@@ -75,7 +75,7 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for Linux / *BSD. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
@@ -128,7 +128,9 @@ def configure(env: "SConsEnvironment"):
                         found_wrapper = True
                         break
                 if not found_wrapper:
-                    print("Couldn't locate mold installation path. Make sure it's installed in /usr or /usr/local.")
+                    print_error(
+                        "Couldn't locate mold installation path. Make sure it's installed in /usr or /usr/local."
+                    )
                     sys.exit(255)
             else:
                 env.Append(LINKFLAGS=["-fuse-ld=mold"])
@@ -185,7 +187,7 @@ def configure(env: "SConsEnvironment"):
     if env["lto"] != "none":
         if env["lto"] == "thin":
             if not env["use_llvm"]:
-                print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
+                print_error("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
                 sys.exit(255)
             env.Append(CCFLAGS=["-flto=thin"])
             env.Append(LINKFLAGS=["-flto=thin"])
@@ -209,7 +211,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["wayland"]:
         if os.system("wayland-scanner -v 2>/dev/null") != 0:
-            print("wayland-scanner not found. Disabling Wayland support.")
+            print_warning("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 
     if env["touch"]:
@@ -227,7 +229,7 @@ def configure(env: "SConsEnvironment"):
         env["builtin_harfbuzz"],
     ]
     if (not all(ft_linked_deps)) and any(ft_linked_deps):  # All or nothing.
-        print(
+        print_error(
             "These libraries should be either all builtin, or all system provided:\n"
             "freetype, libpng, zlib, graphite, harfbuzz.\n"
             "Please specify `builtin_<name>=no` for all of them, or none."
@@ -318,7 +320,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config fontconfig --cflags --libs")
                 env.Append(CPPDEFINES=["FONTCONFIG_ENABLED"])
             else:
-                print("Warning: fontconfig development libraries not found. Disabling the system fonts support.")
+                print_warning("fontconfig development libraries not found. Disabling the system fonts support.")
                 env["fontconfig"] = False
         else:
             env.Append(CPPDEFINES=["FONTCONFIG_ENABLED"])
@@ -329,7 +331,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config alsa --cflags --libs")
                 env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
             else:
-                print("Warning: ALSA development libraries not found. Disabling the ALSA audio driver.")
+                print_warning("ALSA development libraries not found. Disabling the ALSA audio driver.")
                 env["alsa"] = False
         else:
             env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
@@ -340,7 +342,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config libpulse --cflags --libs")
                 env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             else:
-                print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
+                print_warning("PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
                 env["pulseaudio"] = False
         else:
             env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED", "_REENTRANT"])
@@ -351,7 +353,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config dbus-1 --cflags --libs")
                 env.Append(CPPDEFINES=["DBUS_ENABLED"])
             else:
-                print("Warning: D-Bus development libraries not found. Disabling screensaver prevention.")
+                print_warning("D-Bus development libraries not found. Disabling screensaver prevention.")
                 env["dbus"] = False
         else:
             env.Append(CPPDEFINES=["DBUS_ENABLED"])
@@ -362,7 +364,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config speech-dispatcher --cflags --libs")
                 env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
             else:
-                print("Warning: speech-dispatcher development libraries not found. Disabling text to speech support.")
+                print_warning("speech-dispatcher development libraries not found. Disabling text to speech support.")
                 env["speechd"] = False
         else:
             env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
@@ -373,11 +375,11 @@ def configure(env: "SConsEnvironment"):
             env.Append(CPPDEFINES=["XKB_ENABLED"])
         else:
             if env["wayland"]:
-                print("Error: libxkbcommon development libraries required by Wayland not found. Aborting.")
+                print_error("libxkbcommon development libraries required by Wayland not found. Aborting.")
                 sys.exit(255)
             else:
-                print(
-                    "Warning: libxkbcommon development libraries not found. Disabling dead key composition and key label support."
+                print_warning(
+                    "libxkbcommon development libraries not found. Disabling dead key composition and key label support."
                 )
     else:
         env.Append(CPPDEFINES=["XKB_ENABLED"])
@@ -390,7 +392,7 @@ def configure(env: "SConsEnvironment"):
                     env.ParseConfig("pkg-config libudev --cflags --libs")
                     env.Append(CPPDEFINES=["UDEV_ENABLED"])
                 else:
-                    print("Warning: libudev development libraries not found. Disabling controller hotplugging support.")
+                    print_warning("libudev development libraries not found. Disabling controller hotplugging support.")
                     env["udev"] = False
             else:
                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
@@ -416,31 +418,31 @@ def configure(env: "SConsEnvironment"):
     if env["x11"]:
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists x11"):
-                print("Error: X11 libraries not found. Aborting.")
+                print_error("X11 libraries not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config x11 --cflags --libs")
             if os.system("pkg-config --exists xcursor"):
-                print("Error: Xcursor library not found. Aborting.")
+                print_error("Xcursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xcursor --cflags --libs")
             if os.system("pkg-config --exists xinerama"):
-                print("Error: Xinerama library not found. Aborting.")
+                print_error("Xinerama library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xinerama --cflags --libs")
             if os.system("pkg-config --exists xext"):
-                print("Error: Xext library not found. Aborting.")
+                print_error("Xext library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xext --cflags --libs")
             if os.system("pkg-config --exists xrandr"):
-                print("Error: XrandR library not found. Aborting.")
+                print_error("XrandR library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrandr --cflags --libs")
             if os.system("pkg-config --exists xrender"):
-                print("Error: XRender library not found. Aborting.")
+                print_error("XRender library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrender --cflags --libs")
             if os.system("pkg-config --exists xi"):
-                print("Error: Xi library not found. Aborting.")
+                print_error("Xi library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xi --cflags --libs")
         env.Append(CPPDEFINES=["X11_ENABLED"])
@@ -448,20 +450,20 @@ def configure(env: "SConsEnvironment"):
     if env["wayland"]:
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists libdecor-0"):
-                print("Warning: libdecor development libraries not found. Disabling client-side decorations.")
+                print_warning("libdecor development libraries not found. Disabling client-side decorations.")
                 env["libdecor"] = False
             else:
                 env.ParseConfig("pkg-config libdecor-0 --cflags --libs")
             if os.system("pkg-config --exists wayland-client"):
-                print("Error: Wayland client library not found. Aborting.")
+                print_error("Wayland client library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-client --cflags --libs")
             if os.system("pkg-config --exists wayland-cursor"):
-                print("Error: Wayland cursor library not found. Aborting.")
+                print_error("Wayland cursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-cursor --cflags --libs")
             if os.system("pkg-config --exists wayland-egl"):
-                print("Error: Wayland EGL library not found. Aborting.")
+                print_error("Wayland EGL library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-egl --cflags --libs")
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from methods import detect_darwin_sdk_path, get_compiler_version, is_vanilla_clang
+from methods import print_error, detect_darwin_sdk_path, get_compiler_version, is_vanilla_clang
 from platform_methods import detect_arch, detect_mvk
 
 from typing import TYPE_CHECKING
@@ -64,11 +64,11 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for macOS. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     ## Build type
 
@@ -254,7 +254,7 @@ def configure(env: "SConsEnvironment"):
             if mvk_path != "":
                 env.Append(LINKFLAGS=["-L" + mvk_path])
             else:
-                print(
+                print_error(
                     "MoltenVK SDK installation directory not found, use 'vulkan_sdk_path' SCons parameter to specify SDK path."
                 )
                 sys.exit(255)

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from methods import print_error
+
 Import("env")
 
 # The HTTP server "targets". Run with "scons p=web serve", or "scons p=web run"
@@ -11,7 +13,7 @@ if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
     try:
         port = int(port)
     except Exception:
-        print("GODOT_WEB_TEST_PORT must be a valid integer")
+        print_error("GODOT_WEB_TEST_PORT must be a valid integer")
         sys.exit(255)
     serve(env.Dir(env.GetTemplateZipPath()).abspath, port, "run" in COMMAND_LINE_TARGETS)
     sys.exit(0)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -2,6 +2,7 @@ import methods
 import os
 import subprocess
 import sys
+from methods import print_warning, print_error
 from platform_methods import detect_arch
 
 from typing import TYPE_CHECKING
@@ -293,16 +294,14 @@ def setup_msvc_manual(env: "SConsEnvironment"):
 
     env_arch = detect_build_env_arch()
     if env["arch"] != env_arch:
-        print(
-            """
-            Arch argument (%s) is not matching Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings) that is being used to run SCons (%s).
-            Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you.
-            """
+        print_error(
+            "Arch argument (%s) is not matching Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings) that is being used to run SCons (%s).\n"
+            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you."
             % (env["arch"], env_arch)
         )
-        sys.exit(200)
+        sys.exit(255)
 
-    print("Found MSVC, arch %s" % (env_arch))
+    print("Using VCVARS-determined MSVC, arch %s" % (env_arch))
 
 
 def setup_msvc_auto(env: "SConsEnvironment"):
@@ -338,7 +337,7 @@ def setup_msvc_auto(env: "SConsEnvironment"):
     env.Tool("mssdk")  # we want the MS SDK
 
     # Note: actual compiler version can be found in env['MSVC_VERSION'], e.g. "14.1" for VS2015
-    print("Found MSVC version %s, arch %s" % (env["MSVC_VERSION"], env["arch"]))
+    print("Using SCons-detected MSVC version %s, arch %s" % (env["MSVC_VERSION"], env["arch"]))
 
 
 def setup_mingw(env: "SConsEnvironment"):
@@ -346,32 +345,24 @@ def setup_mingw(env: "SConsEnvironment"):
 
     env_arch = detect_build_env_arch()
     if os.getenv("MSYSTEM") == "MSYS":
-        print(
-            """
-            Running from base MSYS2 console/environment, use target specific environment instead (e.g., mingw32, mingw64, clang32, clang64).
-            """
+        print_error(
+            "Running from base MSYS2 console/environment, use target specific environment instead (e.g., mingw32, mingw64, clang32, clang64)."
         )
-        sys.exit(201)
+        sys.exit(255)
 
     if env_arch != "" and env["arch"] != env_arch:
-        print(
-            """
-            Arch argument (%s) is not matching MSYS2 console/environment that is being used to run SCons (%s).
-            Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSYS2 compiler will be executed and inform you.
-            """
+        print_error(
+            "Arch argument (%s) is not matching MSYS2 console/environment that is being used to run SCons (%s).\n"
+            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSYS2 compiler will be executed and inform you."
             % (env["arch"], env_arch)
         )
-        sys.exit(202)
+        sys.exit(255)
 
     if not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
         "clang --version", env["mingw_prefix"], env["arch"]
     ):
-        print(
-            """
-            No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.
-            """
-        )
-        sys.exit(202)
+        print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
+        sys.exit(255)
 
     print("Using MinGW, arch %s" % (env["arch"]))
 
@@ -454,10 +445,10 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
         if os.getenv("WindowsSdkDir") is not None:
             env.Prepend(CPPPATH=[str(os.getenv("WindowsSdkDir")) + "/Include"])
         else:
-            print("Missing environment variable: WindowsSdkDir")
+            print_warning("Missing environment variable: WindowsSdkDir")
 
     if int(env["target_win_version"], 16) < 0x0601:
-        print("`target_win_version` should be 0x0601 or higher (Windows 7).")
+        print_error("`target_win_version` should be 0x0601 or higher (Windows 7).")
         sys.exit(255)
 
     env.AppendUnique(
@@ -515,10 +506,10 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
     if env["d3d12"]:
         # Check whether we have d3d12 dependencies installed.
         if not os.path.exists(env["mesa_libs"]):
-            print("The Direct3D 12 rendering driver requires dependencies to be installed.")
-            print(r"You can install them by running `python misc\scripts\install_d3d12_sdk_windows.py`.")
-            print("See the documentation for more information:")
-            print(
+            print_error(
+                "The Direct3D 12 rendering driver requires dependencies to be installed.\n"
+                "You can install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
+                "See the documentation for more information:\n\t"
                 "https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_windows.html"
             )
             sys.exit(255)
@@ -563,7 +554,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
         if os.getenv("WindowsSdkDir") is not None:
             env.Append(LIBPATH=[str(os.getenv("WindowsSdkDir")) + "/Lib"])
         else:
-            print("Missing environment variable: WindowsSdkDir")
+            print_warning("Missing environment variable: WindowsSdkDir")
 
     ## LTO
 
@@ -572,7 +563,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
 
     if env["lto"] != "none":
         if env["lto"] == "thin":
-            print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
+            print_error("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
             sys.exit(255)
         env.AppendUnique(CCFLAGS=["/GL"])
         env.AppendUnique(ARFLAGS=["/LTCG"])
@@ -690,7 +681,7 @@ def configure_mingw(env: "SConsEnvironment"):
     ## Compile flags
 
     if int(env["target_win_version"], 16) < 0x0601:
-        print("`target_win_version` should be 0x0601 or higher (Windows 7).")
+        print_error("`target_win_version` should be 0x0601 or higher (Windows 7).")
         sys.exit(255)
 
     if not env["use_llvm"]:
@@ -744,10 +735,10 @@ def configure_mingw(env: "SConsEnvironment"):
     if env["d3d12"]:
         # Check whether we have d3d12 dependencies installed.
         if not os.path.exists(env["mesa_libs"]):
-            print("The Direct3D 12 rendering driver requires dependencies to be installed.")
-            print(r"You can install them by running `python misc\scripts\install_d3d12_sdk_windows.py`.")
-            print("See the documentation for more information:")
-            print(
+            print_error(
+                "The Direct3D 12 rendering driver requires dependencies to be installed.\n"
+                "You can install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
+                "See the documentation for more information:\n\t"
                 "https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_windows.html"
             )
             sys.exit(255)
@@ -794,11 +785,11 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for Windows. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     # At this point the env has been set up with basic tools/compilers.
     env.Prepend(CPPPATH=["#platform/windows"])

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -39,8 +39,7 @@ def detect_arch():
         # Catches x86, i386, i486, i586, i686, etc.
         return "x86_32"
     else:
-        print("Unsupported CPU architecture: " + host_machine)
-        print("Falling back to x86_64.")
+        methods.print_warning(f'Unsupported CPU architecture: "{host_machine}". Falling back to x86_64.')
         return "x86_64"
 
 

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -3,6 +3,7 @@
 
 import glob, os
 import math
+from methods import print_error
 from pathlib import Path
 from os.path import normpath, basename
 
@@ -38,7 +39,7 @@ def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exc
     abs_folder = base_folder_path + folder + "/" + sub_folder
 
     if not os.path.isdir(abs_folder):
-        print("SCU: ERROR: %s not found." % abs_folder)
+        print_error(f'SCU: "{abs_folder}" not found.')
         return include_list, found_exceptions
 
     os.chdir(abs_folder)
@@ -70,7 +71,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
         # create
         os.mkdir(output_folder)
         if not os.path.isdir(output_folder):
-            print("SCU: ERROR: %s could not be created." % output_folder)
+            print_error(f'SCU: "{output_folder}" could not be created.')
             return
         if _verbose:
             print("SCU: Creating folder: %s" % output_folder)
@@ -104,7 +105,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
 def write_exception_output_file(file_count, exception_string, output_folder, output_filename_prefix, extension):
     output_folder = os.path.abspath(output_folder)
     if not os.path.isdir(output_folder):
-        print("SCU: ERROR: %s does not exist." % output_folder)
+        print_error(f"SCU: {output_folder} does not exist.")
         return
 
     file_text = exception_string + "\n"


### PR DESCRIPTION
This change adds the ability to substitute `print` with `methods.print_warning` or `methods.print_error`, prepending the messages with `WARNING: `/`ERROR: ` and colorizing them as yellow/red respectively. The messages will also be routed to `stderr` instead of `stdout`, allowing users to silence `stdout` without missing on any crucial information if a build fails or otherwise stops. non-atty environments won't benefit from colorization, but will still enjoy prefix & `stderr` benefits.
![24-04-26 13-22-39 Code](https://github.com/godotengine/godot/assets/17489292/22bc0f5b-5cf0-464f-b526-786c5e03ccae)

**EDIT:** Supersedes #88074

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/9291