### PR TITLE
[WIP] Add option to replay backtraces.

### DIFF
--- a/core/os/crash_handler.cpp
+++ b/core/os/crash_handler.cpp
@@ -1,0 +1,178 @@
+/**************************************************************************/
+/*  crash_handler.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "crash_handler.h"
+
+#include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
+#include "core/io/marshalls.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+#include "core/version.h"
+#include "main/main.h"
+
+void CrashHandlerBase::print_header(int p_signal) const {
+	String msg;
+	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
+	if (proj_settings) {
+		msg = proj_settings->get("debug/settings/crash_handler/message");
+	}
+
+	// Dump the backtrace to stderr with a message to the user.
+	print_error("\n================================================================");
+	if (p_signal != 0) {
+		print_error(vformat("Program crashed with signal %d", p_signal));
+	} else {
+		print_error("Program crashed");
+	}
+
+	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
+	if (String(VERSION_HASH).is_empty()) {
+		print_error(vformat("Engine version: %s", VERSION_FULL_NAME));
+	} else {
+		print_error(vformat("Engine version: %s (%s)", VERSION_FULL_NAME, VERSION_HASH));
+	}
+	print_error(msg);
+	print_error("");
+	print_error("Dumping the backtrace...");
+}
+
+void CrashHandlerBase::print_trace(const CrashHandlerBase::TraceData &p_data) const {
+	print_error("================================================================");
+	print_error("");
+	int longest_name = 0;
+	int longest_addr = 0;
+	for (int i = 0; i < (int)p_data.trace.size(); i++) {
+		const AddressData &addr = p_data.trace[i];
+		longest_name = MAX(longest_name, p_data.modules[addr.module_idx].fname.get_file().length());
+		longest_addr = MAX(longest_addr, vformat("%ux", addr.address - addr.base).length());
+	}
+	for (int i = 0; i < (int)p_data.trace.size(); i++) {
+		const AddressData &addr = p_data.trace[i];
+		print_error(vformat("%3d: %" + itos(longest_addr) + "ux %" + itos(longest_name) + "s - %s", i + 1, addr.address - addr.base, p_data.modules[addr.module_idx].fname.get_file(), addr.fname));
+	}
+	print_error("");
+	print_error("-- END OF BACKTRACE --");
+	print_error("================================================================");
+}
+
+String CrashHandlerBase::encode_trace(const CrashHandlerBase::TraceData &p_data) const {
+	String ret;
+
+	Dictionary td;
+	td["o"] = OS::get_singleton()->get_identifier();
+	td["a"] = Engine::get_singleton()->get_architecture_name();
+	if (String(VERSION_HASH).is_empty()) {
+		td["v"] = String(VERSION_FULL_BUILD);
+	} else {
+		td["v"] = String(VERSION_HASH);
+	}
+	td["s"] = (int8_t)p_data.signal;
+	PackedStringArray modules;
+	for (int i = 0; i < (int)p_data.modules.size(); i++) {
+		modules.push_back(p_data.modules[i].fname);
+	}
+	td["m"] = modules;
+	PackedInt32Array trace_addr;
+	PackedByteArray trace_mod;
+	for (int i = 0; i < (int)p_data.trace.size(); i++) {
+		const AddressData &addr = p_data.trace[i];
+		trace_addr.push_back(addr.address - addr.base);
+		trace_mod.push_back(addr.module_idx);
+	}
+	td["d"] = trace_addr;
+	td["t"] = trace_mod;
+
+	int len;
+	Error err = encode_variant(td, nullptr, len, false);
+	if (err == OK) {
+		Vector<uint8_t> buff;
+		buff.resize(len);
+		err = encode_variant(td, buff.ptrw(), len, false);
+		if (err == OK) {
+			ret = CryptoCore::b64_encode_str(buff.ptr(), buff.size());
+		}
+	}
+	return ret;
+}
+
+CrashHandlerBase::TraceData CrashHandlerBase::decode_trace(const String &p_trace_b64) const {
+	TraceData out;
+
+	CharString cs = p_trace_b64.ascii();
+	Vector<uint8_t> buff;
+	buff.resize(cs.length() / 4 * 3 + 1);
+
+	size_t dict_len = 0;
+	Error err = CryptoCore::b64_decode(buff.ptrw(), buff.size(), &dict_len, (unsigned char *)cs.get_data(), cs.length());
+	if (err) {
+		ERR_FAIL_V_MSG(out, "Invalid trace data, base64 decode error.");
+	}
+	Variant variant;
+	err = decode_variant(variant, buff.ptr(), dict_len, nullptr, false);
+	if (err) {
+		ERR_FAIL_V_MSG(out, "Invalid trace data, variant decede error.");
+	}
+	Dictionary td = variant;
+	if (!td.has("o") || !td.has("a") || !td.has("v") || !td.has("s") || !td.has("m") || !td.has("d") || !td.has("t")) {
+		ERR_FAIL_V_MSG(out, "Invalid trace data, missing dictionary keys.");
+	}
+	String os_name = td["o"];
+	if (os_name != OS::get_singleton()->get_identifier()) {
+		ERR_FAIL_V_MSG(out, vformat("Mismatching trace OS, trace was recorded on %s.", os_name));
+	}
+	String arch_name = td["a"];
+	if (arch_name != Engine::get_singleton()->get_architecture_name()) {
+		ERR_FAIL_V_MSG(out, vformat("Mismatching trace architecture, trace was recorded on %s.", arch_name));
+	}
+	String version = td["v"];
+	if (version != String(VERSION_FULL_BUILD) && version != String(VERSION_HASH)) {
+		ERR_FAIL_V_MSG(out, vformat("Mismatching trace engine version, trace was recorded on %s.", version));
+	}
+
+	PackedStringArray modules = td["m"];
+	for (int i = 0; i < (int)modules.size(); i++) {
+		ModuleData md;
+		md.fname = modules[i];
+		out.modules.push_back(md);
+	}
+	PackedInt32Array trace_addr = td["d"];
+	PackedByteArray trace_mod = td["t"];
+	for (int i = 0; i < (int)trace_addr.size(); i++) {
+		AddressData addr;
+		addr.address = trace_addr[i];
+		addr.module_idx = trace_mod[i];
+		out.trace.push_back(addr);
+		decode_address(out, out.trace.size() - 1, true);
+	}
+	out.signal = td["s"];
+
+	return out;
+}

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -252,6 +252,7 @@ public:
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }
+	virtual void decode_trace(const String &p_trace) const {}
 	virtual void initialize_debugging() {}
 
 	virtual uint64_t get_static_memory_usage() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -620,6 +620,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("-s, --script <script>", "Run a script.\n");
 	print_help_option("--main-loop <main_loop_name>", "Run a MainLoop specified by its global class name.\n");
 	print_help_option("--check-only", "Only parse for errors and quit (use with --script).\n");
+	print_help_option("--decode-trace <trace>", "Decodes and print crash report trace.\n");
 #ifdef TOOLS_ENABLED
 	print_help_option("--import", "Starts the editor, waits for any resources to be imported, and then quits.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--export-release <preset> <path>", "Export the project in release mode using the given preset and output path. The preset name should match one defined in \"export_presets.cfg\".\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -1052,9 +1053,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
+		} else if (arg == "--decode-trace") {
+			if (N) {
+				const String &trace = N->get();
+				OS::get_singleton()->decode_trace(trace);
+				exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
+			} else {
+				OS::get_singleton()->print("Missing decode-trace argument, aborting.\n");
+			}
+			goto error;
+
 		} else if (arg == "-v" || arg == "--verbose") { // verbose output
 
 			OS::get_singleton()->_verbose_stdout = true;
+
 		} else if (arg == "-q" || arg == "--quiet") { // quieter output
 
 			quiet_stdout = true;

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -39,39 +39,16 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(DEBUG_ENABLED)
-#define CRASH_HANDLER_ENABLED 1
-#endif
+CrashHandler *CrashHandler::singleton = nullptr;
 
-#ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
+#include <mach-o/dyld.h>
 #include <signal.h>
 #include <stdlib.h>
 
-#include <mach-o/dyld.h>
-#include <mach-o/getsect.h>
-
-static uint64_t load_address() {
-	const struct segment_command_64 *cmd = getsegbyname("__TEXT");
-	char full_path[1024];
-	uint32_t size = sizeof(full_path);
-
-	if (cmd && !_NSGetExecutablePath(full_path, &size)) {
-		uint32_t dyld_count = _dyld_image_count();
-		for (uint32_t i = 0; i < dyld_count; i++) {
-			const char *image_name = _dyld_get_image_name(i);
-			if (image_name && strncmp(image_name, full_path, 1024) == 0) {
-				return cmd->vmaddr + _dyld_get_image_vmaddr_slide(i);
-			}
-		}
-	}
-
-	return 0;
-}
-
-static void handle_crash(int sig) {
+static void handle_crash(int p_signal) {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGILL, SIG_DFL);
@@ -81,108 +58,138 @@ static void handle_crash(int sig) {
 		abort();
 	}
 
-	void *bt_buffer[256];
-	size_t size = backtrace(bt_buffer, 256);
-	String _execpath = OS::get_singleton()->get_executable_path();
-
-	String msg;
-	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
-	if (proj_settings) {
-		msg = proj_settings->get("debug/settings/crash_handler/message");
-	}
-
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
-	// Dump the backtrace to stderr with a message to the user
-	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
-
-	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
-	if (String(VERSION_HASH).is_empty()) {
-		print_error(vformat("Engine version: %s", VERSION_FULL_NAME));
-	} else {
-		print_error(vformat("Engine version: %s (%s)", VERSION_FULL_NAME, VERSION_HASH));
-	}
-	print_error(vformat("Dumping the backtrace. %s", msg));
-	char **strings = backtrace_symbols(bt_buffer, size);
-	if (strings) {
-		void *load_addr = (void *)load_address();
-
-		for (size_t i = 1; i < size; i++) {
-			char fname[1024];
-			Dl_info info;
-
-			snprintf(fname, 1024, "%s", strings[i]);
-
-			// Try to demangle the function name to provide a more readable one
-			if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
-				if (info.dli_sname[0] == '_') {
-					int status;
-					char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, 0, &status);
-
-					if (status == 0 && demangled) {
-						snprintf(fname, 1024, "%s", demangled);
-					}
-
-					if (demangled) {
-						free(demangled);
-					}
-				}
-			}
-
-			String output = fname;
-
-			// Try to get the file/line number using atos
-			if (bt_buffer[i] > (void *)0x0 && OS::get_singleton()) {
-				List<String> args;
-				char str[1024];
-
-				args.push_back("-o");
-				args.push_back(_execpath);
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
-				args.push_back("-arch");
-				args.push_back("x86_64");
-#elif defined(__aarch64__)
-				args.push_back("-arch");
-				args.push_back("arm64");
-#endif
-				args.push_back("-l");
-				snprintf(str, 1024, "%p", load_addr);
-				args.push_back(str);
-				snprintf(str, 1024, "%p", bt_buffer[i]);
-				args.push_back(str);
-
-				int ret;
-				String out = "";
-				Error err = OS::get_singleton()->execute(String("atos"), args, &out, &ret);
-				if (err == OK && out.substr(0, 2) != "0x") {
-					out = out.substr(0, out.length() - 1);
-					output = out;
-				}
-			}
-
-			print_error(vformat("[%d] %s", (int64_t)i, output));
+	CrashHandler *cs = CrashHandler::get_singleton();
+	if (cs) {
+		cs->print_header(p_signal);
+		CrashHandler::TraceData td = cs->collect_trace(p_signal);
+		String shortcut = cs->encode_trace(td);
+		if (!shortcut.is_empty()) {
+			print_error("================================================================");
+			print_error(shortcut);
 		}
-
-		free(strings);
+		cs->print_trace(td);
 	}
-	print_error("-- END OF BACKTRACE --");
-	print_error("================================================================");
 
-	// Abort to pass the error to the OS
+	// Abort to pass the error to the OS.
 	abort();
 }
-#endif
 
-CrashHandler::CrashHandler() {
-	disabled = false;
+CrashHandler::TraceData CrashHandler::collect_trace(int p_signal) const {
+	TraceData td;
+
+	td.signal = p_signal;
+
+	void *bt_buffer[512];
+	size_t size = backtrace(bt_buffer, 512);
+	for (size_t i = 1; i < size; i++) {
+		AddressData addr;
+		addr.address = 0x7FFFFFFFFFFF & (uint64_t)bt_buffer[i];
+		td.trace.push_back(addr);
+		decode_address(td, td.trace.size() - 1, false);
+	}
+
+	return td;
 }
 
-CrashHandler::~CrashHandler() {
-	disable();
+void CrashHandler::decode_address(CrashHandler::TraceData &p_data, int p_address_idx, bool p_remap) const {
+	if (p_address_idx < 0 || p_address_idx >= (int)p_data.trace.size()) {
+		return;
+	}
+
+	AddressData &addr_data = p_data.trace[p_address_idx];
+	addr_data.fname = "???";
+	if (p_remap) {
+		// Relative address, remap it to the loaded module base address.
+		String module_name = p_data.modules[addr_data.module_idx].fname;
+
+		bool found = false;
+		uint32_t dyld_count = _dyld_image_count();
+		for (uint32_t i = 0; i < dyld_count; i++) {
+			String image_name = String(_dyld_get_image_name(i));
+			if (image_name == module_name) {
+				const struct mach_header *header_addr = _dyld_get_image_header(i);
+				Dl_info info;
+				if (dladdr((void *)header_addr, &info)) {
+					addr_data.address += (uint64_t)info.dli_fbase;
+					found = true;
+					break;
+				}
+			}
+		}
+		if (!found) {
+			return;
+		}
+	}
+	Dl_info info;
+	if (dladdr((void *)((uint64_t)addr_data.address), &info)) {
+		String module_name = String(info.dli_fname);
+		if (!p_remap) {
+			// Absolute address from the current process, save module info.
+			for (int i = 0; i < (int)p_data.modules.size(); i++) {
+				if (p_data.modules[i].fname == module_name) {
+					addr_data.module_idx = i;
+					break;
+				}
+			}
+			if (addr_data.module_idx == -1) {
+				ModuleData md;
+				md.fname = module_name;
+				md.load_address = (uint64_t)info.dli_fbase;
+				p_data.modules.push_back(md);
+				addr_data.module_idx = p_data.modules.size() - 1;
+			}
+		}
+		addr_data.system = (module_name.begins_with("/usr/lib") || module_name.begins_with("/Library") || module_name.begins_with("/System/Library"));
+		addr_data.base = (uint64_t)info.dli_fbase;
+		if (addr_data.system) {
+			addr_data.faddress = (uint64_t)info.dli_saddr;
+			addr_data.fname = String(info.dli_sname);
+			if (info.dli_sname && info.dli_sname[0] == '_') {
+				int status;
+				char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, 0, &status);
+				if (status == 0 && demangled) {
+					addr_data.fname = String(demangled);
+				}
+				if (demangled) {
+					free(demangled);
+				}
+			}
+			addr_data.fname = vformat("%s + %ux", addr_data.fname, addr_data.address - addr_data.faddress);
+		} else {
+			List<String> args;
+			args.push_back("-o");
+			args.push_back(module_name);
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+			args.push_back("-arch");
+			args.push_back("x86_64");
+#elif defined(__aarch64__)
+			args.push_back("-arch");
+			args.push_back("arm64");
+#endif
+			args.push_back("-l");
+			args.push_back(vformat("0x%ux", addr_data.base));
+			args.push_back(vformat("0x%ux", addr_data.address));
+
+			int ret;
+			String out = "";
+			Error err = OS::get_singleton()->execute(String("atos"), args, &out, &ret);
+			if (err == OK && out.substr(0, 2) != "0x") {
+				addr_data.fname = out.substr(0, out.length() - 1);
+			}
+		}
+	}
+}
+
+void CrashHandler::initialize() {
+	signal(SIGSEGV, handle_crash);
+	signal(SIGFPE, handle_crash);
+	signal(SIGILL, handle_crash);
+	signal(SIGTRAP, handle_crash);
 }
 
 void CrashHandler::disable() {
@@ -190,21 +197,20 @@ void CrashHandler::disable() {
 		return;
 	}
 
-#ifdef CRASH_HANDLER_ENABLED
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGILL, SIG_DFL);
 	signal(SIGTRAP, SIG_DFL);
-#endif
 
 	disabled = true;
 }
 
-void CrashHandler::initialize() {
-#ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, handle_crash);
-	signal(SIGFPE, handle_crash);
-	signal(SIGILL, handle_crash);
-	signal(SIGTRAP, handle_crash);
-#endif
+CrashHandler::CrashHandler() {
+	singleton = this;
+	disabled = false;
+}
+
+CrashHandler::~CrashHandler() {
+	disable();
+	singleton = nullptr;
 }

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -121,6 +121,7 @@ public:
 
 	virtual void disable_crash_handler() override;
 	virtual bool is_disable_crash_handler() const override;
+	virtual void decode_trace(const String &p_trace) const override;
 
 	virtual Error move_to_trash(const String &p_path) override;
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -710,6 +710,11 @@ bool OS_MacOS::is_disable_crash_handler() const {
 	return crash_handler.is_disabled();
 }
 
+void OS_MacOS::decode_trace(const String &p_trace) const {
+	CrashHandler::TraceData td = crash_handler.decode_trace(p_trace);
+	crash_handler.print_trace(td);
+}
+
 Error OS_MacOS::move_to_trash(const String &p_path) {
 	NSFileManager *fm = [NSFileManager defaultManager];
 	NSURL *url = [NSURL fileURLWithPath:@(p_path.utf8().get_data())];

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -96,6 +96,12 @@ int trace_callback(void *data, uintptr_t pc) {
 	return 0;
 }
 
+int64_t get_load_address(const String &p_path) {
+	MODULEINFO mi;
+	GetModuleInformation(GetCurrentProcess(), GetModuleHandle(NULL), &mi, sizeof(mi));
+	return reinterpret_cast<int64_t>(mi.lpBaseOfDll);
+}
+
 int64_t get_image_base(const String &p_path) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
@@ -158,9 +164,7 @@ extern void CrashHandlerException(int signal) {
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	// Load process and image info to determine ASLR addresses offset.
-	MODULEINFO mi;
-	GetModuleInformation(GetCurrentProcess(), GetModuleHandle(NULL), &mi, sizeof(mi));
-	int64_t image_mem_base = reinterpret_cast<int64_t>(mi.lpBaseOfDll);
+	int64_t image_mem_base = get_load_address(_execpath);
 	int64_t image_file_base = get_image_base(_execpath);
 	data.offset = image_mem_base - image_file_base;
 


### PR DESCRIPTION
- Cleanup crash log output.
- Add option to replay trace (with external debug symbols).

### TODO:
- [x] Common code
- [x] macOS
- [ ] Linux
- [ ] Windows/MinGW
- [ ] Windows/MSVC
- [ ] Cleanup

### Sample output:

<details>
  <summary>Stripped binary crash - click to expand</summary>

```
% ./godot.macos.editor.arm64 --path ../../godot-tests/_crash
Godot Engine v4.3.dev.custom_build.a4f74dd1b (2024-05-07 09:56:53 UTC) - https://godotengine.org
Vulkan 1.2.280 - Forward+ - Using Device #0: Apple - Apple M1

ERROR: noooo
   at: crash (core/core_bind.cpp:241)

================================================================
Program crashed with signal 5
Engine version: Godot Engine v4.3.dev.custom_build (a4f74dd1bbd7a3a0696d14001fb0b244667fb4c5)
Please include this when reporting the bug to the project developer.

Dumping the backtrace...
================================================================
GwAAAAcAAAAEAAAAAQAAAG8AAAAEAAAABQAAAG1hY29zAAAABAAAAAEAAABhAAAABAAAAAUAAABhcm02NAAAAAQAAAABAAAAdgAAAAQAAAAoAAAAYTRmNzRkZDFiYmQ3YTNhMDY5NmQxNDAwMWZiMGIyNDQ2NjdmYjRjNQQAAAABAAAAcwAAAAIAAAAFAAAABAAAAAEAAABtAAAAIgAAAAMAAAA8AAAAL1ZvbHVtZXMvQmFja3VwL1Byb2plY3RzL2dvZG90L2Jpbi9nb2RvdC5tYWNvcy5lZGl0b3IuYXJtNjQAKQAAAC91c3IvbGliL3N5c3RlbS9saWJzeXN0ZW1fcGxhdGZvcm0uZHlsaWIAAAAADgAAAC91c3IvbGliL2R5bGQAAAAEAAAAAQAAAGQAAAAeAAAAGQAAAABwPgCERQAAqCkjBGSj0wBATc4A9C6BBFygUwTMYIEE8BqRAgwXkQI0FJECLL+aAqx9iALAiYgC5PGIAviQjQJkmI8CcJI+AMyPPgDY10wE4LJMBLiXPwAwFz4AFMpAAOBgAAAEAAAAAQAAAHQAAAAdAAAAGQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAA=
================================================================

  1:  3e7000 godot.macos.editor.arm64 - ???
  2:    4584 libsystem_platform.dylib - _sigtramp + 38
  3: 42329a8 godot.macos.editor.arm64 - ???
  4:  d3a364 godot.macos.editor.arm64 - ???
  5:  ce4d40 godot.macos.editor.arm64 - ???
  6: 4812ef4 godot.macos.editor.arm64 - ???
  7: 453a05c godot.macos.editor.arm64 - ???
  8: 48160cc godot.macos.editor.arm64 - ???
  9: 2911af0 godot.macos.editor.arm64 - ???
 10: 291170c godot.macos.editor.arm64 - ???
 11: 2911434 godot.macos.editor.arm64 - ???
 12: 29abf2c godot.macos.editor.arm64 - ???
 13: 2887dac godot.macos.editor.arm64 - ???
 14: 28889c0 godot.macos.editor.arm64 - ???
 15: 288f1e4 godot.macos.editor.arm64 - ???
 16: 28d90f8 godot.macos.editor.arm64 - ???
 17: 28f9864 godot.macos.editor.arm64 - ???
 18:  3e9270 godot.macos.editor.arm64 - ???
 19:  3e8fcc godot.macos.editor.arm64 - ???
 20: 44cd7d8 godot.macos.editor.arm64 - ???
 21: 44cb2e0 godot.macos.editor.arm64 - ???
 22:  3f97b8 godot.macos.editor.arm64 - ???
 23:  3e1730 godot.macos.editor.arm64 - ???
 24:  40ca14 godot.macos.editor.arm64 - ???
 25:    60e0                     dyld - start + 938

-- END OF BACKTRACE --
================================================================
zsh: abort      ./godot.macos.editor.arm64 --path ../../godot-tests/_crash
```

</details>


<details>
  <summary>Trace replay (same binary, but external `.dSYM` moved to the executable folder) - click to expand</summary>

```
% ./godot.macos.editor.arm64 --decode-trace GwAAAAcAAAAEAAAAAQAAAG8AAAAEAAAABQAAAG1hY29zAAAABAAAAAEAAABhAAAABAAAAAUAAABhcm02NAAAAAQAAAABAAAAdgAAAAQAAAAoAAAAYTRmNzRkZDFiYmQ3YTNhMDY5NmQxNDAwMWZiMGIyNDQ2NjdmYjRjNQQAAAABAAAAcwAAAAIAAAAFAAAABAAAAAEAAABtAAAAIgAAAAMAAAA8AAAAL1ZvbHVtZXMvQmFja3VwL1Byb2plY3RzL2dvZG90L2Jpbi9nb2RvdC5tYWNvcy5lZGl0b3IuYXJtNjQAKQAAAC91c3IvbGliL3N5c3RlbS9saWJzeXN0ZW1fcGxhdGZvcm0uZHlsaWIAAAAADgAAAC91c3IvbGliL2R5bGQAAAAEAAAAAQAAAGQAAAAeAAAAGQAAAABwPgCERQAAqCkjBGSj0wBATc4A9C6BBFygUwTMYIEE8BqRAgwXkQI0FJECLL+aAqx9iALAiYgC5PGIAviQjQJkmI8CcJI+AMyPPgDY10wE4LJMBLiXPwAwFz4AFMpAAOBgAAAEAAAAAQAAAHQAAAAdAAAAGQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAA=
================================================================

  1:  3e7000 godot.macos.editor.arm64 - handle_crash(int) (in godot.macos.editor.arm64) (crash_handler_macos.mm:74)
  2:    4584 libsystem_platform.dylib - _sigtramp + 38
  3: 42329a8 godot.macos.editor.arm64 - core_bind::OS::crash(String const&) (in godot.macos.editor.arm64) (core_bind.cpp:241)
  4:  d3a364 godot.macos.editor.arm64 - MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const (in godot.macos.editor.arm64) (method_bind.h:359)
  5:  ce4d40 godot.macos.editor.arm64 - GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (in godot.macos.editor.arm64) (gdscript_vm.cpp:2145)
  6: 4812ef4 godot.macos.editor.arm64 - Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (in godot.macos.editor.arm64) (object.cpp:820)
  7: 453a05c godot.macos.editor.arm64 - Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (in godot.macos.editor.arm64) (callable.cpp:0)
  8: 48160cc godot.macos.editor.arm64 - Object::emit_signalp(StringName const&, Variant const**, int) (in godot.macos.editor.arm64) (object.cpp:1221)
  9: 2911af0 godot.macos.editor.arm64 - BaseButton::_pressed() (in godot.macos.editor.arm64) (base_button.cpp:138)
 10: 291170c godot.macos.editor.arm64 - BaseButton::on_action_event(Ref<InputEvent>) (in godot.macos.editor.arm64) (base_button.cpp:177)
 11: 2911434 godot.macos.editor.arm64 - BaseButton::gui_input(Ref<InputEvent> const&) (in godot.macos.editor.arm64) (base_button.cpp:69)
 12: 29abf2c godot.macos.editor.arm64 - Control::_call_gui_input(Ref<InputEvent> const&) (in godot.macos.editor.arm64) (control.cpp:0)
 13: 2887dac godot.macos.editor.arm64 - Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) (in godot.macos.editor.arm64) (viewport.cpp:1561)
 14: 28889c0 godot.macos.editor.arm64 - Viewport::_gui_input_event(Ref<InputEvent>) (in godot.macos.editor.arm64) (viewport.cpp:1827)
 15: 288f1e4 godot.macos.editor.arm64 - Viewport::push_input(Ref<InputEvent> const&, bool) (in godot.macos.editor.arm64) (viewport.cpp:3249)
 16: 28d90f8 godot.macos.editor.arm64 - Window::_window_input(Ref<InputEvent> const&) (in godot.macos.editor.arm64) (window.cpp:0)
 17: 28f9864 godot.macos.editor.arm64 - void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) (in godot.macos.editor.arm64) (binder_common.h:304)
 18:  3e9270 godot.macos.editor.arm64 - Variant Callable::call<Ref<InputEvent>>(Ref<InputEvent>) const (in godot.macos.editor.arm64) (variant.h:874)
 19:  3e8fcc godot.macos.editor.arm64 - DisplayServerMacOS::_dispatch_input_event(Ref<InputEvent> const&) (in godot.macos.editor.arm64) (display_server_macos.mm:385)
 20: 44cd7d8 godot.macos.editor.arm64 - Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) (in godot.macos.editor.arm64) (input.cpp:774)
 21: 44cb2e0 godot.macos.editor.arm64 - Input::flush_buffered_events() (in godot.macos.editor.arm64) (input.cpp:1045)
 22:  3f97b8 godot.macos.editor.arm64 - DisplayServerMacOS::process_events() (in godot.macos.editor.arm64) (display_server_macos.mm:3023)
 23:  3e1730 godot.macos.editor.arm64 - OS_MacOS::run() (in godot.macos.editor.arm64) (os_macos.mm:781)
 24:  40ca14 godot.macos.editor.arm64 - main (in godot.macos.editor.arm64) (godot_main_macos.mm:89)
 25:    60e0                     dyld - ???

-- END OF BACKTRACE --
================================================================
```

</details>