### PR TITLE
Fix `layer_viewport` getting cleared on `OpenXRCompositionLayer` in editor

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -77,7 +77,8 @@ protected:
 
 	void update_fallback_mesh();
 
-	static HashSet<SubViewport *> viewports_in_use;
+	static Vector<OpenXRCompositionLayer *> composition_layer_nodes;
+	bool is_viewport_in_use(SubViewport *p_viewport);
 
 public:
 	void set_layer_viewport(SubViewport *p_viewport);


### PR DESCRIPTION
Two `OpenXRCompositionLayer`s cannot use the same `SubViewport`, so there is some code that attempts to track which viewports are in use, and prevent users from setting the same viewport twice (and show a nice message about it).

Unfortunately, this is causing the `layer_viewport` to sometimes get cleared when opening a scene in the editor again.

This PR changes how the tracking is done in order to fix that bug! I think it also makes the interaction with the editor's undo/redo system more rational.
