### PR TITLE
Let materials' shaders update happen on loader threads

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -224,64 +224,7 @@ void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args
 	}
 }
 
-Error CallQueue::_transfer_messages_to_main_queue() {
-	if (pages.size() == 0) {
-		return OK;
-	}
-
-	CallQueue *mq = MessageQueue::main_singleton;
-	DEV_ASSERT(!mq->allocator_is_custom && !allocator_is_custom); // Transferring pages is only safe if using the same alloator parameters.
-
-	mq->mutex.lock();
-
-	// Here we're transferring the data from this queue to the main one.
-	// However, it's very unlikely big amounts of messages will be queued here,
-	// so PagedArray/Pool would be overkill. Also, in most cases the data will fit
-	// an already existing page of the main queue.
-
-	// Let's see if our first (likely only) page fits the current target queue page.
-	uint32_t src_page = 0;
-	{
-		if (mq->pages_used) {
-			uint32_t dst_page = mq->pages_used - 1;
-			uint32_t dst_offset = mq->page_bytes[dst_page];
-			if (dst_offset + page_bytes[0] < uint32_t(PAGE_SIZE_BYTES)) {
-				memcpy(mq->pages[dst_page]->data + dst_offset, pages[0]->data, page_bytes[0]);
-				mq->page_bytes[dst_page] += page_bytes[0];
-				src_page++;
-			}
-		}
-	}
-
-	// Any other possibly existing source page needs to be added.
-
-	if (mq->pages_used + (pages_used - src_page) > mq->max_pages) {
-		fprintf(stderr, "Failed appending thread queue. Message queue out of memory. %s\n", mq->error_text.utf8().get_data());
-		mq->statistics();
-		mq->mutex.unlock();
-		return ERR_OUT_OF_MEMORY;
-	}
-
-	for (; src_page < pages_used; src_page++) {
-		mq->_add_page();
-		memcpy(mq->pages[mq->pages_used - 1]->data, pages[src_page]->data, page_bytes[src_page]);
-		mq->page_bytes[mq->pages_used - 1] = page_bytes[src_page];
-	}
-
-	mq->mutex.unlock();
-
-	page_bytes[0] = 0;
-	pages_used = 1;
-
-	return OK;
-}
-
 Error CallQueue::flush() {
-	// Thread overrides are not meant to be flushed, but appended to the main one.
-	if (unlikely(this == MessageQueue::thread_singleton)) {
-		return _transfer_messages_to_main_queue();
-	}
-
 	LOCK_MUTEX;
 
 	if (pages.size() == 0) {

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -98,8 +98,6 @@ private:
 		}
 	}
 
-	Error _transfer_messages_to_main_queue();
-
 	void _add_page();
 
 	void _call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error);

--- a/scene/resources/canvas_item_material.h
+++ b/scene/resources/canvas_item_material.h
@@ -98,12 +98,11 @@ private:
 	}
 
 	static Mutex material_mutex;
-	static SelfList<CanvasItemMaterial>::List *dirty_materials;
+	static SelfList<CanvasItemMaterial>::List dirty_materials;
 	SelfList<CanvasItemMaterial> element;
 
 	void _update_shader();
 	_FORCE_INLINE_ void _queue_shader_change();
-	_FORCE_INLINE_ bool _is_shader_dirty() const;
 
 	BlendMode blend_mode = BLEND_MODE_MIX;
 	LightMode light_mode = LIGHT_MODE_NORMAL;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -62,7 +62,8 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
-	void _mark_initialized(const Callable &p_queue_shader_change_callable);
+	void _mark_ready();
+	void _mark_initialized(const Callable &p_add_to_dirty_list, const Callable &p_update_shader);
 	bool _is_initialized() { return init_state == INIT_STATE_READY; }
 
 	GDVIRTUAL0RC(RID, _get_shader_rid)
@@ -466,7 +467,6 @@ private:
 
 	void _update_shader();
 	_FORCE_INLINE_ void _queue_shader_change();
-	_FORCE_INLINE_ bool _is_shader_dirty() const;
 
 	bool orm;
 

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -186,7 +186,7 @@ private:
 	}
 
 	static Mutex material_mutex;
-	static SelfList<ParticleProcessMaterial>::List *dirty_materials;
+	static SelfList<ParticleProcessMaterial>::List dirty_materials;
 
 	struct ShaderNames {
 		StringName direction;
@@ -293,7 +293,6 @@ private:
 
 	void _update_shader();
 	_FORCE_INLINE_ void _queue_shader_change();
-	_FORCE_INLINE_ bool _is_shader_dirty() const;
 
 	Vector3 direction;
 	float spread = 0.0f;


### PR DESCRIPTION
Most important material types feature a dirty list that is processed every frame so those materials generate their internal shader. In the case of `ShaderMaterial`, its `_shader_changed()` function is also invoked (if running the editor). During threaded loading, there are some mechanics in place so such those operations don't happen until the load is known to have finished. They eventually happen on the main thread.

The problem in #90565 has to do with that. The resource previewer runs on a thread, from where it loads a material whose preview it wants to generate. Unfortunately, by the time the main thread would have had the chance to run the internal update, the shader is already gone (no error is printed about this). Also, the deferred call to `_shader_changed()` is attempted there on the already freed shader, which causes the error message.

A possible solution would have been to add some API so the resource previewer can somehow force the flush of the loader thread call queue right there instad of being transferred to the main one. However, after some analysis, I think we can just make those update operations happen on the loader thread organically (with added benefits). My only concern is that there might be some resource types that have a similar mechanism of deferred update in a way that they don't support such a thing happening on the loader thread. I can't think of any, but it's important to bear that in mind. If this is considered too risky for 4.3, I may provide a compromise fix for it and reschedule this PR for 4.4.

Finally, as a bonus, a little cleanup is made in terms of init-term, to make it more consistent across material types.

- Fixes #90565.
- Fixes https://github.com/godotengine/godot/issues/58818.
- Fixes https://github.com/godotengine/godot/issues/69861.
- Fixes https://github.com/godotengine/godot/issues/70974.