### PR TITLE
Manually specify build tools

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -117,7 +117,7 @@ for x in sorted(glob.glob("platform/*")):
         platform_exporters.append(platform_name)
     if os.path.exists(x + "/api/api.cpp"):
         platform_apis.append(platform_name)
-    if os.getenv("GODOT_CAN_BUILD_" + x.removeprefix("platform/").upper()) or detect.can_build():
+    if os.getenv("GODOT_CAN_BUILD_" + platform_name.upper()) or detect.can_build():
         x = x.replace("platform/", "")  # rest of world
         x = x.replace("platform\\", "")  # win32
         platform_list += [x]

--- a/SConstruct
+++ b/SConstruct
@@ -305,7 +305,7 @@ opts.Add(BoolVariable("builtin_zstd", "Use the built-in Zstd library", True))
 # Compilation environment setup
 # CXX, CC, and LINK directly set the equivalent `env` values (which may still
 # be overridden for a specific platform if platform_tools is True), the lowercase ones are appended.
-opts.Add(BoolVariable("platform_tools", "Allow the platform to override CC, CXX, LINK, AS, AR, RANLIB, and WINDRES", True))
+opts.Add(BoolVariable("platform_tools", "Allow the platform to override CC, CXX, LINK, AS, AR, RANLIB, WINDRES, and ARCOM", True))
 opts.Add("CXX", "C++ compiler binary")
 opts.Add("CC", "C compiler binary")
 opts.Add("LINK", "Linker binary")
@@ -313,6 +313,9 @@ opts.Add("AS", "Assembler binary")
 opts.Add("AR", "Archiver binary")
 opts.Add("RANLIB", "Ranlib binary")
 opts.Add("RC", "Resource compiler binary")
+# Set this to something like "${TEMPFILE('$AR rcs $TARGET $SOURCES','$ARCOMSTR')}" if you get errors related to a command being too long. 
+# This is a common error on Windows machines.
+opts.Add("ARCOM", "Custom command used to generate an object file from an assembly-language source file.")
 opts.Add("cppdefines", "Custom defines for the pre-processor")
 opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
 opts.Add("cxxflags", "Custom flags for the C++ compiler")

--- a/SConstruct
+++ b/SConstruct
@@ -304,10 +304,15 @@ opts.Add(BoolVariable("builtin_zstd", "Use the built-in Zstd library", True))
 
 # Compilation environment setup
 # CXX, CC, and LINK directly set the equivalent `env` values (which may still
-# be overridden for a specific platform), the lowercase ones are appended.
+# be overridden for a specific platform if platform_tools is True), the lowercase ones are appended.
+opts.Add(BoolVariable("platform_tools", "Allow the platform to override CC, CXX, LINK, AS, AR, RANLIB, and WINDRES", True))
 opts.Add("CXX", "C++ compiler binary")
 opts.Add("CC", "C compiler binary")
 opts.Add("LINK", "Linker binary")
+opts.Add("AS", "Assembler binary")
+opts.Add("AR", "Archiver binary")
+opts.Add("RANLIB", "Ranlib binary")
+opts.Add("WINDRES", "Windres binary")
 opts.Add("cppdefines", "Custom defines for the pre-processor")
 opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
 opts.Add("cxxflags", "Custom flags for the C++ compiler")

--- a/SConstruct
+++ b/SConstruct
@@ -117,7 +117,7 @@ for x in sorted(glob.glob("platform/*")):
         platform_exporters.append(platform_name)
     if os.path.exists(x + "/api/api.cpp"):
         platform_apis.append(platform_name)
-    if detect.can_build():
+    if os.getenv("GODOT_CAN_BUILD_" + x.removeprefix("platform/").upper()) or detect.can_build():
         x = x.replace("platform/", "")  # rest of world
         x = x.replace("platform\\", "")  # win32
         platform_list += [x]
@@ -312,7 +312,7 @@ opts.Add("LINK", "Linker binary")
 opts.Add("AS", "Assembler binary")
 opts.Add("AR", "Archiver binary")
 opts.Add("RANLIB", "Ranlib binary")
-opts.Add("WINDRES", "Windres binary")
+opts.Add("RC", "Resource compiler binary")
 opts.Add("cppdefines", "Custom defines for the pre-processor")
 opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
 opts.Add("cxxflags", "Custom flags for the C++ compiler")

