### PR TITLE
Remove polyline offset duplicates

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -308,7 +308,12 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 
 		Vector<Vector2> polypath2;
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
-			polypath2.push_back(Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
+			// Remove duplicate sequentual points from the polygon.
+			real_t x{static_cast<real_t>(path[j].x)};
+			real_t y{static_cast<real_t>(path[j].y)};
+			if(j == 0 || polypath2[polypath2.size()-1].x != x || polypath2[polypath2.size()-1].y != y) {
+				polypath2.push_back(Point2(x,y));
+			}
 		}
 		polypaths.push_back(polypath2);
 	}

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -309,10 +309,10 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 		Vector<Vector2> polypath2;
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
 			// Remove duplicate sequentual points from the polygon.
-			real_t x{static_cast<real_t>(path[j].x)};
-			real_t y{static_cast<real_t>(path[j].y)};
-			if(j == 0 || polypath2[polypath2.size()-1].x != x || polypath2[polypath2.size()-1].y != y) {
-				polypath2.push_back(Point2(x,y));
+			real_t x = static_cast<real_t>(path[j].x);
+			real_t y = static_cast<real_t>(path[j].y);
+			if (j == 0 || polypath2[polypath2.size() - 1].x != x || polypath2[polypath2.size() - 1].y != y) {
+				polypath2.push_back(Point2(x, y));
 			}
 		}
 		polypaths.push_back(polypath2);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #91607 by removing duplicates generated by InflatePaths so that it doesn't cause decompose_polygon_in_convex to fail.