### PR TITLE
Make `mouse_focus` and `mouse_focus_mask` consistent for `force_drag`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2318,6 +2318,7 @@ void Viewport::_gui_force_drag(Control *p_base, const Variant &p_data, Control *
 	gui.dragging = true;
 	gui.drag_data = p_data;
 	gui.mouse_focus = nullptr;
+	gui.mouse_focus_mask.clear();
 
 	if (p_control) {
 		_gui_set_drag_preview(p_base, p_control);


### PR DESCRIPTION
In `Viewport::_gui_force_drag` currently `Viewport::gui.mouse_focus` gets cleared, but `Viewport::gui.mouse_focus_mask` doesn't get cleared.

This is an inconsistency which can cause a crash.

With the change of this PR, `mouse_focus_mask` also gets cleared. This is in alignment with how regular drag and drop clears both variables.

resolve #91387