### PR TITLE
Improve UX when falling back between Display Servers

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2838,6 +2838,8 @@ Error Main::setup2(bool p_show_boot_logo) {
 		Error err;
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, err);
 		if (err != OK || display_server == nullptr) {
+			String last_name = DisplayServer::get_create_function_name(display_driver_idx);
+
 			// We can't use this display server, try other ones as fallback.
 			// Skip headless (always last registered) because that's not what users
 			// would expect if they didn't request it explicitly.
@@ -2845,6 +2847,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 				if (i == display_driver_idx) {
 					continue; // Don't try the same twice.
 				}
+				String name = DisplayServer::get_create_function_name(i);
+				WARN_PRINT(vformat("Display driver %s failed, falling back to %s.", last_name, name));
+
 				display_server = DisplayServer::create(i, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, err);
 				if (err == OK && display_server != nullptr) {
 					break;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1349,23 +1349,39 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 
 	rendering_driver = p_rendering_driver;
 
+	bool driver_found = false;
+	String executable_name = OS::get_singleton()->get_executable_path().get_file();
+
 #ifdef RD_ENABLED
 #ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
 		rendering_context = memnew(RenderingContextDriverVulkanWayland);
 	}
-#endif
+#endif // VULKAN_ENABLED
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;
 			r_error = ERR_CANT_CREATE;
-			return;
+
+			if (p_rendering_driver == "vulkan") {
+				OS::get_singleton()->alert(
+						vformat("Your video card drivers seem not to support the required Vulkan version.\n\n"
+								"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
+								"You can enable the OpenGL 3 driver by starting the engine from the\n"
+								"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
+								"If you recently updated your video card drivers, try rebooting.",
+								executable_name),
+						"Unable to initialize Vulkan video driver");
+			}
+
+			ERR_FAIL_MSG(vformat("Could not initialize %s", rendering_driver));
 		}
+
+		driver_found = true;
 	}
-#endif
+#endif // RD_ENABLED
 
 #ifdef GLES3_ENABLED
 	if (rendering_driver == "opengl3" || rendering_driver == "opengl3_es") {
@@ -1431,25 +1447,52 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 					rendering_driver = "opengl3_es";
 				} else {
 					r_error = ERR_UNAVAILABLE;
+
+					OS::get_singleton()->alert(
+							vformat("Your video card drivers seem not to support the required OpenGL 3.3 version.\n\n"
+									"If possible, consider updating your video card drivers or using the Vulkan driver.\n\n"
+									"You can enable the Vulkan driver by starting the engine from the\n"
+									"command line with the command:\n\n    \"%s\" --rendering-driver vulkan\n\n"
+									"If you recently updated your video card drivers, try rebooting.",
+									executable_name),
+							"Unable to initialize OpenGL video driver");
+
 					ERR_FAIL_MSG("Could not initialize OpenGL.");
 				}
 			} else {
 				RasterizerGLES3::make_current(true);
+				driver_found = true;
 			}
 		}
 
 		if (rendering_driver == "opengl3_es") {
 			egl_manager = memnew(EGLManagerWaylandGLES);
 
-			if (egl_manager->initialize(wayland_thread.get_wl_display()) != OK) {
+			if (egl_manager->initialize(wayland_thread.get_wl_display()) != OK || egl_manager->open_display(wayland_thread.get_wl_display()) != OK) {
 				memdelete(egl_manager);
 				egl_manager = nullptr;
 				r_error = ERR_CANT_CREATE;
-				ERR_FAIL_MSG("Could not initialize GLES3.");
+
+				OS::get_singleton()->alert(
+						vformat("Your video card drivers seem not to support the required OpenGL ES 3.0 version.\n\n"
+								"If possible, consider updating your video card drivers or using the Vulkan driver.\n\n"
+								"You can enable the Vulkan driver by starting the engine from the\n"
+								"command line with the command:\n\n    \"%s\" --rendering-driver vulkan\n\n"
+								"If you recently updated your video card drivers, try rebooting.",
+								executable_name),
+						"Unable to initialize OpenGL ES video driver");
+
+				ERR_FAIL_MSG("Could not initialize OpenGL ES.");
 			}
 
 			RasterizerGLES3::make_current(false);
+			driver_found = true;
 		}
+	}
+
+	if (!driver_found) {
+		r_error = ERR_UNAVAILABLE;
+		ERR_FAIL_MSG("Video driver not found.");
 	}
 #endif // GLES3_ENABLED
 
