### PR TITLE
Generate docs from GDExtensions using `--gdextension-docs` with `--doctool`

### DIFF
--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1602,7 +1602,7 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 	}
 }
 
-Error DocTools::save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_include_xml_schema) {
+Error DocTools::save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_use_relative_schema) {
 	for (KeyValue<String, DocData::ClassDoc> &E : class_list) {
 		DocData::ClassDoc &c = E.value;
 
@@ -1634,15 +1634,17 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		if (!c.keywords.is_empty()) {
 			header += String(" keywords=\"") + c.keywords.xml_escape(true) + "\"";
 		}
-		if (p_include_xml_schema) {
-			// Reference the XML schema so editors can provide error checking.
+		// Reference the XML schema so editors can provide error checking.
+		String schema_path;
+		if (p_use_relative_schema) {
 			// Modules are nested deep, so change the path to reference the same schema everywhere.
-			const String schema_path = save_path.find("modules/") != -1 ? "../../../doc/class.xsd" : "../class.xsd";
-			header += vformat(
-					R"( xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="%s")",
-					schema_path);
+			schema_path = save_path.find("modules/") != -1 ? "../../../doc/class.xsd" : "../class.xsd";
+		} else {
+			schema_path = "https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd";
 		}
-		header += ">";
+		header += vformat(
+				R"( xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="%s">)",
+				schema_path);
 		_write_string(f, 0, header);
 
 		_write_string(f, 1, "<brief_description>");

--- a/editor/doc_tools.h
+++ b/editor/doc_tools.h
@@ -52,7 +52,7 @@ public:
 	};
 	void generate(BitField<GenerateFlags> p_flags = {});
 	Error load_classes(const String &p_dir);
-	Error save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_include_xml_schema = true);
+	Error save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_use_relative_schema = true);
 
 	Error _load(Ref<XMLParser> parser);
 	Error load_compressed(const uint8_t *p_data, int p_compressed_size, int p_uncompressed_size);


### PR DESCRIPTION
Currently, `--doctool` won't generate docs for GDExtensions, only engine types.

This adds a new option (`--gdextension-docs`) which will generate docs only for GDExtensions used in the current project. It's intended to be paired with `--doctool`, similar to how the existing `--gdscript-docs` option works.

I'm not crazy about adding more stuff to `main.cpp`, but this is more-or-less in line with what we've already got there.

This is intended to be used with godot-cpp PR https://github.com/godotengine/godot-cpp/pull/1374
