### PR TITLE
Fix no reparent after hover and no move.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -75,7 +75,7 @@ void SceneTreeDock::_quick_open() {
 }
 
 void SceneTreeDock::_inspect_hovered_node() {
-	scene_tree->set_selected(node_hovered_now);
+	select_node_hovered_at_end_of_drag = true;
 	scene_tree->set_marked(node_hovered_now);
 	Tree *tree = scene_tree->get_scene_tree();
 	TreeItem *item = tree->get_item_at_position(tree->get_local_mouse_position());
@@ -1588,6 +1588,10 @@ void SceneTreeDock::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_END: {
 			_reset_hovering_timer();
+			if (select_node_hovered_at_end_of_drag) {
+				scene_tree->set_selected(node_hovered_now);
+				select_node_hovered_at_end_of_drag = false;
+			}
 		} break;
 	}
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -241,6 +241,7 @@ class SceneTreeDock : public VBoxContainer {
 	Timer *inspect_hovered_node_delay = nullptr;
 	Node *node_hovered_now = nullptr;
 	Node *node_hovered_previously = nullptr;
+	bool select_node_hovered_at_end_of_drag = false;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
Fixes #91254

I'm not sure why this was setting selected while it is not selecting it but just putting a mark. The only thing I could see as difference is wether the node is selected at the end of the drag or not so I postponed the selection to the end of the drag. I think my modification made so that `set_selected` actually do the modification to the `EditorSelection` which make sense but unvoluntarily this was relying on the broken behavior of it not making the modification.

Edit : forgot to push

* *Bugsquad exit, see also: https://github.com/godotengine/godot/pull/91430*