### PR TITLE
Expose `EditorFileDialog::popup_file_dialog()` to GDScript and GDExtension

### DIFF
--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -90,6 +90,12 @@
 				Notify the [EditorFileDialog] that its view of the data is no longer accurate. Updates the view contents on next view update.
 			</description>
 		</method>
+		<method name="popup_file_dialog">
+			<return type="void" />
+			<description>
+				Shows the [EditorFileDialog] at the default size and position for file dialogs in the editor, and selects the file name if there is a current file.
+			</description>
+		</method>
 		<method name="set_option_default">
 			<return type="void" />
 			<param index="0" name="option" type="int" />

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1929,6 +1929,7 @@ void EditorFileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_disable_overwrite_warning", "disable"), &EditorFileDialog::set_disable_overwrite_warning);
 	ClassDB::bind_method(D_METHOD("is_overwrite_warning_disabled"), &EditorFileDialog::is_overwrite_warning_disabled);
 	ClassDB::bind_method(D_METHOD("add_side_menu", "menu", "title"), &EditorFileDialog::add_side_menu, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("popup_file_dialog"), &EditorFileDialog::popup_file_dialog);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &EditorFileDialog::invalidate);
 


### PR DESCRIPTION
The `EditorFileDialog::popup_file_dialog()` function is used through out the editor when showing a file dialog.

This will show the file dialog at the default size and position for file dialogs in the editor, and select the file name if there is a current file.

This PR exposes the function to GDScript and GDExtension so that editor plugins can show file dialogs in a way that's consistent with the rest of the editor.