### PR TITLE
Add argument options to AnimationPlayer for auto capture

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -213,6 +213,17 @@
 		</member>
 		<member name="playback_auto_capture" type="bool" setter="set_auto_capture" getter="is_auto_capture" default="true">
 			If [code]true[/code], performs [method AnimationMixer.capture] before playback automatically. This means just [method play_with_capture] is executed with default arguments instead of [method play].
+			[b]Note:[/b] Capture interpolation is only performed if the animation contains a capture track. See also [constant Animation.UPDATE_CAPTURE].
+		</member>
+		<member name="playback_auto_capture_duration" type="float" setter="set_auto_capture_duration" getter="get_auto_capture_duration" default="-1.0">
+			See also [method play_with_capture] and [method AnimationMixer.capture].
+			If [member playback_auto_capture_duration] is negative value, the duration is set to the interval between the current position and the first key.
+		</member>
+		<member name="playback_auto_capture_ease_type" type="int" setter="set_auto_capture_ease_type" getter="get_auto_capture_ease_type" enum="Tween.EaseType" default="0">
+			The ease type of the capture interpolation. See also [enum Tween.EaseType].
+		</member>
+		<member name="playback_auto_capture_transition_type" type="int" setter="set_auto_capture_transition_type" getter="get_auto_capture_transition_type" enum="Tween.TransitionType" default="0">
+			The transition type of the capture interpolation. See also [enum Tween.TransitionType].
 		</member>
 		<member name="playback_default_blend_time" type="float" setter="set_default_blend_time" getter="get_default_blend_time" default="0.0">
 			The default time in which to blend animations. Ranges from 0 to 4096 with 0.01 precision.

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -125,6 +125,8 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 		}
 
 		p_property.hint_string = hint;
+	} else if (!auto_capture && p_property.name.begins_with("playback_auto_capture_")) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 
@@ -372,7 +374,7 @@ void AnimationPlayer::play_backwards(const StringName &p_name, double p_custom_b
 
 void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, float p_custom_scale, bool p_from_end) {
 	if (auto_capture) {
-		play_with_capture(p_name, -1.0, p_custom_blend, p_custom_scale, p_from_end);
+		play_with_capture(p_name, auto_capture_duration, p_custom_blend, p_custom_scale, p_from_end, auto_capture_transition_type, auto_capture_ease_type);
 	} else {
 		_play(p_name, p_custom_blend, p_custom_scale, p_from_end);
 	}
@@ -716,10 +718,35 @@ double AnimationPlayer::get_blend_time(const StringName &p_animation1, const Str
 
 void AnimationPlayer::set_auto_capture(bool p_auto_capture) {
 	auto_capture = p_auto_capture;
+	notify_property_list_changed();
 }
 
 bool AnimationPlayer::is_auto_capture() const {
 	return auto_capture;
+}
+
+void AnimationPlayer::set_auto_capture_duration(double p_auto_capture_duration) {
+	auto_capture_duration = p_auto_capture_duration;
+}
+
+double AnimationPlayer::get_auto_capture_duration() const {
+	return auto_capture_duration;
+}
+
+void AnimationPlayer::set_auto_capture_transition_type(Tween::TransitionType p_auto_capture_transition_type) {
+	auto_capture_transition_type = p_auto_capture_transition_type;
+}
+
+Tween::TransitionType AnimationPlayer::get_auto_capture_transition_type() const {
+	return auto_capture_transition_type;
+}
+
+void AnimationPlayer::set_auto_capture_ease_type(Tween::EaseType p_auto_capture_ease_type) {
+	auto_capture_ease_type = p_auto_capture_ease_type;
+}
+
+Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
+	return auto_capture_ease_type;
 }
 
 #ifdef TOOLS_ENABLED
@@ -814,6 +841,12 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_auto_capture", "auto_capture"), &AnimationPlayer::set_auto_capture);
 	ClassDB::bind_method(D_METHOD("is_auto_capture"), &AnimationPlayer::is_auto_capture);
+	ClassDB::bind_method(D_METHOD("set_auto_capture_duration", "auto_capture_duration"), &AnimationPlayer::set_auto_capture_duration);
+	ClassDB::bind_method(D_METHOD("get_auto_capture_duration"), &AnimationPlayer::get_auto_capture_duration);
+	ClassDB::bind_method(D_METHOD("set_auto_capture_transition_type", "auto_capture_transition_type"), &AnimationPlayer::set_auto_capture_transition_type);
+	ClassDB::bind_method(D_METHOD("get_auto_capture_transition_type"), &AnimationPlayer::get_auto_capture_transition_type);
+	ClassDB::bind_method(D_METHOD("set_auto_capture_ease_type", "auto_capture_ease_type"), &AnimationPlayer::set_auto_capture_ease_type);
+	ClassDB::bind_method(D_METHOD("get_auto_capture_ease_type"), &AnimationPlayer::get_auto_capture_ease_type);
 
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(StringName()), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(StringName()), DEFVAL(-1));
@@ -856,6 +889,9 @@ void AnimationPlayer::_bind_methods() {
 
 	ADD_GROUP("Playback Options", "playback_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playback_auto_capture"), "set_auto_capture", "is_auto_capture");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_auto_capture_duration", PROPERTY_HINT_NONE, "suffix:s"), "set_auto_capture_duration", "get_auto_capture_duration");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_auto_capture_transition_type", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Expo,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_auto_capture_transition_type", "get_auto_capture_transition_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_auto_capture_ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_auto_capture_ease_type", "get_auto_capture_ease_type");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:s"), "set_default_blend_time", "get_default_blend_time");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -56,7 +56,12 @@ private:
 
 	float speed_scale = 1.0;
 	double default_blend_time = 0.0;
