### PR TITLE
Compiler warning with unused code causes web builds to fail.

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3289,6 +3289,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		}
 	}
 
+#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 	if (p_paths.size() == 1) {
 		const String &fpath = p_paths[0];
 
@@ -3314,7 +3315,6 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 			}
 		}
 
-#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 		if (!added_separator) {
 			p_popup->add_separator();
 			added_separator = true;
@@ -3332,6 +3332,29 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 
 		p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Terminal")), ED_GET_SHORTCUT("filesystem_dock/open_in_terminal"), FILE_OPEN_IN_TERMINAL);
 		p_popup->set_item_text(p_popup->get_item_index(FILE_OPEN_IN_TERMINAL), is_directory ? TTR("Open in Terminal") : TTR("Open Containing Folder in Terminal"));
+#else
+	if (p_paths.size() == 1) {
+		const String &fpath = p_paths[0];
+
+		if (favorites_list.has(fpath)) {
+			TreeItem *favorites_item = tree->get_root()->get_first_child();
+			TreeItem *cursor_item = tree->get_selected();
+			bool is_item_in_favorites = false;
+			while (cursor_item != nullptr) {
+				if (cursor_item == favorites_item) {
+					is_item_in_favorites = true;
+					break;
+				}
+
+				cursor_item = cursor_item->get_parent();
+			}
+
+			if (is_item_in_favorites) {
+				p_popup->add_separator();
+				added_separator = true;
+				p_popup->add_icon_item(get_editor_theme_icon(SNAME("ShowInFileSystem")), TTR("Show in FileSystem"), FILE_SHOW_IN_FILESYSTEM);
+			}
+		}
 #endif
 
 		current_path = fpath;


### PR DESCRIPTION
I moved the not android and not web sections of the code after the added_separator variable is set.

```
editor/filesystem_dock.cpp:3295:8: error: variable 'added_separator' set but not used [-Werror,-Wunused-but-set-variable]
                bool added_separator = false;
                     ^
1 error generated.
```

https://github.com/V-Sekai/godot/actions/runs/8870785282/job/24353571230