### PR TITLE
Enable tangents in blend shape format when using normals

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1226,6 +1226,10 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 					bsformat |= (1 << j);
 				}
 			}
+			if (bsformat & RS::ARRAY_FORMAT_NORMAL) {
+				// We must use tangents if using normals.
+				bsformat |= RS::ARRAY_FORMAT_TANGENT;
+			}
 
 			ERR_FAIL_COND_V_MSG(bsformat != (format & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/86384

Tangents are required for any mesh that uses normals. Above, we enforce that when validating the format of the source mesh, we just needed to also enforce it for blend shapes. 

CC @lyuma Sorry this slipped through the cracks and took so long