### PR TITLE
Allow writing ConfigFile comments from code

### DIFF
--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -39,7 +39,15 @@
 class ConfigFile : public RefCounted {
 	GDCLASS(ConfigFile, RefCounted);
 
-	HashMap<String, HashMap<String, Variant>> values;
+	struct Entry {
+		Variant value;
+		String comment;
+	};
+
+	HashMap<String, HashMap<String, Entry>> entries;
+
+	void _create_entry_if_needed(const String &p_section, const String &p_key);
+	String _get_entry_as_string(const String &p_key, const Entry &p_entry) const;
 
 	PackedStringArray _get_sections() const;
 	PackedStringArray _get_section_keys(const String &p_section) const;
@@ -54,15 +62,20 @@ protected:
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
 	Variant get_value(const String &p_section, const String &p_key, const Variant &p_default = Variant()) const;
+	
+	void set_section_key_comment(const String &p_section, const String &p_key, const String &p_comment);
+	String get_section_key_comment(const String &p_section, const String &p_key) const;
 
 	bool has_section(const String &p_section) const;
 	bool has_section_key(const String &p_section, const String &p_key) const;
+	bool has_section_key_comment(const String &p_section, const String &p_key) const;
 
 	void get_sections(List<String> *r_sections) const;
 	void get_section_keys(const String &p_section, List<String> *r_keys) const;
 
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);
+	void erase_section_key_comment(const String &p_section, const String &p_key);
 
 	Error save(const String &p_path);
 	Error load(const String &p_path);

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -84,6 +84,45 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		If a game's difficulty is enumerated, the example below shows how the game's configuration file could store a comment as a guide to each value:
+		[codeblocks]
+		[gdscript]
+		enum Difficulty {
+		    CASUAL = 0,
+		    NORMAL = 1,
+		    HARD = 2,
+		    SAFETY = 3,
+		}
+
+		var player_difficulty = Difficulty.NORMAL
+
+		func create_config():
+		    var config = ConfigFile.new()
+		    config.set_value("game", "difficulty", player_difficulty)
+		    config.set_section_key_comment("game", "difficulty", "0: Casual\n1: Normal\n2: Hard\n3: Safety")
+
+		    config.save("user://game_config.ini")
+		[/gdscript]
+		[csharp]
+		public enum Difficulty {
+		    Casual = 0,
+		    Normal = 1,
+		    Hard = 2,
+		    Safety = 3,
+		};
+
+		public var PlayerDifficulty = Difficulty.Normal;
+
+		public void CreateConfig()
+		{
+		    var config = new ConfigFile();
+		    config.SetValue("Game", "Difficulty", PlayerDifficulty);
+		    config.SetSectionKeyComment("Game", "Difficulty", "0: Casual\n1: Normal\n2: Hard\n3: Safety");
+
+		    config.Save("user://GameConfig.ini");
+		}
+		[/csharp]
+		[/codeblocks]
 		Any operation that mutates the ConfigFile such as [method set_value], [method clear], or [method erase_section], only changes what is loaded in memory. If you want to write the change to a file, you have to save the changes with [method save], [method save_encrypted], or [method save_encrypted_pass].
 		Keep in mind that section and property names can't contain spaces. Anything after a space will be ignored on save and on load.
 		ConfigFiles can also contain manually written comment lines starting with a semicolon ([code];[/code]). Those lines will be ignored when parsing the file. Note that comments will be lost when saving the ConfigFile. This can still be useful for dedicated server configuration files, which are typically never overwritten without explicit user action.
@@ -117,6 +156,22 @@
 			<param index="1" name="key" type="String" />
 			<description>
 				Deletes the specified key in a section. Raises an error if either the section or the key do not exist.
+			</description>
+		</method>
+		<method name="erase_section_key_comment">
+			<return type="void" />
+			<param index="0" name="section" type="String" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Blanks out the comment pertaining to a specified key in a section. Raises an error if either the section or the key do not exist.
+			</description>
+		</method>
+		<method name="get_section_key_comment" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="section" type="String" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Returns the comment associated with the specified section and key. If either the section or the key do not exist, an error is raised, and an empty string is returned.
 			</description>
 		</method>
 		<method name="get_section_keys" qualifiers="const">
@@ -154,6 +209,14 @@
 			<param index="1" name="key" type="String" />
 			<description>
 				Returns [code]true[/code] if the specified section-key pair exists.
+			</description>
+		</method>
+		<method name="has_section_key_comment" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="section" type="String" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Returns [code]true[/code] if the specified section-key pair exists and a comment is written for it.
 			</description>
 		</method>
 		<method name="load">
@@ -216,6 +279,15 @@
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+			</description>
+		</method>
+		<method name="set_section_key_comment">
+			<return type="void" />
+			<param index="0" name="section" type="String" />
+			<param index="1" name="key" type="String" />
+			<param index="2" name="comment" type="String" />
+			<description>
+				Assigns a comment to the specified key of the specified section. If either the section or the key do not exist, an error is raised.
 			</description>
 		</method>
 		<method name="set_value">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I want to give guidance for the different properties of a `ConfigFile`, eg. an enum guide above some variable.
There were no methods to add comments, so I added this feature.
```ini
[common]

; Enable this to skip the boot splash screen.
skip_splash=true

[debug]

; If enabled, the mid-line commands in messages will be displayed.
display_talk_commands=false
; Change this to control how the player controls other teams.
; 0: Only the intended teams can be controlled, ie. Band.
; 1: All SLG teams can be controlled.
; 2: Both skirmish squads can be controlled.
; 3: All teams are controllable, in both SLG and Skirmish phases.
player_battle_team_control_override_mode=0

[video]

; 0: Windowed Mode
; 1: Fullscreen Mode
window_style=0
; The size of the window in windowed mode (width, height).
window_size=Vector2i(2560, 1440)
; 0: Bilinear Scaling (Speed)
; 1: AMD FSR 1.0 Scaling (Quality)
render_scale_mode=0
; The scale of the game's 3D rendering compared to the window size, between 0.25 and 1.00.
; Lowering this is recommended on high-resolution displays if your framerate is low.
render_scale=1.0
; If enabled, the user's framerate will be capped to max_fps when the window is focused.
cap_fps=false
; The maximum framerate that the game will run at if cap_fps is enabled.
max_fps=30
; If enabled, the framerate capped to max_fps_unfocused when the game window is not focused to save energy.
; Otherwise, max_fps is used if applicable.
cap_fps_unfocused=true
; The maximum framerate when the window is not focused if cap_fps_unfocused is enabled.
max_fps_unfocused=20
; If enabled, the game will be synchronized to the display's refresh rate, making the game display smoother at the cost of a minor input delay.
; If the framerate is often fluctuating beneath the target, disabling V-Sync or capping the framerate to a factor of your display's refresh rate is recommended.
vertical_sync=true
; The 2D anti-aliasing level.
; Set this to 0 to disable 2D anti-aliasing.
; Otherwise, the available levels are 2, 4, and 8.
msaa_level_2d=8
```
Comments are not loaded from disk, only saved.

The comment field might impact memory usage significantly, but cases where this is an issue are probably far beyond the scope of a config file anyways...
Serialization might also be a bit slower due to how the property string is made now. Should this be adjusted?

- *Production edit: See https://github.com/godotengine/godot-proposals/issues/3509.*