### PR TITLE
Cancel tooltip if no control is hovered

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1956,6 +1956,11 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			if (stopped) {
 				set_input_as_handled();
 			}
+		} else {
+			// No control under mouse.
+			if (gui.tooltip_popup) {
+				_gui_cancel_tooltip();
+			}
 		}
 
 		if (gui.dragging) {


### PR DESCRIPTION
Currently tooltips can get stuck if you move your mouse fast enough such that it doesnt hover any control after the tooltip has opened. This PR addresses the issue by always destroying the tooltip if no control is currently hovered