### PR TITLE
Fix TextEdit minimap tab drawing and click check

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1314,7 +1314,7 @@
 			[b]Note:[/b] This method is only implemented on Linux.
 		</member>
 		<member name="minimap_draw" type="bool" setter="set_draw_minimap" getter="is_drawing_minimap" default="false">
-			If [code]true[/code], a minimap is shown, providing an outline of your source code.
+			If [code]true[/code], a minimap is shown, providing an outline of your source code. The minimap uses a fixed-width text size.
 		</member>
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">
 			The width, in pixels, of the minimap.


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/87453
- Fixes https://github.com/godotengine/godot/issues/72876
- Fixes https://github.com/godotengine/godot/issues/63842

Fixes color leak from last color used in minimap to the `lookup_symbol_word` underline (hold control and hover).

Rewrites the character drawing logic to use a for loop instead of continues, so it can check the next character without needing to go back. This simplifies the logic and was needed to calculate the tab alignment since it can't be reversed.

Also clarified in the docs that the minimap text is fixed-width, since if the font used is not monospaced then it won't match.

Example text:

![image](https://github.com/godotengine/godot/assets/10054226/091d4b70-4484-49f6-b760-5028df138e41)

Before:

![image](https://github.com/godotengine/godot/assets/10054226/fdc4ab01-1f17-45ce-82e7-279c21e7f8c3)

After:

![image](https://github.com/godotengine/godot/assets/10054226/9ffc04ee-0bd2-4a60-8e11-e06d728235ee)
