### PR TITLE
Fix various typos with codespell

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -95,5 +95,5 @@ jobs:
         uses: codespell-project/actions-codespell@v2
         with:
           skip: "./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
-          ignore_words_list: "breaked,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,vai"
+          ignore_words_list: "breaked,colour,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,thirdparty,vai"
           path: ${{ env.CHANGED_FILES }}

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2875,7 +2875,7 @@ typedef void (*GDExtensionInterfaceEditorRemovePlugin)(GDExtensionConstStringNam
  *
  * The provided pointer can be immediately freed once the function returns.
  *
- * @param p_data A pointer to an UTF-8 encoded C string (null terminated).
+ * @param p_data A pointer to a UTF-8 encoded C string (null terminated).
  */
 typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *p_data);
 
@@ -2887,7 +2887,7 @@ typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *
  *
  * The provided pointer can be immediately freed once the function returns.
  *
- * @param p_data A pointer to an UTF-8 encoded C string.
+ * @param p_data A pointer to a UTF-8 encoded C string.
  * @param p_size The number of bytes (not code units).
  */
 typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);

--- a/doc/classes/Compositor.xml
+++ b/doc/classes/Compositor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Compositor" inherits="Resource" experimental="More customisation of the rendering pipeline will be added in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="Compositor" inherits="Resource" experimental="More customization of the rendering pipeline will be added in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Stores attributes used to customize how a Viewport is rendered.
 	</brief_description>

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -30,7 +30,7 @@
 		[/codeblock]
 		Node paths cannot check whether they are valid and may point to nodes or properties that do not exist. Their meaning depends entirely on the context in which they're used.
 		You usually do not have to worry about the [NodePath] type, as strings are automatically converted to the type when necessary. There are still times when defining node paths is useful. For example, exported [NodePath] properties allow you to easily select any node within the currently edited scene. They are also automatically updated when moving, renaming or deleting nodes in the scene tree editor. See also [annotation @GDScript.@export_node_path].
-		See also [StringName], which is a similar type designed for optimised strings.
+		See also [StringName], which is a similar type designed for optimized strings.
 		[b]Note:[/b] In a boolean context, a [NodePath] will evaluate to [code]false[/code] if it is empty ([code]NodePath("")[/code]). Otherwise, a [NodePath] will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -634,7 +634,7 @@
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
 				Transforms both the current and previous stored transform for a canvas item.
-				This allows transforming a canvas item without creating a "glitch" in the interpolation, which is particularly useful for large worlds utilising a shifting origin.
+				This allows transforming a canvas item without creating a "glitch" in the interpolation, which is particularly useful for large worlds utilizing a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_light_attach_to_canvas">
@@ -730,7 +730,7 @@
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
 				Transforms both the current and previous stored transform for a light occluder.
-				This allows transforming an occluder without creating a "glitch" in the interpolation, which is particularly useful for large worlds utilising a shifting origin.
+				This allows transforming an occluder without creating a "glitch" in the interpolation, which is particularly useful for large worlds utilizing a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_light_reset_physics_interpolation">
@@ -901,7 +901,7 @@
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
 				Transforms both the current and previous stored transform for a canvas light.
-				This allows transforming a light without creating a "glitch" in the interpolation, which is is particularly useful for large worlds utilising a shifting origin.
+				This allows transforming a light without creating a "glitch" in the interpolation, which is is particularly useful for large worlds utilizing a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_occluder_polygon_create">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -188,7 +188,7 @@
 			<return type="int" />
 			<param index="0" name="to" type="String" />
 			<description>
-				Like [method naturalcasecmp_to] but prioritises strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
+				Like [method naturalcasecmp_to] but prioritizes strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method filenocasecmp_to], [method naturalcasecmp_to], and [method casecmp_to].
 			</description>
 		</method>
@@ -196,7 +196,7 @@
 			<return type="int" />
 			<param index="0" name="to" type="String" />
 			<description>
-				Like [method naturalnocasecmp_to] but prioritises strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
+				Like [method naturalnocasecmp_to] but prioritizes strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method filecasecmp_to], [method naturalnocasecmp_to], and [method nocasecmp_to].
 			</description>
 		</method>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -172,7 +172,7 @@
 			<return type="int" />
 			<param index="0" name="to" type="String" />
 			<description>
-				Like [method naturalcasecmp_to] but prioritises strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
+				Like [method naturalcasecmp_to] but prioritizes strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method filenocasecmp_to], [method naturalcasecmp_to], and [method casecmp_to].
 			</description>
 		</method>
@@ -180,7 +180,7 @@
 			<return type="int" />
 			<param index="0" name="to" type="String" />
 			<description>
-				Like [method naturalnocasecmp_to] but prioritises strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
+				Like [method naturalnocasecmp_to] but prioritizes strings that begin with periods ([code].[/code]) and underscores ([code]_[/code]) before any other character. Useful when sorting folders or file names.
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method filecasecmp_to], [method naturalnocasecmp_to], and [method nocasecmp_to].
 			</description>
 		</method>

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -110,7 +110,7 @@ public:
 	void free_render_buffer_data();
 
 	void check_backbuffer(bool p_need_color, bool p_need_depth); // Check if we need to initialize our backbuffer.
