### PR TITLE
`CommandQueueMT`: Fix sync command awaiters missing the chance

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -327,7 +327,6 @@ class CommandQueueMT {
 
 	enum {
 		DEFAULT_COMMAND_MEM_SIZE_KB = 256,
-		SYNC_SEMAPHORES = 8
 	};
 
 	BinaryMutex mutex;
@@ -335,6 +334,7 @@ class CommandQueueMT {
 	ConditionVariable sync_cond_var;
 	uint32_t sync_head = 0;
 	uint32_t sync_tail = 0;
+	uint32_t sync_awaiters = 0;
 	WorkerThreadPool::TaskID pump_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	uint64_t flush_read_ptr = 0;
 
@@ -347,6 +347,15 @@ class CommandQueueMT {
 		*(uint64_t *)&command_mem[size] = alloc_size;
 		T *cmd = memnew_placement(&command_mem[size + 8], T);
 		return cmd;
+	}
+
+	_FORCE_INLINE_ void _prevent_sync_wraparound() {
+		bool safe_to_reset = !sync_awaiters;
+		bool already_sync_to_latest = sync_head == sync_tail;
+		if (safe_to_reset && already_sync_to_latest) {
+			sync_head = 0;
+			sync_tail = 0;
+		}
 	}
 
 	void _flush() {
@@ -365,7 +374,9 @@ class CommandQueueMT {
 			cmd->call();
 			if (unlikely(cmd->sync)) {
 				sync_head++;
+				unlock(); // Give an opportunity to awaiters right away.
 				sync_cond_var.notify_all();
+				lock();
 			}
 
 			flush_read_ptr += size;
@@ -374,14 +385,20 @@ class CommandQueueMT {
 
 		command_mem.clear();
 		flush_read_ptr = 0;
+
+		_prevent_sync_wraparound();
+
 		unlock();
 	}
 
 	_FORCE_INLINE_ void _wait_for_sync(MutexLock<BinaryMutex> &p_lock) {
+		sync_awaiters++;
 		uint32_t sync_head_goal = sync_tail;
 		do {
 			sync_cond_var.wait(p_lock);
-		} while (sync_head != sync_head_goal); // Can't use lower-than because of wraparound.
+		} while (sync_head < sync_head_goal);
+		sync_awaiters--;
+		_prevent_sync_wraparound();
 	}
 
 public:


### PR DESCRIPTION
The recent new implementation of waiting for a sync command to have run used `!=` to compare the sync head with the tail. The problem was that an awaiter could be notified due to thread scheduling at any point after the event. That means that, say, an awaiter of sync command `3` could be awaken by the time sync command `6` has already run.

The fix is not as easy as using `<` instead because, as stated by a comment in the code, if wraparound ever happened, sync would break. Therefore, this PR adds some logic to reset the counters at the earliest opportunity so they never reach high values.

Also, the mutex is unlocked to give an opportunity to awaiters of realizing the wait is over and go on.

As a bonus, the leftover `SYNC_SEMAPHORES` constant is removed.

Fixes #91520.