### PR TITLE
CI: Speedup `pre-commit` static check

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Style checks via pre-commit
         uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --verbose --files ${{ env.CHANGED_FILES }}
 
       - name: File formatting checks (file_format.sh)
         run: |


### PR DESCRIPTION
The current implementation of `pre-commit` will always attempt to check every single file in the repo, which is relatively slow for most of the included checks and *absurdly* slow (multiple minutes) for `dotnet-format`. This PR rectifies this by overriding the default `extra_args` in two ways: specifying the actual changed files we currently store in `env.CHANGED_FILES` & making the output verbose for logging convenience. This speeds up the entire static check action to under a minute!