### PR TITLE
Fix disabled files in FileDialog using the wrong color

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1291,7 +1291,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		// Use a different color for folder icons to make them easier to distinguish from files.
 		// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
 		p_theme->set_color("folder_icon_color", "FileDialog", (p_config.dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(p_config.accent_color, 0.7));
-		p_theme->set_color("files_disabled", "FileDialog", p_config.font_disabled_color);
+		p_theme->set_color("file_disabled_color", "FileDialog", p_config.font_disabled_color);
 
 		// PopupDialog.
 		p_theme->set_stylebox("panel", "PopupDialog", p_config.popup_style);


### PR DESCRIPTION
Fixes the wrong color being applied to disabled files in the FileDialog (most notably when using directory mode), rendering their filenames invisible in light mode. I guess at some the name of it got changed (it's in the 3_to_4 migration file) but not in the theme manager.

Before:
![image](https://github.com/godotengine/godot/assets/138269/483dfd13-c693-4022-aceb-9554f72be73a)

After:
![image](https://github.com/godotengine/godot/assets/138269/e097ad1f-8c21-4f75-9f0c-5e5703b8eee2)