-	void check_glow_buffers(); // Check if we need to initialise our glow buffers.
+	void check_glow_buffers(); // Check if we need to initialize our glow buffers.
 
 	GLuint get_render_fbo();
 	GLuint get_msaa3d_fbo() {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7001,7 +7001,7 @@ void AnimationTrackEditor::_auto_fit_bezier() {
 
 void AnimationTrackEditor::_selection_changed() {
 	if (selected_filter->is_pressed()) {
-		_update_tracks(); // Needs updatin.
+		_update_tracks(); // Needs updating.
 	} else {
 		_redraw_tracks();
 		_redraw_groups();

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -401,24 +401,24 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 		bool smooth = false;
 
 		if (i < len - 1) {
-			Vector2 pointout = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
-			if (point != pointout) {
+			Vector2 point_out = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
+			if (point != point_out) {
 				smooth = true;
 				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, pointout, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, pointout, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(pointout - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				vpc->draw_line(point, point_out, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
+				vpc->draw_line(point, point_out, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
+				vpc->draw_texture_rect(curve_handle, Rect2(point_out - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
 			}
 		}
 
 		if (i > 0) {
-			Vector2 pointin = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
-			if (point != pointin) {
+			Vector2 point_in = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
+			if (point != point_in) {
 				smooth = true;
 				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, pointin, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, pointin, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(pointin - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				vpc->draw_line(point, point_in, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
+				vpc->draw_line(point, point_in, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
+				vpc->draw_texture_rect(curve_handle, Rect2(point_in - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
 			}
 		}
 

--- a/misc/scripts/codespell.sh
+++ b/misc/scripts/codespell.sh
@@ -3,6 +3,6 @@ SKIP_LIST="./.*,./**/.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./A
 SKIP_LIST+="./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/renames_map_3_to_4.cpp,./misc/scripts/codespell.sh,"
 SKIP_LIST+="./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json,"
 
-IGNORE_LIST="breaked,cancelled,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,vai"
+IGNORE_LIST="breaked,cancelled,colour,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,thirdparty,vai"
 
 codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}" --builtin "clear,rare,en-GB_to_en-US"

--- a/modules/gdscript/tests/scripts/runtime/features/argument_count.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/argument_count.gd
@@ -57,7 +57,7 @@ func test():
     var lambda_callable_2 : Callable = func(_foo, _bar, _baz): pass
     print(lambda_callable_2.get_argument_count()) # Should print 3.
 
-    # Test lambas with self.
+    # Test lambdas with self.
     var lambda_self_callable_1 : Callable = func(_foo, _bar): return self
     print(lambda_self_callable_1.get_argument_count()) # Should print 2.
     var lambda_self_callable_2 : Callable = func(_foo, _bar, _baz): return self

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1694,7 +1694,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-16 encoded array of bytes.
+        /// Converts the string (which is an array of characters) to a UTF-16 encoded array of bytes.
         /// </summary>
         /// <seealso cref="ToAsciiBuffer(string)"/>
         /// <seealso cref="ToUtf32Buffer(string)"/>
@@ -1707,7 +1707,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-32 encoded array of bytes.
+        /// Converts the string (which is an array of characters) to a UTF-32 encoded array of bytes.
         /// </summary>
         /// <seealso cref="ToAsciiBuffer(string)"/>
         /// <seealso cref="ToUtf16Buffer(string)"/>
@@ -1720,7 +1720,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-8 encoded array of bytes.
+        /// Converts the string (which is an array of characters) to a UTF-8 encoded array of bytes.
         /// The conversion is a bit slower than <see cref="ToAsciiBuffer(string)"/>,
         /// but supports all UTF-8 characters. Therefore, you should prefer this function
         /// over <see cref="ToAsciiBuffer(string)"/>.

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -187,7 +187,7 @@ void OpenXRViewportCompositionLayerProvider::on_pre_render() {
 
 XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_composition_layer() {
 	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
-		// OpenXR not initialised or we're in the editor?
+		// OpenXR not initialized or we're in the editor?
 		return nullptr;
 	}
 
@@ -260,7 +260,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p_static_image) {
 	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
-		// OpenXR not initialised or we're in the editor?
+		// OpenXR not initialized or we're in the editor?
 		return false;
 	}
 	if (!composition_layer_extension->is_available(composition_layer->type)) {

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -215,7 +215,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 	} else if (cur_loop_mode == Animation::LOOP_PINGPONG) {
 		if (!Math::is_zero_approx(anim_size)) {
 			if (Math::fposmod(cur_playback_time, anim_size * 2.0) >= anim_size) {
-				cur_delta = -cur_delta; // Needed for retrieveing discrete keys correctly.
+				cur_delta = -cur_delta; // Needed for retrieving discrete keys correctly.
 			}
 			prev_playback_time = Math::pingpong(prev_playback_time, anim_size);
 			cur_playback_time = Math::pingpong(cur_playback_time, anim_size);

--- a/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
@@ -76,7 +76,7 @@ void main() {
 	vec2 uv = uv_interp;
 #endif
 
-	// Input is standardised. R for X, G for Y, 0.0 (0) = 1, 0.33 (85) = 2, 0.66 (170) = 3, 1.0 (255) = 8
+	// Input is standardized. R for X, G for Y, 0.0 (0) = 1, 0.33 (85) = 2, 0.66 (170) = 3, 1.0 (255) = 8
 	vec4 color = textureLod(source_color, uv, 0.0);
 
 	// Output image shading rate image for VRS according to VK_KHR_fragment_shading_rate.


### PR DESCRIPTION
Using 2.2.7.dev217+g10c2abcf.

Had to add `colour` to the ignore list as we used it as an alias/keyword for the documentation of color-related APIs.
Also ignore recommendations to change `thirdparty` to either `third-party` or `third party`, which are correct but we use the former fairly consistently.