### PR TITLE
Add automatic class_name generation for newly created scripts

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1058,7 +1058,7 @@
 			If [code]true[/code], uses [StringName] instead of [String] when appropriate for code autocompletion.
 		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
-			If [code]true[/code], adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] hints such as [code]-&gt; void[/code] and [code]: int[/code] when using code autocompletion or when creating onready variables by drag and dropping nodes into the script editor while pressing the [kbd]Ctrl[/kbd] key. If [code]true[/code], newly created scripts will also automatically have type hints added to their method parameters and return types.
+			If [code]true[/code], adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] hints such as [code]-&gt; void[/code] and [code]: int[/code] when using code autocompletion or when creating onready variables by drag and dropping nodes into the script editor while pressing the [kbd]Ctrl[/kbd] key. If [code]true[/code], newly created scripts will also automatically have type hints added to their method parameters and return types, as well as a generated [code]class_name[/code] based on the script's file name.
 		</member>
 		<member name="text_editor/completion/auto_brace_complete" type="bool" setter="" getter="">
 			If [code]true[/code], automatically completes braces when making use of code completion.

--- a/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
@@ -1,11 +1,11 @@
 # meta-description: Classic movement for gravity games (platformer, ...)
 
+class_name _CLASS_
 extends _BASE_
 
 
 const SPEED = 300.0
 const JUMP_VELOCITY = -400.0
-
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.

--- a/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
@@ -1,5 +1,6 @@
 # meta-description: Classic movement for gravity games (FPS, TPS, ...)
 
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
+++ b/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic plugin template
 
 @tool
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic import script template
 
 @tool
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic import script template (no comments)
 
 @tool
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/EditorScript/basic_editor_script.gd
+++ b/modules/gdscript/editor/script_templates/EditorScript/basic_editor_script.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic editor script template
 
 @tool
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/Node/default.gd
+++ b/modules/gdscript/editor/script_templates/Node/default.gd
@@ -1,5 +1,6 @@
 # meta-description: Base template for Node with default Godot cycle methods
 
+class_name _CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/editor/script_templates/Object/empty.gd
+++ b/modules/gdscript/editor/script_templates/Object/empty.gd
@@ -1,3 +1,4 @@
 # meta-description: Empty template suitable for all Objects
 
+class_name _CLASS_
 extends _BASE_

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -79,7 +79,8 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	type_hints = EDITOR_GET("text_editor/completion/add_type_hints");
 #endif
 	if (!type_hints) {
-		processed_template = processed_template.replace(": int", "")
+		processed_template = processed_template.replace("class_name _CLASS_\n", "")
+									 .replace(": int", "")
 									 .replace(": Shader.Mode", "")
 									 .replace(": VisualShader.Type", "")
 									 .replace(": float", "")


### PR DESCRIPTION
Add automatic class_name generation for newly created scripts when `Add Type Hints` is enabled.
related to [#9491](https://github.com/godotengine/godot-proposals/issues/9491)

Feel free to suggest other ways to implement this instead, I just did what was most logical to me.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
