### PR TITLE
Fix Steam input "crc" errors, and some other Coverity reports of uninitialized scalar variable

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1504,6 +1504,7 @@ void Input::parse_mapping(const String &p_mapping) {
 		JoyAxis output_axis = _get_output_axis(output);
 		if (output_button == JoyButton::INVALID && output_axis == JoyAxis::INVALID) {
 			print_verbose(vformat("Unrecognized output string \"%s\" in mapping:\n%s", output, p_mapping));
+			continue;
 		}
 		ERR_CONTINUE_MSG(output_button != JoyButton::INVALID && output_axis != JoyAxis::INVALID,
 				vformat("Output string \"%s\" matched both button and axis in mapping:\n%s", output, p_mapping));

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -130,12 +130,9 @@ void RasterizerGLES3::clear_depth(float p_depth) {
 
 #ifdef CAN_DEBUG
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
-	if (type == _EXT_DEBUG_TYPE_OTHER_ARB) {
+	// These are ultimately annoying, so removing for now.
+	if (type == _EXT_DEBUG_TYPE_OTHER_ARB || type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB) {
 		return;
-	}
-
-	if (type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB) {
-		return; //these are ultimately annoying, so removing for now
 	}
 
 	char debSource[256], debType[256], debSev[256];
@@ -152,6 +149,8 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debSource, "Application");
 	} else if (source == _EXT_DEBUG_SOURCE_OTHER_ARB) {
 		strcpy(debSource, "Other");
+	} else {
+		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled source '%d' in debug callback.", source));
 	}
 
 	if (type == _EXT_DEBUG_TYPE_ERROR_ARB) {
@@ -162,10 +161,8 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debType, "Undefined behavior");
 	} else if (type == _EXT_DEBUG_TYPE_PORTABILITY_ARB) {
 		strcpy(debType, "Portability");
-	} else if (type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB) {
-		strcpy(debType, "Performance");
-	} else if (type == _EXT_DEBUG_TYPE_OTHER_ARB) {
-		strcpy(debType, "Other");
+	} else {
+		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled type '%d' in debug callback.", type));
 	}
 
 	if (severity == _EXT_DEBUG_SEVERITY_HIGH_ARB) {
@@ -174,6 +171,8 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debSev, "Medium");
 	} else if (severity == _EXT_DEBUG_SEVERITY_LOW_ARB) {
 		strcpy(debSev, "Low");
+	} else {
+		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled severity '%d' in debug callback.", severity));
 	}
 
 	String output = String() + "GL ERROR: Source: " + debSource + "\tType: " + debType + "\tID: " + itos(id) + "\tSeverity: " + debSev + "\tMessage: " + message;

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -100,10 +100,10 @@ public:
 };
 
 struct Breakpoint {
-	int id;
-	bool verified;
+	int id = 0;
+	bool verified = false;
 	Source source;
-	int line;
+	int line = 0;
 
 	bool operator==(const Breakpoint &p_other) const {
 		return source.path == p_other.source.path && line == p_other.line;
@@ -121,7 +121,7 @@ struct Breakpoint {
 };
 
 struct BreakpointLocation {
-	int line;
+	int line = 0;
 	int endLine = -1;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
@@ -169,10 +169,10 @@ struct Capabilities {
 };
 
 struct Message {
-	int id;
+	int id = 0;
 	String format;
 	bool sendTelemetry = false; // Just in case :)
-	bool showUser;
+	bool showUser = false;
 	Dictionary variables;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
@@ -190,8 +190,8 @@ struct Message {
 struct Scope {
 	String name;
 	String presentationHint;
-	int variablesReference;
-	bool expensive;
+	int variablesReference = 0;
+	bool expensive = false;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
 		Dictionary dict;
@@ -205,7 +205,7 @@ struct Scope {
 };
 
 struct SourceBreakpoint {
-	int line;
+	int line = 0;
 
 	_FORCE_INLINE_ void from_json(const Dictionary &p_params) {
 		line = p_params["line"];
@@ -213,11 +213,11 @@ struct SourceBreakpoint {
 };
 
 struct StackFrame {
-	int id;
+	int id = 0;
 	String name;
 	Source source;
-	int line;
-	int column;
+	int line = 0;
+	int column = 0;
 
 	static uint32_t hash(const StackFrame &p_frame) {
 		return hash_murmur3_one_32(p_frame.id);
@@ -247,7 +247,7 @@ struct StackFrame {
 };
 
 struct Thread {
-	int id;
+	int id = 0;
 	String name;
 
 	_FORCE_INLINE_ Dictionary to_json() const {

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -236,7 +236,7 @@ struct ReferenceContext {
 	/**
 	 * Include the declaration of the current symbol.
 	 */
-	bool includeDeclaration;
+	bool includeDeclaration = false;
 };
 
 struct ReferenceParams : TextDocumentPositionParams {

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -265,8 +265,8 @@ public:
 	class TerrainsPattern {
 		bool valid = false;
 		int terrain = -1;
-		int bits[TileSet::CELL_NEIGHBOR_MAX];
-		bool is_valid_bit[TileSet::CELL_NEIGHBOR_MAX];
+		int bits[TileSet::CELL_NEIGHBOR_MAX] = {};
+		bool is_valid_bit[TileSet::CELL_NEIGHBOR_MAX] = {};
 
 		int not_empty_terrains_count = 0;
 


### PR DESCRIPTION
Going through a few reports on https://scan.coverity.com/projects/godotengine-godot?tab=overview

Lots of low hanging fruits there to improve the code quality and find potential bugs.

The input mapping change fixes these issues:
- Fixes #88630
- Fixes #92578