### PR TITLE
Core: Support floats in `ABS`, remove `Math::abs`

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1100,7 +1100,7 @@ JoyAxis InputEventJoypadMotion::get_axis() const {
 
 void InputEventJoypadMotion::set_axis_value(float p_value) {
 	axis_value = p_value;
-	pressed = Math::abs(axis_value) >= 0.5f;
+	pressed = ABS(axis_value) >= 0.5f;
 	emit_changed();
 }
 
@@ -1120,7 +1120,7 @@ bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event, bool p
 		match &= (axis_value < 0) == (jm->axis_value < 0);
 	}
 	if (match) {
-		float jm_abs_axis_value = Math::abs(jm->get_axis_value());
+		float jm_abs_axis_value = ABS(jm->get_axis_value());
 		bool same_direction = (((axis_value < 0) == (jm->axis_value < 0)) || jm->axis_value == 0);
 		bool pressed_state = same_direction && jm_abs_axis_value >= p_deadzone;
 		if (r_pressed != nullptr) {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -880,7 +880,7 @@ static void _scale_nearest(const uint8_t *__restrict p_src, uint8_t *__restrict 
 #define LANCZOS_TYPE 3
 
 static float _lanczos(float p_x) {
-	return Math::abs(p_x) >= LANCZOS_TYPE ? 0 : Math::sincn(p_x) * Math::sincn(p_x / LANCZOS_TYPE);
+	return ABS(p_x) >= LANCZOS_TYPE ? 0 : Math::sincn(p_x) * Math::sincn(p_x / LANCZOS_TYPE);
 }
 
 template <int CC, typename T>
@@ -4086,23 +4086,23 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 			if (!p_luma_metric) {
 				ERR_FAIL_COND_V_MSG(color_a.r > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				ERR_FAIL_COND_V_MSG(color_b.r > 1.0f, Dictionary(), "Can't compare HDR colors.");
-				hist[Math::abs(color_a.get_r8() - color_b.get_r8())]++;
+				hist[ABS(color_a.get_r8() - color_b.get_r8())]++;
 				ERR_FAIL_COND_V_MSG(color_a.g > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				ERR_FAIL_COND_V_MSG(color_b.g > 1.0f, Dictionary(), "Can't compare HDR colors.");
-				hist[Math::abs(color_a.get_g8() - color_b.get_g8())]++;
+				hist[ABS(color_a.get_g8() - color_b.get_g8())]++;
 				ERR_FAIL_COND_V_MSG(color_a.b > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				ERR_FAIL_COND_V_MSG(color_b.b > 1.0f, Dictionary(), "Can't compare HDR colors.");
-				hist[Math::abs(color_a.get_b8() - color_b.get_b8())]++;
+				hist[ABS(color_a.get_b8() - color_b.get_b8())]++;
 				ERR_FAIL_COND_V_MSG(color_a.a > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				ERR_FAIL_COND_V_MSG(color_b.a > 1.0f, Dictionary(), "Can't compare HDR colors.");
-				hist[Math::abs(color_a.get_a8() - color_b.get_a8())]++;
+				hist[ABS(color_a.get_a8() - color_b.get_a8())]++;
 			} else {
 				ERR_FAIL_COND_V_MSG(color_a.r > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				ERR_FAIL_COND_V_MSG(color_b.r > 1.0f, Dictionary(), "Can't compare HDR colors.");
 				// REC709 weightings
 				int luma_a = (13938U * color_a.get_r8() + 46869U * color_a.get_g8() + 4729U * color_a.get_b8() + 32768U) >> 16U;
 				int luma_b = (13938U * color_b.get_r8() + 46869U * color_b.get_g8() + 4729U * color_b.get_b8() + 32768U) >> 16U;
-				hist[Math::abs(luma_a - luma_b)]++;
+				hist[ABS(luma_a - luma_b)]++;
 			}
 		}
 	}

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -268,7 +268,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	Vector3 dots;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
+			dots[j] += s[i] * ABS(m.get_column(i).normalized().dot(b.get_column(j)));
 		}
 	}
 	if (sign != signbit(dots.x + dots.y + dots.z)) {
@@ -768,7 +768,7 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 	if (Math::is_zero_approx(rows[0][1] - rows[1][0]) && Math::is_zero_approx(rows[0][2] - rows[2][0]) && Math::is_zero_approx(rows[1][2] - rows[2][1])) {
 		// Singularity found.
 		// First check for identity matrix which must have +1 for all terms in leading diagonal and zero in other terms.
-		if (is_diagonal() && (Math::abs(rows[0][0] + rows[1][1] + rows[2][2] - 3) < 3 * CMP_EPSILON)) {
+		if (is_diagonal() && (ABS(rows[0][0] + rows[1][1] + rows[2][2] - 3) < 3 * CMP_EPSILON)) {
 			// This singularity is identity matrix so angle = 0.
 			r_axis = Vector3(0, 1, 0);
 			r_angle = 0;
@@ -820,7 +820,7 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 	// As we have reached here there are no singularities so we can handle normally.
 	double s = Math::sqrt((rows[2][1] - rows[1][2]) * (rows[2][1] - rows[1][2]) + (rows[0][2] - rows[2][0]) * (rows[0][2] - rows[2][0]) + (rows[1][0] - rows[0][1]) * (rows[1][0] - rows[0][1])); // Used to normalize.
 
-	if (Math::abs(s) < CMP_EPSILON) {
+	if (ABS(s) < CMP_EPSILON) {
 		// Prevent divide by zero, should not happen if matrix is orthogonal and should be caught by singularity test above.
 		s = 1;
 	}

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -95,7 +95,7 @@ struct BVH_ABB {
 		const POINT d = (min - neg_max) - (p_b.min - p_b.neg_max);
 		real_t proximity = 0.0;
 		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
-			proximity += Math::abs(d[axis]);
+			proximity += ABS(d[axis]);
 		}
 		return proximity;
 	}

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -226,7 +226,7 @@ DynamicBVH::Node *DynamicBVH::_top_down(Node **leaves, int p_count, int p_bu_thr
 			}
 			for (i = 0; i < 3; ++i) {
 				if ((splitcount[i][0] > 0) && (splitcount[i][1] > 0)) {
-					const int midp = (int)Math::abs(real_t(splitcount[i][0] - splitcount[i][1]));
+					const int midp = (int)ABS(real_t(splitcount[i][0] - splitcount[i][1]));
 					if (midp < bestmidp) {
 						bestaxis = i;
 						bestmidp = midp;

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -118,7 +118,7 @@ private:
 
 		_FORCE_INLINE_ real_t get_proximity_to(const Volume &b) const {
 			const Vector3 d = (min + max) - (b.min + b.max);
-			return (Math::abs(d.x) + Math::abs(d.y) + Math::abs(d.z));
+			return (ABS(d.x) + ABS(d.y) + ABS(d.z));
 		}
 
 		_FORCE_INLINE_ int select_by_proximity(const Volume &a, const Volume &b) const {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -293,7 +293,7 @@ public:
 
 			real_t den = p.normal.dot(dir);
 
-			if (Math::abs(den) <= (real_t)CMP_EPSILON) {
+			if (ABS(den) <= (real_t)CMP_EPSILON) {
 				continue; // Ignore parallel plane.
 			}
 
@@ -733,23 +733,23 @@ public:
 
 		/* Bullet 3:  */
 		/*  test the 9 tests first (this was faster) */
-		fex = Math::abs(e0.x);
-		fey = Math::abs(e0.y);
-		fez = Math::abs(e0.z);
+		fex = ABS(e0.x);
+		fey = ABS(e0.y);
+		fez = ABS(e0.z);
 		AXISTEST_X01(e0.z, e0.y, fez, fey);
 		AXISTEST_Y02(e0.z, e0.x, fez, fex);
 		AXISTEST_Z12(e0.y, e0.x, fey, fex);
 
-		fex = Math::abs(e1.x);
-		fey = Math::abs(e1.y);
-		fez = Math::abs(e1.z);
+		fex = ABS(e1.x);
+		fey = ABS(e1.y);
+		fez = ABS(e1.z);
 		AXISTEST_X01(e1.z, e1.y, fez, fey);
 		AXISTEST_Y02(e1.z, e1.x, fez, fex);
 		AXISTEST_Z0(e1.y, e1.x, fey, fex);
 
-		fex = Math::abs(e2.x);
-		fey = Math::abs(e2.y);
-		fez = Math::abs(e2.z);
+		fex = ABS(e2.x);
+		fey = ABS(e2.y);
+		fez = ABS(e2.z);
 		AXISTEST_X2(e2.z, e2.y, fez, fey);
 		AXISTEST_Y1(e2.z, e2.x, fez, fex);
 		AXISTEST_Z12(e2.y, e2.x, fey, fex);
@@ -833,7 +833,7 @@ public:
 	_FORCE_INLINE_ static Vector3 octahedron_map_decode(const Vector2 &p_uv) {
 		// https://twitter.com/Stubbesaurus/status/937994790553227264
 		const Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
-		Vector3 n = Vector3(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
+		Vector3 n = Vector3(f.x, f.y, 1.0f - ABS(f.x) - ABS(f.y));
 		const real_t t = CLAMP(-n.z, 0.0f, 1.0f);
 		n.x += n.x >= 0 ? -t : t;
 		n.y += n.y >= 0 ? -t : t;

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -72,7 +72,7 @@ int Math::step_decimals(double p_step) {
 		0.0000000009999
 	};
 
-	double abs = Math::abs(p_step);
+	double abs = ABS(p_step);
 	double decs = abs - (int)abs; // Strip away integer part
 	for (int i = 0; i < maxn; i++) {
 		if (decs >= sd[i]) {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -217,10 +217,6 @@ public:
 	static _ALWAYS_INLINE_ bool is_finite(double p_val) { return isfinite(p_val); }
 	static _ALWAYS_INLINE_ bool is_finite(float p_val) { return isfinite(p_val); }
 
-	static _ALWAYS_INLINE_ double abs(double g) { return absd(g); }
-	static _ALWAYS_INLINE_ float abs(float g) { return absf(g); }
-	static _ALWAYS_INLINE_ int abs(int g) { return g > 0 ? g : -g; }
-
 	static _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
 		double value = Math::fmod(p_x, p_y);
 		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
@@ -461,21 +457,21 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ double move_toward(double p_from, double p_to, double p_delta) {
-		return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+		return ABS(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
 	}
 	static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) {
-		return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+		return ABS(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
 	}
 
 	static _ALWAYS_INLINE_ double rotate_toward(double p_from, double p_to, double p_delta) {
 		double difference = Math::angle_difference(p_from, p_to);
-		double abs_difference = Math::abs(difference);
+		double abs_difference = ABS(difference);
 		// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
 		return p_from + CLAMP(p_delta, abs_difference - Math_PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
 	}
 	static _ALWAYS_INLINE_ float rotate_toward(float p_from, float p_to, float p_delta) {
 		float difference = Math::angle_difference(p_from, p_to);
-		float abs_difference = Math::abs(difference);
+		float abs_difference = ABS(difference);
 		// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
 		return p_from + CLAMP(p_delta, abs_difference - (float)Math_PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
 	}
@@ -531,10 +527,10 @@ public:
 		return value - floor(value);
 	}
 	static _ALWAYS_INLINE_ float pingpong(float value, float length) {
-		return (length != 0.0f) ? abs(fract((value - length) / (length * 2.0f)) * length * 2.0f - length) : 0.0f;
+		return (length != 0.0f) ? ABS(fract((value - length) / (length * 2.0f)) * length * 2.0f - length) : 0.0f;
 	}
 	static _ALWAYS_INLINE_ double pingpong(double value, double length) {
-		return (length != 0.0) ? abs(fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
+		return (length != 0.0) ? ABS(fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
 	}
 
 	// double only, as these functions are mainly used by the editor and not performance-critical,
@@ -563,11 +559,11 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		float tolerance = (float)CMP_EPSILON * abs(a);
+		float tolerance = (float)CMP_EPSILON * ABS(a);
 		if (tolerance < (float)CMP_EPSILON) {
 			tolerance = (float)CMP_EPSILON;
 		}
-		return abs(a - b) < tolerance;
+		return ABS(a - b) < tolerance;
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(float a, float b, float tolerance) {
@@ -576,11 +572,11 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		return abs(a - b) < tolerance;
+		return ABS(a - b) < tolerance;
 	}
 
 	static _ALWAYS_INLINE_ bool is_zero_approx(float s) {
-		return abs(s) < (float)CMP_EPSILON;
+		return ABS(s) < (float)CMP_EPSILON;
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(double a, double b) {
@@ -589,11 +585,11 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		double tolerance = CMP_EPSILON * abs(a);
+		double tolerance = CMP_EPSILON * ABS(a);
 		if (tolerance < CMP_EPSILON) {
 			tolerance = CMP_EPSILON;
 		}
-		return abs(a - b) < tolerance;
+		return ABS(a - b) < tolerance;
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(double a, double b, double tolerance) {
@@ -602,32 +598,11 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		return abs(a - b) < tolerance;
+		return ABS(a - b) < tolerance;
 	}
 
 	static _ALWAYS_INLINE_ bool is_zero_approx(double s) {
-		return abs(s) < CMP_EPSILON;
-	}
-
-	static _ALWAYS_INLINE_ float absf(float g) {
-		union {
-			float f;
-			uint32_t i;
-		} u;
-
-		u.f = g;
-		u.i &= 2147483647u;
-		return u.f;
-	}
-
-	static _ALWAYS_INLINE_ double absd(double g) {
-		union {
-			double d;
-			uint64_t i;
-		} u;
-		u.d = g;
-		u.i &= (uint64_t)9223372036854775807ll;
-		return u.d;
+		return ABS(s) < CMP_EPSILON;
 	}
 
 	// This function should be as fast as possible and rounding mode should not matter.
@@ -742,7 +717,7 @@ public:
 			} else {
 				b += p_step;
 			}
-			return (Math::abs(p_target - a) < Math::abs(p_target - b)) ? a : b;
+			return (ABS(p_target - a) < ABS(p_target - b)) ? a : b;
 		}
 		return p_target;
 	}

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -608,7 +608,7 @@ void Projection::invert() {
 		pvt_j[k] = k;
 		for (i = k; i < 4; i++) {
 			for (j = k; j < 4; j++) {
-				if (Math::abs(columns[i][j]) > Math::abs(pvt_val)) {
+				if (ABS(columns[i][j]) > ABS(pvt_val)) {
 					pvt_i[k] = i;
 					pvt_j[k] = j;
 					pvt_val = columns[i][j];
@@ -819,7 +819,7 @@ real_t Projection::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+		return Math::rad_to_deg(Math::acos(ABS(right_plane.normal.x))) * 2.0;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -828,7 +828,7 @@ real_t Projection::get_fov() const {
 				matrix[15] + matrix[12]);
 		left_plane.normalize();
 
-		return Math::rad_to_deg(Math::acos(Math::abs(left_plane.normal.x))) + Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x)));
+		return Math::rad_to_deg(Math::acos(ABS(left_plane.normal.x))) + Math::rad_to_deg(Math::acos(ABS(right_plane.normal.x)));
 	}
 }
 

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -160,7 +160,7 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, real_t p_weight) const {
 
 	real_t dot = from.dot(p_to);
 
-	if (Math::absf(dot) > 0.9999f) {
+	if (ABS(dot) > 0.9999f) {
 		return from;
 	}
 
@@ -281,7 +281,7 @@ Quaternion::operator String() const {
 }
 
 Vector3 Quaternion::get_axis() const {
-	if (Math::abs(w) > 1 - CMP_EPSILON) {
+	if (ABS(w) > 1 - CMP_EPSILON) {
 		return Vector3(x, y, z);
 	}
 	real_t r = ((real_t)1) / Math::sqrt(1 - w * w);

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -103,7 +103,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 			}
 
 			Vector3 n = rel12.cross(p_points[simplex[0]] - p_points[i]).cross(rel12).normalized();
-			real_t d = Math::abs(n.dot(p_points[simplex[0]]) - n.dot(p_points[i]));
+			real_t d = ABS(n.dot(p_points[simplex[0]]) - n.dot(p_points[i]));
 
 			if (i == 0 || d > maxd) {
 				maxd = d;
@@ -123,7 +123,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 				continue;
 			}
 
-			real_t d = Math::abs(p.distance_to(p_points[i]));
+			real_t d = ABS(p.distance_to(p_points[i]));
 
 			if (i == 0 || d > maxd) {
 				maxd = d;

--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -75,5 +75,5 @@ int RandomPCG::random(int p_from, int p_to) {
 	if (p_from == p_to) {
 		return p_from;
 	}
-	return rand(abs(p_from - p_to) + 1) + MIN(p_from, p_to);
+	return rand(ABS(p_from - p_to) + 1) + MIN(p_from, p_to);
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -155,7 +155,7 @@ struct _NO_DISCARD_ Vector2 {
 	static Vector2 from_angle(real_t p_angle);
 
 	_FORCE_INLINE_ Vector2 abs() const {
-		return Vector2(Math::abs(x), Math::abs(y));
+		return Vector2(ABS(x), ABS(y));
 	}
 
 	Vector2 rotated(real_t p_by) const;

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -125,7 +125,7 @@ struct _NO_DISCARD_ Vector2i {
 
 	real_t aspect() const { return width / (real_t)height; }
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
-	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
+	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 	Vector2i snapped(const Vector2i &p_step) const;
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -84,14 +84,14 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, real_t p_delta) const {
 
 Vector2 Vector3::octahedron_encode() const {
 	Vector3 n = *this;
-	n /= Math::abs(n.x) + Math::abs(n.y) + Math::abs(n.z);
+	n /= ABS(n.x) + ABS(n.y) + ABS(n.z);
 	Vector2 o;
 	if (n.z >= 0.0f) {
 		o.x = n.x;
 		o.y = n.y;
 	} else {
-		o.x = (1.0f - Math::abs(n.y)) * (n.x >= 0.0f ? 1.0f : -1.0f);
-		o.y = (1.0f - Math::abs(n.x)) * (n.y >= 0.0f ? 1.0f : -1.0f);
+		o.x = (1.0f - ABS(n.y)) * (n.x >= 0.0f ? 1.0f : -1.0f);
+		o.y = (1.0f - ABS(n.x)) * (n.y >= 0.0f ? 1.0f : -1.0f);
 	}
 	o.x = o.x * 0.5f + 0.5f;
 	o.y = o.y * 0.5f + 0.5f;
@@ -100,7 +100,7 @@ Vector2 Vector3::octahedron_encode() const {
 
 Vector3 Vector3::octahedron_decode(const Vector2 &p_oct) {
 	Vector2 f(p_oct.x * 2.0f - 1.0f, p_oct.y * 2.0f - 1.0f);
-	Vector3 n(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
+	Vector3 n(f.x, f.y, 1.0f - ABS(f.x) - ABS(f.y));
 	const real_t t = CLAMP(-n.z, 0.0f, 1.0f);
 	n.x += n.x >= 0 ? -t : t;
 	n.y += n.y >= 0 ? -t : t;
@@ -120,7 +120,7 @@ Vector3 Vector3::octahedron_tangent_decode(const Vector2 &p_oct, float *r_sign) 
 	Vector2 oct_compressed = p_oct;
 	oct_compressed.y = oct_compressed.y * 2 - 1;
 	*r_sign = oct_compressed.y >= 0.0f ? 1.0f : -1.0f;
-	oct_compressed.y = Math::abs(oct_compressed.y);
+	oct_compressed.y = ABS(oct_compressed.y);
 	Vector3 res = Vector3::octahedron_decode(oct_compressed);
 	return res;
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -197,7 +197,7 @@ real_t Vector3::dot(const Vector3 &p_with) const {
 }
 
 Vector3 Vector3::abs() const {
-	return Vector3(Math::abs(x), Math::abs(y), Math::abs(z));
+	return Vector3(ABS(x), ABS(y), ABS(z));
 }
 
 Vector3 Vector3::sign() const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -139,7 +139,7 @@ double Vector3i::length() const {
 }
 
 Vector3i Vector3i::abs() const {
-	return Vector3i(Math::abs(x), Math::abs(y), Math::abs(z));
+	return Vector3i(ABS(x), ABS(y), ABS(z));
 }
 
 Vector3i Vector3i::sign() const {

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -110,7 +110,7 @@ Vector4 Vector4::direction_to(const Vector4 &p_to) const {
 }
 
 Vector4 Vector4::abs() const {
-	return Vector4(Math::abs(x), Math::abs(y), Math::abs(z), Math::abs(w));
+	return Vector4(ABS(x), ABS(y), ABS(z), ABS(w));
 }
 
 Vector4 Vector4::sign() const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -151,7 +151,7 @@ int64_t Vector4i::distance_squared_to(const Vector4i &p_to) const {
 }
 
 Vector4i Vector4i::abs() const {
-	return Vector4i(Math::abs(x), Math::abs(y), Math::abs(z), Math::abs(w));
+	return Vector4i(ABS(x), ABS(y), ABS(z), ABS(w));
 }
 
 Vector4i Vector4i::sign() const {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1553,7 +1553,7 @@ String String::num(double p_num, int p_decimals) {
 
 	if (p_decimals < 0) {
 		p_decimals = 14;
-		const double abs_num = Math::abs(p_num);
+		const double abs_num = ABS(p_num);
 		if (abs_num > 10) {
 			// We want to align the digits to the above reasonable default, so we only
 			// need to subtract log10 for numbers with a positive power of ten.
@@ -1716,7 +1716,7 @@ String String::num_real(double p_num, bool p_trailing) {
 #endif
 	// We want to align the digits to the above sane default, so we only need
 	// to subtract log10 for numbers with a positive power of ten magnitude.
-	double abs_num = Math::abs(p_num);
+	double abs_num = ABS(p_num);
 	if (abs_num > 10) {
 		decimals -= (int)floor(log10(abs_num));
 	}
@@ -5009,7 +5009,7 @@ String String::sprintf(const Array &values, bool *error) const {
 
 					double value = values[value_index];
 					bool is_negative = signbit(value);
-					String str = String::num(Math::abs(value), min_decimals);
+					String str = String::num(ABS(value), min_decimals);
 					const bool is_finite = Math::is_finite(value);
 
 					// Pad decimals out.
@@ -5071,7 +5071,7 @@ String String::sprintf(const Array &values, bool *error) const {
 					String str = "(";
 					for (int i = 0; i < count; i++) {
 						double val = vec[i];
-						String number_str = String::num(Math::abs(val), min_decimals);
+						String number_str = String::num(ABS(val), min_decimals);
 						const bool is_finite = Math::is_finite(val);
 
 						// Pad decimals out.

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -103,15 +103,14 @@
 #undef MAX
 #undef CLAMP
 
-// Generic ABS function, for math uses please use Math::abs.
 template <typename T>
-constexpr T ABS(T m_v) {
-	return m_v < 0 ? -m_v : m_v;
+constexpr T ABS(const T m_v) {
+	return m_v == T(0) ? T(0) : (m_v > T(0) ? m_v : -m_v);
 }
 
 template <typename T>
 constexpr const T SIGN(const T m_v) {
-	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
+	return m_v > T(0) ? T(1) : (m_v < T(0) ? T(-1) : T(0));
 }
 
 template <typename T, typename T2>

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -248,7 +248,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 			return ABS(VariantInternalAccessor<int64_t>::get(&x));
 		} break;
 		case Variant::FLOAT: {
-			return Math::absd(VariantInternalAccessor<double>::get(&x));
+			return ABS(VariantInternalAccessor<double>::get(&x));
 		} break;
 		case Variant::VECTOR2: {
 			return VariantInternalAccessor<Vector2>::get(&x).abs();
@@ -278,7 +278,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 }
 
 double VariantUtilityFunctions::absf(double x) {
-	return Math::absd(x);
+	return ABS(x);
 }
 
 int64_t VariantUtilityFunctions::absi(int64_t x) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -380,8 +380,8 @@ float EditorAudioBus::_scaled_db_to_normalized_volume(float db) {
 			/* To accommodate for NaN on negative numbers for root, we will mirror the
 			 * results of the positive db range in order to get the desired numerical
 			 * value on the negative side. */
-			float positive_x = Math::pow(Math::abs(db) / 45.0f, 1.0f / 3.0f) + 1.0f;
-			Vector2 translation = Vector2(1.0f, 0.0f) - Vector2(positive_x, Math::abs(db));
+			float positive_x = Math::pow(ABS(db) / 45.0f, 1.0f / 3.0f) + 1.0f;
+			Vector2 translation = Vector2(1.0f, 0.0f) - Vector2(positive_x, ABS(db));
 			Vector2 reflected_position = Vector2(1.0, 0.0f) + translation;
 			return reflected_position.x;
 		} else {
@@ -1417,7 +1417,7 @@ Size2 EditorAudioMeterNotches::get_minimum_size() const {
 
 	for (int i = 0; i < notches.size(); i++) {
 		if (notches[i].render_db_value) {
-			width = MAX(width, font->get_string_size(String::num(Math::abs(notches[i].db_value)) + "dB", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x);
+			width = MAX(width, font->get_string_size(String::num(ABS(notches[i].db_value)) + "dB", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x);
 			height += font_height;
 		}
 	}
@@ -1462,7 +1462,7 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 			draw_string(theme_cache.font,
 					Vector2((line_length + label_space) * EDSCALE,
 							(1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + (font_height / 4) + top_padding),
-					String::num(Math::abs(n.db_value)) + "dB",
+					String::num(ABS(n.db_value)) + "dB",
 					HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size,
 					theme_cache.notch_color);
 		}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1535,7 +1535,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 		float val = get_edited_property_value();
 		bool sg = val < 0;
-		val = Math::absf(val);
+		val = ABS(val);
 
 		val = Math::log(val) / Math::log((float)2.0);
 		// Logarithmic space.
@@ -1596,11 +1596,11 @@ void EditorPropertyEasing::_draw_easing() {
 	easing_draw->draw_polyline(points, line_color, 1.0, true);
 	// Draw more decimals for small numbers since higher precision is usually required for fine adjustments.
 	int decimals;
-	if (Math::abs(exp) < 0.1 - CMP_EPSILON) {
+	if (ABS(exp) < 0.1 - CMP_EPSILON) {
 		decimals = 4;
-	} else if (Math::abs(exp) < 1 - CMP_EPSILON) {
+	} else if (ABS(exp) < 1 - CMP_EPSILON) {
 		decimals = 3;
-	} else if (Math::abs(exp) < 10 - CMP_EPSILON) {
+	} else if (ABS(exp) < 10 - CMP_EPSILON) {
 		decimals = 2;
 	} else {
 		decimals = 1;

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -335,7 +335,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				Vector3 src_dir = src_tail - src_head;
 
 				// Rotate rest.
-				if (Math::abs(Math::rad_to_deg(src_dir.angle_to(prof_dir))) > float(p_options["retarget/rest_fixer/fix_silhouette/threshold"])) {
+				if (ABS(Math::rad_to_deg(src_dir.angle_to(prof_dir))) > float(p_options["retarget/rest_fixer/fix_silhouette/threshold"])) {
 					// Get rotation difference.
 					Vector3 up_vec; // Need to rotate other than roll axis.
 					switch (Vector3(abs(src_dir.x), abs(src_dir.y), abs(src_dir.z)).min_axis_index()) {

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -364,7 +364,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	if (normalize) {
 		float max = 0;
 		for (int i = 0; i < data.size(); i++) {
-			float amp = Math::abs(data[i]);
+			float amp = ABS(data[i]);
 			if (amp > max) {
 				max = amp;
 			}
@@ -389,10 +389,10 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		for (int i = 0; i < data.size() / format_channels; i++) {
 			float ampChannelSum = 0;
 			for (int j = 0; j < format_channels; j++) {
-				ampChannelSum += Math::abs(data[(i * format_channels) + j]);
+				ampChannelSum += ABS(data[(i * format_channels) + j]);
 			}
 
-			float amp = Math::abs(ampChannelSum / (float)format_channels);
+			float amp = ABS(ampChannelSum / (float)format_channels);
 
 			if (!found && amp > limit) {
 				first = i;

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -131,7 +131,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		_update_tool_erase();
 
 		for (int i = 0; i < points.size(); i++) {
-			if (Math::abs(float(points[i] - mb->get_position().x)) < 10 * EDSCALE) {
+			if (ABS(float(points[i] - mb->get_position().x)) < 10 * EDSCALE) {
 				selected_point = i;
 
 				Ref<AnimationNode> node = blend_space->get_blend_point_node(i);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -272,8 +272,8 @@ void CanvasItemEditor::_snap_if_closer_float(
 		const real_t p_target_value, const SnapTarget p_snap_target,
 		const real_t p_radius) {
 	const real_t radius = p_radius / zoom;
-	const real_t dist = Math::abs(p_value - p_target_value);
-	if ((p_radius < 0 || dist < radius) && (r_current_snap_target == SNAP_TARGET_NONE || dist < Math::abs(r_current_snap - p_value))) {
+	const real_t dist = ABS(p_value - p_target_value);
+	if ((p_radius < 0 || dist < radius) && (r_current_snap_target == SNAP_TARGET_NONE || dist < ABS(r_current_snap - p_value))) {
 		r_current_snap = p_target_value;
 		r_current_snap_target = p_snap_target;
 	}
@@ -1629,7 +1629,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 
 			bool use_single_axis = m->is_shift_pressed();
 			Vector2 drag_vector = xform.xform(drag_to) - xform.xform(drag_from);
-			bool use_y = Math::abs(drag_vector.y) > Math::abs(drag_vector.x);
+			bool use_y = ABS(drag_vector.y) > ABS(drag_vector.x);
 
 			switch (drag_type) {
 				case DRAG_ANCHOR_TOP_LEFT:

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -128,7 +128,7 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 			if (idx < 2) {
 				Ref<CapsuleShape2D> capsule = node->get_shape();
 
-				real_t parameter = Math::abs(p_point[idx]);
+				real_t parameter = ABS(p_point[idx]);
 
 				if (idx == 0) {
 					capsule->set_radius(parameter);
@@ -166,7 +166,7 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 		case SEPARATION_RAY_SHAPE: {
 			Ref<SeparationRayShape2D> ray = node->get_shape();
 
-			ray->set_length(Math::abs(p_point.y));
+			ray->set_length(ABS(p_point.y));
 		} break;
 
 		case RECTANGLE_SHAPE: {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -292,7 +292,7 @@ void CurveEdit::gui_input(const Ref<InputEvent> &p_event) {
 					// Allow to snap to axes with Shift.
 					if (mm->is_shift_pressed()) {
 						Vector2 initial_mpos = get_view_pos(initial_grab_pos);
-						if (Math::abs(mpos.x - initial_mpos.x) > Math::abs(mpos.y - initial_mpos.y)) {
+						if (ABS(mpos.x - initial_mpos.x) > ABS(mpos.y - initial_mpos.y)) {
 							new_pos.y = initial_grab_pos.y;
 						} else {
 							new_pos.x = initial_grab_pos.x;

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -120,7 +120,7 @@ void GradientTexture2DEdit::gui_input(const Ref<InputEvent> &p_event) {
 		// Allow to snap to an axis with Shift.
 		if (mm->is_shift_pressed()) {
 			Vector2 initial_mpos = initial_grab_pos * size;
-			if (Math::abs(mpos.x - initial_mpos.x) > Math::abs(mpos.y - initial_mpos.y)) {
+			if (ABS(mpos.x - initial_mpos.x) > ABS(mpos.y - initial_mpos.y)) {
 				new_pos.y = initial_grab_pos.y;
 			} else {
 				new_pos.x = initial_grab_pos.x;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -372,7 +372,7 @@ void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
 		Vector3 axis_3d = camera_basis.get_column(i);
 		Vector2i axis_vector = Vector2(axis_3d.x, -axis_3d.y) * radius;
 
-		if (Math::abs(axis_3d.z) <= 1.0) {
+		if (ABS(axis_3d.z) <= 1.0) {
 			Axis2D pos_axis;
 			pos_axis.axis = i;
 			pos_axis.screen_point = center + axis_vector;
@@ -530,11 +530,11 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
-			if (Math::abs(camera_cursor.x_rot - cursor.x_rot) < 0.1) {
+			if (ABS(camera_cursor.x_rot - cursor.x_rot) < 0.1) {
 				camera_cursor.x_rot = cursor.x_rot;
 			}
 
-			if (Math::abs(camera_cursor.y_rot - cursor.y_rot) < 0.1) {
+			if (ABS(camera_cursor.y_rot - cursor.y_rot) < 0.1) {
 				camera_cursor.y_rot = cursor.y_rot;
 			}
 
@@ -549,11 +549,11 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
-			if (Math::abs(camera_cursor.x_rot - cursor.x_rot) < 0.1) {
+			if (ABS(camera_cursor.x_rot - cursor.x_rot) < 0.1) {
 				camera_cursor.x_rot = cursor.x_rot;
 			}
 
-			if (Math::abs(camera_cursor.y_rot - cursor.y_rot) < 0.1) {
+			if (ABS(camera_cursor.y_rot - cursor.y_rot) < 0.1) {
 				camera_cursor.y_rot = cursor.y_rot;
 			}
 
@@ -3797,17 +3797,17 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 	const Vector3 camz = -camera_xform.get_basis().get_column(2).normalized();
 	const Vector3 camy = -camera_xform.get_basis().get_column(1).normalized();
 	const Plane p = Plane(camz, camera_xform.origin);
-	const real_t gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
+	const real_t gizmo_d = MAX(ABS(p.distance_to(xform.origin)), CMP_EPSILON);
 	const real_t d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
 	const real_t d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;
-	const real_t dd = MAX(Math::abs(d0 - d1), CMP_EPSILON);
+	const real_t dd = MAX(ABS(d0 - d1), CMP_EPSILON);
 
 	const real_t gizmo_size = EDITOR_GET("editors/3d/manipulator_gizmo_size");
 	// At low viewport heights, multiply the gizmo scale based on the viewport height.
 	// This prevents the gizmo from growing very large and going outside the viewport.
 	const int viewport_base_height = 400 * MAX(1, EDSCALE);
 	gizmo_scale =
-			(gizmo_size / Math::abs(dd)) * MAX(1, EDSCALE) *
+			(gizmo_size / ABS(dd)) * MAX(1, EDSCALE) *
 			MIN(viewport_base_height, subviewport_container->get_size().height) / viewport_base_height /
 			subviewport_container->get_stretch_shrink();
 	Vector3 scale = Vector3(1, 1, 1) * gizmo_scale;
@@ -7191,7 +7191,7 @@ void Node3DEditor::_init_grid() {
 		Vector3 normal;
 		normal[c] = 1.0;
 
-		real_t camera_distance = Math::abs(camera_position[c]);
+		real_t camera_distance = ABS(camera_position[c]);
 
 		if (orthogonal) {
 			camera_distance = camera->get_size() / 2.0;
@@ -7203,7 +7203,7 @@ void Node3DEditor::_init_grid() {
 			}
 		}
 
-		real_t division_level = Math::log(Math::abs(camera_distance)) / Math::log((double)primary_grid_steps) + division_level_bias;
+		real_t division_level = Math::log(ABS(camera_distance)) / Math::log((double)primary_grid_steps) + division_level_bias;
 
 		real_t clamped_division_level = CLAMP(division_level, division_level_min, division_level_max);
 		real_t division_level_floored = Math::floor(clamped_division_level);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1415,7 +1415,7 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			int closest = -1;
 			real_t closest_d = 0.0;
 			for (int j = 0; j < 3; j++) {
-				real_t dp = Math::abs(skeleton->get_bone_global_rest(current_bone_idx).basis[j].normalized().dot(d));
+				real_t dp = ABS(skeleton->get_bone_global_rest(current_bone_idx).basis[j].normalized().dot(d));
 				if (j == 0 || dp > closest_d) {
 					closest = j;
 				}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -369,16 +369,16 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 							mtx.basis_xform(rect.position + Vector2(margins[2], 0)) - draw_ofs * draw_zoom,
 							mtx.basis_xform(rect.position + rect.size - Vector2(margins[3], 0)) - draw_ofs * draw_zoom
 						};
-						if (Math::abs(mb->get_position().y - pos[0].y) < 8) {
+						if (ABS(mb->get_position().y - pos[0].y) < 8) {
 							edited_margin = 0;
 							prev_margin = margins[0];
-						} else if (Math::abs(mb->get_position().y - pos[1].y) < 8) {
+						} else if (ABS(mb->get_position().y - pos[1].y) < 8) {
 							edited_margin = 1;
 							prev_margin = margins[1];
-						} else if (Math::abs(mb->get_position().x - pos[2].x) < 8) {
+						} else if (ABS(mb->get_position().x - pos[2].x) < 8) {
 							edited_margin = 2;
 							prev_margin = margins[2];
-						} else if (Math::abs(mb->get_position().x - pos[3].x) < 8) {
+						} else if (ABS(mb->get_position().x - pos[3].x) < 8) {
 							edited_margin = 3;
 							prev_margin = margins[3];
 						}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -939,9 +939,9 @@ void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw() {
 
 	Point2 ofs;
 	if (is_layout_rtl()) {
-		ofs = Point2(get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(Math::abs((size.height - arrow->get_height()) / 2)));
+		ofs = Point2(get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(ABS((size.height - arrow->get_height()) / 2)));
 	} else {
-		ofs = Point2(size.width - arrow->get_width() - get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(Math::abs((size.height - arrow->get_height()) / 2)));
+		ofs = Point2(size.width - arrow->get_width() - get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(ABS((size.height - arrow->get_height()) / 2)));
 	}
 	arrow->draw(ci, ofs, clr);
 }

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -624,7 +624,7 @@ bool CSGBrushOperation::MeshMerge::_bvh_inside(FaceBVH *r_facebvhptr, int p_max_
 									potential_intersection.found = true;
 									potential_intersection.conormal = face_normal.dot(current_normal);
 									potential_intersection.distance_squared = face_center.distance_squared_to(intersection_point);
-									potential_intersection.origin_angle = Math::abs(potential_intersection.conormal);
+									potential_intersection.origin_angle = ABS(potential_intersection.conormal);
 									real_t intersection_dist_from_face = face_normal.dot(intersection_point - face_center);
 									for (int i = 0; i < 3; i++) {
 										real_t point_dist_from_face = face_normal.dot(current_points[i] - face_center);
@@ -869,7 +869,7 @@ void CSGBrushOperation::Build2DFaces::_add_vertex_idx_sorted(Vector<int> &r_vert
 
 			// Sort along the axis with the greatest difference.
 			int axis = 0;
-			if (Math::abs(new_point.x - first_point.x) < Math::abs(new_point.y - first_point.y)) {
+			if (ABS(new_point.x - first_point.x) < ABS(new_point.y - first_point.y)) {
 				axis = 1;
 			}
 
@@ -890,7 +890,7 @@ void CSGBrushOperation::Build2DFaces::_add_vertex_idx_sorted(Vector<int> &r_vert
 
 		// Determine axis being sorted against i.e. the axis with the greatest difference.
 		int axis = 0;
-		if (Math::abs(last_point.x - first_point.x) < Math::abs(last_point.y - first_point.y)) {
+		if (ABS(last_point.x - first_point.x) < ABS(last_point.y - first_point.y)) {
 			axis = 1;
 		}
 

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
@@ -218,13 +218,13 @@ Vector2 OpenXRCompositionLayerCylinder::intersects_ray(const Vector3 &p_origin, 
 
 	Vector2 projected_point = Vector2(relative_point.x, relative_point.z);
 	float intersection_angle = Math::atan2(projected_point.y, projected_point.x);
-	if (Math::abs(intersection_angle) > central_angle / 2.0) {
+	if (ABS(intersection_angle) > central_angle / 2.0) {
 		return Vector2(-1.0, -1.0);
 	}
 
 	float arc_length = radius * central_angle;
 	float height = aspect_ratio * arc_length;
-	if (Math::abs(relative_point.y) > height / 2.0) {
+	if (ABS(relative_point.y) > height / 2.0) {
 		return Vector2(-1.0, -1.0);
 	}
 

--- a/modules/openxr/scene/openxr_composition_layer_equirect.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.cpp
@@ -235,13 +235,13 @@ Vector2 OpenXRCompositionLayerEquirect::intersects_ray(const Vector3 &p_origin, 
 	Vector3 relative_point = correction.xform(intersection - equirect_transform.origin);
 
 	float horizontal_intersection_angle = Math::atan2(relative_point.z, relative_point.x);
-	if (Math::abs(horizontal_intersection_angle) > central_horizontal_angle / 2.0) {
+	if (ABS(horizontal_intersection_angle) > central_horizontal_angle / 2.0) {
 		return Vector2(-1.0, -1.0);
 	}
 
 	float vertical_intersection_angle = Math::acos(relative_point.y / radius) - (Math_PI / 2.0);
 	if (vertical_intersection_angle < 0) {
-		if (Math::abs(vertical_intersection_angle) > upper_vertical_angle) {
+		if (ABS(vertical_intersection_angle) > upper_vertical_angle) {
 			return Vector2(-1.0, -1.0);
 		}
 	} else if (vertical_intersection_angle > lower_vertical_angle) {

--- a/modules/openxr/scene/openxr_composition_layer_quad.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_quad.cpp
@@ -102,7 +102,7 @@ Vector2 OpenXRCompositionLayerQuad::intersects_ray(const Vector3 &p_origin, cons
 	Vector3 quad_normal = quad_transform.basis.get_column(2);
 
 	float denom = quad_normal.dot(p_direction);
-	if (Math::abs(denom) > 0.0001) {
+	if (ABS(denom) > 0.0001) {
 		Vector3 vector = quad_transform.origin - p_origin;
 		float t = vector.dot(quad_normal) / denom;
 		if (t < 0.0) {
@@ -114,10 +114,10 @@ Vector2 OpenXRCompositionLayerQuad::intersects_ray(const Vector3 &p_origin, cons
 		Vector2 projected_point = Vector2(
 				relative_point.dot(quad_transform.basis.get_column(0)),
 				relative_point.dot(quad_transform.basis.get_column(1)));
-		if (Math::abs(projected_point.x) > quad_size.x / 2.0) {
+		if (ABS(projected_point.x) > quad_size.x / 2.0) {
 			return Vector2(-1.0, -1.0);
 		}
-		if (Math::abs(projected_point.y) > quad_size.y / 2.0) {
+		if (ABS(projected_point.y) > quad_size.y / 2.0) {
 			return Vector2(-1.0, -1.0);
 		}
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4962,8 +4962,8 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 				BitField<FontStyle> style = _font_get_style(F.rid);
 				int weight = _font_get_weight(F.rid);
 				int stretch = _font_get_stretch(F.rid);
-				int score = (20 - Math::abs(weight - font_weight) / 50);
-				score += (20 - Math::abs(stretch - font_stretch) / 10);
+				int score = (20 - ABS(weight - font_weight) / 50);
+				score += (20 - ABS(stretch - font_stretch) / 10);
 				if (bool(style & TextServer::FONT_ITALIC) == bool(font_style & TextServer::FONT_ITALIC)) {
 					score += 30;
 				}
@@ -5010,8 +5010,8 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 				BitField<FontStyle> style = _font_get_style(sysf.rid);
 				int weight = _font_get_weight(sysf.rid);
 				int stretch = _font_get_stretch(sysf.rid);
-				int score = (20 - Math::abs(weight - font_weight) / 50);
-				score += (20 - Math::abs(stretch - font_stretch) / 10);
+				int score = (20 - ABS(weight - font_weight) / 50);
+				score += (20 - ABS(stretch - font_stretch) / 10);
 				if (bool(style & TextServer::FONT_ITALIC) == bool(font_style & TextServer::FONT_ITALIC)) {
 					score += 30;
 				}

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3782,8 +3782,8 @@ RID TextServerFallback::_find_sys_font_for_text(const RID &p_fdef, const String 
 					BitField<FontStyle> style = _font_get_style(F.rid);
 					int weight = _font_get_weight(F.rid);
 					int stretch = _font_get_stretch(F.rid);
-					int score = (20 - Math::abs(weight - font_weight) / 50);
-					score += (20 - Math::abs(stretch - font_stretch) / 10);
+					int score = (20 - ABS(weight - font_weight) / 50);
+					score += (20 - ABS(stretch - font_stretch) / 10);
 					if (bool(style & TextServer::FONT_ITALIC) == bool(font_style & TextServer::FONT_ITALIC)) {
 						score += 30;
 					}
@@ -3830,8 +3830,8 @@ RID TextServerFallback::_find_sys_font_for_text(const RID &p_fdef, const String 
 					BitField<FontStyle> style = _font_get_style(sysf.rid);
 					int weight = _font_get_weight(sysf.rid);
 					int stretch = _font_get_stretch(sysf.rid);
-					int score = (20 - Math::abs(weight - font_weight) / 50);
-					score += (20 - Math::abs(stretch - font_stretch) / 10);
+					int score = (20 - ABS(weight - font_weight) / 50);
+					score += (20 - ABS(stretch - font_stretch) / 10);
 					if (bool(style & TextServer::FONT_ITALIC) == bool(font_style & TextServer::FONT_ITALIC)) {
 						score += 30;
 					}

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -579,8 +579,8 @@ Vector<String> OS_Android::get_system_font_path_for_text(const String &p_font_na
 		if (E->get().script.has(p_script)) {
 			score += 240;
 		}
-		score += (20 - Math::abs(E->get().weight - p_weight) / 50);
-		score += (20 - Math::abs(E->get().stretch - p_stretch) / 10);
+		score += (20 - ABS(E->get().weight - p_weight) / 50);
+		score += (20 - ABS(E->get().stretch - p_stretch) / 10);
 		if (E->get().italic == p_italic) {
 			score += 30;
 		}
@@ -620,8 +620,8 @@ String OS_Android::get_system_font_path(const String &p_font_name, int p_weight,
 		if (E->get().font_name == font_name) {
 			score += (65 - E->get().priority);
 		}
-		score += (20 - Math::abs(E->get().weight - p_weight) / 50);
-		score += (20 - Math::abs(E->get().stretch - p_stretch) / 10);
+		score += (20 - ABS(E->get().weight - p_weight) / 50);
+		score += (20 - ABS(E->get().stretch - p_stretch) / 10);
 		if (E->get().italic == p_italic) {
 			score += 30;
 		}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3996,7 +3996,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 					float pressure = float(packet.pkNormalPressure - windows[window_id].min_pressure) / float(windows[window_id].max_pressure - windows[window_id].min_pressure);
 					double azim = (packet.pkOrientation.orAzimuth / 10.0f) * (Math_PI / 180);
-					double alt = Math::tan((Math::abs(packet.pkOrientation.orAltitude / 10.0f)) * (Math_PI / 180));
+					double alt = Math::tan((ABS(packet.pkOrientation.orAltitude / 10.0f)) * (Math_PI / 180));
 					bool inverted = packet.pkStatus & TPS_INVERT;
 
 					Vector2 tilt = (windows[window_id].tilt_supported) ? Vector2(Math::atan(Math::sin(azim) / alt), Math::atan(Math::cos(azim) / alt)) : Vector2();

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -482,7 +482,7 @@ void JoypadWindows::post_hat(int p_device, DWORD p_dpad) {
 }
 
 float JoypadWindows::axis_correct(int p_val, bool p_xinput, bool p_trigger, bool p_negate) const {
-	if (Math::abs(p_val) < MIN_JOY_AXIS) {
+	if (ABS(p_val) < MIN_JOY_AXIS) {
 		return p_trigger ? -1.0f : 0.0f;
 	}
 	if (!p_xinput) {

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -182,7 +182,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			while (remaining) {
 				// Animation speed may be changed by animation_finished or frame_changed signals.
 				double speed = frames->get_animation_speed(animation) * speed_scale * custom_speed_scale * frame_speed_scale;
-				double abs_speed = Math::abs(speed);
+				double abs_speed = ABS(speed);
 
 				if (speed == 0) {
 					return; // Do nothing.

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -505,7 +505,7 @@ void LineBuilder::strip_add_arc(Vector2 center, float angle_delta, Orientation o
 	Vector2 vbegin = vertices[_last_index[opposite_orientation]] - center;
 	float radius = vbegin.length();
 	float angle_step = Math_PI / static_cast<float>(round_precision);
-	float steps = Math::abs(angle_delta) / angle_step;
+	float steps = ABS(angle_delta) / angle_step;
 
 	if (angle_delta < 0.f) {
 		angle_step = -angle_step;
@@ -532,7 +532,7 @@ void LineBuilder::new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Col
 
 	float radius = vbegin.length();
 	float angle_step = Math_PI / static_cast<float>(round_precision);
-	float steps = Math::abs(angle_delta) / angle_step;
+	float steps = ABS(angle_delta) / angle_step;
 
 	if (angle_delta < 0.f) {
 		angle_step = -angle_step;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -863,7 +863,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 							p.velocity.y = velocity_2d.y;
 						} else {
 							Vector3 normal = emission_normals.get(random_idx);
-							Vector3 v0 = Math::abs(normal.z) < 0.999 ? Vector3(0.0, 0.0, 1.0) : Vector3(0, 1.0, 0.0);
+							Vector3 v0 = ABS(normal.z) < 0.999 ? Vector3(0.0, 0.0, 1.0) : Vector3(0, 1.0, 0.0);
 							Vector3 tangent = v0.cross(normal).normalized();
 							Vector3 bitangent = tangent.cross(normal).normalized();
 							Basis m3;

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -209,7 +209,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					// to properly test the angle and avoid standing on slopes
 					Vector3 horizontal_motion = motion.slide(up_direction);
 					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
+					real_t motion_angle = ABS(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
 
 					// Avoid to move forward on a wall if floor_block_on_wall is true.
 					// Applies only when the motion angle is under 90 degrees,
@@ -290,7 +290,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				// Stop horizontal motion when under wall slide threshold.
 				if (p_was_on_floor && (wall_min_slide_angle > 0.0) && result_state.wall) {
 					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
+					real_t motion_angle = ABS(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
 					if (motion_angle < wall_min_slide_angle) {
 						motion = up_direction * motion.dot(up_direction);
 						velocity = up_direction * velocity.dot(up_direction);

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -127,7 +127,7 @@ void FabrikInverseKinematic::solve_simple(Task *p_task, bool p_solve_magnet, Vec
 	real_t distance_to_goal(1e4);
 	real_t previous_distance_to_goal(0);
 	int can_solve(p_task->max_iterations);
-	while (distance_to_goal > p_task->min_distance && Math::abs(previous_distance_to_goal - distance_to_goal) > 0.005 && can_solve) {
+	while (distance_to_goal > p_task->min_distance && ABS(previous_distance_to_goal - distance_to_goal) > 0.005 && can_solve) {
 		previous_distance_to_goal = distance_to_goal;
 		--can_solve;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1102,7 +1102,7 @@ void AnimatedSprite3D::_notification(int p_what) {
 			while (remaining) {
 				// Animation speed may be changed by animation_finished or frame_changed signals.
 				double speed = frames->get_animation_speed(animation) * speed_scale * custom_speed_scale * frame_speed_scale;
-				double abs_speed = Math::abs(speed);
+				double abs_speed = ABS(speed);
 
 				if (speed == 0) {
 					return; // Do nothing.

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -519,7 +519,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 
 	double p_time = p_playback_info.time;
 	double p_delta = p_playback_info.delta;
-	double abs_delta = Math::abs(p_delta);
+	double abs_delta = ABS(p_delta);
 	bool p_seek = p_playback_info.seeked;
 	bool p_is_external_seeking = p_playback_info.is_external_seeking;
 
@@ -653,7 +653,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 				set_parameter(time_to_restart, restart_sec);
 			}
 		}
-		double d = Math::abs(os_nti.delta);
+		double d = ABS(os_nti.delta);
 		if (!do_start) {
 			cur_fade_in_remaining = MAX(0, cur_fade_in_remaining - d); // Don't consider seeked delta by restart.
 		}
@@ -1353,7 +1353,7 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 			if (cur_prev_xfading <= 0) {
 				set_parameter(prev_index, -1);
 			}
-			cur_prev_xfading -= Math::abs(p_playback_info.delta);
+			cur_prev_xfading -= ABS(p_playback_info.delta);
 		}
 	}
 

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1746,9 +1746,9 @@ void AnimationMixer::_blend_apply() {
 
 				// Trim unused elements if init array/string is not blended.
 				if (t->value.is_array()) {
-					int actual_blended_size = (int)Math::round(Math::abs(t->element_size.operator real_t()));
+					int actual_blended_size = (int)Math::round(ABS(t->element_size.operator real_t()));
 					if (actual_blended_size < (t->value.operator Array()).size()) {
-						real_t abs_weight = Math::abs(track->total_weight);
+						real_t abs_weight = ABS(track->total_weight);
 						if (abs_weight >= 1.0) {
 							(t->value.operator Array()).resize(actual_blended_size);
 						} else if (t->init_value.is_string()) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -826,7 +826,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(const St
 			fading_from = StringName();
 		} else {
 			if (!p_seek) {
-				fading_pos += Math::abs(p_delta);
+				fading_pos += ABS(p_delta);
 			}
 			fade_blend = MIN(1.0, fading_pos / fading_time);
 		}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -271,7 +271,7 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 	List<List<Blend>::Element *> to_erase;
 	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
 		Blend &b = E->get();
-		b.blend_left = MAX(0, b.blend_left - Math::absf(speed_scale * p_delta) / b.blend_time);
+		b.blend_left = MAX(0, b.blend_left - ABS(speed_scale * p_delta) / b.blend_time);
 		if (b.blend_left <= 0) {
 			to_erase.push_back(E);
 			b.blend_left = CMP_EPSILON; // May want to play last frame.
@@ -311,7 +311,7 @@ bool AnimationPlayer::_blend_pre_process(double p_delta, int p_track_count, cons
 }
 
 void AnimationPlayer::_blend_capture(double p_delta) {
-	blend_capture(p_delta * Math::abs(speed_scale));
+	blend_capture(p_delta * ABS(speed_scale));
 }
 
 void AnimationPlayer::_blend_post_process() {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -273,7 +273,7 @@ AnimationNode::NodeTimeInfo AnimationNode::_blend_node(Ref<AnimationNode> p_node
 	if (r_activity) {
 		*r_activity = 0;
 		for (int i = 0; i < blend_count; i++) {
-			*r_activity = MAX(*r_activity, Math::abs(blendw[i]));
+			*r_activity = MAX(*r_activity, ABS(blendw[i]));
 		}
 	}
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -682,7 +682,7 @@ void Control::_update_canvas_item_transform() {
 	xform[2] += get_position();
 
 	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
-	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
+	if (is_inside_tree() && ABS(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
 		xform[2] = xform[2].round();
 	}
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -88,11 +88,11 @@ void GraphEditMinimap::update_minimap() {
 	if (graph_ratio > target_ratio) {
 		graph_proportions.width = graph_size.width;
 		graph_proportions.height = graph_size.width / target_ratio;
-		graph_padding.y = Math::abs(graph_size.height - graph_proportions.y) / 2;
+		graph_padding.y = ABS(graph_size.height - graph_proportions.y) / 2;
 	} else {
 		graph_proportions.width = graph_size.height * target_ratio;
 		graph_proportions.height = graph_size.height;
-		graph_padding.x = Math::abs(graph_size.width - graph_proportions.x) / 2;
+		graph_padding.x = ABS(graph_size.width - graph_proportions.x) / 2;
 	}
 
 	// This centers minimap inside the minimap rectangle.

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -120,9 +120,9 @@ void OptionButton::_notification(int p_what) {
 
 			Point2 ofs;
 			if (is_layout_rtl()) {
-				ofs = Point2(theme_cache.arrow_margin, int(Math::abs((size.height - theme_cache.arrow_icon->get_height()) / 2)));
+				ofs = Point2(theme_cache.arrow_margin, int(ABS((size.height - theme_cache.arrow_icon->get_height()) / 2)));
 			} else {
-				ofs = Point2(size.width - theme_cache.arrow_icon->get_width() - theme_cache.arrow_margin, int(Math::abs((size.height - theme_cache.arrow_icon->get_height()) / 2)));
+				ofs = Point2(size.width - theme_cache.arrow_icon->get_width() - theme_cache.arrow_margin, int(ABS((size.height - theme_cache.arrow_icon->get_height()) / 2)));
 			}
 			theme_cache.arrow_icon->draw(ci, ofs, clr);
 		} break;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -331,7 +331,7 @@ void ScrollBar::_notification(int p_what) {
 					double dist = abs(target);
 					double vel = ((target / dist) * 500) * get_physics_process_delta_time();
 
-					if (Math::abs(vel) >= dist) {
+					if (ABS(vel) >= dist) {
 						scroll_to(target_scroll);
 						scrolling = false;
 						set_physics_process_internal(false);
@@ -364,7 +364,7 @@ void ScrollBar::_notification(int p_what) {
 						scroll_to(pos.x);
 
 						float sgn_x = drag_node_speed.x < 0 ? -1 : 1;
-						float val_x = Math::abs(drag_node_speed.x);
+						float val_x = ABS(drag_node_speed.x);
 						val_x -= 1000 * get_physics_process_delta_time();
 
 						if (val_x < 0) {
@@ -387,7 +387,7 @@ void ScrollBar::_notification(int p_what) {
 						scroll_to(pos.y);
 
 						float sgn_y = drag_node_speed.y < 0 ? -1 : 1;
-						float val_y = Math::abs(drag_node_speed.y);
+						float val_y = ABS(drag_node_speed.y);
 						val_y -= 1000 * get_physics_process_delta_time();
 
 						if (val_y < 0) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -202,7 +202,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 			Vector2 motion = mm->get_relative();
 			drag_accum -= motion;
 
-			if (beyond_deadzone || (h_scroll_enabled && Math::abs(drag_accum.x) > deadzone) || (v_scroll_enabled && Math::abs(drag_accum.y) > deadzone)) {
+			if (beyond_deadzone || (h_scroll_enabled && ABS(drag_accum.x) > deadzone) || (v_scroll_enabled && ABS(drag_accum.y) > deadzone)) {
 				if (!beyond_deadzone) {
 					propagate_notification(NOTIFICATION_SCROLL_BEGIN);
 					emit_signal(SNAME("scroll_started"));
@@ -398,7 +398,7 @@ void ScrollContainer::_notification(int p_what) {
 					}
 
 					float sgn_x = drag_speed.x < 0 ? -1 : 1;
-					float val_x = Math::abs(drag_speed.x);
+					float val_x = ABS(drag_speed.x);
 					val_x -= 1000 * get_physics_process_delta_time();
 
 					if (val_x < 0) {
@@ -406,7 +406,7 @@ void ScrollContainer::_notification(int p_what) {
 					}
 
 					float sgn_y = drag_speed.y < 0 ? -1 : 1;
-					float val_y = Math::abs(drag_speed.y);
+					float val_y = ABS(drag_speed.y);
 					val_y -= 1000 * get_physics_process_delta_time();
 
 					if (val_y < 0) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -497,11 +497,11 @@ void TextEdit::_notification(int p_what) {
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
 
 				// Prevent small velocities from blocking scrolling.
-				if (Math::abs(vel) < v_scroll->get_step()) {
+				if (ABS(vel) < v_scroll->get_step()) {
 					vel = v_scroll->get_step() * SIGN(vel);
 				}
 
-				if (Math::abs(vel) >= dist) {
+				if (ABS(vel) >= dist) {
 					set_v_scroll(target_v_scroll);
 					scrolling = false;
 					minimap_clicked = false;
@@ -7604,7 +7604,7 @@ void TextEdit::_scroll_up(real_t p_delta, bool p_animate) {
 		if (target_v_scroll <= 0) {
 			target_v_scroll = 0;
 		}
-		if (!p_animate || Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
+		if (!p_animate || ABS(target_v_scroll - v_scroll->get_value()) < 1.0) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
@@ -7632,7 +7632,7 @@ void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 		if (target_v_scroll > max_v_scroll) {
 			target_v_scroll = max_v_scroll;
 		}
-		if (!p_animate || Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
+		if (!p_animate || ABS(target_v_scroll - v_scroll->get_value()) < 1.0) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4251,7 +4251,7 @@ void Tree::_notification(int p_what) {
 
 					v_scroll->set_value(pos);
 					float sgn = drag_speed < 0 ? -1 : 1;
-					float val = Math::abs(drag_speed);
+					float val = ABS(drag_speed);
 					val -= 1000 * get_physics_process_delta_time();
 
 					if (val < 0) {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3366,8 +3366,8 @@ void Animation::bezier_track_set_key_handle_mode(int p_track, int p_index, Handl
 				}
 			} else {
 				real_t handle_length = 1.0 / 4.0;
-				real_t prev_interval = Math::abs(bt->values[p_index].time - bt->values[prev_key].time);
-				real_t next_interval = Math::abs(bt->values[p_index].time - bt->values[next_key].time);
+				real_t prev_interval = ABS(bt->values[p_index].time - bt->values[prev_key].time);
+				real_t next_interval = ABS(bt->values[p_index].time - bt->values[next_key].time);
 				real_t min_time = 0;
 				if (Math::is_zero_approx(prev_interval)) {
 					min_time = next_interval;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -371,13 +371,13 @@ static float perpendicular_distance(const Vector2 &i, const Vector2 &start, cons
 	float intercept;
 
 	if (start.x == end.x) {
-		res = Math::absf(i.x - end.x);
+		res = ABS(i.x - end.x);
 	} else if (start.y == end.y) {
-		res = Math::absf(i.y - end.y);
+		res = ABS(i.y - end.y);
 	} else {
 		slope = (end.y - start.y) / (end.x - start.x);
 		intercept = start.y - (slope * start.x);
-		res = Math::absf(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
+		res = ABS(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
 	}
 	return res;
 }
@@ -558,7 +558,7 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 	}
 
 	bool bit_value = p_pixels > 0;
-	p_pixels = Math::abs(p_pixels);
+	p_pixels = ABS(p_pixels);
 
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -3158,8 +3158,8 @@ void SystemFont::_update_base_font() {
 			BitField<TextServer::FontStyle> style = file->get_font_style();
 			int font_weight = file->get_font_weight();
 			int font_stretch = file->get_font_stretch();
-			score += (20 - Math::abs(font_weight - weight) / 50);
-			score += (20 - Math::abs(font_stretch - stretch) / 10);
+			score += (20 - ABS(font_weight - weight) / 50);
+			score += (20 - ABS(font_stretch - stretch) / 10);
 			if (bool(style & TextServer::FONT_ITALIC) == italic) {
 				score += 30;
 			}

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -302,7 +302,7 @@ float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {
 	} else if (fill == Fill::FILL_RADIAL) {
 		ofs = (pos - fill_from).length() / (fill_to - fill_from).length();
 	} else if (fill == Fill::FILL_SQUARE) {
-		ofs = MAX(Math::abs(pos.x - fill_from.x), Math::abs(pos.y - fill_from.y)) / MAX(Math::abs(fill_to.x - fill_from.x), Math::abs(fill_to.y - fill_from.y));
+		ofs = MAX(ABS(pos.x - fill_from.x), ABS(pos.y - fill_from.y)) / MAX(ABS(fill_to.x - fill_from.x), ABS(fill_to.y - fill_from.y));
 	}
 	if (repeat == Repeat::REPEAT_NONE) {
 		ofs = CLAMP(ofs, 0.0, 1.0);
@@ -312,7 +312,7 @@ float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {
 			ofs = 1 + ofs;
 		}
 	} else if (repeat == Repeat::REPEAT_MIRROR) {
-		ofs = Math::abs(ofs);
+		ofs = ABS(ofs);
 		ofs = Math::fmod(ofs, 2.0f);
 		if (ofs > 1.0) {
 			ofs = 2.0 - ofs;

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -59,8 +59,8 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 	for (int i = 0; i < p_frame_count; i++) {
 		AudioFrame s = src[i];
 		//convert to positive
-		s.left = Math::abs(s.left);
-		s.right = Math::abs(s.right);
+		s.left = ABS(s.left);
+		s.right = ABS(s.right);
 
 		float peak = MAX(s.left, s.right);
 

--- a/servers/audio/effects/audio_effect_limiter.cpp
+++ b/servers/audio/effects/audio_effect_limiter.cpp
@@ -38,7 +38,7 @@ void AudioEffectLimiterInstance::process(const AudioFrame *p_src_frames, AudioFr
 	float sc = -base->soft_clip;
 	float scv = Math::db_to_linear(sc);
 	float peakdb = ceildb + 25;
-	float scmult = Math::abs((ceildb - sc) / (peakdb - sc));
+	float scmult = ABS((ceildb - sc) / (peakdb - sc));
 
 	for (int i = 0; i < p_frame_count; i++) {
 		float spl0 = p_src_frames[i].left;
@@ -47,8 +47,8 @@ void AudioEffectLimiterInstance::process(const AudioFrame *p_src_frames, AudioFr
 		spl1 = spl1 * makeup;
 		float sign0 = (spl0 < 0.0 ? -1.0 : 1.0);
 		float sign1 = (spl1 < 0.0 ? -1.0 : 1.0);
-		float abs0 = Math::abs(spl0);
-		float abs1 = Math::abs(spl1);
+		float abs0 = ABS(spl0);
+		float abs1 = ABS(spl1);
 		float overdb0 = Math::linear_to_db(abs0) - ceildb;
 		float overdb1 = Math::linear_to_db(abs1) - ceildb;
 
@@ -59,8 +59,8 @@ void AudioEffectLimiterInstance::process(const AudioFrame *p_src_frames, AudioFr
 			spl1 = sign1 * (scv + Math::db_to_linear(overdb1 * scmult));
 		}
 
-		spl0 = MIN(ceiling, Math::abs(spl0)) * (spl0 < 0.0 ? -1.0 : 1.0);
-		spl1 = MIN(ceiling, Math::abs(spl1)) * (spl1 < 0.0 ? -1.0 : 1.0);
+		spl0 = MIN(ceiling, ABS(spl0)) * (spl0 < 0.0 ? -1.0 : 1.0);
+		spl1 = MIN(ceiling, ABS(spl1)) * (spl1 < 0.0 ? -1.0 : 1.0);
 
 		p_dst_frames[i].left = spl0;
 		p_dst_frames[i].right = spl1;

--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -705,7 +705,7 @@ bool GodotBody2D::sleep_test(real_t p_step) {
 		return false;
 	}
 
-	if (Math::abs(angular_velocity) < get_space()->get_body_angular_velocity_sleep_threshold() && Math::abs(linear_velocity.length_squared()) < get_space()->get_body_linear_velocity_sleep_threshold() * get_space()->get_body_linear_velocity_sleep_threshold()) {
+	if (ABS(angular_velocity) < get_space()->get_body_angular_velocity_sleep_threshold() && ABS(linear_velocity.length_squared()) < get_space()->get_body_linear_velocity_sleep_threshold() * get_space()->get_body_linear_velocity_sleep_threshold()) {
 		still_time += p_step;
 
 		return still_time > get_space()->get_body_time_to_sleep();

--- a/servers/physics_2d/godot_body_pair_2d.cpp
+++ b/servers/physics_2d/godot_body_pair_2d.cpp
@@ -553,7 +553,7 @@ void GodotBodyPair2D::solve(real_t p_step) {
 
 		vbn = dbv.dot(c.normal);
 
-		if (Math::abs(-vbn + c.bias) > MIN_VELOCITY) {
+		if (ABS(-vbn + c.bias) > MIN_VELOCITY) {
 			real_t jbn_com = (-vbn + c.bias) / (inv_mass_A + inv_mass_B);
 			real_t jbnOld_com = c.acc_bias_impulse_center_of_mass;
 			c.acc_bias_impulse_center_of_mass = MAX(jbnOld_com + jbn_com, 0.0f);

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -274,7 +274,7 @@ public:
 
 		//use the smallest depth
 
-		dmin = Math::abs(dmin);
+		dmin = ABS(dmin);
 
 		if (dmax < dmin) {
 			if (dmax < best_depth) {

--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -96,7 +96,7 @@ bool GodotWorldBoundaryShape2D::intersect_segment(const Vector2 &p_begin, const 
 	real_t den = normal.dot(segment);
 
 	//printf("den is %i\n",den);
-	if (Math::abs(den) <= CMP_EPSILON) {
+	if (ABS(den) <= CMP_EPSILON) {
 		return false;
 	}
 
@@ -179,7 +179,7 @@ Variant GodotSeparationRayShape2D::get_data() const {
 /*********************************************************/
 
 void GodotSegmentShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_supports, int &r_amount) const {
-	if (Math::abs(p_normal.dot(n)) > segment_is_valid_support_threshold) {
+	if (ABS(p_normal.dot(n)) > segment_is_valid_support_threshold) {
 		r_supports[0] = a;
 		r_supports[1] = b;
 		r_amount = 2;
@@ -308,7 +308,7 @@ void GodotRectangleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_sup
 		Vector2 ag;
 		ag[i] = 1.0;
 		real_t dp = ag.dot(p_normal);
-		if (Math::abs(dp) <= segment_is_valid_support_threshold) {
+		if (ABS(dp) <= segment_is_valid_support_threshold) {
 			continue;
 		}
 
@@ -370,7 +370,7 @@ void GodotCapsuleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_suppo
 
 	real_t h = height * 0.5 - radius; // half-height of the rectangle part
 
-	if (h > 0 && Math::abs(n.x) > segment_is_valid_support_threshold) {
+	if (h > 0 && ABS(n.x) > segment_is_valid_support_threshold) {
 		// make it flat
 		n.y = 0.0;
 		n.x = SIGN(n.x) * radius;
@@ -390,7 +390,7 @@ void GodotCapsuleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_suppo
 
 bool GodotCapsuleShape2D::contains_point(const Vector2 &p_point) const {
 	Vector2 p = p_point;
-	p.y = Math::abs(p.y);
+	p.y = ABS(p.y);
 	p.y -= height * 0.5 - radius;
 	if (p.y < 0) {
 		p.y = 0;

--- a/servers/physics_2d/godot_shape_2d.h
+++ b/servers/physics_2d/godot_shape_2d.h
@@ -98,7 +98,7 @@ public:
 		}
 
 		if (r_amount == 1) {
-			if (Math::abs(p_normal.dot(p_cast.normalized())) < segment_is_valid_support_threshold_lower) {
+			if (ABS(p_normal.dot(p_cast.normalized())) < segment_is_valid_support_threshold_lower) {
 				//make line because they are parallel
 				r_amount = 2;
 				r_supports[1] = r_supports[0] + p_cast;
@@ -108,7 +108,7 @@ public:
 			}
 
 		} else {
-			if (Math::abs(p_normal.dot(p_cast.normalized())) < segment_is_valid_support_threshold_lower) {
+			if (ABS(p_normal.dot(p_cast.normalized())) < segment_is_valid_support_threshold_lower) {
 				//optimize line and make it larger because they are parallel
 				if ((r_supports[1] - r_supports[0]).dot(p_cast) > 0) {
 					//larger towards 1

--- a/servers/physics_3d/gjk_epa.cpp
+++ b/servers/physics_3d/gjk_epa.cpp
@@ -396,7 +396,7 @@ struct	GJK
 				break;
 			case	4:
 				{
-					if(Math::abs(det(	m_simplex->c[0]->w-m_simplex->c[3]->w,
+					if(ABS(det(	m_simplex->c[0]->w-m_simplex->c[3]->w,
 						m_simplex->c[1]->w-m_simplex->c[3]->w,
 						m_simplex->c[2]->w-m_simplex->c[3]->w))>0) {
 						return(true);
@@ -500,7 +500,7 @@ struct	GJK
 			const Vector3		dl[]={a-d,b-d,c-d};
 			const real_t		vl=det(dl[0],dl[1],dl[2]);
 			const bool			ng=(vl*vec3_dot(a,vec3_cross(b-c,a-b)))<=0;
-			if(ng&&(Math::abs(vl)>GJK_SIMPLEX4_EPS))
+			if(ng&&(ABS(vl)>GJK_SIMPLEX4_EPS))
 			{
 				real_t	mindist=-1;
 				real_t	subw[3] = {0.f, 0.f, 0.f};

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -784,7 +784,7 @@ bool GodotBody3D::sleep_test(real_t p_step) {
 		return false;
 	}
 
-	if (Math::abs(angular_velocity.length()) < get_space()->get_body_angular_velocity_sleep_threshold() && Math::abs(linear_velocity.length_squared()) < get_space()->get_body_linear_velocity_sleep_threshold() * get_space()->get_body_linear_velocity_sleep_threshold()) {
+	if (ABS(angular_velocity.length()) < get_space()->get_body_angular_velocity_sleep_threshold() && ABS(linear_velocity.length_squared()) < get_space()->get_body_linear_velocity_sleep_threshold() * get_space()->get_body_linear_velocity_sleep_threshold()) {
 		still_time += p_step;
 
 		return still_time > get_space()->get_body_time_to_sleep();

--- a/servers/physics_3d/godot_body_pair_3d.cpp
+++ b/servers/physics_3d/godot_body_pair_3d.cpp
@@ -483,7 +483,7 @@ void GodotBodyPair3D::solve(real_t p_step) {
 
 		real_t vbn = dbv.dot(c.normal);
 
-		if (Math::abs(-vbn + c.bias) > MIN_VELOCITY) {
+		if (ABS(-vbn + c.bias) > MIN_VELOCITY) {
 			real_t jbn = (-vbn + c.bias) * c.mass_normal;
 			real_t jbnOld = c.acc_bias_impulse;
 			c.acc_bias_impulse = MAX(jbnOld + jbn, 0.0f);
@@ -503,7 +503,7 @@ void GodotBodyPair3D::solve(real_t p_step) {
 
 			vbn = dbv.dot(c.normal);
 
-			if (Math::abs(-vbn + c.bias) > MIN_VELOCITY) {
+			if (ABS(-vbn + c.bias) > MIN_VELOCITY) {
 				real_t jbn_com = (-vbn + c.bias) / (inv_mass_A + inv_mass_B);
 				real_t jbnOld_com = c.acc_bias_impulse_center_of_mass;
 				c.acc_bias_impulse_center_of_mass = MAX(jbnOld_com + jbn_com, 0.0f);
@@ -528,7 +528,7 @@ void GodotBodyPair3D::solve(real_t p_step) {
 		//normal impulse
 		real_t vn = dv.dot(c.normal);
 
-		if (Math::abs(vn) > MIN_VELOCITY) {
+		if (ABS(vn) > MIN_VELOCITY) {
 			real_t jn = -(c.bounce + vn) * c.mass_normal;
 			real_t jnOld = c.acc_normal_impulse;
 			c.acc_normal_impulse = MAX(jnOld + jn, 0.0f);
@@ -864,7 +864,7 @@ void GodotBodySoftBodyPair3D::solve(real_t p_step) {
 
 		real_t vbn = dbv.dot(c.normal);
 
-		if (Math::abs(-vbn + c.bias) > MIN_VELOCITY) {
+		if (ABS(-vbn + c.bias) > MIN_VELOCITY) {
 			real_t jbn = (-vbn + c.bias) * c.mass_normal;
 			real_t jbnOld = c.acc_bias_impulse;
 			c.acc_bias_impulse = MAX(jbnOld + jbn, 0.0f);
@@ -883,7 +883,7 @@ void GodotBodySoftBodyPair3D::solve(real_t p_step) {
 
 			vbn = dbv.dot(c.normal);
 
-			if (Math::abs(-vbn + c.bias) > MIN_VELOCITY) {
+			if (ABS(-vbn + c.bias) > MIN_VELOCITY) {
 				real_t jbn_com = (-vbn + c.bias) / (body_inv_mass + node_inv_mass);
 				real_t jbnOld_com = c.acc_bias_impulse_center_of_mass;
 				c.acc_bias_impulse_center_of_mass = MAX(jbnOld_com + jbn_com, 0.0f);
@@ -907,7 +907,7 @@ void GodotBodySoftBodyPair3D::solve(real_t p_step) {
 		// Normal impulse.
 		real_t vn = dv.dot(c.normal);
 
-		if (Math::abs(vn) > MIN_VELOCITY) {
+		if (ABS(vn) > MIN_VELOCITY) {
 			real_t jn = -(c.bounce + vn) * c.mass_normal;
 			real_t jnOld = c.acc_normal_impulse;
 			c.acc_normal_impulse = MAX(jnOld + jn, 0.0f);

--- a/servers/physics_3d/godot_joint_3d.h
+++ b/servers/physics_3d/godot_joint_3d.h
@@ -40,7 +40,7 @@ protected:
 	bool dynamic_B = false;
 
 	void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
-		if (Math::abs(n.z) > Math_SQRT12) {
+		if (ABS(n.z) > Math_SQRT12) {
 			// choose p in y-z plane
 			real_t a = n[1] * n[1] + n[2] * n[2];
 			real_t k = 1.0 / Math::sqrt(a);
@@ -60,7 +60,7 @@ protected:
 	_FORCE_INLINE_ real_t atan2fast(real_t y, real_t x) {
 		real_t coeff_1 = Math_PI / 4.0f;
 		real_t coeff_2 = 3.0f * coeff_1;
-		real_t abs_y = Math::abs(y);
+		real_t abs_y = ABS(y);
 		real_t angle;
 		if (x >= 0.0f) {
 			real_t r = (x - abs_y) / (x + abs_y);

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -191,7 +191,7 @@ Vector3 GodotSeparationRayShape3D::get_support(const Vector3 &p_normal) const {
 }
 
 void GodotSeparationRayShape3D::get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const {
-	if (Math::abs(p_normal.z) < edge_support_threshold_lower) {
+	if (ABS(p_normal.z) < edge_support_threshold_lower) {
 		r_amount = 2;
 		r_type = FEATURE_EDGE;
 		r_supports[0] = Vector3(0, 0, 0);
@@ -342,7 +342,7 @@ void GodotBoxShape3D::get_supports(const Vector3 &p_normal, int p_max, Vector3 *
 		Vector3 axis;
 		axis[i] = 1.0;
 		real_t dot = p_normal.dot(axis);
-		if (Math::abs(dot) > face_support_threshold) {
+		if (ABS(dot) > face_support_threshold) {
 			//Vector3 axis_b;
 
 			bool neg = dot < 0;
@@ -383,7 +383,7 @@ void GodotBoxShape3D::get_supports(const Vector3 &p_normal, int p_max, Vector3 *
 		Vector3 axis;
 		axis[i] = 1.0;
 
-		if (Math::abs(p_normal.dot(axis)) < edge_support_threshold_lower) {
+		if (ABS(p_normal.dot(axis)) < edge_support_threshold_lower) {
 			r_amount = 2;
 			r_type = FEATURE_EDGE;
 
@@ -424,7 +424,7 @@ bool GodotBoxShape3D::intersect_segment(const Vector3 &p_begin, const Vector3 &p
 }
 
 bool GodotBoxShape3D::intersect_point(const Vector3 &p_point) const {
-	return (Math::abs(p_point.x) < half_extents.x && Math::abs(p_point.y) < half_extents.y && Math::abs(p_point.z) < half_extents.z);
+	return (ABS(p_point.x) < half_extents.x && ABS(p_point.y) < half_extents.y && ABS(p_point.z) < half_extents.z);
 }
 
 Vector3 GodotBoxShape3D::get_closest_point_to(const Vector3 &p_point) const {
@@ -432,7 +432,7 @@ Vector3 GodotBoxShape3D::get_closest_point_to(const Vector3 &p_point) const {
 	Vector3 min_point;
 
 	for (int i = 0; i < 3; i++) {
-		if (Math::abs(p_point[i]) > half_extents[i]) {
+		if (ABS(p_point[i]) > half_extents[i]) {
 			outside++;
 			if (outside == 1) {
 				//use plane if only one side matches
@@ -530,7 +530,7 @@ void GodotCapsuleShape3D::get_supports(const Vector3 &p_normal, int p_max, Vecto
 	real_t d = n.y;
 	real_t h = height * 0.5 - radius; // half-height of the cylinder part
 
-	if (h > 0 && Math::abs(d) < edge_support_threshold_lower) {
+	if (h > 0 && ABS(d) < edge_support_threshold_lower) {
 		// make it flat
 		n.y = 0.0;
 		n.normalize();
@@ -608,11 +608,11 @@ bool GodotCapsuleShape3D::intersect_segment(const Vector3 &p_begin, const Vector
 }
 
 bool GodotCapsuleShape3D::intersect_point(const Vector3 &p_point) const {
-	if (Math::abs(p_point.y) < height * 0.5 - radius) {
+	if (ABS(p_point.y) < height * 0.5 - radius) {
 		return Vector3(p_point.x, 0, p_point.z).length() < radius;
 	} else {
 		Vector3 p = p_point;
-		p.y = Math::abs(p.y) - height * 0.5 + radius;
+		p.y = ABS(p.y) - height * 0.5 + radius;
 		return p.length() < radius;
 	}
 }
@@ -676,10 +676,10 @@ void GodotCylinderShape3D::project_range(const Vector3 &p_normal, const Transfor
 	real_t scaled_height = height * scale;
 
 	real_t length;
-	if (Math::abs(axis_dot) > 1.0) {
+	if (ABS(axis_dot) > 1.0) {
 		length = scaled_height * 0.5;
 	} else {
-		length = Math::abs(axis_dot * scaled_height * 0.5) + scaled_radius * Math::sqrt(1.0 - axis_dot * axis_dot);
+		length = ABS(axis_dot * scaled_height * 0.5) + scaled_radius * Math::sqrt(1.0 - axis_dot * axis_dot);
 	}
 
 	real_t distance = p_normal.dot(p_transform.origin);
@@ -708,7 +708,7 @@ Vector3 GodotCylinderShape3D::get_support(const Vector3 &p_normal) const {
 
 void GodotCylinderShape3D::get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const {
 	real_t d = p_normal.y;
-	if (Math::abs(d) > cylinder_face_support_threshold) {
+	if (ABS(d) > cylinder_face_support_threshold) {
 		real_t h = (d > 0) ? height : -height;
 
 		Vector3 n = p_normal;
@@ -723,7 +723,7 @@ void GodotCylinderShape3D::get_supports(const Vector3 &p_normal, int p_max, Vect
 		r_supports[1].x += radius;
 		r_supports[2] = n;
 		r_supports[2].z += radius;
-	} else if (Math::abs(d) < cylinder_edge_support_threshold_lower) {
+	} else if (ABS(d) < cylinder_edge_support_threshold_lower) {
 		// make it flat
 		Vector3 n = p_normal;
 		n.y = 0.0;
@@ -748,14 +748,14 @@ bool GodotCylinderShape3D::intersect_segment(const Vector3 &p_begin, const Vecto
 }
 
 bool GodotCylinderShape3D::intersect_point(const Vector3 &p_point) const {
-	if (Math::abs(p_point.y) < height * 0.5) {
+	if (ABS(p_point.y) < height * 0.5) {
 		return Vector3(p_point.x, 0, p_point.z).length() < radius;
 	}
 	return false;
 }
 
 Vector3 GodotCylinderShape3D::get_closest_point_to(const Vector3 &p_point) const {
-	if (Math::absf(p_point.y) > height * 0.5) {
+	if (ABS(p_point.y) > height * 0.5) {
 		// Project point to top disk.
 		real_t dir = p_point.y > 0.0 ? 1.0 : -1.0;
 		Vector3 circle_pos(0.0, dir * height * 0.5, 0.0);
@@ -1204,7 +1204,7 @@ void GodotFaceShape3D::get_supports(const Vector3 &p_normal, int p_max, Vector3 
 	Vector3 n = p_normal;
 
 	/** TEST FACE AS SUPPORT **/
-	if (Math::abs(normal.dot(n)) > face_support_threshold) {
+	if (ABS(normal.dot(n)) > face_support_threshold) {
 		r_amount = 3;
 		r_type = FEATURE_FACE;
 		for (int i = 0; i < 3; i++) {
@@ -1842,8 +1842,8 @@ bool GodotHeightMapShape3D::_intersect_grid_segment(ProcessFunction &p_process, 
 	const int z_step = (ray_dir_flat.y > CMP_EPSILON) ? 1 : ((ray_dir_flat.y < -CMP_EPSILON) ? -1 : 0);
 
 	const real_t infinite = 1e20;
-	const real_t delta_x = (x_step != 0) ? 1.f / Math::abs(ray_dir_flat.x) : infinite;
-	const real_t delta_z = (z_step != 0) ? 1.f / Math::abs(ray_dir_flat.y) : infinite;
+	const real_t delta_x = (x_step != 0) ? 1.f / ABS(ray_dir_flat.x) : infinite;
+	const real_t delta_z = (z_step != 0) ? 1.f / ABS(ray_dir_flat.y) : infinite;
 
 	real_t cross_x; // At which value of `param` we will cross a x-axis lane?
 	real_t cross_z; // At which value of `param` we will cross a z-axis lane?

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -254,7 +254,7 @@ void GodotSoftBody3D::update_area() {
 		for (int j = 0; j < 3; ++j) {
 			const int index = (int)(face.n[j] - &nodes[0]);
 			counts[index]++;
-			face.n[j]->area += Math::abs(face.ra);
+			face.n[j]->area += ABS(face.ra);
 		}
 	}
 
@@ -943,7 +943,7 @@ void GodotSoftBody3D::apply_forces(const LocalVector<GodotArea3D *> &p_wind_area
 
 	// Apply nodal pressure forces.
 	if (pressure_coefficient > CMP_EPSILON) {
-		real_t ivolumetp = 1.0 / Math::abs(volume) * pressure_coefficient;
+		real_t ivolumetp = 1.0 / ABS(volume) * pressure_coefficient;
 		for (Node &node : nodes) {
 			if (node.im > 0) {
 				node.f += node.n * (node.area * ivolumetp);

--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -148,7 +148,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 
 	real_t RMaxAngle1Sq = 1.0f / (m_swingSpan1 * m_swingSpan1);
 	real_t RMaxAngle2Sq = 1.0f / (m_swingSpan2 * m_swingSpan2);
-	real_t EllipseAngle = Math::abs(swing1 * swing1) * RMaxAngle1Sq + Math::abs(swing2 * swing2) * RMaxAngle2Sq;
+	real_t EllipseAngle = ABS(swing1 * swing1) * RMaxAngle1Sq + ABS(swing2 * swing2) * RMaxAngle2Sq;
 
 	if (EllipseAngle > 1.0f) {
 		m_swingCorrection = EllipseAngle - 1.0f;

--- a/servers/physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_slider_joint_3d.cpp
@@ -163,7 +163,7 @@ void GodotSliderJoint3D::solve(real_t p_step) {
 				real_t motor_relvel = desiredMotorVel + rel_vel;
 				normalImpulse = -motor_relvel * m_jacLinDiagABInv[i];
 				// clamp accumulated impulse
-				real_t new_acc = m_accumulatedLinMotorImpulse + Math::abs(normalImpulse);
+				real_t new_acc = m_accumulatedLinMotorImpulse + ABS(normalImpulse);
 				if (new_acc > m_maxLinMotorForce) {
 					new_acc = m_maxLinMotorForce;
 				}
@@ -248,7 +248,7 @@ void GodotSliderJoint3D::solve(real_t p_step) {
 
 			real_t angImpulse = m_kAngle * motor_relvel;
 			// clamp accumulated impulse
-			real_t new_acc = m_accumulatedAngMotorImpulse + Math::abs(angImpulse);
+			real_t new_acc = m_accumulatedAngMotorImpulse + ABS(angImpulse);
 			if (new_acc > m_maxAngMotorForce) {
 				new_acc = m_maxAngMotorForce;
 			}

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -130,7 +130,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 				}
 			}
 			Plane p(vertices[0], vertices[1], vertices[2]);
-			min_d = MIN(Math::abs(p.d), min_d);
+			min_d = MIN(ABS(p.d), min_d);
 		}
 		sphere_overfit = 1.0 / min_d;
 	}
@@ -183,7 +183,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 				Vector3 b = vertices[(zero_index + 2) % 3];
 				Vector3 c = a + Vector3(0, 0, 1);
 				Plane p(a, b, c);
-				min_d = MIN(Math::abs(p.d), min_d);
+				min_d = MIN(ABS(p.d), min_d);
 			}
 		}
 		cone_overfit = 1.0 / min_d;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -349,7 +349,7 @@ public:
 			xform.basis.rows[i] /= s;
 		};
 
-		float box_depth = Math::abs(xform.basis.xform_inv(Vector3(0, 0, -1)).dot(scale));
+		float box_depth = ABS(xform.basis.xform_inv(Vector3(0, 0, -1)).dot(scale));
 		float depth = -xform.origin.z;
 
 		if (camera_orthogonal) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -339,7 +339,7 @@ void _get_axis_angle(const Vector3 &p_normal, const Vector4 &p_tangent, float &r
 // and p_angle includes the binormal direction.
 void _get_tbn_from_axis_angle(const Vector3 &p_axis, float p_angle, Vector3 &r_normal, Vector4 &r_tangent) {
 	float binormal_sign = p_angle > 0.5 ? 1.0 : -1.0;
-	float angle = Math::abs(p_angle * 2.0 - 1.0) * Math_PI;
+	float angle = ABS(p_angle * 2.0 - 1.0) * Math_PI;
 
 	Basis tbn = Basis(p_axis, angle);
 	Vector3 tan = tbn.rows[0];

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -91,10 +91,10 @@ TEST_CASE("[Math] Power of two functions") {
 }
 
 TEST_CASE_TEMPLATE("[Math] abs", T, int, float, double) {
-	CHECK(Math::abs((T)-1) == (T)1);
-	CHECK(Math::abs((T)0) == (T)0);
-	CHECK(Math::abs((T)1) == (T)1);
-	CHECK(Math::abs((T)0.1) == (T)0.1);
+	CHECK(ABS((T)-1) == (T)1);
+	CHECK(ABS((T)0) == (T)0);
+	CHECK(ABS((T)1) == (T)1);
+	CHECK(ABS((T)0.1) == (T)0.1);
 }
 
 TEST_CASE_TEMPLATE("[Math] round/floor/ceil", T, float, double) {

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -301,7 +301,7 @@ TEST_CASE("[SceneTree][Primitive][Cylinder] Cylinder Primitive") {
 				Vector3 point_to_normal = normals[index].normalized() - yaxis_to_point.normalized();
 				//				std::cout << "<" << point_to_normal.x << ", " << point_to_normal.y << ", " << point_to_normal.z << ">\n";
 				if (!(point_to_normal.is_equal_approx(Vector3(0, 0, 0))) &&
-						(!Math::is_equal_approx(Math::abs(normals[index].normalized().y), 1))) {
+						(!Math::is_equal_approx(ABS(normals[index].normalized().y), 1))) {
 					is_correct_normals = false;
 					break;
 				}


### PR DESCRIPTION
Adjusted the generic `ABS` template function to support signed zeros, which consequently allows it to handle floating-point numbers. This puts it on even footing with `SIGN`, where a single constexpr function can be used exclusively thoughout the repo. As such, it removes the need for the various `Math::abs` implementations; everything can simply call `ABS` instead. All instances of `Math::abs` have been replaced with `ABS`, and the Math functions themselves were safely removed as they were never directly bound.