### PR TITLE
Fix focusing on AnimationPlayer/AnimationTree dock

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -2271,7 +2271,7 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 }
 
 bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("AnimationPlayer") || p_object->is_class("AnimationTree") || p_object->is_class("AnimationMixer");
+	return p_object->is_class("AnimationPlayer");
 }
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -290,8 +290,6 @@ bool AnimationTreeEditorPlugin::handles(Object *p_object) const {
 
 void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		//editor->hide_animation_player_editors();
-		//editor->animation_panel_make_visible(true);
 		button->show();
 		EditorNode::get_bottom_panel()->make_item_visible(anim_tree_editor);
 		anim_tree_editor->set_process(true);


### PR DESCRIPTION
The AnimationPlayerEditorPlugin dock is checked for handling AnimationTree nodes after the AnimationTreeEditorPlugin and claims to handle AnimationTree nodes, so the Player editor grabs focus last.

After this change, selecting the AnimationPlayer and AnimationTree nodes immediately focus the correct dock tab.

An alternative is to check that `p_object` is *not* an `AnimationTree`, but I chose this solution because `AnimationMixer` is an abstract base.

Fixes #87797