### PR TITLE
Fix viewport attach position when forced integer stretch scale of 1 makes it bigger than window

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1373,6 +1373,8 @@ void Window::_update_viewport_size() {
 		screen_size = screen_size.floor();
 		viewport_size = viewport_size.floor();
 
+		Size2 attach_to_screen_offset;
+
 		if (content_scale_stretch == Window::CONTENT_SCALE_STRETCH_INTEGER) {
 			Size2i screen_scale = (screen_size / viewport_size).floor();
 			int scale_factor = MIN(screen_scale.x, screen_scale.y);
@@ -1382,19 +1384,20 @@ void Window::_update_viewport_size() {
 			}
 
 			screen_size = viewport_size * scale_factor;
+
+			if (screen_size.y > video_mode.y) {
+				attach_to_screen_offset.y = video_mode.y - screen_size.y;
+			}
 		}
 
 		Size2 margin;
-		Size2 offset;
 
 		if (screen_size.x < video_mode.x) {
 			margin.x = Math::round((video_mode.x - screen_size.x) / 2.0);
-			offset.x = Math::round(margin.x * viewport_size.y / screen_size.y);
 		}
 
 		if (screen_size.y < video_mode.y) {
 			margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
-			offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
 		}
 
 		switch (content_scale_mode) {
@@ -1403,13 +1406,13 @@ void Window::_update_viewport_size() {
 			case CONTENT_SCALE_MODE_CANVAS_ITEMS: {
 				final_size = screen_size;
 				final_size_override = viewport_size / content_scale_factor;
-				attach_to_screen_rect = Rect2(margin, screen_size);
+				attach_to_screen_rect = Rect2(margin + attach_to_screen_offset, screen_size);
 
 				window_transform.translate_local(margin);
 			} break;
 			case CONTENT_SCALE_MODE_VIEWPORT: {
 				final_size = (viewport_size / content_scale_factor).floor();
-				attach_to_screen_rect = Rect2(margin, screen_size);
+				attach_to_screen_rect = Rect2(margin + attach_to_screen_offset, screen_size);
 
 				window_transform.translate_local(margin);
 				if (final_size.x != 0 && final_size.y != 0) {


### PR DESCRIPTION
Fixes #89578.
Fixes (partially?) #117813.


Supersedes #90257.

---

Before: https://github.com/godotengine/godot/issues/89578#issuecomment-2002130555
After:
![vBZrrso3gT](https://github.com/godotengine/godot/assets/9283098/80b51583-53d9-4a6c-8bdb-0d99865c9454)|![TmsHhpSyAO](https://github.com/godotengine/godot/assets/9283098/e598c0e4-3fe0-40ef-a951-402e8f85fa5f)|![o7v4NNcJJ8](https://github.com/godotengine/godot/assets/9283098/a8c37175-c9bd-4004-988e-bf9b7d874873)|![nPSywsAOqf](https://github.com/godotengine/godot/assets/9283098/df949845-d647-4ba8-9d3d-fafdaa791ad0)
-|-|-|-

---

Haven't dived deep into the code (looked only into `Window::_update_viewport_size`) so please test thoroughly. Firstly I've tried just adding a proper offset to the `margin`, it resulted in the opposite issue compared to https://github.com/godotengine/godot/issues/89578#issuecomment-2002130555:

![kQEXwsbmYt](https://github.com/godotengine/godot/assets/9283098/956671f9-aba3-41cb-a5f0-37dd6caa65d5)


Then I've noticed `margin` is also applied to `window_transform`, hence tried a separate additional offset just for `attach_to_screen_rect`. And that's this PR, seems to work. :upside_down_face: