### PR TITLE
Fix `Range` step rounding

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -107,7 +107,7 @@ void Range::_set_value_no_signal(double p_val) {
 	}
 
 	if (shared->step > 0) {
-		 p_val = Math::round(p_val / shared->step) * shared->step;
+		p_val = Math::round(p_val / shared->step) * shared->step;
 	}
 
 	if (_rounded_values) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -98,20 +98,20 @@ void Range::_set_value_no_signal(double p_val) {
 		return;
 	}
 
-	if (shared->step > 0) {
-		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
-	}
-
-	if (_rounded_values) {
-		p_val = Math::round(p_val);
-	}
-
 	if (!shared->allow_greater && p_val > shared->max - shared->page) {
 		p_val = shared->max - shared->page;
 	}
 
 	if (!shared->allow_lesser && p_val < shared->min) {
 		p_val = shared->min;
+	}
+
+	if (shared->step > 0) {
+		 p_val = Math::round(p_val / shared->step) * shared->step;
+	}
+
+	if (_rounded_values) {
+		p_val = Math::round(p_val);
 	}
 
 	if (shared->val == p_val) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- Range's value was previously being _rounded to `min_value` plus a multiple of `step`_, which is unintuitive and does not reflect the [`step` documentation](https://docs.godotengine.org/en/stable/classes/class_range.html#class-range-property-step). This change fixes this - `value` is now rounded to a multiple of `step`.
    - Additionally I encountered some issues where when `value = 1` and you set `min_value = 0.001`, the (SpinBox) value would change to 1.001, which is now fixed too.
- I moved the `min_value` and `max_value` enforcement _before_ the `step` rounding. This way the Range should never be in a state where the _value_ is not a multiple of _step_. I think this is the right behavior.

Fixes #91482 . Also check this issue for my debugging notes and more context. There are some videos and example project pinned there.