### PR TITLE
Add a note for `String::reverse` to warn about its implementation

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -747,7 +747,7 @@
 		<method name="reverse" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the copy of this string in reverse order.
+				Returns the copy of this string in reverse order. This operation works on unicode codepoints, rather than sequences of codepoints, and may break things like compound letters or emojis.
 			</description>
 		</method>
 		<method name="rfind" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -648,7 +648,7 @@
 		<method name="reverse" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the copy of this string in reverse order.
+				Returns the copy of this string in reverse order. This operation works on unicode codepoints, rather than sequences of codepoints, and may break things like compound letters or emojis.
 			</description>
 		</method>
 		<method name="rfind" qualifiers="const">


### PR DESCRIPTION
Just a note for `String`/`StringName` docs to warn user to not use emojis/compound symbols with that method. This is an addition for https://github.com/godotengine/godot/pull/78529 implementation.
