### PR TITLE
Clarify `SceneTree.get_frame` description

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -108,7 +108,7 @@
 		<method name="get_frame" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns how many frames have been processed, since the application started. This is [i]not[/i] a measurement of elapsed time.
+				Returns how many physics_process steps have been processed, since the application started. This is [i]not[/i] a measurement of elapsed time.
 			</description>
 		</method>
 		<method name="get_multiplayer" qualifiers="const">


### PR DESCRIPTION
to reflect that it returns physics steps that have been processed, not frames rendered.

fixes #90539
