### PR TITLE
Make adding track process to set interpolation type on creating RESET

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4485,6 +4485,7 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 			if (p_id.type == Animation::TYPE_VALUE) {
 				undo_redo->add_do_method(reset_anim, "value_track_set_update_mode", p_next_tracks.reset, update_mode);
 			}
+			undo_redo->add_do_method(reset_anim, "track_set_interpolation_type", p_next_tracks.reset, interp_type);
 			undo_redo->add_do_method(reset_anim, "track_insert_key", p_next_tracks.reset, 0.0f, value);
 			undo_redo->add_undo_method(reset_anim, "remove_track", reset_anim->get_track_count());
 			p_next_tracks.reset++;


### PR DESCRIPTION
When creating the RESET track by key insertion, the angle property defaults to `Linear Angle` at some point, but when creating the RESET track, the interpolation_type setting is lacking, so the warning is always generated due to those discrepancies. Fix them to match.

![image](https://github.com/godotengine/godot/assets/61938263/c6311c4f-2e42-4f11-9f93-187db8b2f339)
