### PR TITLE
Tighter light culling - fix directional lights colinear case

### DIFF
--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -279,9 +279,11 @@ bool RenderingLightCuller::add_light_camera_planes_directional(LightCullPlanes &
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, pt2);
-		r_cull_planes.add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			r_cull_planes.add_cull_plane(p);
+		}
 	}
 
 	// Last to 0 edge.
@@ -295,9 +297,11 @@ bool RenderingLightCuller::add_light_camera_planes_directional(LightCullPlanes &
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, pt2);
-		r_cull_planes.add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			r_cull_planes.add_cull_plane(p);
+		}
 	}
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING


### PR DESCRIPTION
Exactly the same fix as done already for non-directional lights.

Fixes #89560 for 4.x

## Notes
* Same fix as #89714 but for directional lights.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
