### PR TITLE
[Core] Fix COW allocates too much memory

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -133,14 +133,10 @@ private:
 	}
 
 	_FORCE_INLINE_ USize _get_alloc_size(USize p_elements) const {
-		return next_po2(p_elements * sizeof(T));
+		return next_po2(p_elements) * sizeof(T);
 	}
 
 	_FORCE_INLINE_ bool _get_alloc_size_checked(USize p_elements, USize *out) const {
-		if (unlikely(p_elements == 0)) {
-			*out = 0;
-			return true;
-		}
 #if defined(__GNUC__) && defined(IS_32_BIT)
 		USize o;
 		USize p;
@@ -157,7 +153,7 @@ private:
 		// and hope for the best.
 		*out = _get_alloc_size(p_elements);
 #endif
-		return *out;
+		return true;
 	}
 
 	void _unref(void *p_data);


### PR DESCRIPTION
I found a place where COW allocates too much memory for types whose size is not a multiple of 2.
For example, we have a type size of 20 bytes and want to change the COW size to 4. To do this, call the `resize(4)` method.
This method calls the `_get_alloc_size` method which allocates too much memory for us. `_next_po2(20 * 4) = 128`.
But instead it should be `_next_po2(4) * 20 = 80`.

I haven't done performance benchmarks yet, but only looked at the amount of memory used by the project from CI https://github.com/godotengine/regression-test-project/archive/4.0.zip. 

Before:
![image](https://github.com/godotengine/godot/assets/116561933/b0336d20-9f26-4eb7-ba1c-9de0e4045b89)

After:
![image](https://github.com/godotengine/godot/assets/116561933/e514a4bd-42f5-4247-8c96-270f070b7675)

