### PR TITLE
Add clearer error messages when using set/get incorrectly.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1095,7 +1095,33 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 	}
 
 	complete_extents(variable);
+
+	bool malformed_setget_found = false;
+
+	if (p_allow_property && check(GDScriptTokenizer::Token::IDENTIFIER)) {
+		StringName identifier_name = current.get_identifier();
+		if (identifier_name == SNAME("set") || identifier_name == SNAME("get")) {
+			push_error(vformat(R"(Expected ":" before "%s".)", identifier_name));
+			malformed_setget_found = true;
+		}
+	}
+
 	end_statement("variable declaration");
+
+	if (p_allow_property && !malformed_setget_found && match(GDScriptTokenizer::Token::INDENT)) {
+		if (check(GDScriptTokenizer::Token::IDENTIFIER)) {
+			StringName identifier_name = current.get_identifier();
+			if (identifier_name == SNAME("set") || identifier_name == SNAME("get")) {
+				malformed_setget_found = true;
+			}
+		}
+
+		if (malformed_setget_found) {
+			push_error(vformat(R"(Expected ":" at end of variable declaration when using "set" or "get")"), variable);
+		} else {
+			push_error(R"(Unexpected "Indent" after variable declaration.)");
+		}
+	}
 
 	return variable;
 }

--- a/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_indent.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_indent.gd
@@ -1,0 +1,8 @@
+#GDTEST_PARSER_ERROR
+
+var property
+	get():
+		return 0
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_indent.out
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_indent.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected ":" at end of variable declaration when using "set" or "get"

--- a/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_inline.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_inline.gd
@@ -1,0 +1,9 @@
+#GDTEST_PARSER_ERROR
+
+var property get = get_property
+
+func test():
+	pass
+	
+func get_property():
+	return 0

--- a/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_inline.out
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_colon_setget_inline.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected ":" before "get".


### PR DESCRIPTION
It's quite easy for users to forget to use the colon before their setters and getters, but in this situation error messages are unclear about the real nature of the problem.

This commit adds a check for malformed set/get statements and provides error messages containing more direct guidance to users.

Closes #91216