### PR TITLE
Fix typo in shader breaking gles3

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1444,7 +1444,7 @@ void main() {
 	vec2 anisotropy_flow = vec2(1.0, 0.0);
 #ifdef PREMUL_ALPHA_USED
 	float premul_alpha = 1.0;
-#endif PREMUL_ALPHA_USED
+#endif // PREMUL_ALPHA_USED
 #ifndef FOG_DISABLED
 	vec4 fog = vec4(0.0);
 #endif // !FOG_DISABLED
@@ -2151,5 +2151,5 @@ void main() {
 
 #ifdef PREMUL_ALPHA_USED
 	frag_color.rgb *= premul_alpha;
-#endif PREMUL_ALPHA_USED
+#endif // PREMUL_ALPHA_USED
 }


### PR DESCRIPTION
caused by https://github.com/godotengine/godot/commit/e41064388e67cc9bec320ee467757089b150bf20

```
ERROR: SceneShaderGLES3: Fragment shader compilation failed:
0(1142) : error C0116: #endif should not have arguments
0(1860) : error C0116: #endif should not have arguments

   at: _display_error_with_code (drivers\gles3\shader_gles3.cpp:253)
ERROR: Method/function failed.
   at: ShaderGLES3::_compile_specialization (drivers\gles3\shader_gles3.cpp:395)
```