### PR TITLE
Fix an issue where Object was not selectable in the AnimationTrackKeyEditor inspector.

### DIFF
--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -155,7 +155,7 @@ public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
 		VariantInternal::clear(&r_ret);
 		if (p_args[0]->get_type() == Variant::NIL) {
-			VariantInternal::object_assign_null(&r_ret);
+			VariantInternal::init_object(&r_ret);
 			r_error.error = Callable::CallError::CALL_OK;
 		} else if (p_args[0]->get_type() == Variant::OBJECT) {
 			VariantInternal::object_assign(&r_ret, p_args[0]);


### PR DESCRIPTION
Fixed an issue where Object was not selectable in the AnimationTrackKeyEditor inspector.

The problem was that the VariantConstructorObject was not setting the type to Object, when coming from a Nil variant type. I fixed this by calling VariantInternal::init_object instead of object_assign_null.

fixes #91289 

* *Bugsquad edit, see also: https://github.com/godotengine/godot/pull/90134*