### PR TITLE
Add a method to get points of intersection between camera frustum and a plane

### DIFF
--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -108,7 +108,8 @@ struct _NO_DISCARD_ Projection {
 
 	Vector<Plane> get_projection_planes(const Transform3D &p_transform) const;
 
-	bool get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const;
+	bool get_endpoints(const Transform3D &p_transform, Vector3 *r_8points) const;
+	bool get_frustum_endpoints(const Transform3D &p_transform, Vector3 *r_8points) const;
 	Vector2 get_viewport_half_extents() const;
 	Vector2 get_far_plane_half_extents() const;
 

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -48,6 +48,13 @@
 				Returns the camera's frustum planes in world space units as an array of [Plane]s in the following order: near, far, left, top, right, bottom. Not to be confused with [member frustum_offset].
 			</description>
 		</method>
+		<method name="get_frustum_plane_intersection" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<param index="0" name="plane" type="Plane" />
+			<description>
+				Returns the points of intersection between camera's frustum planes and [param plane] in world space.
+			</description>
+		</method>
 		<method name="get_pyramid_shape_rid">
 			<return type="RID" />
 			<description>

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -161,6 +161,7 @@ public:
 	bool get_cull_mask_value(int p_layer_number) const;
 
 	virtual Vector<Plane> get_frustum() const;
+	virtual Vector<Vector3> get_frustum_plane_intersection(const Plane &p_plane) const;
 	bool is_position_in_frustum(const Vector3 &p_position) const;
 
 	void set_environment(const Ref<Environment> &p_environment);

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -61,6 +61,7 @@ public:
 	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
 	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const override;
 	virtual Vector<Plane> get_frustum() const override;
+	virtual Vector<Vector3> get_frustum_plane_intersection(const Plane &p_plane) const override;
 
 	XRCamera3D();
 	~XRCamera3D();


### PR DESCRIPTION
I've decided to make remake of https://github.com/godotengine/godot/pull/77188 since author is probably abandoned it.

Closes https://github.com/godotengine/godot-proposals/issues/6015
