### PR TITLE
Allow flipping a Button's icon texture

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -62,6 +62,12 @@
 		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
 			Specifies if the icon should be aligned horizontally to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.
 		</member>
+		<member name="icon_flip_h" type="bool" setter="set_icon_flip_h" getter="is_icon_flipped_h" default="false">
+			If [code]true[/code], the icon texture is flipped horizontally.
+		</member>
+		<member name="icon_flip_v" type="bool" setter="set_icon_flip_v" getter="is_icon_flipped_v" default="false">
+			If [code]true[/code], the icon texture is flipped vertically.
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -337,8 +337,18 @@ void Button::_notification(int p_what) {
 						} break;
 					}
 
-					Rect2 icon_region = Rect2(icon_ofs, icon_size);
-					draw_texture_rect(_icon, icon_region, false, icon_modulate_color);
+
+					Rect2 icon_draw_region = Rect2(icon_ofs, icon_size);
+
+					if (icon_hflip) {
+						icon_draw_region.size.x = -icon_draw_region.size.x;
+					}
+
+					if (icon_vflip) {
+						icon_draw_region.size.y = -icon_draw_region.size.y;
+					}
+
+					draw_texture_rect(_icon, icon_draw_region, false, icon_modulate_color);
 				}
 
 				if (!xl_text.is_empty()) {
@@ -609,6 +619,32 @@ bool Button::is_expand_icon() const {
 	return expand_icon;
 }
 
+void Button::set_icon_flip_h(bool p_flip) {
+	if (icon_hflip == p_flip) {
+		return;
+	}
+
+	icon_hflip = p_flip;
+	queue_redraw();
+}
+
+bool Button::is_icon_flipped_h() const {
+	return icon_hflip;
+}
+
+void Button::set_icon_flip_v(bool p_flip) {
+	if (icon_vflip == p_flip) {
+		return;
+	}
+
+	icon_vflip = p_flip;
+	queue_redraw();
+}
+
+bool Button::is_icon_flipped_v() const {
+	return icon_vflip;
+}
+
 void Button::set_flat(bool p_enabled) {
 	if (flat != p_enabled) {
 		flat = p_enabled;
@@ -702,6 +738,10 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertical_icon_alignment"), &Button::get_vertical_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
+	ClassDB::bind_method(D_METHOD("set_icon_flip_h", "flip"), &Button::set_icon_flip_h);
+	ClassDB::bind_method(D_METHOD("is_icon_flipped_h"), &Button::is_icon_flipped_h);
+	ClassDB::bind_method(D_METHOD("set_icon_flip_v", "flip"), &Button::set_icon_flip_v);
+	ClassDB::bind_method(D_METHOD("is_icon_flipped_v"), &Button::is_icon_flipped_v);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_button_icon", "get_button_icon");
@@ -717,6 +757,8 @@ void Button::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_icon_alignment", "get_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vertical_icon_alignment", PROPERTY_HINT_ENUM, "Top,Center,Bottom"), "set_vertical_icon_alignment", "get_vertical_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_icon"), "set_expand_icon", "is_expand_icon");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "icon_flip_h"), "set_icon_flip_h", "is_icon_flipped_h");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "icon_flip_v"), "set_icon_flip_v", "is_icon_flipped_v");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -50,6 +50,8 @@ private:
 
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
+	bool icon_hflip = false;
+	bool icon_vflip = false;
 	bool clip_text = false;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
@@ -132,6 +134,12 @@ public:
 
 	void set_expand_icon(bool p_enabled);
 	bool is_expand_icon() const;
+
+	void set_icon_flip_h(bool p_flip);
+	bool is_icon_flipped_h() const;
+
+	void set_icon_flip_v(bool p_flip);
+	bool is_icon_flipped_v() const;
 
 	void set_flat(bool p_enabled);
 	bool is_flat() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Self-explanatory, it's a useful feature. I'm using it to flip the character icons associated with dialogue choices to face towards the response text rather than having to store a flipped version of the icon texture on-disk.
The implementation of this feature is similar to the one for `Sprite2D`.