### PR TITLE
Expose `set_edited` and `is_edited` on `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -266,6 +266,13 @@
 				Returns [code]true[/code] if the 3D editor currently has snapping mode enabled, and [code]false[/code] otherwise.
 			</description>
 		</method>
+		<method name="is_object_edited" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="object" type="Object" />
+			<description>
+				Returns [code]true[/code] if the object has been marked as edited through [method set_object_edited].
+			</description>
+		</method>
 		<method name="is_playing_scene" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -488,6 +495,16 @@
 			<param index="0" name="name" type="String" />
 			<description>
 				Sets the editor's current main screen to the one specified in [param name]. [param name] must match the title of the tab in question exactly (e.g. [code]2D[/code], [code]3D[/code], [code skip-lint]Script[/code], [code]Game[/code], or [code]AssetLib[/code] for default tabs).
+			</description>
+		</method>
+		<method name="set_object_edited">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="edited" type="bool" />
+			<description>
+				If [param edited] is [code]true[/code], the object is marked as edited.
+				[b]Note:[/b] This is primarily used by the editor for [Resource] based objects to track their modified state. For example, any changes to an open scene, a resource in the inspector, or an edited script will cause this method to be called with [code]true[/code]. Saving the scene, script, or resource resets the edited state by calling this method with [code]false[/code].
+				[b]Note:[/b] Each call to this method increments the object's edited version. This is used to track changes in the editor and to trigger when thumbnails should be regenerated for resources.
 			</description>
 		</method>
 		<method name="set_plugin_enabled">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -705,6 +705,16 @@ void EditorInterface::reload_scene_from_path(const String &scene_path) {
 	EditorNode::get_singleton()->reload_scene(scene_path);
 }
 
+void EditorInterface::set_object_edited(Object *p_object, bool p_edited) {
+	ERR_FAIL_NULL_MSG(p_object, "Cannot change edited status on a null object.");
+	p_object->set_edited(p_edited);
+}
+
+bool EditorInterface::is_object_edited(Object *p_object) const {
+	ERR_FAIL_NULL_V_MSG(p_object, false, "Cannot check edit status on a null object.");
+	return p_object->is_edited();
+}
+
 Node *EditorInterface::get_edited_scene_root() const {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
@@ -894,6 +904,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath", "set_inherited"), &EditorInterface::open_scene_from_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
+
+	ClassDB::bind_method(D_METHOD("set_object_edited", "object", "edited"), &EditorInterface::set_object_edited);
+	ClassDB::bind_method(D_METHOD("is_object_edited", "object"), &EditorInterface::is_object_edited);
 
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
 	ClassDB::bind_method(D_METHOD("get_open_scene_roots"), &EditorInterface::get_open_scene_roots);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -175,6 +175,9 @@ public:
 	void open_scene_from_path(const String &scene_path, bool p_set_inherited = false);
 	void reload_scene_from_path(const String &scene_path);
 
+	void set_object_edited(Object *p_object, bool p_edited);
+	bool is_object_edited(Object *p_object) const;
+
 	PackedStringArray get_open_scenes() const;
 	TypedArray<Node> get_open_scene_roots() const;
 	Node *get_edited_scene_root() const;


### PR DESCRIPTION
Exposes several tools-based methods on `Object`.

The reason to expose these is simple.  If an editor plugin provides a `EditorResourcePreviewGenerator` implementation to create thumbnails for custom resources, there isn't a way for the plugin to have the `EditorResourcePreview` regenerate thumbnails when the resource is modified. In the engine, this is handled by calling `set_edited(true)`, which increments the edited version that is used by the hash algorithm to determine whether the cached thumbnail should be discarded and regenerated.

By exposing these three methods, addons can easily use the thumbnail generator framework and regenerate the thumbnails when the underlying resource is changed rather than requiring an editor restart.