### PR TITLE
[Editor] Don't open `AnimationLibrary` as a scene

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1220,8 +1220,10 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 			if (is_imported) {
 				SceneImportSettingsDialog::get_singleton()->open_settings(p_path, resource_type == "AnimationLibrary");
-			} else {
+			} else if (resource_type == "PackedScene") {
 				EditorNode::get_singleton()->open_request(fpath);
+			} else {
+				EditorNode::get_singleton()->load_resource(fpath);
 			}
 		} else if (ResourceLoader::is_imported(fpath)) {
 			// If the importer has advanced settings, show them.


### PR DESCRIPTION
If opening an `AnimationLibrary` in the file dock and it is not imported the editor will treat it as a scene, rather than a resource. This fails to open it correctly.

The inspector might be confusing to users as the animation dock won't be valid, but it shouldn't be opened as a scene, further improvements might be desired but it looks like an oversight, especially as newly created resources show up in the inspector 

* Fixes: https://github.com/godotengine/godot/issues/91516
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
