### PR TITLE
Make native shader source visualizer highlight uint suffix

### DIFF
--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -66,6 +66,8 @@ void EditorNativeShaderSourceVisualizer::_load_theme_settings() {
 	// Colorize preprocessor statements.
 	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
 	syntax_highlighter->add_color_region("#", "", user_type_color, true);
+
+	syntax_highlighter->set_uint_suffix_enabled(true);
 }
 
 void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -335,7 +335,7 @@ void ShaderTextEditor::_load_theme_settings() {
 		warnings_panel->add_theme_font_size_override("normal_font_size", EditorNode::get_singleton()->get_editor_theme()->get_font_size(SNAME("main_size"), EditorStringName(EditorFonts)));
 	}
 
-	syntax_highlighter->set_uint_suffix_enabled();
+	syntax_highlighter->set_uint_suffix_enabled(true);
 }
 
 void ShaderTextEditor::_check_shader_mode() {

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -142,7 +142,7 @@ public:
 	void set_member_variable_color(Color p_color);
 	Color get_member_variable_color() const;
 
-	void set_uint_suffix_enabled(bool p_enabled = true);
+	void set_uint_suffix_enabled(bool p_enabled);
 };
 
 #endif // SYNTAX_HIGHLIGHTER_H


### PR DESCRIPTION
As mentioned in https://github.com/godotengine/godot/pull/89690#discussion_r1590502146

Also as suggested in https://github.com/godotengine/godot/pull/85014#discussion_r1591608491, I remove the setter's default parameter.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
