### PR TITLE
Avoid incorrect computing anchor of Control node when reset on save

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1383,6 +1383,13 @@ void Control::_set_position(const Point2 &p_point) {
 
 void Control::set_position(const Point2 &p_point, bool p_keep_offsets) {
 	ERR_MAIN_THREAD_GUARD;
+
+	// Can't compute anchors, set position directly and return immediately.
+	if (!is_inside_tree()) {
+		data.pos_cache = p_point;
+		return;
+	}
+
 	if (p_keep_offsets) {
 		_compute_anchors(Rect2(p_point, data.size_cache), data.offset, data.anchor);
 	} else {
@@ -1439,6 +1446,12 @@ void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
 	}
 	if (new_size.y < min.y) {
 		new_size.y = min.y;
+	}
+
+	// Can't compute anchors, set size directly and return immediately.
+	if (!is_inside_tree()) {
+		data.size_cache = new_size;
+		return;
 	}
 
 	if (p_keep_offsets) {


### PR DESCRIPTION
Fixes #90079.

The fundamental cause of this issue is that get_parent_anchorable_rect() returns an incorrect result when the SceneTree does not exist, due to the Control nodes unable to get the parent.

This may not be a problem in `Position` layout mode, but at least in `Anchor` layout mode, when the SceneTree does not exist, the anchor calculation should avoid setting an incorrect value.

I am not sure if this approach will cause new problems in cases where set position and size without SceneTree, so it would be appreciated if someone with more knowledge of Control node could review this issue.