### PR TITLE
Allow users to override `SkeletonModifier3D._process_modification`

### DIFF
--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -6,9 +6,19 @@
 	<description>
 		[SkeletonModifier3D] retrieves a target [Skeleton3D] by having a [Skeleton3D] parent.
 		If there is [AnimationMixer], modification always performs after playback process of the [AnimationMixer].
+		This node should be used to implement custom IK solvers, constraints, or skeleton physics
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="_process_modification" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this virtual method to implement a custom skeleton modifier. You should do things like get the [Skeleton3D]'s current pose and apply the pose here.
+				[method _process_modification] must not apply [member influence] to bone poses because the [Skeleton3D] automatically applies influence to all bone poses set by the modifier.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="is_active" default="true">
 			If [code]true[/code], the [SkeletonModifier3D] will be processing.

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -110,7 +110,7 @@ void SkeletonModifier3D::process_modification() {
 }
 
 void SkeletonModifier3D::_process_modification() {
-	//
+	GDVIRTUAL_CALL(_process_modification);
 }
 
 void SkeletonModifier3D::_notification(int p_what) {
@@ -133,6 +133,7 @@ void SkeletonModifier3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "influence", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_influence", "get_influence");
 
 	ADD_SIGNAL(MethodInfo("modification_processed"));
+	GDVIRTUAL_BIND(_process_modification);
 }
 
 SkeletonModifier3D::SkeletonModifier3D() {

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -60,6 +60,7 @@ protected:
 	virtual void _set_active(bool p_active);
 
 	virtual void _process_modification();
+	GDVIRTUAL0(_process_modification);
 
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -589,7 +589,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CPUParticles3D);
 	GDREGISTER_CLASS(Marker3D);
 	GDREGISTER_CLASS(RootMotionView);
-	GDREGISTER_ABSTRACT_CLASS(SkeletonModifier3D);
+	GDREGISTER_VIRTUAL_CLASS(SkeletonModifier3D);
 
 	OS::get_singleton()->yield(); // may take time to init
 


### PR DESCRIPTION
Currently, SkeletonModifer3D is abstract. This changes it so that it and _process_modification can be implemented.

This is needed so users can build their own custom IK, spring bones or body tracking.