### PR TITLE
Fix Parallax2D physics interpolation

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -54,16 +54,18 @@ void Camera2D::_update_scroll() {
 	if (is_current()) {
 		ERR_FAIL_COND(custom_viewport && !ObjectDB::get_instance(custom_viewport_id));
 
+		Size2 screen_size = _get_camera_screen_size();
+
 		Transform2D xform;
 		if (is_physics_interpolated_and_enabled()) {
 			xform = _interpolation_data.xform_prev.interpolate_with(_interpolation_data.xform_curr, Engine::get_singleton()->get_physics_interpolation_fraction());
+			camera_screen_center = xform.affine_inverse().xform(0.5 * screen_size);
 		} else {
 			xform = get_camera_transform();
 		}
 
 		viewport->set_canvas_transform(xform);
 
-		Size2 screen_size = _get_camera_screen_size();
 		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5) : Point2());
 		Point2 adj_screen_pos = camera_screen_center - (screen_size * 0.5);
 


### PR DESCRIPTION
The `camera_screen_center` value was stale in case of interpolation, so in that case we compute it using the affine inverse of the interpolated camera transform.

- Fixes https://github.com/godotengine/godot/issues/91625