### PR TITLE
Store previous relative transforms in `XRHandModifier3D`

### DIFF
--- a/scene/3d/xr_hand_modifier_3d.h
+++ b/scene/3d/xr_hand_modifier_3d.h
@@ -73,6 +73,9 @@ private:
 	BoneUpdate bone_update = BONE_UPDATE_FULL;
 	JointData joints[XRHandTracker::HAND_JOINT_MAX];
 
+	bool has_stored_previous_transforms = false;
+	Vector<Transform3D> previous_relative_transforms;
+
 	void _get_joint_data();
 	void _tracker_changed(StringName p_tracker_name, XRServer::TrackerType p_tracker_type);
 };


### PR DESCRIPTION
This change makes it so that `XRHandModifier3D` stores the transforms of each joint on every full execution of the `_process_modification()` function. These transforms can then be applied if `XRHandTracker::get_has_tracking_data()` returns false.

After recent updates I was bumping into issues on Quest 2 / Pro where, on opening the system menu, the hand models would jarringly snap back to a resting position. With this PR, the hands will instead remain frozen in position.