### PR TITLE
Fix documentation typo that flipped the description of `window_set_max_size` and `window_set_min_size`

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1602,7 +1602,7 @@
 			<param index="0" name="max_size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the maximum size of the window specified by [param window_id] in pixels. Normally, the user will not be able to drag the window to make it smaller than the specified size. See also [method window_get_max_size].
+				Sets the maximum size of the window specified by [param window_id] in pixels. Normally, the user will not be able to drag the window to make it larger than the specified size. See also [method window_get_max_size].
 				[b]Note:[/b] It's recommended to change this value using [member Window.max_size] instead.
 				[b]Note:[/b] Using third-party tools, it is possible for users to disable window geometry restrictions and therefore bypass this limit.
 			</description>
@@ -1612,7 +1612,7 @@
 			<param index="0" name="min_size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the minimum size for the given window to [param min_size] (in pixels). Normally, the user will not be able to drag the window to make it larger than the specified size. See also [method window_get_min_size].
+				Sets the minimum size for the given window to [param min_size] in pixels. Normally, the user will not be able to drag the window to make it smaller than the specified size. See also [method window_get_min_size].
 				[b]Note:[/b] It's recommended to change this value using [member Window.min_size] instead.
 				[b]Note:[/b] By default, the main window has a minimum size of [code]Vector2i(64, 64)[/code]. This prevents issues that can arise when the window is resized to a near-zero size.
 				[b]Note:[/b] Using third-party tools, it is possible for users to disable window geometry restrictions and therefore bypass this limit.


### PR DESCRIPTION
doc fix typo that flipped the description of window_set_max_size and window_set_min_size

The documentation had the "smaller/larger" words in the descriptions of "window_set_max_size" and "window_set_min_size" flipped.

Old window_set_max_size description:

> window_set_max_size:
> Sets the maximum size of the window specified by [param window_id] in pixels. Normally, the user will not be able to drag the window to make it **smaller** than the specified size. See also [method window_get_max_size].

The function "window_set_max_size" sets the maximum size of the window, if you set this to 640x480, you can then not drag your window to be larger than 640x480. You can still drag your window to be smaller.

And vice versa for "window_set_max_size".
