### PR TITLE
Autocompletion: Analyze CLASS types as they are encountered

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2064,6 +2064,12 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 		found = false;
 	}
 
+	// If the found type was not fully analyzed we analyze it now.
+	if (found && r_type.type.kind == GDScriptParser::DataType::CLASS && !r_type.type.class_type->resolved_body) {
+		Error err;
+		Ref<GDScriptParserRef> r = GDScriptCache::get_parser(r_type.type.script_path, GDScriptParserRef::FULLY_SOLVED, err);
+	}
+
 	// Check type hint last. For collections we want chance to get the actual value first
 	// This way we can detect types from the content of dictionaries and arrays
 	if (!found && p_expression->get_datatype().is_hard_type()) {


### PR DESCRIPTION
Supersedes #84266

Second part of fixing https://github.com/godotengine/godot/issues/78003 (can be closed if #84264 was already merged)

When `_guess_expression_types` encounters a CLASS type that was not analysed before it will now fully analyse it before returning the type. Compared to #84266 this moves the recursive approach to the autocompletion code, and leaves the parser as is. This reduces the possibility to introduce cyclic reference issues with that.

This shouldn't lead to infinite loops as the analysing is still shallow and the autocompletion already has save guards for recursion limits.