--- a/SConstruct
+++ b/SConstruct
@@ -313,7 +313,7 @@ opts.Add("AS", "Assembler binary")
 opts.Add("AR", "Archiver binary")
 opts.Add("RANLIB", "Ranlib binary")
 opts.Add("RC", "Resource compiler binary")
-# Set this to something like "${TEMPFILE('$AR rcs $TARGET $SOURCES','$ARCOMSTR')}" if you get errors related to a command being too long. 
+# Set this to something like "${TEMPFILE('$AR rcs $TARGET $SOURCES','$ARCOMSTR')}" if you get errors related to a command being too long.
 # This is a common error on Windows machines.
 opts.Add("ARCOM", "Custom command used to generate an object file from an assembly-language source file.")
 opts.Add("cppdefines", "Custom defines for the pre-processor")

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -169,11 +169,12 @@ def configure(env: "SConsEnvironment"):
     toolchain_path = ndk_root + "/toolchains/llvm/prebuilt/" + host_subpath
     compiler_path = toolchain_path + "/bin"
 
-    env["CC"] = compiler_path + "/clang"
-    env["CXX"] = compiler_path + "/clang++"
-    env["AR"] = compiler_path + "/llvm-ar"
-    env["RANLIB"] = compiler_path + "/llvm-ranlib"
-    env["AS"] = compiler_path + "/clang"
+    if env["platform_tools"]:
+        env["CC"] = compiler_path + "/clang"
+        env["CXX"] = compiler_path + "/clang++"
+        env["AR"] = compiler_path + "/llvm-ar"
+        env["RANLIB"] = compiler_path + "/llvm-ranlib"
+        env["AS"] = compiler_path + "/clang"
 
     env.Append(
         CCFLAGS=("-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden".split())

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -87,18 +87,20 @@ def configure(env: "SConsEnvironment"):
     compiler_path = "$IOS_TOOLCHAIN_PATH/usr/bin/${ios_triple}"
 
     ccache_path = os.environ.get("CCACHE")
-    if ccache_path is None:
-        env["CC"] = compiler_path + "clang"
-        env["CXX"] = compiler_path + "clang++"
-        env["S_compiler"] = compiler_path + "clang"
-    else:
-        # there aren't any ccache wrappers available for iOS,
-        # to enable caching we need to prepend the path to the ccache binary
-        env["CC"] = ccache_path + " " + compiler_path + "clang"
-        env["CXX"] = ccache_path + " " + compiler_path + "clang++"
-        env["S_compiler"] = ccache_path + " " + compiler_path + "clang"
-    env["AR"] = compiler_path + "ar"
-    env["RANLIB"] = compiler_path + "ranlib"
+
+    if env["platform_tools"]:
+        if ccache_path is None:
+            env["CC"] = compiler_path + "clang"
+            env["CXX"] = compiler_path + "clang++"
+            env["S_compiler"] = compiler_path + "clang"
+        else:
+            # there aren't any ccache wrappers available for iOS,
+            # to enable caching we need to prepend the path to the ccache binary
+            env["CC"] = ccache_path + " " + compiler_path + "clang"
+            env["CXX"] = ccache_path + " " + compiler_path + "clang++"
+            env["S_compiler"] = ccache_path + " " + compiler_path + "clang"
+        env["AR"] = compiler_path + "ar"
+        env["RANLIB"] = compiler_path + "ranlib"
 
     ## Compile flags
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -492,7 +492,7 @@ def configure(env: "SConsEnvironment"):
             # The default crash handler depends on glibc, so if the host uses
             # a different libc (BSD libc, musl), libexecinfo is required.
             print("Note: Using `execinfo=no` disables the crash handler on platforms where glibc is missing.")
-    elif not "execinfo" in env or env["execinfo"]:
+    elif "execinfo" not in env or env["execinfo"]:
         env.Append(CPPDEFINES=["CRASH_HANDLER_ENABLED"])
 
     if platform.system() == "FreeBSD":

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -109,7 +109,7 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(CCFLAGS=["-fobjc-arc"])
 
-    if "osxcross" not in env:  # regular native build
+    if env["platform_tools"] and "osxcross" not in env:  # regular native build
         if env["macports_clang"] != "no":
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
@@ -134,17 +134,18 @@ def configure(env: "SConsEnvironment"):
             basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
         ccache_path = os.environ.get("CCACHE")
-        if ccache_path is None:
-            env["CC"] = basecmd + "cc"
-            env["CXX"] = basecmd + "c++"
-        else:
-            # there aren't any ccache wrappers available for macOS cross-compile,
-            # to enable caching we need to prepend the path to the ccache binary
-            env["CC"] = ccache_path + " " + basecmd + "cc"
-            env["CXX"] = ccache_path + " " + basecmd + "c++"
-        env["AR"] = basecmd + "ar"
-        env["RANLIB"] = basecmd + "ranlib"
-        env["AS"] = basecmd + "as"
+        if env["platform_tools"]:
+            if ccache_path is None:
+                env["CC"] = basecmd + "cc"
+                env["CXX"] = basecmd + "c++"
+            else:
+                # there aren't any ccache wrappers available for macOS cross-compile,
+                # to enable caching we need to prepend the path to the ccache binary
+                env["CC"] = ccache_path + " " + basecmd + "cc"
+                env["CXX"] = ccache_path + " " + basecmd + "c++"
+            env["AR"] = basecmd + "ar"
+            env["RANLIB"] = basecmd + "ranlib"
+            env["AS"] = basecmd + "as"
 
     # LTO
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -169,11 +169,11 @@ def configure(env: "SConsEnvironment"):
     # Closure compiler extern and support for ecmascript specs (const, let, etc).
     env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT_2021"
 
-    env["CC"] = "emcc"
-    env["CXX"] = "em++"
-
-    env["AR"] = "emar"
-    env["RANLIB"] = "emranlib"
+    if env["platform_tools"]:
+        env["CC"] = "emcc"
+        env["CXX"] = "em++"
+        env["AR"] = "emar"
+        env["RANLIB"] = "emranlib"
 
     # Use TempFileMunge since some AR invocations are too long for cmd.exe.
     # Use POSIX-style paths, required with TempFileMunge.

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -376,8 +376,10 @@ def setup_mingw(env: "SConsEnvironment"):
         )
         sys.exit(255)
 
