### PR TITLE
Revert `as_sortable_control()` change in SplitContainer

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -126,8 +126,8 @@ Control *SplitContainer::get_containable_child(int p_idx) const {
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *c = as_sortable_control(get_child(i, false));
-		if (!c) {
+		Control *c = Object::cast_to<Control>(get_child(i, false));
+		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
 			continue;
 		}
 


### PR DESCRIPTION
Seems like #91613 broke the editor.

https://github.com/godotengine/godot/assets/2223172/1b268d83-8bfd-44c2-968e-47c360f59486

idk if it's SplitContainer bug, but I don't feel like delving for reason.