### PR TITLE
Added feature to customize the minimap.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -985,6 +985,12 @@
 		<member name="text_editor/appearance/lines/word_wrap" type="int" setter="" getter="">
 			If [code]true[/code], wraps long lines over multiple lines to avoid horizontal scrolling. This is a display-only feature; it does not actually insert line breaks in your scripts.
 		</member>
+		<member name="text_editor/appearance/minimap/minimap_line_spacing" type="int" setter="" getter="">
+			The line spacing of the minimap in the script editor (in pixels).
+		</member>
+		<member name="text_editor/appearance/minimap/minimap_line_scale" type="int" setter="" getter="">
+			The line scale of the minimap in the script editor (in pixels).
+		</member>
 		<member name="text_editor/appearance/minimap/minimap_width" type="int" setter="" getter="">
 			The width of the minimap in the script editor (in pixels).
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1319,6 +1319,12 @@
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">
 			The width, in pixels, of the minimap.
 		</member>
+		<member name="minimap_line_scale" type="int" setter="set_minimap_line_scale" getter="get_minimap_line_scale" default="2">
+			The line scale, in pixels, of the minimap.
+		</member>
+		<member name="minimap_line_spacing" type="int" setter="set_minimap_line_spacing" getter="get_minimap_line_spacing" default="2">
+			The line spacing, in pixels, of the minimap.
+		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="1" />
 		<member name="placeholder_text" type="String" setter="set_placeholder" getter="get_placeholder" default="&quot;&quot;">
 			Text shown when the [TextEdit] is empty. It is [b]not[/b] the [TextEdit]'s default value (see [member text]).

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1031,6 +1031,8 @@ void CodeTextEditor::update_editor_settings() {
 	// Appearance: Minimap
 	text_editor->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
 	text_editor->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);
+	text_editor->set_minimap_line_scale((int)EDITOR_GET("text_editor/appearance/minimap/minimap_line_scale") * EDSCALE);
+	text_editor->set_minimap_line_spacing((int)EDITOR_GET("text_editor/appearance/minimap/minimap_line_spacing") * EDSCALE);
 
 	// Appearance: Lines
 	text_editor->set_line_folding_enabled(EDITOR_GET("text_editor/appearance/lines/code_folding"));

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -111,6 +111,8 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 			// Appearance: Minimap
 			code_edit->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
 			code_edit->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);
+			code_edit->set_minimap_line_scale((int)EDITOR_GET("text_editor/appearance/minimap/minimap_line_scale") * EDSCALE);
+			code_edit->set_minimap_line_spacing((int)EDITOR_GET("text_editor/appearance/minimap/minimap_line_spacing") * EDSCALE);
 
 			// Appearance: Lines
 			code_edit->set_line_folding_enabled(EDITOR_GET("text_editor/appearance/lines/code_folding"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -618,6 +618,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Appearance: Minimap
 	_initial_set("text_editor/appearance/minimap/show_minimap", true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap/minimap_width", 80, "50,250,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap/minimap_line_scale", 2, "1,4,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap/minimap_line_spacing", 2, "1,4,1")
 
 	// Appearance: Lines
 	_initial_set("text_editor/appearance/lines/code_folding", true);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -827,15 +827,15 @@ void TextEdit::_notification(int p_what) {
 
 						if (caret_line_wrap_index_map.has(minimap_line) && caret_line_wrap_index_map[minimap_line].has(line_wrap_index) && highlight_current_line) {
 							if (rtl) {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, i * 3, minimap_width, 2), theme_cache.current_line_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, (i * minimap_line_height), minimap_width, minimap_line_height / 2), theme_cache.current_line_color);
 							} else {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), i * 3, minimap_width, 2), theme_cache.current_line_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), (i * minimap_line_height), minimap_width, minimap_line_height / 2), theme_cache.current_line_color);
 							}
 						} else if (line_background_color != Color(0, 0, 0, 0)) {
 							if (rtl) {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, i * 3, minimap_width, 2), line_background_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, (i * minimap_line_height), minimap_width, minimap_line_height / 2), line_background_color);
 							} else {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), i * 3, minimap_width, 2), line_background_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), (i * minimap_line_height), minimap_width, minimap_line_height / 2), line_background_color);
 							}
 						}
 
@@ -5955,6 +5955,37 @@ int TextEdit::get_minimap_width() const {
 	return minimap_width;
 }
 
