### PR TITLE
Fix Control resizing wrongly after "change type" in editor

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2907,6 +2907,13 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 		}
 	}
 
+	// HACK: Remember size of anchored control.
+	Control *old_control = Object::cast_to<Control>(oldnode);
+	Size2 size;
+	if (old_control) {
+		size = old_control->get_size();
+	}
+
 	String newname = oldnode->get_name();
 
 	List<Node *> to_erase;
@@ -2916,6 +2923,12 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 		}
 	}
 	oldnode->replace_by(newnode, true);
+
+	// Re-apply size of anchored control.
+	Control *new_control = Object::cast_to<Control>(newnode);
+	if (old_control && new_control) {
+		new_control->set_size(size);
+	}
 
 	//small hack to make collisionshapes and other kind of nodes to work
 	for (int i = 0; i < newnode->get_child_count(); i++) {


### PR DESCRIPTION
Fixes #78779 

This bug has been bothering me for a while now, so I decided to tackle it once and for all. Yes it's a hacky fix, but since nobody has stepped up with a proper solution so far, I'd argue this is better than keeping this bug around for even longer.

Similar (six year old!) hacks are also found right below where I did my change, for making other node types work properly with this editor feature. So maybe this method is flawed in some way?

Note that this does NOT fix the undo issues that come with this (so undoing a "change type" may still cause the control to end up wrongly sized). There are similar issues with the editor showing outdated sizes, or undo/redo not reverting this, so it's likely a more fundamental issue at play.

## Background

See [this very helpful comment](https://github.com/godotengine/godot/issues/78779#issuecomment-1625424823) for some details.

The PR #78009 made it so that Control updates its size cache in a lot more places, including when entering the tree (`NOTIFICATION_THEME_CHANGED`).

As I understand it, the editor's "replace by" feature (used by "change type") works by first calling `Node::replace_by` and then re-applying same-named properties. However, since `replace_by` also adds the node to the scene tree, the size is recomputed through `_size_changed()`.

I'm not exactly sure why it ends up using the parent viewport's size in this case, instead of the project settings size, but this is the best fix I could come up with.
Tried changing `Control::get_parent_anchorable_rect` logic a bunch, but it doesn't seem to be the culprit from my understanding. Don't want to remove/delay the problematic `_size_changed()` call since it seems to have fixed a bunch of bugs.

