### PR TITLE
SCons: Process platform-specific flags earlier

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -374,6 +374,14 @@ if env["platform"] in platform_opts:
     for opt in platform_opts[env["platform"]]:
         opts.Add(opt)
 
+# Platform-specific flags.
+# These can sometimes override default options, so they need to be processed
+# as early as possible to ensure that we're using the correct values.
+flag_list = platform_flags[env["platform"]]
+for key, value in flag_list.items():
+    if key not in ARGUMENTS or ARGUMENTS[key] == "auto":  # Allow command line to override platform flags
+        env[key] = value
+
 # Update the environment to take platform-specific options into account.
 opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
 
@@ -568,17 +576,8 @@ if env["build_profile"] != "":
         print_error('Failed to open feature build profile: "{}"'.format(env["build_profile"]))
         Exit(255)
 
-# Platform specific flags.
-# These can sometimes override default options.
-flag_list = platform_flags[env["platform"]]
-for key, value in flag_list.items():
-    if key not in ARGUMENTS or ARGUMENTS[key] == "auto":  # Allow command line to override platform flags
-        env[key] = value
-
 # 'dev_mode' and 'production' are aliases to set default options if they haven't been
 # set manually by the user.
-# These need to be checked *after* platform specific flags so that different
-# default values can be set (e.g. to keep LTO off for `production` on some platforms).
 if env["dev_mode"]:
     env["verbose"] = methods.get_cmdline_bool("verbose", True)
     env["warnings"] = ARGUMENTS.get("warnings", "extra")

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,7 +68,7 @@ def get_min_target_api():
 
 def get_flags():
     return {
-        "arch": "arm64",  # Default for convenience.
+        "arch": "arm64",
         "target": "template_debug",
         "supported": ["mono"],
     }

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -48,7 +48,7 @@ def get_doc_path():
 
 def get_flags():
     return {
-        "arch": "arm64",  # Default for convenience.
+        "arch": "arm64",
         "target": "template_debug",
         "use_volk": False,
         "supported": ["mono"],


### PR DESCRIPTION
Some of the logic in SCons depends on flags that get overridden in the platform-specific `detect.py`, so it needs to be processed first.

For example the Android/iOS/Web platforms override the default `target` to `template_debug`, but this was processed too late so e.g. the logic that sets `env.editor_build` would set it to true due to the default `target` value in the environment being `editor`.