-    if env["platform_tools"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
-        "clang --version", env["mingw_prefix"], env["arch"]
+    if (
+        env["platform_tools"]
+        and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"])
+        and not try_cmd("clang --version", env["mingw_prefix"], env["arch"])
     ):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -269,7 +269,7 @@ def build_res_file(target, source, env: "SConsEnvironment"):
         cmdbase += " --include-dir . --target=" + arch_aliases[env["arch"]]
     else:
         # rc doesn't seem to have a target architecture arg.  So not passing.
-        cmdbase += " /i ."
+        cmdbase += " /nologo /i ."
 
     for x in range(len(source)):
         ok = True

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -967,7 +967,7 @@ def configure_mingw(env: "SConsEnvironment"):
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 
-    if env["platform_tools"]:
+    if not env["platform_tools"]:
         # resrc
         env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -384,7 +384,9 @@ def setup_mingw(env: "SConsEnvironment"):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
 
-    env.Tool("mingw")
+    if env["platform_tools"]:
+        env.Tool("mingw")
+
     env.AppendUnique(CCFLAGS=env.get("ccflags", "").split())
     env.AppendUnique(RCFLAGS=env.get("rcflags", "").split())
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -200,6 +200,7 @@ def get_opts():
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
         BoolVariable("incremental_link", "Use MSVC incremental linking. May increase or decrease build times.", False),
         BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting any errors to stderr.", True),
+        BoolVariable("use_windres", "Use the windres compiler, even if Microsoft's rc is installed", True),
         ("angle_libs", "Path to the ANGLE static libraries", ""),
         # Direct3D 12 support.
         (
@@ -252,18 +253,31 @@ def build_res_file(target, source, env: "SConsEnvironment"):
         "arm32": "armv7-w64-mingw32",
         "arm64": "aarch64-w64-mingw32",
     }
-    cmdbase = "windres --include-dir . --target=" + arch_aliases[env["arch"]]
 
-    mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
-
-    if not env["platform_tools"]:
-        cmdbase = env["WINDRES"]
+    if env["platform_tools"]:
+        if env["use_windres"]:
+            cmdbase = "windres"
+            mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+        else:
+            cmdbase = "rc"
+            mingw_bin_prefix = ""
+    else:
+        cmdbase = env["RC"]
         mingw_bin_prefix = ""
+
+    if env["use_windres"]:
+        cmdbase += " --include-dir . --target=" + arch_aliases[env["arch"]]
+    else:
+        # rc doesn't seem to have a target architecture arg.  So not passing.
+        cmdbase += " /i ."
 
     for x in range(len(source)):
         ok = True
         # Try prefixed executable (MinGW on Linux).
-        cmd = mingw_bin_prefix + cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+        if env["use_windres"]:
+            cmd = mingw_bin_prefix + cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+        else:
+            cmd = cmdbase + " /fo " + str(target[x]) + " " + str(source[x])
         try:
             out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
             if len(out[1]):
@@ -273,7 +287,10 @@ def build_res_file(target, source, env: "SConsEnvironment"):
 
         # Try generic executable (MSYS2).
         if not ok:
-            cmd = cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+            if env["use_windres"]:
+                cmd = cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+            else:
+                cmd = cmdbase + " /fo " + str(target[x]) + " " + str(source[x])
             try:
                 out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
                 if len(out[1]):
@@ -359,7 +376,7 @@ def setup_mingw(env: "SConsEnvironment"):
         )
         sys.exit(255)
 