+
 	bool auto_capture = true;
+	double auto_capture_duration = -1.0;
+	Tween::TransitionType auto_capture_transition_type = Tween::TRANS_LINEAR;
+	Tween::EaseType auto_capture_ease_type = Tween::EASE_IN;
+
 	bool is_stopping = false;
 
 	struct PlaybackData {
@@ -163,6 +168,12 @@ public:
 
 	void set_auto_capture(bool p_auto_capture);
 	bool is_auto_capture() const;
+	void set_auto_capture_duration(double p_auto_capture_duration);
+	double get_auto_capture_duration() const;
+	void set_auto_capture_transition_type(Tween::TransitionType p_auto_capture_transition_type);
+	Tween::TransitionType get_auto_capture_transition_type() const;
+	void set_auto_capture_ease_type(Tween::EaseType p_auto_capture_ease_type);
+	Tween::EaseType get_auto_capture_ease_type() const;
 
 	void play(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void play_backwards(const StringName &p_name = StringName(), double p_custom_blend = -1);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2705,7 +2705,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 	vt->update_mode = p_mode;
 
-	capture_included = capture_included || (p_mode == UPDATE_CAPTURE);
+	_check_capture_included();
 	emit_changed();
 }
 
@@ -3901,7 +3901,7 @@ void Animation::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "0.001,99999,0.001,suffix:s"), "set_length", "get_length");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Ping-Pong"), "set_loop_mode", "get_loop_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step", PROPERTY_HINT_RANGE, "0,4096,0.001,suffix:s"), "set_step", "get_step");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "capture_included", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_NO_EDITOR), "_set_capture_included", "is_capture_included");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "capture_included", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_NO_EDITOR), "_set_capture_included", "is_capture_included");
 
 	BIND_ENUM_CONSTANT(TYPE_VALUE);
 	BIND_ENUM_CONSTANT(TYPE_POSITION_3D);


### PR DESCRIPTION
Follow up #91437.

Add option for auto capture interpolation. This is expected to substitute for the deprecated capture + cubic interpolation as easing will be performed in such case https://github.com/godotengine/godot/pull/86715#pullrequestreview-1872207298. cc @Calinou @KoBeWi 

![image](https://github.com/godotengine/godot/assets/61938263/e38727fd-9068-419b-8f58-43cff980e1b1)
![image](https://github.com/godotengine/godot/assets/61938263/6f5ec8d5-ab43-4779-a7f1-dfed59dda01d)
