### PR TITLE
OpenXR: Add support for visibility mask

### DIFF
--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -22,6 +22,7 @@ def get_doc_classes():
         "OpenXRInteractionProfileMetadata",
         "OpenXRIPBinding",
         "OpenXRHand",
+        "OpenXRVisibilityMask",
         "OpenXRCompositionLayer",
         "OpenXRCompositionLayerQuad",
         "OpenXRCompositionLayerCylinder",

--- a/modules/openxr/doc_classes/OpenXRVisibilityMask.xml
+++ b/modules/openxr/doc_classes/OpenXRVisibilityMask.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRVisibilityMask" inherits="VisualInstance3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Draws a stereo correct visibility mask.
+	</brief_description>
+	<description>
+		The visibility mask allows us to black out the part of the render result that is invisible due to lens distortion.
+		As this is rendered first, it prevents fragments with expensive lighting calculations to be processed as they are discarded through z-checking.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -1,0 +1,279 @@
+/**************************************************************************/
+/*  openxr_visibility_mask_extension.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_visibility_mask_extension.h"
+
+#include "../openxr_api.h"
+#include "core/string/print_string.h"
+#include "core/variant/array.h"
+#include "core/variant/variant.h"
+#include "servers/rendering_server.h"
+
+static const char *VISIBILITY_MASK_SHADER_CODE =
+		"shader_type spatial;\n"
+		"render_mode unshaded, shadows_disabled, cull_disabled;\n"
+		"void vertex() {\n"
+		"\tif (int(VERTEX.z) == VIEW_INDEX) {\n"
+		"\t\tVERTEX.z = -1.0;\n"
+		"\t\tVERTEX += EYE_OFFSET;\n"
+		"\t\tPOSITION = PROJECTION_MATRIX * vec4(VERTEX, 1.0);\n"
+		"\t\tPOSITION.xy /= POSITION.w;\n"
+		"\t\tPOSITION.z = 1.0;\n"
+		"\t\tPOSITION.w = 1.0;\n"
+		"\t} else {\n"
+		"\t\tPOSITION = vec4(2.0, 2.0, 2.0, 1.0);\n"
+		"\t}\n"
+		"}\n"
+		"void fragment() {\n"
+		"\tALBEDO = vec3(0.0, 0.0, 0.0);\n"
+		"}\n";
+
+OpenXRVisibilityMaskExtension *OpenXRVisibilityMaskExtension::singleton = nullptr;
+
+OpenXRVisibilityMaskExtension *OpenXRVisibilityMaskExtension::get_singleton() {
+	return singleton;
+}
+
+OpenXRVisibilityMaskExtension::OpenXRVisibilityMaskExtension() {
+	singleton = this;
+}
+
+OpenXRVisibilityMaskExtension::~OpenXRVisibilityMaskExtension() {
+	singleton = nullptr;
+}
+
+HashMap<String, bool *> OpenXRVisibilityMaskExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_KHR_VISIBILITY_MASK_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}
+
+void OpenXRVisibilityMaskExtension::on_instance_created(const XrInstance p_instance) {
+	if (available) {
+		EXT_INIT_XR_FUNC(xrGetVisibilityMaskKHR);
+	}
+}
+
+void OpenXRVisibilityMaskExtension::on_session_created(const XrSession p_instance) {
+	if (available) {
+		RS *rendering_server = RS::get_singleton();
+		ERR_FAIL_NULL(rendering_server);
+
+		OpenXRAPI *openxr_api = (OpenXRAPI *)OpenXRAPI::get_singleton();
+		ERR_FAIL_NULL(openxr_api);
+
+		// Create our shader.
+		shader = rendering_server->shader_create();
+		rendering_server->shader_set_code(shader, VISIBILITY_MASK_SHADER_CODE);
+
+		// Create our material.
+		material = rendering_server->material_create();
+		rendering_server->material_set_shader(material, shader);
+		rendering_server->material_set_render_priority(material, 99);
+
+		// Create our mesh.
+		mesh = rendering_server->mesh_create();
+
+		// Get our initial mesh data.
+		mesh_count = openxr_api->get_view_count(); // We need a mesh for each view.
+		for (uint32_t i = 0; i < mesh_count; i++) {
+			_update_mesh_data(i);
+		}
+
+		// And update our mesh
+		_update_mesh();
+	}
+}
+
+void OpenXRVisibilityMaskExtension::on_session_destroyed() {
+	RS *rendering_server = RS::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	// Free our mesh.
+	if (mesh.is_valid()) {
+		rendering_server->free(mesh);
+		mesh = RID();
+	}
+
+	// Free our material.
+	if (material.is_valid()) {
+		rendering_server->free(material);
+		material = RID();
+	}
+
+	// Free our shader.
+	if (shader.is_valid()) {
+		rendering_server->free(shader);
+		shader = RID();
+	}
+
+	mesh_count = 0;
+}
+
+void OpenXRVisibilityMaskExtension::on_pre_render() {
+	// Update mesh data if its dirty.
+	// Here we call this from the rendering thread however as we're going through the rendering server this is safe.
+	_update_mesh();
+}
+
+bool OpenXRVisibilityMaskExtension::on_event_polled(const XrEventDataBuffer &event) {
+	if (event.type == XR_TYPE_EVENT_DATA_VISIBILITY_MASK_CHANGED_KHR) {
+		XrEventDataVisibilityMaskChangedKHR *vismask_event = (XrEventDataVisibilityMaskChangedKHR *)&event;
+
+		print_verbose("OpenXR EVENT: Visibility mask changed for view " + String::num_uint64(vismask_event->viewIndex));
+
+		if (available) { // This event won't be called if this extension is not available but better safe than sorry.
+			_update_mesh_data(vismask_event->viewIndex);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool OpenXRVisibilityMaskExtension::is_available() {
+	return available;
+}
+
+RID OpenXRVisibilityMaskExtension::get_mesh() {
+	return mesh;
+}
+
+void OpenXRVisibilityMaskExtension::_update_mesh_data(uint32_t p_view) {
+	if (available) {
+		ERR_FAIL_UNSIGNED_INDEX(p_view, 4);
+
+		OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+		ERR_FAIL_NULL(openxr_api);
+
+		XrSession session = openxr_api->get_session();
+		XrViewConfigurationType view_configuration_type = openxr_api->get_view_configuration();
+
+		// Figure out how much data we're getting.
+		XrVisibilityMaskKHR visibility_mask_data = {
+			XR_TYPE_VISIBILITY_MASK_KHR,
+			nullptr,
+			0,
+			0,
+			nullptr,
+			0,
+			0,
+			nullptr,
+		};
+
+		XrResult result = xrGetVisibilityMaskKHR(session, view_configuration_type, p_view, XR_VISIBILITY_MASK_TYPE_HIDDEN_TRIANGLE_MESH_KHR, &visibility_mask_data);
+		if (XR_FAILED(result)) {
+			print_line("OpenXR: Unable to obtain visibility mask metrics [", openxr_api->get_error_string(result), "]");
+			return;
+		}
+
+		// Resize buffers
+		mesh_data[p_view].vertices.resize(visibility_mask_data.vertexCountOutput);
+		mesh_data[p_view].indices.resize(visibility_mask_data.indexCountOutput);
+
+		visibility_mask_data.vertexCapacityInput = visibility_mask_data.vertexCountOutput;
+		visibility_mask_data.vertices = mesh_data[p_view].vertices.ptrw();
+		visibility_mask_data.indexCapacityInput = visibility_mask_data.indexCountOutput;
+		visibility_mask_data.indices = mesh_data[p_view].indices.ptrw();
+
+		result = xrGetVisibilityMaskKHR(session, view_configuration_type, p_view, XR_VISIBILITY_MASK_TYPE_HIDDEN_TRIANGLE_MESH_KHR, &visibility_mask_data);
+		if (XR_FAILED(result)) {
+			print_line("OpenXR: Unable to obtain visibility mask data [", openxr_api->get_error_string(result), "]");
+			return;
+		}
+
+		// Mark as dirty, we have updated mesh data.
+		is_dirty = true;
+	}
+}
+
+void OpenXRVisibilityMaskExtension::_update_mesh() {
+	if (available && is_dirty && mesh_count > 0) {
+		RS *rendering_server = RS::get_singleton();
+		ERR_FAIL_NULL(rendering_server);
+
+		OpenXRAPI *openxr_api = (OpenXRAPI *)OpenXRAPI::get_singleton();
+		ERR_FAIL_NULL(openxr_api);
+
+		// Combine all vertex and index buffers into one.
+		PackedVector3Array vertices;
+		PackedInt32Array indices;
+
+		uint64_t vertice_count = 0;
+		uint64_t index_count = 0;
+
+		for (uint32_t i = 0; i < mesh_count; i++) {
+			vertice_count += mesh_data[i].vertices.size();
+			index_count += mesh_data[i].indices.size();
+		}
+
+		vertices.resize(vertice_count);
+		indices.resize(index_count);
+		uint64_t offset = 0;
+
+		Vector3 *v_out = vertices.ptrw();
+		int32_t *i_out = indices.ptrw();
+
+		for (uint32_t i = 0; i < mesh_count; i++) {
+			const XrVector2f *v_in = mesh_data[i].vertices.ptr();
+			for (uint32_t j = 0; j < mesh_data[i].vertices.size(); j++) {
+				v_out->x = v_in->x;
+				v_out->y = v_in->y;
+				v_out->z = float(i); // We store our view in our Z component, our shader will filter the right faces out.
+				v_out++;
+				v_in++;
+			}
+			const uint32_t *i_in = mesh_data[i].indices.ptr();
+			for (uint32_t j = 0; j < mesh_data[i].indices.size(); j++) {
+				*i_out = offset + *i_in;
+				i_out++;
+				i_in++;
+			}
+
+			offset += mesh_data[i].vertices.size();
+		}
+
+		// Update our mesh.
+		Array arr;
+		arr.resize(RS::ARRAY_MAX);
+		arr[RS::ARRAY_VERTEX] = vertices;
+		arr[RS::ARRAY_INDEX] = indices;
+
+		rendering_server->mesh_clear(mesh);
+		rendering_server->mesh_add_surface_from_arrays(mesh, RS::PRIMITIVE_TRIANGLES, arr);
+		rendering_server->mesh_surface_set_material(mesh, 0, material);
+
+		// Set no longer dirty.
+		is_dirty = false;
+	}
+}

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.h
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.h
@@ -1,0 +1,95 @@
+/**************************************************************************/
+/*  openxr_visibility_mask_extension.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_VISIBILITY_MASK_EXTENSION_H
+#define OPENXR_VISIBILITY_MASK_EXTENSION_H
+
+#include "../util.h"
+
+#include "core/templates/vector.h"
+#include "openxr_extension_wrapper.h"
+#include "scene/resources/mesh.h"
+
+// The OpenXR visibility mask extension provides a mesh for each eye that
+// can be used as a mask to determine which part of our rendered result
+// is actually visible to the user. Due to lens distortion the edges of
+// the rendered image are never used in the final result output on the HMD.
+//
+// Blacking out this are of the render result can remove a fair amount of
+// overhead in rendering part of the screen that is unused.
+//
+// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_KHR_visibility_mask
+
+class OpenXRVisibilityMaskExtension : public OpenXRExtensionWrapper {
+public:
+	static OpenXRVisibilityMaskExtension *get_singleton();
+
+	OpenXRVisibilityMaskExtension();
+	virtual ~OpenXRVisibilityMaskExtension() override;
+
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+
+	virtual void on_instance_created(const XrInstance p_instance) override;
+
+	virtual void on_session_created(const XrSession p_instance) override;
+	virtual void on_session_destroyed() override;
+
+	virtual void on_pre_render() override;
+	virtual bool on_event_polled(const XrEventDataBuffer &event) override;
+
+	bool is_available();
+	RID get_mesh();
+
+private:
+	static OpenXRVisibilityMaskExtension *singleton;
+
+	bool available = false;
+	bool is_dirty = false;
+
+	RID shader;
+	RID material;
+	RID mesh;
+
+	struct MeshData {
+		Vector<XrVector2f> vertices;
+		Vector<uint32_t> indices;
+	};
+
+	uint32_t mesh_count = 0;
+	MeshData mesh_data[4];
+
+	void _update_mesh_data(uint32_t p_view);
+	void _update_mesh();
+
+	// OpenXR API call wrappers
+	EXT_PROTO_XRRESULT_FUNC5(xrGetVisibilityMaskKHR, (XrSession), session, (XrViewConfigurationType), viewConfigurationType, (uint32_t), viewIndex, (XrVisibilityMaskTypeKHR), visibilityMaskType, (XrVisibilityMaskKHR *), visibilityMask);
+};
+
+#endif // OPENXR_VISIBILITY_MASK_EXTENSION_H

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1459,6 +1459,10 @@ void OpenXRAPI::set_form_factor(XrFormFactor p_form_factor) {
 	form_factor = p_form_factor;
 }
 
+uint32_t OpenXRAPI::get_view_count() {
+	return view_count;
+}
+
 void OpenXRAPI::set_view_configuration(XrViewConfigurationType p_view_configuration) {
 	ERR_FAIL_COND(is_initialized());
 
@@ -1913,15 +1917,6 @@ bool OpenXRAPI::poll_events() {
 
 				// We probably didn't poll fast enough, just output warning
 				WARN_PRINT("OpenXR EVENT: " + itos(event->lostEventCount) + " event data lost!");
-			} break;
-			case XR_TYPE_EVENT_DATA_VISIBILITY_MASK_CHANGED_KHR: {
-				// XrEventDataVisibilityMaskChangedKHR *event = (XrEventDataVisibilityMaskChangedKHR *)&runtimeEvent;
-
-				// TODO implement this in the future, we should call xrGetVisibilityMaskKHR to obtain a mask,
-				// this will allow us to prevent rendering the part of our view which is never displayed giving us
-				// a decent performance improvement.
-
-				print_verbose("OpenXR EVENT: STUB: visibility mask changed");
 			} break;
 			case XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING: {
 				XrEventDataInstanceLossPending *event = (XrEventDataInstanceLossPending *)&runtimeEvent;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -434,6 +434,7 @@ public:
 	void set_form_factor(XrFormFactor p_form_factor);
 	XrFormFactor get_form_factor() const { return form_factor; }
 
+	uint32_t get_view_count();
 	void set_view_configuration(XrViewConfigurationType p_view_configuration);
 	XrViewConfigurationType get_view_configuration() const { return view_configuration; }
 

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -44,6 +44,7 @@
 #include "scene/openxr_composition_layer_equirect.h"
 #include "scene/openxr_composition_layer_quad.h"
 #include "scene/openxr_hand.h"
+#include "scene/openxr_visibility_mask.h"
 
 #include "extensions/openxr_composition_layer_depth_extension.h"
 #include "extensions/openxr_composition_layer_extension.h"
@@ -60,6 +61,7 @@
 #include "extensions/openxr_mxink_extension.h"
 #include "extensions/openxr_palm_pose_extension.h"
 #include "extensions/openxr_pico_controller_extension.h"
+#include "extensions/openxr_visibility_mask_extension.h"
 #include "extensions/openxr_wmr_controller_extension.h"
 
 #ifdef TOOLS_ENABLED
@@ -128,6 +130,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXREyeGazeInteractionExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRHandInteractionExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMxInkExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVisibilityMaskExtension));
 
 			// register gated extensions
 			if (GLOBAL_GET("xr/openxr/extensions/hand_tracking")) {
@@ -180,6 +183,8 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(OpenXRCompositionLayerQuad);
 
 		GDREGISTER_CLASS(OpenXRHand);
+
+		GDREGISTER_CLASS(OpenXRVisibilityMask);
 
 		XRServer *xr_server = XRServer::get_singleton();
 		if (xr_server) {

--- a/modules/openxr/scene/openxr_visibility_mask.cpp
+++ b/modules/openxr/scene/openxr_visibility_mask.cpp
@@ -1,0 +1,106 @@
+/**************************************************************************/
+/*  openxr_visibility_mask.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_visibility_mask.h"
+
+#include "../extensions/openxr_visibility_mask_extension.h"
+#include "../openxr_interface.h"
+#include "scene/3d/xr_nodes.h"
+
+void OpenXRVisibilityMask::_bind_methods() {
+}
+
+void OpenXRVisibilityMask::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			OpenXRVisibilityMaskExtension *vis_mask_ext = OpenXRVisibilityMaskExtension::get_singleton();
+			if (vis_mask_ext && vis_mask_ext->is_available()) {
+				set_base(vis_mask_ext->get_mesh());
+			}
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			set_base(RID());
+		} break;
+	}
+}
+
+void OpenXRVisibilityMask::_on_openxr_session_begun() {
+	if (is_inside_tree()) {
+		OpenXRVisibilityMaskExtension *vis_mask_ext = OpenXRVisibilityMaskExtension::get_singleton();
+		if (vis_mask_ext && vis_mask_ext->is_available()) {
+			set_base(vis_mask_ext->get_mesh());
+		}
+	}
+}
+
+void OpenXRVisibilityMask::_on_openxr_session_stopping() {
+	set_base(RID());
+}
+
+PackedStringArray OpenXRVisibilityMask::get_configuration_warnings() const {
+	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+
+	if (is_visible() && is_inside_tree()) {
+		XRCamera3D *camera = Object::cast_to<XRCamera3D>(get_parent());
+		if (camera == nullptr) {
+			warnings.push_back(RTR("OpenXR visibility mask must have an XRCamera3D node as their parent."));
+		}
+	}
+
+	return warnings;
+}
+
+AABB OpenXRVisibilityMask::get_aabb() const {
+	AABB ret;
+
+	// Make sure it's always visible, this is positioned through its shader.
+	ret.position = Vector3(-1000.0, -1000.0, -1000.0);
+	ret.size = Vector3(2000.0, 2000.0, 2000.0);
+
+	return ret;
+}
+
+OpenXRVisibilityMask::OpenXRVisibilityMask() {
+	Ref<OpenXRInterface> openxr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+	if (openxr_interface.is_valid()) {
+		openxr_interface->connect("session_begun", callable_mp(this, &OpenXRVisibilityMask::_on_openxr_session_begun));
+		openxr_interface->connect("session_stopping", callable_mp(this, &OpenXRVisibilityMask::_on_openxr_session_stopping));
+	}
+
+	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(get_instance(), RS::SHADOW_CASTING_SETTING_OFF);
+}
+
+OpenXRVisibilityMask::~OpenXRVisibilityMask() {
+	Ref<OpenXRInterface> openxr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+	if (openxr_interface.is_valid()) {
+		openxr_interface->disconnect("session_begun", callable_mp(this, &OpenXRVisibilityMask::_on_openxr_session_begun));
+		openxr_interface->disconnect("session_stopping", callable_mp(this, &OpenXRVisibilityMask::_on_openxr_session_stopping));
+	}
+}

--- a/modules/openxr/scene/openxr_visibility_mask.h
+++ b/modules/openxr/scene/openxr_visibility_mask.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  openxr_visibility_mask.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_VISIBILITY_MASK_H
+#define OPENXR_VISIBILITY_MASK_H
+
+#include "scene/3d/visual_instance_3d.h"
+
+class OpenXRVisibilityMask : public VisualInstance3D {
+	GDCLASS(OpenXRVisibilityMask, VisualInstance3D);
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+	void _on_openxr_session_begun();
+	void _on_openxr_session_stopping();
+
+public:
+	virtual PackedStringArray get_configuration_warnings() const override;
+
+	virtual AABB get_aabb() const override;
+
+	OpenXRVisibilityMask();
+	~OpenXRVisibilityMask();
+};
+
+#endif // OPENXR_VISIBILITY_MASK_H


### PR DESCRIPTION
This PR adds a new OpenXR node that, if supported by the XR runtime, renders a mask that covers the parts of the screen that are never visible to the user due to lens distortion. This prevents costly fragments being rendered in those areas and should lead to a small performance boost.

It's simply a matter of adding the node as a child node of the camera:
![image](https://github.com/godotengine/godot/assets/1945449/100c0dec-5b8d-4230-b4d9-49d0386f377b)

The end result is visible in the preview:
![image](https://github.com/godotengine/godot/assets/1945449/fb484204-d2b0-425a-96b6-f110ad045436)

Todos:
- [ ] Need an icon (help please!)
