### PR TITLE
Fix sqrt application for radius in particle ring emission

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -880,7 +880,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				} break;
 				case EMISSION_SHAPE_RING: {
 					real_t ring_random_angle = Math::randf() * Math_TAU;
-					real_t ring_random_radius = Math::sqrt(Math::randf() * (emission_ring_radius - emission_ring_inner_radius * emission_ring_inner_radius) + emission_ring_inner_radius * emission_ring_inner_radius);
+					real_t ring_random_radius = Math::sqrt(Math::randf() * (emission_ring_radius * emission_ring_radius - emission_ring_inner_radius * emission_ring_inner_radius) + emission_ring_inner_radius * emission_ring_inner_radius);
 					Vector3 axis = emission_ring_axis == Vector3(0.0, 0.0, 0.0) ? Vector3(0.0, 0.0, 1.0) : emission_ring_axis.normalized();
 					Vector3 ortho_axis;
 					if (axis.abs() == Vector3(1.0, 0.0, 0.0)) {

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -634,7 +634,7 @@ void ParticleProcessMaterial::_update_shader() {
 	if (emission_shape == EMISSION_SHAPE_RING) {
 		code += "		\n";
 		code += "		float ring_spawn_angle = rand_from_seed(alt_seed) * 2.0 * pi;\n";
-		code += "		float ring_random_radius = sqrt(rand_from_seed(alt_seed) * (emission_ring_radius - emission_ring_inner_radius * emission_ring_inner_radius) + emission_ring_inner_radius * emission_ring_inner_radius);\n";
+		code += "		float ring_random_radius = sqrt(rand_from_seed(alt_seed) * (emission_ring_radius * emission_ring_radius - emission_ring_inner_radius * emission_ring_inner_radius) + emission_ring_inner_radius * emission_ring_inner_radius);\n";
 		code += "		vec3 axis = emission_ring_axis == vec3(0.0) ? vec3(0.0, 0.0, 1.0) : normalize(emission_ring_axis);\n";
 		code += "		vec3 ortho_axis = vec3(0.0);\n";
 		code += "		if (abs(axis) == vec3(1.0, 0.0, 0.0)) {\n";


### PR DESCRIPTION
This is a follow up to https://github.com/godotengine/godot/pull/91223.

I did not apply the sqrt correctly in that PR. The radius control is broken.

I also failed to realise that the even distribution for a circle shape becomes more and more like a cylindrical strip the closer the inner radius get's to the outer radius. I think the best solution for this is to lerp between the two distributions.

The inner radius could also be above the the outer radius before, it is now clamped by the outer radius to avoid unexpected behaviour.

https://github.com/godotengine/godot/assets/4955051/3e9e430e-ae67-49a8-9250-86936d81544d

**Note if this not merged before 4.3, then https://github.com/godotengine/godot/pull/91223 has to be reverted.**