### PR TITLE
Fix `FileSystemDock` thumbnails sometimes not displaying

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -778,7 +778,7 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 }
 
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
-	if ((file_list_vb->is_visible_in_tree() || current_path.trim_suffix("/") == p_path.get_base_dir()) && p_preview.is_valid()) {
+	if (p_preview.is_valid()) {
 		Array uarr = p_udata;
 		int idx = uarr[0];
 		String file = uarr[1];


### PR DESCRIPTION
There were (at least) three cases where thumbnails would not display, if they were generated while the `FileSystemDock` was not visible:
	- `current_path` == "Favorites", due to `p_path` not starting with "Favorites"
	- `current_path` == "res://", due to `current_path` having last "/" trimmed for comparison
	- `current_path` pointing to a selected file instead of folder, since it no longer matches `p_path`'s base directory

This change removes the `current_path` and `is_visible_in_tree` checks when determining whether to update the file's icon.

Fixes #90801
Fixes #91432

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
