### PR TITLE
Fix animation loop import hints becoming lost

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -324,6 +324,12 @@ void SceneImportSettingsDialog::_fill_animation(Tree *p_tree, const Ref<Animatio
 		ad.animation = p_anim;
 
 		_load_default_subresource_settings(ad.settings, "animations", p_name, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION);
+		if (!ad.settings.has("settings/loop_mode")) {
+			// Update the loop mode to match detected mode (from import hints).
+			// This is necessary on the first import of a scene, otherwise the
+			// default (0/NONE) is set when filling out defaults.
+			ad.settings["settings/loop_mode"] = p_anim->get_loop_mode();
+		}
 
 		animation_map[p_name] = ad;
 	}


### PR DESCRIPTION
The scene importer settings dialog was not respecting the inferred loop mode of animation clips. As long as the scene is never reimported via the advanced settings dialog, the import settings for clips would be correct. Opening the advanced importer loads all animation settings with their default values, and confirming serializes those values. **Even making zero changes** will result in the animation clips reverting to all default values losing any import hints.

This change sets expected loop mode based on the clip information when creating `AnimationData` for a clip.

I confirmed this works as expected now by:
1. making sure the advanced importer dialog shows Linear mode on first import, 
2. stays Linear on subsequent imports
3. respects resetting clips to None despite the `-loop` import hint if set manually
4. saves clips as looped when setting animation save paths (unrelated to the bug, but just to confirm it really does fix  #75912)

Fixes #75912
