### PR TITLE
Improve transition enabled header in interactive music editor

### DIFF
--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
@@ -340,8 +340,8 @@ AudioStreamInteractiveTransitionEditor::AudioStreamInteractiveTransitionEditor()
 	split->add_child(edit_vb);
 
 	transition_enabled = memnew(CheckBox);
-	transition_enabled->set_text(TTR("Use Transition"));
-	edit_vb->add_margin_child(TTR("Transition Enabled:"), transition_enabled);
+	transition_enabled->set_text(TTR("Enabled"));
+	edit_vb->add_margin_child(TTR("Use Transition:"), transition_enabled);
 	transition_enabled->connect("pressed", callable_mp(this, &AudioStreamInteractiveTransitionEditor::_edited));
 
 	transition_from = memnew(OptionButton);


### PR DESCRIPTION
AudioStreamInteractive editor has a slightly awkward label for enabling transition:
![image](https://github.com/godotengine/godot/assets/2223172/ac1626a6-87fe-4161-822d-9cfa4280c713)
It has header called "Transition Enabled:" followed by a checkbox "Use Transition"

This PR rewords it a bit:
![image](https://github.com/godotengine/godot/assets/2223172/2b12d25d-4922-4af2-ab77-853478a96aa0)
It's also consistent with Hold Previous below.