### PR TITLE
Fix CheckBox and CheckButton not using `icon_max_width`

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -122,7 +122,7 @@
 			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="icon_max_width" data_type="constant" type="int" default="0">
-			The maximum allowed width of the [Button]'s icon. This limit is applied on top of the default size of the icon, or its expanded size if [member expand_icon] is [code]true[/code]. The height is adjusted according to the icon's ratio.
+			The maximum allowed width of the [Button]'s icon. This limit is applied on top of the default size of the icon, or its expanded size if [member expand_icon] is [code]true[/code]. The height is adjusted according to the icon's ratio. If the button has additional icons (e.g. [CheckBox]), they will also be limited.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -100,8 +100,6 @@ private:
 		int icon_max_width = 0;
 	} theme_cache;
 
-	Size2 _fit_icon_size(const Size2 &p_size) const;
-
 	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "");
 	void _texture_changed();
 
@@ -111,6 +109,7 @@ protected:
 	void _set_internal_margin(Side p_side, float p_value);
 	virtual void _queue_update_size_cache();
 
+	Size2 _fit_icon_size(const Size2 &p_size) const;
 	Ref<StyleBox> _get_current_stylebox() const;
 	Size2 _get_largest_stylebox_size() const;
 	void _notification(int p_what);

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -59,7 +59,7 @@ Size2 CheckBox::get_icon_size() const {
 	if (!theme_cache.radio_unchecked_disabled.is_null()) {
 		tex_size = tex_size.max(theme_cache.radio_unchecked_disabled->get_size());
 	}
-	return tex_size;
+	return _fit_icon_size(tex_size);
 }
 
 Size2 CheckBox::get_minimum_size() const {
@@ -127,9 +127,9 @@ void CheckBox::_notification(int p_what) {
 			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw(ci, ofs);
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
 			} else {
-				off_tex->draw(ci, ofs);
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
 			}
 		} break;
 	}

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -63,7 +63,7 @@ Size2 CheckButton::get_icon_size() const {
 		tex_size = tex_size.max(off_tex->get_size());
 	}
 
-	return tex_size;
+	return _fit_icon_size(tex_size);
 }
 
 Size2 CheckButton::get_minimum_size() const {
@@ -134,9 +134,9 @@ void CheckButton::_notification(int p_what) {
 			ofs.y = (get_size().height - tex_size.height) / 2 + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw(ci, ofs);
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
 			} else {
-				off_tex->draw(ci, ofs);
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
 			}
 		} break;
 	}


### PR DESCRIPTION
quick attempt. follows original rendering behavior in terms of where things are drawn if the other currently not drawn icons are larger.
fixes #91697
