### PR TITLE
Core: Implement Math equivalents of `typedefs.h` macros

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -50,6 +50,31 @@ public:
 	// Not using 'RANDOM_MAX' to avoid conflict with system headers on some OSes (at least NetBSD).
 	static const uint64_t RANDOM_32BIT_MAX = 0xFFFFFFFF;
 
+	template <typename T>
+	static constexpr T abs(T p_value) {
+		return p_value == T(0) ? T(0) : (p_value < T(0) ? -p_value : p_value);
+	}
+
+	template <typename T>
+	static constexpr T sign(T p_value) {
+		return p_value > T(0) ? T(1) : (p_value < T(0) ? T(-1) : T(0));
+	}
+
+	template <typename T>
+	static constexpr T min(T p_left, T p_right) {
+		return p_left < p_right ? p_left : p_right;
+	}
+
+	template <typename T>
+	static constexpr T max(T p_left, T p_right) {
+		return p_left > p_right ? p_left : p_right;
+	}
+
+	template <typename T>
+	static constexpr T clamp(T p_value, T p_min, T p_max) {
+		return p_value < p_min ? p_min : (p_value > p_max ? p_max : p_value);
+	}
+
 	static _ALWAYS_INLINE_ double sin(double p_x) { return ::sin(p_x); }
 	static _ALWAYS_INLINE_ float sin(float p_x) { return ::sinf(p_x); }
 
@@ -216,10 +241,6 @@ public:
 
 	static _ALWAYS_INLINE_ bool is_finite(double p_val) { return isfinite(p_val); }
 	static _ALWAYS_INLINE_ bool is_finite(float p_val) { return isfinite(p_val); }
-
-	static _ALWAYS_INLINE_ double abs(double g) { return absd(g); }
-	static _ALWAYS_INLINE_ float abs(float g) { return absf(g); }
-	static _ALWAYS_INLINE_ int abs(int g) { return g > 0 ? g : -g; }
 
 	static _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
 		double value = Math::fmod(p_x, p_y);
@@ -449,35 +470,35 @@ public:
 		if (is_equal_approx(p_from, p_to)) {
 			return p_from;
 		}
