### PR TITLE
Fix TextEdit crash with multiple carets disabled and paste

### DIFF
--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -7220,6 +7220,11 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		CHECK(text_edit->get_caret_count() == 1);
 		CHECK(text_edit->get_caret_line(0) == 0);
 		CHECK(text_edit->get_caret_column(0) == 0);
+
+		// Does nothing if multiple carets are disabled.
+		text_edit->set_multiple_carets_enabled(false);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 1);
 	}
 
 	memdelete(text_edit);


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/91440
- fixes https://github.com/godotengine/godot/issues/91441

`add_caret_at_carets` now only runs if multiple carets are enabled. Added a simple test, and a check to make sure add caret worked.
`menu_option(2)` calls paste which used the wrong value in the for loop condition.
Made sure multiple caret functionality only runs if it is enabled.
Made sure that multi caret ignore carets will only be added to if there is multiple carets, since it is to prevent overlapping carets from affecting anything.