### PR TITLE
Ensure `--doctool` is run from root directory

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3182,6 +3182,7 @@ int Main::start() {
 
 #ifdef TOOLS_ENABLED
 	String doc_tool_path;
+	bool doc_tool_implicit_cwd = false;
 	BitField<DocTools::GenerateFlags> gen_flags;
 	String _export_preset;
 	bool export_debug = false;
@@ -3252,6 +3253,7 @@ int Main::start() {
 				if (doc_tool_path.begins_with("-")) {
 					// Assuming other command line arg, so default to cwd.
 					doc_tool_path = ".";
+					doc_tool_implicit_cwd = true;
 					parsed_pair = false;
 				}
 #ifdef MODULE_GDSCRIPT_ENABLED
@@ -3282,6 +3284,7 @@ int Main::start() {
 		// Handle case where no path is given to --doctool.
 		else if (args[i] == "--doctool") {
 			doc_tool_path = ".";
+			doc_tool_implicit_cwd = true;
 		}
 #endif
 	}
@@ -3308,6 +3311,11 @@ int Main::start() {
 		{
 			Ref<DirAccess> da = DirAccess::open(doc_tool_path);
 			ERR_FAIL_COND_V_MSG(da.is_null(), EXIT_FAILURE, "Argument supplied to --doctool must be a valid directory path.");
+			// Ensure that doctool is running in the root dir, but only if
+			// user did not manually specify a path as argument.
+			if (doc_tool_implicit_cwd) {
+				ERR_FAIL_COND_V_MSG(!da->dir_exists("doc"), EXIT_FAILURE, "--doctool must be run from the Godot repository's root folder, or specify a path that points there.");
+			}
 		}
 
 #ifndef MODULE_MONO_ENABLED
@@ -3636,7 +3644,7 @@ int Main::start() {
 				}
 			}
 
-			if (doc_tool_path == ".") {
+			if (doc_tool_implicit_cwd) {
 				doc_tool_path = "./docs";
 			}
 


### PR DESCRIPTION
There are two ways to run doctool:

* `--doctool` (uses cwd by setting `.` as the path)
* `--doctool <path>` (absolute or relative path)

While convenient, the former method *implicitly* relies on the cwd. So it might end up generating `doc`, `modules` and `platform` directories inside of your build directory or home directory.
Now we check for the existence of the `doc` folder for this case only, to avoid accidents.

This is technically a breaking change, but I assume most scripted usage of `--doctool` either runs in the repository root already, or specifies a path in the command line.

While we could also check for the `doc` folder in the case of an explicit path being passed, it might be desired to generate the XML structure outside of the repository folder for other purposes (such as a simple to parse list of classes, members, etc.)?