### PR TITLE
Update `ConnectDialog::_filter_method_list` to be case insensitive for search string

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -282,7 +282,7 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 	List<MethodInfo> ret;
 
 	for (const MethodInfo &mi : p_methods) {
-		if (!p_search_string.is_empty() && !mi.name.contains(p_search_string)) {
+		if (!p_search_string.is_empty() && mi.name.findn(p_search_string) == -1) {
 			continue;
 		}
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/9679

This should make it more inline with other search boxes in the editor. Unsure if there is an existing paradigm, or just .to_lower() as I did here