@@ -1481,12 +1524,12 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 
 		RendererCompositorRD::make_current();
 	}
-#endif
+#endif // RD_ENABLED
 
 #ifdef DBUS_ENABLED
 	portal_desktop = memnew(FreeDesktopPortalDesktop);
 	screensaver = memnew(FreeDesktopScreenSaver);
-#endif
+#endif // DBUS_ENABLED
 
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5428,25 +5428,6 @@ Vector<String> DisplayServerX11::get_rendering_drivers_func() {
 
 DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
 	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
-	if (r_error != OK) {
-		if (p_rendering_driver == "vulkan") {
-			String executable_name = OS::get_singleton()->get_executable_path().get_file();
-			OS::get_singleton()->alert(
-					vformat("Your video card drivers seem not to support the required Vulkan version.\n\n"
-							"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
-							"You can enable the OpenGL 3 driver by starting the engine from the\n"
-							"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
-							"If you recently updated your video card drivers, try rebooting.",
-							executable_name),
-					"Unable to initialize Vulkan video driver");
-		} else {
-			OS::get_singleton()->alert(
-					"Your video card drivers seem not to support the required OpenGL 3.3 version.\n\n"
-					"If possible, consider updating your video card drivers.\n\n"
-					"If you recently updated your video card drivers, try rebooting.",
-					"Unable to initialize OpenGL video driver");
-		}
-	}
 	return ds;
 }
 
@@ -6160,25 +6141,40 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	rendering_driver = p_rendering_driver;
 
 	bool driver_found = false;
+	String executable_name = OS::get_singleton()->get_executable_path().get_file();
+
+	// Initialize context and rendering device.
+
 #if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
 		rendering_context = memnew(RenderingContextDriverVulkanX11);
 	}
-#endif
+#endif // VULKAN_ENABLED
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;
 			r_error = ERR_CANT_CREATE;
-			return;
+
+			if (p_rendering_driver == "vulkan") {
+				OS::get_singleton()->alert(
+						vformat("Your video card drivers seem not to support the required Vulkan version.\n\n"
+								"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
+								"You can enable the OpenGL 3 driver by starting the engine from the\n"
+								"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
+								"If you recently updated your video card drivers, try rebooting.",
+								executable_name),
+						"Unable to initialize Vulkan video driver");
+			}
+
+			ERR_FAIL_MSG(vformat("Could not initialize %s", rendering_driver));
 		}
 		driver_found = true;
 	}
