### PR TITLE
CSharpScript should not own method infos of the base class

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1596,14 +1596,7 @@ void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
 		return;
 	}
 
-	const CSharpScript *top = script.ptr();
-	while (top != nullptr) {
-		for (const CSharpScript::CSharpMethodInfo &E : top->methods) {
-			p_list->push_back(E.method_info);
-		}
-
-		top = top->base_script.ptr();
-	}
+	script->get_script_method_list(p_list);
 }
 
 bool CSharpInstance::has_method(const StringName &p_method) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1764,16 +1764,19 @@ void CSharpInstance::mono_object_disposed_baseref(GCHandleIntPtr p_gchandle_to_f
 }
 
 void CSharpInstance::connect_event_signals() {
-	// The script signals list includes the signals declared in base scripts.
-	for (CSharpScript::EventSignalInfo &signal : script->get_script_event_signals()) {
-		String signal_name = signal.name;
+	const CSharpScript *top = script.ptr();
+	while (top != nullptr && top->valid) {
+		for (const CSharpScript::EventSignalInfo &signal : top->event_signals) {
+			String signal_name = signal.name;
 
-		// TODO: Use pooling for ManagedCallable instances.
-		EventSignalCallable *event_signal_callable = memnew(EventSignalCallable(owner, signal_name));
+			// TODO: Use pooling for ManagedCallable instances.
+			EventSignalCallable *event_signal_callable = memnew(EventSignalCallable(owner, signal_name));
 
-		Callable callable(event_signal_callable);
-		connected_event_signals.push_back(callable);
-		owner->connect(signal_name, callable);
+			Callable callable(event_signal_callable);
+			connected_event_signals.push_back(callable);
+			owner->connect(signal_name, callable);
+		}
+		top = top->base_script.ptr();
 	}
 }
 
@@ -2617,25 +2620,33 @@ bool CSharpScript::has_script_signal(const StringName &p_signal) const {
 		}
 	}
 
+	if (base_script.is_valid()) {
+		return base_script->has_script_signal(p_signal);
+	}
+
 	return false;
 }
 
-void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
+void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const {
 	if (!valid) {
 		return;
 	}
 
-	for (const EventSignalInfo &signal : get_script_event_signals()) {
+	for (const EventSignalInfo &signal : event_signals) {
 		r_signals->push_back(signal.method_info);
+	}
+
+	if (!p_include_base) {
+		return;
+	}
+
+	if (base_script.is_valid()) {
+		base_script->get_script_signal_list(r_signals);
 	}
 }
 
-Vector<CSharpScript::EventSignalInfo> CSharpScript::get_script_event_signals() const {
-	if (!valid) {
-		return Vector<EventSignalInfo>();
-	}
-
-	return event_signals;
+void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
+	_get_script_signal_list(r_signals, true);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -215,6 +215,8 @@ private:
 	// Do not use unless you know what you are doing
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
+	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
+
 protected:
 	static void _bind_methods();
 
@@ -250,8 +252,6 @@ public:
 
 	bool has_script_signal(const StringName &p_signal) const override;
 	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
-
-	Vector<EventSignalInfo> get_script_event_signals() const;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 	void get_script_property_list(List<PropertyInfo> *r_list) const override;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -798,15 +798,15 @@ namespace Godot.Bridge
 
                 GetScriptTypeInfo(scriptType, outTypeInfo);
 
+                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
+
                 // Methods
 
                 // Performance is not critical here as this will be replaced with source generators.
                 using var methods = new Collections.Array();
 
                 Type? top = scriptType;
-                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
-
-                if (scriptType != null && scriptType != native)
+                if (scriptType != native)
                 {
                     var methodList = GetMethodListForType(scriptType);
 
@@ -910,11 +910,9 @@ namespace Godot.Bridge
                 // Performance is not critical here as this will be replaced with source generators.
                 using var signals = new Collections.Dictionary();
 
-                top = scriptType;
-
-                while (top != null && top != native)
+                if (scriptType != native)
                 {
-                    var signalList = GetSignalListForType(top);
+                    var signalList = GetSignalListForType(scriptType);
 
                     if (signalList != null)
                     {
@@ -949,8 +947,6 @@ namespace Godot.Bridge
                             signals.Add(signalName, signalParams);
                         }
                     }
-
-                    top = top.BaseType;
                 }
 
                 *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new_copy(

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -804,11 +804,11 @@ namespace Godot.Bridge
                 using var methods = new Collections.Array();
 
                 Type? top = scriptType;
-                Type native = GodotObject.InternalGetClassNativeBase(top);
+                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
 
-                while (top != null && top != native)
+                if (scriptType != null && scriptType != native)
                 {
-                    var methodList = GetMethodListForType(top);
+                    var methodList = GetMethodListForType(scriptType);
 
                     if (methodList != null)
                     {
@@ -859,8 +859,6 @@ namespace Godot.Bridge
                             methods.Add(methodInfo);
                         }
                     }
-
-                    top = top.BaseType;
                 }
 
                 *outMethodsDest = NativeFuncs.godotsharp_array_new_copy(


### PR DESCRIPTION
- Supersedes #77273

This is simply a rebased and squashed version of the original PR. We took way too long to review this, and the original author has not been answering the last ping. But this is still a needed, and appreciated, fix.