### PR TITLE
Document 0, 90, 180, and 270 degree TileMap cell rotations

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -295,6 +295,15 @@
 			    # If tile is not already flipped, flip it.
 			    $TileMap.set_cell(0, Vector2i(2, 2), source_id, atlas_coords, alternate_id | TileSetAtlasSource.TRANSFORM_FLIP_H)
 			[/codeblock]
+			[b]Note:[/b] These transformations can be combined to do the equivalent of 0, 90, 180, and 270 degree rotations, as shown below:
+			[codeblock]
+			enum TileTransform {
+			    ROTATE_0 = 0,
+			    ROTATE_90 = TileSetAtlasSource.TRANSFORM_TRANSPOSE | TileSetAtlasSource.TRANSFORM_FLIP_H,
+			    ROTATE_180 = TileSetAtlasSource.TRANSFORM_FLIP_H | TileSetAtlasSource.TRANSFORM_FLIP_V,
+			    ROTATE_270 = TileSetAtlasSource.TRANSFORM_TRANSPOSE | TileSetAtlasSource.TRANSFORM_FLIP_V,
+			}
+			[/codeblock]
 		</constant>
 		<constant name="TRANSFORM_FLIP_V" value="8192">
 			Represents cell's vertical flip flag. See [constant TRANSFORM_FLIP_H] for usage.


### PR DESCRIPTION
documents 0, 90, 180, and 270 degree TileMap cell rotations