### PR TITLE
[Memory] Add `calloc_static` method

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -130,8 +130,7 @@ void FileAccessEncrypted::_close() {
 		unsigned char hash[16];
 		ERR_FAIL_COND(CryptoCore::md5(data.ptr(), data.size(), hash) != OK); // Bug?
 
-		compressed.resize(len);
-		memset(compressed.ptrw(), 0, len);
+		compressed.resize_zeroed(len);
 		for (int i = 0; i < data.size(); i++) {
 			compressed.write[i] = data[i];
 		}

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -162,8 +162,7 @@ int zipio_testerror(voidpf opaque, voidpf stream) {
 }
 
 voidpf zipio_alloc(voidpf opaque, uInt items, uInt size) {
-	voidpf ptr = memalloc((size_t)items * size);
-	memset(ptr, 0, items * size);
+	voidpf ptr = Memory::calloc_static(items * size);
 	return ptr;
 }
 

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -317,8 +317,7 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 
 Vector<Vector3i> Geometry2D::partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size) {
 	Vector<stbrp_node> nodes;
-	nodes.resize(p_atlas_size.width);
-	memset(nodes.ptrw(), 0, sizeof(stbrp_node) * nodes.size());
+	nodes.resize_zeroed(p_atlas_size.width);
 
 	stbrp_context context;
 	stbrp_init_target(&context, p_atlas_size.width, p_atlas_size.height, nodes.ptrw(), p_atlas_size.width);

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -169,13 +169,8 @@ private:
 		uint32_t *old_hashes = hashes;
 
 		num_elements = 0;
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		hashes = reinterpret_cast<uint32_t *>(Memory::calloc_static(sizeof(uint32_t) * capacity));
 		elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * capacity));
-
-		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = 0;
-			elements[i] = nullptr;
-		}
 
 		if (old_capacity == 0) {
 			// Nothing to do.

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -148,14 +148,10 @@ private:
 		uint32_t *old_hashes = hashes;
 		uint32_t *old_key_to_hash = key_to_hash;
 
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		hashes = reinterpret_cast<uint32_t *>(Memory::calloc_static(sizeof(uint32_t) * capacity));
 		keys = reinterpret_cast<TKey *>(Memory::realloc_static(keys, sizeof(TKey) * capacity));
 		key_to_hash = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
 		hash_to_key = reinterpret_cast<uint32_t *>(Memory::realloc_static(hash_to_key, sizeof(uint32_t) * capacity));
-
-		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = EMPTY_HASH;
-		}
 
 		for (uint32_t i = 0; i < num_elements; i++) {
 			uint32_t h = old_hashes[old_key_to_hash[i]];
@@ -171,14 +167,10 @@ private:
 		if (unlikely(keys == nullptr)) {
 			// Allocate on demand to save memory.
 
-			hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+			hashes = reinterpret_cast<uint32_t *>(Memory::calloc_static(sizeof(uint32_t) * capacity));
 			keys = reinterpret_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
 			key_to_hash = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
 			hash_to_key = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-
-			for (uint32_t i = 0; i < capacity; i++) {
-				hashes[i] = EMPTY_HASH;
-			}
 		}
 
 		uint32_t pos = 0;

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -309,6 +309,22 @@ public:
 		return ret;
 	}
 
+	void init_with_zeros(U p_size) {
+		if (data) {
+			reset();
+		}
+
+		if (p_size == 0) {
+			return;
+		}
+
+		capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
+		data = (T *)Memory::calloc_static(capacity * sizeof(T));
+		CRASH_COND_MSG(!data, "Out of memory");
+
+		count = p_size;
+	}
+
 	_FORCE_INLINE_ LocalVector() {}
 	_FORCE_INLINE_ LocalVector(std::initializer_list<T> p_init) {
 		reserve(p_init.size());

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -154,11 +154,7 @@ private:
 		num_elements = 0;
 		keys = static_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
 		values = static_cast<TValue *>(Memory::alloc_static(sizeof(TValue) * capacity));
-		hashes = static_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-
-		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = 0;
-		}
+		hashes = static_cast<uint32_t *>(Memory::calloc_static(sizeof(uint32_t) * capacity));
 
 		if (old_capacity == 0) {
 			// Nothing to do.


### PR DESCRIPTION
Adds new method `calloc_static` to class `Memory`

The logic of 
```c++
ptr = (int *)Memory::calloc_static(size * sizeof(int));
```
is the same as
```c++
ptr = (int *)Memory::alloc_static(size * sizeof(int));
memset(ptr_zero, 0, size * sizeof(int));
```
But then why this is necessary?
The point is that `calloc` is much more optimized for this.

Read more here https://stackoverflow.com/questions/2688466/why-mallocmemset-is-slower-than-calloc
