### PR TITLE
GDScript: Call implicit ready on base script first

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -365,6 +365,8 @@ class GDScriptInstance : public ScriptInstance {
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 
+	void _call_implicit_ready_recursively(GDScript *p_script);
+
 public:
 	virtual Object *get_owner() { return owner; }
 

--- a/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.gd
@@ -1,0 +1,18 @@
+#GH-63329
+class A extends Node:
+	@onready var a := get_value("a")
+
+	func get_value(var_name: String) -> String:
+		print(var_name)
+		return var_name
+
+class B extends A:
+	@onready var b := get_value("b")
+
+	func _ready():
+		pass
+
+func test():
+	var node := B.new()
+	node._ready()
+	node.free()

--- a/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.out
+++ b/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+a
+b


### PR DESCRIPTION
It is generally expected that the base class is called before the inherited clas. This commit implements this behavior for the implicit ready function (`@onready` annotation) to make it consistent with the expectations.

Fix #63329
