### PR TITLE
Fix incorrect example in the documentation for the `expand` method in `Rect2`

### DIFF
--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -89,13 +89,13 @@
 				var rect = Rect2(0, 0, 5, 2)
 
 				rect = rect.expand(Vector2(10, 0)) # rect is Rect2(0, 0, 10, 2)
-				rect = rect.expand(Vector2(-5, 5)) # rect is Rect2(-5, 0, 10, 5)
+				rect = rect.expand(Vector2(-5, 5)) # rect is Rect2(-5, 0, 15, 5)
 				[/gdscript]
 				[csharp]
 				var rect = new Rect2(0, 0, 5, 2);
 
 				rect = rect.Expand(new Vector2(10, 0)); // rect is Rect2(0, 0, 10, 2)
-				rect = rect.Expand(new Vector2(-5, 5)); // rect is Rect2(-5, 0, 10, 5)
+				rect = rect.Expand(new Vector2(-5, 5)); // rect is Rect2(-5, 0, 15, 5)
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -88,13 +88,13 @@
 				var rect = Rect2i(0, 0, 5, 2)
 
 				rect = rect.expand(Vector2i(10, 0)) # rect is Rect2i(0, 0, 10, 2)
-				rect = rect.expand(Vector2i(-5, 5)) # rect is Rect2i(-5, 0, 10, 5)
+				rect = rect.expand(Vector2i(-5, 5)) # rect is Rect2i(-5, 0, 15, 5)
 				[/gdscript]
 				[csharp]
 				var rect = new Rect2I(0, 0, 5, 2);
 
 				rect = rect.Expand(new Vector2I(10, 0)); // rect is Rect2I(0, 0, 10, 2)
-				rect = rect.Expand(new Vector2I(-5, 5)); // rect is Rect2I(-5, 0, 10, 5)
+				rect = rect.Expand(new Vector2I(-5, 5)); // rect is Rect2I(-5, 0, 15, 5)
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
The documentation for the `expand` method in the `Rect2` class currently contains this example:
```
var rect = Rect2(0, 0, 5, 2)

rect = rect.expand(Vector2(10, 0)) # rect is Rect2(0, 0, 10, 2)
rect = rect.expand(Vector2(-5, 5)) # rect is Rect2(-5, 0, 10, 5)
```
However, running the following code
```
var rect = Rect2(0, 0, 5, 2)

rect = rect.expand(Vector2(10, 0))
print(rect)
rect = rect.expand(Vector2(-5, 5))
print(rect)
```
produces this output:
```
[P: (0, 0), S: (10, 2)]
[P: (-5, 0), S: (15, 5)]
```

After the second call the rectangle becomes (-5, 0, 15, 5) instead of (-5, 0, 10, 5) because the first call modifies the `rect` variable, while the example assumes that the `expand` function is still called on the original rectangle.

Changing the example to
```
var rect = Rect2(0, 0, 5, 2)

var rect1 = rect.expand(Vector2(10, 0)) # rect1 is Rect2(0, 0, 10, 2)
var rect2 = rect.expand(Vector2(-5, 5)) # rect2 is Rect2(-5, 0, 10, 5)
```
should make it clear that the initial rectangle is still the same.