### PR TITLE
[Web] Fix debug symbols in web builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -716,7 +716,13 @@ else:
         # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
         # otherwise addr2line doesn't understand them
         env.Append(CCFLAGS=["-gdwarf-4"])
-        if env.dev_build:
+        if methods.using_emcc(env):
+            # Emscripten only produces dwarf symbols when using "-g3".
+            env.Append(CCFLAGS=["-g3"])
+            # Emscripten linker needs debug symbols options too.
+            env.Append(LINKFLAGS=["-gdwarf-4"])
+            env.Append(LINKFLAGS=["-g3"])
+        elif env.dev_build:
             env.Append(CCFLAGS=["-g3"])
         else:
             env.Append(CCFLAGS=["-g2"])


### PR DESCRIPTION
This seem to have regressed at some point, not sure if it regressed in emcc or the godot build system yet.

In general, `-g` options are [also link flags emcc](https://emscripten.org/docs/tools_reference/emcc.html#emcc-g).

Draft as this needs some more investigation.