### PR TITLE
mbedtls: Disable AESCE on Linux ARM32, doesn't compile on our target arch

### DIFF
--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -49,8 +49,10 @@
 #undef MBEDTLS_DES_C
 #undef MBEDTLS_DHM_C
 
-#ifndef __linux__
+#if !(defined(__linux__) && defined(__aarch64__))
 // ARMv8 hardware AES operations. Detection only possible on linux.
+// May technically be supported on some ARM32 arches but doesn't seem
+// to be in our current Linux SDK's neon-fp-armv8.
 #undef MBEDTLS_AESCE_C
 #endif
 


### PR DESCRIPTION
Our current Linux SDK for ARM32 from https://github.com/godotengine/buildroot targets a relatively conservative baseline of neon-fp-armv8, and (at least based on build issues I got) this doesn't seem to include hardware AES support.

Fixes #91352.