### PR TITLE
OpenXR: Fix composition layers not having correct play space

### DIFF
--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -209,6 +209,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 	switch (composition_layer->type) {
 		case XR_TYPE_COMPOSITION_LAYER_QUAD: {
 			XrCompositionLayerQuad *quad_layer = (XrCompositionLayerQuad *)composition_layer;
+			quad_layer->space = openxr_api->get_play_space();
 			quad_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			quad_layer->subImage.imageArrayIndex = 0;
 			quad_layer->subImage.imageRect.offset.x = 0;
@@ -219,6 +220,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 		case XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR: {
 			XrCompositionLayerCylinderKHR *cylinder_layer = (XrCompositionLayerCylinderKHR *)composition_layer;
+			cylinder_layer->space = openxr_api->get_play_space();
 			cylinder_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			cylinder_layer->subImage.imageArrayIndex = 0;
 			cylinder_layer->subImage.imageRect.offset.x = 0;
@@ -229,6 +231,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
 			XrCompositionLayerEquirect2KHR *equirect_layer = (XrCompositionLayerEquirect2KHR *)composition_layer;
+			equirect_layer->space = openxr_api->get_play_space();
 			equirect_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			equirect_layer->subImage.imageArrayIndex = 0;
 			equirect_layer->subImage.imageRect.offset.x = 0;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2302,7 +2302,7 @@ void OpenXRAPI::end_frame() {
 		};
 		result = xrEndFrame(session, &frame_end_info);
 		if (XR_FAILED(result)) {
-			print_line("OpenXR: failed to end frame! [", get_error_string(result), "]");
+			print_line("OpenXR: rendering skipped and failed to end frame! [", get_error_string(result), "]");
 			return;
 		}
 

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
@@ -76,13 +76,6 @@ void OpenXRCompositionLayerCylinder::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fallback_segments", PROPERTY_HINT_NONE, ""), "set_fallback_segments", "get_fallback_segments");
 }
 
-void OpenXRCompositionLayerCylinder::_on_openxr_session_begun() {
-	OpenXRCompositionLayer::_on_openxr_session_begun();
-	if (openxr_api) {
-		composition_layer.space = openxr_api->get_play_space();
-	}
-}
-
 Ref<Mesh> OpenXRCompositionLayerCylinder::_create_fallback_mesh() {
 	Ref<ArrayMesh> mesh;
 	mesh.instantiate();

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.h
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.h
@@ -50,7 +50,6 @@ protected:
 
 	void _notification(int p_what);
 
-	virtual void _on_openxr_session_begun() override;
 	virtual Ref<Mesh> _create_fallback_mesh() override;
 
 public:

--- a/modules/openxr/scene/openxr_composition_layer_equirect.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.cpp
@@ -81,13 +81,6 @@ void OpenXRCompositionLayerEquirect::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fallback_segments", PROPERTY_HINT_NONE, ""), "set_fallback_segments", "get_fallback_segments");
 }
 
-void OpenXRCompositionLayerEquirect::_on_openxr_session_begun() {
-	OpenXRCompositionLayer::_on_openxr_session_begun();
-	if (openxr_api) {
-		composition_layer.space = openxr_api->get_play_space();
-	}
-}
-
 Ref<Mesh> OpenXRCompositionLayerEquirect::_create_fallback_mesh() {
 	Ref<ArrayMesh> mesh;
 	mesh.instantiate();

--- a/modules/openxr/scene/openxr_composition_layer_equirect.h
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.h
@@ -51,7 +51,6 @@ protected:
 
 	void _notification(int p_what);
 
-	virtual void _on_openxr_session_begun() override;
 	virtual Ref<Mesh> _create_fallback_mesh() override;
 
 public:

--- a/modules/openxr/scene/openxr_composition_layer_quad.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_quad.cpp
@@ -62,13 +62,6 @@ void OpenXRCompositionLayerQuad::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "quad_size", PROPERTY_HINT_NONE, ""), "set_quad_size", "get_quad_size");
 }
 
-void OpenXRCompositionLayerQuad::_on_openxr_session_begun() {
-	OpenXRCompositionLayer::_on_openxr_session_begun();
-	if (openxr_api) {
-		composition_layer.space = openxr_api->get_play_space();
-	}
-}
-
 Ref<Mesh> OpenXRCompositionLayerQuad::_create_fallback_mesh() {
 	Ref<QuadMesh> mesh;
 	mesh.instantiate();

--- a/modules/openxr/scene/openxr_composition_layer_quad.h
+++ b/modules/openxr/scene/openxr_composition_layer_quad.h
@@ -47,7 +47,6 @@ protected:
 
 	void _notification(int p_what);
 
-	virtual void _on_openxr_session_begun() override;
 	virtual Ref<Mesh> _create_fallback_mesh() override;
 
 public:


### PR DESCRIPTION
Composition layers broke for a non-obvious reason as a result of PR https://github.com/godotengine/godot/pull/89734

_(Sorry for missing this issue as part of my testing of that PR!)_

Basically, after that PR, the play space isn't available until a little bit later, so when we're trying to set the play space on composition layers at session start, we're setting it to `nullptr`. However, after thinking about it for a bit, the way it's implemented isn't quite right anyway, because it can't handle the play space being replaced mid-way through an OpenXR session (which is a valid thing that can happen).

This PR fixes both issues, getting composition layers working again!