### PR TITLE
Fix crash when switching main screen from a disabled plugin main screen if code editor is floating.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3486,6 +3486,10 @@ void EditorNode::remove_editor_plugin(EditorPlugin *p_editor, bool p_config_chan
 			}
 		}
 
+		if (singleton->editor_plugin_screen == p_editor) {
+			singleton->editor_plugin_screen = nullptr;
+		}
+
 		singleton->editor_table.erase(p_editor);
 	}
 	p_editor->make_visible(false);


### PR DESCRIPTION
If currently main screen is provide by editor plugin, remove this editor plugin will switch to script editor automatically.
But the ScriptEditorPlugin will switch to previous editor plugin main screen again if script editor is floating, and lead to crash when switching main screen later.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
