### PR TITLE
Don't use feature tag when filtering property sections

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -31,18 +31,24 @@
 #include "editor_sectioned_inspector.h"
 
 #include "editor/editor_property_name_processor.h"
-#include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"
 
 static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
-	if (p_property_path.containsn(p_filter)) {
+	// Strip feature tag.
+	String property_path = p_property_path;
+	const int dot = property_path.rfind(".");
+	if (dot != -1) {
+		property_path = property_path.substr(0, dot);
+	}
+
+	if (property_path.containsn(p_filter)) {
 		return true;
 	}
 
-	const Vector<String> sections = p_property_path.split("/");
+	const Vector<String> sections = property_path.split("/");
 	for (int i = 0; i < sections.size(); i++) {
-		if (p_filter.is_subsequence_ofn(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style, p_property_path))) {
+		if (p_filter.is_subsequence_ofn(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style, property_path))) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Fixes part of #91694

Most of the filtering results shown in the issue are intentional as it uses `is_subsequence_ofn()`. The only problem is searching for `window` results in empty sections like `Display Server` and `Pen Table`.

That's caused by feature tags (`path/to/property.windows`). Feature tags are stripped before filtering on the right side. This PR does the same for the left side (section tree).