### PR TITLE
Add Explicit Error when using CONNECT with HTTPRequest

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -193,6 +193,7 @@
 				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
 				[b]Note:[/b] When [param method] is [constant HTTPClient.METHOD_GET], the payload sent via [param request_data] might be ignored by the server or even cause the server to reject the request (check [url=https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1]RFC 7231 section 4.3.1[/url] for more details). As a workaround, you can send data as a query string in the URL (see [method String.uri_encode] for an example).
 				[b]Note:[/b] It's recommended to use transport encryption (TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
+				[b]Note:[/b] HTTPRequest is used for communicating with origin servers and does not support the CONNECT verb for connecting to a proxy server. You must use the lower-level [HTTPClient] if you need to use the CONNECT verb.
 			</description>
 		</method>
 		<method name="request_raw">
@@ -203,7 +204,7 @@
 			<param index="3" name="request_data_raw" type="PackedByteArray" default="PackedByteArray()" />
 			<description>
 				Creates request on the underlying [HTTPClient] using a raw array of bytes for the request body. If there is no configuration errors, it tries to connect using [method HTTPClient.connect_to_host] and passes parameters onto [method HTTPClient.request].
-				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
+				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format or if the method is [constant HTTPClient.METHOD_CONNECT] (see [method request]), or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
 			</description>
 		</method>
 		<method name="set_http_proxy">

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -99,6 +99,8 @@ String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const S
 }
 
 Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_headers, HTTPClient::Method p_method, const String &p_request_data) {
+	ERR_FAIL_COND_V_MSG(p_method == HTTPClient::METHOD_CONNECT, ERR_INVALID_PARAMETER, "HTTPRequest sends requests to origin servers and does not support the CONNECT verb. You must use HTTPClient to connect to a proxy server.");
+
 	// Copy the string into a raw buffer.
 	Vector<uint8_t> raw_data;
 
@@ -116,6 +118,7 @@ Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_h
 Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_custom_headers, HTTPClient::Method p_method, const Vector<uint8_t> &p_request_data_raw) {
 	ERR_FAIL_COND_V(!is_inside_tree(), ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V_MSG(requesting, ERR_BUSY, "HTTPRequest is processing a request. Wait for completion or cancel it before attempting a new one.");
+	ERR_FAIL_COND_V_MSG(p_method == HTTPClient::METHOD_CONNECT, ERR_INVALID_PARAMETER, "HTTPRequest sends requests to origin servers and does not support the CONNECT verb. You must use HTTPClient to connect to a proxy server.");
 
 	if (timeout > 0) {
 		timer->stop();


### PR DESCRIPTION
Fix #91259

This PR is being marked as a draft since #91259 is still being discussed, but this change was very simple to make, so I'm opening this PR to have it ready in case the maintainers decide to make using CONNECT in HTTPRequest an explicit error. :)

The current implementation of `HTTPRequest::request` and `request_raw` fails every time we try to use the CONNECT http verb because it uses the path portion of the url, but the CONNECT method needs to connect to the server's domain or ip with a mandatory port number. See: https://www.rfc-editor.org/rfc/rfc9110#name-connect.

Additionally, it doesn't make sense for the current HTTPRequest node to make CONNECT requests because the convenience layer that HTTPRequest provides only allows making requests directly to origin servers. The CONNECT method is for negotiating a connection with a proxy server before connecting to the origin server. For this reason, we can't use CONNECT with the current implementation, and the behavior should be an explicit error.

Another option is to add official support for using CONNECT in HTTPRequest, but this is a much more complicated change, and I would argue that HTTPClient should be used for more advanced use-cases like that.

As for the changes this PR adds, I have added the ERR_FAIL_COND_V_MSG macro with ERR_INVALID_PARAMETER to the top of both `request` and `request_raw`. Currently, `request` calls `request_raw` internally, and this is unlikely to change, but I thought it would be better to fail early when calling `request` instead of allocating a buffer for the request data and then failing inside the call to the `request_raw` method.

I also updated the class reference to include a note in the description of the `HTTPRequest.request` method that indicates that the CONNECT verb is not supported and HTTPClient must be used instead. And I also added to the current explanation of error conditions in the description of the `HTTPRequest.request_raw` method to indicate that
`ERR_INVALID_PARAMETER` will be returned if HTTPClient.METHOD_CONNECT is provided as the `method` argument.

My wording for both the documentation updates and error messages is probably not the best, so if anyone has suggestions for improvements to the error messages and documentation notes, that would be appreciated!

Side note: I was very tempted to use https://github.com/godotengine/godot/blob/d282e4f0e6b6ebcf3bd6e05cd62f2a8fe1f9a238/core/error/error_list.h#L95 as the error code for this, but I guess invalid parameter makes more sense. :laughing: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
