### PR TITLE
Add a GDB pretty printer to aid in debugging

### DIFF
--- a/misc/scripts/godot_gdb_pretty_print.py
+++ b/misc/scripts/godot_gdb_pretty_print.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Load this file to your GDB session to enable pretty-printing
+# of some Godot C++ types.
+# GDB command: source misc/scripts/godot_gdb_pretty_print.py
+#
+# To load these automatically in Visual Studio Code,
+# add the source command to the setupCommands of your configuration
+# in launch.json.
+# "setupCommands": [
+# ...
+# {
+#     "description": "Load custom pretty-printers for Godot types.",
+#     "text": "source ${workspaceRoot}/misc/scripts/godot_gdb_pretty_print.py"
+# }
+# ]
+# Other UI:s that use GDB under the hood are likely to have their own ways to achieve this.
+#
+# To debug this script it's easiest to use the interactive python from a command-line
+# GDB session. Stop at a breakpoint, then use
+# python-interactive to enter the python shell and
+# acquire a Value object using gdb.selected_frame().read_var("variable name").
+# From there you can figure out how to print it nicely.
+import re
+
+import gdb
+
+
+# Printer for Godot StringName variables.
+class GodotStringNamePrinter:
+    def __init__(self, value):
+        self.value = value
+
+    def to_string(self):
+        return self.value["_data"]["name"]["_cowdata"]["_ptr"]
+
+    # Hint that the object is string-like.
+    def display_hint(self):
+        return "string"
+
+
+# Printer for Godot String variables.
+class GodotStringPrinter:
+    def __init__(self, value):
+        self.value = value
+
+    def to_string(self):
+        return self.value["_cowdata"]["_ptr"]
+
+    # Hint that the object is string-like.
+    def display_hint(self):
+        return "string"
+
+
+# Printer for Godot Vector variables.
+class GodotVectorPrinter:
+    def __init__(self, value):
+        self.value = value
+
+    # The COW (Copy On Write) object does a bunch of pointer arithmetic to access
+    # its members.
+    # The offsets are constants on the C++ side, optimized out, so not accessible to us.
+    # I'll just hard code the observed values and hope they are the same forever.
+    # See core/templates/cowdata.h
+    SIZE_OFFSET = 8
+    DATA_OFFSET = 16
+
+    # Figures out the number of elements in the vector.
+    def get_size(self):
+        cowdata = self.value["_cowdata"]
+        if cowdata["_ptr"] == 0:
+            return 0
+        else:
+            # The ptr member of cowdata does not point to the beginning of the
+            # cowdata. It points to the beginning of the data section of the cowdata.
+            # To get to the length section, we must back up to the beginning of the struct,
+            # then move back forward to the size.
+            # cf. CowData::_get_size
+            ptr = cowdata["_ptr"].cast(gdb.lookup_type("uint8_t").pointer())
+            return int((ptr - self.DATA_OFFSET + self.SIZE_OFFSET).dereference())
+
+    # Lists children of the value, in this case the vector's items.
+    def children(self):
+        # Return nothing if ptr is null.
+        ptr = self.value["_cowdata"]["_ptr"]
+        if ptr == 0:
+            return
+        # Yield the items one by one.
+        for i in range(self.get_size()):
+            yield str(i), (ptr + i).dereference()
+
+    def to_string(self):
+        return "%s [%d]" % (self.value.type.name, self.get_size())
+
+    # Hint that the object is array-like.
+    def display_hint(self):
+        return "array"
+
+
+VECTOR_REGEX = re.compile("^Vector<.*$")
+
+
+# Tries to find a pretty printer for a debugger value.
+def lookup_pretty_printer(value):
+    if value.type.name == "StringName":
+        return GodotStringNamePrinter(value)
+    if value.type.name == "String":
+        return GodotStringPrinter(value)
+    if value.type.name and VECTOR_REGEX.match(value.type.name):
+        return GodotVectorPrinter(value)
+    return None
+
+
+# Register our printer lookup function.
+# The first parameter could be used to limit the scope of the printer
+# to a specific object file, but that is unnecessary for us.
+gdb.printing.register_pretty_printer(None, lookup_pretty_printer)


