### PR TITLE
Wayland: Add support for OpenGL ES driver

### DIFF
--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -199,6 +199,7 @@ if env["vulkan"]:
 
 if env["opengl3"]:
     source_files.append("egl_manager_wayland.cpp")
+    source_files.append("egl_manager_wayland_gles.cpp")
 
 objects = []
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -46,6 +46,8 @@
 #ifdef GLES3_ENABLED
 #include "detect_prime_egl.h"
 #include "drivers/gles3/rasterizer_gles3.h"
+#include "wayland/egl_manager_wayland.h"
+#include "wayland/egl_manager_wayland_gles.h"
 #endif
 
 String DisplayServerWayland::_get_app_id_from_context(Context p_context) {
@@ -1208,6 +1210,7 @@ Vector<String> DisplayServerWayland::get_rendering_drivers_func() {
 
 #ifdef GLES3_ENABLED
 	drivers.push_back("opengl3");
+	drivers.push_back("opengl3_es");
 #endif
 
 	return drivers;
@@ -1258,14 +1261,14 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 
 #ifdef RD_ENABLED
 #ifdef VULKAN_ENABLED
-	if (p_rendering_driver == "vulkan") {
+	if (rendering_driver == "vulkan") {
 		rendering_context = memnew(RenderingContextDriverVulkanWayland);
 	}
 #endif
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			ERR_PRINT(vformat("Could not initialize %s", p_rendering_driver));
+			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;
 			r_error = ERR_CANT_CREATE;
@@ -1275,7 +1278,14 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 #endif
 
 #ifdef GLES3_ENABLED
-	if (p_rendering_driver == "opengl3") {
+	if (rendering_driver == "opengl3" || rendering_driver == "opengl3_es") {
+#ifdef SOWRAP_ENABLED
+		if (initialize_wayland_egl(dylibloader_verbose) != 0) {
+			WARN_PRINT("Can't load the Wayland EGL library.");
+			return;
+		}
+#endif // SOWRAP_ENABLED
+
 		if (getenv("DRI_PRIME") == nullptr) {
 			int prime_idx = -1;
 
@@ -1318,23 +1328,38 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 			}
 		}
 
-		egl_manager = memnew(EGLManagerWayland);
+		if (rendering_driver == "opengl3") {
+			egl_manager = memnew(EGLManagerWayland);
 
-#ifdef SOWRAP_ENABLED
-		if (initialize_wayland_egl(dylibloader_verbose) != 0) {
-			WARN_PRINT("Can't load the Wayland EGL library.");
-			return;
+			if (egl_manager->initialize() != OK || egl_manager->open_display(wayland_thread.get_wl_display()) != OK) {
+				memdelete(egl_manager);
+				egl_manager = nullptr;
+
+				bool fallback = GLOBAL_GET("rendering/gl_compatibility/fallback_to_gles");
+				if (fallback) {
+					WARN_PRINT("Your video card drivers seem not to support the required OpenGL version, switching to OpenGLES.");
+					rendering_driver = "opengl3_es";
+				} else {
+					r_error = ERR_UNAVAILABLE;
+					ERR_FAIL_MSG("Could not initialize OpenGL.");
+				}
+			} else {
+				RasterizerGLES3::make_current(true);
+			}
 		}
-#endif // SOWRAP_ENABLED
 
-		if (egl_manager->initialize() != OK) {
-			memdelete(egl_manager);
-			egl_manager = nullptr;
-			r_error = ERR_CANT_CREATE;
-			ERR_FAIL_MSG("Could not initialize GLES3.");
+		if (rendering_driver == "opengl3_es") {
+			egl_manager = memnew(EGLManagerWaylandGLES);
+
+			if (egl_manager->initialize() != OK) {
+				memdelete(egl_manager);
+				egl_manager = nullptr;
+				r_error = ERR_CANT_CREATE;
+				ERR_FAIL_MSG("Could not initialize GLES3.");
+			}
+
+			RasterizerGLES3::make_current(false);
 		}
-
-		RasterizerGLES3::make_current(true);
 	}
 #endif // GLES3_ENABLED
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -45,7 +45,7 @@
 #endif //RD_ENABLED
 
 #ifdef GLES3_ENABLED
-#include "wayland/egl_manager_wayland.h"
+#include "drivers/egl/egl_manager.h"
 #endif
 
 #if defined(SPEECHD_ENABLED)
@@ -126,7 +126,7 @@ class DisplayServerWayland : public DisplayServer {
 #endif
 
 #ifdef GLES3_ENABLED
-	EGLManagerWayland *egl_manager = nullptr;
+	EGLManager *egl_manager = nullptr;
 #endif
 
 #ifdef SPEECHD_ENABLED

--- a/platform/linuxbsd/wayland/egl_manager_wayland_gles.cpp
+++ b/platform/linuxbsd/wayland/egl_manager_wayland_gles.cpp
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  egl_manager_wayland_gles.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "egl_manager_wayland_gles.h"
+
+#ifdef WAYLAND_ENABLED
+#ifdef EGL_ENABLED
+#ifdef GLES3_ENABLED
+
+const char *EGLManagerWaylandGLES::_get_platform_extension_name() const {
+	return "EGL_KHR_platform_wayland";
+}
+
+EGLenum EGLManagerWaylandGLES::_get_platform_extension_enum() const {
+	return EGL_PLATFORM_WAYLAND_KHR;
+}
+
+EGLenum EGLManagerWaylandGLES::_get_platform_api_enum() const {
+	return EGL_OPENGL_ES_API;
+}
+
+Vector<EGLAttrib> EGLManagerWaylandGLES::_get_platform_display_attributes() const {
+	return Vector<EGLAttrib>();
+}
+
+Vector<EGLint> EGLManagerWaylandGLES::_get_platform_context_attribs() const {
+	Vector<EGLint> ret;
+	ret.push_back(EGL_CONTEXT_MAJOR_VERSION);
+	ret.push_back(3);
+	ret.push_back(EGL_NONE);
+
+	return ret;
+}
+
+#endif // GLES3_ENABLED
+#endif // EGL_ENABLED
+#endif // WAYLAND_ENABLED

--- a/platform/linuxbsd/wayland/egl_manager_wayland_gles.h
+++ b/platform/linuxbsd/wayland/egl_manager_wayland_gles.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  egl_manager_wayland_gles.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EGL_MANAGER_WAYLAND_GLES_H
+#define EGL_MANAGER_WAYLAND_GLES_H
+
+#ifdef WAYLAND_ENABLED
+#ifdef EGL_ENABLED
+#ifdef GLES3_ENABLED
+
+#include "drivers/egl/egl_manager.h"
+
+class EGLManagerWaylandGLES : public EGLManager {
+public:
+	virtual const char *_get_platform_extension_name() const override;
+	virtual EGLenum _get_platform_extension_enum() const override;
+	virtual EGLenum _get_platform_api_enum() const override;
+	virtual Vector<EGLAttrib> _get_platform_display_attributes() const override;
+	virtual Vector<EGLint> _get_platform_context_attribs() const override;
+};
+
+#endif // GLES3_ENABLED
+#endif // EGL_ENABLED
+#endif // WAYLAND_ENABLED
+
+#endif // EGL_MANAGER_WAYLAND_GLES_H


### PR DESCRIPTION
Fixes #91371.

Everything was already there, we just had to wire it up in the display server.