### PR TITLE
Update Variant documentation comment about `class_name`

### DIFF
--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -42,8 +42,8 @@
 		        # Note that Objects are their own special category.
 		        # To get the name of the underlying Object type, you need the `get_class()` method.
 		        print("foo is a(n) %s" % foo.get_class()) # inject the class name into a formatted string.
-		        # Note also that there is not yet any way to get a script's `class_name` string easily.
-		        # To fetch that value, you can use ProjectSettings.get_global_class_list().
+		        # Note that this does not get the script's `class_name` global identifier.
+		        # If the `class_name` is needed, use `foo.get_script().get_global_name()` instead.
 		[/gdscript]
 		[csharp]
 		Variant foo = 2;


### PR DESCRIPTION
Comment was outdated - you can now get a script's `class_name` easily by calling `get_global_name()` on the script of a given object.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
