### PR TITLE
[Core] Add convenience access to front/back element of `List`

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -238,7 +238,7 @@ void RemoteDebugger::flush_output() {
 	}
 
 	while (errors.size()) {
-		ErrorMessage oe = errors.front()->get();
+		ErrorMessage oe = errors.get_front();
 		_put_msg("error", oe.serialize());
 		errors.pop_front();
 	}
@@ -383,8 +383,8 @@ Array RemoteDebugger::_get_message() {
 
 	Array msg;
 	msg.resize(2);
-	msg[0] = message_list.front()->get().message;
-	msg[1] = message_list.front()->get().data;
+	msg[0] = message_list.get_front().message;
+	msg[1] = message_list.get_front().data;
 	message_list.pop_front();
 	return msg;
 }

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -45,7 +45,7 @@ bool RemoteDebuggerPeerTCP::has_message() {
 Array RemoteDebuggerPeerTCP::get_message() {
 	MutexLock lock(mutex);
 	ERR_FAIL_COND_V(!has_message(), Array());
-	Array out = in_queue.front()->get();
+	Array out = in_queue.get_front();
 	in_queue.pop_front();
 	return out;
 }
@@ -100,7 +100,7 @@ void RemoteDebuggerPeerTCP::_write_out() {
 				break; // Nothing left to send
 			}
 			mutex.lock();
-			Variant var = out_queue.front()->get();
+			Variant var = out_queue.get_front();
 			out_queue.pop_front();
 			mutex.unlock();
 			int size = 0;

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1152,7 +1152,7 @@ void Input::parse_input_event(const Ref<InputEvent> &p_event) {
 #endif
 
 	if (use_accumulated_input) {
-		if (buffered_events.is_empty() || !buffered_events.back()->get()->accumulate(p_event)) {
+		if (buffered_events.is_empty() || !buffered_events.get_back()->accumulate(p_event)) {
 			buffered_events.push_back(p_event);
 		}
 	} else if (agile_input_event_flushing) {

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -513,12 +513,12 @@ Error DirAccessPack::list_dir_begin() {
 String DirAccessPack::get_next() {
 	if (list_dirs.size()) {
 		cdir = true;
-		String d = list_dirs.front()->get();
+		String d = list_dirs.get_front();
 		list_dirs.pop_front();
 		return d;
 	} else if (list_files.size()) {
 		cdir = false;
-		String f = list_files.front()->get();
+		String f = list_files.get_front();
 		list_files.pop_front();
 		return f;
 	} else {

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -704,7 +704,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 				// Add subnode end enter it.
 				Ref<PListNode> dict = PListNode::new_dict();
 				dict->data_type = PList::PLNodeType::PL_NODE_TYPE_DICT;
-				if (!stack.back()->get()->push_subnode(dict, key)) {
+				if (!stack.get_back()->push_subnode(dict, key)) {
 					r_err_out = "Can't push subnode, invalid parent type.";
 					return false;
 				}
@@ -724,7 +724,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 
 		if (token == "/dict") {
 			// Exit current dict.
-			if (stack.is_empty() || stack.back()->get()->data_type != PList::PLNodeType::PL_NODE_TYPE_DICT) {
+			if (stack.is_empty() || stack.get_back()->data_type != PList::PLNodeType::PL_NODE_TYPE_DICT) {
 				r_err_out = "Mismatched </dict> tag.";
 				return false;
 			}
@@ -736,7 +736,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 			if (!stack.is_empty()) {
 				// Add subnode end enter it.
 				Ref<PListNode> arr = PListNode::new_array();
-				if (!stack.back()->get()->push_subnode(arr, key)) {
+				if (!stack.get_back()->push_subnode(arr, key)) {
 					r_err_out = "Can't push subnode, invalid parent type.";
 					return false;
 				}
@@ -756,7 +756,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 
 		if (token == "/array") {
 			// Exit current array.
-			if (stack.is_empty() || stack.back()->get()->data_type != PList::PLNodeType::PL_NODE_TYPE_ARRAY) {
+			if (stack.is_empty() || stack.get_back()->data_type != PList::PLNodeType::PL_NODE_TYPE_ARRAY) {
 				r_err_out = "Mismatched </array> tag.";
 				return false;
 			}
@@ -803,7 +803,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 				r_err_out = vformat("Invalid value type: %s.", token);
 				return false;
 			}
-			if (stack.is_empty() || !stack.back()->get()->push_subnode(var, key)) {
+			if (stack.is_empty() || !stack.get_back()->push_subnode(var, key)) {
 				r_err_out = "Can't push subnode, invalid parent type.";
 				return false;
 			}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1347,7 +1347,7 @@ void ResourceLoader::reload_translation_remaps() {
 
 	//now just make sure to not delete any of these resources while changing locale..
 	while (to_reload.front()) {
-		to_reload.front()->get()->reload_from_file();
+		to_reload.get_front()->reload_from_file();
 		to_reload.pop_front();
 	}
 }

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -161,7 +161,7 @@ Ref<PacketPeerUDP> UDPServer::take_connection() {
 		return conn;
 	}
 
-	Peer peer = pending.front()->get();
+	Peer peer = pending.get_front();
 	pending.pop_front();
 	peers.push_back(peer);
 	return peer.peer;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -214,9 +214,9 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 	uint32_t debug_stop = debug_stop_after;
 
-	while (debug_stop > 0 && faces.back()->get().points_over.size()) {
+	while (debug_stop > 0 && faces.get_back().points_over.size()) {
 		debug_stop--;
-		Face &f = faces.back()->get();
+		Face &f = faces.get_back();
 
 		//find vertex most outside
 		int next = -1;
@@ -315,7 +315,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		//erase lit faces
 
 		while (lit_faces.size()) {
-			faces.erase(lit_faces.front()->get());
+			faces.erase(lit_faces.get_front());
 			lit_faces.pop_front();
 		}
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -444,7 +444,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	}
 
 	for (int i = 1; i < p_names.size() - 1; i++) {
-		value_stack.push_back(value_stack.back()->get().get_named(p_names[i], valid));
+		value_stack.push_back(value_stack.get_back().get_named(p_names[i], valid));
 		if (r_valid) {
 			*r_valid = valid;
 		}
@@ -458,7 +458,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	value_stack.push_back(p_value); // p_names[p_names.size() - 1]
 
 	for (int i = p_names.size() - 1; i > 0; i--) {
-		value_stack.back()->prev()->get().set_named(p_names[i], value_stack.back()->get(), valid);
+		value_stack.back()->prev()->get().set_named(p_names[i], value_stack.get_back(), valid);
 		value_stack.pop_back();
 
 		if (r_valid) {
@@ -470,7 +470,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 		}
 	}
 
-	set(p_names[0], value_stack.back()->get(), r_valid);
+	set(p_names[0], value_stack.get_back(), r_valid);
 	value_stack.pop_back();
 
 	ERR_FAIL_COND(!value_stack.is_empty());
@@ -2222,7 +2222,7 @@ Object::~Object() {
 
 	// Disconnect signals that connect to this object.
 	while (connections.size()) {
-		Connection c = connections.front()->get();
+		Connection c = connections.get_front();
 		Object *obj = c.callable.get_object();
 		bool disconnected = false;
 		if (likely(obj)) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -797,7 +797,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 	}
 
 	while (to_remove.size()) {
-		values.erase(to_remove.front()->get());
+		values.erase(to_remove.get_front());
 		to_remove.pop_front();
 	}
 

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -283,6 +283,26 @@ public:
 		return _data ? _data->last : nullptr;
 	}
 
+	_FORCE_INLINE_ const T &get_front() const {
+		DEV_ASSERT(_data);
+		return _data->first->get();
+	}
+
+	_FORCE_INLINE_ T &get_front() {
+		DEV_ASSERT(_data);
+		return _data->first->get();
+	}
+
+	_FORCE_INLINE_ const T &get_back() const {
+		DEV_ASSERT(_data);
+		return _data->last->get();
+	}
+
+	_FORCE_INLINE_ T &get_back() {
+		DEV_ASSERT(_data);
+		return _data->last->get();
+	}
+
 	/**
 	 * store a new element at the end of the list
 	 */

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -846,7 +846,7 @@ ShaderGLES3::~ShaderGLES3() {
 	if (remaining.size()) {
 		ERR_PRINT(itos(remaining.size()) + " shaders of type " + name + " were never freed");
 		while (remaining.size()) {
-			version_free(remaining.front()->get());
+			version_free(remaining.get_front());
 			remaining.pop_front();
 		}
 	}

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1035,7 +1035,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 		}
 
 		while (to_delete.front()) {
-			used_global_textures.erase(to_delete.front()->get());
+			used_global_textures.erase(to_delete.get_front());
 			to_delete.pop_front();
 		}
 		//handle registering/unregistering global textures

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4234,10 +4234,10 @@ void AnimationTrackEditor::_insert_track(bool p_reset_wanted, bool p_create_bezi
 	TrackIndices next_tracks(animation.ptr(), reset_anim.ptr());
 	bool advance = false;
 	while (insert_data.size()) {
-		if (insert_data.front()->get().advance) {
+		if (insert_data.get_front().advance) {
 			advance = true;
 		}
-		next_tracks = _confirm_insert(insert_data.front()->get(), next_tracks, p_reset_wanted, reset_anim, p_create_beziers);
+		next_tracks = _confirm_insert(insert_data.get_front(), next_tracks, p_reset_wanted, reset_anim, p_create_beziers);
 		insert_data.pop_front();
 	}
 
@@ -4540,10 +4540,10 @@ void AnimationTrackEditor::_confirm_insert_list() {
 	TrackIndices next_tracks(animation.ptr(), reset_anim.ptr());
 	bool advance = false;
 	while (insert_data.size()) {
-		if (insert_data.front()->get().advance) {
+		if (insert_data.get_front().advance) {
 			advance = true;
 		}
-		next_tracks = _confirm_insert(insert_data.front()->get(), next_tracks, create_reset, reset_anim, insert_confirm_bezier->is_pressed());
+		next_tracks = _confirm_insert(insert_data.get_front(), next_tracks, create_reset, reset_anim, insert_confirm_bezier->is_pressed());
 		insert_data.pop_front();
 	}
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -410,7 +410,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 		int frame = get_animation()->track_get_key_value(get_track(), p_index);
 		String animation_name;
 		if (animations.size() == 1) {
-			animation_name = animations.front()->get();
+			animation_name = animations.get_front();
 		} else {
 			// Go through other track to find if animation is set
 			String animation_path = get_animation()->track_get_path(get_track());
@@ -502,7 +502,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		int frame = get_animation()->track_get_key_value(get_track(), p_index);
 		String animation_name;
 		if (animations.size() == 1) {
-			animation_name = animations.front()->get();
+			animation_name = animations.get_front();
 		} else {
 			// Go through other track to find if animation is set
 			String animation_path = get_animation()->track_get_path(get_track());

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -241,7 +241,7 @@ void AudioStreamPreviewGenerator::_notification(int p_what) {
 			}
 
 			while (to_erase.front()) {
-				previews.erase(to_erase.front()->get());
+				previews.erase(to_erase.get_front());
 				to_erase.pop_front();
 			}
 		} break;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -112,7 +112,7 @@ Error DAPeer::handle_data() {
 
 Error DAPeer::send_data() {
 	while (res_queue.size()) {
-		Dictionary data = res_queue.front()->get();
+		Dictionary data = res_queue.get_front();
 		if (!data.has("seq")) {
 			data["seq"] = ++seq;
 		}

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -467,7 +467,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 				file_dialog->add_filter("*." + extension, extension.to_upper());
 			}
 
-			String filename = get_selected_path().get_file() + "." + extensions.front()->get().to_lower();
+			String filename = get_selected_path().get_file() + "." + extensions.get_front().to_lower();
 			file_dialog->set_current_path(filename);
 			file_dialog->popup_file_dialog();
 		} break;

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -205,7 +205,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		TreeItem *parent = nullptr;
 		Pair<TreeItem *, TreeItem *> move_from_to;
 		if (parents.size()) { // Find last parent.
-			ParentItem &p = parents.front()->get();
+			ParentItem &p = parents.get_front();
 			parent = p.tree_item;
 			if (!(--p.child_count)) { // If no child left, remove it.
 				parents.pop_front();

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -222,7 +222,7 @@ void EditorPerformanceProfiler::_build_monitor_tree() {
 		item->set_checked(0, monitor_checked.has(E.key));
 		E.value.item = item;
 		if (!E.value.history.is_empty()) {
-			E.value.update_value(E.value.history.front()->get());
+			E.value.update_value(E.value.history.get_front());
 		}
 	}
 }

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -63,7 +63,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 		}
 
 		if (stack.size()) {
-			full_name = stack.back()->get() + name;
+			full_name = stack.get_back() + name;
 		} else {
 			full_name = name;
 		}
@@ -345,7 +345,7 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 	TreeItem *ensure_selected = nullptr;
 
 	for (int i = 1; i < m.areas.size() - 1; i++) {
-		TreeItem *parent = stack.size() ? stack.back()->get() : root;
+		TreeItem *parent = stack.size() ? stack.get_back() : root;
 
 		String name = m.areas[i].name;
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -427,7 +427,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 		// Populate documentation data for each exposed class.
 		while (classes.size()) {
-			const String &name = classes.front()->get();
+			const String &name = classes.get_front();
 			if (!ClassDB::is_class_exposed(name)) {
 				print_verbose(vformat("Class '%s' is not exposed, skipping.", name));
 				classes.pop_front();
@@ -1275,7 +1275,7 @@ Error DocTools::erase_classes(const String &p_dir) {
 	da->list_dir_end();
 
 	while (to_erase.size()) {
-		da->remove(to_erase.front()->get());
+		da->remove(to_erase.get_front());
 		to_erase.pop_front();
 	}
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -519,7 +519,7 @@ void EditorAutoloadSettings::update_autoload() {
 		autoload_cache.push_back(info);
 
 		if (need_to_add) {
-			to_add.push_back(&(autoload_cache.back()->get()));
+			to_add.push_back(&(autoload_cache.get_back()));
 		}
 
 		TreeItem *item = tree->create_item(root);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2492,7 +2492,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 		const String tag = bbcode.substr(brk_pos + 1, brk_end - brk_pos - 1);
 
 		if (tag.begins_with("/")) {
-			bool tag_ok = tag_stack.size() && tag_stack.front()->get() == tag.substr(1);
+			bool tag_ok = tag_stack.size() && tag_stack.get_front() == tag.substr(1);
 
 			if (!tag_ok) {
 				p_rt->add_text("[");

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3120,12 +3120,12 @@ EditorProperty *EditorInspector::instantiate_property_editor(Object *p_object, c
 				memdelete(E->get().property_editor);
 			}
 
-			EditorProperty *prop = Object::cast_to<EditorProperty>(inspector_plugins[i]->added_editors.front()->get().property_editor);
+			EditorProperty *prop = Object::cast_to<EditorProperty>(inspector_plugins[i]->added_editors.get_front().property_editor);
 			if (prop) {
 				inspector_plugins[i]->added_editors.clear();
 				return prop;
 			} else {
-				memdelete(inspector_plugins[i]->added_editors.front()->get().property_editor);
+				memdelete(inspector_plugins[i]->added_editors.get_front().property_editor);
 				inspector_plugins[i]->added_editors.clear();
 			}
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1561,7 +1561,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		} else {
 			if (!preferred.is_empty()) {
 				String resource_name_snake_case = p_resource->get_class().to_snake_case();
-				file->set_current_file("new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower());
+				file->set_current_file("new_" + resource_name_snake_case + "." + preferred.get_front().to_lower());
 			} else {
 				file->set_current_file(String());
 			}
@@ -1571,12 +1571,12 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		if (!extensions.is_empty()) {
 			const String ext = p_resource->get_path().get_extension().to_lower();
 			if (extensions.find(ext) == nullptr) {
-				file->set_current_path(p_resource->get_path().replacen("." + ext, "." + extensions.front()->get()));
+				file->set_current_path(p_resource->get_path().replacen("." + ext, "." + extensions.get_front()));
 			}
 		}
 	} else if (!preferred.is_empty()) {
 		const String resource_name_snake_case = p_resource->get_class().to_snake_case();
-		const String existing = "new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower();
+		const String existing = "new_" + resource_name_snake_case + "." + preferred.get_front().to_lower();
 		file->set_current_path(existing);
 	}
 	file->set_title(TTR("Save Resource As..."));
@@ -2903,7 +2903,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case FILE_OPEN_PREV: {
 			if (!prev_closed_scenes.is_empty()) {
-				load_scene(prev_closed_scenes.back()->get());
+				load_scene(prev_closed_scenes.get_back());
 			}
 		} break;
 		case EditorSceneTabs::SCENE_CLOSE_OTHERS: {
@@ -3001,13 +3001,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->set_current_path(path);
 				if (extensions.size()) {
 					if (extensions.find(ext) == nullptr) {
-						file->set_current_path(path.replacen("." + ext, "." + extensions.front()->get()));
+						file->set_current_path(path.replacen("." + ext, "." + extensions.get_front()));
 					}
 				}
 			} else if (extensions.size()) {
 				String root_name = scene->get_name();
 				root_name = EditorNode::adjust_scene_name_casing(root_name);
-				file->set_current_path(root_name + "." + extensions.front()->get().to_lower());
+				file->set_current_path(root_name + "." + extensions.get_front().to_lower());
 			}
 			file->set_title(TTR("Save Scene As..."));
 			file->popup_file_dialog();
@@ -5851,7 +5851,7 @@ void EditorNode::_proceed_save_asing_scene_tabs() {
 	if (scenes_to_save_as.is_empty()) {
 		return;
 	}
-	int scene_idx = scenes_to_save_as.front()->get();
+	int scene_idx = scenes_to_save_as.get_front();
 	scenes_to_save_as.pop_front();
 	_set_current_scene(scene_idx);
 	_menu_option_confirm(FILE_MULTI_SAVE_AS_SCENE, false);

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -267,7 +267,7 @@ void EditorResourcePreview::_iterate() {
 		return;
 	}
 
-	QueueItem item = queue.front()->get();
+	QueueItem item = queue.get_front();
 	queue.pop_front();
 
 	if (cache.has(item.path)) {

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -220,7 +220,7 @@ OS::ProcessID EditorRun::get_current_process() const {
 	if (pids.front() == nullptr) {
 		return 0;
 	}
-	return pids.front()->get();
+	return pids.get_front();
 }
 
 EditorRun::WindowPlacement EditorRun::get_window_placement() {

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -304,7 +304,7 @@ bool EditorUndoRedoManager::undo_history(int p_id) {
 	ERR_FAIL_COND_V(p_id == INVALID_HISTORY, false);
 	History &history = get_or_create_history(p_id);
 
-	Action action = history.undo_stack.back()->get();
+	Action action = history.undo_stack.get_back();
 	history.undo_stack.pop_back();
 	history.redo_stack.push_back(action);
 
@@ -328,21 +328,21 @@ bool EditorUndoRedoManager::redo() {
 		History &history = get_or_create_history(GLOBAL_HISTORY);
 		if (!history.redo_stack.is_empty()) {
 			selected_history = history.id;
-			global_timestamp = history.redo_stack.back()->get().timestamp;
+			global_timestamp = history.redo_stack.get_back().timestamp;
 		}
 	}
 
 	{
 		History &history = get_or_create_history(REMOTE_HISTORY);
-		if (!history.redo_stack.is_empty() && history.redo_stack.back()->get().timestamp < global_timestamp) {
+		if (!history.redo_stack.is_empty() && history.redo_stack.get_back().timestamp < global_timestamp) {
 			selected_history = history.id;
-			global_timestamp = history.redo_stack.back()->get().timestamp;
+			global_timestamp = history.redo_stack.get_back().timestamp;
 		}
 	}
 
 	{
 		History &history = get_or_create_history(EditorNode::get_editor_data().get_current_edited_scene_history_id());
-		if (!history.redo_stack.is_empty() && history.redo_stack.back()->get().timestamp < global_timestamp) {
+		if (!history.redo_stack.is_empty() && history.redo_stack.get_back().timestamp < global_timestamp) {
 			selected_history = history.id;
 		}
 	}
@@ -357,7 +357,7 @@ bool EditorUndoRedoManager::redo_history(int p_id) {
 	ERR_FAIL_COND_V(p_id == INVALID_HISTORY, false);
 	History &history = get_or_create_history(p_id);
 
-	Action action = history.redo_stack.back()->get();
+	Action action = history.redo_stack.get_back();
 	history.redo_stack.pop_back();
 	history.undo_stack.push_back(action);
 
@@ -469,21 +469,21 @@ EditorUndoRedoManager::History *EditorUndoRedoManager::_get_newest_undo() {
 		History &history = get_or_create_history(GLOBAL_HISTORY);
 		if (!history.undo_stack.is_empty()) {
 			selected_history = &history;
-			global_timestamp = history.undo_stack.back()->get().timestamp;
+			global_timestamp = history.undo_stack.get_back().timestamp;
 		}
 	}
 
 	{
 		History &history = get_or_create_history(REMOTE_HISTORY);
-		if (!history.undo_stack.is_empty() && history.undo_stack.back()->get().timestamp > global_timestamp) {
+		if (!history.undo_stack.is_empty() && history.undo_stack.get_back().timestamp > global_timestamp) {
 			selected_history = &history;
-			global_timestamp = history.undo_stack.back()->get().timestamp;
+			global_timestamp = history.undo_stack.get_back().timestamp;
 		}
 	}
 
 	{
 		History &history = get_or_create_history(EditorNode::get_editor_data().get_current_edited_scene_history_id());
-		if (!history.undo_stack.is_empty() && history.undo_stack.back()->get().timestamp > global_timestamp) {
+		if (!history.undo_stack.is_empty() && history.undo_stack.get_back().timestamp > global_timestamp) {
 			selected_history = &history;
 		}
 	}

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -758,7 +758,7 @@ Vector<String> CodeSignRequirements::parse_requirements() const {
 		}
 
 		if (tokens.size() == 1) {
-			list.push_back(out + tokens.front()->get());
+			list.push_back(out + tokens.get_front());
 		} else {
 			ERR_FAIL_V_MSG(list, "CodeSign/Requirements: Invalid token sequence.");
 		}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1311,7 +1311,7 @@ void ProjectExportDialog::_export_project() {
 		export_project->set_current_path(current->get_export_path());
 	} else {
 		if (extension_list.size() >= 1) {
-			export_project->set_current_file(default_filename + "." + extension_list.front()->get());
+			export_project->set_current_file(default_filename + "." + extension_list.get_front());
 		} else {
 			export_project->set_current_file(default_filename);
 		}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -347,7 +347,7 @@ Vector<String> FileSystemDock::get_uncollapsed_paths() const {
 			queue.push_back(res_subtree);
 
 			while (!queue.is_empty()) {
-				TreeItem *ti = queue.back()->get();
+				TreeItem *ti = queue.get_back();
 				queue.pop_back();
 				if (!ti->is_collapsed() && ti->get_child_count() > 0) {
 					Variant path = ti->get_metadata(0);
@@ -2007,7 +2007,7 @@ void FileSystemDock::_before_move(HashMap<String, ResourceUID::ID> &r_uids, Hash
 			List<EditorFileSystemDirectory *> folders;
 			folders.push_back(current_folder);
 			while (folders.front()) {
-				current_folder = folders.front()->get();
+				current_folder = folders.get_front();
 				for (int j = 0; j < current_folder->get_file_count(); j++) {
 					const String file_path = current_folder->get_file_path(j);
 					renamed_files.insert(file_path);

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1125,7 +1125,7 @@ void EditorFileDialog::update_file_list() {
 	}
 
 	while (!dirs.is_empty()) {
-		const String &dir_name = dirs.front()->get();
+		const String &dir_name = dirs.get_front();
 
 		bool bundle = dir_access->is_bundle(dir_name);
 		bool found = true;
@@ -1165,7 +1165,7 @@ void EditorFileDialog::update_file_list() {
 	while (!file_infos.is_empty()) {
 		bool match = patterns.is_empty();
 
-		FileInfo file_info = file_infos.front()->get();
+		FileInfo file_info = file_infos.get_front();
 		for (const String &E : patterns) {
 			if (file_info.name.matchn(E)) {
 				match = true;

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1620,7 +1620,7 @@ void SceneTreeEditor::_edited() {
 		ERR_FAIL_COND(nodes_to_rename.is_empty());
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTR("Rename Nodes"), UndoRedo::MERGE_DISABLE, nodes_to_rename.front()->get(), true);
+		undo_redo->create_action(TTR("Rename Nodes"), UndoRedo::MERGE_DISABLE, nodes_to_rename.get_front(), true);
 
 		TreeItem *item = which;
 		String new_name = edited->get_text(0);

--- a/editor/history_dock.cpp
+++ b/editor/history_dock.cpp
@@ -137,11 +137,11 @@ void HistoryDock::refresh_version() {
 	double newest_undo_timestamp = 0;
 
 	if (include_scene && !current_scene_history.undo_stack.is_empty()) {
-		newest_undo_timestamp = current_scene_history.undo_stack.front()->get().timestamp;
+		newest_undo_timestamp = current_scene_history.undo_stack.get_front().timestamp;
 	}
 
 	if (include_global && !global_history.undo_stack.is_empty()) {
-		double global_undo_timestamp = global_history.undo_stack.front()->get().timestamp;
+		double global_undo_timestamp = global_history.undo_stack.get_front().timestamp;
 		if (global_undo_timestamp > newest_undo_timestamp) {
 			newest_undo_timestamp = global_undo_timestamp;
 		}

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -2298,7 +2298,7 @@ void Collada::_optimize() {
 			}
 
 			while (!mgeom.is_empty()) {
-				Node *n = mgeom.front()->get();
+				Node *n = mgeom.get_front();
 				n->parent->children.push_back(n);
 				mgeom.pop_front();
 			}

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1634,7 +1634,7 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 
 		if (nm.anim_tracks.size() == 1) {
 			//use snapshot keys from anim track instead, because this was most likely exported baked
-			const Collada::AnimationTrack &at = collada.state.animation_tracks[nm.anim_tracks.front()->get()];
+			const Collada::AnimationTrack &at = collada.state.animation_tracks[nm.anim_tracks.get_front()];
 			snapshots.clear();
 			for (int i = 0; i < at.keys.size(); i++) {
 				snapshots.push_back(at.keys[i].time);

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -671,7 +671,7 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 
 	String save_path = p_save_path + ".mesh";
 
-	err = ResourceSaver::save(meshes.front()->get()->get_mesh(), save_path);
+	err = ResourceSaver::save(meshes.get_front()->get_mesh(), save_path);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Mesh to file '" + save_path + "'.");
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3247,7 +3247,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 				List<StringName> libs;
 				ap->get_animation_library_list(&libs);
 				if (libs.size()) {
-					library = ap->get_animation_library(libs.front()->get());
+					library = ap->get_animation_library(libs.get_front());
 					break;
 				}
 			}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1435,7 +1435,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					List<StringName> anim_list;
 					anim_player->get_animation_list(&anim_list);
 					if (anim_list.size() == 1) {
-						selected_animation_name = anim_list.front()->get();
+						selected_animation_name = anim_list.get_front();
 					}
 					rest_animation = anim_player->get_animation(selected_animation_name);
 					if (rest_animation.is_valid()) {
@@ -1451,7 +1451,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						List<StringName> anim_list;
 						library->get_animation_list(&anim_list);
 						if (anim_list.size() == 1) {
-							selected_animation_name = String(anim_list.front()->get());
+							selected_animation_name = String(anim_list.get_front());
 						}
 						rest_animation = library->get_animation(selected_animation_name);
 					}
@@ -2277,7 +2277,7 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 						List<StringName> anim_list;
 						library->get_animation_list(&anim_list);
 						if (anim_list.size() == 1) {
-							selected_animation_name = String(anim_list.front()->get());
+							selected_animation_name = String(anim_list.get_front());
 						}
 						if (library->has_animation(selected_animation_name)) {
 							anim = library->get_animation(selected_animation_name);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -151,7 +151,7 @@ class SceneImportSettingsData : public Object {
 						List<StringName> anim_names;
 						library->get_animation_list(&anim_names);
 						if (anim_names.size() == 1) {
-							(*settings)["rest_pose/selected_animation"] = String(anim_names.front()->get());
+							(*settings)["rest_pose/selected_animation"] = String(anim_names.get_front());
 						}
 						for (StringName anim_name : anim_names) {
 							hint_string += "," + anim_name; // Include preceding, as a catch-all.

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -980,8 +980,8 @@ void EditorAssetLibrary::_update_image_queue() {
 	}
 
 	while (to_delete.size()) {
-		image_queue[to_delete.front()->get()].request->queue_free();
-		image_queue.erase(to_delete.front()->get());
+		image_queue[to_delete.get_front()].request->queue_free();
+		image_queue.erase(to_delete.get_front());
 		to_delete.pop_front();
 	}
 }

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -554,7 +554,7 @@ Rect2 CanvasItemEditor::_get_encompassing_rect_from_list(const List<CanvasItem *
 	ERR_FAIL_COND_V(p_list.is_empty(), Rect2());
 
 	// Handles the first element
-	CanvasItem *ci = p_list.front()->get();
+	CanvasItem *ci = p_list.get_front();
 	Rect2 rect = Rect2(ci->get_global_transform_with_canvas().xform(ci->_edit_get_rect().get_center()), Size2());
 
 	// Expand with the other ones
@@ -2042,9 +2042,9 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			Transform2D edit_transform;
 			bool using_temp_pivot = !Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y);
 			if (using_temp_pivot) {
-				edit_transform = Transform2D(drag_selection.front()->get()->_edit_get_rotation(), temp_pivot);
+				edit_transform = Transform2D(drag_selection.get_front()->_edit_get_rotation(), temp_pivot);
 			} else {
-				edit_transform = drag_selection.front()->get()->_edit_get_transform();
+				edit_transform = drag_selection.get_front()->_edit_get_transform();
 			}
 			for (CanvasItem *ci : drag_selection) {
 				Transform2D parent_xform = ci->get_screen_transform() * ci->get_transform().affine_inverse();
@@ -2213,7 +2213,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 
 			Point2 drag_delta = drag_to - drag_from;
 			if (drag_type == DRAG_MOVE_X || drag_type == DRAG_MOVE_Y) {
-				const CanvasItem *selected = drag_selection.front()->get();
+				const CanvasItem *selected = drag_selection.get_front();
 				Transform2D parent_xform = selected->get_screen_transform() * selected->get_transform().affine_inverse();
 				Transform2D unscaled_transform = (transform * parent_xform * selected->_edit_get_transform()).orthonormalized();
 				Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
@@ -3678,7 +3678,7 @@ void CanvasItemEditor::_draw_selection() {
 	}
 
 	if (!selection.is_empty() && transform_tool && show_transformation_gizmos) {
-		CanvasItem *ci = selection.front()->get();
+		CanvasItem *ci = selection.get_front();
 
 		Transform2D xform = transform * ci->get_screen_transform();
 		bool is_ctrl = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
@@ -3926,8 +3926,8 @@ void CanvasItemEditor::_draw_hover() {
 }
 
 void CanvasItemEditor::_draw_message() {
-	if (drag_type != DRAG_NONE && !drag_selection.is_empty() && drag_selection.front()->get()) {
-		Transform2D current_transform = drag_selection.front()->get()->get_global_transform();
+	if (drag_type != DRAG_NONE && !drag_selection.is_empty() && drag_selection.get_front()) {
+		Transform2D current_transform = drag_selection.get_front()->get_global_transform();
 
 		double snap = EDITOR_GET("interface/inspector/default_float_step");
 		int snap_step_decimals = Math::range_step_decimals(snap);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -467,8 +467,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		Point2 offset = grid_offset;
 		if (snap_relative) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
-			if (selection.size() == 1 && Object::cast_to<Node2D>(selection.front()->get())) {
-				offset = Object::cast_to<Node2D>(selection.front()->get())->get_global_position();
+			if (selection.size() == 1 && Object::cast_to<Node2D>(selection.get_front())) {
+				offset = Object::cast_to<Node2D>(selection.get_front())->get_global_position();
 			} else if (selection.size() > 0) {
 				offset = _get_encompassing_rect_from_list(selection).position;
 			}
@@ -787,7 +787,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			still_selected = false;
 
 			if (top_node_list.size() == 1) {
-				EditorNode::get_singleton()->push_item(top_node_list.front()->get());
+				EditorNode::get_singleton()->push_item(top_node_list.get_front());
 			}
 		} else {
 			// Add the item to the selection
@@ -1425,7 +1425,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 				drag_from = transform.affine_inverse().xform(event_pos);
 				Vector2 new_pos;
 				if (drag_selection.size() == 1) {
-					new_pos = snap_point(drag_from, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.front()->get());
+					new_pos = snap_point(drag_from, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.get_front());
 				} else {
 					new_pos = snap_point(drag_from, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, nullptr, drag_selection);
 				}
@@ -1446,7 +1446,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 			_restore_canvas_item_state(drag_selection);
 			Vector2 new_pos;
 			if (drag_selection.size() == 1) {
-				new_pos = snap_point(drag_to, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.front()->get());
+				new_pos = snap_point(drag_to, SNAP_NODE_SIDES | SNAP_NODE_CENTER | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, drag_selection.get_front());
 			} else {
 				new_pos = snap_point(drag_to, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL);
 			}
@@ -1464,9 +1464,9 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 					drag_selection,
 					vformat(
 							TTR("Set CanvasItem \"%s\" Pivot Offset to (%d, %d)"),
-							drag_selection.front()->get()->get_name(),
-							drag_selection.front()->get()->_edit_get_pivot().x,
-							drag_selection.front()->get()->_edit_get_pivot().y));
+							drag_selection.get_front()->get_name(),
+							drag_selection.get_front()->_edit_get_pivot().x,
+							drag_selection.get_front()->_edit_get_pivot().y));
 			_reset_drag();
 			return true;
 		}
@@ -1520,7 +1520,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				if (drag_selection.size() > 0) {
 					drag_type = DRAG_ROTATE;
 					drag_from = transform.affine_inverse().xform(b->get_position());
-					CanvasItem *ci = drag_selection.front()->get();
+					CanvasItem *ci = drag_selection.get_front();
 					if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
 						drag_rotation_center = temp_pivot;
 					} else if (ci->_edit_use_pivot()) {
@@ -1574,8 +1574,8 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Rotate CanvasItem \"%s\" to %d degrees"),
-								drag_selection.front()->get()->get_name(),
-								Math::rad_to_deg(drag_selection.front()->get()->_edit_get_rotation())),
+								drag_selection.get_front()->get_name(),
+								Math::rad_to_deg(drag_selection.get_front()->_edit_get_rotation())),
 						true);
 			}
 
@@ -1605,7 +1605,7 @@ bool CanvasItemEditor::_gui_input_open_scene_on_double_click(const Ref<InputEven
 	if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && b->is_double_click() && tool == TOOL_SELECT) {
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (selection.size() == 1) {
-			CanvasItem *ci = selection.front()->get();
+			CanvasItem *ci = selection.get_front();
 			if (!ci->get_scene_file_path().is_empty() && ci != EditorNode::get_singleton()->get_edited_scene()) {
 				EditorNode::get_singleton()->load_scene(ci->get_scene_file_path());
 				return true;
@@ -1624,7 +1624,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && tool == TOOL_SELECT) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
 			if (selection.size() == 1) {
-				Control *control = Object::cast_to<Control>(selection.front()->get());
+				Control *control = Object::cast_to<Control>(selection.get_front());
 				if (control && _is_node_movable(control)) {
 					Vector2 anchor_pos[4];
 					anchor_pos[0] = Vector2(control->get_anchor(SIDE_LEFT), control->get_anchor(SIDE_TOP));
@@ -1673,7 +1673,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		// Drag the anchor
 		if (m.is_valid()) {
 			_restore_canvas_item_state(drag_selection);
-			Control *control = Object::cast_to<Control>(drag_selection.front()->get());
+			Control *control = Object::cast_to<Control>(drag_selection.get_front());
 
 			drag_to = transform.affine_inverse().xform(m->get_position());
 
@@ -1744,7 +1744,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == MouseButton::LEFT && !b->is_pressed()) {
 			_commit_canvas_item_state(
 					drag_selection,
-					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection.front()->get()->get_name()));
+					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection.get_front()->get_name()));
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
@@ -1774,7 +1774,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && b->is_pressed() && tool == TOOL_SELECT) {
 			List<CanvasItem *> selection = _get_edited_canvas_items();
 			if (selection.size() == 1) {
-				CanvasItem *ci = selection.front()->get();
+				CanvasItem *ci = selection.get_front();
 				if (ci->_edit_use_rect() && _is_node_movable(ci)) {
 					Rect2 rect = ci->_edit_get_rect();
 					Transform2D xform = transform * ci->get_screen_transform();
@@ -1835,7 +1835,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			drag_type == DRAG_TOP_LEFT || drag_type == DRAG_TOP_RIGHT || drag_type == DRAG_BOTTOM_LEFT || drag_type == DRAG_BOTTOM_RIGHT) {
 		// Resize the node
 		if (m.is_valid()) {
-			CanvasItem *ci = drag_selection.front()->get();
+			CanvasItem *ci = drag_selection.get_front();
 			CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci);
 			//Reset state
 			ci->_edit_set_state(se->undo_state);
@@ -1920,7 +1920,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 		// Confirm resize
 		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == MouseButton::LEFT && !b->is_pressed()) {
-			const Node2D *node2d = Object::cast_to<Node2D>(drag_selection.front()->get());
+			const Node2D *node2d = Object::cast_to<Node2D>(drag_selection.get_front());
 			if (node2d) {
 				// Extends from Node2D.
 				// Node2D doesn't have an actual stored rect size, unlike Controls.
@@ -1928,9 +1928,9 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						drag_selection,
 						vformat(
 								TTR("Scale Node2D \"%s\" to (%s, %s)"),
-								drag_selection.front()->get()->get_name(),
-								Math::snapped(drag_selection.front()->get()->_edit_get_scale().x, 0.01),
-								Math::snapped(drag_selection.front()->get()->_edit_get_scale().y, 0.01)),
+								drag_selection.get_front()->get_name(),
+								Math::snapped(drag_selection.get_front()->_edit_get_scale().x, 0.01),
+								Math::snapped(drag_selection.get_front()->_edit_get_scale().y, 0.01)),
 						true);
 			} else {
 				// Extends from Control.
@@ -1938,9 +1938,9 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						drag_selection,
 						vformat(
 								TTR("Resize Control \"%s\" to (%d, %d)"),
-								drag_selection.front()->get()->get_name(),
-								drag_selection.front()->get()->_edit_get_rect().size.x,
-								drag_selection.front()->get()->_edit_get_rect().size.y),
+								drag_selection.get_front()->get_name(),
+								drag_selection.get_front()->_edit_get_rect().size.x,
+								drag_selection.get_front()->_edit_get_rect().size.y),
 						true);
 			}
 
@@ -1987,7 +1987,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			}
 
 			if (!selection.is_empty()) {
-				CanvasItem *ci = selection.front()->get();
+				CanvasItem *ci = selection.get_front();
 
 				Transform2D edit_transform;
 				if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
@@ -2119,9 +2119,9 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Scale CanvasItem \"%s\" to (%s, %s)"),
-								drag_selection.front()->get()->get_name(),
-								Math::snapped(drag_selection.front()->get()->_edit_get_scale().x, 0.01),
-								Math::snapped(drag_selection.front()->get()->_edit_get_scale().y, 0.01)),
+								drag_selection.get_front()->get_name(),
+								Math::snapped(drag_selection.get_front()->_edit_get_scale().x, 0.01),
+								Math::snapped(drag_selection.get_front()->_edit_get_scale().y, 0.01)),
 						true);
 			}
 			if (key_auto_insert_button->is_pressed()) {
@@ -2166,7 +2166,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 
 					drag_type = DRAG_MOVE;
 
-					CanvasItem *ci = selection.front()->get();
+					CanvasItem *ci = selection.get_front();
 					Transform2D parent_xform = ci->get_screen_transform() * ci->get_transform().affine_inverse();
 					Transform2D unscaled_transform = (transform * parent_xform * ci->_edit_get_transform()).orthonormalized();
 					Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
@@ -2205,8 +2205,8 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			drag_to = transform.affine_inverse().xform(m->get_position());
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D parent_xform = drag_selection.front()->get()->get_screen_transform() * drag_selection.front()->get()->get_transform().affine_inverse();
-				previous_pos = parent_xform.xform(drag_selection.front()->get()->_edit_get_position());
+				Transform2D parent_xform = drag_selection.get_front()->get_screen_transform() * drag_selection.get_front()->get_transform().affine_inverse();
+				previous_pos = parent_xform.xform(drag_selection.get_front()->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
 			}
@@ -2257,9 +2257,9 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 							drag_selection,
 							vformat(
 									TTR("Move CanvasItem \"%s\" to (%d, %d)"),
-									drag_selection.front()->get()->get_name(),
-									drag_selection.front()->get()->_edit_get_position().x,
-									drag_selection.front()->get()->_edit_get_position().y),
+									drag_selection.get_front()->get_name(),
+									drag_selection.get_front()->_edit_get_position().x,
+									drag_selection.get_front()->_edit_get_position().y),
 							true);
 				}
 			}
@@ -2335,15 +2335,15 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D xform = drag_selection.front()->get()->get_global_transform_with_canvas() * drag_selection.front()->get()->get_transform().affine_inverse();
-				previous_pos = xform.xform(drag_selection.front()->get()->_edit_get_position());
+				Transform2D xform = drag_selection.get_front()->get_global_transform_with_canvas() * drag_selection.get_front()->get_transform().affine_inverse();
+				previous_pos = xform.xform(drag_selection.get_front()->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
 			}
 
 			Point2 new_pos;
 			if (drag_selection.size() == 1) {
-				Node2D *node_2d = Object::cast_to<Node2D>(drag_selection.front()->get());
+				Node2D *node_2d = Object::cast_to<Node2D>(drag_selection.get_front());
 				if (node_2d && move_local_base_rotated) {
 					Transform2D m2;
 					m2.rotate(node_2d->get_rotation());
@@ -2381,9 +2381,9 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Move CanvasItem \"%s\" to (%d, %d)"),
-								drag_selection.front()->get()->get_name(),
-								drag_selection.front()->get()->_edit_get_position().x,
-								drag_selection.front()->get()->_edit_get_position().y),
+								drag_selection.get_front()->get_name(),
+								drag_selection.get_front()->_edit_get_position().x,
+								drag_selection.get_front()->_edit_get_position().y),
 						true);
 			}
 			_reset_drag();
@@ -2610,7 +2610,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 				_find_canvas_items_in_rect(Rect2(bsfrom, bsto - bsfrom), scene, &selitems);
 				if (selitems.size() == 1 && editor_selection->get_top_selected_node_list().is_empty()) {
-					EditorNode::get_singleton()->push_item(selitems.front()->get());
+					EditorNode::get_singleton()->push_item(selitems.get_front());
 				}
 				for (CanvasItem *E : selitems) {
 					editor_selection->add_node(E);
@@ -2864,7 +2864,7 @@ Control::CursorShape CanvasItemEditor::get_cursor_shape(const Point2 &p_pos) con
 
 	List<CanvasItem *> selection = _get_edited_canvas_items();
 	if (selection.size() == 1) {
-		const double angle = Math::fposmod((double)selection.front()->get()->get_global_transform_with_canvas().get_rotation(), Math_PI);
+		const double angle = Math::fposmod((double)selection.get_front()->get_global_transform_with_canvas().get_rotation(), Math_PI);
 		if (angle > Math_PI * 7.0 / 8.0) {
 			rotation_array_index = 0;
 		} else if (angle > Math_PI * 5.0 / 8.0) {
@@ -6327,7 +6327,7 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
 	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() > 0) {
-		Node *selected_node = selected_nodes.front()->get();
+		Node *selected_node = selected_nodes.get_front();
 		if (is_alt) {
 			target_node = root_node;
 		} else if (is_shift) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -811,7 +811,7 @@ void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
 
 		const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
 		if (top_node_list.size() == 1) {
-			EditorNode::get_singleton()->edit_node(top_node_list.front()->get());
+			EditorNode::get_singleton()->edit_node(top_node_list.get_front());
 		}
 	}
 }
@@ -1143,7 +1143,7 @@ void Node3DEditorViewport::_select_region() {
 
 	const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
 	if (top_node_list.size() == 1) {
-		EditorNode::get_singleton()->edit_node(top_node_list.front()->get());
+		EditorNode::get_singleton()->edit_node(top_node_list.get_front());
 	}
 }
 
@@ -5039,7 +5039,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
 	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() > 0) {
-		Node *selected_node = selected_nodes.front()->get();
+		Node *selected_node = selected_nodes.get_front();
 		if (is_alt) {
 			target_node = root_node;
 		} else if (is_shift) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -792,7 +792,7 @@ void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
 	if (p_allow_locked || (selected != nullptr && !_is_node_locked(selected))) {
 		if (clicked_wants_append) {
 			const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
-			const Node *active_node = top_node_list.is_empty() ? nullptr : top_node_list.back()->get();
+			const Node *active_node = top_node_list.is_empty() ? nullptr : top_node_list.get_back();
 			if (editor_selection->is_selected(selected)) {
 				editor_selection->remove_node(selected);
 				if (selected != active_node) {
@@ -3181,7 +3181,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 				} else {
 					const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 					if (selection.size() == 1) {
-						selected_node = Object::cast_to<Node3D>(selection.front()->get());
+						selected_node = Object::cast_to<Node3D>(selection.get_front());
 					}
 				}
 
@@ -4426,7 +4426,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 	if (!preview_node->is_inside_tree() && !ruler->is_inside_tree()) {
 		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 
-		Node3D *first_selected_node = Object::cast_to<Node3D>(selection.front()->get());
+		Node3D *first_selected_node = Object::cast_to<Node3D>(selection.get_front());
 
 		Array children = first_selected_node->get_children();
 
@@ -7927,7 +7927,7 @@ void Node3DEditor::_selection_changed() {
 			continue;
 		}
 
-		if (sp == editor_selection->get_top_selected_node_list().back()->get()) {
+		if (sp == editor_selection->get_top_selected_node_list().get_back()) {
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance, active_selection_box->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray, active_selection_box_xray->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_offset, active_selection_box->get_rid());

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -354,7 +354,7 @@ public:
 		}
 
 		while (to_clean.front()) {
-			cached.erase(to_clean.front()->get());
+			cached.erase(to_clean.get_front());
 			to_clean.pop_front();
 		}
 	}
@@ -1026,7 +1026,7 @@ void ScriptEditor::_close_all_tabs() {
 
 void ScriptEditor::_queue_close_tabs() {
 	while (!script_close_queue.is_empty()) {
-		int idx = script_close_queue.front()->get();
+		int idx = script_close_queue.get_front();
 		script_close_queue.pop_front();
 
 		tab_container->set_current_tab(idx);
@@ -1359,7 +1359,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				return;
 			}
 
-			String path = previous_scripts.back()->get();
+			String path = previous_scripts.get_back();
 			previous_scripts.pop_back();
 
 			List<String> extensions;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -554,9 +554,9 @@ void ScriptTextEditor::_validate_script() {
 
 		if (errors.size() > 0) {
 			// TRANSLATORS: Script error pointing to a line and column number.
-			String error_text = vformat(TTR("Error at (%d, %d):"), errors.front()->get().line, errors.front()->get().column) + " " + errors.front()->get().message;
+			String error_text = vformat(TTR("Error at (%d, %d):"), errors.get_front().line, errors.get_front().column) + " " + errors.get_front().message;
 			code_editor->set_error(error_text);
-			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
+			code_editor->set_error_pos(errors.get_front().line - 1, errors.get_front().column - 1);
 		}
 		script_is_valid = false;
 	} else {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1619,7 +1619,7 @@ void SpriteFramesEditor::edit(Ref<SpriteFrames> p_frames) {
 		frames->get_animation_list(&anim_names);
 		anim_names.sort_custom<StringName::AlphCompare>();
 		if (anim_names.size()) {
-			edited_anim = anim_names.front()->get();
+			edited_anim = anim_names.get_front();
 		} else {
 			edited_anim = StringName();
 		}

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1835,7 +1835,7 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
 	if (top_node_list.size() == 1) {
-		selected = top_node_list.front()->get();
+		selected = top_node_list.get_front();
 	}
 
 	bool show_node_edit = false;

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -490,12 +490,12 @@ void ShaderTextEditor::_validate_script() {
 		ERR_FAIL_COND(err_positions.is_empty());
 
 		String err_text = error_pp;
-		int err_line = err_positions.front()->get().line;
+		int err_line = err_positions.get_front().line;
 		if (err_positions.size() == 1) {
 			// Error in main file
 			err_text = "error(" + itos(err_line) + "): " + err_text;
 		} else {
-			err_text = "error(" + itos(err_line) + ") in include " + err_positions.back()->get().file.get_file() + ":" + itos(err_positions.back()->get().line) + ": " + err_text;
+			err_text = "error(" + itos(err_line) + ") in include " + err_positions.get_back().file.get_file() + ":" + itos(err_positions.get_back().line) + ": " + err_text;
 			set_error_count(err_positions.size() - 1);
 		}
 

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -1212,7 +1212,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_bucket_fill(
 			List<Vector2i> to_check;
 			to_check.push_back(p_coords);
 			while (!to_check.is_empty()) {
-				Vector2i coords = to_check.back()->get();
+				Vector2i coords = to_check.get_back();
 				to_check.pop_back();
 				if (!already_checked.has(coords)) {
 					if (source_cell.source_id == edited_layer->get_cell_source_id(coords) &&
@@ -2748,7 +2748,7 @@ RBSet<Vector2i> TileMapLayerEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vec
 		List<Vector2i> to_check;
 		to_check.push_back(p_coords);
 		while (!to_check.is_empty()) {
-			Vector2i coords = to_check.back()->get();
+			Vector2i coords = to_check.get_back();
 			to_check.pop_back();
 			if (!already_checked.has(coords)) {
 				// Get the candidate cell pattern.

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -77,7 +77,7 @@ void TilesEditorUtils::_thread() {
 		if (pattern_preview_queue.is_empty()) {
 			pattern_preview_mutex.unlock();
 		} else {
-			QueueItem item = pattern_preview_queue.front()->get();
+			QueueItem item = pattern_preview_queue.get_front();
 			pattern_preview_queue.pop_front();
 			pattern_preview_mutex.unlock();
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4274,7 +4274,7 @@ bool VisualShaderEditor::_check_node_drop_on_connection(const Vector2 &p_positio
 		return false;
 	}
 
-	Ref<GraphEdit::Connection> intersecting_connection = intersecting_connections.front()->get();
+	Ref<GraphEdit::Connection> intersecting_connection = intersecting_connections.get_front();
 
 	if (selected_vsnode->is_any_port_connected() || selected_vsnode->get_input_port_count() == 0 || selected_vsnode->get_output_port_count() == 0) {
 		return false;
@@ -6307,8 +6307,8 @@ void VisualShaderEditor::_update_preview() {
 		if (err != OK) {
 			ERR_FAIL_COND(err_positions.is_empty());
 
-			String file = err_positions.front()->get().file;
-			int err_line = err_positions.front()->get().line;
+			String file = err_positions.get_front().file;
+			int err_line = err_positions.get_front().line;
 			Color error_line_color = EDITOR_GET("text_editor/theme/highlighting/mark_color");
 			preview_text->set_line_background_color(err_line - 1, error_line_color);
 			error_panel->show();

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4337,7 +4337,7 @@ void VisualShaderEditor::_handle_node_drop_on_connection() {
 		return;
 	}
 
-	int selected_node_id = drag_buffer.front()->get().node;
+	int selected_node_id = drag_buffer.get_front().node;
 	VisualShader::Type shader_type = get_current_shader_type();
 	Ref<VisualShaderNode> selected_vsnode = visual_shader->get_node(shader_type, selected_node_id);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -740,7 +740,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			Node *selected = scene_tree->get_selected();
 			const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
 			if (!selected && !top_node_list.is_empty()) {
-				selected = top_node_list.front()->get();
+				selected = top_node_list.get_front();
 			}
 
 			if (selected) {
@@ -892,7 +892,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Duplicate Node(s)"), UndoRedo::MERGE_DISABLE, selection.front()->get());
+			undo_redo->create_action(TTR("Duplicate Node(s)"), UndoRedo::MERGE_DISABLE, selection.get_front());
 			undo_redo->add_do_method(editor_selection, "clear");
 
 			Node *dupsingle = nullptr;
@@ -997,7 +997,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			List<Node *> nodes = editor_selection->get_top_selected_node_list();
 			ERR_FAIL_COND(nodes.size() != 1);
 
-			Node *node = nodes.front()->get();
+			Node *node = nodes.get_front();
 			Node *root = get_tree()->get_edited_scene_root();
 
 			if (node == root) {
@@ -1155,7 +1155,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			Node *tocopy = selection.front()->get();
+			Node *tocopy = selection.get_front();
 
 			if (tocopy == scene) {
 				accept->set_text(TTR("Can't save the root node branch as an instantiated scene.\nTo create an editable copy of the current scene, duplicate it using the FileSystem dock context menu\nor create an inherited scene using Scene > New Inherited Scene... instead."));
@@ -1195,7 +1195,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (extensions.size()) {
 				String root_name(tocopy->get_name());
 				root_name = EditorNode::adjust_scene_name_casing(root_name);
-				existing = root_name + "." + extensions.front()->get().to_lower();
+				existing = root_name + "." + extensions.get_front().to_lower();
 			}
 			new_scene_from_dialog->set_current_path(existing);
 
@@ -2554,7 +2554,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Attach Script"), UndoRedo::MERGE_DISABLE, selected.front()->get());
+	undo_redo->create_action(TTR("Attach Script"), UndoRedo::MERGE_DISABLE, selected.get_front());
 	for (Node *E : selected) {
 		Ref<Script> existing = E->get_script();
 		undo_redo->add_do_method(InspectorDock::get_singleton(), "store_script_properties", E);
@@ -2773,7 +2773,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	EditorNode::get_singleton()->hide_unused_editors(this);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(p_cut ? TTR("Cut Node(s)") : TTR("Remove Node(s)"), UndoRedo::MERGE_DISABLE, remove_list.front()->get());
+	undo_redo->create_action(p_cut ? TTR("Cut Node(s)") : TTR("Remove Node(s)"), UndoRedo::MERGE_DISABLE, remove_list.get_front());
 
 	if (entire_scene) {
 		undo_redo->add_do_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
@@ -2987,7 +2987,7 @@ void SceneTreeDock::_create() {
 		ERR_FAIL_COND(selection.is_empty());
 
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-		ur->create_action(TTR("Change type of node(s)"), UndoRedo::MERGE_DISABLE, selection.front()->get());
+		ur->create_action(TTR("Change type of node(s)"), UndoRedo::MERGE_DISABLE, selection.get_front());
 
 		for (Node *n : selection) {
 			ERR_FAIL_NULL(n);
@@ -3008,7 +3008,7 @@ void SceneTreeDock::_create() {
 		// Find top level node in selection
 		bool only_one_top_node = true;
 
-		Node *first = selection.front()->get();
+		Node *first = selection.get_front();
 		ERR_FAIL_NULL(first);
 		int smaller_path_to_top = first->get_path_to(scene_root).get_name_count();
 		Node *top_node = first;
@@ -3236,7 +3236,7 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 		memdelete(oldnode);
 
 		while (to_erase.front()) {
-			memdelete(to_erase.front()->get());
+			memdelete(to_erase.get_front());
 			to_erase.pop_front();
 		}
 	}
@@ -3365,7 +3365,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 		return;
 	}
 
-	Node *base = selection.front()->get();
+	Node *base = selection.get_front();
 
 	HashMap<const Node *, Node *> duplimap;
 	HashMap<const Node *, Node *> inverse_duplimap;
@@ -3798,7 +3798,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		if (selection.size() == 1 && !node_clipboard.is_empty()) {
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
-			if (selection.front()->get() == edited_scene) {
+			if (selection.get_front() == edited_scene) {
 				menu->set_item_disabled(-1, true);
 			}
 		}
@@ -4101,7 +4101,7 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 
 	Node *selected = scene_tree->get_selected();
 	if (!selected) {
-		selected = selection.front()->get();
+		selected = selection.get_front();
 	}
 
 	Ref<Script> existing = selected->get_script();
@@ -4226,7 +4226,7 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 
 	List<Node *> selection = editor_selection->get_top_selected_node_list();
 	if (selection.size() > 0) {
-		paste_parent = selection.back()->get();
+		paste_parent = selection.get_back();
 	}
 
 	if (p_paste_as_sibling) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1102,7 +1102,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					msg = vformat(any_children ? TTR("Delete %d nodes and any children?") : TTR("Delete %d nodes?"), remove_list.size());
 				} else {
 					if (!p_confirm_override) {
-						Node *node = remove_list.front()->get();
+						Node *node = remove_list.get_front();
 						if (node == editor_data->get_edited_scene_root()) {
 							msg = vformat(TTR("Delete the root node \"%s\"?"), node->get_name());
 						} else if (node->get_scene_file_path().is_empty() && node->get_child_count() > 0) {
@@ -3587,7 +3587,7 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 			return;
 		}
 		if (!valid_properties.is_empty()) {
-			_perform_property_drop(node, valid_properties.front()->get(), ResourceLoader::load(res_path));
+			_perform_property_drop(node, valid_properties.get_front(), ResourceLoader::load(res_path));
 			return;
 		}
 	}
@@ -3764,7 +3764,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	bool existing_script_removable = true;
 	bool allow_attach_new_script = true;
 	if (selection.size() == 1) {
-		Node *selected = selection.front()->get();
+		Node *selected = selection.get_front();
 
 		if (profile_allow_editing) {
 			subresources.clear();
@@ -3901,17 +3901,17 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			if (menu->get_item_index(TOOL_COPY_NODE_PATH) == -1) {
 				menu->add_separator();
 			}
-			Node *node = full_selection.front()->get();
+			Node *node = full_selection.get_front();
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("SceneUniqueName")), ED_GET_SHORTCUT("scene_tree/toggle_unique_name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
 			menu->set_item_text(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), node->is_unique_name_in_owner() ? TTR("Revoke Unique Name") : TTR("Access as Unique Name"));
 		}
 	}
 
 	if (selection.size() == 1) {
-		bool is_external = (!selection.front()->get()->get_scene_file_path().is_empty());
+		bool is_external = (!selection.get_front()->get_scene_file_path().is_empty());
 		if (is_external) {
-			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
-			bool is_top_level = selection.front()->get()->get_owner() == nullptr;
+			bool is_inherited = selection.get_front()->get_scene_inherited_state().is_valid();
+			bool is_top_level = selection.get_front()->get_owner() == nullptr;
 			if (is_inherited && is_top_level) {
 				menu->add_separator();
 				if (profile_allow_editing) {
@@ -3920,8 +3920,8 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open in Editor"), TOOL_SCENE_OPEN_INHERITED);
 			} else if (!is_top_level) {
 				menu->add_separator();
-				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
-				bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
+				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.get_front());
+				bool placeholder = selection.get_front()->get_scene_instance_load_placeholder();
 				if (profile_allow_editing) {
 					menu->add_check_item(TTR("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 					menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
@@ -3945,7 +3945,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	}
 	menu->add_separator();
 
-	if (full_selection.size() == 1 && !selection.front()->get()->get_scene_file_path().is_empty()) {
+	if (full_selection.size() == 1 && !selection.get_front()->get_scene_file_path().is_empty()) {
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ShowInFileSystem")), ED_GET_SHORTCUT("scene_tree/show_in_file_system"), TOOL_SHOW_IN_FILE_SYSTEM);
 	}
 

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -120,9 +120,9 @@ Error ENetMultiplayerPeer::add_mesh_peer(int p_id, Ref<ENetConnection> p_host) {
 	ERR_FAIL_COND_V_MSG(active_mode != MODE_MESH, ERR_UNCONFIGURED, "The multiplayer instance is not configured as a mesh. Call 'create_mesh' first.");
 	List<Ref<ENetPacketPeer>> host_peers;
 	p_host->get_peers(host_peers);
-	ERR_FAIL_COND_V_MSG(host_peers.size() != 1 || host_peers.front()->get()->get_state() != ENetPacketPeer::STATE_CONNECTED, ERR_INVALID_PARAMETER, "The provided host must have exactly one peer in the connected state.");
+	ERR_FAIL_COND_V_MSG(host_peers.size() != 1 || host_peers.get_front()->get_state() != ENetPacketPeer::STATE_CONNECTED, ERR_INVALID_PARAMETER, "The provided host must have exactly one peer in the connected state.");
 	hosts[p_id] = p_host;
-	peers[p_id] = host_peers.front()->get();
+	peers[p_id] = host_peers.get_front();
 	emit_signal(SNAME("peer_connected"), p_id);
 	return OK;
 }

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -38,19 +38,19 @@ int ENetMultiplayerPeer::get_packet_peer() const {
 	ERR_FAIL_COND_V_MSG(!_is_active(), 1, "The multiplayer instance isn't currently active.");
 	ERR_FAIL_COND_V(incoming_packets.is_empty(), 1);
 
-	return incoming_packets.front()->get().from;
+	return incoming_packets.get_front().from;
 }
 
 MultiplayerPeer::TransferMode ENetMultiplayerPeer::get_packet_mode() const {
 	ERR_FAIL_COND_V_MSG(!_is_active(), TRANSFER_MODE_RELIABLE, "The multiplayer instance isn't currently active.");
 	ERR_FAIL_COND_V(incoming_packets.is_empty(), TRANSFER_MODE_RELIABLE);
-	return incoming_packets.front()->get().transfer_mode;
+	return incoming_packets.get_front().transfer_mode;
 }
 
 int ENetMultiplayerPeer::get_packet_channel() const {
 	ERR_FAIL_COND_V_MSG(!_is_active(), 1, "The multiplayer instance isn't currently active.");
 	ERR_FAIL_COND_V(incoming_packets.is_empty(), 1);
-	int ch = incoming_packets.front()->get().channel;
+	int ch = incoming_packets.get_front().channel;
 	if (ch >= SYSCH_MAX) { // First 2 channels are reserved.
 		return ch - SYSCH_MAX + 1;
 	}
@@ -322,7 +322,7 @@ Error ENetMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_si
 
 	_pop_current_packet();
 
-	current_packet = incoming_packets.front()->get();
+	current_packet = incoming_packets.get_front();
 	incoming_packets.pop_front();
 
 	*r_buffer = (const uint8_t *)(current_packet.packet->data);

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -95,7 +95,7 @@ Error ENetPacketPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 		enet_packet_destroy(last_packet);
 		last_packet = nullptr;
 	}
-	last_packet = packet_queue.front()->get();
+	last_packet = packet_queue.get_front();
 	packet_queue.pop_front();
 	*r_buffer = (const uint8_t *)(last_packet->data);
 	r_buffer_size = last_packet->dataLength;
@@ -177,7 +177,7 @@ int ENetPacketPeer::get_channels() const {
 
 int ENetPacketPeer::get_packet_flags() const {
 	ERR_FAIL_COND_V(packet_queue.is_empty(), 0);
-	return packet_queue.front()->get()->flags;
+	return packet_queue.get_front()->flags;
 }
 
 void ENetPacketPeer::_on_disconnect() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -821,10 +821,10 @@ Error GDScript::reload(bool p_keep_state) {
 	}
 	if (err) {
 		if (EngineDebugger::is_active()) {
-			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
+			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().get_front().line, "Parser Error: " + parser.get_errors().get_front().message);
 		}
 		// TODO: Show all error messages.
-		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().get_front().line, ("Parse Error: " + parser.get_errors().get_front().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		reloading = false;
 		return ERR_PARSE_ERROR;
 	}
@@ -834,7 +834,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 	if (err) {
 		if (EngineDebugger::is_active()) {
-			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
+			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().get_front().line, "Parser Error: " + parser.get_errors().get_front().message);
 		}
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -128,7 +128,7 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 		pool.push_back(idx);
 		temporaries.push_back(new_temp);
 	}
-	int slot = pool.front()->get();
+	int slot = pool.get_front();
 	pool.pop_front();
 	used_temporaries.push_back(slot);
 	return slot;
@@ -136,7 +136,7 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 
 void GDScriptByteCodeGenerator::pop_temporary() {
 	ERR_FAIL_COND(used_temporaries.is_empty());
-	int slot_idx = used_temporaries.back()->get();
+	int slot_idx = used_temporaries.get_back();
 	if (temporaries[slot_idx].can_contain_object) {
 		// Avoid keeping in the stack long-lived references to objects,
 		// which may prevent `RefCounted` objects from being freed.
@@ -714,8 +714,8 @@ void GDScriptByteCodeGenerator::write_end_and(const Address &p_target) {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
 	append(opcodes.size() + 3);
 	// Here it means one of operands is false.
-	patch_jump(logic_op_jump_pos1.back()->get());
-	patch_jump(logic_op_jump_pos2.back()->get());
+	patch_jump(logic_op_jump_pos1.get_back());
+	patch_jump(logic_op_jump_pos2.get_back());
 	logic_op_jump_pos1.pop_back();
 	logic_op_jump_pos2.pop_back();
 	append_opcode(GDScriptFunction::OPCODE_ASSIGN_FALSE);
@@ -744,8 +744,8 @@ void GDScriptByteCodeGenerator::write_end_or(const Address &p_target) {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
 	append(opcodes.size() + 3);
 	// Here it means one of operands is true.
-	patch_jump(logic_op_jump_pos1.back()->get());
-	patch_jump(logic_op_jump_pos2.back()->get());
+	patch_jump(logic_op_jump_pos1.get_back());
+	patch_jump(logic_op_jump_pos2.get_back());
 	logic_op_jump_pos1.pop_back();
 	logic_op_jump_pos2.pop_back();
 	append_opcode(GDScriptFunction::OPCODE_ASSIGN_TRUE);
@@ -765,25 +765,25 @@ void GDScriptByteCodeGenerator::write_ternary_condition(const Address &p_conditi
 
 void GDScriptByteCodeGenerator::write_ternary_true_expr(const Address &p_expr) {
 	append_opcode(GDScriptFunction::OPCODE_ASSIGN);
-	append(ternary_result.back()->get());
+	append(ternary_result.get_back());
 	append(p_expr);
 	// Jump away from the false path.
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
 	ternary_jump_skip_pos.push_back(opcodes.size());
 	append(0);
 	// Fail must jump here.
-	patch_jump(ternary_jump_fail_pos.back()->get());
+	patch_jump(ternary_jump_fail_pos.get_back());
 	ternary_jump_fail_pos.pop_back();
 }
 
 void GDScriptByteCodeGenerator::write_ternary_false_expr(const Address &p_expr) {
 	append_opcode(GDScriptFunction::OPCODE_ASSIGN);
-	append(ternary_result.back()->get());
+	append(ternary_result.get_back());
 	append(p_expr);
 }
 
 void GDScriptByteCodeGenerator::write_end_ternary() {
-	patch_jump(ternary_jump_skip_pos.back()->get());
+	patch_jump(ternary_jump_skip_pos.get_back());
 	ternary_jump_skip_pos.pop_back();
 	ternary_result.pop_back();
 }
@@ -1523,13 +1523,13 @@ void GDScriptByteCodeGenerator::write_else() {
 	int else_jmp_addr = opcodes.size();
 	append(0); // Jump destination, will be patched.
 
-	patch_jump(if_jmp_addrs.back()->get());
+	patch_jump(if_jmp_addrs.get_back());
 	if_jmp_addrs.pop_back();
 	if_jmp_addrs.push_back(else_jmp_addr);
 }
 
 void GDScriptByteCodeGenerator::write_endif() {
-	patch_jump(if_jmp_addrs.back()->get());
+	patch_jump(if_jmp_addrs.get_back());
 	if_jmp_addrs.pop_back();
 }
 
@@ -1541,7 +1541,7 @@ void GDScriptByteCodeGenerator::write_jump_if_shared(const Address &p_value) {
 }
 
 void GDScriptByteCodeGenerator::write_end_jump_if_shared() {
-	patch_jump(if_jmp_addrs.back()->get());
+	patch_jump(if_jmp_addrs.get_back());
 	if_jmp_addrs.pop_back();
 }
 
@@ -1555,7 +1555,7 @@ void GDScriptByteCodeGenerator::start_for(const GDScriptDataType &p_iterator_typ
 }
 
 void GDScriptByteCodeGenerator::write_for_assignment(const Address &p_list) {
-	const Address &container = for_container_variables.back()->get();
+	const Address &container = for_container_variables.get_back();
 
 	// Assign container.
 	append_opcode(GDScriptFunction::OPCODE_ASSIGN);
@@ -1564,8 +1564,8 @@ void GDScriptByteCodeGenerator::write_for_assignment(const Address &p_list) {
 }
 
 void GDScriptByteCodeGenerator::write_for(const Address &p_variable, bool p_use_conversion) {
-	const Address &counter = for_counter_variables.back()->get();
-	const Address &container = for_container_variables.back()->get();
+	const Address &counter = for_counter_variables.get_back();
+	const Address &container = for_container_variables.get_back();
 
 	current_breaks_to_patch.push_back(List<int>());
 
@@ -1696,17 +1696,17 @@ void GDScriptByteCodeGenerator::write_for(const Address &p_variable, bool p_use_
 void GDScriptByteCodeGenerator::write_endfor() {
 	// Jump back to loop check.
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	append(continue_addrs.back()->get());
+	append(continue_addrs.get_back());
 	continue_addrs.pop_back();
 
 	// Patch end jumps (two of them).
 	for (int i = 0; i < 2; i++) {
-		patch_jump(for_jmp_addrs.back()->get());
+		patch_jump(for_jmp_addrs.get_back());
 		for_jmp_addrs.pop_back();
 	}
 
 	// Patch break statements.
-	for (const int &E : current_breaks_to_patch.back()->get()) {
+	for (const int &E : current_breaks_to_patch.get_back()) {
 		patch_jump(E);
 	}
 	current_breaks_to_patch.pop_back();
@@ -1732,15 +1732,15 @@ void GDScriptByteCodeGenerator::write_while(const Address &p_condition) {
 void GDScriptByteCodeGenerator::write_endwhile() {
 	// Jump back to loop check.
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	append(continue_addrs.back()->get());
+	append(continue_addrs.get_back());
 	continue_addrs.pop_back();
 
 	// Patch end jump.
-	patch_jump(while_jmp_addrs.back()->get());
+	patch_jump(while_jmp_addrs.get_back());
 	while_jmp_addrs.pop_back();
 
 	// Patch break statements.
-	for (const int &E : current_breaks_to_patch.back()->get()) {
+	for (const int &E : current_breaks_to_patch.get_back()) {
 		patch_jump(E);
 	}
 	current_breaks_to_patch.pop_back();
@@ -1748,13 +1748,13 @@ void GDScriptByteCodeGenerator::write_endwhile() {
 
 void GDScriptByteCodeGenerator::write_break() {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	current_breaks_to_patch.back()->get().push_back(opcodes.size());
+	current_breaks_to_patch.get_back().push_back(opcodes.size());
 	append(0);
 }
 
 void GDScriptByteCodeGenerator::write_continue() {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	append(continue_addrs.back()->get());
+	append(continue_addrs.get_back());
 }
 
 void GDScriptByteCodeGenerator::write_breakpoint() {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -184,9 +184,9 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void pop_stack_identifiers() {
-		int current_locals = stack_identifiers_counts.back()->get();
+		int current_locals = stack_identifiers_counts.get_back();
 		stack_identifiers_counts.pop_back();
-		stack_identifiers = stack_id_stack.back()->get();
+		stack_identifiers = stack_id_stack.get_back();
 		stack_id_stack.pop_back();
 #ifdef DEBUG_ENABLED
 		if (!used_temporaries.is_empty()) {
@@ -206,7 +206,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 				sd.pos = E.value;
 				stack_debug.push_back(sd);
 			}
-			block_identifiers = block_identifier_stack.back()->get();
+			block_identifiers = block_identifier_stack.get_back();
 			block_identifier_stack.pop_back();
 		}
 	}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1065,7 +1065,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				/* Chain of gets */
 
 				// Get at (potential) root stack pos, so it can be returned.
-				GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, chain.back()->get()->base);
+				GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, chain.get_back()->base);
 				const bool base_known_type = base.type.has_type;
 				const bool base_is_shared = Variant::is_type_shared(base.type.builtin_type);
 

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -136,7 +136,7 @@ class GDScriptCompiler {
 		}
 
 		void end_block() {
-			locals = locals_stack.back()->get();
+			locals = locals_stack.get_back();
 			locals_stack.pop_back();
 			generator->end_block();
 		}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3699,17 +3699,17 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 
 		int ilevel = 0;
 		if (indent_stack.size()) {
-			ilevel = indent_stack.back()->get();
+			ilevel = indent_stack.get_back();
 		}
 
 		if (tc > ilevel) {
 			indent_stack.push_back(tc);
 		} else if (tc < ilevel) {
-			while (indent_stack.size() && indent_stack.back()->get() > tc) {
+			while (indent_stack.size() && indent_stack.get_back() > tc) {
 				indent_stack.pop_back();
 			}
 
-			if (indent_stack.size() && indent_stack.back()->get() != tc) {
+			if (indent_stack.size() && indent_stack.get_back() != tc) {
 				indent_stack.push_back(tc); // this is not right but gets the job done
 			}
 		}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -90,7 +90,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 		_GDFKCS spp;
 		spp.id = E.key;
 		spp.order = E.value.order;
-		spp.pos = E.value.pos.back()->get();
+		spp.pos = E.value.pos.get_back();
 		stackpositions.push_back(spp);
 	}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -270,7 +270,7 @@ void GDScriptParser::override_completion_context(const Node *p_for_node, Complet
 	context.node = p_node;
 	context.parser = this;
 	if (!completion_call_stack.is_empty()) {
-		context.call = completion_call_stack.back()->get();
+		context.call = completion_call_stack.get_back();
 	}
 	completion_context = context;
 }
@@ -292,7 +292,7 @@ void GDScriptParser::make_completion_context(CompletionType p_type, Node *p_node
 	context.node = p_node;
 	context.parser = this;
 	if (!completion_call_stack.is_empty()) {
-		context.call = completion_call_stack.back()->get();
+		context.call = completion_call_stack.get_back();
 	}
 	completion_context = context;
 }
@@ -313,7 +313,7 @@ void GDScriptParser::make_completion_context(CompletionType p_type, Variant::Typ
 	context.builtin_type = p_builtin_type;
 	context.parser = this;
 	if (!completion_call_stack.is_empty()) {
-		context.call = completion_call_stack.back()->get();
+		context.call = completion_call_stack.get_back();
 	}
 	completion_context = context;
 }
@@ -341,7 +341,7 @@ void GDScriptParser::set_last_completion_call_arg(int p_argument) {
 		return;
 	}
 	ERR_FAIL_COND_MSG(completion_call_stack.is_empty(), "Trying to set argument on empty completion call stack");
-	completion_call_stack.back()->get().argument = p_argument;
+	completion_call_stack.get_back().argument = p_argument;
 }
 
 Error GDScriptParser::parse(const String &p_source_code, const String &p_script_path, bool p_for_completion, bool p_parse_body) {
@@ -568,7 +568,7 @@ void GDScriptParser::push_multiline(bool p_state) {
 void GDScriptParser::pop_multiline() {
 	ERR_FAIL_COND_MSG(multiline_stack.is_empty(), "Parser bug: trying to pop from multiline stack without available value.");
 	multiline_stack.pop_back();
-	tokenizer->set_multiline_mode(multiline_stack.size() > 0 ? multiline_stack.back()->get() : false);
+	tokenizer->set_multiline_mode(multiline_stack.size() > 0 ? multiline_stack.get_back() : false);
 }
 
 bool GDScriptParser::is_statement_end_token() const {
@@ -944,7 +944,7 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)(b
 	// Consume annotations.
 	List<AnnotationNode *> annotations;
 	while (!annotation_stack.is_empty()) {
-		AnnotationNode *last_annotation = annotation_stack.back()->get();
+		AnnotationNode *last_annotation = annotation_stack.get_back();
 		if (last_annotation->applies_to(p_target)) {
 			annotations.push_front(last_annotation);
 			annotation_stack.pop_back();
@@ -1853,7 +1853,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 	List<AnnotationNode *> annotations;
 	if (current.type != GDScriptTokenizer::Token::ANNOTATION) {
 		while (!annotation_stack.is_empty()) {
-			AnnotationNode *last_annotation = annotation_stack.back()->get();
+			AnnotationNode *last_annotation = annotation_stack.get_back();
 			if (last_annotation->applies_to(AnnotationInfo::STATEMENT)) {
 				annotations.push_front(last_annotation);
 				annotation_stack.pop_back();
@@ -3518,7 +3518,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_lambda(ExpressionNode *p_p
 		function->identifier = parse_identifier();
 	}
 
-	bool multiline_context = multiline_stack.back()->get();
+	bool multiline_context = multiline_stack.get_back();
 
 	// Reset the multiline stack since we don't want the multiline mode one in the lambda body.
 	push_multiline(false);
@@ -5374,7 +5374,7 @@ bool GDScriptParser::DataType::can_reference(const GDScriptParser::DataType &p_o
 }
 
 void GDScriptParser::complete_extents(Node *p_node) {
-	while (!nodes_in_progress.is_empty() && nodes_in_progress.back()->get() != p_node) {
+	while (!nodes_in_progress.is_empty() && nodes_in_progress.get_back() != p_node) {
 		ERR_PRINT("Parser bug: Mismatch in extents tracking stack.");
 		nodes_in_progress.pop_back();
 	}

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -294,7 +294,7 @@ void GDScriptTokenizerText::push_expression_indented_block() {
 
 void GDScriptTokenizerText::pop_expression_indented_block() {
 	ERR_FAIL_COND(indent_stack_stack.is_empty());
-	indent_stack = indent_stack_stack.back()->get();
+	indent_stack = indent_stack_stack.get_back();
 	indent_stack_stack.pop_back();
 }
 
@@ -346,14 +346,14 @@ bool GDScriptTokenizerText::pop_paren(char32_t p_expected) {
 	if (paren_stack.is_empty()) {
 		return false;
 	}
-	char32_t actual = paren_stack.back()->get();
+	char32_t actual = paren_stack.get_back();
 	paren_stack.pop_back();
 
 	return actual == p_expected;
 }
 
 GDScriptTokenizer::Token GDScriptTokenizerText::pop_error() {
-	Token error = error_stack.back()->get();
+	Token error = error_stack.get_back();
 	error_stack.pop_back();
 	return error;
 }
@@ -449,7 +449,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_paren_error(char32_t p_pare
 	if (paren_stack.is_empty()) {
 		return make_error(vformat("Closing \"%c\" doesn't have an opening counterpart.", p_paren));
 	}
-	Token error = make_error(vformat("Closing \"%c\" doesn't match the opening \"%c\".", p_paren, paren_stack.back()->get()));
+	Token error = make_error(vformat("Closing \"%c\" doesn't match the opening \"%c\".", p_paren, paren_stack.get_back()));
 	paren_stack.pop_back(); // Remove opening one anyway.
 	return error;
 }
@@ -1299,7 +1299,7 @@ void GDScriptTokenizerText::check_indent() {
 		// Check if indent or dedent.
 		int previous_indent = 0;
 		if (indent_level() > 0) {
-			previous_indent = indent_stack.back()->get();
+			previous_indent = indent_stack.get_back();
 		}
 		if (indent_count == previous_indent) {
 			// No change in indentation.
@@ -1315,11 +1315,11 @@ void GDScriptTokenizerText::check_indent() {
 				push_error("Tokenizer bug: trying to dedent without previous indent.");
 				return;
 			}
-			while (indent_level() > 0 && indent_stack.back()->get() > indent_count) {
+			while (indent_level() > 0 && indent_stack.get_back() > indent_count) {
 				indent_stack.pop_back();
 				pending_indents--;
 			}
-			if ((indent_level() > 0 && indent_stack.back()->get() != indent_count) || (indent_level() == 0 && indent_count != 0)) {
+			if ((indent_level() > 0 && indent_stack.get_back() != indent_count) || (indent_level() == 0 && indent_count != 0)) {
 				// Mismatched indentation alignment.
 				Token error = make_error("Unindent doesn't match the previous indentation level.");
 				error.start_line = line;

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -410,7 +410,7 @@ void GDScriptTokenizerBuffer::push_expression_indented_block() {
 
 void GDScriptTokenizerBuffer::pop_expression_indented_block() {
 	ERR_FAIL_COND(indent_stack_stack.is_empty());
-	indent_stack = indent_stack_stack.back()->get();
+	indent_stack = indent_stack_stack.get_back();
 	indent_stack_stack.pop_back();
 }
 
@@ -461,7 +461,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::scan() {
 		if (!multiline_mode) {
 			uint32_t previous_indent = 0;
 			if (!indent_stack.is_empty()) {
-				previous_indent = indent_stack.back()->get();
+				previous_indent = indent_stack.get_back();
 			}
 			if (current_column - 1 > previous_indent) {
 				pending_indents++;
@@ -473,7 +473,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::scan() {
 					if (indent_stack.is_empty()) {
 						break;
 					}
-					previous_indent = indent_stack.back()->get();
+					previous_indent = indent_stack.get_back();
 				}
 			}
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -519,7 +519,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 	node_stack.push_back(p_func->body);
 
 	while (!node_stack.is_empty()) {
-		GDScriptParser::Node *node = node_stack.front()->get();
+		GDScriptParser::Node *node = node_stack.get_front();
 		node_stack.pop_front();
 
 		switch (node->type) {

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -425,8 +425,8 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 	params.load(p_params);
 	List<const LSP::DocumentSymbol *> symbols;
 	Array arr = find_symbols(params, symbols);
-	if (arr.is_empty() && !symbols.is_empty() && !symbols.front()->get()->native_class.is_empty()) { // Find a native symbol
-		const LSP::DocumentSymbol *symbol = symbols.front()->get();
+	if (arr.is_empty() && !symbols.is_empty() && !symbols.get_front()->native_class.is_empty()) { // Find a native symbol
+		const LSP::DocumentSymbol *symbol = symbols.get_front();
 		if (GDScriptLanguageProtocol::get_singleton()->is_goto_native_symbols_enabled()) {
 			String id;
 			switch (symbol->kind) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -223,7 +223,7 @@ void GDScriptWorkspace::reload_all_workspace_scripts() {
 			HashMap<String, ExtendGDScriptParser *>::Iterator S = parse_results.find(path);
 			String err_msg = "Failed parse script " + path;
 			if (S) {
-				err_msg += "\n" + S->value->get_errors().front()->get().message;
+				err_msg += "\n" + S->value->get_errors().get_front().message;
 			}
 			ERR_CONTINUE_MSG(err != OK, err_msg);
 		}

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -571,7 +571,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
 		if (!errors.is_empty()) {
 			// Only the first error since the following might be cascading.
-			result.output += errors.front()->get().message + "\n"; // TODO: line, column?
+			result.output += errors.get_front().message + "\n"; // TODO: line, column?
 		}
 		if (!p_is_generating) {
 			result.passed = check_output(result.output);

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -281,7 +281,7 @@ void test(TestType p_type) {
 		return;
 	}
 
-	String test = cmdlargs.back()->get();
+	String test = cmdlargs.get_back();
 	if (!test.ends_with(".gd") && !test.ends_with(".gdc")) {
 		print_line("This test expects a path to a GDScript file as its last parameter. Got: " + test);
 		return;

--- a/modules/gltf/skin_tool.cpp
+++ b/modules/gltf/skin_tool.cpp
@@ -565,7 +565,7 @@ Error SkinTool::_create_skeletons(
 		bones.sort();
 
 		while (!bones.is_empty()) {
-			const SkinNodeIndex node_i = bones.front()->get();
+			const SkinNodeIndex node_i = bones.get_front();
 			bones.pop_front();
 
 			Ref<GLTFNode> node = nodes[node_i];

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1097,8 +1097,8 @@ void GridMap::_update_octants_callback() {
 	}
 
 	while (to_delete.front()) {
-		memdelete(octant_map[to_delete.front()->get()]);
-		octant_map.erase(to_delete.front()->get());
+		memdelete(octant_map[to_delete.get_front()]);
+		octant_map.erase(to_delete.get_front());
 		to_delete.pop_front();
 	}
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2908,8 +2908,8 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 	StringBuilder default_args_doc;
 
-	// Retrieve information from the arguments
-	const ArgumentInterface &first = p_imethod.arguments.front()->get();
+	// Retrieve information from the arguments.
+	const List<ArgumentInterface>::Element *first = p_imethod.arguments.front();
 	for (const ArgumentInterface &iarg : p_imethod.arguments) {
 		const TypeInterface *arg_type = _get_type_or_singleton_or_null(iarg.type);
 		ERR_FAIL_NULL_V_MSG(arg_type, ERR_BUG, "Argument type '" + iarg.type.cname + "' was not found.");
@@ -2935,7 +2935,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		// Add the current arguments to the signature
 		// If the argument has a default value which is not a constant, we will make it Nullable
 		{
-			if (&iarg != &first) {
+			if (&iarg != &first->get()) {
 				arguments_sig += ", ";
 			}
 
@@ -3171,8 +3171,8 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output) {
 	String arguments_sig;
 
-	// Retrieve information from the arguments
-	const ArgumentInterface &first = p_isignal.arguments.front()->get();
+	// Retrieve information from the arguments.
+	const List<ArgumentInterface>::Element *first = p_isignal.arguments.front();
 	for (const ArgumentInterface &iarg : p_isignal.arguments) {
 		const TypeInterface *arg_type = _get_type_or_singleton_or_null(iarg.type);
 		ERR_FAIL_NULL_V_MSG(arg_type, ERR_BUG, "Argument type '" + iarg.type.cname + "' was not found.");
@@ -3188,7 +3188,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 
 		// Add the current arguments to the signature
 
-		if (&iarg != &first) {
+		if (&iarg != &first->get()) {
 			arguments_sig += ", ";
 		}
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -229,7 +229,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 		String tag = bbcode.substr(brk_pos + 1, brk_end - brk_pos - 1);
 
 		if (tag.begins_with("/")) {
-			bool tag_ok = tag_stack.size() && tag_stack.front()->get() == tag.substr(1);
+			bool tag_ok = tag_stack.size() && tag_stack.get_front() == tag.substr(1);
 
 			if (!tag_ok) {
 				output.append("]");
@@ -522,7 +522,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 		String tag = bbcode.substr(brk_pos + 1, brk_end - brk_pos - 1);
 
 		if (tag.begins_with("/")) {
-			bool tag_ok = tag_stack.size() && tag_stack.front()->get() == tag.substr(1);
+			bool tag_ok = tag_stack.size() && tag_stack.get_front() == tag.substr(1);
 
 			if (!tag_ok) {
 				if (!line_del) {
@@ -1434,7 +1434,7 @@ bool BindingsGenerator::_validate_api_type(const TypeInterface *p_target_itype, 
 int BindingsGenerator::_determine_enum_prefix(const EnumInterface &p_ienum) {
 	CRASH_COND(p_ienum.constants.is_empty());
 
-	const ConstantInterface &front_iconstant = p_ienum.constants.front()->get();
+	const ConstantInterface &front_iconstant = p_ienum.constants.get_front();
 	Vector<String> front_parts = front_iconstant.name.split("_", /* p_allow_empty: */ true);
 	int candidate_len = front_parts.size() - 1;
 
@@ -2268,7 +2268,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		output.append(" : long");
 		output.append(MEMBER_BEGIN OPEN_BLOCK);
 
-		const ConstantInterface &last = ienum.constants.back()->get();
+		const ConstantInterface &last = ienum.constants.get_back();
 		for (const ConstantInterface &iconstant : ienum.constants) {
 			if (iconstant.const_doc && iconstant.const_doc->description.size()) {
 				String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), &itype);
@@ -2730,7 +2730,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	}
 
 	if (getter && setter) {
-		const ArgumentInterface &setter_first_arg = setter->arguments.back()->get();
+		const ArgumentInterface &setter_first_arg = setter->arguments.get_back();
 		if (getter->return_type.cname != setter_first_arg.type.cname) {
 			// Special case for Node::set_name
 			bool whitelisted = getter->return_type.cname == name_cache.type_StringName &&
@@ -2742,7 +2742,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 		}
 	}
 
-	const TypeReference &proptype_name = getter ? getter->return_type : setter->arguments.back()->get().type;
+	const TypeReference &proptype_name = getter ? getter->return_type : setter->arguments.get_back().type;
 
 	const TypeInterface *prop_itype = _get_type_or_singleton_or_null(proptype_name);
 	ERR_FAIL_NULL_V_MSG(prop_itype, ERR_BUG, "Property type '" + proptype_name.cname + "' was not found.");
@@ -2806,7 +2806,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 		p_output.append("return ");
 		p_output.append(getter->proxy_name + "(");
 		if (p_iprop.index != -1) {
-			const ArgumentInterface &idx_arg = getter->arguments.front()->get();
+			const ArgumentInterface &idx_arg = getter->arguments.get_front();
 			if (idx_arg.type.cname != name_cache.type_int) {
 				// Assume the index parameter is an enum
 				const TypeInterface *idx_arg_type = _get_type_or_null(idx_arg.type);
@@ -2824,7 +2824,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 		p_output.append(setter->proxy_name + "(");
 		if (p_iprop.index != -1) {
-			const ArgumentInterface &idx_arg = setter->arguments.front()->get();
+			const ArgumentInterface &idx_arg = setter->arguments.get_front();
 			if (idx_arg.type.cname != name_cache.type_int) {
 				// Assume the index parameter is an enum
 				const TypeInterface *idx_arg_type = _get_type_or_null(idx_arg.type);
@@ -3868,7 +3868,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 	class_list.sort_custom<StringName::AlphCompare>();
 
 	while (class_list.size()) {
-		StringName type_cname = class_list.front()->get();
+		StringName type_cname = class_list.get_front();
 
 		ClassDB::APIType api_type = ClassDB::get_api_type(type_cname);
 

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -151,7 +151,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			directories.push_back(dir_access->get_current_dir());
 
 			while (!directories.is_empty()) {
-				dir_access->change_dir(directories.back()->get());
+				dir_access->change_dir(directories.get_back());
 				directories.pop_back();
 
 				dir_access->list_dir_begin();

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -239,7 +239,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		// Try to apply synchronizer Net ID
 		ERR_FAIL_COND_V_MSG(pending_sync_net_ids.is_empty(), ERR_INVALID_DATA, vformat("The MultiplayerSynchronizer at path \"%s\" is unable to process the pending spawn since it has no network ID. This might happen when changing the multiplayer authority during the \"_ready\" callback. Make sure to only change the authority of multiplayer synchronizers during \"_enter_tree\" or the \"_spawn_custom\" callback of their multiplayer spawner.", sync->get_path()));
 		ERR_FAIL_COND_V(!peers_info.has(pending_spawn_remote), ERR_INVALID_DATA);
-		uint32_t net_id = pending_sync_net_ids.front()->get();
+		uint32_t net_id = pending_sync_net_ids.get_front();
 		pending_sync_net_ids.pop_front();
 		peers_info[pending_spawn_remote].recv_sync_ids[net_id] = sync->get_instance_id();
 		sync->set_net_id(net_id);

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -74,7 +74,7 @@ void RemoteDebuggerPeerWebSocket::poll() {
 	}
 
 	while (ws_peer->get_ready_state() == WebSocketPeer::STATE_OPEN && out_queue.size() > 0) {
-		Array var = out_queue.front()->get();
+		Array var = out_queue.get_front();
 		Error err = ws_peer->put_var(var);
 		ERR_BREAK(err != OK); // Peer buffer full?
 		out_queue.pop_front();
@@ -92,7 +92,7 @@ bool RemoteDebuggerPeerWebSocket::has_message() {
 
 Array RemoteDebuggerPeerWebSocket::get_message() {
 	ERR_FAIL_COND_V(in_queue.is_empty(), Array());
-	Array msg = in_queue.front()->get();
+	Array msg = in_queue.get_front();
 	in_queue.pop_front();
 	return msg;
 }

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -127,7 +127,7 @@ Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buff
 
 	ERR_FAIL_COND_V(incoming_packets.is_empty(), ERR_UNAVAILABLE);
 
-	current_packet = incoming_packets.front()->get();
+	current_packet = incoming_packets.get_front();
 	incoming_packets.pop_front();
 
 	*r_buffer = current_packet.data;
@@ -167,7 +167,7 @@ void WebSocketMultiplayerPeer::set_target_peer(int p_target_peer) {
 int WebSocketMultiplayerPeer::get_packet_peer() const {
 	ERR_FAIL_COND_V(incoming_packets.is_empty(), 1);
 
-	return incoming_packets.front()->get().source;
+	return incoming_packets.get_front().source;
 }
 
 int WebSocketMultiplayerPeer::get_unique_id() const {

--- a/platform/ios/tts_ios.mm
+++ b/platform/ios/tts_ios.mm
@@ -73,7 +73,7 @@
 
 - (void)update {
 	if (!speaking && queue.size() > 0) {
-		DisplayServer::TTSUtterance &message = queue.front()->get();
+		DisplayServer::TTSUtterance &message = queue.get_front();
 
 		AVSpeechUtterance *new_utterance = [[AVSpeechUtterance alloc] initWithString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
 		[new_utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:[NSString stringWithUTF8String:message.voice.utf8().get_data()]]];

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -808,7 +808,7 @@ void FreeDesktopPortalDesktop::process_callbacks() {
 	{
 		MutexLock lock(file_dialog_mutex);
 		while (!pending_file_cbs.is_empty()) {
-			FileDialogCallback cb = pending_file_cbs.front()->get();
+			FileDialogCallback cb = pending_file_cbs.get_front();
 			pending_file_cbs.pop_front();
 
 			if (cb.opt_in_cb) {
@@ -835,7 +835,7 @@ void FreeDesktopPortalDesktop::process_callbacks() {
 	{
 		MutexLock lock(color_picker_mutex);
 		while (!pending_color_cbs.is_empty()) {
-			ColorPickerCallback cb = pending_color_cbs.front()->get();
+			ColorPickerCallback cb = pending_color_cbs.get_front();
 			pending_color_cbs.pop_front();
 
 			Variant ret;

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -136,7 +136,7 @@ void TTS_Linux::_speech_event(int p_msg_id, int p_type) {
 		}
 	}
 	if (!speaking && queue.size() > 0) {
-		DisplayServer::TTSUtterance &message = queue.front()->get();
+		DisplayServer::TTSUtterance &message = queue.get_front();
 
 		// Inject index mark after each word.
 		String text;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -108,7 +108,7 @@ void DisplayServerWayland::_dispatch_input_event(const Ref<InputEvent> &p_event)
 		Ref<InputEventKey> key_event = p_event;
 		if (!popup_menu_list.is_empty() && key_event.is_valid()) {
 			// Redirect to the highest popup menu.
-			window_id = popup_menu_list.back()->get();
+			window_id = popup_menu_list.get_back();
 		}
 
 		// Send to a single window.
@@ -850,15 +850,15 @@ void DisplayServerWayland::delete_sub_window(WindowID p_window_id) {
 	}
 
 	// The XDG shell specification requires us to clear all popups in reverse order.
-	while (!root_wd.popup_stack.is_empty() && root_wd.popup_stack.back()->get() != p_window_id) {
-		_send_window_event(WINDOW_EVENT_FORCE_CLOSE, root_wd.popup_stack.back()->get());
+	while (!root_wd.popup_stack.is_empty() && root_wd.popup_stack.get_back() != p_window_id) {
+		_send_window_event(WINDOW_EVENT_FORCE_CLOSE, root_wd.popup_stack.get_back());
 	}
 
-	if (root_wd.popup_stack.back() && root_wd.popup_stack.back()->get() == p_window_id) {
+	if (root_wd.popup_stack.back() && root_wd.popup_stack.get_back() == p_window_id) {
 		root_wd.popup_stack.pop_back();
 	}
 
-	if (popup_menu_list.back() && popup_menu_list.back()->get() == p_window_id) {
+	if (popup_menu_list.back() && popup_menu_list.get_back() == p_window_id) {
 		popup_menu_list.pop_back();
 	}
 
@@ -897,7 +897,7 @@ DisplayServer::WindowID DisplayServerWayland::window_get_active_popup() const {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	if (!popup_menu_list.is_empty()) {
-		return popup_menu_list.back()->get();
+		return popup_menu_list.get_back();
 	}
 
 	return INVALID_WINDOW_ID;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3411,7 +3411,7 @@ bool WaylandThread::has_message() {
 
 Ref<WaylandThread::Message> WaylandThread::pop_message() {
 	if (messages.front() != nullptr) {
-		Ref<Message> msg = messages.front()->get();
+		Ref<Message> msg = messages.get_front();
 		messages.pop_front();
 		return msg;
 	}

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -119,7 +119,7 @@
 
 - (void)update {
 	if (!speaking && queue.size() > 0) {
-		DisplayServer::TTSUtterance &message = queue.front()->get();
+		DisplayServer::TTSUtterance &message = queue.get_front();
 
 		if (@available(macOS 10.14, *)) {
 			AVSpeechSynthesizer *av_synth = synth;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -809,7 +809,7 @@ Error DisplayServerWindows::_file_dialog_with_options_show(const String &p_title
 void DisplayServerWindows::process_file_dialog_callbacks() {
 	MutexLock lock(file_dialog_mutex);
 	while (!pending_cbs.is_empty()) {
-		FileDialogCallback cb = pending_cbs.front()->get();
+		FileDialogCallback cb = pending_cbs.get_front();
 		pending_cbs.pop_front();
 
 		if (cb.opt_in_cb) {

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -62,7 +62,7 @@ void __stdcall TTS_Windows::speech_event_callback(WPARAM wParam, LPARAM lParam) 
 
 void TTS_Windows::process_events() {
 	if (update_requested && !paused && queue.size() > 0 && !is_speaking()) {
-		DisplayServer::TTSUtterance &message = queue.front()->get();
+		DisplayServer::TTSUtterance &message = queue.get_front();
 
 		String text;
 		DWORD flags = SPF_ASYNC | SPF_PURGEBEFORESPEAK | SPF_IS_XML;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -317,7 +317,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
-				set_animation(al.front()->get());
+				set_animation(al.get_front());
 			}
 			if (!frames->has_animation(autoplay)) {
 				autoplay = String();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1191,7 +1191,7 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
-				set_animation(al.front()->get());
+				set_animation(al.get_front());
 			}
 			if (!frames->has_animation(autoplay)) {
 				autoplay = String();

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -178,7 +178,7 @@ void AnimationMixer::_animation_set_cache_update() {
 	}
 
 	while (to_erase.size()) {
-		animation_set.erase(to_erase.front()->get());
+		animation_set.erase(to_erase.get_front());
 		to_erase.pop_front();
 	}
 
@@ -944,7 +944,7 @@ bool AnimationMixer::_update_caches() {
 	}
 
 	while (to_delete.front()) {
-		Animation::TypeHash thash = to_delete.front()->get();
+		Animation::TypeHash thash = to_delete.get_front();
 		memdelete(track_cache[thash]);
 		track_cache.erase(thash);
 		to_delete.pop_front();
@@ -1709,7 +1709,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						List<int> to_play;
 						a->track_get_key_indices_in_range(i, time, delta, &to_play, looped_flag);
 						if (to_play.size()) {
-							idx = to_play.back()->get();
+							idx = to_play.get_back();
 						}
 					}
 					if (idx < 0) {
@@ -1824,7 +1824,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						List<int> to_play;
 						a->track_get_key_indices_in_range(i, time, delta, &to_play, looped_flag);
 						if (to_play.size()) {
-							int idx = to_play.back()->get();
+							int idx = to_play.get_back();
 							StringName anim_name = a->animation_track_get_key_animation(i, idx);
 							if (String(anim_name) == "[stop]" || !player2->has_animation(anim_name)) {
 								if (playing_caches.has(t)) {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -110,7 +110,7 @@ protected:
 		get_animation_list(&animations);
 		Vector<String> ret;
 		while (animations.size()) {
-			ret.push_back(animations.front()->get());
+			ret.push_back(animations.get_front());
 			animations.pop_front();
 		}
 		return ret;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -333,7 +333,7 @@ void AnimationPlayer::_blend_post_process() {
 		if (tmp_from == playback.current.from->animation->get_instance_id()) {
 			if (playback_queue.size()) {
 				String old = playback.assigned;
-				play(playback_queue.front()->get());
+				play(playback_queue.get_front());
 				String new_name = playback.assigned;
 				playback_queue.pop_front();
 				if (end_notify) {
@@ -904,7 +904,7 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 	}
 
 	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
+		blend_times.erase(to_erase.get_front());
 		to_erase.pop_front();
 	}
 }
@@ -935,7 +935,7 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 	}
 
 	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
+		blend_times.erase(to_erase.get_front());
 		to_erase.pop_front();
 	}
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -690,7 +690,7 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 	const StringName &is_visible_sn = SNAME("is_visible");
 	const StringName &is_visible_in_tree_sn = SNAME("is_visible_in_tree");
 	while (stack.size()) {
-		Node *n = stack.front()->get();
+		Node *n = stack.get_front();
 		stack.pop_front();
 
 		int count = n->get_child_count();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -890,7 +890,7 @@ void FileDialog::update_file_list() {
 	}
 
 	while (!dirs.is_empty()) {
-		const String &dir_name = dirs.front()->get();
+		const String &dir_name = dirs.get_front();
 
 		bool bundle = dir_access->is_bundle(dir_name);
 		bool found = true;
@@ -930,19 +930,19 @@ void FileDialog::update_file_list() {
 		String match_str;
 
 		for (const String &E : patterns) {
-			if (files.front()->get().matchn(E)) {
+			if (files.get_front().matchn(E)) {
 				match_str = E;
 				match = true;
 				break;
 			}
 		}
 
-		if (match && (filename_filter_lower.is_empty() || files.front()->get().to_lower().contains(filename_filter_lower))) {
+		if (match && (filename_filter_lower.is_empty() || files.get_front().to_lower().contains(filename_filter_lower))) {
 			TreeItem *ti = tree->create_item(root);
-			ti->set_text(0, files.front()->get());
+			ti->set_text(0, files.get_front());
 
 			if (get_icon_func) {
-				Ref<Texture2D> icon = get_icon_func(base_dir.path_join(files.front()->get()));
+				Ref<Texture2D> icon = get_icon_func(base_dir.path_join(files.get_front()));
 				ti->set_icon(0, icon);
 			} else {
 				ti->set_icon(0, theme_cache.file);
@@ -954,12 +954,12 @@ void FileDialog::update_file_list() {
 				ti->set_selectable(0, false);
 			}
 			Dictionary d;
-			d["name"] = files.front()->get();
+			d["name"] = files.get_front();
 			d["dir"] = false;
 			d["bundle"] = false;
 			ti->set_metadata(0, d);
 
-			if (file->get_text() == files.front()->get() || match_str == files.front()->get()) {
+			if (file->get_text() == files.get_front() || match_str == files.get_front()) {
 				ti->select(0);
 			}
 		}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -536,7 +536,7 @@ void GraphEdit::_ensure_node_order_from(Node *p_node) {
 	attached_nodes_to_move.push_back(frame);
 
 	while (!attached_nodes_to_move.is_empty()) {
-		GraphFrame *attached_frame = attached_nodes_to_move.front()->get();
+		GraphFrame *attached_frame = attached_nodes_to_move.get_front();
 		attached_nodes_to_move.pop_front();
 
 		// Move the frame to the front of the background node index range.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -64,7 +64,7 @@ RichTextLabel::Item *RichTextLabel::_get_next_item(Item *p_item, bool p_free) co
 	}
 	if (p_free) {
 		if (p_item->subitems.size()) {
-			return p_item->subitems.front()->get();
+			return p_item->subitems.get_front();
 		} else if (!p_item->parent) {
 			return nullptr;
 		} else if (p_item->E->next()) {
@@ -84,7 +84,7 @@ RichTextLabel::Item *RichTextLabel::_get_next_item(Item *p_item, bool p_free) co
 
 	} else {
 		if (p_item->subitems.size() && p_item->type != ITEM_TABLE) {
-			return p_item->subitems.front()->get();
+			return p_item->subitems.get_front();
 		} else if (p_item->type == ITEM_FRAME) {
 			return nullptr;
 		} else if (p_item->E->next()) {
@@ -114,7 +114,7 @@ RichTextLabel::Item *RichTextLabel::_get_prev_item(Item *p_item, bool p_free) co
 		} else if (p_item->E->prev()) {
 			p_item = p_item->E->prev()->get();
 			while (p_item->subitems.size()) {
-				p_item = p_item->subitems.back()->get();
+				p_item = p_item->subitems.get_back();
 			}
 			return p_item;
 		} else {
@@ -131,7 +131,7 @@ RichTextLabel::Item *RichTextLabel::_get_prev_item(Item *p_item, bool p_free) co
 		} else if (p_item->E->prev()) {
 			p_item = p_item->E->prev()->get();
 			while (p_item->subitems.size() && p_item->type != ITEM_TABLE) {
-				p_item = p_item->subitems.back()->get();
+				p_item = p_item->subitems.get_back();
 			}
 			return p_item;
 		} else {
@@ -3798,9 +3798,9 @@ void RichTextLabel::add_text(const String &p_text) {
 		}
 
 		if (line.length() > 0) {
-			if (current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT) {
+			if (current->subitems.size() && current->subitems.get_back()->type == ITEM_TEXT) {
 				//append text condition!
-				ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
+				ItemText *ti = static_cast<ItemText *>(current->subitems.get_back());
 				ti->text += line;
 				_invalidate_current_line(main);
 
@@ -5059,15 +5059,15 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 		}
 
 		if (tag.begins_with("/") && tag_stack.size()) {
-			bool tag_ok = tag_stack.size() && tag_stack.front()->get() == tag.substr(1);
+			bool tag_ok = tag_stack.size() && tag_stack.get_front() == tag.substr(1);
 
-			if (tag_stack.front()->get() == "b") {
+			if (tag_stack.get_front() == "b") {
 				in_bold = false;
 			}
-			if (tag_stack.front()->get() == "i") {
+			if (tag_stack.get_front() == "i") {
 				in_italics = false;
 			}
-			if ((tag_stack.front()->get() == "indent") || (tag_stack.front()->get() == "ol") || (tag_stack.front()->get() == "ul")) {
+			if ((tag_stack.get_front() == "indent") || (tag_stack.get_front() == "ol") || (tag_stack.get_front() == "ul")) {
 				current_frame->indent_level--;
 			}
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -200,7 +200,7 @@ private:
 		void _clear_children() {
 			RichTextLabel *owner_rtl = ObjectDB::get_instance<RichTextLabel>(owner);
 			while (subitems.size()) {
-				Item *subitem = subitems.front()->get();
+				Item *subitem = subitems.get_front();
 				if (subitem && subitem->rid.is_valid() && owner_rtl) {
 					owner_rtl->items.free(subitem->rid);
 				}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4493,13 +4493,13 @@ void TextEdit::end_complex_operation() {
 		return;
 	}
 
-	undo_stack.back()->get().end_carets = carets;
-	if (undo_stack.back()->get().chain_forward) {
-		undo_stack.back()->get().chain_forward = false;
+	undo_stack.get_back().end_carets = carets;
+	if (undo_stack.get_back().chain_forward) {
+		undo_stack.get_back().chain_forward = false;
 		return;
 	}
 
-	undo_stack.back()->get().chain_backward = true;
+	undo_stack.get_back().chain_backward = true;
 }
 
 bool TextEdit::has_undo() const {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -335,7 +335,7 @@ void Node::_notification(int p_notification) {
 			}
 
 			while (!data.owned.is_empty()) {
-				Node *n = data.owned.back()->get();
+				Node *n = data.owned.get_back();
 				n->_clean_up_owner(); // This will change data.owned. So it's impossible to loop over the list in the usual manner.
 			}
 
@@ -3229,7 +3229,7 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 	List<const Node *> process_list;
 	process_list.push_back(this);
 	while (!process_list.is_empty()) {
-		const Node *n = process_list.front()->get();
+		const Node *n = process_list.get_front();
 		process_list.pop_front();
 
 		List<Connection> conns;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1576,7 +1576,7 @@ void SceneTree::_flush_delete_queue() {
 	_THREAD_SAFE_METHOD_
 
 	while (delete_queue.size()) {
-		Object *obj = ObjectDB::get_instance(delete_queue.front()->get());
+		Object *obj = ObjectDB::get_instance(delete_queue.get_front());
 		if (obj) {
 			memdelete(obj);
 		}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -795,7 +795,7 @@ void Viewport::_process_picking() {
 			vp->local_input_handled = false;
 		}
 
-		Ref<InputEvent> ev = physics_picking_events.front()->get();
+		Ref<InputEvent> ev = physics_picking_events.get_front();
 		physics_picking_events.pop_front();
 
 		Vector2 pos;
@@ -4173,7 +4173,7 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 	}
 
 	while (to_erase.size()) {
-		physics_2d_mouseover.erase(to_erase.front()->get());
+		physics_2d_mouseover.erase(to_erase.get_front());
 		to_erase.pop_front();
 	}
 
@@ -4200,19 +4200,19 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 	}
 
 	while (shapes_to_erase.size()) {
-		physics_2d_shape_mouseover.erase(shapes_to_erase.front()->get());
+		physics_2d_shape_mouseover.erase(shapes_to_erase.get_front());
 		shapes_to_erase.pop_front();
 	}
 
 	while (to_mouse_exit.size()) {
-		Object *o = ObjectDB::get_instance(to_mouse_exit.front()->get());
+		Object *o = ObjectDB::get_instance(to_mouse_exit.get_front());
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 		co->_mouse_exit();
 		to_mouse_exit.pop_front();
 	}
 
 	while (shapes_to_mouse_exit.size()) {
-		Pair<ObjectID, int> e = shapes_to_mouse_exit.front()->get();
+		Pair<ObjectID, int> e = shapes_to_mouse_exit.get_front();
 		Object *o = ObjectDB::get_instance(e.first);
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 		co->_mouse_shape_exit(e.second);

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -194,7 +194,7 @@ void SkeletonModification2DPhysicalBones::fetch_physical_bones() {
 	node_queue.push_back(stack->skeleton);
 
 	while (node_queue.size() > 0) {
-		Node *node_to_process = node_queue.front()->get();
+		Node *node_to_process = node_queue.get_front();
 		node_queue.pop_front();
 
 		if (node_to_process != nullptr) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -615,7 +615,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	//remove nodes that could not be added, likely as a result that
 	while (stray_instances.size()) {
-		memdelete(stray_instances.front()->get());
+		memdelete(stray_instances.get_front());
 		stray_instances.pop_front();
 	}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1149,7 +1149,7 @@ bool VisualShader::_check_reroute_subgraph(Type p_type, int p_target_port_type, 
 		r_visited_reroute_nodes->push_back(p_reroute_node);
 	}
 	while (!queue.is_empty()) {
-		int current_node_id = queue.front()->get();
+		int current_node_id = queue.get_front();
 		VisualShader::Node current_node = g->nodes[current_node_id];
 		queue.pop_front();
 		for (const int &next_node_id : current_node.next_connected_nodes) {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -896,7 +896,7 @@ ShaderRD::~ShaderRD() {
 	if (remaining.size()) {
 		ERR_PRINT(itos(remaining.size()) + " shaders of type " + name + " were never freed");
 		while (remaining.size()) {
-			version_free(remaining.front()->get());
+			version_free(remaining.get_front());
 			remaining.pop_front();
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1065,7 +1065,7 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 		}
 
 		while (to_delete.front()) {
-			used_global_textures.erase(to_delete.front()->get());
+			used_global_textures.erase(to_delete.get_front());
 			to_delete.pop_front();
 		}
 		//handle registering/unregistering global textures

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -106,7 +106,7 @@ Vector<RendererViewport::Viewport *> RendererViewport::_sort_active_viewports() 
 	}
 
 	while (!nodes.is_empty()) {
-		const Viewport *node = nodes.front()->get();
+		const Viewport *node = nodes.get_front();
 		nodes.pop_front();
 
 		for (int i = active_viewports.size() - 1; i >= 0; --i) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6274,7 +6274,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 	// Free in dependency usage order, so nothing weird happens.
 	// Pipelines.
 	while (frames[p_frame].render_pipelines_to_dispose_of.front()) {
-		RenderPipeline *pipeline = &frames[p_frame].render_pipelines_to_dispose_of.front()->get();
+		RenderPipeline *pipeline = &frames[p_frame].render_pipelines_to_dispose_of.get_front();
 
 		driver->pipeline_free(pipeline->driver_id);
 
@@ -6282,7 +6282,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 	}
 
 	while (frames[p_frame].compute_pipelines_to_dispose_of.front()) {
-		ComputePipeline *pipeline = &frames[p_frame].compute_pipelines_to_dispose_of.front()->get();
+		ComputePipeline *pipeline = &frames[p_frame].compute_pipelines_to_dispose_of.get_front();
 
 		driver->pipeline_free(pipeline->driver_id);
 
@@ -6291,7 +6291,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	// Uniform sets.
 	while (frames[p_frame].uniform_sets_to_dispose_of.front()) {
-		UniformSet *uniform_set = &frames[p_frame].uniform_sets_to_dispose_of.front()->get();
+		UniformSet *uniform_set = &frames[p_frame].uniform_sets_to_dispose_of.get_front();
 
 		driver->uniform_set_free(uniform_set->driver_id);
 
@@ -6300,7 +6300,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	// Shaders.
 	while (frames[p_frame].shaders_to_dispose_of.front()) {
-		Shader *shader = &frames[p_frame].shaders_to_dispose_of.front()->get();
+		Shader *shader = &frames[p_frame].shaders_to_dispose_of.get_front();
 
 		driver->shader_free(shader->driver_id);
 
@@ -6309,7 +6309,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	// Samplers.
 	while (frames[p_frame].samplers_to_dispose_of.front()) {
-		RDD::SamplerID sampler = frames[p_frame].samplers_to_dispose_of.front()->get();
+		RDD::SamplerID sampler = frames[p_frame].samplers_to_dispose_of.get_front();
 
 		driver->sampler_free(sampler);
 
@@ -6318,14 +6318,14 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	// Framebuffers.
 	while (frames[p_frame].framebuffers_to_dispose_of.front()) {
-		Framebuffer *framebuffer = &frames[p_frame].framebuffers_to_dispose_of.front()->get();
+		Framebuffer *framebuffer = &frames[p_frame].framebuffers_to_dispose_of.get_front();
 		draw_graph.framebuffer_cache_free(driver, framebuffer->framebuffer_cache);
 		frames[p_frame].framebuffers_to_dispose_of.pop_front();
 	}
 
 	// Textures.
 	while (frames[p_frame].textures_to_dispose_of.front()) {
-		Texture *texture = &frames[p_frame].textures_to_dispose_of.front()->get();
+		Texture *texture = &frames[p_frame].textures_to_dispose_of.get_front();
 		if (texture->bound) {
 			WARN_PRINT("Deleted a texture while it was bound.");
 		}
@@ -6340,7 +6340,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	// Buffers.
 	while (frames[p_frame].buffers_to_dispose_of.front()) {
-		Buffer &buffer = frames[p_frame].buffers_to_dispose_of.front()->get();
+		Buffer &buffer = frames[p_frame].buffers_to_dispose_of.get_front();
 		driver->buffer_free(buffer.driver_id);
 		buffer_memory -= buffer.size;
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -182,7 +182,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 void RenderingServerDefault::_run_post_draw_steps() {
 	while (frame_drawn_callbacks.front()) {
-		Callable c = frame_drawn_callbacks.front()->get();
+		Callable c = frame_drawn_callbacks.get_front();
 		Variant result;
 		Callable::CallError ce;
 		c.callp(nullptr, 0, result, ce);

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -96,8 +96,8 @@ public:
 		}
 
 		while (to_clean_up.size()) {
-			to_clean_up.front()->get().first->instances.erase(to_clean_up.front()->get().second);
-			dependencies.erase(to_clean_up.front()->get().first);
+			to_clean_up.get_front().first->instances.erase(to_clean_up.get_front().second);
+			dependencies.erase(to_clean_up.get_front().first);
 			to_clean_up.pop_front();
 		}
 	}

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -357,7 +357,7 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 	}
 
 	if (getter && setter) {
-		const ArgumentData &setter_first_arg = setter->arguments.back()->get();
+		const ArgumentData &setter_first_arg = setter->arguments.get_back();
 		if (getter->return_type.name != setter_first_arg.type.name) {
 			// Special case for Node::set_name
 			bool whitelisted = getter->return_type.name == p_context.names_cache.string_name_type &&
@@ -368,7 +368,7 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 		}
 	}
 
-	const TypeReference &prop_type_ref = getter ? getter->return_type : setter->arguments.back()->get().type;
+	const TypeReference &prop_type_ref = getter ? getter->return_type : setter->arguments.get_back().type;
 
 	const ExposedClass *prop_class = p_context.find_exposed_class(prop_type_ref);
 	if (prop_class) {
@@ -388,7 +388,7 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 
 	if (getter) {
 		if (p_prop.index != -1) {
-			const ArgumentData &idx_arg = getter->arguments.front()->get();
+			const ArgumentData &idx_arg = getter->arguments.get_front();
 			if (idx_arg.type.name != p_context.names_cache.int_type) {
 				// If not an int, it can be an enum
 				TEST_COND(!p_context.enum_types.has(idx_arg.type.name),
@@ -399,7 +399,7 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 
 	if (setter) {
 		if (p_prop.index != -1) {
-			const ArgumentData &idx_arg = setter->arguments.front()->get();
+			const ArgumentData &idx_arg = setter->arguments.get_front();
 			if (idx_arg.type.name != p_context.names_cache.int_type) {
 				// Assume the index parameter is an enum
 				// If not an int, it can be an enum
@@ -525,7 +525,7 @@ void add_exposed_classes(Context &r_context) {
 	class_list.sort_custom<StringName::AlphCompare>();
 
 	while (class_list.size()) {
-		StringName class_name = class_list.front()->get();
+		StringName class_name = class_list.get_front();
 
 		ClassDB::APIType api_type = ClassDB::get_api_type(class_name);
 


### PR DESCRIPTION
This also catches some cases of apparently unsafe use, see the change to pointers in `modules/mono/editor/bindings_generator.cpp`

Second commit includes cases that were subscript access before https://github.com/godotengine/godot/pull/90705, which already has checks so suffer no performance concerns they didn't already 

Third commit is remaining uses, which are the ones that might be problematic for performance, and are fully optional

See https://github.com/godotengine/godot/pull/90705#discussion_r1589985336
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
