### PR TITLE
[3.x] Tighter light culling - fix directional lights colinear case

### DIFF
--- a/servers/visual/visual_server_light_culler.cpp
+++ b/servers/visual/visual_server_light_culler.cpp
@@ -227,9 +227,11 @@ bool VisualServerLightCuller::add_light_camera_planes_directional(const LightSou
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, pt2);
-		add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			add_cull_plane(p);
+		}
 	}
 
 	// Last to 0 edge.
@@ -243,9 +245,11 @@ bool VisualServerLightCuller::add_light_camera_planes_directional(const LightSou
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, pt2);
-		add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			add_cull_plane(p);
+		}
 	}
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING


### PR DESCRIPTION
Exactly the same fix as done already for non-directional lights.

Fixes #89560 for 3.x

## Notes
* Same fix as #89714 but for directional lights.
* I wouldn't worry about this re: beta 5, it should be a pretty rare bug and it's easy to fix by changing project setting.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
