### PR TITLE
Improve Remove Missing of project manager

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -32,7 +32,6 @@
 #define PROJECT_MANAGER_H
 
 #include "scene/gui/dialogs.h"
-#include "scene/gui/scroll_container.h"
 
 class CheckBox;
 class EditorAbout;
@@ -48,6 +47,7 @@ class PanelContainer;
 class ProjectDialog;
 class ProjectList;
 class QuickSettingsDialog;
+class RemoveMissingDialog;
 class RichTextLabel;
 class TabContainer;
 class VBoxContainer;
@@ -165,7 +165,7 @@ class ProjectManager : public Control {
 	// Comment out for now until we have a better warning system to
 	// ensure users delete their project only.
 	//CheckBox *delete_project_contents = nullptr;
-	ConfirmationDialog *erase_missing_ask = nullptr;
+	RemoveMissingDialog *remove_missing_dialog = nullptr;
 	ConfirmationDialog *multi_open_ask = nullptr;
 	ConfirmationDialog *multi_run_ask = nullptr;
 
@@ -184,7 +184,7 @@ class ProjectManager : public Control {
 	void _erase_project();
 	void _erase_missing_projects();
 	void _erase_project_confirm();
-	void _erase_missing_projects_confirm();
+	void _erase_missing_projects_confirm(const Vector<String> &p_paths);
 	void _update_project_buttons();
 
 	void _on_project_created(const String &dir);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -897,6 +897,16 @@ Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
 	return items;
 }
 
+Vector<String> ProjectList::get_missing_project_paths() const {
+	Vector<String> paths;
+	for (const Item &project : _projects) {
+		if (project.missing) {
+			paths.push_back(project.path);
+		}
+	}
+	return paths;
+}
+
 const HashSet<String> &ProjectList::get_selected_project_keys() const {
 	// Faster if that's all you need
 	return _selected_project_paths;
@@ -963,22 +973,17 @@ bool ProjectList::is_any_project_missing() const {
 	return false;
 }
 
-void ProjectList::erase_missing_projects() {
-	if (_projects.is_empty()) {
-		return;
-	}
-
+void ProjectList::erase_missing_projects(const Vector<String> &p_paths) {
 	int deleted_count = 0;
 	int remaining_count = 0;
 
 	for (int i = 0; i < _projects.size(); ++i) {
 		const Item &item = _projects[i];
 
-		if (item.missing) {
+		if (item.missing && p_paths.has(item.path)) {
 			_remove_project(i, true);
 			--i;
 			++deleted_count;
-
 		} else {
 			++remaining_count;
 		}

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -240,6 +240,7 @@ public:
 	void select_project(int p_index);
 	void select_first_visible_project();
 	Vector<Item> get_selected_projects() const;
+	Vector<String> get_missing_project_paths() const;
 	const HashSet<String> &get_selected_project_keys() const;
 	int get_single_selected_index() const;
 	void erase_selected_projects(bool p_delete_project_contents);
@@ -247,7 +248,7 @@ public:
 	// Missing projects.
 
 	bool is_any_project_missing() const;
-	void erase_missing_projects();
+	void erase_missing_projects(const Vector<String> &p_paths);
 
 	// Project list sorting and filtering.
 

--- a/editor/project_manager/remove_missing_dialog.cpp
+++ b/editor/project_manager/remove_missing_dialog.cpp
@@ -1,0 +1,98 @@
+/**************************************************************************/
+/*  remove_missing_dialog.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "remove_missing_dialog.h"
+
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/label.h"
+#include "scene/gui/tree.h"
+
+void RemoveMissingDialog::_on_item_edited() {
+	bool has_checked = false;
+	for (TreeItem *item = tree->get_root()->get_next_visible(); item != nullptr; item = item->get_next_visible()) {
+		if (item->is_checked(0)) {
+			has_checked = true;
+			break;
+		}
+	}
+	get_ok_button()->set_disabled(!has_checked);
+}
+
+void RemoveMissingDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("remove_missing_projects", PropertyInfo(Variant::PACKED_STRING_ARRAY, "paths")));
+}
+
+void RemoveMissingDialog::ok_pressed() {
+	Vector<String> paths;
+	for (TreeItem *item = tree->get_root()->get_next_visible(); item != nullptr; item = item->get_next_visible()) {
+		if (item->is_checked(0)) {
+			paths.push_back(item->get_text(0));
+		}
+	}
+	hide();
+	emit_signal("remove_missing_projects", paths);
+}
+
+void RemoveMissingDialog::show_dialog(const Vector<String> &p_paths) {
+	tree->clear();
+
+	TreeItem *root = tree->create_item();
+
+	for (const String &path : p_paths) {
+		TreeItem *item = tree->create_item(root);
+		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+		item->set_editable(0, true);
+		item->set_checked(0, true);
+		item->set_text(0, path);
+	}
+
+	popup_centered_clamped(Size2(480, 260) * EDSCALE);
+}
+
+RemoveMissingDialog::RemoveMissingDialog() {
+	set_title(TTR("Remove Missing"));
+	set_hide_on_ok(false);
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
+
+	vb->add_child(memnew(Label(TTR("The following paths will be removed from the project list."))));
+
+	tree = memnew(Tree);
+	tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tree->set_h_scroll_enabled(false);
+	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->set_hide_root(true);
+	tree->set_select_mode(Tree::SELECT_ROW);
+	tree->connect("item_edited", callable_mp(this, &RemoveMissingDialog::_on_item_edited));
+	vb->add_child(tree);
+}

--- a/editor/project_manager/remove_missing_dialog.h
+++ b/editor/project_manager/remove_missing_dialog.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  remove_missing_dialog.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef REMOVE_MISSING_DIALOG_H
+#define REMOVE_MISSING_DIALOG_H
+
+#include "scene/gui/dialogs.h"
+
+class Tree;
+
+class RemoveMissingDialog : public ConfirmationDialog {
+	GDCLASS(RemoveMissingDialog, ConfirmationDialog);
+
+	Tree *tree;
+
+	void _on_item_edited();
+
+protected:
+	static void _bind_methods();
+
+	virtual void ok_pressed() override;
+
+public:
+	void show_dialog(const Vector<String> &p_paths);
+
+	RemoveMissingDialog();
+};
+
+#endif // REMOVE_MISSING_DIALOG_H


### PR DESCRIPTION
This PR:

- Shows paths to be removed when asking for confirmation.
- Allows deselecting paths that should not be removed.
- Moves "Remove Missing" to the top bar. This button is only shown when there're missing projects.
    - Closes https://github.com/godotengine/godot-proposals/issues/8572

![remove-missing](https://github.com/godotengine/godot/assets/372476/06d5c520-983c-4342-93a5-b7e0b1e69e5c)