-    if not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
+    if env["platform_tools"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
         "clang --version", env["mingw_prefix"], env["arch"]
     ):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
@@ -730,10 +747,10 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Build type
 
-    if not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
+    if env["platform_tools"] and not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = True
 
-    if env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
+    if env["platform_tools"] and env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = False
 
     if not env["use_llvm"] and try_cmd("gcc --version", env["mingw_prefix"], env["arch"], True):
@@ -777,6 +794,9 @@ def configure_mingw(env: "SConsEnvironment"):
 
     mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
 
+    if env["use_llvm"]:
+        env.extra_suffix = ".llvm" + env.extra_suffix
+
     if env["platform_tools"]:
         if env["use_llvm"]:
             env["CC"] = get_detected(env, "clang")
@@ -784,7 +804,6 @@ def configure_mingw(env: "SConsEnvironment"):
             env["AR"] = get_detected(env, "ar")
             env["RANLIB"] = get_detected(env, "ranlib")
             env.Append(ASFLAGS=["-c"])
-            env.extra_suffix = ".llvm" + env.extra_suffix
         else:
             env["CC"] = get_detected(env, "gcc")
             env["CXX"] = get_detected(env, "g++")

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -779,7 +779,9 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
-    if os.name != "nt":
+    # If env["platform_tools"] is true, this will be handled by env.Tool("mingw").
+    # Otherwise we need to set it here.
+    if not env["platform_tools"] and os.name != "nt":
         env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
 
     if env["arch"] == "x86_32":


### PR DESCRIPTION
Currently Godot overrides build tools such as CC and CXX depending on which platform is being targeted.  This adds a boolean to the build process that prevents this from happening.  It helps solve a lot of the pain points that I have been running into in the godot-src project: https://github.com/lange-studios/godot-src

This allows me to more easily use zig and other tools for cross compilation.  Example:

```sh
  "CC=zig cc -target x86_64-linux-gnu"
  "CXX=zig c++ -target x86_64-linux-gnu"
  "LINK=zig c++ -target x86_64-linux-gnu"
  "AS=zig c++ -target x86_64-linux-gnu"
  "AR=zig ar"
  "RANLIB=zig ranlib"
  "WINDRES=zig rc"
```

And just like that, I can compile godot from any platform zig supports compiling from to any platform zig supports compiling to!  In this case from Windows, Mac, or Linux to Linux! :)

I'm still testing out things as we build our own game with this tool to different platforms.  So far it is working good!  I'll leave it in draft state while I test things a little more and see what other changes I may need to make to the build process.  I'm doing my best to keep the changes as small as possible.  Please feel free to leave any feedback in the meantime.

Another thing to note:

zig handles the linking of libatomic (or so it seems in my tests) so I added a boolean to prevent that from being linked as well.  I have set the default values to mirror exactly how godot currently behaves so as to avoid any breaking changes for existing build processes.