### PR TITLE
Increase threshold for files per directory in editor Find in Files

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -222,7 +222,9 @@ void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, 
 
 	dir->list_dir_begin();
 
-	for (int i = 0; i < 1000; ++i) {
+	// Limit to 100,000 iterations to avoid an infinite loop just in case
+	// (this technically limits results to 100,000 files per folder).
+	for (int i = 0; i < 100'000; ++i) {
 		String file = dir->get_next();
 
 		if (file.is_empty()) {


### PR DESCRIPTION
This allows up to 100,000 files per folder to be searched with Find in Files, as opposed to just 1,000.

This means searches can potentially take more time in huge projects, but this pretty much ensures all results will be displayed as you'd expect. In the era of SSDs, I don't expect this increased limit to cause too much of an issue.

- This closes https://github.com/godotengine/godot/issues/52789.
- See https://github.com/godotengine/godot-proposals/issues/4717 (which might be superseded by this PR).
