### PR TITLE
miniupnpc: Disable socket timeout on Windows, matching upstream

### DIFF
--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -30,7 +30,8 @@ if env["builtin_miniupnpc"]:
 
     env_upnp.Prepend(CPPPATH=[thirdparty_dir + "include"])
     env_upnp.Append(CPPDEFINES=["MINIUPNP_STATICLIB"])
-    env_upnp.Append(CPPDEFINES=["MINIUPNPC_SET_SOCKET_TIMEOUT"])
+    if env["platform"] != "windows":
+        env_upnp.Append(CPPDEFINES=["MINIUPNPC_SET_SOCKET_TIMEOUT"])
 
     env_thirdparty = env_upnp.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
- Fixes #88471.
- Alternative to #88487.

This matches what upstream does in their CMake config:

https://github.com/miniupnp/miniupnp/blob/cb2026239c2a3aff393952ccb0ee1c448189402d/miniupnpc/CMakeLists.txt#L31-L35