### PR TITLE
Fix help overview tooltip flicker

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1933,7 +1933,7 @@ void ScriptEditor::_update_members_overview_visibility() {
 	if (!se) {
 		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
-		overview_vbox->set_visible(false);
+		overview_vbox->set_visible(help_overview_enabled);
 		return;
 	}
 


### PR DESCRIPTION
Fixes the help overview tooltip flickering caused by `_tree_changed`, which was being triggered by `overview_vbox` being set to visible `false` and then back to `true ` if the help overview was enabled.

This change makes it so that we avoid changing hiding the overview vbox if we have the help overview enabled, preventing the `_tree_changed` signal from firing in the first place.

The bug:

https://github.com/godotengine/godot/assets/138269/db185a71-977d-4afd-a1c5-04c49c0f9d62

* _Bugsquad Edit:_ Fixes #91467.