### PR TITLE
Add `DRAW_FOCUS_PRESSED` to facilitate `font_focus_pressed_color` on Button

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -120,6 +120,9 @@
 		<constant name="DRAW_HOVER_PRESSED" value="4" enum="DrawMode">
 			The state of buttons are both hovered and pressed.
 		</constant>
+		<constant name="DRAW_FOCUS_PRESSED" value="5" enum="DrawMode">
+			The state of buttons are both focused and pressed.
+		</constant>
 		<constant name="ACTION_MODE_BUTTON_PRESS" value="0" enum="ActionMode">
 			Require just a press to consider the button clicked.
 		</constant>

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -88,6 +88,9 @@
 		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
 			Text [Color] used when the [Button] is focused. Only replaces the normal text color of the button. Disabled, hovered, and pressed states take precedence over this color.
 		</theme_item>
+		<theme_item name="font_focus_pressed_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
+			Text [Color] used when the [Button] is both focused and pressed.
+		</theme_item>
 		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -284,6 +284,9 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 		}
 
 		if (pressing) {
+			if (has_focus()) {
+				return DRAW_FOCUS_PRESSED;
+			}
 			return DRAW_PRESSED;
 		} else {
 			return DRAW_NORMAL;
@@ -493,6 +496,7 @@ void BaseButton::_bind_methods() {
 	BIND_ENUM_CONSTANT(DRAW_HOVER);
 	BIND_ENUM_CONSTANT(DRAW_DISABLED);
 	BIND_ENUM_CONSTANT(DRAW_HOVER_PRESSED);
+	BIND_ENUM_CONSTANT(DRAW_FOCUS_PRESSED);
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -98,6 +98,7 @@ public:
 		DRAW_HOVER,
 		DRAW_DISABLED,
 		DRAW_HOVER_PRESSED,
+		DRAW_FOCUS_PRESSED,
 	};
 
 	DrawMode get_draw_mode() const;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -75,6 +75,7 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 			}
 		}
 			[[fallthrough]];
+		case DRAW_FOCUS_PRESSED:
 		case DRAW_PRESSED: {
 			if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
 				stylebox = theme_cache.pressed_mirrored;
@@ -219,6 +220,17 @@ void Button::_notification(int p_what) {
 						if (has_theme_color(SNAME("icon_normal_color"))) {
 							icon_modulate_color = theme_cache.icon_normal_color;
 						}
+					}
+				} break;
+				case DRAW_FOCUS_PRESSED: {
+					// Edge case for CheckButton and CheckBox.
+					if (has_theme_color(SNAME("font_focus_pressed_color"))) {
+						font_color = theme_cache.font_focus_pressed_color;
+					} else {
+						font_color = theme_cache.font_color;
+					}
+					if (has_theme_color(SNAME("icon_pressed_color"))) {
+						icon_modulate_color = theme_cache.icon_pressed_color;
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
@@ -739,6 +751,7 @@ void Button::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_pressed_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_hover_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_hover_pressed_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_focus_pressed_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_disabled_color);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT, Button, font);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -74,6 +74,7 @@ private:
 		Color font_pressed_color;
 		Color font_hover_color;
 		Color font_hover_pressed_color;
+		Color font_focus_pressed_color;
 		Color font_disabled_color;
 
 		Ref<Font> font;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -181,6 +181,7 @@ void LinkButton::_notification(int p_what) {
 
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 				} break;
+				case DRAW_FOCUS_PRESSED:
 				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
 					if (has_theme_color(SNAME("font_pressed_color"))) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -95,6 +95,7 @@ void OptionButton::_notification(int p_what) {
 			Color clr = Color(1, 1, 1);
 			if (theme_cache.modulate_arrow) {
 				switch (get_draw_mode()) {
+					case DRAW_FOCUS_PRESSED:
 					case DRAW_PRESSED:
 						clr = theme_cache.font_pressed_color;
 						break;

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -131,6 +131,7 @@ void TextureButton::_notification(int p_what) {
 						texdraw = normal;
 					}
 				} break;
+				case DRAW_FOCUS_PRESSED:
 				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
 					if (pressed.is_null()) {

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -173,6 +173,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_hover_color", "Button", control_font_hover_color);
 	theme->set_color("font_focus_color", "Button", control_font_focus_color);
 	theme->set_color("font_hover_pressed_color", "Button", control_font_pressed_color);
+	theme->set_color("font_focus_pressed_color", "Button", control_font_focus_color);
 	theme->set_color("font_disabled_color", "Button", control_font_disabled_color);
 	theme->set_color("font_outline_color", "Button", Color(0, 0, 0));
 


### PR DESCRIPTION
Proposal with more context https://github.com/godotengine/godot-proposals/issues/9650

# Background

While implementing controller support to the UI in my game, I noticed buttons have a special color `font_hover_pressed_color` but no equivalent for focus. This means that mouse will be able to get a special color while the controller will not for its primary "hover/selected" state. This seems to be particularly used for CheckBox and CheckButton. This PR attempts to add `font_focus_pressed_color` to allow consistent font color styling behavior between mouse and controller

# Questions
- Should this PR also add a stylebox for `focus_pressed` akin to the existing `hover_pressed`?
- Should this PR also add an icon color for `icon_hover_focus_color` akin to the existing `icon_hover_pressed_color`?
- Is there anything else I need to add for this PR to be considered for merge?
- It did not seem that there are existing button tests, happy to add if needed and with guidance
  - Started this in https://github.com/godotengine/godot/pull/91255
- I had to update LinkButton, TextureButton, and OptionButton to get CI test suite passing, should there be further updates here?

# Screenshots
### Problem in 4.2
![2024_04_27_0](https://github.com/godotengine/godot/assets/5893112/5b18d7e9-97ab-402b-8cd6-c3a08381cd5b)
The first part of the gif is using the controller when the checkbox is pressed and has focus, it remains yellow. The second part of the gif is using the mouse when the checkbox is pressed and has hover, it is red

### Fixed with this PR
![2024_04_27_1](https://github.com/godotengine/godot/assets/5893112/3d8d5740-b9e7-48df-acd3-762c5efbd15a)
The first part of the gif is using the controller when the checkbox is pressed and has focus, it is orange, when pressed and not focused it is yellow. The second part of the gif is using the mouse when the checkbox is pressed and has hover it is red, when not hovered it is yellow

### Theme
![image](https://github.com/godotengine/godot/assets/5893112/21f6fb66-4a3b-463b-83ee-eedf5e9f13e6)

# Demo project
[ButtonFocusPressed.zip](https://github.com/godotengine/godot/files/15136929/ButtonFocusPressed.zip)
