### PR TITLE
Add markers to Animation

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -34,6 +34,14 @@
 		<link title="Animation documentation index">$DOCS_URL/tutorials/animation/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="add_marker">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="time" type="float" />
+			<description>
+				Adds a marker to this Animation.
+			</description>
+		</method>
 		<method name="add_track">
 			<return type="int" />
 			<param index="0" name="type" type="int" enum="Animation.TrackType" />
@@ -271,10 +279,58 @@
 				Returns the index of the specified track. If the track is not found, return -1.
 			</description>
 		</method>
+		<method name="get_marker_at_time" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="time" type="float" />
+			<description>
+				Returns the name of the marker located at the given time.
+			</description>
+		</method>
+		<method name="get_marker_color" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the given marker's color.
+			</description>
+		</method>
+		<method name="get_marker_names" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns every marker in this Animation, sorted ascending by time.
+			</description>
+		</method>
+		<method name="get_marker_time" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the given marker's time.
+			</description>
+		</method>
+		<method name="get_next_marker" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="time" type="float" />
+			<description>
+				Returns the closest marker that comes after the given time. If no such marker exists, an empty string is returned.
+			</description>
+		</method>
+		<method name="get_prev_marker" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="time" type="float" />
+			<description>
+				Returns the closest marker that comes before the given time. If no such marker exists, an empty string is returned.
+			</description>
+		</method>
 		<method name="get_track_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the amount of tracks in the animation.
+			</description>
+		</method>
+		<method name="has_marker" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if this Animation contains a marker with the given name.
 			</description>
 		</method>
 		<method name="method_track_get_name" qualifiers="const">
@@ -320,6 +376,13 @@
 				Returns the interpolated position value at the given time (in seconds). The [param track_idx] must be the index of a 3D position track.
 			</description>
 		</method>
+		<method name="remove_marker">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes the marker with the given name from this Animation.
+			</description>
+		</method>
 		<method name="remove_track">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -361,6 +424,14 @@
 			<param index="2" name="backward" type="bool" default="false" />
 			<description>
 				Returns the interpolated scale value at the given time (in seconds). The [param track_idx] must be the index of a 3D scale track.
+			</description>
+		</method>
+		<method name="set_marker_color">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="color" type="Color" />
+			<description>
+				Sets the given marker's color.
 			</description>
 		</method>
 		<method name="track_find_key" qualifiers="const">

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -75,6 +75,24 @@
 				Returns the node which node path references will travel from.
 			</description>
 		</method>
+		<method name="get_section_end_time" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the end time of the section currently being played.
+			</description>
+		</method>
+		<method name="get_section_start_time" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the start time of the section currently being played.
+			</description>
+		</method>
+		<method name="has_section" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if an animation is currently playing with section.
+			</description>
+		</method>
 		<method name="is_playing" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -110,6 +128,54 @@
 				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
 			</description>
 		</method>
+		<method name="play_section">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="start_time" type="float" default="-1" />
+			<param index="2" name="end_time" type="float" default="-1" />
+			<param index="3" name="custom_blend" type="float" default="-1" />
+			<param index="4" name="custom_speed" type="float" default="1.0" />
+			<param index="5" name="from_end" type="bool" default="false" />
+			<description>
+				Plays the animation with key [param name] and the section starting from [param start_time] and ending on [param end_time]. See also [method play].
+				Setting [param start_time] to a value outside the range of the animation means the start of the animation will be used instead, and setting [param end_time] to a value outside the range of the animation means the end of the animation will be used instead. [param start_time] cannot be equal to [param end_time].
+			</description>
+		</method>
+		<method name="play_section_backwards">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="start_time" type="float" default="-1" />
+			<param index="2" name="end_time" type="float" default="-1" />
+			<param index="3" name="custom_blend" type="float" default="-1" />
+			<description>
+				Plays the animation with key [param name] and the section starting from [param start_time] and ending on [param end_time] in reverse.
+				This method is a shorthand for [method play_section] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], see its description for more information.
+			</description>
+		</method>
+		<method name="play_section_with_markers">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="start_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="2" name="end_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="3" name="custom_blend" type="float" default="-1" />
+			<param index="4" name="custom_speed" type="float" default="1.0" />
+			<param index="5" name="from_end" type="bool" default="false" />
+			<description>
+				Plays the animation with key [param name] and the section starting from [param start_marker] and ending on [param end_marker].
+				If the start marker is empty, the section starts from the beginning of the animation. If the end marker is empty, the section ends on the end of the animation. See also [method play].
+			</description>
+		</method>
+		<method name="play_section_with_markers_backwards">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="start_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="2" name="end_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="3" name="custom_blend" type="float" default="-1" />
+			<description>
+				Plays the animation with key [param name] and the section starting from [param start_marker] and ending on [param end_marker] in reverse.
+				This method is a shorthand for [method play_section_with_markers] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], see its description for more information.
+			</description>
+		</method>
 		<method name="play_with_capture">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
@@ -137,6 +203,12 @@
 			<description>
 				Queues an animation for playback once the current animation and all previously queued animations are done.
 				[b]Note:[/b] If a looped animation is currently playing, the queued animation will never play unless the looped animation is stopped somehow.
+			</description>
+		</method>
+		<method name="reset_section">
+			<return type="void" />
+			<description>
+				Resets the current section if section is set.
 			</description>
 		</method>
 		<method name="seek">
@@ -178,6 +250,23 @@
 			<param index="0" name="path" type="NodePath" />
 			<description>
 				Sets the node which node path references will travel from.
