### PR TITLE
Fix a performance regression when duplicating a node

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -266,7 +266,7 @@ private:
 	void _propagate_groups_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
 
-	void _duplicate_properties_node(const Node *p_root, const Node *p_original, Node *p_copy) const;
+	void _duplicate_properties(const Node *p_root, const Node *p_original, Node *p_copy, int p_flags) const;
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	Node *_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap = nullptr) const;
 


### PR DESCRIPTION
@Calinou reported a performance regression when duplicating empty node so I fixed it by moving all property duplication away from ```duplicate```to ```_duplicate_properties``` function so that we wouldn't loop through them twice. 

Fixes: https://github.com/godotengine/godot/issues/91230

Duplicating empty node now takes on my Macbook 1336 milliseconds compared to before (2246 milliseconds).
```
Iteration 0: 60.805 MB
Iteration 1: 60.811 MB
Iteration 2: 60.819 MB
Iteration 3: 60.839 MB
Iteration 4: 60.879 MB
Iteration 5: 60.958 MB
Iteration 6: 61.115 MB
Iteration 7: 61.430 MB
Iteration 8: 62.090 MB
Iteration 9: 63.412 MB
Iteration 10: 65.923 MB
Iteration 11: 71.076 MB
Iteration 12: 81.382 MB
Iteration 13: 101.994 MB
Iteration 14: 143.217 MB
Iteration 15: 225.661 MB
Done running in 1336 milliseconds.
```

~~Edit: Should also fix https://github.com/godotengine/godot/issues/91461~~