### PR TITLE
Add docs note about remap returning undefined when istart == istop

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1097,6 +1097,7 @@
 				remap(75, 0, 100, -1, 1) # Returns 0.5
 				[/codeblock]
 				For complex use cases where multiple ranges are needed, consider using [Curve] or [Gradient] instead.
+				[b]Note:[/b] If [code]istart == istop[/code], the return value is undefined (most likely NaN, INF, or -INF).
 			</description>
 		</method>
 		<method name="rid_allocate_id">

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -381,6 +381,9 @@ TEST_CASE_TEMPLATE("[Math] remap", T, float, double) {
 	CHECK(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)0.0));
 	CHECK(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1000.0));
 	CHECK(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1500.0));
+
+	// Note: undefined behaviour can happen when `p_istart == p_istop`. We don't bother testing this as it will
+	// vary between hardware and compilers properly implementing IEEE 754.
 }
 
 TEST_CASE_TEMPLATE("[Math] angle_difference", T, float, double) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/9680

It does not implement my initial proposal, and instead updates the documentation as suggested in the comments https://github.com/godotengine/godot-proposals/issues/9680#issuecomment-2095229515

~I haven't tested any other cases that could lead to NaN, might be worth just mentioning it can return NaN and to use is_nan, open to feedback here~ It was updated to be a bit more generic based on findings in the comments of this PR