### PR TITLE
Fix arm64/Windows build.

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -39,7 +39,7 @@ if env["builtin_libpng"]:
 
     if env["arch"].startswith("arm"):
         if env.msvc:  # Can't compile assembly files with MSVC.
-            env_thirdparty.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT"), 0])
+            env_thirdparty.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT", 0)])
         else:
             env_neon = env_thirdparty.Clone()
             if "S_compiler" in env:

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,8 +1,9 @@
 def can_build(env, platform):
-    # Supported architectures depend on the Embree library.
+    # Supported architectures and platforms depend on the Embree library.
+    if env["arch"] == "arm64" and platform == "windows":
+        return False
     if env["arch"] in ["x86_64", "arm64", "wasm32"]:
         return True
-    # x86_32 only seems supported on Windows for now.
     if env["arch"] == "x86_32" and platform == "windows":
         return True
     return False


### PR DESCRIPTION
- Fixes typo in the PNG driver SCsub
- Disables unsupported `raycast/embree` for arm64/Windows.