### PR TITLE
[4.2] Add forward compat parsing of PackedVector4Array

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1395,6 +1395,25 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
+		} else if (id == "PackedVector4Array" || id == "PoolVector4Array" || id == "Vector4Array") {
+			// Not supported for writing, added for compatibility with 4.3.
+			// Handled as a plain array of Vector4 elements.
+			Vector<real_t> args;
+			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
+			if (err) {
+				return err;
+			}
+
+			Array arr;
+			{
+				int len = args.size() / 4;
+				arr.resize(len);
+				for (int i = 0; i < len; i++) {
+					arr[i] = Vector4(args[i * 4 + 0], args[i * 4 + 1], args[i * 4 + 2], args[i * 4 + 3]);
+				}
+			}
+
+			value = arr;
 		} else if (id == "PackedColorArray" || id == "PoolColorArray" || id == "ColorArray") {
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -37,10 +37,11 @@
 #include "core/object/script_language.h"
 #include "core/version.h"
 
-// Version 2: changed names for Basis, AABB, Vectors, etc.
-// Version 3: new string ID for ext/subresources, breaks forward compat.
-// Version 4: PackedByteArray is now stored as base64 encoded.
+// Version 2: Changed names for Basis, AABB, Vectors, etc.
+// Version 3: New string ID for ext/subresources, breaks forward compat.
 #define FORMAT_VERSION 3
+// Version 4: PackedByteArray can be base64 encoded, and PackedVector4Array was added.
+// Parsing only, for forward compat with 4.3+.
 #define FORMAT_VERSION_READABLE 4
 
 #define BINARY_FORMAT_VERSION 4


### PR DESCRIPTION
This new Variant type is being added in 4.3, and breaks compatibility with earlier releases. By adding minimal parsing support (converting to plain Array) we can at least open the scenes, and minimize the data loss when going back and forth between minor versions.

- Needed once #85474 is merged.
- Similar to #91250.