### PR TITLE
Remove "AnalyzeTemporaryDtors" from clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,cppcoreguidelines-pro-type-member-init,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements,readability-redundant-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle: none
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes


### PR DESCRIPTION
It has been [deprecated](https://reviews.llvm.org/D156303), and raises an error when clangd LSP is indexing.