### PR TITLE
Fix reparenting after hover delay

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -160,7 +160,6 @@ public:
 
 	void set_marked(const HashSet<Node *> &p_marked, bool p_selectable = true, bool p_children_selectable = true);
 	void set_marked(Node *p_marked, bool p_selectable = true, bool p_children_selectable = true);
-	bool has_marked() const { return !marked.is_empty(); }
 	void set_selected(Node *p_node, bool p_emit_selected = true);
 	Node *get_selected();
 	void set_can_rename(bool p_can_rename) { can_rename = p_can_rename; }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -239,8 +239,11 @@ class SceneTreeDock : public VBoxContainer {
 	void _inspect_hovered_node();
 	void _reset_hovering_timer();
 	Timer *inspect_hovered_node_delay = nullptr;
+	TreeItem *tree_item_inspected = nullptr;
 	Node *node_hovered_now = nullptr;
 	Node *node_hovered_previously = nullptr;
+	bool select_node_hovered_at_end_of_drag = false;
+	bool hovered_but_reparenting = false;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/91254
Also keep all nodes selected after reparenting and not just top level ones (before hover delay, because after it's the hovered/inspected node that should be the one selected)