### PR TITLE
Fix aabb intersects ray normal being incorrectly always negative

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -159,7 +159,7 @@ bool AABB::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *
 	}
 	if (r_normal) {
 		*r_normal = Vector3();
-		(*r_normal)[axis] = p_dir[axis] ? -1 : 1;
+		(*r_normal)[axis] = (p_dir[axis] > 0.0) ? -1 : 1;
 	}
 
 	return true;


### PR DESCRIPTION
Also, I am pretty sure that the intersection point result is also incorrect, or its in other coords that I don't know about, but the results don't even seem consistent with the other ray intersection functions... so the whole functions may need a proper review and/or rewrite.