### PR TITLE
Revert "Implement "get_mingw_tool" to fix mingw prefixes"

### DIFF
--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -1,20 +1,24 @@
 """Functions used to generate source files during build time"""
 
 import os
-from detect import get_mingw_tool
+from detect import get_mingw_bin_prefix
+from detect import try_cmd
 
 
 def make_debug_mingw(target, source, env):
     dst = str(target[0])
     # Force separate debug symbols if executable size is larger than 1.9 GB.
     if env["separate_debug_symbols"] or os.stat(dst).st_size >= 2040109465:
-        objcopy = get_mingw_tool("objcopy", env["mingw_prefix"], env["arch"])
-        strip = get_mingw_tool("strip", env["mingw_prefix"], env["arch"])
-
-        if not objcopy or not strip:
-            print('`separate_debug_symbols` requires both "objcopy" and "strip" to function.')
-            return
-
-        os.system("{0} --only-keep-debug {1} {1}.debugsymbols".format(objcopy, dst))
-        os.system("{0} --strip-debug --strip-unneeded {1}".format(strip, dst))
-        os.system("{0} --add-gnu-debuglink={1}.debugsymbols {1}".format(objcopy, dst))
+        mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
+        else:
+            os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
+        if try_cmd("strip --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "strip --strip-debug --strip-unneeded {0}".format(dst))
+        else:
+            os.system("strip --strip-debug --strip-unneeded {0}".format(dst))
+        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))
+        else:
+            os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))


### PR DESCRIPTION
This reverts commits ecebe0b40d4f3c645f2732b7b8f0f0cb5bc2ddff and 15d37ed2a891c099858abcddc1a470563b3166a4.

- Fixes #91710.
- Supersedes #91734.
- Reverts #85319 and its fixup #91698.