### PR TITLE
Properly set size of shadow atlas quadrant when subdivision is 8 or higher.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -2025,7 +2025,7 @@ void LightStorage::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits
 	for (int i = 0; i < 4; i++) {
 		//clear subdivisions
 		shadow_atlas->quadrants[i].shadows.clear();
-		shadow_atlas->quadrants[i].shadows.resize(int64_t(1) << int64_t(shadow_atlas->quadrants[i].subdivision));
+		shadow_atlas->quadrants[i].shadows.resize(int64_t(shadow_atlas->quadrants[i].subdivision * shadow_atlas->quadrants[i].subdivision));
 	}
 
 	//erase shadow atlas reference from lights

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3451,9 +3451,9 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 	if (p_region != Rect2() && p_region != Rect2(Vector2(), viewport_size)) { // Check custom region.
 		Rect2i viewport(viewport_offset, viewport_size);
 		Rect2i regioni = p_region;
-		if (!(regioni.position.x >= viewport.position.x) && (regioni.position.y >= viewport.position.y) &&
-				((regioni.position.x + regioni.size.x) <= (viewport.position.x + viewport.size.x)) &&
-				((regioni.position.y + regioni.size.y) <= (viewport.position.y + viewport.size.y))) {
+		if (!((regioni.position.x >= viewport.position.x) && (regioni.position.y >= viewport.position.y) &&
+					((regioni.position.x + regioni.size.x) <= (viewport.position.x + viewport.size.x)) &&
+					((regioni.position.y + regioni.size.y) <= (viewport.position.y + viewport.size.y)))) {
 			ERR_FAIL_V_MSG(INVALID_ID, "When supplying a custom region, it must be contained within the framebuffer rectangle");
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/89312

I still can't figure out why this seemingly regressed between dev1 and dev2. Both of these problems have been present for a long time. 

### Problem 1: Shadow atlas quadrant allocation

Each atlas stores shadows for up to subdivision * subdivision lights (omnilights count for 2). When we set the quadrant subdivisions we reserve enough space in the shadows array for that many lights. We use the length of this shadows array to validate how many shadows can go in each quadrant. 

When we set the size of the atlas, we have to clear the quadrants and then resize them. But there we were reserving enough space for `1 << subdivision` lights. This is not always the same as `subdivision * subdivision`! For the last quadrant, this led the system to think that it could store 256 shadows, when it really only had space for 64. So the 65th shadow would try to render outside the framebuffer and cause the error. 

Oddly enough I caught this bug in the OpenGL renderer when implementing shadows. I remember at the time noticing it, but not doing anything in the RD renderers because it wasn't causing any issues and I didn't have time to investigate why.

### Problem 2: No validation for render pass rect size

`draw_list_begin` is supposed to validate the size of the render pass rect. But it was missing a pair of parentheses, so instead of checking if the rect was fully inside the framebuffer. It checked if the rect began outside the framebuffer on the X-axis, but otherwise fit within the framebuffer. This bug has been present for a long time.

Not every device crashed/froze despite us allowing values that should not have been allowed as different drivers handle breaking spec differently. 