### PR TITLE
C#: Ignore late bound methods in MustBeVariantAnalyzer

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MustBeVariant.GD0301.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MustBeVariant.GD0301.cs
@@ -66,6 +66,12 @@ public class MustBeVariantGD0301
         Method<Rid[]>();
     }
 
+    public void MethodCallDynamic()
+    {
+        dynamic self = this;
+        self.Method<object>();
+    }
+
     public void Method<[MustBeVariant] T>()
     {
     }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
@@ -50,8 +50,18 @@ namespace Godot.SourceGenerators
                 var typeSymbol = sm.GetSymbolInfo(typeSyntax).Symbol as ITypeSymbol;
                 Helper.ThrowIfNull(typeSymbol);
 
-                var parentSymbol = sm.GetSymbolInfo(parentSyntax).Symbol;
-                Helper.ThrowIfNull(parentSymbol);
+                var parentSymbolInfo = sm.GetSymbolInfo(parentSyntax);
+                var parentSymbol = parentSymbolInfo.Symbol;
+                if (parentSymbol == null)
+                {
+                    if (parentSymbolInfo.CandidateReason == CandidateReason.LateBound)
+                    {
+                        // Invocations on dynamic are late bound so we can't retrieve the symbol.
+                        continue;
+                    }
+
+                    Helper.ThrowIfNull(parentSymbol);
+                }
 
                 if (!ShouldCheckTypeArgument(context, parentSyntax, parentSymbol, typeSyntax, typeSymbol, i))
                 {


### PR DESCRIPTION
If symbol is late bound (as is the case when using `dynamic`) we can't obtain the symbol to analyze the usage of `[MustBeVariant]`.

- Fixes https://github.com/godotengine/godot/issues/91345.