### PR TITLE
Editor: Fix `EditorHelpBitTooltip` + `ProgressDialog` causes crash

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -325,6 +325,10 @@ class EditorHelpBitTooltip : public PopupPanel {
 	GDCLASS(EditorHelpBitTooltip, PopupPanel);
 
 	Timer *timer = nullptr;
+	int _pushing_input = 0;
+	bool _need_free = false;
+
+	void _safe_queue_free();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
* Fixes #91652.

The crash only (?) occurs in sanitizer builds. The reason is that `ProgressDialog` calls `Main::iteration()` which makes `queue_free()` unsafe, see https://github.com/godotengine/godot/issues/91652#issuecomment-2099229220 for details.

This is probably not the only such bug in the editor, and in the future we should reconsider the approach of calling `Main::iteration()` in many places. But for now, this fix is probably the least invasive option.

CC @timothyqiu @KoBeWi
