### PR TITLE
Unhide carets in add selection for occurrence and fix error

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5182,7 +5182,7 @@ void TextEdit::add_selection_for_next_occurrence() {
 
 	const String &highlighted_text = get_selected_text(caret);
 	int column = get_selection_from_column(caret) + 1;
-	int line = get_caret_line(caret);
+	int line = get_selection_from_line(caret);
 
 	const Point2i next_occurrence = search(highlighted_text, SEARCH_MATCH_CASE, line, column);
 
@@ -5196,6 +5196,7 @@ void TextEdit::add_selection_for_next_occurrence() {
 
 	if (new_caret != -1) {
 		select(next_occurrence.y, next_occurrence.x, next_occurrence.y, end, new_caret);
+		_unhide_carets();
 		adjust_viewport_to_caret(new_caret);
 		merge_overlapping_carets();
 	}
@@ -5219,8 +5220,8 @@ void TextEdit::skip_selection_for_next_occurrence() {
 	// Due to const and &(reference) presence, ternary operator is a way to avoid errors and warnings.
 	const String &searched_text = has_selection(caret) ? get_selected_text(caret) : get_word_under_caret(caret);
 
-	int column = (has_selection(caret) ? get_selection_from_column(caret) : get_caret_column(caret)) + 1;
-	int line = get_caret_line(caret);
+	int column = get_selection_from_column(caret) + 1;
+	int line = get_selection_from_line(caret);
 
 	const Point2i next_occurrence = search(searched_text, SEARCH_MATCH_CASE, line, column);
 
@@ -5228,12 +5229,13 @@ void TextEdit::skip_selection_for_next_occurrence() {
 		return;
 	}
 
-	int to_column = (has_selection(caret) ? get_selection_to_column(caret) : get_caret_column(caret)) + 1;
+	int to_column = get_selection_to_column(caret) + 1;
 	int end = next_occurrence.x + (to_column - column);
 	int new_caret = add_caret(next_occurrence.y, end);
 
 	if (new_caret != -1) {
 		select(next_occurrence.y, next_occurrence.x, next_occurrence.y, end, new_caret);
+		_unhide_carets();
 		adjust_viewport_to_caret(new_caret);
 		merge_overlapping_carets();
 	}

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3331,6 +3331,45 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		CHECK_FALSE(code_edit->is_line_folded(1));
 	}
 
+	SUBCASE("[CodeEdit] actions unfold") {
+		// add_selection_for_next_occurrence unfolds.
+		code_edit->set_text("test\n\tline1 test\n\t\tline 2\ntest2");
+		code_edit->select(0, 0, 0, 4);
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
+		code_edit->add_selection_for_next_occurrence();
+
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_caret_column() == 4);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_selection_origin_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 11);
+		CHECK(code_edit->get_selection_origin_column(1) == 7);
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		code_edit->remove_secondary_carets();
+
+		// skip_selection_for_next_occurrence unfolds.
+		code_edit->select(0, 0, 0, 4);
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
+		code_edit->skip_selection_for_next_occurrence();
+
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_caret_column() == 11);
+		CHECK(code_edit->get_selection_origin_column() == 7);
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		code_edit->remove_secondary_carets();
+		code_edit->deselect();
+	}
+
 	SUBCASE("[CodeEdit] toggle folding carets") {
 		code_edit->set_text("test\n\tline1\ntest2\n\tline2");
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/87310
- fixes https://github.com/godotengine/godot/issues/71217

Applies to both `add_selection_for_next_occurrence` (ctrl+d) and `skip_selection_for_next_occurrence` (ctrl+alt+d).
Uses the selection from line in the search, this way if multiple lines are selected nothing happens instead of printing an error.
Uses `_unhide_carets();` from #86978 to make sure the carets are always visible.