### PR TITLE
Don't call `ReleaseCapture` unless the (godot) window is actually capturing mouse input

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4488,7 +4488,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					}
 				} else {
 					if (--pressrc <= 0 || last_button_state.is_empty()) {
-						if (mouse_mode != MOUSE_MODE_CAPTURED) {
+						if (mouse_mode != MOUSE_MODE_CAPTURED && GetCapture() == hWnd) {
 							ReleaseCapture();
 						}
 						pressrc = 0;


### PR DESCRIPTION
Currently godot will call `ReleaseCapture` whenever it receives a mouse button up event. This can cause issues if godot is not currently the one actually holding mouse capture. Ie being the Window that last called `SetCapture` as this will apparently globally release the mouse capture state. This PR addresses this by adding a check that the window that receives the mouse button up message is actually the one that is currently capturing mouse input before calling `ReleaseCapture`.