### PR TITLE
Use `as_sortable_control()` in SplitContainer

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -59,12 +59,13 @@ void DockSplitContainer::_update_visibility() {
 	}
 	is_updating = true;
 	bool any_visible = false;
-	for (int i = 0; i < 2; i++) {
-		Control *split = get_containable_child(i);
-		if (split && split->is_visible()) {
-			any_visible = true;
-			break;
+	for (int i = 0; i < get_child_count(false); i++) {
+		Control *c = Object::cast_to<Control>(get_child(i, false));
+		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
+			continue;
 		}
+		any_visible = c;
+		break;
 	}
 	set_visible(any_visible);
 	is_updating = false;
@@ -74,10 +75,13 @@ void DockSplitContainer::add_child_notify(Node *p_child) {
 	SplitContainer::add_child_notify(p_child);
 
 	Control *child_control = nullptr;
-	for (int i = 0; i < 2; i++) {
-		Control *split = get_containable_child(i);
-		if (p_child == split) {
-			child_control = split;
+	for (int i = 0; i < get_child_count(false); i++) {
+		Control *c = Object::cast_to<Control>(get_child(i, false));
+		if (!c || c->is_set_as_top_level()) {
+			continue;
+		}
+		if (p_child == c) {
+			child_control = c;
 			break;
 		}
 	}
@@ -93,10 +97,13 @@ void DockSplitContainer::remove_child_notify(Node *p_child) {
 	SplitContainer::remove_child_notify(p_child);
 
 	Control *child_control = nullptr;
-	for (int i = 0; i < 2; i++) {
-		Control *split = get_containable_child(i);
-		if (p_child == split) {
-			child_control = split;
+	for (int i = 0; i < get_child_count(false); i++) {
+		Control *c = Object::cast_to<Control>(get_child(i, false));
+		if (!c || c->is_set_as_top_level()) {
+			continue;
+		}
+		if (p_child == c) {
+			child_control = c;
 			break;
 		}
 	}

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -39,7 +39,7 @@ void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 
 	SplitContainer *sc = Object::cast_to<SplitContainer>(get_parent());
 
-	if (sc->collapsed || !sc->get_containable_child(0) || !sc->get_containable_child(1) || sc->dragger_visibility != SplitContainer::DRAGGER_VISIBLE) {
+	if (sc->collapsed || !sc->_get_sortable_child(0) || !sc->_get_sortable_child(1) || sc->dragger_visibility != SplitContainer::DRAGGER_VISIBLE) {
 		return;
 	}
 
@@ -122,12 +122,12 @@ void SplitContainerDragger::_notification(int p_what) {
 	}
 }
 
-Control *SplitContainer::get_containable_child(int p_idx) const {
+Control *SplitContainer::_get_sortable_child(int p_idx) const {
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *c = Object::cast_to<Control>(get_child(i, false));
-		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
+		Control *c = as_sortable_control(get_child(i, false));
+		if (!c) {
 			continue;
 		}
 
@@ -154,8 +154,8 @@ Ref<Texture2D> SplitContainer::_get_grabber_icon() const {
 }
 
 void SplitContainer::_compute_middle_sep(bool p_clamp) {
-	Control *first = get_containable_child(0);
-	Control *second = get_containable_child(1);
+	Control *first = _get_sortable_child(0);
+	Control *second = _get_sortable_child(1);
 
 	// Determine expanded children.
 	bool first_expanded = (vertical ? first->get_v_size_flags() : first->get_h_size_flags()) & SIZE_EXPAND;
@@ -196,8 +196,8 @@ void SplitContainer::_compute_middle_sep(bool p_clamp) {
 }
 
 void SplitContainer::_resort() {
-	Control *first = get_containable_child(0);
-	Control *second = get_containable_child(1);
+	Control *first = _get_sortable_child(0);
+	Control *second = _get_sortable_child(1);
 
 	// If we have only one element.
 	if (!first || !second) {
@@ -258,7 +258,7 @@ Size2 SplitContainer::get_minimum_size() const {
 	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? g->get_height() : g->get_width()) : 0;
 
 	for (int i = 0; i < 2; i++) {
-		if (!get_containable_child(i)) {
+		if (!_get_sortable_child(i)) {
 			break;
 		}
 
@@ -270,7 +270,7 @@ Size2 SplitContainer::get_minimum_size() const {
 			}
 		}
 
-		Size2 ms = get_containable_child(i)->get_combined_minimum_size();
+		Size2 ms = _get_sortable_child(i)->get_combined_minimum_size();
 
 		if (vertical) {
 			minimum.height += ms.height;
@@ -322,7 +322,7 @@ int SplitContainer::get_split_offset() const {
 }
 
 void SplitContainer::clamp_split_offset() {
-	if (!get_containable_child(0) || !get_containable_child(1)) {
+	if (!_get_sortable_child(0) || !_get_sortable_child(1)) {
 		return;
 	}
 

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -82,11 +82,10 @@ private:
 	Ref<Texture2D> _get_grabber_icon() const;
 	void _compute_middle_sep(bool p_clamp);
 	void _resort();
+	Control *_get_sortable_child(int p_idx) const;
 
 protected:
 	bool is_fixed = false;
-
-	Control *get_containable_child(int p_idx) const;
 
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/91613
- see https://github.com/godotengine/godot/pull/91708

Changed DockSplitContainer to improve the check, using `get_containable_child()` wasn't a great fit.

Made `get_containable_child()` private and renamed to match `as_sortable_control()` better.