### PR TITLE
[Core] Remove zero check in `next_power_of_2`

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -72,10 +72,6 @@ public:
 private:
 	// Function to find the next power of 2 to an integer.
 	static _FORCE_INLINE_ USize next_po2(USize x) {
-		if (x == 0) {
-			return 0;
-		}
-
 		--x;
 		x |= x >> 1;
 		x |= x >> 2;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -144,10 +144,6 @@ inline void __swap_tmpl(T &x, T &y) {
 
 // Function to find the next power of 2 to an integer.
 static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
-	if (x == 0) {
-		return 0;
-	}
-
 	--x;
 	x |= x >> 1;
 	x |= x >> 2;


### PR DESCRIPTION
I just found an unnecessary check and why not remove it.