### PR TITLE
[HTTPRequest] Add Missing Redirect Status Codes

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -231,6 +231,22 @@ Error HTTPRequest::_get_redirect_headers(Vector<String> *r_headers) {
 	return OK;
 }
 
+bool HTTPRequest::_is_automatic_redirect() const {
+	if (unlikely(method == HTTPClient::METHOD_CONNECT)) {
+		// Never automatically redirect CONNECT requests.
+		return false;
+	} else if (response_code == 301 || response_code == 302 || response_code == 303 || response_code == 305) {
+		// We change unsafe methods to GET for 301, 302, and 303, so these are always redirected.
+		// 305 is deprecated and treated as equivalent to 302.
+		return true;
+	} else if ((response_code == 307 || response_code == 308) && _is_method_safe()) {
+		// We only automatically redirect for safe methods on method-preserving status codes.
+		return true;
+	} else {
+		return false;
+	}
+}
+
 bool HTTPRequest::_handle_response(bool *ret_value) {
 	if (!client->has_response()) {
 		_defer_done(RESULT_NO_RESPONSE, 0, PackedStringArray(), PackedByteArray());
@@ -251,8 +267,8 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 		response_headers.push_back(E);
 	}
 
-	if (response_code == 301 || response_code == 302) {
-		// Handle redirect.
+	if (_is_automatic_redirect()) {
+		// Follow redirect.
 
 		if (max_redirects >= 0 && redirections >= max_redirects) {
 			_defer_done(RESULT_REDIRECT_LIMIT_REACHED, response_code, response_headers, PackedByteArray());

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -105,6 +105,7 @@ private:
 	bool _is_content_header(const String &p_header) const;
 	bool _is_method_safe() const;
 	Error _get_redirect_headers(Vector<String> *r_headers);
+	bool _is_automatic_redirect() const;
 
 	bool _handle_response(bool *ret_value);
 


### PR DESCRIPTION
Fix #90160

The HTTPRequest node only handled 301 and 302 redirects. This adds redirect handling for 303, 305, 307, and 308.

300 and 304 are not handled since they always require client intervention.

301, 302, and 303 status codes are always automatically redirected since those codes are not method preserving, so we change any unsafe methods to GET before redirecting with these codes per
[rfc9110](https://www.rfc-editor.org/rfc/rfc9110#section-15.4-2.4).

The method changing behavior for these codes is implemented in #91199, so it is not included in this commit, but the changes introduced in this commit do not conflict with the changes in #91199.

Status code 305 USE PROXY is deprecated, so we are treating it as a synonym of 302.

For 307 and 308, these are method-preserving responses, so we cannot change an unsafe method to GET. For this reason, we do not follow the redirect if the method is unsafe. 307 and 308 responses will only be automatically followed if they use GET, HEAD, OPTIONS, or TRACE.

Lastly, redirects on CONNECT requests that result in a 3xx status code are never automatically followed. CONNECT is an unsafe method, and it makes no sense to change it to a GET request, so we simply don't follow redirects on CONNECT and the client will have to handle the redirect manually.

We don't currently have a way to write unit tests for network requests see: https://github.com/godotengine/godot-proposals/issues/9581, so I am using the following caddy server config and gdscript test project to test these changes locally:

Caddyfile
<details>

```
{
	http_port 8000
}


localhost:8000 {

	@get method GET
	@head method HEAD
	@options method OPTIONS
	@trace method TRACE

	@post method POST

	@no-content-location header !Content-Location

	redir /301-basic /redirected-from-301 301
	redir /302-basic /redirected-from-302 302
	redir /303-basic /redirected-from-303 303
	redir /304-basic /redirected-from-304 304
	redir /305-basic /redirected-from-305 305
	redir /307-basic /redirected-from-307 307
	redir /308-basic /redirected-from-308 308

	respond /redirected-from-301 200 {
		body "Redirected from 301 basic response"
	}

	respond /redirected-from-302 200 {
		body "Redirected from 302 basic response"
	}

	respond /redirected-from-303 200 {
		body "Redirected from 303 basic response"
	}

	respond /redirected-from-305 200 {
		body "Redirected from 305 basic response"
	}

	respond /redirected-from-307 200 {
		body "Redirected from 307 basic response"
	}

	respond /redirected-from-308 200 {
		body "Redirected from 308 basic response"
	}

	redir /301-converts-method-to-get /redirected-from-301-get-only 301

	handle /redirected-from-301-get-only {
		respond @get 200 {
			body "Redirected from 301 method converted to GET"
		}
	}

	redir /302-converts-method-to-get /redirected-from-302-get-only 302

	handle /redirected-from-302-get-only {
		respond @get 200 {
			body "Redirected from 302 method converted to GET"
		}
	}

	redir /303-converts-method-to-get /redirected-from-303-get-only 303

	handle /redirected-from-303-get-only {
		respond @get 200 {
			body "Redirected from 303 method converted to GET"
		}
	}

	redir /305-converts-method-to-get /redirected-from-305-get-only 305

	handle /redirected-from-305-get-only {
		respond @get 200 {
			body "Redirected from 305 method converted to GET"
		}
	}



	redir /301-strips-headers /stripped-headers 301
	redir /302-strips-headers /stripped-headers 302
	redir /303-strips-headers /stripped-headers 303
	redir /305-strips-headers /stripped-headers 305

	handle /stripped-headers {
		respond @no-content-location 200 {
			body "Redirected with headers stripped"
		}
	}

	handle /307-automatic {
		redir @get /redirected-from-307-get 307
		redir @head /redirected-from-307-head 307
		redir @options /redirected-from-307-options 307
		redir @trace /redirected-from-307-trace 307
	}

	handle /redirected-from-307-get {
		respond @get 200 {
			body "Redirected from 307 automatic with GET"
		}
	}

	handle /redirected-from-307-head {
		respond @head 200 {
			body "Redirected from 307 automatic with HEAD"
		}
	}

	handle /redirected-from-307-options {
		respond @options 200 {
			body "Redirected from 307 automatic with OPTIONS"
		}
	}

	handle /redirected-from-307-trace {
		respond @trace 200 {
			body "Redirected from 307 automatic with TRACE"
		}
	}

	handle /308-automatic {
		redir @get /redirected-from-308-get 308
		redir @head /redirected-from-308-head 308
		redir @options /redirected-from-308-options 308
		redir @trace /redirected-from-308-trace 308
	}

	handle /redirected-from-308-get {
		respond @get 200 {
			body "Redirected from 308 automatic with GET"
		}
	}

	handle /redirected-from-308-head {
		respond @head 200 {
			body "Redirected from 308 automatic with HEAD"
		}
	}

	handle /redirected-from-308-options {
		respond @options 200 {
			body "Redirected from 308 automatic with OPTIONS"
		}
	}

	handle /redirected-from-308-trace {
		respond @trace 200 {
			body "Redirected from 308 automatic with TRACE"
		}
	}
}
```

GDScript test project:
```
extends Node

var req: HTTPRequest = HTTPRequest.new()
var REQUESTING: bool = false
var test_count: int = 0

func _ready() -> void:
    add_child(req)

func _process(delta):
    if REQUESTING:
        return
    if test_count >= test_cases.size():
        set_process(false)
        return
    var prev_test = test_cases[test_count - 1]
    if prev_test != null:
        if req.request_completed.is_connected(prev_test.callback):
            req.request_completed.disconnect(prev_test.callback)
    var curr_test = test_cases[test_count]
    print("Test ", curr_test.callback.get_method(), "...")
    if not req.request_completed.is_connected(curr_test.callback):
        req.request_completed.connect(curr_test.callback)
    req.request(curr_test.url, curr_test.headers, curr_test.method)
    REQUESTING = true
    test_count += 1


var test_cases = [
    {
        "url": "http://localhost:8000/301-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_301_basic_get,
    },
    {
        "url": "http://localhost:8000/301-basic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_301_basic_head,
    },
    {
        "url": "http://localhost:8000/301-basic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_301_basic_options,
    },
    {
        "url": "http://localhost:8000/301-basic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_301_basic_trace,
    },
    # {
    #     "url": "http://localhost:8000/301-converts-method-to-get",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": [],
    #     "callback": self.redirect_301_converts_post_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/301-converts-method-to-get",
    #     "method": HTTPClient.METHOD_PUT,
    #     "headers": [],
    #     "callback": self.redirect_301_converts_put_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/301-converts-method-to-get",
    #     "method": HTTPClient.METHOD_DELETE,
    #     "headers": [],
    #     "callback": self.redirect_301_converts_delete_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/301-strips-headers",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": ["Content-Location: /some-location"],
    #     "callback": self.redirect_headers_stripped,
    # },
    {
        "url": "http://localhost:8000/302-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_302_basic_get,
    },
    {
        "url": "http://localhost:8000/302-basic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_302_basic_head,
    },
    {
        "url": "http://localhost:8000/302-basic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_302_basic_options,
    },
    {
        "url": "http://localhost:8000/302-basic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_302_basic_trace,
    },
    # {
    #     "url": "http://localhost:8000/302-converts-method-to-get",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": [],
    #     "callback": self.redirect_302_converts_post_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/302-converts-method-to-get",
    #     "method": HTTPClient.METHOD_PUT,
    #     "headers": [],
    #     "callback": self.redirect_302_converts_put_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/302-converts-method-to-get",
    #     "method": HTTPClient.METHOD_DELETE,
    #     "headers": [],
    #     "callback": self.redirect_302_converts_delete_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/302-strips-headers",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": ["Content-Location: /some-location"],
    #     "callback": self.redirect_headers_stripped,
    # },
    {
        "url": "http://localhost:8000/303-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_303_basic_get,
    },
    {
        "url": "http://localhost:8000/303-basic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_303_basic_head,
    },
    {
        "url": "http://localhost:8000/303-basic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_303_basic_options,
    },
    {
        "url": "http://localhost:8000/303-basic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_303_basic_trace,
    },
    # {
    #     "url": "http://localhost:8000/303-converts-method-to-get",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": [],
    #     "callback": self.redirect_303_converts_post_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/303-converts-method-to-get",
    #     "method": HTTPClient.METHOD_PUT,
    #     "headers": [],
    #     "callback": self.redirect_303_converts_put_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/303-converts-method-to-get",
    #     "method": HTTPClient.METHOD_DELETE,
    #     "headers": [],
    #     "callback": self.redirect_303_converts_delete_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/303-strips-headers",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": ["Content-Location: /some-location"],
    #     "callback": self.redirect_headers_stripped,
    # },
    {
        "url": "http://localhost:8000/304-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_304_not_automatic,
    },
    {
        "url": "http://localhost:8000/305-basic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_305_basic_get,
    },
    {
        "url": "http://localhost:8000/305-basic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_305_basic_head,
   },
    {
        "url": "http://localhost:8000/305-basic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_305_basic_options,
    },
    {
        "url": "http://localhost:8000/305-basic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_305_basic_trace,
    },
    # {
    #     "url": "http://localhost:8000/305-converts-method-to-get",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": [],
    #     "callback": self.redirect_305_converts_post_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/305-converts-method-to-get",
    #     "method": HTTPClient.METHOD_PUT,
    #     "headers": [],
    #     "callback": self.redirect_305_converts_put_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/305-converts-method-to-get",
    #     "method": HTTPClient.METHOD_DELETE,
    #     "headers": [],
    #     "callback": self.redirect_305_converts_delete_to_get,
    # },
    # {
    #     "url": "http://localhost:8000/305-strips-headers",
    #     "method": HTTPClient.METHOD_POST,
    #     "headers": ["Content-Location: /some-location"],
    #     "callback": self.redirect_headers_stripped,
    # },
    {
        "url": "http://localhost:8000/307-automatic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_307_automatic_get,
    },
    {
        "url": "http://localhost:8000/307-automatic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_307_automatic_head,
    },
    {
        "url": "http://localhost:8000/307-automatic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_307_automatic_options,
    },
    {
        "url": "http://localhost:8000/307-automatic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_307_automatic_trace,
    },
    {
        "url": "http://localhost:8000/307-basic",
        "method": HTTPClient.METHOD_POST,
        "headers": [],
        "callback": self.redirect_307_not_automatic_post,
    },
    {
        "url": "http://localhost:8000/307-basic",
        "method": HTTPClient.METHOD_PUT,
        "headers": [],
        "callback": self.redirect_307_not_automatic_put,
    },
    {
        "url": "http://localhost:8000/307-basic",
        "method": HTTPClient.METHOD_PATCH,
        "headers": [],
        "callback": self.redirect_307_not_automatic_patch,
    },
    {
        "url": "http://localhost:8000/307-basic",
        "method": HTTPClient.METHOD_DELETE,
        "headers": [],
        "callback": self.redirect_307_not_automatic_delete,
    },
    {
        "url": "http://localhost:8000/308-automatic",
        "method": HTTPClient.METHOD_GET,
        "headers": [],
        "callback": self.redirect_308_automatic_get,
    },
    {
        "url": "http://localhost:8000/308-automatic",
        "method": HTTPClient.METHOD_HEAD,
        "headers": [],
        "callback": self.redirect_308_automatic_head,
    },
    {
        "url": "http://localhost:8000/308-automatic",
        "method": HTTPClient.METHOD_OPTIONS,
        "headers": [],
        "callback": self.redirect_308_automatic_options,
    },
    {
        "url": "http://localhost:8000/308-automatic",
        "method": HTTPClient.METHOD_TRACE,
        "headers": [],
        "callback": self.redirect_308_automatic_trace,
    },
    {
        "url": "http://localhost:8000/308-basic",
        "method": HTTPClient.METHOD_POST,
        "headers": [],
        "callback": self.redirect_308_not_automatic_post,
    },
    {
        "url": "http://localhost:8000/308-basic",
        "method": HTTPClient.METHOD_PUT,
        "headers": [],
        "callback": self.redirect_308_not_automatic_put,
    },
    {
        "url": "http://localhost:8000/308-basic",
        "method": HTTPClient.METHOD_PATCH,
        "headers": [],
        "callback": self.redirect_308_not_automatic_patch,
    },
    {
        "url": "http://localhost:8000/308-basic",
        "method": HTTPClient.METHOD_DELETE,
        "headers": [],
        "callback": self.redirect_308_not_automatic_delete,
    },
]

func debug(result, response_code, headers, body):
    print("Result: ", result)
    print("Response Code: ", response_code)
    print("Headers: ", headers)
    print("body: ", body.get_string_from_utf8())

func redirect_301_basic_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 basic response", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false
    
func redirect_301_basic_head(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "Head should give no response body")
    print("Passed!")
    REQUESTING = false

func redirect_301_basic_options(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 basic response", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_basic_trace(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 basic response", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_converts_post_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_converts_put_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_301_converts_delete_to_get(result, response_code, headers, body):
    assert(result == 0, "301 should not error")
    assert(response_code == 200, "301 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 301 method converted to GET", "301 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_302_basic_get(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 basic response", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false
    
func redirect_302_basic_head(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "Head should give no response body")
    print("Passed!")
    REQUESTING = false

func redirect_302_basic_options(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 basic response", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_302_basic_trace(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 basic response", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_302_converts_post_to_get(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 method converted to GET", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_302_converts_put_to_get(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 method converted to GET", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_302_converts_delete_to_get(result, response_code, headers, body):
    assert(result == 0, "302 should not error")
    assert(response_code == 200, "302 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 302 method converted to GET", "302 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_303_basic_get(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 basic response", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false
    
func redirect_303_basic_head(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "Head should give no response body")
    print("Passed!")
    REQUESTING = false

func redirect_303_basic_options(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 basic response", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_303_basic_trace(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 basic response", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_303_converts_post_to_get(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 method converted to GET", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_303_converts_put_to_get(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 method converted to GET", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_303_converts_delete_to_get(result, response_code, headers, body):
    assert(result == 0, "303 should not error")
    assert(response_code == 200, "303 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 303 method converted to GET", "303 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_305_basic_get(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 basic response", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false
    
func redirect_305_basic_head(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "Head should give no response body")
    print("Passed!")
    REQUESTING = false

func redirect_305_basic_options(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 basic response", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_305_basic_trace(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 basic response", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_305_converts_post_to_get(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 method converted to GET", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_305_converts_put_to_get(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 method converted to GET", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_305_converts_delete_to_get(result, response_code, headers, body):
    assert(result == 0, "305 should not error")
    assert(response_code == 200, "305 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 305 method converted to GET", "305 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_headers_stripped(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 200, "Request should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected with headers stripped", "Request should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_304_not_automatic(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 304, "Request should not automatically redirect")
    print("Passed!")
    REQUESTING = false

func redirect_307_automatic_get(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 307 automatic with GET", "307 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_307_automatic_head(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "HEAD should give no response body")
    print("Passed!")
    REQUESTING = false

func redirect_307_automatic_options(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 307 automatic with OPTIONS", "307 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_307_automatic_trace(result, response_code, headers, body):
    assert(result == 0, "307 should not error")
    assert(response_code == 200, "307 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 307 automatic with TRACE", "307 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_307_not_automatic_post(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 307, "Request should not automatically redirect with POST")
    print("Passed!")
    REQUESTING = false

func redirect_307_not_automatic_put(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 307, "Request should not automatically redirect with PUT")
    print("Passed!")
    REQUESTING = false

func redirect_307_not_automatic_patch(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 307, "Request should not automatically redirect with PATCH")
    print("Passed!")
    REQUESTING = false

func redirect_307_not_automatic_delete(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 307, "Request should not automatically redirect with DELETE")
    print("Passed!")
    REQUESTING = false
func redirect_308_automatic_get(result, response_code, headers, body):
    assert(result == 0, "308 should not error")
    assert(response_code == 200, "308 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 308 automatic with GET", "308 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_308_automatic_head(result, response_code, headers, body):
    assert(result == 0, "308 should not error")
    assert(response_code == 200, "308 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "", "HEAD should have no response body")
    print("Passed!")
    REQUESTING = false

func redirect_308_automatic_options(result, response_code, headers, body):
    assert(result == 0, "308 should not error")
    assert(response_code == 200, "308 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 308 automatic with OPTIONS", "308 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_308_automatic_trace(result, response_code, headers, body):
    assert(result == 0, "308 should not error")
    assert(response_code == 200, "308 should give 200 after redirect")
    assert(body.get_string_from_utf8() == "Redirected from 308 automatic with TRACE", "308 should give response from redirected location body")
    print("Passed!")
    REQUESTING = false

func redirect_308_not_automatic_post(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 308, "Request should not automatically redirect with POST")
    print("Passed!")
    REQUESTING = false

func redirect_308_not_automatic_put(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 308, "Request should not automatically redirect with PUT")
    print("Passed!")
    REQUESTING = false

func redirect_308_not_automatic_patch(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 308, "Request should not automatically redirect with PATCH")
    print("Passed!")
    REQUESTING = false

func redirect_308_not_automatic_delete(result, response_code, headers, body):
    assert(result == 0, "Request should not error")
    assert(response_code == 308, "Request should not automatically redirect with DELETE")
    print("Passed!")
    REQUESTING = false
```

</details>

The commented out test cases are related to #91199. I tested them together to make sure that these changes didn't interfere with the changes in that PR, and everything works. :)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
