### PR TITLE
Add animation_paused property to TileMapLayer

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -123,7 +123,7 @@ public:
 	void set_rendering_quadrant_size(int p_size);
 	int get_rendering_quadrant_size() const;
 
-	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr, real_t p_normalized_animation_offset = 0.0);
+	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr, real_t p_normalized_animation_offset = 0.0, bool p_animation_paused = false);
 
 	// Accessors.
 	void set_tileset(const Ref<TileSet> &p_tileset);
@@ -151,6 +151,8 @@ public:
 	bool is_layer_navigation_enabled(int p_layer) const;
 	void set_layer_navigation_map(int p_layer, RID p_map);
 	RID get_layer_navigation_map(int p_layer) const;
+	void set_layer_animation_paused(int p_layer, bool p_animation_paused);
+	bool is_layer_animation_paused(int p_layer) const;
 
 	void set_collision_animatable(bool p_collision_animatable);
 	bool is_collision_animatable() const;

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -342,7 +342,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 					}
 
 					// Drawing the tile in the canvas item.
-					TileMap::draw_tile(ci, local_tile_pos - rendering_quadrant->canvas_items_position, tile_set, cell_data.cell.source_id, cell_data.cell.get_atlas_coords(), cell_data.cell.alternative_tile, -1, get_self_modulate(), tile_data, random_animation_offset);
+					TileMap::draw_tile(ci, local_tile_pos - rendering_quadrant->canvas_items_position, tile_set, cell_data.cell.source_id, cell_data.cell.get_atlas_coords(), cell_data.cell.alternative_tile, -1, get_self_modulate(), tile_data, random_animation_offset, animation_paused);
 				}
 
 				// Reset physics interpolation for any recreated canvas items.
@@ -1788,6 +1788,8 @@ void TileMapLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &TileMapLayer::get_navigation_map);
 	ClassDB::bind_method(D_METHOD("set_navigation_visibility_mode", "show_navigation"), &TileMapLayer::set_navigation_visibility_mode);
 	ClassDB::bind_method(D_METHOD("get_navigation_visibility_mode"), &TileMapLayer::get_navigation_visibility_mode);
+	ClassDB::bind_method(D_METHOD("set_animation_paused", "enabled"), &TileMapLayer::set_animation_paused);
+	ClassDB::bind_method(D_METHOD("is_animation_paused"), &TileMapLayer::is_animation_paused);
 
 	GDVIRTUAL_BIND(_use_tile_data_runtime_update, "coords");
 	GDVIRTUAL_BIND(_tile_data_runtime_update, "coords", "tile_data");
@@ -1806,6 +1808,7 @@ void TileMapLayer::_bind_methods() {
 	ADD_GROUP("Navigation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "navigation_enabled"), "set_navigation_enabled", "is_navigation_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_visibility_mode", PROPERTY_HINT_ENUM, "Default,Force Show,Force Hide"), "set_navigation_visibility_mode", "get_navigation_visibility_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "animation_paused"), "set_animation_paused", "is_animation_paused");
 
 	ADD_SIGNAL(MethodInfo(CoreStringNames::get_singleton()->changed));
 
@@ -2826,6 +2829,20 @@ void TileMapLayer::set_navigation_visibility_mode(TileMapLayer::DebugVisibilityM
 
 TileMapLayer::DebugVisibilityMode TileMapLayer::get_navigation_visibility_mode() const {
 	return navigation_visibility_mode;
+}
+
+void TileMapLayer::set_animation_paused(bool p_animation_paused) {
+	if (animation_paused == p_animation_paused) {
+		return;
+	}
+	animation_paused = p_animation_paused;
+	dirty.flags[DIRTY_FLAGS_TILE_SET] = true;
+	_queue_internal_update();
+	emit_signal(CoreStringNames::get_singleton()->changed);
+}
+
+bool TileMapLayer::is_animation_paused() const {
+	return animation_paused;
 }
 
 TileMapLayer::TileMapLayer() {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -288,6 +288,8 @@ private:
 	RID navigation_map_override;
 	DebugVisibilityMode navigation_visibility_mode = DEBUG_VISIBILITY_MODE_DEFAULT;
 
+	bool animation_paused = false;
+
 	// Internal.
 	bool pending_update = false;
 
@@ -484,6 +486,9 @@ public:
 	RID get_navigation_map() const;
 	void set_navigation_visibility_mode(DebugVisibilityMode p_show_navigation);
 	DebugVisibilityMode get_navigation_visibility_mode() const;
+
+	void set_animation_paused(bool p_animation_paused);
+	bool is_animation_paused() const;
 
 	TileMapLayer();
 	~TileMapLayer();


### PR DESCRIPTION
This is an attempt to provide a workaround for issue #44625. It isn't perfect though. Since the rendering server controls the animation like a black box, changing the speed or frame duration in runtime will jump frames. I'm changing speed and frame duration, thus paused animations will show the first frame and when resuming will jump to the frame they would have been playing if not paused.

Some way of controlling the animation in the rendering server would be needed, or maybe doing the animation outside of the rendering server. I would like to do something else but I don't know better for now.

It's missing the documentation.

Workaround for #44625.

Doesn't fix () #41582 but could help.