### PR TITLE
Bind compatibility GDExtension methods removed in #88418

### DIFF
--- a/core/extension/gdextension.compat.inc
+++ b/core/extension/gdextension.compat.inc
@@ -1,0 +1,49 @@
+/**************************************************************************/
+/*  gdextension.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error GDExtension::_open_library_bind_compat_88418(const String &p_path, const String &p_entry_symbol) {
+	return ERR_UNAVAILABLE;
+}
+
+void GDExtension::_close_library_bind_compat_88418() {
+}
+
+void GDExtension::_initialize_library_bind_compat_88418(InitializationLevel p_level) {
+}
+
+void GDExtension::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::_open_library_bind_compat_88418);
+	ClassDB::bind_compatibility_method(D_METHOD("close_library"), &GDExtension::_close_library_bind_compat_88418);
+	ClassDB::bind_compatibility_method(D_METHOD("initialize_library", "level"), &GDExtension::_initialize_library_bind_compat_88418);
+}
+
+#endif

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "gdextension.h"
+#include "gdextension.compat.inc"
+
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/object/class_db.h"

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -136,6 +136,15 @@ public:
 		INITIALIZATION_LEVEL_EDITOR = GDEXTENSION_INITIALIZATION_EDITOR
 	};
 
+protected:
+#ifndef DISABLE_DEPRECATED
+	Error _open_library_bind_compat_88418(const String &p_path, const String &p_entry_symbol);
+	void _close_library_bind_compat_88418();
+	void _initialize_library_bind_compat_88418(InitializationLevel p_level);
+	static void _bind_compatibility_methods();
+#endif
+
+public:
 	bool is_library_open() const;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
- Reproducible in 4.3dev6
- System Information: Godot v4.3.dev (6118592c6) - Windows 10.0.19045 - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 3090 (NVIDIA; 31.0.15.3713) - Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz (16 Threads)

These functions were likely not used, but we must ensure they are still bound to ensure API stability.

Without this PR, rust addons give this error:
```
ERROR: Panic msg:
  Failed to load class method GDExtension::open_library (hash 852856452).
  Make sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html
```

`GDExtension::open_library()` with hash 852856452 needs to be re-added as a bind_compatibility_method.
