### PR TITLE
Fix crash when adding a child while duplicating a node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2930,8 +2930,10 @@ void Node::_duplicate_properties_node(const Node *p_root, const Node *p_original
 		}
 	}
 
-	for (int i = 0; i < p_copy->get_child_count(); i++) {
-		_duplicate_properties_node(p_root, p_original->get_child(i), p_copy->get_child(i));
+	for (int i = 0; i < p_original->get_child_count(); i++) {
+		Node *copy_child = p_copy->get_child(i);
+		ERR_FAIL_NULL_MSG(copy_child, "Child node disappeared while duplicating.");
+		_duplicate_properties_node(p_root, p_original->get_child(i), copy_child);
 	}
 }
 


### PR DESCRIPTION
Regression from #87387 (according to blame).
```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.3.dev.custom_build (55b8724bd5188932b69a6ee484ab092cd95d4498)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[0] Object::get (C:\godot_source\core\object\object.cpp:318)
[1] Object::get (C:\godot_source\core\object\object.cpp:318)
[2] Node::_duplicate_properties_node (C:\godot_source\scene\main\node.cpp:2911)
[3] Node::_duplicate_properties_node (C:\godot_source\scene\main\node.cpp:2935)
[4] Node::duplicate (C:\godot_source\scene\main\node.cpp:2825)
[5] call_with_variant_args_retc_helper<Node,Node *,int,0> (C:\godot_source\core\variant\binder_common.h:807)
[6] call_with_variant_args_retc_dv<Node,Node *,int> (C:\godot_source\core\variant\binder_common.h:569)
[7] MethodBindTRC<Node,Node *,int>::call (C:\godot_source\core\object\method_bind.h:622)
[8] GDScriptFunction::call (C:\godot_source\modules\gdscript\gdscript_vm.cpp:1862)
[9] GDScriptInstance::callp (C:\godot_source\modules\gdscript\gdscript.cpp:2005)
[10] Node::_gdvirtual__ready_call<0> (C:\godot_source\scene\main\node.h:354)
[11] Node::_notification (C:\godot_source\scene\main\node.cpp:214)
[12] Node::_notificationv (C:\godot_source\scene\main\node.h:49)
[13] CanvasItem::_notificationv (C:\godot_source\scene\main\canvas_item.h:45)
[14] Node2D::_notificationv (C:\godot_source\scene\2d\node_2d.h:37)
[15] CollisionObject2D::_notificationv (C:\godot_source\scene\2d\physics\collision_object_2d.h:40)
[16] PhysicsBody2D::_notificationv (C:\godot_source\scene\2d\physics\physics_body_2d.h:41)
[17] CharacterBody2D::_notificationv (C:\godot_source\scene\2d\physics\character_body_2d.h:38)
[18] Object::notification (C:\godot_source\core\object\object.cpp:907)
[19] Node::_propagate_ready (C:\godot_source\scene\main\node.cpp:269)
[20] Node::_propagate_ready (C:\godot_source\scene\main\node.cpp:260)
[21] Node::_propagate_ready (C:\godot_source\scene\main\node.cpp:260)
[22] Node::_set_tree (C:\godot_source\scene\main\node.cpp:3181)
[23] Node::_add_child_nocheck (C:\godot_source\scene\main\node.cpp:1552)
[24] Node::add_child (C:\godot_source\scene\main\node.cpp:1580)
[25] call_with_variant_args_helper<Node,Node *,bool,enum Node::InternalMode,0,1,2> (C:\godot_source\core\variant\binder_common.h:309)
[26] call_with_variant_args_dv<Node,Node *,bool,enum Node::InternalMode> (C:\godot_source\core\variant\binder_common.h:452)
[27] MethodBindT<Node,Node *,bool,enum Node::InternalMode>::call (C:\godot_source\core\object\method_bind.h:347)
[28] GDScriptFunction::call (C:\godot_source\modules\gdscript\gdscript_vm.cpp:1864)
[29] GDScriptFunctionState::resume (C:\godot_source\modules\gdscript\gdscript_function.cpp:218)
[30] GDScriptFunctionState::_signal_callback (C:\godot_source\modules\gdscript\gdscript_function.cpp:166)
[31] MethodBindVarArgTR<GDScriptFunctionState,Variant>::call (C:\godot_source\core\object\method_bind.h:271)
[32] Object::callp (C:\godot_source\core\object\object.cpp:842)
[33] Callable::callp (C:\godot_source\core\variant\callable.cpp:69)
[34] CallableCustomBind::call (C:\godot_source\core\variant\callable_bind.cpp:153)
[35] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[36] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1221)
[37] Object::emit_signal<> (C:\godot_source\core\object\object.h:936)
[38] SceneTree::process (C:\godot_source\scene\main\scene_tree.cpp:523)
[39] Main::iteration (C:\godot_source\main\main.cpp:4044)
[40] OS_Windows::run (C:\godot_source\platform\windows\os_windows.cpp:1686)
[41] widechar_main (C:\godot_source\platform\windows\godot_windows.cpp:181)
[42] _main (C:\godot_source\platform\windows\godot_windows.cpp:206)
[43] main (C:\godot_source\platform\windows\godot_windows.cpp:220)
[44] WinMain (C:\godot_source\platform\windows\godot_windows.cpp:234)
```
This can happen when duplicate's child count changes right after it's created, e.g. by adding a child in `_init()`:
```GDScript
extends Node

func _init() -> void:
	add_child(Node.new())

func _ready() -> void:
	duplicate()
```
The additional error check is for opposite case where child disappears:
```GDScript
extends Node

func _init() -> void:
	remove_child(get_child(0))

func _ready() -> void:
	duplicate()
```

EDIT:
Fixes #91461