### PR TITLE
Update the description and parameter name for Vector3 reflect to correct how the plane is constructed

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1896,7 +1896,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, project, sarray("b"), varray());
 	bind_method(Vector3, slide, sarray("n"), varray());
 	bind_method(Vector3, bounce, sarray("n"), varray());
-	bind_method(Vector3, reflect, sarray("direction"), varray());
+	bind_method(Vector3, reflect, sarray("n"), varray());
 	bind_method(Vector3, sign, sarray(), varray());
 	bind_method(Vector3, octahedron_encode, sarray(), varray());
 	bind_static_method(Vector3, octahedron_decode, sarray("uv"), varray());

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -307,10 +307,10 @@
 		</method>
 		<method name="reflect" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="direction" type="Vector3" />
+			<param index="0" name="n" type="Vector3" />
 			<description>
-				Returns the result of reflecting the vector from a plane defined by the given direction vector [param direction].
-				[b]Note:[/b] [method reflect] differs from what other engines and frameworks call [code skip-lint]reflect()[/code]. In other engines, [code skip-lint]reflect()[/code] takes a normal direction which is a direction perpendicular to the plane. In Godot, you specify a direction parallel to the plane. See also [method bounce] which does what most engines call [code skip-lint]reflect()[/code].
+				Returns the result of reflecting the vector through a plane defined by the given normal vector [param n].
+				[b]Note:[/b] [method reflect] differs from what other engines and frameworks call [code skip-lint]reflect()[/code]. In other engines, [code skip-lint]reflect()[/code] returns the result of the vector reflected by the given plane. The reflection thus passes through the given normal. While in Godot the reflection passes through the plane and can be thought of as bouncing off the normal. See also [method bounce] which does what most engines call [code skip-lint]reflect()[/code].
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">


### PR DESCRIPTION
Addresses the comment in https://github.com/godotengine/godot/pull/89404#discussion_r1559763941

The previous name/description was wrong. While describing the plane as a direction seemed convenient. It doesn't make sense in practice since a direction can be used to create an infinite number of planes (by rotating on that axis). Calling the param a normal is more correct. 

When describing the parameter as a normal, we have to be very careful to distinguish between reflection and bouncing as the words in plain English essentially mean the same thing. 

CC @aaronfranke What do you think? 