### PR TITLE
Limit icon size in `EditorDebuggerTree`.

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -314,12 +314,18 @@ void EditorDebuggerNode::stop(bool p_force) {
 void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (tabs->get_tab_count() > 1 && EditorThemeManager::is_generated_theme_outdated()) {
+			if (!EditorThemeManager::is_generated_theme_outdated()) {
+				return;
+			}
+
+			if (tabs->get_tab_count() > 1) {
 				add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("BottomPanelDebuggerOverride"), EditorStringName(EditorStyles))->get_margin(SIDE_LEFT));
 				add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("BottomPanelDebuggerOverride"), EditorStringName(EditorStyles))->get_margin(SIDE_RIGHT));
 
 				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("DebuggerPanel"), EditorStringName(EditorStyles)));
 			}
+
+			remote_scene_tree->update_icon_max_width();
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -31,6 +31,7 @@
 #include "editor_debugger_tree.h"
 
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/scene_tree_dock.h"
 #include "scene/debugger/scene_debugger.h"
@@ -61,6 +62,10 @@ void EditorDebuggerTree::_notification(int p_what) {
 			connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
 			connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
 			connect("item_mouse_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			update_icon_max_width();
 		} break;
 	}
 }
@@ -291,6 +296,10 @@ Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
 	}
 
 	return vformat("\"%s\"", path);
+}
+
+void EditorDebuggerTree::update_icon_max_width() {
+	add_theme_constant_override("icon_max_width", get_theme_constant("class_icon_size", EditorStringName(Editor)));
 }
 
 String EditorDebuggerTree::get_selected_path() {

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -72,6 +72,7 @@ public:
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 
+	void update_icon_max_width();
 	String get_selected_path();
 	ObjectID get_selected_object();
 	int get_current_debugger(); // Would love to have one tree for every debugger.


### PR DESCRIPTION
Limit custom classes icon size in `EditorDebuggerTree`.

Before:
"Remote" Tab:
![QQ图片20240506223825](https://github.com/godotengine/godot/assets/61624558/77a01a52-65b8-43a4-bcf7-4337faf87402)
But the scene tree editor can display it correctly.
![QQ图片20240506232416](https://github.com/godotengine/godot/assets/61624558/d123f2a7-9bf4-4deb-b524-620e02cbe060)

After:
![QQ图片20240506232541](https://github.com/godotengine/godot/assets/61624558/ae808b25-5034-45e7-b55f-7cbb74048261)


* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/92309*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
