### PR TITLE
MobileVR: Orientation is progressive and needs to be initialized

### DIFF
--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -126,7 +126,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	// 9dof is a misleading marketing term coming from 3 accelerometer axis + 3 gyro axis + 3 magnetometer axis = 9 axis
 	// but in reality this only offers 3 dof (yaw, pitch, roll) orientation
 
-	Basis orientation;
+	Basis orientation = head_transform.basis;
 
 	uint64_t ticks = OS::get_singleton()->get_ticks_usec();
 	uint64_t ticks_elapsed = ticks - last_ticks;


### PR DESCRIPTION
Somewhere in converting our native mobile implementation from Godot 3 to Godot 4 we broke the orientation logic.
`Orientation` used to be a member variable which is cumulative, either mixing in new magneto data or adjusting with gyro data.
In the new logic `orientation` is a local variable that is not initialised and we lost this cumulation of values. As we store the new orientation in the head transform, we can initialise our variable with this value as well.

Tested on Pixel 6 and works fine on that now.

This fixes the orientation issue reported in #89755
I could not reproduce the flickering issue reported in that same issue, however I believe that may be a Qualcomm issue, or something entirely unrelated.

This PR also does not address:
- predicting head location at display time
- configuring sensor data update rate to a higher than default setting

Test project, works both on desktop (but without the gyro) and on mobile (though no inputs to move, just for testing orientation):
[TestMobileVR.zip](https://github.com/godotengine/godot/files/15148729/TestMobileVR.zip)
