### PR TITLE
Update `area_create` description in `PhysicsServer2D/3D` to clear up possible confusions

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -52,7 +52,8 @@
 		<method name="area_create">
 			<return type="RID" />
 			<description>
-				Creates a 2D area object in the physics server, and returns the [RID] that identifies it. Use [method area_add_shape] to add shapes to it, use [method area_set_transform] to set its transform, and use [method area_set_space] to add the area to a space.
+				Creates a 2D area object in the physics server, and returns the [RID] that identifies it. The default settings for the created area include a collision layer and mask set to [code]1[/code], and [code]monitorable[/code] set to [code]false[/code].
+				Use [method area_add_shape] to add shapes to it, use [method area_set_transform] to set its transform, and use [method area_set_space] to add the area to a space. If you want the area to be detectable use [method area_set_monitorable].
 			</description>
 		</method>
 		<method name="area_get_canvas_instance_id" qualifiers="const">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -44,7 +44,8 @@
 		<method name="area_create">
 			<return type="RID" />
 			<description>
-				Creates an [Area3D].
+				Creates a 3D area object in the physics server, and returns the [RID] that identifies it. The default settings for the created area include a collision layer and mask set to [code]1[/code], and [code]monitorable[/code] set to [code]false[/code].
+				Use [method area_add_shape] to add shapes to it, use [method area_set_transform] to set its transform, and use [method area_set_space] to add the area to a space. If you want the area to be detectable use [method area_set_monitorable].
 			</description>
 		</method>
 		<method name="area_get_collision_layer" qualifiers="const">


### PR DESCRIPTION
I'm a newbie who never worked with game engine before so apologies in advance if this is incorrect.

I spent way too long trying to figure out why collisions with areas created from Area2D nodes were working but not between areas created using PhysicsServer2D.area_create().

From my testing it looks like by default the `monitorable` property is set to false, which can be confusing since there is no easy way to check it (no `area_get_monitorable()` method for example). Especially since areas created with Area2D nodes have this enabled by default.

To reduce chances other people will be confused like me I updated the description of the method to explicitly state that. 

I didn't mention `monitoring` property since areas are always monitoring, and disabling it in Area2D node just means setting empty callback. If you think there may be value in adding this as well, feel free to suggest changes.
