### PR TITLE
Fix scene tree selection

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2384,7 +2384,7 @@ void EditorNode::_add_to_history(const Object *p_object, const String &p_propert
 	}
 }
 
-void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update) {
+void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update, bool p_update_scene_selection) {
 	ObjectID current_id = editor_history.get_current();
 	Object *current_obj = current_id.is_valid() ? ObjectDB::get_instance(current_id) : nullptr;
 
@@ -2467,7 +2467,9 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		if (current_node->is_inside_tree()) {
 			NodeDock::get_singleton()->set_node(current_node);
 			SceneTreeDock::get_singleton()->set_selected(current_node);
-			SceneTreeDock::get_singleton()->set_selection({ current_node });
+			if (p_update_scene_selection) {
+				SceneTreeDock::get_singleton()->set_selection({ current_node });
+			}
 			InspectorDock::get_singleton()->update(current_node);
 			if (!inspector_only && !skip_main_plugin) {
 				skip_main_plugin = stay_in_script_editor_on_node_selected && !ScriptEditor::get_singleton()->is_editor_floating() && ScriptEditor::get_singleton()->is_visible_in_tree();
@@ -2514,7 +2516,9 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		InspectorDock::get_inspector_singleton()->edit(current_obj);
 		NodeDock::get_singleton()->set_node(nullptr);
 		SceneTreeDock::get_singleton()->set_selected(selected_node);
-		SceneTreeDock::get_singleton()->set_selection(multi_nodes);
+		if (p_update_scene_selection) {
+			SceneTreeDock::get_singleton()->set_selection(multi_nodes);
+		}
 		InspectorDock::get_singleton()->update(nullptr);
 	}
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -517,7 +517,7 @@ private:
 	void _dialog_action(String p_file);
 
 	void _add_to_history(const Object *p_object, const String &p_property, bool p_inspector_only);
-	void _edit_current(bool p_skip_foreign = false, bool p_skip_inspector_update = false);
+	void _edit_current(bool p_skip_foreign = false, bool p_skip_inspector_update = false, bool p_update_scene_selection = false);
 	void _dialog_display_save_error(String p_file, Error p_error);
 	void _dialog_display_load_error(String p_file, Error p_error);
 
@@ -890,7 +890,7 @@ public:
 	void dim_editor(bool p_dimming);
 	bool is_editor_dimmed() const;
 
-	void edit_current() { _edit_current(); };
+	void edit_current(bool p_update_scene_selection = false) { _edit_current(false, false, p_update_scene_selection); };
 
 	bool has_scenes_in_session();
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -278,7 +278,7 @@ void InspectorDock::_unref_resource() {
 	Ref<Resource> current_res = _get_current_resource();
 	ERR_FAIL_COND(current_res.is_null());
 	current_res->set_path("");
-	EditorNode::get_singleton()->edit_current();
+	EditorNode::get_singleton()->edit_current(true);
 }
 
 void InspectorDock::_copy_resource() {
@@ -389,14 +389,14 @@ void InspectorDock::_resource_selected(const Ref<Resource> &p_res, const String 
 
 void InspectorDock::_edit_forward() {
 	if (EditorNode::get_singleton()->get_editor_selection_history()->next()) {
-		EditorNode::get_singleton()->edit_current();
+		EditorNode::get_singleton()->edit_current(true);
 	}
 }
 
 void InspectorDock::_edit_back() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
-		EditorNode::get_singleton()->edit_current();
+		EditorNode::get_singleton()->edit_current(true);
 	}
 }
 


### PR DESCRIPTION
This PR should fix https://github.com/godotengine/godot/issues/91254 and fix https://github.com/godotengine/godot/issues/91411

I tried to modify as little code as possible while maintaining the fix for https://github.com/godotengine/godot/issues/90636

The problem was caused by the addition of `SceneTreeDock::get_singleton()->set_selection` in the editor_node. Modifying the `editor_selection` from outside the SceneTreeDock seems causing a lot of problem so I just update the scene selection when moving back or forward in the Inspector which was the original bug.


https://github.com/godotengine/godot/assets/81109165/c9395e0e-97dd-4d0d-8a2d-13633a8b818b


https://github.com/godotengine/godot/assets/81109165/5939fdbe-98cb-4076-87bb-e761e25d7462


https://github.com/godotengine/godot/assets/81109165/d455e65d-98ec-453d-b294-f1a2c6afa94c


* *Bugsquad exit, see also: https://github.com/godotengine/godot/pull/91439*