### PR TITLE
Fix 2d editor selection persisting after application loses focus.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4073,6 +4073,13 @@ void CanvasItemEditor::_notification(int p_what) {
 				override_camera_button->set_pressed(false);
 			}
 		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			if (drag_type != DRAG_NONE) {
+				_reset_drag();
+				viewport->queue_redraw();
+			}
+		} break;
 	}
 }
 


### PR DESCRIPTION

https://github.com/godotengine/godot/assets/2223172/91163c50-0a83-4c58-95b5-ec2d81cdfaca

_Originally posted by @KoBeWi in https://github.com/godotengine/godot/issues/90090#issuecomment-2100559464_


