### PR TITLE
Remove old path remaps system

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -159,7 +159,6 @@ private:
 	static bool abort_on_missing_resource;
 	static bool create_missing_resources_if_class_unavailable;
 	static HashMap<String, Vector<String>> translation_remaps;
-	static HashMap<String, String> path_remaps;
 
 	static String _path_remap(const String &p_path, bool *r_translation_remapped = nullptr);
 	friend class Resource;
@@ -288,9 +287,6 @@ public:
 
 	static String path_remap(const String &p_path);
 	static String import_remap(const String &p_path);
-
-	static void load_path_remaps();
-	static void clear_path_remaps();
 
 	static void reload_translation_remaps();
 	static void load_translation_remaps();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7142,7 +7142,6 @@ EditorNode::EditorNode() {
 
 	SceneState::set_disable_placeholders(true);
 	ResourceLoader::clear_translation_remaps(); // Using no remaps if in editor.
-	ResourceLoader::clear_path_remaps();
 	ResourceLoader::set_create_missing_resources_if_class_unavailable(true);
 
 	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1542,28 +1542,22 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		custom_list.append_array(export_plugins[i]->_get_export_features(Ref<EditorExportPlatform>(this), p_debug));
 	}
 
-	ProjectSettings::CustomMap custom_map = get_custom_project_settings(p_preset);
 	if (path_remaps.size()) {
-		if (true) { //new remap mode, use always as it's friendlier with multiple .pck exports
-			for (int i = 0; i < path_remaps.size(); i += 2) {
-				const String &from = path_remaps[i];
-				const String &to = path_remaps[i + 1];
-				String remap_file = "[remap]\n\npath=\"" + to.c_escape() + "\"\n";
-				CharString utf8 = remap_file.utf8();
-				Vector<uint8_t> new_file;
-				new_file.resize(utf8.length());
-				for (int j = 0; j < utf8.length(); j++) {
-					new_file.write[j] = utf8[j];
-				}
-
-				err = save_proxy.save_file(p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed);
-				if (err != OK) {
-					return err;
-				}
+		for (int i = 0; i < path_remaps.size(); i += 2) {
+			const String &from = path_remaps[i];
+			const String &to = path_remaps[i + 1];
+			String remap_file = "[remap]\n\npath=\"" + to.c_escape() + "\"\n";
+			CharString utf8 = remap_file.utf8();
+			Vector<uint8_t> new_file;
+			new_file.resize(utf8.length());
+			for (int j = 0; j < utf8.length(); j++) {
+				new_file.write[j] = utf8[j];
 			}
-		} else {
-			//old remap mode, will still work, but it's unused because it's not multiple pck export friendly
-			custom_map["path_remap/remapped_paths"] = path_remaps;
+
+			err = save_proxy.save_file(p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+			if (err != OK) {
+				return err;
+			}
 		}
 	}
 
@@ -1595,6 +1589,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 	String config_file = "project.binary";
 	String engine_cfb = EditorPaths::get_singleton()->get_temp_dir().path_join("tmp" + config_file);
+	ProjectSettings::CustomMap custom_map = get_custom_project_settings(p_preset);
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -759,8 +759,6 @@ Error Main::test_setup() {
 	translation_server->load_translations();
 	ResourceLoader::load_translation_remaps(); //load remaps for resources
 
-	ResourceLoader::load_path_remaps();
-
 	// Initialize ThemeDB early so that scene types can register their theme items.
 	// Default theme will be initialized later, after modules and ScriptServer are ready.
 	initialize_theme_db();
@@ -3475,8 +3473,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 		translation_server->load_translations();
 		ResourceLoader::load_translation_remaps(); //load remaps for resources
 
-		ResourceLoader::load_path_remaps();
-
 		OS::get_singleton()->benchmark_end_measure("Startup", "Translations and Remaps");
 	}
 
@@ -4915,7 +4911,6 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->_local_clipboard = "";
 
 	ResourceLoader::clear_translation_remaps();
-	ResourceLoader::clear_path_remaps();
 
 	WorkerThreadPool::get_singleton()->exit_languages_threads();
 


### PR DESCRIPTION
Removes the legacy path remap system.

- Is unused in [open source repositories](https://sourcegraph.com/search?q=context:global+file:project%5C.godot+path_remap+or+remapped_paths&patternType=keyword&sm=0)
- Deprecated for over 6 years
- The replacement system is well-tested by now
- reduz wrote in a [comment](https://github.com/godotengine/godot/commit/b3a1bf324566af58ceedc918c83396cba97aeedb#diff-b1c2231c6358092d95bb8555e82b0bfe34e9f576b1ad5844919b007e2dcb2e08) that the old system should be removed in the future

**Reviewers:** In "Files changed", click the ⚙️ button and hide whitespace changes for a better diff view.