### PR TITLE
Add missing bone name return information

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -41,7 +41,7 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the bone index that matches [param name] as its name.
+				Returns the bone index that matches [param name] as its name. Returns [code]-1[/code] if no bone with this name exists.
 			</description>
 		</method>
 		<method name="force_update_all_bone_transforms" deprecated="This method should only be called internally.">


### PR DESCRIPTION
A simple PR that improves the documentation for `Skeleton3D::find_bone()` that explains what will be returned when a bone name wasn't found. This is consistent with [MeshInstance3D::find_blend_shape_by_name()](https://docs.godotengine.org/en/stable/classes/class_meshinstance3d.html#class-meshinstance3d-method-find-blend-shape-by-name)