### PR TITLE
Close focused Popup when the main window loses focus

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4198,6 +4198,19 @@ void DisplayServerX11::popup_close(WindowID p_window) {
 	}
 }
 
+bool DisplayServerX11::close_top_popup() {
+	List<WindowID>::Element *E = popup_list.back();
+	while (E) {
+		WindowData wd = windows[E->get()];
+		if (wd.is_popup && wd.focused) {
+			_send_window_event(wd, DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
+			return true;
+		}
+		E = E->prev();
+	}
+	return false;
+}
+
 bool DisplayServerX11::mouse_process_popups() {
 	_THREAD_SAFE_METHOD_
 
@@ -4669,6 +4682,7 @@ void DisplayServerX11::process_events() {
 				wd.focused = false;
 
 				Input::get_singleton()->release_pressed_events();
+				close_top_popup();
 				_send_window_event(wd, WINDOW_EVENT_FOCUS_OUT);
 
 				if (mouse_mode_grab) {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -380,6 +380,7 @@ protected:
 	void _window_changed(XEvent *event);
 
 public:
+	bool close_top_popup();
 	bool mouse_process_popups();
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);


### PR DESCRIPTION
Fixes [91450](https://github.com/godotengine/godot/issues/91450)

Important Note: I've just started checking out Godot's code like a week ago, so it's totally possible that I've failed to notice some unintended consequences of this change proposal. My idea was to close the top-most focused popup whenever the window loses focus.