### PR TITLE
Fix selecting root when opening scene.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4055,11 +4055,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	EditorDebuggerNode::get_singleton()->update_live_edit_root();
 
-	// Tell everything to edit this object, unless we're in the process of restoring scenes.
-	// If we are, we'll edit it after the restoration is done.
-	if (!restoring_scenes) {
-		push_item(new_scene);
-	} else {
+	if (restoring_scenes) {
 		// Initialize history for restored scenes.
 		ObjectID id = new_scene->get_instance_id();
 		if (id != editor_history.get_current()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4354,7 +4354,6 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	scene_tree->set_v_size_flags(SIZE_EXPAND | SIZE_FILL);
 	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));
 
-	scene_tree->connect("node_selected", callable_mp(this, &SceneTreeDock::_node_selected), CONNECT_DEFERRED);
 	scene_tree->connect("node_renamed", callable_mp(this, &SceneTreeDock::_node_renamed), CONNECT_DEFERRED);
 	scene_tree->connect("node_prerename", callable_mp(this, &SceneTreeDock::_node_prerenamed));
 	scene_tree->connect("open", callable_mp(this, &SceneTreeDock::_load_request));


### PR DESCRIPTION
Fixes #91411
This part was literaly pushing the root to be edited whenever loaded. This made a lot of issues and my modifications to `edit_current` and selection made it more visible. 
This was removed in #80517 during restoration of scenes because those problems became too apparent there but kept it for normal loading. The fact is some of those bugs can be reproduced with simple loading like the theme one 

https://github.com/godotengine/godot/assets/66184050/26b572da-d762-4946-989e-72779d87f265


Here I removed it untirely but I'm wondering if it is a feature that if nothing is selected when opening the scene it automatically selects the root if so then I can update the PR to make it so in a non problematic way.
