### PR TITLE
[EditorSettings/SceneTabs] Add option to restore only active tab.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -792,9 +792,12 @@
 		<member name="interface/scene_tabs/maximum_width" type="int" setter="" getter="">
 			The maximum width of each scene tab at the top editor (in pixels).
 		</member>
-		<member name="interface/scene_tabs/restore_scenes_on_load" type="bool" setter="" getter="">
-			If [code]true[/code], when a project is loaded, restores scenes that were opened on the last editor session.
-			[b]Note:[/b] With many opened scenes, the editor may take longer to become usable. If starting the editor quickly is necessary, consider setting this to [code]false[/code].
+		<member name="interface/scene_tabs/restore_scenes_on_load" type="int" setter="" getter="">
+			Determines whether and how to restore scenes that were open during the previous editor session.
+			If set to [code]all[/code], when a project is loaded the editor will restore all scenes that were open when the editor was last closed.
+			If set to [code]active tab[/code], only the single scene from the previous editor session's active tab will be restored.
+			If set to [code]none[/code], no scenes from the previous session will automatically be restored.
+			[b]Note:[/b] With many opened scenes, the editor may take longer to become usable. If starting the editor quickly is necessary, consider setting this to [code]active tab[/code] or [code]none[/code].
 		</member>
 		<member name="interface/scene_tabs/show_script_button" type="bool" setter="" getter="">
 			If [code]true[/code], show a button next to each scene tab that opens the scene's "dominant" script when clicked. The "dominant" script is the one that is at the highest level in the scene's hierarchy.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5037,7 +5037,9 @@ void EditorNode::_load_central_editor_layout_from_config(Ref<ConfigFile> p_confi
 }
 
 void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
-	if (!bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
+	const SessionRestorePolicy policy = SessionRestorePolicy(int(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load")));
+
+	if (policy == RESTORE_NONE) {
 		return;
 	}
 
@@ -5048,14 +5050,24 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 
 	restoring_scenes = true;
 
-	PackedStringArray scenes = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
-	for (int i = 0; i < scenes.size(); i++) {
-		load_scene(scenes[i]);
-	}
+	const PackedStringArray scenes = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
+	const bool has_current_scene = p_layout->has_section_key(EDITOR_NODE_CONFIG_SECTION, "current_scene");
+	const String current_scene = has_current_scene ? p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene") : "";
 
-	if (p_layout->has_section_key(EDITOR_NODE_CONFIG_SECTION, "current_scene")) {
-		String current_scene = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene");
-		int current_scene_idx = scenes.find(current_scene);
+	if (policy == RESTORE_ACTIVE && has_current_scene) {
+		load_scene(current_scene);
+	} else { // RESTORE_ALL
+		int current_scene_idx = -1;
+		for (int i = 0; i < scenes.size(); i++) {
+			const bool is_current_scene = has_current_scene && current_scene == scenes[i];
+
+			load_scene(scenes[i]);
+
+			if (is_current_scene) {
+				current_scene_idx = i;
+			}
+		}
+
 		if (current_scene_idx >= 0) {
 			_set_current_scene(current_scene_idx);
 		}
@@ -5067,7 +5079,7 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 }
 
 bool EditorNode::has_scenes_in_session() {
-	if (!bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
+	if (int(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load")) == RESTORE_NONE) {
 		return false;
 	}
 	Ref<ConfigFile> config;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -247,6 +247,13 @@ private:
 		MAX_BUILD_CALLBACKS = 128
 	};
 
+	enum SessionRestorePolicy {
+		RESTORE_NONE,
+		RESTORE_ACTIVE,
+		RESTORE_ALL,
+		NUM_RESTORE
+	};
+
 	struct ExportDefer {
 		String preset;
 		String path;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -531,7 +531,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "interface/scene_tabs/maximum_width", 350, "0,9999,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("interface/scene_tabs/show_script_button", false);
-	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/scene_tabs/restore_scenes_on_load", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/scene_tabs/restore_scenes_on_load", 2, "None,Active Tab,All", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Multi Window
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/multi_window/enable", true, "");


### PR DESCRIPTION
Hi there!

This pull request implements a small editor feature to _restore only the active tab from the previous session_, thus changing the editor setting for property `interface/scene_tabs/restore_scenes_on_load` from a simple boolean to a drop down menu with possible values of `None`, `Active Tab`, and `All`.

- `All` restores _all scenes that were open_ in the previous session. (_default_; same behavior as old `TRUE` value)
- `Active Tab` restores _only the scene that was active_ when the previous session was exited.
- `None` doesn't restore anything from the previous session and simply loads the project's _main scene_, if available. (same behavior as old `FALSE` value) 

_(META: As I'm trying to upstream a small patch that I wrote for myself, I haven't written any corresponding proposal in the godot-proposals repo. This is my first Godot PR, so I don't know if a proposal is needed for a patch like this. If so, just let me know and I can go and write one retroactively.)_

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9608*
* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/4197*