### PR TITLE
FBX: Fix handling missing skins using ufbx importer

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -693,10 +693,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 
 				// Find the first imported skin deformer
 				for (ufbx_skin_deformer *fbx_skin : fbx_mesh->skin_deformers) {
-					if (!p_state->skin_indices.has(fbx_skin->typed_id)) {
-						continue;
-					}
-					GLTFSkinIndex skin_i = p_state->skin_indices[fbx_skin->typed_id];
+					GLTFSkinIndex skin_i = p_state->original_skin_indices[fbx_skin->typed_id];
 					if (skin_i < 0) {
 						continue;
 					}
@@ -2341,7 +2338,7 @@ Error FBXDocument::_parse_skins(Ref<FBXState> p_state) {
 	HashMap<GLTFNodeIndex, bool> joint_mapping;
 
 	for (const ufbx_skin_deformer *fbx_skin : fbx_scene->skin_deformers) {
-		if (fbx_skin->clusters.count == 0) {
+		if (fbx_skin->clusters.count == 0 || fbx_skin->weights.count == 0) {
 			p_state->skin_indices.push_back(-1);
 			continue;
 		}
@@ -2387,8 +2384,9 @@ Error FBXDocument::_parse_skins(Ref<FBXState> p_state) {
 			}
 		}
 	}
+	p_state->original_skin_indices = p_state->skin_indices.duplicate();
 	Error err = SkinTool::_asset_parse_skins(
-			p_state->skin_indices.duplicate(),
+			p_state->original_skin_indices,
 			p_state->skins.duplicate(),
 			p_state->nodes.duplicate(),
 			p_state->skin_indices,

--- a/modules/fbx/fbx_state.h
+++ b/modules/fbx/fbx_state.h
@@ -53,6 +53,7 @@ class FBXState : public GLTFState {
 	HashMap<Pair<uint64_t, uint64_t>, GLTFTextureIndex, PairHash<uint64_t, uint64_t>> albedo_transparency_textures;
 
 	Vector<GLTFSkinIndex> skin_indices;
+	Vector<GLTFSkinIndex> original_skin_indices;
 	HashMap<ObjectID, GLTFSkeletonIndex> skeleton3d_to_fbx_skeleton;
 	HashMap<ObjectID, HashMap<ObjectID, GLTFSkinIndex>> skin_and_skeleton3d_to_fbx_skin;
 	HashSet<String> unique_mesh_names; // Not in GLTFState because GLTFState prefixes mesh names with the scene name (or _)


### PR DESCRIPTION
Previously, `_asset_parse_skins()` would mess with the order of skin indices. However, the rest of the code expected these to match to ufbx skin indices. To fix this, retain the original skin indices in `FBXState::original_skin_indices`.

This issue was visible in for example in the file https://ufbx-dataset.b-cdn.net/local/hana/hana.fbx,
where using the ufbx importer the hair and shoes were missing:

**FBX2glTF**
![FBX2glTF](https://github.com/godotengine/godot/assets/3875461/753fa180-3273-4cbd-aab7-5772c9b55d96)

**ufbx**
![ufbx](https://github.com/godotengine/godot/assets/3875461/4c09f2ef-4a21-4d4a-a994-a6d6f1b6845d)

This PR also tightens the valid skin condition to include `fbx_skin->weights.count > 0`, meaning the skin must have at least a single weight. This seems to be consistent with what FBX2glTF is doing.