### PR TITLE
Fix crash when generating thumbnails for certain texture types

### DIFF
--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -143,7 +143,17 @@ void NoiseTexture2D::_queue_update() {
 	}
 
 	update_queued = true;
-	callable_mp(this, &NoiseTexture2D::_update_texture).call_deferred();
+	reference(); // Make sure we aren't deallocated while invoking deferred call.
+	callable_mp(this, &NoiseTexture2D::_do_queued_update).call_deferred();
+}
+
+void NoiseTexture2D::_do_queued_update() {
+	_update_texture();
+
+	// Release the reference we acquired when queueing the update.
+	if (unreference()) {
+		memdelete(this);
+	}
 }
 
 Ref<Image> NoiseTexture2D::_generate_texture() {

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -68,6 +68,7 @@ private:
 	static void _thread_function(void *p_ud);
 
 	void _queue_update();
+	void _do_queued_update();
 	Ref<Image> _generate_texture();
 	void _update_texture();
 	void _set_texture_image(const Ref<Image> &p_image);

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -131,7 +131,17 @@ void NoiseTexture3D::_queue_update() {
 	}
 
 	update_queued = true;
-	callable_mp(this, &NoiseTexture3D::_update_texture).call_deferred();
+	reference(); // Make sure we aren't deallocated while invoking deferred call.
+	callable_mp(this, &NoiseTexture3D::_do_queued_update).call_deferred();
+}
+
+void NoiseTexture3D::_do_queued_update() {
+	_update_texture();
+
+	// Release the reference we acquired when queueing the update.
+	if (unreference()) {
+		memdelete(this);
+	}
 }
 
 TypedArray<Image> NoiseTexture3D::_generate_texture() {

--- a/modules/noise/noise_texture_3d.h
+++ b/modules/noise/noise_texture_3d.h
@@ -66,6 +66,7 @@ private:
 	static void _thread_function(void *p_ud);
 
 	void _queue_update();
+	void _do_queued_update();
 	TypedArray<Image> _generate_texture();
 	void _update_texture();
 	void _set_texture_data(const TypedArray<Image> &p_data);

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -83,7 +83,17 @@ void GradientTexture1D::_queue_update() {
 		return;
 	}
 	update_pending = true;
-	callable_mp(this, &GradientTexture1D::update_now).call_deferred();
+	reference(); // Make sure we aren't deallocated while invoking deferred call.
+	callable_mp(this, &GradientTexture1D::_do_queued_update).call_deferred();
+}
+
+void GradientTexture1D::_do_queued_update() {
+	update_now();
+
+	// Release the reference we acquired when queueing the update.
+	if (unreference()) {
+		memdelete(this);
+	}
 }
 
 void GradientTexture1D::_update() {
@@ -222,7 +232,17 @@ void GradientTexture2D::_queue_update() {
 		return;
 	}
 	update_pending = true;
-	callable_mp(this, &GradientTexture2D::update_now).call_deferred();
+	reference(); // Make sure we aren't deallocated while invoking deferred call.
+	callable_mp(this, &GradientTexture2D::_do_queued_update).call_deferred();
+}
+
+void GradientTexture2D::_do_queued_update() {
+	update_now();
+
+	// Release the reference we acquired when queueing the update.
+	if (unreference()) {
+		memdelete(this);
+	}
 }
 
 void GradientTexture2D::_update() {

--- a/scene/resources/gradient_texture.h
+++ b/scene/resources/gradient_texture.h
@@ -44,6 +44,7 @@ private:
 	bool use_hdr = false;
 
 	void _queue_update();
+	void _do_queued_update();
 	void _update();
 
 protected:
@@ -104,6 +105,7 @@ private:
 
 	bool update_pending = false;
 	void _queue_update();
+	void _do_queued_update();
 	void _update();
 
 protected:


### PR DESCRIPTION
Fixes #58818.
Fixes #69861.
Fixes #70974.

This is unlikely to be an acceptable fix for this, but I figured this could maybe start a conversation about what else can be done.

I'm able to reproduce the above linked issue in a fairly big project, even on latest `master`, which is c4279fe3e as of writing this. The repro is unfortunately not consistent at all. Sometimes I can start the editor dozens of time without any issue, with or without an existing thumbnail cache, whereas other times the crash can happen several times in a row. Everything seems to point towards a multi-threaded race condition of some sort.

The symptoms seem pretty straight-forward to me. The queued update of these texture types (although there may be more resource types like this) are sometimes called after the instance has been deallocated. I can say with 100% certainty that the instance has indeed been deallocated at that point, but I can't say exactly what allocated it, nor what deallocated it. Any attempts at logging stuff seems to add enough stalls that the race condition doesn't manifest itself anymore.

Seeing as how the `ObjectID` check in `CallableCustomMethodPointer::call` (seen [here](https://github.com/godotengine/godot/blob/c4279fe3e0b27d0f40857c00eece7324a967285f/core/object/callable_method_pointer.h#L102)) should prohibit this from ever happening as long as everything's done on a single thread, it stands to reason that this is happening because another thread (like `EditorResourcePreviewGenerator`) is allocating these resources, thus scheduling the deferred call, and then happens to deallocate them right as `CallableCustomMethodPointer::call` is being invoked, after the above mentioned `ObjectID` check. The fact that this issue can also be reproduced by hovering over an editor tab seems to imply that `EditorResourcePreviewGenerator` is indeed the culprit, presumably `EditorResourcePreviewGenerator::generate_from_path`.

This PR fixes this in a somewhat brute-force manner, by simply allowing the resource instances to always outlive their deferred call, by bumping their reference counter for the duration of it. I have been unable to reproduce the crash with this PR applied.

If my diagnosis seems incorrect, or if there's a better fix, I'd love to know.

(I suppose it's also possible that this fix instead leads to memory leaks at shutdown if for some reason the message queue isn't flushed after one of these texture updates is queued up.)