### PR TITLE
CI: Use Emscripten 3.1.59 for Web platform

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.39
+  EM_VERSION: 3.1.59
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:


### PR DESCRIPTION
Works around CI failure due to mismatch between current emsdk and older releases.

We started getting these failures a few hours ago, like this: https://github.com/godotengine/godot/actions/runs/8991461748/job/24699364877
```
/home/runner/work/_temp/420ffe62-49fa-4c68-ba47-dcf266930d7b/emsdk-main/emsdk install 3.1.39
Resolving SDK version '3.1.39' to 'sdk-releases-1b56b171b627af0841cf8d4d8c0160c6cb6d855f-64bit'
Installing SDK 'sdk-releases-1b56b171b627af0841cf8d4d8c0160c6cb6d855f-64bit'..
Installing tool 'node-16.20.0-64bit'..
Downloading: /home/runner/work/_temp/420ffe62-49fa-4c68-ba47-dcf266930d7b/emsdk-main/downloads/node-v16.20.0-linux-x64.tar.xz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v16.20.0-linux-x64.tar.xz, 22559772 Bytes
 [----------------------------------------------------------------------------]
Error: Downloading URL 'https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/1b56b171b627af0841cf8d4d8c0160c6cb6d855f/wasm-binaries.tar.xz': HTTP Error 404: Not Found
```

This seems related to https://github.com/emscripten-core/emsdk/issues/1379.