+void TextEdit::set_minimap_line_scale(int p_minimap_line_scale) {
+	if (minimap_line_scale == p_minimap_line_scale) {
+		return;
+	}
+
+	minimap_line_scale = p_minimap_line_scale;
+	//Essentially overide the minimap_char_size with the new scale values.
+	minimap_char_size.y = minimap_line_scale;
+	minimap_char_size.x = minimap_line_scale / 2;
+	_update_wrap_at_column();
+	queue_redraw();
+}
+
+int TextEdit::get_minimap_line_scale() const {
+	return minimap_line_scale;
+}
+
+void TextEdit::set_minimap_line_spacing(int p_minimap_line_spacing) {
+	if (minimap_line_spacing == p_minimap_line_spacing) {
+		return;
+	}
+
+	minimap_line_spacing = p_minimap_line_spacing;
+	_update_wrap_at_column();
+	queue_redraw();
+}
+
+int TextEdit::get_minimap_line_spacing() const {
+	return minimap_line_spacing;
+}
+
 int TextEdit::get_minimap_visible_lines() const {
 	return _get_control_height() / (minimap_char_size.y + minimap_line_spacing);
 }
@@ -6646,6 +6677,12 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_minimap_width", "width"), &TextEdit::set_minimap_width);
 	ClassDB::bind_method(D_METHOD("get_minimap_width"), &TextEdit::get_minimap_width);
 
+	ClassDB::bind_method(D_METHOD("set_minimap_line_scale", "line scale"), &TextEdit::set_minimap_line_scale);
+	ClassDB::bind_method(D_METHOD("get_minimap_line_scale"), &TextEdit::get_minimap_line_scale);
+
+	ClassDB::bind_method(D_METHOD("set_minimap_line_spacing", "line spacing"), &TextEdit::set_minimap_line_spacing);
+	ClassDB::bind_method(D_METHOD("get_minimap_line_spacing"), &TextEdit::get_minimap_line_spacing);
+
 	ClassDB::bind_method(D_METHOD("get_minimap_visible_lines"), &TextEdit::get_minimap_visible_lines);
 
 	/* Gutters. */
@@ -6747,6 +6784,8 @@ void TextEdit::_bind_methods() {
 	ADD_GROUP("Minimap", "minimap_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "set_draw_minimap", "is_drawing_minimap");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_width", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_width", "get_minimap_width");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_line_scale", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_line_scale", "get_minimap_line_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_line_spacing", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_line_spacing", "get_minimap_line_spacing");
 
 	ADD_GROUP("Caret", "caret_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_type", PROPERTY_HINT_ENUM, "Line,Block"), "set_caret_type", "get_caret_type");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -827,15 +827,15 @@ void TextEdit::_notification(int p_what) {
 
 						if (caret_line_wrap_index_map.has(minimap_line) && caret_line_wrap_index_map[minimap_line].has(line_wrap_index) && highlight_current_line) {
 							if (rtl) {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, i * 3, minimap_width, 2), theme_cache.current_line_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, (i * minimap_line_height), minimap_width, minimap_line_height / 2), theme_cache.current_line_color);
 							} else {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), i * 3, minimap_width, 2), theme_cache.current_line_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), (i * minimap_line_height), minimap_width, minimap_line_height / 2), theme_cache.current_line_color);
 							}
 						} else if (line_background_color != Color(0, 0, 0, 0)) {
 							if (rtl) {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, i * 3, minimap_width, 2), line_background_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, (i * minimap_line_height), minimap_width, minimap_line_height / 2), line_background_color);
 							} else {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), i * 3, minimap_width, 2), line_background_color);
+								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), (i * minimap_line_height), minimap_width, minimap_line_height / 2), line_background_color);
 							}
 						}
 
@@ -5955,6 +5955,37 @@ int TextEdit::get_minimap_width() const {
 	return minimap_width;
 }
 
+void TextEdit::set_minimap_line_scale(int p_minimap_line_scale) {
+	if (minimap_line_scale == p_minimap_line_scale) {
+		return;
+	}
+
+	minimap_line_scale = p_minimap_line_scale;
+	//Essentially override the minimap_char_size with the new scale values.
+	minimap_char_size.y = minimap_line_scale;
+	minimap_char_size.x = minimap_line_scale / 2;
+	_update_wrap_at_column();
+	queue_redraw();
+}
+
+int TextEdit::get_minimap_line_scale() const {
+	return minimap_line_scale;
+}
+
+void TextEdit::set_minimap_line_spacing(int p_minimap_line_spacing) {
+	if (minimap_line_spacing == p_minimap_line_spacing) {
+		return;
+	}
+
+	minimap_line_spacing = p_minimap_line_spacing;
+	_update_wrap_at_column();
+	queue_redraw();
+}
+
+int TextEdit::get_minimap_line_spacing() const {
+	return minimap_line_spacing;
+}
+
 int TextEdit::get_minimap_visible_lines() const {
 	return _get_control_height() / (minimap_char_size.y + minimap_line_spacing);
 }
