### PR TITLE
Implement visible characters enter/exit FX in RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -672,11 +672,16 @@
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
 			Sets the clipping behavior when [member visible_characters] or [member visible_ratio] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+			[b]Note:[/b] This property cannot be set to [constant TextServer.CHARS_BEFORE_SHAPING] when [member RichTextLabel.visibility_transition] is set.
 		</member>
 		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
 			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
 			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
 		</member>
+		<member name="visiblity_transition" type="RichTextTransition" setter="set_visibility_transition" getter="get_visibility_transition">
+			Set [RichTextTransition] to use for enter/exit effects when [member RichTextLabel.visible_characters] changes.
+			[b]Note:[/b] Setting this property disables the ability to set [member visible_characters_behavior] to [constant TextServer.CHARS_BEFORE_SHAPING], as characters must be clipped [i]after shaping[/i] for exit effects.
+ 		</member>
 	</members>
 	<signals>
 		<signal name="finished">

--- a/doc/classes/RichTextTransition.xml
+++ b/doc/classes/RichTextTransition.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RichTextTransition" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Provides enter/exit effects for [RichTextLabel].
+	</brief_description>
+	<description>
+		Provides enter/exit effects for characters that are shown/hidden via [member RichTextLabel.visible_characters]. This resource can be applied using [member RichTextLabel.visiblity_transition].
+		[b]Note:[/b] To preview [member RichTextLabel.visiblity_transition] in the editor, the script attatched to this resource must be marked with [code]@tool[/code].
+		[codeblock]
+		@tool
+		class_name FadeInFadeOut
+		extends RichTextTransition
+
+		@export var speed:float = 2.5;
+
+		# Fade in
+		func _process_enter_fx(char_fx: CharFXTransform) -> bool:
+            char_fx.color.a = lerp(0.0, 1.0, char_fx.elapsed_time * speed);
+            return char_fx.color.a == 1; # Stop when alpha reaches 1
+
+		# Fade out
+		func _process_exit_fx(char_fx: CharFXTransform) -> bool:
+            char_fx.color.a = lerp(1.0, 0.0, char_fx.elapsed_time * speed);
+            return char_fx.color.a == 0; # Stop when alpha reaches 0
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_process_enter_fx" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="char_fx" type="CharFXTransform" />
+			<description>
+				Override this method to animate new characters shown when [member RichTextLabel.visible_characters] increases. Modified properties in [param char_fx] will be applied until this method returns [code]true[/code]. Return [code]true[/code] when the enter fx has finished.
+			</description>
+		</method>
+		<method name="_process_exit_fx" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="char_fx" type="CharFXTransform" />
+			<description>
+				Override this method to animate characters before they're hidden when [member RichTextLabel.visible_characters] decreases. Modified properties in [param char_fx] will be applied until this method returns [code]true[/code]. Return [code]true[/code] when the exit fx has finished.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -114,4 +114,36 @@ public:
 	RichTextEffect();
 };
 
+class RichTextTransition : public Resource {
+	GDCLASS(RichTextTransition, Resource);
+	OBJ_SAVE_TYPE(RichTextTransition);
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL1RC(bool, _process_enter_fx, Ref<CharFXTransform>);
+	GDVIRTUAL1RC(bool, _process_exit_fx, Ref<CharFXTransform>);
+
+public:
+	struct CharacterToTransition {
+		bool is_enter = true;
+		float elapsed_time = 0.0;
+
+		CharacterToTransition() {}
+		CharacterToTransition(bool p_is_enter) {
+			is_enter = p_is_enter;
+		}
+	};
+	const uint8_t MAX_CONCURRENT_TRANSITIONING_CHARS = 20;
+	// key: index of character in source text
+	HashMap<int, CharacterToTransition> characters_to_transition;
+	Ref<CharFXTransform> char_fx_transform;
+
+	void _update_characters_to_transition(int p_previous_visible_characters, int p_current_visible_characters);
+	bool _process_enter_fx_impl(Ref<class CharFXTransform> p_cfx);
+	bool _process_exit_fx_impl(Ref<class CharFXTransform> p_cfx);
+
+	RichTextTransition();
+};
+
 #endif // RICH_TEXT_EFFECT_H

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -39,6 +39,7 @@
 
 class CharFXTransform;
 class RichTextEffect;
+class RichTextTransition;
 
 class RichTextLabel : public Control {
 	GDCLASS(RichTextLabel, Control);
@@ -485,6 +486,8 @@ private:
 
 	Array custom_effects;
 
+	Ref<RichTextTransition> visibility_transition;
+
 	void _invalidate_current_line(ItemFrame *p_frame);
 
 	void _thread_function(void *p_userdata);
@@ -831,6 +834,9 @@ public:
 
 	void set_effects(Array p_effects);
 	Array get_effects();
+
+	void set_visibility_transition(Ref<RichTextTransition> p_visibility_transition);
+	Ref<RichTextTransition> get_visibility_transition();
 
 	void install_effect(const Variant effect);
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -465,6 +465,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(ColorPickerButton);
 	GDREGISTER_CLASS(RichTextLabel);
 	GDREGISTER_CLASS(RichTextEffect);
+	GDREGISTER_CLASS(RichTextTransition);
 	GDREGISTER_CLASS(CharFXTransform);
 
 	GDREGISTER_CLASS(AcceptDialog);


### PR DESCRIPTION
Resolves godotengine/godot-proposals#9137

Adds `visibility_transition` property to `RichTextLabel`, which takes a `RichTextTransition` resource.
This resource functions similarly to `RichTextEffect`, but instead of `_process_custom_fx`, there are 2 separate funcs for enter or exit fx.

## Example
```swift
@tool
extends RichTextTransition

@export var speed:float = 2.5;

func _process_enter_fx(char_fx: CharFXTransform) -> bool:
	char_fx.color.a = lerp(0.0, 1.0, char_fx.elapsed_time * speed);
	char_fx.offset.y = lerp(-15.0, 0.0, char_fx.elapsed_time * speed);
	return char_fx.color.a >= 1;

func _process_exit_fx(char_fx: CharFXTransform) -> bool:
	char_fx.color.a = lerp(1.0, 0.0, char_fx.elapsed_time * speed);
	char_fx.offset.y = lerp(0.0, 15.0, char_fx.elapsed_time * speed);
	return char_fx.color.a <= 0;
```
![text-transitions](https://github.com/godotengine/godot/assets/12436824/a9c593f3-1861-4f18-9466-f760ab80a513)

## Implementation Details
When a `visibility_transition` is set, making changes to `visible_characters` or `visible_ratio` will call `_update_characters_to_transition`, which will calculate the characters removed or added, and map a `CharacterToTransition` struct to the character. The `CharacterToTransition` struct contains data on if the character is entering or exiting, along with the transition's time elapsed. Before FX is processed, the `RichTextLabel` will check if the character currently being drawn is in the `characters_to_transition` map, and use the `CharacterToTransition` struct to call either `_process_enter_fx` or `_process_exit_fx` on the assigned `RichTextTransition`. If either of these methods return `true`, the character is done transitioning, and removed from the "to transition" map. Due to the nature of `VisibleCharactersBehaviour::CHARS_BEFORE_SHAPING`, having a `RichTextTransition` assigned restricts the visible character clipping behaviour to _after_ shaping, to allow for exit fx.