### PR TITLE
Fix for Android build on Windows

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 import subprocess
 
 Import("env")
@@ -81,10 +82,21 @@ if lib_arch_dir != "":
     env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
 
     def generate_apk(target, source, env):
+        gradle_process = []
+
+        if sys.platform.startswith("win"):
+            gradle_process = [
+                "cmd",
+                "/c",
+                "gradlew.bat",
+            ]
+        else:
+            gradle_process = ["./gradlew"]
+
         if env["target"] != "editor" and env["dev_build"]:
             subprocess.run(
-                [
-                    "./gradlew",
+                gradle_process
+                + [
                     "generateDevTemplate",
                     "--quiet",
                 ],
@@ -93,8 +105,8 @@ if lib_arch_dir != "":
         else:
             # Android editor with `dev_build=yes` is handled by the `generateGodotEditor` task.
             subprocess.run(
-                [
-                    "./gradlew",
+                gradle_process
+                + [
                     "generateGodotEditor" if env["target"] == "editor" else "generateGodotTemplates",
                     "--quiet",
                 ],


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/91195

Copying in issue description for ease of reading:

### Tested versions

Godot v4.3.dev.mono (463ede1f7)

### System information

Windows 10

### Issue description

Scons currently errors when building an apk during the template creation process.  This is due to this line here: 

https://github.com/godotengine/godot/blob/11d3768132582d192b8464769f26b493ae822321/platform/android/SCsub#L87

There are 2 issues with this line.

1. It is executing the bash script instead of the batch script
2. It appears that Windows has some special cases with ``subprocess.call`` as can be seen in this stack overflow: https://stackoverflow.com/a/4616867/9733262

- That particular solution suggests passing "Shell=true", but when testing that also causes its own issues due to trying to treat the ``.`` operator as a program itself.

- This solution appears to actually fix it on my local test: https://stackoverflow.com/a/39474235/9733262

This was discovered when adding windows support to my ``godot-src`` project over here: https://github.com/Lange-Studios/godot-src.git.
