### PR TITLE
[macOS export] Add support for privacy manifest configuration.

### DIFF
--- a/misc/dist/macos_template.app/Contents/Resources/PrivacyInfo.xcprivacy
+++ b/misc/dist/macos_template.app/Contents/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	$priv_tracking
+	$priv_collection
+</dict>
+</plist>

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -211,6 +211,426 @@
 		<member name="privacy/camera_usage_description_localized" type="Dictionary" setter="" getter="">
 			A message displayed when requesting access to the device's camera (localized).
 		</member>
+		<member name="privacy/collected_data/advertising_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects advertising data.
+		</member>
+		<member name="privacy/collected_data/advertising_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects advertising data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/advertising_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links advertising data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/advertising_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses advertising data for tracking.
+		</member>
+		<member name="privacy/collected_data/audio_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects audio data data.
+		</member>
+		<member name="privacy/collected_data/audio_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects audio data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/audio_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links audio data data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/audio_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses audio data data for tracking.
+		</member>
+		<member name="privacy/collected_data/browsing_history/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects browsing history.
+		</member>
+		<member name="privacy/collected_data/browsing_history/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects browsing history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/browsing_history/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links browsing history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/browsing_history/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses browsing history for tracking.
+		</member>
+		<member name="privacy/collected_data/coarse_location/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects coarse location data.
+		</member>
+		<member name="privacy/collected_data/coarse_location/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects coarse location data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/coarse_location/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links coarse location data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/coarse_location/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses coarse location data for tracking.
+		</member>
+		<member name="privacy/collected_data/contacts/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects contacts.
+		</member>
+		<member name="privacy/collected_data/contacts/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects contacts. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/contacts/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links contacts to the user's identity.
+		</member>
+		<member name="privacy/collected_data/contacts/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses contacts for tracking.
+		</member>
+		<member name="privacy/collected_data/crash_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects crash data.
+		</member>
+		<member name="privacy/collected_data/crash_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects crash data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/crash_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links crash data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/crash_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses crash data for tracking.
+		</member>
+		<member name="privacy/collected_data/credit_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects credit information.
+		</member>
+		<member name="privacy/collected_data/credit_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects credit information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/credit_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links credit information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/credit_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses credit information for tracking.
+		</member>
+		<member name="privacy/collected_data/customer_support/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects customer support data.
+		</member>
+		<member name="privacy/collected_data/customer_support/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects customer support data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/customer_support/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links customer support data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/customer_support/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses customer support data for tracking.
+		</member>
+		<member name="privacy/collected_data/device_id/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects device IDs.
+		</member>
+		<member name="privacy/collected_data/device_id/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects device IDs. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/device_id/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links device IDs to the user's identity.
+		</member>
+		<member name="privacy/collected_data/device_id/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses device IDs for tracking.
+		</member>
+		<member name="privacy/collected_data/email_address/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects email address.
+		</member>
+		<member name="privacy/collected_data/email_address/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects email address. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/email_address/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links email address to the user's identity.
+		</member>
+		<member name="privacy/collected_data/email_address/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses email address for tracking.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects emails or text messages.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects emails or text messages. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links emails or text messages to the user's identity.
+		</member>
+		<member name="privacy/collected_data/emails_or_text_messages/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses emails or text messages for tracking.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects environment scanning data.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects environment scanning data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/environment_scanning/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links environment scanning data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/environment_scanning/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses environment scanning data for tracking.
+		</member>
+		<member name="privacy/collected_data/fitness/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects fitness and exercise data.
+		</member>
+		<member name="privacy/collected_data/fitness/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects fitness and exercise data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/fitness/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links fitness and exercise data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/fitness/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses fitness and exercise data for tracking.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects gameplay content.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects gameplay content. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/gameplay_content/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links gameplay content to the user's identity.
+		</member>
+		<member name="privacy/collected_data/gameplay_content/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses gameplay content for tracking.
+		</member>
+		<member name="privacy/collected_data/hands/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's hand structure and hand movements.
+		</member>
+		<member name="privacy/collected_data/hands/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's hand structure and hand movements. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/hands/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's hand structure and hand movements to the user's identity.
+		</member>
+		<member name="privacy/collected_data/hands/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's hand structure and hand movements for tracking.
+		</member>
+		<member name="privacy/collected_data/head/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's head movement.
+		</member>
+		<member name="privacy/collected_data/head/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's head movement. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/head/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's head movement to the user's identity.
+		</member>
+		<member name="privacy/collected_data/head/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's head movement for tracking.
+		</member>
+		<member name="privacy/collected_data/health/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects health and medical data.
+		</member>
+		<member name="privacy/collected_data/health/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects health and medical data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/health/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links health and medical data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/health/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses health and medical data for tracking.
+		</member>
+		<member name="privacy/collected_data/name/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user's name.
+		</member>
+		<member name="privacy/collected_data/name/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user's name. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/name/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user's name to the user's identity.
+		</member>
+		<member name="privacy/collected_data/name/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user's name for tracking.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other contact information.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other contact information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_contact_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other contact information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_contact_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other contact information for tracking.
+		</member>
+		<member name="privacy/collected_data/other_data_types/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other data.
+		</member>
+		<member name="privacy/collected_data/other_data_types/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_data_types/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_data_types/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other diagnostic data.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other diagnostic data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other diagnostic data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_diagnostic_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other diagnostic data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other financial information.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other financial information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_financial_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other financial information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_financial_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other financial information for tracking.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other usage data.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other usage data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_usage_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other usage data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_usage_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other usage data for tracking.
+		</member>
+		<member name="privacy/collected_data/other_user_content/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects any other user generated content.
+		</member>
+		<member name="privacy/collected_data/other_user_content/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects any other user generated content. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/other_user_content/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links any other user generated content to the user's identity.
+		</member>
+		<member name="privacy/collected_data/other_user_content/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses any other user generated content for tracking.
+		</member>
+		<member name="privacy/collected_data/payment_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects payment information.
+		</member>
+		<member name="privacy/collected_data/payment_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects payment information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/payment_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links payment information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/payment_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses payment information for tracking.
+		</member>
+		<member name="privacy/collected_data/performance_data/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects performance data.
+		</member>
+		<member name="privacy/collected_data/performance_data/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects performance data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/performance_data/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links performance data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/performance_data/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses performance data for tracking.
+		</member>
+		<member name="privacy/collected_data/phone_number/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects phone number.
+		</member>
+		<member name="privacy/collected_data/phone_number/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects phone number. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/phone_number/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links phone number to the user's identity.
+		</member>
+		<member name="privacy/collected_data/phone_number/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses phone number for tracking.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects photos or videos.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects photos or videos. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links photos or videos to the user's identity.
+		</member>
+		<member name="privacy/collected_data/photos_or_videos/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses photos or videos for tracking.
+		</member>
+		<member name="privacy/collected_data/physical_address/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects physical address.
+		</member>
+		<member name="privacy/collected_data/physical_address/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects physical address. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/physical_address/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links physical address to the user's identity.
+		</member>
+		<member name="privacy/collected_data/physical_address/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses physical address for tracking.
+		</member>
+		<member name="privacy/collected_data/precise_location/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects precise location data.
+		</member>
+		<member name="privacy/collected_data/precise_location/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects precise location data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/precise_location/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links precise location data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/precise_location/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses precise location data for tracking.
+		</member>
+		<member name="privacy/collected_data/product_interaction/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects product interaction data.
+		</member>
+		<member name="privacy/collected_data/product_interaction/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects product interaction data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/product_interaction/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links product interaction data to the user's identity.
+		</member>
+		<member name="privacy/collected_data/product_interaction/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses product interaction data for tracking.
+		</member>
+		<member name="privacy/collected_data/purchase_history/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects purchase history.
+		</member>
+		<member name="privacy/collected_data/purchase_history/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects purchase history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/purchase_history/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links purchase history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/purchase_history/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses purchase history for tracking.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects search history.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects search history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/search_hhistory/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links search history to the user's identity.
+		</member>
+		<member name="privacy/collected_data/search_hhistory/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses search history for tracking.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects sensitive user information.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects sensitive user information. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/sensitive_info/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links sensitive user information to the user's identity.
+		</member>
+		<member name="privacy/collected_data/sensitive_info/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses sensitive user information for tracking.
+		</member>
+		<member name="privacy/collected_data/user_id/collected" type="bool" setter="" getter="">
+			Indicates whether your app collects user IDs.
+		</member>
+		<member name="privacy/collected_data/user_id/collection_purposes" type="int" setter="" getter="">
+			The reasons your app collects user IDs. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
+		</member>
+		<member name="privacy/collected_data/user_id/linked_to_user" type="bool" setter="" getter="">
+			Indicates whether your app links user IDs to the user's identity.
+		</member>
+		<member name="privacy/collected_data/user_id/used_for_tracking" type="bool" setter="" getter="">
+			Indicates whether your app uses user IDs for tracking.
+		</member>
 		<member name="privacy/desktop_folder_usage_description" type="String" setter="" getter="">
 			A message displayed when requesting access to the user's "Desktop" folder (in English).
 		</member>
@@ -258,6 +678,12 @@
 		</member>
 		<member name="privacy/removable_volumes_usage_description_localized" type="Dictionary" setter="" getter="">
 			A message displayed when requesting access to the user's removable drives (localized).
+		</member>
+		<member name="privacy/tracking_domains" type="PackedStringArray" setter="" getter="">
+			The list of internet domains your app connects to that engage in tracking. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files]Privacy manifest files[/url].
+		</member>
+		<member name="privacy/tracking_enabled" type="bool" setter="" getter="">
+			Indicates whether your app uses data for tracking. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files]Privacy manifest files[/url].
 		</member>
 		<member name="ssh_remote_deploy/cleanup_script" type="String" setter="" getter="">
 			Script code to execute on the remote host when app is finished.

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -85,6 +85,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	OS::ProcessID ssh_pid = 0;
 	int menu_options = 0;
 
+	void _fix_privacy_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist);
 	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary);
 	void _make_icon(const Ref<EditorExportPreset> &p_preset, const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/90375 but for macOS
