### PR TITLE
Improve bad hash functions

### DIFF
--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -99,9 +99,9 @@ class Delaunay3D {
 
 	struct TriangleHasher {
 		_FORCE_INLINE_ static uint32_t hash(const Triangle &p_triangle) {
-			uint32_t h = hash_djb2_one_32(p_triangle.triangle[0]);
-			h = hash_djb2_one_32(p_triangle.triangle[1], h);
-			return hash_fmix32(hash_djb2_one_32(p_triangle.triangle[2], h));
+			uint32_t h = hash_murmur3_one_32(p_triangle.triangle[0]);
+			h = hash_murmur3_one_32(p_triangle.triangle[1], h);
+			return hash_fmix32(hash_murmur3_one_32(p_triangle.triangle[2], h));
 		}
 	};
 

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -343,16 +343,22 @@ struct HashMapHasherDefault {
 		h = hash_murmur3_one_32(p_vec.w, h);
 		return hash_fmix32(h);
 	}
-	static _FORCE_INLINE_ uint32_t hash(const Vector2 &p_vec) {
-		uint32_t h = hash_murmur3_one_real(p_vec.x);
+	static _FORCE_INLINE_ uint32_t hash_seed(const Vector2 &p_vec, uint32_t p_seed = HASH_MURMUR3_SEED) {
+		uint32_t h = hash_murmur3_one_real(p_vec.x, p_seed);
 		h = hash_murmur3_one_real(p_vec.y, h);
-		return hash_fmix32(h);
+		return h;
 	}
-	static _FORCE_INLINE_ uint32_t hash(const Vector3 &p_vec) {
-		uint32_t h = hash_murmur3_one_real(p_vec.x);
+	static _FORCE_INLINE_ uint32_t hash(const Vector2 &p_vec) {
+		return hash_fmix32(hash_seed(p_vec));
+	}
+	static _FORCE_INLINE_ uint32_t hash_seed(const Vector3 &p_vec, uint32_t p_seed = HASH_MURMUR3_SEED) {
+		uint32_t h = hash_murmur3_one_real(p_vec.x, p_seed);
 		h = hash_murmur3_one_real(p_vec.y, h);
 		h = hash_murmur3_one_real(p_vec.z, h);
-		return hash_fmix32(h);
+		return h;
+	}
+	static _FORCE_INLINE_ uint32_t hash(const Vector3 &p_vec) {
+		return hash_fmix32(hash_seed(p_vec));
 	}
 	static _FORCE_INLINE_ uint32_t hash(const Vector4 &p_vec) {
 		uint32_t h = hash_murmur3_one_real(p_vec.x);

--- a/editor/plugins/gizmos/navigation_region_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/navigation_region_3d_gizmo_plugin.h
@@ -41,7 +41,13 @@ class NavigationRegion3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 		Vector3 to;
 
 		static uint32_t hash(const _EdgeKey &p_key) {
-			return HashMapHasherDefault::hash(p_key.from) ^ HashMapHasherDefault::hash(p_key.to);
+			uint32_t hash = hash_murmur3_one_real(p_key.from.x);
+			hash = hash_murmur3_one_real(p_key.from.y, hash);
+			hash = hash_murmur3_one_real(p_key.from.z, hash);
+			hash = hash_murmur3_one_real(p_key.to.x, hash);
+			hash = hash_murmur3_one_real(p_key.to.y, hash);
+			hash = hash_murmur3_one_real(p_key.to.z, hash);
+			return hash_fmix32(hash);
 		}
 
 		bool operator==(const _EdgeKey &p_with) const {

--- a/editor/plugins/gizmos/navigation_region_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/navigation_region_3d_gizmo_plugin.h
@@ -41,12 +41,8 @@ class NavigationRegion3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 		Vector3 to;
 
 		static uint32_t hash(const _EdgeKey &p_key) {
-			uint32_t hash = hash_murmur3_one_real(p_key.from.x);
-			hash = hash_murmur3_one_real(p_key.from.y, hash);
-			hash = hash_murmur3_one_real(p_key.from.z, hash);
-			hash = hash_murmur3_one_real(p_key.to.x, hash);
-			hash = hash_murmur3_one_real(p_key.to.y, hash);
-			hash = hash_murmur3_one_real(p_key.to.z, hash);
+			uint32_t hash = HashMapHasherDefault::hash_seed(p_key.from);
+			hash = HashMapHasherDefault::hash_seed(p_key.to, hash);
 			return hash_fmix32(hash);
 		}
 

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -56,7 +56,9 @@ struct EdgeKey {
 	PointKey b;
 
 	static uint32_t hash(const EdgeKey &p_val) {
-		return hash_one_uint64(p_val.a.key) ^ hash_one_uint64(p_val.b.key);
+		uint32_t hash = hash_murmur3_one_64(p_val.a.key);
+		hash = hash_murmur3_one_64(p_val.b.key, hash);
+		return hash_fmix32(hash);
 	}
 
 	bool operator==(const EdgeKey &p_key) const {

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -43,13 +43,8 @@ class ConcavePolygonShape3D : public Shape3D {
 		Vector3 a;
 		Vector3 b;
 		static uint32_t hash(const DrawEdge &p_edge) {
-			uint32_t h = hash_murmur3_one_real(p_edge.a.x);
-			h = hash_murmur3_one_real(p_edge.a.y, h);
-			h = hash_murmur3_one_real(p_edge.a.z, h);
-			h = hash_murmur3_one_real(p_edge.b.x, h);
-			h = hash_murmur3_one_real(p_edge.b.y, h);
-			h = hash_murmur3_one_real(p_edge.b.z, h);
-
+			uint32_t h = HashMapHasherDefault::hash_seed(p_edge.a);
+			h = HashMapHasherDefault::hash_seed(p_edge.b, h);
 			return hash_fmix32(h);
 		}
 		bool operator==(const DrawEdge &p_edge) const {

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -43,8 +43,14 @@ class ConcavePolygonShape3D : public Shape3D {
 		Vector3 a;
 		Vector3 b;
 		static uint32_t hash(const DrawEdge &p_edge) {
-			uint32_t h = hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.a));
-			return hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.b), h);
+			uint32_t h = hash_murmur3_one_real(p_edge.a.x);
+			h = hash_murmur3_one_real(p_edge.a.y, h);
+			h = hash_murmur3_one_real(p_edge.a.z, h);
+			h = hash_murmur3_one_real(p_edge.b.x, h);
+			h = hash_murmur3_one_real(p_edge.b.y, h);
+			h = hash_murmur3_one_real(p_edge.b.z, h);
+
+			return hash_fmix32(h);
 		}
 		bool operator==(const DrawEdge &p_edge) const {
 			return (a == p_edge.a && b == p_edge.b);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -343,7 +343,7 @@ private:
 		}
 
 		static uint32_t hash(const MaterialKey &p_key) {
-			return hash_djb2_buffer((const uint8_t *)&p_key, sizeof(MaterialKey));
+			return hash_murmur3_buffer((const uint8_t *)&p_key, sizeof(MaterialKey));
 		}
 		bool operator==(const MaterialKey &p_key) const {
 			return memcmp(this, &p_key, sizeof(MaterialKey)) == 0;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -142,24 +142,12 @@ uint32_t SurfaceTool::VertexHasher::hash(const Vertex &p_vtx) {
 	h = hash_murmur3_one_float(p_vtx.color.b, h);
 	h = hash_murmur3_one_float(p_vtx.color.a, h);
 
-	h = hash_murmur3_one_real(p_vtx.normal.x, h);
-	h = hash_murmur3_one_real(p_vtx.normal.y, h);
-	h = hash_murmur3_one_real(p_vtx.normal.z, h);
-	h = hash_murmur3_one_real(p_vtx.binormal.x, h);
-	h = hash_murmur3_one_real(p_vtx.binormal.y, h);
-	h = hash_murmur3_one_real(p_vtx.binormal.z, h);
-	h = hash_murmur3_one_real(p_vtx.tangent.x, h);
-	h = hash_murmur3_one_real(p_vtx.tangent.y, h);
-	h = hash_murmur3_one_real(p_vtx.tangent.z, h);
-
-	h = hash_murmur3_one_real(p_vtx.uv.x, h);
-	h = hash_murmur3_one_real(p_vtx.uv.y, h);
-	h = hash_murmur3_one_real(p_vtx.uv2.x, h);
-	h = hash_murmur3_one_real(p_vtx.uv2.y, h);
-
-	h = hash_murmur3_one_real(p_vtx.vertex.x, h);
-	h = hash_murmur3_one_real(p_vtx.vertex.y, h);
-	h = hash_murmur3_one_real(p_vtx.vertex.z, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.normal, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.binormal, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.tangent, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.uv, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.uv2, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.vertex, h);
 
 	h = hash_murmur3_buffer((const uint8_t *)p_vtx.bones.ptr(), p_vtx.bones.size() * sizeof(int), h);
 	h = hash_murmur3_buffer((const uint8_t *)p_vtx.weights.ptr(), p_vtx.weights.size() * sizeof(float), h);
@@ -182,9 +170,7 @@ bool SurfaceTool::SmoothGroupVertex::operator==(const SmoothGroupVertex &p_verte
 
 uint32_t SurfaceTool::SmoothGroupVertexHasher::hash(const SmoothGroupVertex &p_vtx) {
 	uint32_t h = hash_murmur3_one_32(p_vtx.smooth_group);
-	h = hash_murmur3_one_real(p_vtx.vertex.x, h);
-	h = hash_murmur3_one_real(p_vtx.vertex.y, h);
-	h = hash_murmur3_one_real(p_vtx.vertex.z, h);
+	h = HashMapHasherDefault::hash_seed(p_vtx.vertex, h);
 	return hash_fmix32(h);
 }
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -135,18 +135,36 @@ bool SurfaceTool::Vertex::operator==(const Vertex &p_vertex) const {
 }
 
 uint32_t SurfaceTool::VertexHasher::hash(const Vertex &p_vtx) {
-	uint32_t h = hash_djb2_buffer((const uint8_t *)&p_vtx.vertex, sizeof(real_t) * 3);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.normal, sizeof(real_t) * 3, h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.binormal, sizeof(real_t) * 3, h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.tangent, sizeof(real_t) * 3, h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.uv, sizeof(real_t) * 2, h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.uv2, sizeof(real_t) * 2, h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.color, sizeof(real_t) * 4, h);
-	h = hash_djb2_buffer((const uint8_t *)p_vtx.bones.ptr(), p_vtx.bones.size() * sizeof(int), h);
-	h = hash_djb2_buffer((const uint8_t *)p_vtx.weights.ptr(), p_vtx.weights.size() * sizeof(float), h);
-	h = hash_djb2_buffer((const uint8_t *)&p_vtx.custom[0], sizeof(Color) * RS::ARRAY_CUSTOM_COUNT, h);
-	h = hash_murmur3_one_32(p_vtx.smooth_group, h);
-	h = hash_fmix32(h);
+	uint32_t h = hash_murmur3_one_32(p_vtx.smooth_group);
+
+	h = hash_murmur3_one_float(p_vtx.color.r, h);
+	h = hash_murmur3_one_float(p_vtx.color.g, h);
+	h = hash_murmur3_one_float(p_vtx.color.b, h);
+	h = hash_murmur3_one_float(p_vtx.color.a, h);
+
+	h = hash_murmur3_one_real(p_vtx.normal.x, h);
+	h = hash_murmur3_one_real(p_vtx.normal.y, h);
+	h = hash_murmur3_one_real(p_vtx.normal.z, h);
+	h = hash_murmur3_one_real(p_vtx.binormal.x, h);
+	h = hash_murmur3_one_real(p_vtx.binormal.y, h);
+	h = hash_murmur3_one_real(p_vtx.binormal.z, h);
+	h = hash_murmur3_one_real(p_vtx.tangent.x, h);
+	h = hash_murmur3_one_real(p_vtx.tangent.y, h);
+	h = hash_murmur3_one_real(p_vtx.tangent.z, h);
+
+	h = hash_murmur3_one_real(p_vtx.uv.x, h);
+	h = hash_murmur3_one_real(p_vtx.uv.y, h);
+	h = hash_murmur3_one_real(p_vtx.uv2.x, h);
+	h = hash_murmur3_one_real(p_vtx.uv2.y, h);
+
+	h = hash_murmur3_one_real(p_vtx.vertex.x, h);
+	h = hash_murmur3_one_real(p_vtx.vertex.y, h);
+	h = hash_murmur3_one_real(p_vtx.vertex.z, h);
+
+	h = hash_murmur3_buffer((const uint8_t *)p_vtx.bones.ptr(), p_vtx.bones.size() * sizeof(int), h);
+	h = hash_murmur3_buffer((const uint8_t *)p_vtx.weights.ptr(), p_vtx.weights.size() * sizeof(float), h);
+	h = hash_murmur3_buffer((const uint8_t *)&p_vtx.custom[0], sizeof(Color) * RS::ARRAY_CUSTOM_COUNT, h);
+
 	return h;
 }
 
@@ -163,10 +181,11 @@ bool SurfaceTool::SmoothGroupVertex::operator==(const SmoothGroupVertex &p_verte
 }
 
 uint32_t SurfaceTool::SmoothGroupVertexHasher::hash(const SmoothGroupVertex &p_vtx) {
-	uint32_t h = hash_djb2_buffer((const uint8_t *)&p_vtx.vertex, sizeof(real_t) * 3);
-	h = hash_murmur3_one_32(p_vtx.smooth_group, h);
-	h = hash_fmix32(h);
-	return h;
+	uint32_t h = hash_murmur3_one_32(p_vtx.smooth_group);
+	h = hash_murmur3_one_real(p_vtx.vertex.x, h);
+	h = hash_murmur3_one_real(p_vtx.vertex.y, h);
+	h = hash_murmur3_one_real(p_vtx.vertex.z, h);
+	return hash_fmix32(h);
 }
 
 uint32_t SurfaceTool::TriangleHasher::hash(const int *p_triangle) {


### PR DESCRIPTION
Working on #90082. When using the collision checker, I found that hash maps/sets with these hash functions do not work well and create a large number of collisions (max number of collisions is more than 13). So I improved the algorithm for their work. In most cases, I changed the hashing algorithm from `djb2` to `murmur3`. The maximum number of collisions after these changes decreased by 1.5 - 2 times.