-		double s = CLAMP((p_s - p_from) / (p_to - p_from), 0.0, 1.0);
+		double s = clamp((p_s - p_from) / (p_to - p_from), 0.0, 1.0);
 		return s * s * (3.0 - 2.0 * s);
 	}
 	static _ALWAYS_INLINE_ float smoothstep(float p_from, float p_to, float p_s) {
 		if (is_equal_approx(p_from, p_to)) {
 			return p_from;
 		}
-		float s = CLAMP((p_s - p_from) / (p_to - p_from), 0.0f, 1.0f);
+		float s = clamp((p_s - p_from) / (p_to - p_from), 0.0f, 1.0f);
 		return s * s * (3.0f - 2.0f * s);
 	}
 
 	static _ALWAYS_INLINE_ double move_toward(double p_from, double p_to, double p_delta) {
-		return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+		return abs(p_to - p_from) <= p_delta ? p_to : p_from + sign(p_to - p_from) * p_delta;
 	}
 	static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) {
-		return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+		return abs(p_to - p_from) <= p_delta ? p_to : p_from + sign(p_to - p_from) * p_delta;
 	}
 
 	static _ALWAYS_INLINE_ double rotate_toward(double p_from, double p_to, double p_delta) {
 		double difference = Math::angle_difference(p_from, p_to);
 		double abs_difference = Math::abs(difference);
 		// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-		return p_from + CLAMP(p_delta, abs_difference - Math_PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
+		return p_from + clamp(p_delta, abs_difference - Math_PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
 	}
 	static _ALWAYS_INLINE_ float rotate_toward(float p_from, float p_to, float p_delta) {
 		float difference = Math::angle_difference(p_from, p_to);
 		float abs_difference = Math::abs(difference);
 		// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-		return p_from + CLAMP(p_delta, abs_difference - (float)Math_PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
+		return p_from + clamp(p_delta, abs_difference - (float)Math_PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
 	}
 
 	static _ALWAYS_INLINE_ double linear_to_db(double p_linear) {
@@ -607,27 +628,6 @@ public:
 
 	static _ALWAYS_INLINE_ bool is_zero_approx(double s) {
 		return abs(s) < CMP_EPSILON;
-	}
-
-	static _ALWAYS_INLINE_ float absf(float g) {
-		union {
-			float f;
-			uint32_t i;
-		} u;
-
-		u.f = g;
-		u.i &= 2147483647u;
-		return u.f;
-	}
-
-	static _ALWAYS_INLINE_ double absd(double g) {
-		union {
-			double d;
-			uint64_t i;
-		} u;
-		u.d = g;
-		u.i &= (uint64_t)9223372036854775807ll;
-		return u.d;
 	}
 
 	// This function should be as fast as possible and rounding mode should not matter.

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -160,7 +160,7 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, real_t p_weight) const {
 
 	real_t dot = from.dot(p_to);
 
-	if (Math::absf(dot) > 0.9999f) {
+	if (Math::abs(dot) > 0.9999f) {
 		return from;
 	}
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -103,27 +103,31 @@
 #undef MAX
 #undef CLAMP
 
-// Generic ABS function, for math uses please use Math::abs.
+// DEPRECATED. Use `Math::abs` instead.
 template <typename T>
 constexpr T ABS(T m_v) {
 	return m_v < 0 ? -m_v : m_v;
 }
 
+// DEPRECATED. Use `Math::sign` instead.
 template <typename T>
 constexpr const T SIGN(const T m_v) {
 	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
 }
 
+// DEPRECATED. Use `Math::min` instead.
 template <typename T, typename T2>
 constexpr auto MIN(const T m_a, const T2 m_b) {
 	return m_a < m_b ? m_a : m_b;
 }
 
+// DEPRECATED. Use `Math::max` instead.
 template <typename T, typename T2>
 constexpr auto MAX(const T m_a, const T2 m_b) {
 	return m_a > m_b ? m_a : m_b;
 }
 
+// DEPRECATED. Use `Math::clamp` instead.
 template <typename T, typename T2, typename T3>
 constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
 	return m_a < m_min ? m_min : (m_a > m_max ? m_max : m_a);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -248,7 +248,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 			return ABS(VariantInternalAccessor<int64_t>::get(&x));
 		} break;
 		case Variant::FLOAT: {
-			return Math::absd(VariantInternalAccessor<double>::get(&x));
+			return Math::abs(VariantInternalAccessor<double>::get(&x));
 		} break;
 		case Variant::VECTOR2: {
 			return VariantInternalAccessor<Vector2>::get(&x).abs();
@@ -278,7 +278,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 }
 
 double VariantUtilityFunctions::absf(double x) {
-	return Math::absd(x);
+	return Math::abs(x);
 }
 
 int64_t VariantUtilityFunctions::absi(int64_t x) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1535,7 +1535,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 		float val = get_edited_property_value();
 		bool sg = val < 0;
-		val = Math::absf(val);
+		val = Math::abs(val);
 
 		val = Math::log(val) / Math::log((float)2.0);
 		// Logarithmic space.

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -271,7 +271,7 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 	List<List<Blend>::Element *> to_erase;
 	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
 		Blend &b = E->get();
-		b.blend_left = MAX(0, b.blend_left - Math::absf(speed_scale * p_delta) / b.blend_time);
+		b.blend_left = MAX(0, b.blend_left - Math::abs(speed_scale * p_delta) / b.blend_time);
 		if (b.blend_left <= 0) {
 			to_erase.push_back(E);
 			b.blend_left = CMP_EPSILON; // May want to play last frame.

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -371,13 +371,13 @@ static float perpendicular_distance(const Vector2 &i, const Vector2 &start, cons
 	float intercept;
 
 	if (start.x == end.x) {
-		res = Math::absf(i.x - end.x);
+		res = Math::abs(i.x - end.x);
 	} else if (start.y == end.y) {
-		res = Math::absf(i.y - end.y);
+		res = Math::abs(i.y - end.y);
 	} else {
 		slope = (end.y - start.y) / (end.x - start.x);
 		intercept = start.y - (slope * start.x);
-		res = Math::absf(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
+		res = Math::abs(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
 	}
 	return res;
 }

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -755,7 +755,7 @@ bool GodotCylinderShape3D::intersect_point(const Vector3 &p_point) const {
 }
 
 Vector3 GodotCylinderShape3D::get_closest_point_to(const Vector3 &p_point) const {
-	if (Math::absf(p_point.y) > height * 0.5) {
+	if (Math::abs(p_point.y) > height * 0.5) {
 		// Project point to top disk.
 		real_t dir = p_point.y > 0.0 ? 1.0 : -1.0;
 		Vector3 circle_pos(0.0, dir * height * 0.5, 0.0);


### PR DESCRIPTION
An alternative to #91283, where the `typedefs.h` math macros are setup for deprecation. Now each macro has a comment warning of future deprecation, and recommends using their new Math equivalents instead. The only function that already had an equivalent, `abs`, has been consolidated into a single constexpr template; the other functions were simply relocated. Both `abs` and `sign` were slightly refactored from their macros, while `min`, `max` and `clamp` ~~had their return type changed from `auto` to `std::common_return_t<T...>`~~ only use a single template parameter. The only changes to files outside of these were changing any instances of `Math::absf` and `Math::absd` to `Math::abs`, as those functions no longer exist after consolidating `abs`.