### PR TITLE
Stop user from being able to bind multiple identical events to the same action

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -58,10 +58,15 @@ void ActionMapEditor::_event_config_confirmed() {
 	Array events = new_action["events"].duplicate();
 
 	if (current_action_event_index == -1) {
-		// Add new event
+		// Add new event if not already bound.
+		for (const Ref<InputEvent> event_to_check : events) {
+			if (event_to_check.is_valid() && event_to_check->is_match(ev)) {
+				return;
+			}
+		}
 		events.push_back(ev);
 	} else {
-		// Edit existing event
+		// Edit existing event.
 		events[current_action_event_index] = ev;
 	}
 


### PR DESCRIPTION
Fixes #91243 

In `ActionMapEditor`, when we return from `InputEventConfigurationDialog`, and we have confirmed that this input relates to a new event being added, we loop through the events currently bound and early out if the new event matches any of the ones that have already been added. 