### PR TITLE
Disable 3D for root editor Viewport to curb tough-to-diagnose performance issues

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1750,6 +1750,11 @@ SceneTree::SceneTree() {
 	root->set_title(GLOBAL_GET("application/config/name"));
 
 	if (Engine::get_singleton()->is_editor_hint()) {
+#ifndef _3D_DISABLED
+		// 3D is always obscured by editor GUI, disabling helps prevent tough-to-diagnose performance issues with editor-enabled autoload nodes.
+		root->set_disable_3d(true);
+#endif // _3D_DISABLED
+
 		root->set_wrap_controls(true);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
The 3D scene is never visible from the root editor viewport since it's obscured by the editor GUI.
This can cause major performance issues with editor-enabled autoloads! I was wondering why the editor was stuttering so bad, but turns out that a depth-of-field effect was tanking the framerate with a large window! Eventually, I realized what might be happening, so I made a test scene that modifies the opacity of the editor's base control, and lo and behold, the scene was rendering behind it.
This shouldn't happen anyways (I've since switched to using `EditorInterface.get_editor_viewport_2d` as the parent of the visual nodes) but it's much tougher to diagnose than 2D, which will display in front of the editor GUI. Since the 3D scene would never be visible anyways, I think that it'd be best to disable it.