### PR TITLE
Fix export dialog sizing issue on small devices

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -131,7 +131,7 @@ void ProjectExportDialog::popup_export() {
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
-		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
+		popup_centered_clamped(Size2(900, 500) * EDSCALE, 0.7);
 	}
 }
 
@@ -1311,9 +1311,15 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	// Resources export parameters.
 
+	ScrollContainer *resources_scroll_container = memnew(ScrollContainer);
+	resources_scroll_container->set_name(TTR("Resources"));
+	resources_scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	sections->add_child(resources_scroll_container);
+
 	VBoxContainer *resources_vb = memnew(VBoxContainer);
-	sections->add_child(resources_vb);
-	resources_vb->set_name(TTR("Resources"));
+	resources_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	resources_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	resources_scroll_container->add_child(resources_vb);
 
 	export_filter = memnew(OptionButton);
 	export_filter->add_item(TTR("Export all resources in the project"));
@@ -1332,6 +1338,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	resources_vb->add_child(include_margin);
 
 	include_files = memnew(Tree);
+	include_files->set_custom_minimum_size(Size2(1, 75 * EDSCALE));
 	include_margin->add_child(include_files);
 	include_files->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	include_files->connect("item_edited", callable_mp(this, &ProjectExportDialog::_tree_changed));
@@ -1384,18 +1391,25 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	VBoxContainer *feature_vb = memnew(VBoxContainer);
 	feature_vb->set_name(TTR("Features"));
+	feature_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	custom_features = memnew(LineEdit);
 	custom_features->connect("text_changed", callable_mp(this, &ProjectExportDialog::_custom_features_changed));
 	feature_vb->add_margin_child(TTR("Custom (comma-separated):"), custom_features);
 	custom_feature_display = memnew(RichTextLabel);
+	custom_feature_display->set_custom_minimum_size(Size2(1, 75 * EDSCALE));
 	custom_feature_display->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	feature_vb->add_margin_child(TTR("Feature List:"), custom_feature_display, true);
 	sections->add_child(feature_vb);
 
 	// Encryption export parameters.
 
+	ScrollContainer *sec_scroll_container = memnew(ScrollContainer);
+	sec_scroll_container->set_name(TTR("Encryption"));
+	sec_scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+
 	VBoxContainer *sec_vb = memnew(VBoxContainer);
-	sec_vb->set_name(TTR("Encryption"));
+	sec_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	sec_scroll_container->add_child(sec_vb);
 
 	enc_pck = memnew(CheckButton);
 	enc_pck->connect("toggled", callable_mp(this, &ProjectExportDialog::_enc_pck_changed));
@@ -1426,7 +1440,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_key_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
 	sec_vb->add_margin_child(TTR("Encryption Key (256-bits as hexadecimal):"), script_key);
 	sec_vb->add_child(script_key_error);
-	sections->add_child(sec_vb);
+	sections->add_child(sec_scroll_container);
 
 	Label *sec_info = memnew(Label);
 	sec_info->set_text(TTR("Note: Encryption key needs to be stored in the binary,\nyou need to build the export templates from source."));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73130

- Update the min height from `700` to `500` to match the editor's min height of `600`
- Wrap the `Resources` and `Encryption` sections of the `TabContainer` within a `ScrollContainer`. This prevents the export dialog from trying to resize to fit the tallest of those sections, and make them accessible on small screen devices.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
