### PR TITLE
Windows: Enhance UX of modals (exclusive windows)

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1729,12 +1729,13 @@ void DisplayServerWindows::window_set_exclusive(WindowID p_window, bool p_exclus
 	if (wd.exclusive != p_exclusive) {
 		wd.exclusive = p_exclusive;
 		if (wd.transient_parent != INVALID_WINDOW_ID) {
+			WindowData &wd_parent = windows[wd.transient_parent];
 			if (wd.exclusive) {
-				WindowData &wd_parent = windows[wd.transient_parent];
 				SetWindowLongPtr(wd.hWnd, GWLP_HWNDPARENT, (LONG_PTR)wd_parent.hWnd);
 			} else {
 				SetWindowLongPtr(wd.hWnd, GWLP_HWNDPARENT, (LONG_PTR) nullptr);
 			}
+			EnableWindow(wd_parent.hWnd, !wd.exclusive);
 		}
 	}
 }
@@ -1763,6 +1764,7 @@ void DisplayServerWindows::window_set_transient(WindowID p_window, WindowID p_pa
 
 		if (wd_window.exclusive) {
 			SetWindowLongPtr(wd_window.hWnd, GWLP_HWNDPARENT, (LONG_PTR) nullptr);
+			EnableWindow(wd_parent.hWnd, TRUE);
 		}
 	} else {
 		ERR_FAIL_COND(!windows.has(p_parent));
@@ -1774,6 +1776,7 @@ void DisplayServerWindows::window_set_transient(WindowID p_window, WindowID p_pa
 
 		if (wd_window.exclusive) {
 			SetWindowLongPtr(wd_window.hWnd, GWLP_HWNDPARENT, (LONG_PTR)wd_parent.hWnd);
+			EnableWindow(wd_parent.hWnd, FALSE);
 		}
 	}
 }


### PR DESCRIPTION
I'm always a bit unconfortable about the dialog boxes UX in Godot on Windows. Dialogs, either modal (exclusive) or not, are implemented in a contrived manner, which is somewhat due to the `DisplayServer` API not quite fitting Windows' API idiosyncrasies.

However, the current implementation can still be taken a little step closer to the native experience. This PR does its part by keeping parents of exclusive children windows disabled, which addresses one of the alien aspects of the current UX: the fact that you can focus the parent window of a modal dialog.