### PR TITLE
[Core] Optimize math interpolation

### DIFF
--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -639,6 +639,14 @@ TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {
 	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0) == doctest::Approx((T)1.0));
 }
 
+TEST_CASE_TEMPLATE("[Math] bezier_derivative", T, float, double) {
+	CHECK(Math::bezier_derivative((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.0) == doctest::Approx((T)0.6));
+	CHECK(Math::bezier_derivative((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.25) == doctest::Approx((T)1.05));
+	CHECK(Math::bezier_derivative((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.5) == doctest::Approx((T)1.2));
+	CHECK(Math::bezier_derivative((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.75) == doctest::Approx((T)1.05));
+	CHECK(Math::bezier_derivative((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0) == doctest::Approx((T)0.6));
+}
+
 } // namespace TestMath
 
 #endif // TEST_MATH_FUNCS_H


### PR DESCRIPTION
To reduce the number of operations for `cubic_interpolate`, `bezier_interpolate` and `bezier_derivative`, I used simple simplifications. The speed increased by about (10 - 20)%.

I added `fmod_TAU` method, which is ten times faster than `fmod(x, Math_TAU)`, which optimized angular interpolations by 3-5 times. I also applied this to the `angle_difference` method.