### PR TITLE
Fix `builtin_embree=no` build linking the wrong version of Embree

### DIFF
--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -49,7 +49,7 @@ protected:
 	static StaticRaycaster *(*create_function)();
 
 public:
-	// compatible with embree3 rays
+	// Compatible with embree4 rays.
 	struct __aligned(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -309,7 +309,7 @@ def configure(env: "SConsEnvironment"):
 
     if not env["builtin_embree"] and env["arch"] in ["x86_64", "arm64"]:
         # No pkgconfig file so far, hardcode expected lib name.
-        env.Append(LIBS=["embree3"])
+        env.Append(LIBS=["embree4"])
 
     if not env["builtin_openxr"]:
         env.ParseConfig("pkg-config openxr --cflags --libs")

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -61,7 +61,7 @@ protected:
 	static LightmapRaycaster *(*create_function)();
 
 public:
-	// compatible with embree3 rays
+	// Compatible with embree4 rays.
 	struct __aligned(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 


### PR DESCRIPTION
- Fallout of #88783, pretty self-explanatory.
- Should fix #90586.
