### PR TITLE
Add optional driver workaround to RenderingDevice for Adreno 6XX.

### DIFF
--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -173,6 +173,7 @@ Error RenderingContextDriverD3D12::_initialize_devices() {
 		Device &device = driver_devices[i];
 		device.name = desc.Description;
 		device.vendor = Vendor(desc.VendorId);
+		device.workarounds = Workarounds();
 
 		if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
 			device.type = DEVICE_TYPE_CPU;

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -105,6 +105,7 @@ private:
 	Error _initialize_instance_extensions();
 	Error _initialize_instance();
 	Error _initialize_devices();
+	void _check_driver_workarounds(const VkPhysicalDeviceProperties &p_device_properties, Device &r_device);
 
 	// Static callbacks.
 	static VKAPI_ATTR VkBool32 VKAPI_CALL _debug_messenger_callback(VkDebugUtilsMessageSeverityFlagBitsEXT p_message_severity, VkDebugUtilsMessageTypeFlagsEXT p_message_type, const VkDebugUtilsMessengerCallbackDataEXT *p_callback_data, void *p_user_data);

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -73,10 +73,15 @@ public:
 		DEVICE_TYPE_MAX = 0x5
 	};
 
+	struct Workarounds {
+		bool avoid_compute_after_draw = false;
+	};
+
 	struct Device {
 		String name = "Unknown";
 		Vendor vendor = VENDOR_UNKNOWN;
 		DeviceType type = DEVICE_TYPE_OTHER;
+		Workarounds workarounds;
 	};
 
 	virtual ~RenderingContextDriver();

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1261,6 +1261,9 @@ private:
 		// Swap chains prepared for drawing during the frame that must be presented.
 		LocalVector<RDD::SwapChainID> swap_chains_to_present;
 
+		// Extra command buffer pool used for driver workarounds.
+		RDG::CommandBufferPool command_buffer_pool;
+
 		struct Timestamp {
 			String description;
 			uint64_t value = 0;

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -184,6 +184,20 @@ public:
 		}
 	};
 
+	struct CommandBufferPool {
+		// Provided by RenderingDevice.
+		RDD::CommandPoolID pool;
+
+		// Created internally by RenderingDeviceGraph.
+		LocalVector<RDD::CommandBufferID> buffers;
+		LocalVector<RDD::SemaphoreID> semaphores;
+		uint32_t buffers_used = 0;
+	};
+
+	struct WorkaroundsState {
+		bool draw_list_found = false;
+	};
+
 private:
 	struct InstructionList {
 		LocalVector<uint8_t> data;
@@ -560,6 +574,7 @@ private:
 	};
 
 	RDD *driver = nullptr;
+	RenderingContextDriver::Device device;
 	int64_t tracking_frame = 0;
 	LocalVector<uint8_t> command_data;
 	LocalVector<uint32_t> command_data_offsets;
@@ -582,6 +597,7 @@ private:
 	bool command_synchronization_pending = false;
 	BarrierGroup barrier_group;
 	bool driver_honors_barriers = false;
+	WorkaroundsState workarounds_state;
 	TightLocalVector<Frame> frames;
 	uint32_t frame = 0;
 
@@ -608,7 +624,7 @@ private:
 	void _run_draw_list_command(RDD::CommandBufferID p_command_buffer, const uint8_t *p_instruction_data, uint32_t p_instruction_data_size);
 	void _run_secondary_command_buffer_task(const SecondaryCommandBuffer *p_secondary);
 	void _wait_for_secondary_command_buffer_tasks();
-	void _run_render_commands(RDD::CommandBufferID p_command_buffer, int32_t p_level, const RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, int32_t &r_current_label_index, int32_t &r_current_label_level);
+	void _run_render_commands(int32_t p_level, const RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, RDD::CommandBufferID &r_command_buffer, CommandBufferPool &r_command_buffer_pool, int32_t &r_current_label_index, int32_t &r_current_label_level);
 	void _run_label_command_change(RDD::CommandBufferID p_command_buffer, int32_t p_new_label_index, int32_t p_new_level, bool p_ignore_previous_value, bool p_use_label_for_empty, const RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, int32_t &r_current_label_index, int32_t &r_current_label_level);
 	void _boost_priority_for_render_commands(RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, uint32_t &r_boosted_priority);
 	void _group_barriers_for_render_commands(RDD::CommandBufferID p_command_buffer, const RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, bool p_full_memory_barrier);
@@ -619,7 +635,7 @@ private:
 public:
 	RenderingDeviceGraph();
 	~RenderingDeviceGraph();
-	void initialize(RDD *p_driver, uint32_t p_frame_count, RDD::CommandQueueFamilyID p_secondary_command_queue_family, uint32_t p_secondary_command_buffers_per_frame);
+	void initialize(RDD *p_driver, RenderingContextDriver::Device p_device, uint32_t p_frame_count, RDD::CommandQueueFamilyID p_secondary_command_queue_family, uint32_t p_secondary_command_buffers_per_frame);
 	void finalize();
 	void begin();
 	void add_buffer_clear(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, uint32_t p_offset, uint32_t p_size);
@@ -664,7 +680,7 @@ public:
 	void add_synchronization();
 	void begin_label(const String &p_label_name, const Color &p_color);
 	void end_label();
-	void end(RDD::CommandBufferID p_command_buffer, bool p_reorder_commands, bool p_full_barriers);
+	void end(bool p_reorder_commands, bool p_full_barriers, RDD::CommandBufferID &r_command_buffer, CommandBufferPool &r_command_buffer_pool);
 	static ResourceTracker *resource_tracker_create();
 	static void resource_tracker_free(ResourceTracker *tracker);
 };


### PR DESCRIPTION
Fixes #90459. This was a perceived regression by the end user as #84976 was the one that introduced the crash. However, the reality turned out to be the graph exposed a driver bug we were successfully dodging in Mobile. This very well could explain why Forward+ was prone to crashing on this family of devices.

Quoting from the PR itself for the in-depth explanation.

> Workaround for the Adreno 6XX family of devices.
> 
> There's a known issue with the Vulkan driver in this family of devices where it'll crash if a dynamic state for drawing is used in a command buffer before a dispatch call is issued. As both dynamic scissor and viewport are basic requirements for the engine to not bake this state into the PSO, the only known way to fix this issue is to reset the command buffer entirely.
> 
> As the render graph has no built in limitations of whether it'll issue compute work before anything needs to draw on the frame, and there's no guarantee that compute work will never be dependent on rasterization in the future, this workaround will end recording on the current command buffer any time a compute list is encountered after a draw list was executed. A new command buffer will be created afterwards and the appropriate synchronization primitives will be inserted.
> 
> Executing this workaround has the added cost of synchronization between all the command buffers that are created as well as all the individual submissions. This performance hit is accepted for the sake of being able to support these devices without limiting the design of the renderer.

### TODO:

- [x] Implement the logic for enabling this workaround [here](https://github.com/DarioSamo/godot/blob/db14cf4b9b9c82ff316f68f9433a42effa5ceefb/servers/rendering/rendering_device_graph.cpp#L1274) only for the affected devices. Tagging @clayjohn as he has a device that can reproduce the issue.