### PR TITLE
CI: Add MinGW build actions for Windows

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -30,15 +30,34 @@ jobs:
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
             bin: "./bin/godot.windows.editor.x86_64.exe"
+            compiler: msvc
+
+          - name: Editor with GCC compilation (target=editor, tests=yes, use_mingw=yes)
+            cache-name: windows-editor-gcc
+            target: editor
+            tests: true
+            sconsflags: debug_symbols=no windows_subsystem=console use_mingw=yes
+            bin: "./bin/godot.windows.editor.x86_64.exe"
+            compiler: gcc
+
+          - name: Editor with clang compilation (target=editor, tests=yes, use_mingw=yes, use_llvm=yes)
+            cache-name: windows-editor-clang
+            target: editor
+            tests: true
+            sconsflags: debug_symbols=no windows_subsystem=console use_mingw=yes use_llvm=yes
+            bin: "./bin/godot.windows.editor.x86_64.llvm.exe"
+            compiler: clang
 
           - name: Template (target=template_release)
             cache-name: windows-template
             target: template_release
             tests: false
             sconsflags: debug_symbols=no
+            compiler: msvc
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -55,7 +74,20 @@ jobs:
         run: python ./misc/scripts/install_d3d12_sdk_windows.py
 
       - name: Setup MSVC problem matcher
+        if: ${{ matrix.compiler == 'msvc' }}
         uses: ammaraskar/msvc-problem-matcher@master
+
+      - name: Setup GCC problem matcher
+        if: ${{ matrix.compiler != 'msvc' }}
+        uses: ammaraskar/gcc-problem-matcher@master
+
+      # "windows-latest" mingw lacks clang & will try to use the MSVC builtin instead.
+      # Circumvent by using WinLibs, which prepends its bin folder to `$PATH`.
+      - name: Setup WinLibs
+        if: ${{ matrix.compiler == 'clang' }}
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          with_clang: true
 
       - name: Compilation
         uses: ./.github/actions/godot-build
@@ -66,10 +98,12 @@ jobs:
           tests: ${{ matrix.tests }}
 
       - name: Prepare artifact
+        if: ${{ matrix.compiler == 'msvc' }}
         run: |
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
 
       - name: Upload artifact
+        if: ${{ matrix.compiler == 'msvc' }}
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}

--- a/SConstruct
+++ b/SConstruct
@@ -816,6 +816,8 @@ else:  # GCC, Clang
             common_warnings += ["-Wno-type-limits"]
         if cc_version_major >= 12:  # False positives in our error macros, see GH-58747.
             common_warnings += ["-Wno-return-type"]
+        if cc_version_major < 13:  # region & endregion not recognized as valid pragmas.
+            common_warnings += ["-Wno-unknown-pragmas"]
     elif methods.using_clang(env) or methods.using_emcc(env):
         common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
         # We often implement `operator<` for structs of pointers as a requirement

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -139,6 +139,12 @@ else:
         ("__REQUIRED_RPCNDR_H_VERSION__", 475),
         "HAVE_STRUCT_TIMESPEC",
     ]
+    env_d3d12_rdd.Append(
+        CXXFLAGS=[
+            "-fno-strict-aliasing",  # tex_info->desc = *(CD3DX12_RESOURCE_DESC *)&resource_desc
+        ]
+    )
+
 
 # This is needed since rendering_device_d3d12.cpp needs to include some Mesa internals.
 env_d3d12_rdd.Prepend(CPPPATH=mesa_private_inc_paths)

--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -45,6 +45,16 @@
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch"
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wtautological-undefined-compare"
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(disable : 4189 4324 4505)
 #endif

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -45,10 +45,20 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#pragma clang diagnostic ignored "-Wstring-plus-int"
+#endif
+
 #include "dxcapi.h"
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 #if !defined(_MSC_VER)

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -48,6 +48,13 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#pragma clang diagnostic ignored "-Wswitch"
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
 #if defined(AS)
 #undef AS
 #endif
@@ -59,6 +66,10 @@
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 using Microsoft::WRL::ComPtr;

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -45,6 +45,13 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#pragma clang diagnostic ignored "-Wswitch"
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
 #include "d3dx12.h"
 #include <dxgi1_6.h>
 #define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
@@ -61,9 +68,18 @@
 #pragma GCC diagnostic pop
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 using Microsoft::WRL::ComPtr;
 
 #define D3D12_BITCODE_OFFSETS_NUM_STAGES 3
+
+#ifdef DEV_ENABLED
+//#define DEBUG_COUNT_BARRIERS
+#define CUSTOM_INFO_QUEUE_ENABLED 0
+#endif
 
 struct dxil_validator;
 class RenderingContextDriverD3D12;
@@ -257,7 +273,7 @@ private:
 	LocalVector<D3D12_RESOURCE_BARRIER> res_barriers;
 	uint32_t res_barriers_count = 0;
 	uint32_t res_barriers_batch = 0;
-#ifdef DEV_ENABLED
+#ifdef DEBUG_COUNT_BARRIERS
 	int frame_barriers_count = 0;
 	int frame_barriers_batches_count = 0;
 	uint64_t frame_barriers_cpu_time = 0;

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -92,7 +92,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 			DWORD Offset;
 		};
 
-		const DWORD nb10_magic = '01BN';
+		const DWORD nb10_magic = 808534606; // '01BN'
 		struct CV_INFO_PDB20 {
 			CV_HEADER CvHeader; // CvHeader.Signature = "NB10"
 			DWORD Signature;
@@ -100,7 +100,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 			BYTE PdbFileName[1];
 		};
 
-		const DWORD rsds_magic = 'SDSR';
+		const DWORD rsds_magic = 1396986706; // 'SDSR'
 		struct CV_INFO_PDB70 {
 			DWORD Signature; // "RSDS"
 			BYTE Guid[16];
@@ -220,7 +220,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 
 		int original_path_size = pdb_info.path.utf8().length();
 		// Double-check file bounds.
-		ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
+		ERR_FAIL_UNSIGNED_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
 
 		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
 		file->seek(pdb_info.address);


### PR DESCRIPTION
In the interest of keeping MinGW as a viable alternative for compiling on Windows alongside msvc, this PR adds two new GitHub Actions for Windows: compiling with GCC and compiling with clang. `windows-latest` actually comes with a builtin support for GCC, but a new action to setup `WinLibs` is required for clang. A handful of files had slight adjustments to account for GCC and clang that weren't properly parsed before; most notably the D3D12 scripts. I tried to be as conservative as possible when making changes, but this isn't the most familiar territory for me so feedback is very appreciated!