### PR TITLE
Fix shadow calculation on shadow to opacity

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -861,7 +861,9 @@ void main() {
 #endif
 #endif
 
-#ifndef USE_SHADOW_TO_OPACITY
+#ifdef USE_SHADOW_TO_OPACITY
+	float shadow_to_opacity = 0.0;
+#endif
 
 #ifdef ALPHA_SCISSOR_USED
 	if (alpha < alpha_scissor_threshold) {
@@ -897,8 +899,6 @@ void main() {
 	}
 #endif // USE_OPAQUE_PREPASS || ALPHA_ANTIALIASING_EDGE_USED
 #endif // MODE_RENDER_DEPTH
-
-#endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
 
@@ -1640,7 +1640,10 @@ void main() {
 #else
 					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
 #endif
-					true, shadow, f0, orms, 1.0, albedo, alpha,
+					true, shadow, f0, orms, 1.0, albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+					shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
 #endif
@@ -1687,7 +1690,10 @@ void main() {
 
 			shadow = blur_shadow(shadow);
 
-			light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, shadow, albedo, alpha,
+			light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, shadow, albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+					shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
 #endif
@@ -1732,7 +1738,10 @@ void main() {
 
 			shadow = blur_shadow(shadow);
 
-			light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, shadow, albedo, alpha,
+			light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, shadow, albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+					shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
 #endif
@@ -1758,20 +1767,13 @@ void main() {
 		}
 	} //spot lights
 
+#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
 #ifdef USE_SHADOW_TO_OPACITY
 #ifndef MODE_RENDER_DEPTH
-	alpha = min(alpha, clamp(length(ambient_light), 0.0, 1.0));
-
-#if defined(ALPHA_SCISSOR_USED)
-	if (alpha < alpha_scissor) {
-		discard;
-	}
-#endif // !ALPHA_SCISSOR_USED
-
+	alpha = min(shadow_to_opacity, 1.0 - clamp(length(ambient_light), 0.0, 1.0));
 #endif // !MODE_RENDER_DEPTH
 #endif // USE_SHADOW_TO_OPACITY
-
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifdef MODE_RENDER_DEPTH
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -39,7 +39,10 @@ vec3 F0(float metallic, float specular, vec3 albedo) {
 	return mix(vec3(dielectric), albedo, vec3(metallic));
 }
 
-void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, uint orms, float specular_amount, vec3 albedo, inout float alpha,
+void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, uint orms, float specular_amount, vec3 albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
 #endif
@@ -249,7 +252,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	}
 
 #ifdef USE_SHADOW_TO_OPACITY
-	alpha = min(alpha, clamp(1.0 - attenuation, 0.0, 1.0));
+	shadow_to_opacity = max(shadow_to_opacity, clamp(1.0 - attenuation, 0.0, 1.0));
 #endif
 
 #endif //defined(LIGHT_CODE_USED)
@@ -547,7 +550,10 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 	return 1.0;
 }
 
-void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo, inout float alpha,
+void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
 #endif
@@ -670,7 +676,10 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 
 	light_attenuation *= shadow;
 
-	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, omni_lights.data[idx].specular_amount, albedo, alpha,
+	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, omni_lights.data[idx].specular_amount, albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+			shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
 #endif
@@ -788,7 +797,10 @@ vec2 normal_to_panorama(vec3 n) {
 	return panorama_coords;
 }
 
-void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo, inout float alpha,
+void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
 #endif
@@ -877,7 +889,10 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 	}
 	light_attenuation *= shadow;
 
-	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, spot_lights.data[idx].specular_amount, albedo, alpha,
+	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, spot_lights.data[idx].specular_amount, albedo,
+#ifdef USE_SHADOW_TO_OPACITY
+			shadow_to_opacity,
+#endif
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
 #endif


### PR DESCRIPTION
This PR changes the shadow to opacity logic so that we get shadows casted on real world objects:
![image](https://github.com/godotengine/godot/assets/1945449/2445b44c-f522-4c5b-8447-137f37e9b2ef)

For reference, this is what we're rendering (with a fake greenscreen for visualising transparency) and would be submitting to the AR device in the above scenario:
![image](https://github.com/godotengine/godot/assets/1945449/1004f99a-fbc3-4aa1-8565-22a751420b21)

This solution is far from perfect, and it may never be. One has to remember that a rendering engine "renders light". Shadows are created by the absence of light. In our use case here we have a real world object that is already lit, we're thus trying to "remove" that light by darkening our output where there is shadow. It's really a trick that goes against the principles of a rendering engine.

Still broken:
- ~~This does not work on the compatibility renderer. The compatibility renderer applies an additive process where each light is added in a pass, which does not work when we want to subtract shadows. I have some ideas yet to try but...~~ Managed to get it sort of working on compatibility, but really feeling this needs a different approach.
- Omni lights cast "shadows" outside of their range
- Spot lights are just broken, I'm not sure why yet.

Fixes:
- https://github.com/godotengine/godot/issues/91496