@@ -6646,6 +6677,12 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_minimap_width", "width"), &TextEdit::set_minimap_width);
 	ClassDB::bind_method(D_METHOD("get_minimap_width"), &TextEdit::get_minimap_width);
 
+	ClassDB::bind_method(D_METHOD("set_minimap_line_scale", "line scale"), &TextEdit::set_minimap_line_scale);
+	ClassDB::bind_method(D_METHOD("get_minimap_line_scale"), &TextEdit::get_minimap_line_scale);
+
+	ClassDB::bind_method(D_METHOD("set_minimap_line_spacing", "line spacing"), &TextEdit::set_minimap_line_spacing);
+	ClassDB::bind_method(D_METHOD("get_minimap_line_spacing"), &TextEdit::get_minimap_line_spacing);
+
 	ClassDB::bind_method(D_METHOD("get_minimap_visible_lines"), &TextEdit::get_minimap_visible_lines);
 
 	/* Gutters. */
@@ -6747,6 +6784,8 @@ void TextEdit::_bind_methods() {
 	ADD_GROUP("Minimap", "minimap_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "set_draw_minimap", "is_drawing_minimap");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_width", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_width", "get_minimap_width");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_line_scale", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_line_scale", "get_minimap_line_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_line_spacing", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_line_spacing", "get_minimap_line_spacing");
 
 	ADD_GROUP("Caret", "caret_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_type", PROPERTY_HINT_ENUM, "Line,Block"), "set_caret_type", "get_caret_type");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5961,7 +5961,7 @@ void TextEdit::set_minimap_line_scale(int p_minimap_line_scale) {
 	}
 
 	minimap_line_scale = p_minimap_line_scale;
-	//Essentially overide the minimap_char_size with the new scale values.
+	//Essentially override the minimap_char_size with the new scale values.
 	minimap_char_size.y = minimap_line_scale;
 	minimap_char_size.x = minimap_line_scale / 2;
 	_update_wrap_at_column();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -525,8 +525,9 @@ private:
 	bool draw_minimap = false;
 
 	int minimap_width = 80;
-	Point2 minimap_char_size = Point2(1, 2);
-	int minimap_line_spacing = 1;
+	Point2 minimap_char_size = Point2(2, 4);
+	int minimap_line_scale = 2;
+	int minimap_line_spacing = 2;
 
 	// Minimap scroll.
 	bool minimap_clicked = false;
@@ -995,6 +996,12 @@ public:
 
 	void set_minimap_width(int p_minimap_width);
 	int get_minimap_width() const;
+
+	void set_minimap_line_spacing(int p_minimap_line_spacing);
+	int get_minimap_line_spacing() const;
+
+	void set_minimap_line_scale(int p_minimap_line_scale);
+	int get_minimap_line_scale() const;
 
 	int get_minimap_visible_lines() const;
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -7829,6 +7829,20 @@ TEST_CASE("[SceneTree][TextEdit] setter getters") {
 		CHECK(text_edit->get_minimap_width() == 1000);
 	}
 
+	SUBCASE("[TextEdit] minimap line_spacing") {
+		text_edit->set_minimap_line_spacing(1);
+		CHECK(text_edit->get_minimap_line_spacing() == 1);
+		text_edit->set_minimap_line_spacing(4);
+		CHECK(text_edit->get_minimap_line_spacing() == 4);
+	}
+
+	SUBCASE("[TextEdit] minimap line_scale") {
+		text_edit->set_minimap_line_scale(2);
+		CHECK(text_edit->get_minimap_line_scale() == 2);
+		text_edit->set_minimap_line_scale(4);
+		CHECK(text_edit->get_minimap_line_scale() == 4);
+	}
+
 	SUBCASE("[TextEdit] line color background") {
 		ERR_PRINT_OFF;
 		text_edit->set_line_background_color(-1, Color("#ff0000"));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

# Minimap (line spacing and line scaling) Feature
Added feature that allows us to edit the line spacing and line scale of the Minimap.

<img width="1040" alt="Screenshot 2024-05-01 at 05 25 56" 
src="https://github.com/godotengine/godot/assets/90724319/2249f98f-98ca-409b-8a3b-889a7e33364c">


https://github.com/godotengine/godot/assets/90724319/1ce6e157-3928-4a62-9389-f0d63ac69604


## Why?

The current minimap in Godot is tiny and small.. This PR increased the default size and allows for customization to look more visually appealing.