### PR TITLE
Rework global class hiding in addons

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -160,8 +160,13 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		if (script_path.begins_with("res://addons/")) {
-			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {
-				return true; // Plugin is not enabled.
+			int i = script_path.find("/", 13); // 13 is length of "res://addons/".
+			while (i > -1) {
+				const String plugin_path = script_path.substr(0, i).path_join("plugin.cfg");
+				if (FileAccess::exists(plugin_path)) {
+					return !EditorNode::get_singleton()->is_addon_plugin_enabled(plugin_path);
+				}
+				i = script_path.find("/", i + 1);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #78400
Supersedes #86325

Currently when global class scrip is inside addons folder, the editor will check whether the middle directory is an enabled addon. This is a legacy code; now addons are enabled by their full path to `plugin.cfg`, which can be inside a sub-folder. With this PR it is taken into account by scanning script's parent directories for plugin config. I also added extra check for the config existence - if a script is inside addons subfolder that isn't actually an addon, the class will always be visible. This allows creating custom class addons without making a plugin. CC @Calinou I remember you requested it once.