### PR TITLE
Compare binary size with latest `master` build on CI

### DIFF
--- a/.github/actions/check-artifact-sizes/action.yml
+++ b/.github/actions/check-artifact-sizes/action.yml
@@ -1,0 +1,47 @@
+name: Check master and artifact binary sizes
+description: Check master and artifact binary sizes for Godot artifacts.
+inputs:
+  name:
+    description: The artifact name.
+    default: "${{ github.job }}"
+runs:
+  using: "composite"
+  steps:
+    - name: Compare binary size with latest successful master build
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          echo "Running on macOS, exiting..."
+          exit 0
+        fi
+
+        echo "Current commit: $(git rev-parse HEAD)"
+
+        template_name=$(echo ${{ github.job }} | sed 's/[^a-zA-Z0-9_]/_/g')
+        template=${template_name//-/_}
+
+        file_path="$GITHUB_WORKSPACE/bin/*"
+
+        if [ ! -d "${file_path}" ]; then
+          echo "Directory ${file_path} does not exist, exiting..."
+          exit 0
+        fi
+
+        actual_size=$(du -sb "$file_path" | awk '{print $1}')
+
+        last_artifact_file="./last_artifact/${{ github.job }}"
+        if [[ -d "$last_artifact_file" ]]; then
+          expected_size=$(du -sb "$last_artifact_file" | awk '{print $1}')
+        else
+          echo "No previous artifact found for comparison."
+          exit 0
+        fi
+
+        size_difference=$((actual_size - expected_size))
+
+        if [[ $size_difference -ge 1 ]]; then
+          echo -e "\033[1mBinary size:\033[0m The $template binary is \033[1;91m$size_difference bytes larger\033[0m than the last successful commit."
+        elif [[ $size_difference -lt 0 ]]; then
+          echo -e "\033[1mBinary size:\033[0m The $template binary is \033[1;92m$size_difference bytes smaller\033[0m than the last successful commit."
+        else
+          echo -e "\033[1mBinary size:\033[0m The $template binary is \033[1;92mexactly as the last successful commit.\033[0m"

--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -16,3 +16,6 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+
+
+

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -60,3 +60,8 @@ jobs:
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        with:
+          name: ${{ matrix.cache-name }}

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -39,3 +39,8 @@ jobs:
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        with:
+          name: ${{ matrix.cache-name }}

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -151,6 +151,12 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}
 
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        if: ${{ matrix.artifact }}
+        with:
+          name: ${{ matrix.cache-name }}
+
       - name: Dump Godot API
         uses: ./.github/actions/godot-api-dump
         if: ${{ matrix.api-dump }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -78,6 +78,11 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}
 
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        with:
+          name: ${{ matrix.cache-name }}
+
       # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -74,3 +74,8 @@ jobs:
         if: ${{ matrix.artifact }}
         with:
           name: ${{ matrix.cache-name }}
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        with:
+          name: ${{ matrix.cache-name }}

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}
 
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-sizes
+        with:
+          name: ${{ matrix.cache-name }}
+
       # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}


### PR DESCRIPTION
This makes it easier to track binary size regressions, as you no longer have to build the editor and/or export templates locally to do so.

@Calinou Can you link the proposal number for your pr?


- [x] Copy the correct numbers for the hard coded values