### PR DESCRIPTION
The GDB debugger supports pretty-printing of a project's custom types using a python script.
This PR adds a GDB pretty-printer script that can pretty-print Godot's `String`, `StringName` and `Vector`.
This significantly increses the readability, especially of the two latter objects, as the payload is deep in them.

Before:
```
gdb bin/godot.linuxbsd.editor.dev.x86_64
(gdb) break gdscript.cpp:1079
(gdb) set args --test --test-suite="*GDScript*"
(gdb) run
...
(gdb) print sourcef
$1 = {write = {<No data fields>}, _cowdata = {static MAX_INT = <optimized out>, static REF_COUNT_OFFSET = <optimized out>, static SIZE_OFFSET = <optimized out>, 
    static DATA_OFFSET = <optimized out>, _ptr = 0x5555624edd40 "const dictionary := {0: [0]}\n\nfunc test():\n\tvar array := dictionary[0]\n\tvar key: int = 0\n\tarray[key] = 0\n"}}
(gdb) print p_path
$2 = (const String &) @0x7fffffffcf60: {_cowdata = {static MAX_INT = <optimized out>, static REF_COUNT_OFFSET = <optimized out>, static SIZE_OFFSET = <optimized out>, 
    static DATA_OFFSET = <optimized out>, _ptr = 0x555562365f50 U"/mnt/SSD-General2/projects/godot/godot/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.gd"}, 
  static _null = 0 U'\000', static _replacement_char = 65533 U'�'}
```

After:
```
(gdb) source misc/scripts/godot_gdb_pretty_print.py
(gdb) print sourcef
$3 = Vector<unsigned char> [106] = {99 'c', 111 'o', 110 'n', 115 's', 116 't', 32 ' ', 100 'd', 105 'i', 99 'c', 116 't', 105 'i', 111 'o', 110 'n', 97 'a', 114 'r', 121 'y', 32 ' ', 58 ':', 
  61 '=', 32 ' ', 123 '{', 48 '0', 58 ':', 32 ' ', 91 '[', 48 '0', 93 ']', 125 '}', 10 '\n', 10 '\n', 102 'f', 117 'u', 110 'n', 99 'c', 32 ' ', 116 't', 101 'e', 115 's', 116 't', 40 '(', 
  41 ')', 58 ':', 10 '\n', 9 '\t', 118 'v', 97 'a', 114 'r', 32 ' ', 97 'a', 114 'r', 114 'r', 97 'a', 121 'y', 32 ' ', 58 ':', 61 '=', 32 ' ', 100 'd', 105 'i', 99 'c', 116 't', 105 'i', 
  111 'o', 110 'n', 97 'a', 114 'r', 121 'y', 91 '[', 48 '0', 93 ']', 10 '\n', 9 '\t', 118 'v', 97 'a', 114 'r', 32 ' ', 107 'k', 101 'e', 121 'y', 58 ':', 32 ' ', 105 'i', 110 'n', 116 't', 
  32 ' ', 61 '=', 32 ' ', 48 '0', 10 '\n', 9 '\t', 97 'a', 114 'r', 114 'r', 97 'a', 121 'y', 91 '[', 107 'k', 101 'e', 121 'y', 93 ']', 32 ' ', 61 '=', 32 ' ', 48 '0', 10 '\n', 0 '\000'}
(gdb) print p_path
$4 = (const String &) @0x7fffffffcf60: U"/mnt/SSD-General2/projects/godot/godot/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.gd"
```

You can enable the pretty printer by default in VS code by adding this to your configuration in launch.json:
```json
"setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                },
                {
                    "description": "Load custom pretty-printers for Godot types.",
                    "text": "source ${workspaceRoot}/misc/scripts/godot_gdb_pretty_print.py"
                }
]

```

`Vector<StringName>` in VS code without this:
![vs_code_debug_godot_vector_string_name_before](https://github.com/godotengine/godot/assets/8913801/7251d330-523e-408e-9713-ff960a2b8cbb)

`Vector<StringName>` in VS code with this:
![vs_code_debug_godot_vector_string_name_after](https://github.com/godotengine/godot/assets/8913801/1ee4b027-5a9f-4890-9c90-3644b272a397)

GDB supports some ways of loading the pretty printer automatically, but all of the would require adding the source of
the script to the safe autoload path. If the user needs to do configuration anyway, best to let them specify the loading of pretty printing explicitly, instead of making them enable magic that does the loading implicitly.
