### PR TITLE
Improve Audio Bus button pressed state visibility

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -87,9 +87,14 @@ void EditorAudioBus::_notification(int p_what) {
 
 			disabled_vu = get_editor_theme_icon(SNAME("BusVuFrozen"));
 
-			Color solo_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.89, 0.22) : Color(1.0, 0.92, 0.44);
-			Color mute_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(1.0, 0.44, 0.44);
-			Color bypass_color = EditorThemeManager::is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(0.44, 0.87, 1.0);
+			Color solo_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.89, 0.22) : Color(1.9, 1.74, 0.83);
+			Color mute_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(2.35, 1.03, 1.03);
+			Color bypass_color = EditorThemeManager::is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(1.03, 2.04, 2.35);
+			float darkening_factor = EditorThemeManager::is_dark_theme() ? 0.15 : 0.65;
+
+			Ref<StyleBoxFlat>(solo->get_theme_stylebox("pressed"))->set_border_color(solo_color.darkened(darkening_factor));
+			Ref<StyleBoxFlat>(mute->get_theme_stylebox("pressed"))->set_border_color(mute_color.darkened(darkening_factor));
+			Ref<StyleBoxFlat>(bypass->get_theme_stylebox("pressed"))->set_border_color(bypass_color.darkened(darkening_factor));
 
 			solo->set_icon(get_editor_theme_icon(SNAME("AudioBusSolo")));
 			solo->add_theme_color_override("icon_pressed_color", solo_color);
@@ -835,7 +840,13 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 		child->add_theme_style_override("normal", sbempty);
 		child->add_theme_style_override("hover", sbempty);
 		child->add_theme_style_override("focus", sbempty);
-		child->add_theme_style_override("pressed", sbempty);
+
+		Ref<StyleBoxFlat> sbflat = memnew(StyleBoxFlat);
+		sbflat->set_content_margin_all(0);
+		sbflat->set_bg_color(Color(1, 1, 1, 0));
+		sbflat->set_border_width(Side::SIDE_BOTTOM, Math::round(3 * EDSCALE));
+		child->add_theme_style_override("pressed", sbflat);
+
 		child->end_bulk_theme_override();
 	}
 


### PR DESCRIPTION
Light theme audio bus buttons have an issue where I believe thanks to how the icons are loaded, they're much darker by default, which means it's a lot more difficult to modulate them into being bright colors like it would be on dark themes. This caused me (and probably other users, I'm sure) to accidentally click "solo" on a bus and I being unable to figure out why audio wasn't working for a while since at a glance I could not distinguish the button's pressed state.

This PR addresses that by adding a colored underline to the buttons which keeps them as compact as before but allows you to tell at a glance which buses are solo/muted/bypassed.

Before & After comparison:
![bus_icons_before_and_after](https://github.com/godotengine/godot/assets/138269/e57f7df2-8fd5-4689-bcc5-803e357d2fe6)

The worst offender:
![imperceptible](https://github.com/godotengine/godot/assets/138269/080c9724-b1ae-4b00-8be5-b16b7dcce0c2)
