### PR TITLE
Fix reordering color swatches in color picker is not saved

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -839,6 +839,59 @@ void ColorPicker::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		if (preset_from_id == hover_now || hover_now == -1) {
 			return;
 		}
+
+		{
+			List<Color>::Element *from = presets.front();
+			List<Color>::Element *to = presets.front();
+			{
+				int c = 0;
+				while (c < preset_from_id - 1) {
+					from = from->next();
+					c++;
+				}
+			}
+			{
+				int c = 0;
+				while (c < hover_now - 1) {
+					to = to->next();
+					c++;
+				}
+			}
+			if (hover_now == presets.size()) {
+				presets.move_to_back(from);
+			} else if (hover_now == 1) {
+				presets.move_to_front(from);
+			} else {
+				presets.move_before(from, to->next());
+			}
+		}
+
+		{
+			List<Color>::Element *from = preset_cache.front();
+			List<Color>::Element *to = preset_cache.front();
+			{
+				int c = 0;
+				while (c < preset_from_id - 1) {
+					from = from->next();
+					c++;
+				}
+			}
+			{
+				int c = 0;
+				while (c < hover_now - 1) {
+					to = to->next();
+					c++;
+				}
+			}
+			if (hover_now == presets.size()) {
+				preset_cache.move_to_back(from);
+			} else if (hover_now == 1) {
+				preset_cache.move_to_front(from);
+			} else {
+				preset_cache.move_before(from, to->next());
+			}
+		}
+
 		preset_container->move_child(preset_container->get_child(preset_from_id), hover_now);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91774

lol, it seems the list api don't support doing this kind of thing conveniently, so the code is a little messy... Feel free to correct me

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