+			</description>
+		</method>
+		<method name="set_section">
+			<return type="void" />
+			<param index="0" name="start_time" type="float" default="-1" />
+			<param index="1" name="end_time" type="float" default="-1" />
+			<description>
+				Changes the start and end times of the section being played. The current playback position will be clamped within the new section. See also [method play_section].
+			</description>
+		</method>
+		<method name="set_section_with_markers">
+			<return type="void" />
+			<param index="0" name="start_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="end_marker" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Changes the start and end markers of the section being played. The current playback position will be clamped within the new section. See also [method play_section_with_markers].
+				If the argument is empty, the section uses the beginning or end of the animation. If both are empty, it means that the section is not set.
 			</description>
 		</method>
 		<method name="stop">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7722,6 +7722,7 @@ EditorNode::EditorNode() {
 
 	add_editor_plugin(memnew(AnimationPlayerEditorPlugin));
 	add_editor_plugin(memnew(AnimationTrackKeyEditEditorPlugin));
+	add_editor_plugin(memnew(AnimationMarkerKeyEditEditorPlugin));
 	add_editor_plugin(memnew(CanvasItemEditorPlugin));
 	add_editor_plugin(memnew(Node3DEditorPlugin));
 	add_editor_plugin(memnew(ScriptEditorPlugin));

--- a/editor/icons/Marker.svg
+++ b/editor/icons/Marker.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="-959.5 540.5 10 10"><path fill="#e0e0e0" d="m-954.5 550-3-3v-6h6v6z"/></svg>

--- a/editor/icons/MarkerSelected.svg
+++ b/editor/icons/MarkerSelected.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="-959.5 540.5 10 10"><path fill="#5fb2ff" d="m-952 541.5v5.086l-2.5 2.5-2.5-2.5v-5.086zm1-1h-7v6.5l3.5 3.5 3.5-3.5z"/><path fill="#003e7a" d="m-957 546.586 2.5 2.5 2.5-2.5v-5.086h-5z"/></svg>

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -32,9 +32,11 @@
 #define ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H
 
 #include "core/object/script_language.h"
+#include "editor/editor_inspector.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
@@ -47,6 +49,7 @@ class EditorFileDialog;
 class EditorProperty;
 class MenuButton;
 class PanelContainer;
+class EditorInspectorPluginAnimationNodeAnimation;
 
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);
@@ -147,6 +150,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 		MENU_LOAD_FILE_CONFIRM = 1002
 	};
 
+	Ref<EditorInspectorPluginAnimationNodeAnimation> animation_node_inspector_plugin;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -165,6 +170,48 @@ public:
 	void update_graph();
 
 	AnimationNodeBlendTreeEditor();
+	~AnimationNodeBlendTreeEditor();
+};
+
+// EditorPluginAnimationNodeAnimation
+
+class EditorInspectorPluginAnimationNodeAnimation : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginAnimationNodeAnimation, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) override;
+};
+
+class AnimationNodeAnimationEditorDialog : public ConfirmationDialog {
+	GDCLASS(AnimationNodeAnimationEditorDialog, ConfirmationDialog);
+
+	friend class AnimationNodeAnimationEditor;
+
+	OptionButton *select_start = nullptr;
+	OptionButton *select_end = nullptr;
+
+public:
+	AnimationNodeAnimationEditorDialog();
+	~AnimationNodeAnimationEditorDialog();
+};
+
+class AnimationNodeAnimationEditor : public VBoxContainer {
+	GDCLASS(AnimationNodeAnimationEditor, VBoxContainer);
+
+	Ref<AnimationNodeAnimation> animation_node_animation;
+	Button *button = nullptr;
+	AnimationNodeAnimationEditorDialog *dialog = nullptr;
+	void _open_set_custom_timeline_from_marker_dialog();
+	void _validate_markers(int p_id);
+	void _confirm_set_custom_timeline_from_marker_dialog();
+
+public:
+	AnimationNodeAnimationEditor(Ref<AnimationNodeAnimation> p_animation_node_animation);
+	~AnimationNodeAnimationEditor();
+
+protected:
+	void _notification(int p_what);
 };
 
 #endif // ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_validation_panel.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/canvas_item_editor_plugin.h" // For onion skinning.
 #include "editor/plugins/node_3d_editor_plugin.h" // For onion skinning.
@@ -295,7 +296,14 @@ void AnimationPlayerEditor::_play_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->play(current);
+		PackedStringArray markers = track_editor->get_selected_section();
+		if (markers.size() == 2) {
+			StringName start_marker = markers[0];
+			StringName end_marker = markers[1];
+			player->play_section_with_markers(current, start_marker, end_marker);
+		} else {
+			player->play(current);
+		}
 	}
 
 	//unstop
@@ -312,7 +320,14 @@ void AnimationPlayerEditor::_play_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		player->play(current);
+		PackedStringArray markers = track_editor->get_selected_section();
+		if (markers.size() == 2) {
+			StringName start_marker = markers[0];
+			StringName end_marker = markers[1];
+			player->play_section_with_markers(current, start_marker, end_marker);
+		} else {
+			player->play(current);
+		}
 	}
 
 	//unstop
@@ -333,7 +348,14 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->play_backwards(current);
+		PackedStringArray markers = track_editor->get_selected_section();
+		if (markers.size() == 2) {
+			StringName start_marker = markers[0];
+			StringName end_marker = markers[1];
+			player->play_section_with_markers_backwards(current, start_marker, end_marker);
+		} else {
+			player->play_backwards(current);
+		}
 	}
 
 	//unstop
@@ -350,7 +372,14 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		player->play_backwards(current);
+		PackedStringArray markers = track_editor->get_selected_section();
+		if (markers.size() == 2) {
+			StringName start_marker = markers[0];
+			StringName end_marker = markers[1];
+			player->play_section_with_markers_backwards(current, start_marker, end_marker);
+		} else {
+			player->play_backwards(current);
+		}
 	}
 
 	//unstop
