### PR TITLE
Add text to icon-only interpolation OptionButton in blend space editor

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -583,9 +583,9 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 			snap->set_icon(get_editor_theme_icon(SNAME("SnapGrid")));
 			open_editor->set_icon(get_editor_theme_icon(SNAME("Edit")));
 			interpolation->clear();
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), "", 0);
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), "", 1);
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), "", 2);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
 		} break;
 
 		case NOTIFICATION_PROCESS: {

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -807,9 +807,9 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			open_editor->set_icon(get_editor_theme_icon(SNAME("Edit")));
 			auto_triangles->set_icon(get_editor_theme_icon(SNAME("AutoTriangle")));
 			interpolation->clear();
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), "", 0);
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), "", 1);
-			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), "", 2);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
+			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
 		} break;
 
 		case NOTIFICATION_PROCESS: {


### PR DESCRIPTION


<table><tr><th>Before</th><td>

![before](https://github.com/godotengine/godot/assets/372476/44200f09-c1b2-4371-97fc-bda419c4a183)
</td></tr><tr><th>After</th><td>

![after](https://github.com/godotengine/godot/assets/372476/79ebd656-f7cb-4c8c-b49f-66bedc233579)
</td></tr></table>