### PR TITLE
Change `bulk_theme_override` variable to an integer

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2962,14 +2962,14 @@ int Control::get_theme_default_font_size() const {
 
 void Control::begin_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
-	data.bulk_theme_override = true;
+	data.bulk_theme_override += 1;
 }
 
 void Control::end_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!data.bulk_theme_override);
 
-	data.bulk_theme_override = false;
+	data.bulk_theme_override -= 1;
 	_notify_theme_override_changed();
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2967,7 +2967,7 @@ void Control::begin_bulk_theme_override() {
 
 void Control::end_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!data.bulk_theme_override);
+	ERR_FAIL_COND_MSG(data.bulk_theme_override <= 0, "end_bulk_theme_override() called without a matching begin_bulk_theme_override().");
 
 	data.bulk_theme_override -= 1;
 	_notify_theme_override_changed();

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -232,7 +232,7 @@ private:
 		Ref<Theme> theme;
 		StringName theme_type_variation;
 
-		bool bulk_theme_override = false;
+		int bulk_theme_override = 0;
 		Theme::ThemeIconMap theme_icon_override;
 		Theme::ThemeStyleMap theme_style_override;
 		Theme::ThemeFontMap theme_font_override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2523,7 +2523,7 @@ void Window::begin_bulk_theme_override() {
 
 void Window::end_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND_MSG(data.bulk_theme_override <= 0, "end_bulk_theme_override() called without a matching begin_bulk_theme_override().");
+	ERR_FAIL_COND_MSG(bulk_theme_override <= 0, "end_bulk_theme_override() called without a matching begin_bulk_theme_override().");
 
 	bulk_theme_override -= 1;
 	_notify_theme_override_changed();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2518,14 +2518,14 @@ int Window::get_theme_default_font_size() const {
 
 void Window::begin_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
-	bulk_theme_override = true;
+	bulk_theme_override += 1;
 }
 
 void Window::end_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!bulk_theme_override);
 
-	bulk_theme_override = false;
+	bulk_theme_override -= 1;
 	_notify_theme_override_changed();
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2523,7 +2523,7 @@ void Window::begin_bulk_theme_override() {
 
 void Window::end_bulk_theme_override() {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!bulk_theme_override);
+	ERR_FAIL_COND_MSG(data.bulk_theme_override <= 0, "end_bulk_theme_override() called without a matching begin_bulk_theme_override().");
 
 	bulk_theme_override -= 1;
 	_notify_theme_override_changed();

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -176,7 +176,7 @@ private:
 	Ref<Theme> theme;
 	StringName theme_type_variation;
 
-	bool bulk_theme_override = false;
+	int bulk_theme_override = 0;
 	Theme::ThemeIconMap theme_icon_override;
 	Theme::ThemeStyleMap theme_style_override;
 	Theme::ThemeFontMap theme_font_override;


### PR DESCRIPTION
TL;DR: The value being a boolean caused issues with editor plugins that modified active themes. Even when the user calls `begin_bulk_theme_override()` themselves, engine would internally call `begin_bulk_theme_override()` and `end_bulk_theme_override()`, essentially overwriting the previous override call.

[Related proposal](https://github.com/godotengine/godot-proposals/issues/9672)

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/9672