@@ -2396,4 +2425,25 @@ AnimationTrackKeyEditEditorPlugin::AnimationTrackKeyEditEditorPlugin() {
 
 bool AnimationTrackKeyEditEditorPlugin::handles(Object *p_object) const {
 	return p_object->is_class("AnimationTrackKeyEdit");
+}
+
+bool EditorInspectorPluginAnimationMarkerKeyEdit::can_handle(Object *p_object) {
+	return Object::cast_to<AnimationMarkerKeyEdit>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginAnimationMarkerKeyEdit::parse_begin(Object *p_object) {
+	AnimationMarkerKeyEdit *amk = Object::cast_to<AnimationMarkerKeyEdit>(p_object);
+	ERR_FAIL_NULL(amk);
+
+	amk_editor = memnew(AnimationMarkerKeyEditEditor(amk->animation, amk->marker_name, amk->use_fps));
+	add_custom_control(amk_editor);
+}
+
+AnimationMarkerKeyEditEditorPlugin::AnimationMarkerKeyEditEditorPlugin() {
+	amk_plugin = memnew(EditorInspectorPluginAnimationMarkerKeyEdit);
+	EditorInspector::add_inspector_plugin(amk_plugin);
+}
+
+bool AnimationMarkerKeyEditEditorPlugin::handles(Object *p_object) const {
+	return p_object->is_class("AnimationMarkerKeyEdit");
 }

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -338,4 +338,30 @@ public:
 	AnimationTrackKeyEditEditorPlugin();
 };
 
+// AnimationMarkerKeyEditEditorPlugin
+
+class EditorInspectorPluginAnimationMarkerKeyEdit : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginAnimationMarkerKeyEdit, EditorInspectorPlugin);
+
+	AnimationMarkerKeyEditEditor *amk_editor = nullptr;
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class AnimationMarkerKeyEditEditorPlugin : public EditorPlugin {
+	GDCLASS(AnimationMarkerKeyEditEditorPlugin, EditorPlugin);
+
+	EditorInspectorPluginAnimationMarkerKeyEdit *amk_plugin = nullptr;
+
+public:
+	bool has_main_screen() const override { return false; }
+	virtual bool handles(Object *p_object) const override;
+
+	virtual String get_name() const override { return "AnimationMarkerKeyEdit"; }
+
+	AnimationMarkerKeyEditEditorPlugin();
+};
+
 #endif // ANIMATION_PLAYER_EDITOR_PLUGIN_H

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -245,6 +245,8 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 
 	if (!p_test_only) {
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
+		pi.start = 0.0;
+		pi.end = cur_len;
 		if (play_mode == PLAY_MODE_FORWARD) {
 			pi.time = cur_playback_time;
 			pi.delta = cur_delta;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1117,6 +1117,8 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 		Ref<Animation> a = ai.animation_data.animation;
 		double time = ai.playback_info.time;
 		double delta = ai.playback_info.delta;
+		double start = ai.playback_info.start;
+		double end = ai.playback_info.end;
 		bool seeked = ai.playback_info.seeked;
 		Animation::LoopedFlag looped_flag = ai.playback_info.looped_flag;
 		bool is_external_seeking = ai.playback_info.is_external_seeking;
@@ -1168,32 +1170,32 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					if (track->root_motion && calc_root) {
 						double prev_time = time - delta;
 						if (!backward) {
-							if (Animation::is_less_approx(prev_time, 0)) {
+							if (Animation::is_less_approx(prev_time, start)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = 0;
+										prev_time = start;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
 								}
 							}
 						} else {
-							if (Animation::is_greater_approx(prev_time, (double)a_length)) {
+							if (Animation::is_greater_approx(prev_time, end)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = (double)a_length;
+										prev_time = end;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
@@ -1208,10 +1210,10 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-								a->try_position_track_interpolate(i, (double)a_length, &loc[1]);
+								a->try_position_track_interpolate(i, end, &loc[1]);
 								loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 								root_motion_cache.loc += (loc[1] - loc[0]) * blend;
-								prev_time = 0;
+								prev_time = start;
 							}
 						} else {
 							if (Animation::is_less_approx(prev_time, time)) {
@@ -1220,10 +1222,10 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-								a->try_position_track_interpolate(i, 0, &loc[1]);
+								a->try_position_track_interpolate(i, start, &loc[1]);
 								loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 								root_motion_cache.loc += (loc[1] - loc[0]) * blend;
-								prev_time = (double)a_length;
+								prev_time = end;
 							}
 						}
 						Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
@@ -1234,7 +1236,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						a->try_position_track_interpolate(i, time, &loc[1]);
 						loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 						root_motion_cache.loc += (loc[1] - loc[0]) * blend;
-						prev_time = !backward ? 0 : (double)a_length;
+						prev_time = !backward ? start : end;
 					}
 					{
 						Vector3 loc;
@@ -1256,32 +1258,32 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					if (track->root_motion && calc_root) {
 						double prev_time = time - delta;
 						if (!backward) {
-							if (Animation::is_less_approx(prev_time, 0)) {
+							if (Animation::is_less_approx(prev_time, start)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = 0;
+										prev_time = start;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
 								}
 							}
 						} else {
-							if (Animation::is_greater_approx(prev_time, (double)a_length)) {
+							if (Animation::is_greater_approx(prev_time, end)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = (double)a_length;
+										prev_time = end;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
@@ -1296,10 +1298,10 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								rot[0] = post_process_key_value(a, i, rot[0], t->object_id, t->bone_idx);
-								a->try_rotation_track_interpolate(i, (double)a_length, &rot[1]);
+								a->try_rotation_track_interpolate(i, end, &rot[1]);
 								rot[1] = post_process_key_value(a, i, rot[1], t->object_id, t->bone_idx);
 								root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
-								prev_time = 0;
+								prev_time = start;
 							}
 						} else {
 							if (Animation::is_less_approx(prev_time, time)) {
@@ -1308,9 +1310,9 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								rot[0] = post_process_key_value(a, i, rot[0], t->object_id, t->bone_idx);
-								a->try_rotation_track_interpolate(i, 0, &rot[1]);
+								a->try_rotation_track_interpolate(i, start, &rot[1]);
 								root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
-								prev_time = (double)a_length;
+								prev_time = end;
 							}
 						}
 						Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0]);
@@ -1321,7 +1323,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						a->try_rotation_track_interpolate(i, time, &rot[1]);
 						rot[1] = post_process_key_value(a, i, rot[1], t->object_id, t->bone_idx);
 						root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
-						prev_time = !backward ? 0 : (double)a_length;
+						prev_time = !backward ? start : end;
 					}
 					{
 						Quaternion rot;
@@ -1343,32 +1345,32 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					if (track->root_motion && calc_root) {
 						double prev_time = time - delta;
 						if (!backward) {
-							if (Animation::is_less_approx(prev_time, 0)) {
+							if (Animation::is_less_approx(prev_time, start)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = 0;
+										prev_time = start;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
 								}
 							}
 						} else {
-							if (Animation::is_greater_approx(prev_time, (double)a_length)) {
+							if (Animation::is_greater_approx(prev_time, end)) {
 								switch (a->get_loop_mode()) {
 									case Animation::LOOP_NONE: {
-										prev_time = (double)a_length;
+										prev_time = end;
 									} break;
 									case Animation::LOOP_LINEAR: {
-										prev_time = Math::fposmod(prev_time, (double)a_length);
+										prev_time = Math::fposmod(prev_time - start, end - start) + start;
 									} break;
 									case Animation::LOOP_PINGPONG: {
-										prev_time = Math::pingpong(prev_time, (double)a_length);
+										prev_time = Math::pingpong(prev_time - start, end - start) + start;
 									} break;
 									default:
 										break;
@@ -1383,10 +1385,10 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								scale[0] = post_process_key_value(a, i, scale[0], t->object_id, t->bone_idx);
-								a->try_scale_track_interpolate(i, (double)a_length, &scale[1]);
+								a->try_scale_track_interpolate(i, end, &scale[1]);
 								root_motion_cache.scale += (scale[1] - scale[0]) * blend;
 								scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
-								prev_time = 0;
+								prev_time = start;
 							}
 						} else {
 							if (Animation::is_less_approx(prev_time, time)) {
@@ -1395,10 +1397,10 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									continue;
 								}
 								scale[0] = post_process_key_value(a, i, scale[0], t->object_id, t->bone_idx);
-								a->try_scale_track_interpolate(i, 0, &scale[1]);
+								a->try_scale_track_interpolate(i, start, &scale[1]);
 								scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 								root_motion_cache.scale += (scale[1] - scale[0]) * blend;
-								prev_time = (double)a_length;
+								prev_time = end;
 							}
 						}
 						Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0]);
@@ -1409,7 +1411,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						a->try_scale_track_interpolate(i, time, &scale[1]);
 						scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 						root_motion_cache.scale += (scale[1] - scale[0]) * blend;
-						prev_time = !backward ? 0 : (double)a_length;
+						prev_time = !backward ? start : end;
 					}
 					{
 						Vector3 scale;
@@ -1671,6 +1673,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					if (!player2) {
 						continue;
 					}
+					// TODO: Make it possible to embed section info in animation track keys.
 					if (seeked) {
 						// Seek.
 						int idx = a->track_find_key(i, time, Animation::FIND_MODE_NEAREST, true);
@@ -1683,19 +1686,19 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							continue;
 						}
 						Ref<Animation> anim = player2->get_animation(anim_name);
-						double at_anim_pos = 0.0;
+						double at_anim_pos = start;
 						switch (anim->get_loop_mode()) {
 							case Animation::LOOP_NONE: {
-								if (!is_external_seeking && ((!backward && Animation::is_greater_or_equal_approx(time, pos + (double)anim->get_length())) || (backward && Animation::is_less_or_equal_approx(time, pos)))) {
+								if (!is_external_seeking && ((!backward && Animation::is_greater_or_equal_approx(time, pos + end)) || (backward && Animation::is_less_or_equal_approx(time, pos + start)))) {
 									continue; // Do nothing if current time is outside of length when started.
 								}
-								at_anim_pos = MIN((double)anim->get_length(), time - pos); // Seek to end.
+								at_anim_pos = MIN(end, time - pos); // Seek to end.
 							} break;
 							case Animation::LOOP_LINEAR: {
-								at_anim_pos = Math::fposmod(time - pos, (double)anim->get_length()); // Seek to loop.
+								at_anim_pos = Math::fposmod(time - pos - start, end - start) + start; // Seek to loop.
 							} break;
 							case Animation::LOOP_PINGPONG: {
-								at_anim_pos = Math::pingpong(time - pos, (double)a_length);
+								at_anim_pos = Math::pingpong(time - pos - start, end - start) + start;
 							} break;
 							default:
 								break;
@@ -2092,6 +2095,8 @@ Ref<AnimatedValuesBackup> AnimationMixer::make_backup() {
 	PlaybackInfo pi;
 	pi.time = 0;
 	pi.delta = 0;
+	pi.start = 0;
+	pi.end = reset_anim->get_length();
 	pi.seeked = true;
 	pi.weight = 1.0;
 	make_animation_instance(SceneStringName(RESET), pi);

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -85,6 +85,8 @@ public:
 	struct PlaybackInfo {
 		double time = 0.0;
 		double delta = 0.0;
+		double start = 0.0;
+		double end = 0.0;
 		bool seeked = false;
 		bool is_external_seeking = false;
 		Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -164,39 +164,41 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	double delta = p_started ? 0 : p_delta * speed;
 	double next_pos = cd.pos + delta;
 
-	double len = cd.from->animation->get_length();
+	double start = get_section_start_time();
+	double end = get_section_end_time();
+
 	Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;
 
 	switch (cd.from->animation->get_loop_mode()) {
 		case Animation::LOOP_NONE: {
-			if (Animation::is_less_approx(next_pos, 0)) {
-				next_pos = 0;
-			} else if (Animation::is_greater_approx(next_pos, len)) {
-				next_pos = len;
+			if (Animation::is_less_approx(next_pos, start)) {
+				next_pos = start;
+			} else if (Animation::is_greater_approx(next_pos, end)) {
+				next_pos = end;
 			}
 			delta = next_pos - cd.pos; // Fix delta (after determination of backwards because negative zero is lost here).
 		} break;
 
 		case Animation::LOOP_LINEAR: {
-			if (Animation::is_less_approx(next_pos, 0) && Animation::is_greater_or_equal_approx(cd.pos, 0)) {
+			if (Animation::is_less_approx(next_pos, start) && Animation::is_greater_or_equal_approx(cd.pos, start)) {
 				looped_flag = Animation::LOOPED_FLAG_START;
 			}
-			if (Animation::is_greater_approx(next_pos, len) && Animation::is_less_or_equal_approx(cd.pos, len)) {
+			if (Animation::is_greater_approx(next_pos, end) && Animation::is_less_or_equal_approx(cd.pos, end)) {
 				looped_flag = Animation::LOOPED_FLAG_END;
 			}
-			next_pos = Math::fposmod(next_pos, (double)len);
+			next_pos = Math::fposmod(next_pos - start, end - start) + start;
 		} break;
 
 		case Animation::LOOP_PINGPONG: {
-			if (Animation::is_less_approx(next_pos, 0) && Animation::is_greater_or_equal_approx(cd.pos, 0)) {
+			if (Animation::is_less_approx(next_pos, start) && Animation::is_greater_or_equal_approx(cd.pos, start)) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_START;
 			}
-			if (Animation::is_greater_approx(next_pos, len) && Animation::is_less_or_equal_approx(cd.pos, len)) {
+			if (Animation::is_greater_approx(next_pos, end) && Animation::is_less_or_equal_approx(cd.pos, end)) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_END;
 			}
-			next_pos = Math::pingpong(next_pos, (double)len);
+			next_pos = Math::pingpong(next_pos - start, end - start) + start;
 		} break;
 
 		default:
@@ -208,18 +210,18 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	// End detection.
 	if (p_is_current) {
 		if (cd.from->animation->get_loop_mode() == Animation::LOOP_NONE) {
-			if (!backwards && Animation::is_less_or_equal_approx(prev_pos, len) && Math::is_equal_approx(next_pos, len)) {
+			if (!backwards && Animation::is_less_or_equal_approx(prev_pos, end) && Math::is_equal_approx(next_pos, end)) {
 				// Playback finished.
-				next_pos = len; // Snap to the edge.
+				next_pos = end; // Snap to the edge.
 				end_reached = true;
-				end_notify = Animation::is_less_approx(prev_pos, len); // Notify only if not already at the end.
+				end_notify = Animation::is_less_approx(prev_pos, end); // Notify only if not already at the end.
 				p_blend = 1.0;
 			}
-			if (backwards && Animation::is_greater_or_equal_approx(prev_pos, 0) && Math::is_equal_approx(next_pos, 0)) {
+			if (backwards && Animation::is_greater_or_equal_approx(prev_pos, start) && Math::is_equal_approx(next_pos, start)) {
 				// Playback finished.
-				next_pos = 0; // Snap to the edge.
+				next_pos = start; // Snap to the edge.
 				end_reached = true;
-				end_notify = Animation::is_greater_approx(prev_pos, 0); // Notify only if not already at the beginning.
+				end_notify = Animation::is_greater_approx(prev_pos, start); // Notify only if not already at the beginning.
 				p_blend = 1.0;
 			}
 		}
@@ -231,10 +233,14 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	if (p_started) {
 		pi.time = prev_pos;
 		pi.delta = 0;
+		pi.start = start;
+		pi.end = end;
 		pi.seeked = true;
 	} else {
 		pi.time = next_pos;
 		pi.delta = delta;
+		pi.start = start;
+		pi.end = end;
 		pi.seeked = p_seeked;
 	}
 	if (Math::is_zero_approx(pi.delta) && backwards) {
@@ -378,6 +384,14 @@ void AnimationPlayer::play_backwards(const StringName &p_name, double p_custom_b
 	play(p_name, p_custom_blend, -1, true);
 }
 
+void AnimationPlayer::play_section_with_markers_backwards(const StringName &p_name, const StringName &p_start_marker, const StringName &p_end_marker, double p_custom_blend) {
+	play_section_with_markers(p_name, p_start_marker, p_end_marker, p_custom_blend, -1, true);
+}
+
+void AnimationPlayer::play_section_backwards(const StringName &p_name, double p_start_time, double p_end_time, double p_custom_blend) {
+	play_section(p_name, p_start_time, p_end_time, -1, true);
+}
+
 void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, float p_custom_scale, bool p_from_end) {
 	if (auto_capture) {
 		play_with_capture(p_name, auto_capture_duration, p_custom_blend, p_custom_scale, p_from_end, auto_capture_transition_type, auto_capture_ease_type);
@@ -387,6 +401,10 @@ void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, floa
 }
 
 void AnimationPlayer::_play(const StringName &p_name, double p_custom_blend, float p_custom_scale, bool p_from_end) {
+	play_section_with_markers(p_name, StringName(), StringName(), p_custom_blend, p_custom_scale, p_from_end);
+}
+
+void AnimationPlayer::play_section_with_markers(const StringName &p_name, const StringName &p_start_marker, const StringName &p_end_marker, double p_custom_blend, float p_custom_scale, bool p_from_end) {
 	StringName name = p_name;
 
 	if (name == StringName()) {
@@ -394,6 +412,38 @@ void AnimationPlayer::_play(const StringName &p_name, double p_custom_blend, flo
 	}
 
 	ERR_FAIL_COND_MSG(!animation_set.has(name), vformat("Animation not found: %s.", name));
+
+	Ref<Animation> animation = animation_set[name].animation;
+
+	ERR_FAIL_COND_MSG(p_start_marker == p_end_marker && p_start_marker, vformat("Start marker and end marker cannot be the same marker: %s.", p_start_marker));
+	ERR_FAIL_COND_MSG(p_start_marker && !animation->has_marker(p_start_marker), vformat("Marker %s not found in animation: %s.", p_start_marker, name));
+	ERR_FAIL_COND_MSG(p_end_marker && !animation->has_marker(p_end_marker), vformat("Marker %s not found in animation: %s.", p_end_marker, name));
+
+	double start_time = p_start_marker ? animation->get_marker_time(p_start_marker) : -1;
+	double end_time = p_end_marker ? animation->get_marker_time(p_end_marker) : -1;
+
+	ERR_FAIL_COND_MSG(p_start_marker && p_end_marker && Animation::is_greater_approx(start_time, end_time), vformat("End marker %s is placed earlier than start marker %s in animation: %s.", p_end_marker, p_start_marker, name));
+
+	if (p_start_marker && Animation::is_less_approx(start_time, 0)) {
+		WARN_PRINT_ED(vformat("Negative time start marker: %s is invalid in the section, so the start of the animation: %s is used instead.", p_start_marker, playback.current.from->animation->get_name()));
+	}
+	if (p_end_marker && Animation::is_less_approx(end_time, 0)) {
+		WARN_PRINT_ED(vformat("Negative time end marker: %s is invalid in the section, so the end of the animation: %s is used instead.", p_end_marker, playback.current.from->animation->get_name()));
+	}
+
+	play_section(name, start_time, end_time, p_custom_blend, p_custom_scale, p_from_end);
+}
+
+void AnimationPlayer::play_section(const StringName &p_name, double p_start_time, double p_end_time, double p_custom_blend, float p_custom_scale, bool p_from_end) {
+	StringName name = p_name;
+
+	if (name == StringName()) {
+		name = playback.assigned;
+	}
+
+	ERR_FAIL_COND_MSG(!animation_set.has(name), vformat("Animation not found: %s.", name));
+	ERR_FAIL_COND_MSG(p_start_time >= 0 && p_end_time >= 0 && Math::is_equal_approx(p_start_time, p_end_time), "Start time and end time must not equal to each other.");
+	ERR_FAIL_COND_MSG(p_start_time >= 0 && p_end_time >= 0 && Animation::is_greater_approx(p_start_time, p_end_time), vformat("Start time %f is greater than end time %f.", p_start_time, p_end_time));
 
 	Playback &c = playback;
 
@@ -442,22 +492,27 @@ void AnimationPlayer::_play(const StringName &p_name, double p_custom_blend, flo
 
 	c.current.from = &animation_set[name];
 	c.current.speed_scale = p_custom_scale;
+	c.current.start_time = p_start_time;
+	c.current.end_time = p_end_time;
+
+	double start = get_section_start_time();
+	double end = get_section_end_time();
 
 	if (!end_reached) {
 		playback_queue.clear();
 	}
 
 	if (c.assigned != name) { // Reset.
-		c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
+		c.current.pos = p_from_end ? end : start;
 		c.assigned = name;
 		emit_signal(SNAME("current_animation_changed"), c.assigned);
 	} else {
-		if (p_from_end && Math::is_zero_approx(c.current.pos)) {
+		if (p_from_end && Math::is_equal_approx(c.current.pos, start)) {
 			// Animation reset but played backwards, set position to the end.
-			seek_internal(c.current.from->animation->get_length(), true, true, true);
-		} else if (!p_from_end && Math::is_equal_approx(c.current.pos, (double)c.current.from->animation->get_length())) {
+			seek_internal(end, true, true, true);
+		} else if (!p_from_end && Math::is_equal_approx(c.current.pos, end)) {
 			// Animation resumed but already ended, set position to the beginning.
-			seek_internal(0, true, true, true);
+			seek_internal(start, true, true, true);
 		} else if (playing) {
 			return;
 		}
@@ -551,6 +606,8 @@ void AnimationPlayer::set_assigned_animation(const String &p_animation) {
 		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation));
 		playback.current.pos = 0;
 		playback.current.from = &animation_set[p_animation];
+		playback.current.start_time = -1;
+		playback.current.end_time = -1;
 		playback.assigned = p_animation;
 		emit_signal(SNAME("current_animation_changed"), playback.assigned);
 	}
@@ -603,6 +660,12 @@ void AnimationPlayer::seek_internal(double p_time, bool p_update, bool p_update_
 		}
 	}
 
+	double start = get_section_start_time();
+	double end = get_section_end_time();
+
+	// Clamp the seek position.
+	p_time = CLAMP(p_time, start, end);
+
 	playback.seeked = true;
 	playback.internal_seeked = p_is_internal_seek;
 
@@ -641,6 +704,55 @@ double AnimationPlayer::get_current_animation_length() const {
 	return playback.current.from->animation->get_length();
 }
 
+void AnimationPlayer::set_section_with_markers(const StringName &p_start_marker, const StringName &p_end_marker) {
+	ERR_FAIL_NULL_MSG(playback.current.from, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_MSG(p_start_marker == p_end_marker && p_start_marker, vformat("Start marker and end marker cannot be the same marker: %s.", p_start_marker));
+	ERR_FAIL_COND_MSG(p_start_marker && !playback.current.from->animation->has_marker(p_start_marker), vformat("Marker %s not found in animation: %s.", p_start_marker, playback.current.from->animation->get_name()));
+	ERR_FAIL_COND_MSG(p_end_marker && !playback.current.from->animation->has_marker(p_end_marker), vformat("Marker %s not found in animation: %s.", p_end_marker, playback.current.from->animation->get_name()));
+	double start_time = p_start_marker ? playback.current.from->animation->get_marker_time(p_start_marker) : -1;
+	double end_time = p_end_marker ? playback.current.from->animation->get_marker_time(p_end_marker) : -1;
+	if (p_start_marker && Animation::is_less_approx(start_time, 0)) {
+		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_start_marker, playback.current.from->animation->get_name()));
+	}
+	if (p_end_marker && Animation::is_less_approx(end_time, 0)) {
+		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_end_marker, playback.current.from->animation->get_name()));
+	}
+	set_section(start_time, end_time);
+}
+
+void AnimationPlayer::set_section(double p_start_time, double p_end_time) {
+	ERR_FAIL_NULL_MSG(playback.current.from, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_MSG(Animation::is_greater_or_equal_approx(p_start_time, 0) && Animation::is_greater_or_equal_approx(p_end_time, 0) && Animation::is_greater_or_equal_approx(p_start_time, p_end_time), vformat("Start time %f is greater than end time %f.", p_start_time, p_end_time));
+	playback.current.start_time = p_start_time;
+	playback.current.end_time = p_end_time;
+	playback.current.pos = CLAMP(playback.current.pos, get_section_start_time(), get_section_end_time());
+}
+
+void AnimationPlayer::reset_section() {
+	playback.current.start_time = -1;
+	playback.current.end_time = -1;
+}
+
+double AnimationPlayer::get_section_start_time() const {
+	ERR_FAIL_NULL_V_MSG(playback.current.from, playback.current.start_time, "AnimationPlayer has no current animation.");
+	if (Animation::is_less_approx(playback.current.start_time, 0) || playback.current.start_time > playback.current.from->animation->get_length()) {
+		return 0;
+	}
+	return playback.current.start_time;
+}
+
+double AnimationPlayer::get_section_end_time() const {
+	ERR_FAIL_NULL_V_MSG(playback.current.from, playback.current.end_time, "AnimationPlayer has no current animation.");
+	if (Animation::is_less_approx(playback.current.end_time, 0) || playback.current.end_time > playback.current.from->animation->get_length()) {
+		return playback.current.from->animation->get_length();
+	}
+	return playback.current.end_time;
+}
+
+bool AnimationPlayer::has_section() const {
+	return Animation::is_greater_or_equal_approx(playback.current.start_time, 0) || Animation::is_greater_or_equal_approx(playback.current.end_time, 0);
+}
+
 void AnimationPlayer::set_autoplay(const String &p_name) {
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
 		WARN_PRINT("Setting autoplay after the node has been added to the scene has no effect.");
@@ -665,13 +777,14 @@ void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 	_clear_caches();
 	Playback &c = playback;
 	// c.blend.clear();
+	double start = get_section_start_time();
 	if (p_reset) {
 		c.blend.clear();
 		if (p_keep_state) {
-			c.current.pos = 0;
+			c.current.pos = start;
 		} else {
 			is_stopping = true;
-			seek_internal(0, true, true, true);
+			seek_internal(start, true, true, true);
 			is_stopping = false;
 		}
 		c.current.from = nullptr;
@@ -763,20 +876,6 @@ Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
 	return auto_capture_ease_type;
 }
 
-#ifdef TOOLS_ENABLED
-void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	const String pf = p_function;
-	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
-		List<StringName> al;
-		get_animation_list(&al);
-		for (const StringName &name : al) {
-			r_options->push_back(String(name).quote());
-		}
-	}
-	AnimationMixer::get_argument_options(p_function, p_idx, r_options);
-}
-#endif
-
 void AnimationPlayer::_animation_removed(const StringName &p_name, const StringName &p_library) {
 	AnimationMixer::_animation_removed(p_name, p_library);
 
@@ -863,7 +962,11 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_auto_capture_ease_type"), &AnimationPlayer::get_auto_capture_ease_type);
 
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(StringName()), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play_section_with_markers", "name", "start_marker", "end_marker", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play_section_with_markers, DEFVAL(StringName()), DEFVAL(StringName()), DEFVAL(StringName()), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play_section", "name", "start_time", "end_time", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play_section, DEFVAL(StringName()), DEFVAL(-1), DEFVAL(-1), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(StringName()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("play_section_with_markers_backwards", "name", "start_marker", "end_marker", "custom_blend"), &AnimationPlayer::play_section_with_markers_backwards, DEFVAL(StringName()), DEFVAL(StringName()), DEFVAL(StringName()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("play_section_backwards", "name", "start_time", "end_time", "custom_blend"), &AnimationPlayer::play_section_backwards, DEFVAL(StringName()), DEFVAL(-1), DEFVAL(-1), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("play_with_capture", "name", "duration", "custom_blend", "custom_speed", "from_end", "trans_type", "ease_type"), &AnimationPlayer::play_with_capture, DEFVAL(StringName()), DEFVAL(-1.0), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false), DEFVAL(Tween::TRANS_LINEAR), DEFVAL(Tween::EASE_IN));
 	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
 	ClassDB::bind_method(D_METHOD("stop", "keep_state"), &AnimationPlayer::stop, DEFVAL(false));
@@ -892,6 +995,14 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_current_animation_position"), &AnimationPlayer::get_current_animation_position);
 	ClassDB::bind_method(D_METHOD("get_current_animation_length"), &AnimationPlayer::get_current_animation_length);
+
+	ClassDB::bind_method(D_METHOD("set_section_with_markers", "start_marker", "end_marker"), &AnimationPlayer::set_section_with_markers, DEFVAL(StringName()), DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("set_section", "start_time", "end_time"), &AnimationPlayer::set_section, DEFVAL(-1), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("reset_section"), &AnimationPlayer::reset_section);
+
+	ClassDB::bind_method(D_METHOD("get_section_start_time"), &AnimationPlayer::get_section_start_time);
+	ClassDB::bind_method(D_METHOD("get_section_end_time"), &AnimationPlayer::get_section_end_time);
+	ClassDB::bind_method(D_METHOD("has_section"), &AnimationPlayer::has_section);
 
 	ClassDB::bind_method(D_METHOD("seek", "seconds", "update", "update_only"), &AnimationPlayer::seek, DEFVAL(false), DEFVAL(false));
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -68,6 +68,8 @@ private:
 		AnimationData *from = nullptr;
 		double pos = 0.0;
 		float speed_scale = 1.0;
+		double start_time = 0.0;
+		double end_time = 0.0;
 	};
 
 	struct Blend {
@@ -177,7 +179,11 @@ public:
 	Tween::EaseType get_auto_capture_ease_type() const;
 
 	void play(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
+	void play_section_with_markers(const StringName &p_name = StringName(), const StringName &p_start_marker = StringName(), const StringName &p_end_marker = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
+	void play_section(const StringName &p_name = StringName(), double p_start_time = -1, double p_end_time = -1, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void play_backwards(const StringName &p_name = StringName(), double p_custom_blend = -1);
+	void play_section_with_markers_backwards(const StringName &p_name = StringName(), const StringName &p_start_marker = StringName(), const StringName &p_end_marker = StringName(), double p_custom_blend = -1);
+	void play_section_backwards(const StringName &p_name = StringName(), double p_start_time = -1, double p_end_time = -1, double p_custom_blend = -1);
 	void play_with_capture(const StringName &p_name = StringName(), double p_duration = -1.0, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
@@ -207,9 +213,13 @@ public:
 	double get_current_animation_position() const;
 	double get_current_animation_length() const;
 
-#ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
+	void set_section_with_markers(const StringName &p_start_marker = StringName(), const StringName &p_end_marker = StringName());
+	void set_section(double p_start_time = -1, double p_end_time = -1);
+	void reset_section();
+
+	double get_section_start_time() const;
+	double get_section_end_time() const;
+	bool has_section() const;
 
 	virtual void advance(double p_time) override;
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -237,6 +237,20 @@ private:
 		}
 	};
 
+	/* Marker */
+
+	struct MarkerKey {
+		double time;
+		StringName name;
+		MarkerKey(double p_time, const StringName &p_name) :
+				time(p_time), name(p_name) {}
+		MarkerKey() = default;
+	};
+
+	Vector<MarkerKey> marker_names; // time -> name
+	HashMap<StringName, double> marker_times; // name -> time
+	HashMap<StringName, Color> marker_colors; // name -> color
+
 	Vector<Track *> tracks;
 
 	template <typename T>
@@ -244,6 +258,8 @@ private:
 
 	template <typename T, typename V>
 	int _insert(double p_time, T &p_keys, const V &p_value);
+
+	int _marker_insert(double p_time, Vector<MarkerKey> &p_keys, const MarkerKey &p_value);
 
 	template <typename K>
 
@@ -500,6 +516,17 @@ public:
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
 	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE) const;
+
+	void add_marker(const StringName &p_name, double p_time);
+	void remove_marker(const StringName &p_name);
+	bool has_marker(const StringName &p_name) const;
+	StringName get_marker_at_time(double p_time) const;
+	StringName get_next_marker(double p_time) const;
+	StringName get_prev_marker(double p_time) const;
+	double get_marker_time(const StringName &p_time) const;
+	PackedStringArray get_marker_names() const;
+	Color get_marker_color(const StringName &p_name) const;
+	void set_marker_color(const StringName &p_name, const Color &p_color);
 
 	void set_length(real_t p_length);
 	real_t get_length() const;


### PR DESCRIPTION
_Bugsquad edited:_
- Closes https://github.com/godotengine/godot-proposals/issues/2159
- Closes https://github.com/godotengine/godot-proposals/issues/8414 
- Closes https://github.com/godotengine/godot-proposals/issues/8526

This PR introduces a marker system for Animations. Markers are keys that are inserted alongside the timeline, and can be used to play specific parts of animations. A pair of markers is called a _section_.

For the Animation resource class, there are now new methods to query marker information with.

For AnimationPlayer, there is now a new `play_section` method that can be used to specify a pair of markers that denote a playback section. 
* When the start marker is set to an empty string, the system interprets it as the start of the original animation, and when the end marker is set to an empty string, the system interprets it as the end of the original animation.
  * The vanilla `play` method is equivalent to passing empty strings as start and end markers to `play_section`.
* Markers can be placed beyond the original animation's length, ~~in which case the AnimationMixer effectively does nothing while playing the out-of-range part of the section. (FEEDBACK WELCOME: Is this behavior desirable?)~~  The AnimationMixer will clamp the end of the section so it does not exceed the Animation's length.
* In the Animation editor, new markers can be inserted by right-clicking the timeline and then selecting a name through a dialog.
  * Names have to be unique. The validation panel in the dialog will alert the user and prevent them from creating a second marker with the same name.
* Select two markers and the section between them will be highlighted in red. Clicking play buttons will then make AnimationPlayer play the section.
  * `play_section` uses the original Animation's loop mode.

https://github.com/godotengine/godot/assets/56677134/a57ed7ee-8287-4b77-9fce-a50410e92218

For AnimationTree, specifically AnimationNodeAnimation, Custom Timelines can now be configured using the `Set Custom Timeline from Marker` button.
* Clicking the button opens up a dialog that lets you select a start marker and an end marker. The start marker's time is copied to the timeline's start offset, and the end marker's time is copied to the timeline's length.

https://github.com/godotengine/godot/assets/56677134/46368b3d-40ee-4ba2-834e-1cc1bda9343a

