### PR TITLE
Round the icon's drawing rect when drawing the button

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -298,6 +298,7 @@ void Button::_notification(int p_what) {
 						icon_size = Size2(icon_width, icon_height);
 					}
 					icon_size = _fit_icon_size(icon_size);
+					icon_size = icon_size.round();
 				}
 
 				if (icon_size.width > 0.0f) {
@@ -336,6 +337,7 @@ void Button::_notification(int p_what) {
 							icon_ofs.y = size.y - style_margin_bottom - icon_size.height;
 						} break;
 					}
+					icon_ofs = icon_ofs.floor();
 
 					Rect2 icon_region = Rect2(icon_ofs, icon_size);
 					draw_texture_rect(_icon, icon_region, false, icon_modulate_color);


### PR DESCRIPTION
Each component of the icon's drawing rect needs to be snapped to an integer.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix #88165.
