### PR TITLE
Expose joypad `vendor_id` and `product_id` in Windows

### DIFF
--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -104,8 +104,19 @@ private:
 		uint64_t ff_end_timestamp = 0;
 	};
 
+	struct xinput_capabilities_ex {
+		XINPUT_CAPABILITIES Capabilities;
+		WORD vendorId;
+		WORD productId;
+		WORD revisionId;
+		DWORD a4; // unknown
+	};
+
 	typedef DWORD(WINAPI *XInputGetState_t)(DWORD dwUserIndex, XINPUT_STATE *pState);
 	typedef DWORD(WINAPI *XInputSetState_t)(DWORD dwUserIndex, XINPUT_VIBRATION *pVibration);
+	typedef DWORD(_stdcall *_XInputGetCapabilitiesEx)(DWORD a1, DWORD dwUserIndex, DWORD dwFlags, xinput_capabilities_ex *pCapabilities);
+
+	_XInputGetCapabilitiesEx XInputGetCapabilitiesEx = nullptr;
 
 	HWND *hWnd = nullptr;
 	HANDLE xinput_dll;


### PR DESCRIPTION
The `vendor_id`  and `product_id` can already be extracted but only in Linux. It was implemented back in #78539 through `Input.get_joy_info(device_id)` and this PR implements the same functionality but for Windows.

I should add that through the XInput API the `vendor_id` and `product_id` extraction happens through an [undocumented function in XInput1_4.dll](https://stackoverflow.com/questions/64251320/is-it-possible-to-get-an-xinput-devices-name-product-id-vendor-id-or-some-oth) which is the same way [SDL does it](https://github.com/libsdl-org/SDL/blob/7856c8fb8fec5114af54299a8cafa81db507a0b6/src/core/windows/SDL_xinput.c#L115-L116).

This PR is inspired by the following proposal:
* https://github.com/godotengine/godot-proposals/issues/8519

I was looking for a way to map a joypad to its type in order to correctly show button prompts and by reading through the proposal one can find the following databases which allow users to do so:

* https://github.com/libsdl-org/SDL/blob/main/src/joystick/controller_list.h
* https://github.com/JujuAdams/Input/blob/community-data/community_gamepad_type.txt

The reason I didn't implement `Input.get_joy_type()` is because I don't think the function nor those databases should be compiled into the engine. The joypad type database needs could differ greatly between users, and once the `vendor_id` and `product_id` can be extracted with ease, the mapping of a joypad to its type seems straightforward through an addon.