### PR TITLE
Reduce import metafile size for scenes with many animations

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1260,7 +1260,7 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 				Dictionary anim_settings = p_animation_data[name];
 
 				{
-					int slices_count = anim_settings["slices/amount"];
+					int slices_count = anim_settings.get_or_add("slices/amount", 0);
 
 					for (int i = 0; i < slices_count; i++) {
 						String slice_name = anim_settings["slice_" + itos(i + 1) + "/name"];
@@ -1284,21 +1284,11 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 						_create_slices(ap, anim, animation_slices, true);
 					}
 				}
-				{
-					//fill with default values
-					List<ImportOption> iopts;
-					get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
-					for (const ImportOption &F : iopts) {
-						if (!anim_settings.has(F.option.name)) {
-							anim_settings[F.option.name] = F.default_value;
-						}
-					}
-				}
 
 				anim->set_loop_mode(static_cast<Animation::LoopMode>((int)anim_settings["settings/loop_mode"]));
-				bool save = anim_settings["save_to_file/enabled"];
-				String path = anim_settings["save_to_file/path"];
-				bool keep_custom = anim_settings["save_to_file/keep_custom_tracks"];
+				bool save = anim_settings.get_or_add("save_to_file/enabled", false);
+				bool keep_custom = anim_settings.get_or_add("save_to_file/keep_custom_tracks", false);
+				String path = anim_settings.get("save_to_file/path", String());
 
 				Ref<Animation> saved_anim = _save_animation_to_file(anim, save, path, keep_custom);
 
@@ -1714,16 +1704,6 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 				if (p_animation_data.has(name)) {
 					Ref<Animation> anim = ap->get_animation(name);
 					Dictionary anim_settings = p_animation_data[name];
-					{
-						//fill with default values
-						List<ImportOption> iopts;
-						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
-						for (const ImportOption &F : iopts) {
-							if (!anim_settings.has(F.option.name)) {
-								anim_settings[F.option.name] = F.default_value;
-							}
-						}
-					}
 
 					for (int i = 0; i < post_importer_plugins.size(); i++) {
 						post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION, p_root, p_node, anim, anim_settings);
@@ -2008,7 +1988,7 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "settings/loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Pingpong"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "save_to_file/path", PROPERTY_HINT_SAVE_FILE, "*.res,*.tres"), ""));
-			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/keep_custom_tracks"), ""));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/keep_custom_tracks", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "slices/amount", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
 
 			for (int i = 0; i < 256; i++) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -288,6 +288,8 @@ public:
 	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps, float p_applied_root_scale);
 	Node *_post_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps, bool p_remove_immutable_tracks);
 
+	void _fill_animation_setting_defaults(Dictionary &anim_settings);
+
 	Ref<Animation> _save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, const String &p_save_to_path, bool p_keep_custom_tracks);
 	void _create_slices(AnimationPlayer *ap, Ref<Animation> anim, const Array &p_clips, bool p_bake_all);
 	void _optimize_animations(AnimationPlayer *anim, float p_max_vel_error, float p_max_ang_error, int p_prc_error);


### PR DESCRIPTION
This change reduces the number of lines serialized and deserialized by 1,792 lines per animation clip (256 slice defaults *7 slice properties) in import settings for scene types that have been imported using the advanced import settings dialog.

I haven't benchmarked this, but it does make debugging import settings massively easier.

Reviewer: AFAICT no code depends on defaults actually existing, and in fact no defaults do exist if the advanced import dialog is not invoked. However, this is not something I can easily verify yet. Another approach I considered is to leave the default filling code, and then strip `slice_X` settings where `X >= slices/amount` in the two locations defaults were set. I felt that was more brittle than simply checking for settings as needed but this is subjective so I'm open to more tenured thoughts.

Example difference on a simple import of a character with ~10+/- animation clips:
before: 18058 lines
<img width="410" alt="image" src="https://github.com/godotengine/godot/assets/1476969/92e23e3c-7fdc-49cb-92b5-325d0affb043">

after: 103 lines
<img width="639" alt="image" src="https://github.com/godotengine/godot/assets/1476969/af0d0971-c8b9-4e20-a9f6-d629a89af797">