### PR TITLE
Reduce precision to eliminate duplicate points from InflatePaths

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -298,9 +298,13 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	}
 
 	// Inflate/deflate.
-	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, PRECISION, 0.0);
+	const int precision = 2;
+	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, precision, 0.0);
 	// Here the miter_limit = 2.0 and arc_tolerance = 0.0 are Clipper2 defaults,
 	// and the PRECISION is used to scale points up internally, to attain the desired precision.
+	// precision is less than the module default because:
+	// (a) clipper2's default is 2 and
+	// (b) a precision of 5 causes duplicated points in the inflated path.
 
 	Vector<Vector<Point2>> polypaths;
 	for (PathsD::size_type i = 0; i < paths.size(); ++i) {

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -301,8 +301,7 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	const int precision = 2;
 	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, precision, 0.0);
 	// Here the miter_limit = 2.0 and arc_tolerance = 0.0 are Clipper2 defaults,
-	// and the PRECISION is used to scale points up internally, to attain the desired precision.
-	// precision is less than the module default because:
+	// precision is less than the module default (PRECISION) because:
 	// (a) clipper2's default is 2 and
 	// (b) a precision of 5 causes duplicated points in the inflated path.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes https://github.com/godotengine/godot/issues/91607 by locally reducing the precision of InflatePaths to the Clipper2 default. This prevents duplicate points from being generated and thus it doesn't cause decompose_polygon_in_convex to fail.
This also replaces [pull request 91627](https://github.com/godotengine/godot/pull/91627)