-#endif
-	// Initialize context and rendering device.
+#endif // RD_ENABLED
+
 #if defined(GLES3_ENABLED)
 	if (rendering_driver == "opengl3" || rendering_driver == "opengl3_es") {
 		if (getenv("DRI_PRIME") == nullptr) {
@@ -6233,6 +6229,16 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 				rendering_driver = "opengl3_es";
 			} else {
 				r_error = ERR_UNAVAILABLE;
+
+				OS::get_singleton()->alert(
+						vformat("Your video card drivers seem not to support the required OpenGL 3.3 version.\n\n"
+								"If possible, consider updating your video card drivers or using the Vulkan driver.\n\n"
+								"You can enable the Vulkan driver by starting the engine from the\n"
+								"command line with the command:\n\n    \"%s\" --rendering-driver vulkan\n\n"
+								"If you recently updated your video card drivers, try rebooting.",
+								executable_name),
+						"Unable to initialize OpenGL video driver");
+
 				ERR_FAIL_MSG("Could not initialize OpenGL.");
 			}
 		} else {
@@ -6243,20 +6249,28 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	if (rendering_driver == "opengl3_es") {
 		gl_manager_egl = memnew(GLManagerEGL_X11);
-		if (gl_manager_egl->initialize() != OK) {
+		if (gl_manager_egl->initialize() != OK || gl_manager_egl->open_display(x11_display) != OK) {
 			memdelete(gl_manager_egl);
 			gl_manager_egl = nullptr;
 			r_error = ERR_UNAVAILABLE;
-			ERR_FAIL_MSG("Could not initialize OpenGLES.");
+
+			OS::get_singleton()->alert(
+					"Your video card drivers seem not to support the required OpenGL ES 3.0 version.\n\n"
+					"If possible, consider updating your video card drivers.\n\n"
+					"If you recently updated your video card drivers, try rebooting.",
+					"Unable to initialize OpenGL ES video driver");
+
+			ERR_FAIL_MSG("Could not initialize OpenGL ES.");
 		}
 		driver_found = true;
 		RasterizerGLES3::make_current(false);
 	}
 
-#endif
+#endif // GLES3_ENABLED
+
 	if (!driver_found) {
 		r_error = ERR_UNAVAILABLE;
-		ERR_FAIL_MSG("Video driver not found");
+		ERR_FAIL_MSG("Video driver not found.");
 	}
 
 	Point2i window_position;
@@ -6297,7 +6311,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 		RendererCompositorRD::make_current();
 	}
-#endif
+#endif // RD_ENABLED
 
 	{
 		//set all event master mask
@@ -6450,7 +6464,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 
 	portal_desktop = memnew(FreeDesktopPortalDesktop);
-#endif
+#endif // DBUS_ENABLED
+
 	XSetErrorHandler(&default_window_error_handler);
 
 	r_error = OK;


### PR DESCRIPTION
The current UX for DS fallbacks is a bit confusing, as there's quite a bit of (possibly unrelated) errors and then a working game:

<details><summary>Example log from X11 to Wayland</summary>

```
$ DISPLAY=/dev/null bin/godot.linuxbsd.editor.dev.x86_64 --display-driver x11 --rendering-driver opengl3
Godot Engine v4.3.dev.custom_build.1313cd90a (2024-05-09 09:51:35 UTC) - https://godotengine.org
Error loading shared library libXinerama.so.1: No such file or directory
ERROR: X11 Display is not available
   at: DisplayServerX11 (platform/linuxbsd/x11/display_server_x11.cpp:5861)
Your video card drivers seem not to support the required OpenGL 3.3 version.

If possible, consider updating your video card drivers.

If you recently updated your video card drivers, try rebooting.
Plugin "GTK3 plugin" uses conflicting symbol "png_free".
Error loading shared library libspeechd.so.2: No such file or directory
Invalid value (0) for DRI_PRIME. Should be > 0
Inconsistent value (1) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
Inconsistent value (2) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
Inconsistent value (3) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
OpenGL API 4.6 (Core Profile) Mesa 23.3.5 - Compatibility - Using Device: AMD - AMD Radeon Vega 8 Graphics (radeonsi, raven, LLVM 17.0.6, DRM 3.57, 6.8.8)
```

</details>

This patchset[^1] aims to improve the situation where possible, without introducing any big change yet:

 - From core, we display a warning whenever a fallback is being attempted;

 - From X11, we alert the user about a failed rendering driver initialization only if it was actually attempted;

 - From Wayland we actually implement the aforementioned alerts, as they were missing (oops).


<details><summary>New log when falling back from X11 to Wayland</summary>

```
$ DISPLAY=/dev/null bin/godot.linuxbsd.editor.dev.x86_64 --display-driver x11 --rendering-driver opengl3
Godot Engine v4.3.dev.custom_build.1313cd90a (2024-05-09 09:51:35 UTC) - https://godotengine.org
Error loading shared library libXinerama.so.1: No such file or directory
ERROR: X11 Display is not available
   at: DisplayServerX11 (platform/linuxbsd/x11/display_server_x11.cpp:5842)
WARNING: Display driver x11 failed, falling back to wayland.
     at: setup2 (main/main.cpp:2701)
Plugin "GTK3 plugin" uses conflicting symbol "png_free".
Error loading shared library libspeechd.so.2: No such file or directory
Invalid value (0) for DRI_PRIME. Should be > 0
Inconsistent value (1) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
Inconsistent value (2) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
Inconsistent value (3) for DRI_PRIME. Should be < 1 (GPU devices count). Using: 0
OpenGL API 4.6 (Core Profile) Mesa 23.3.5 - Compatibility - Using Device: AMD - AMD Radeon Vega 8 Graphics (radeonsi, raven, LLVM 17.0.6, DRM 3.57, 6.8.8)
```

</details>

It's not perfect by any means (the DRI_PRIME stuff is especially annoying), but those were some fairly low-hanging fruits and so this will do in the meantime.

[^1]: Yes, sorry for making _three_ commits but they feel all equally sensitive and unrelated. Please tell me if a single squashed commit is preferred.