### PR TITLE
`CommandQueueMT`: Pre-allocate memory to avoid a bunch of allocations at startup

### DIFF
--- a/core/templates/command_queue_mt.cpp
+++ b/core/templates/command_queue_mt.cpp
@@ -42,6 +42,7 @@ void CommandQueueMT::unlock() {
 }
 
 CommandQueueMT::CommandQueueMT() {
+	command_mem.reserve(DEFAULT_COMMAND_MEM_SIZE_KB * 1024);
 }
 
 CommandQueueMT::~CommandQueueMT() {

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -325,9 +325,7 @@ class CommandQueueMT {
 
 	/***** BASE *******/
 
-	enum {
-		DEFAULT_COMMAND_MEM_SIZE_KB = 256,
-	};
+	static const uint32_t DEFAULT_COMMAND_MEM_SIZE_KB = 64;
 
 	BinaryMutex mutex;
 	LocalVector<uint8_t> command_mem;


### PR DESCRIPTION
There was an unused `DEFAULT_COMMAND_MEM_SIZE_KB` constant. I've not been able to find if it had ever been used. However, it's not a bad idea to preallocate a bit of memory so the first bunch of commands added to the queue don't cause reallocations. Not a big deal, but very easy to prevent.

I've lowered the pre-allocation size constant from 256 KiB to 64 KiB to be a bit more conservative. A lot of commands already fit there and exponential growth will take care of further needs just fine.

Made on top of #91725 because of the conflicts.