### PR TITLE
Clarify `Test` property from Internationalization

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -682,10 +682,10 @@ bool TranslationServer::_load_translations(const String &p_from) {
 }
 
 void TranslationServer::setup() {
-	String test = GLOBAL_DEF("internationalization/locale/test", "");
-	test = test.strip_edges();
-	if (!test.is_empty()) {
-		set_locale(test);
+	String custom = GLOBAL_DEF("internationalization/locale/override", "");
+	custom = custom.strip_edges();
+	if (!custom.is_empty()) {
+		set_locale(custom);
 	} else {
 		set_locale(OS::get_singleton()->get_locale());
 	}

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1412,8 +1412,8 @@
 			[b]Note:[/b] "ICU / HarfBuzz / Graphite" text server data includes dictionaries for Burmese, Chinese, Japanese, Khmer, Lao and Thai as well as Unicode Standard Annex #29 and Unicode Standard Annex #14 word and line breaking rules. Data is about 4 MB large.
 			[b]Note:[/b] "Fallback" text server does not use additional data.
 		</member>
-		<member name="internationalization/locale/test" type="String" setter="" getter="" default="&quot;&quot;">
-			If non-empty, this locale will be used when running the project from the editor.
+		<member name="internationalization/locale/override" type="String" setter="" getter="" default="&quot;&quot;">
+			If non-empty, this locale will be used.
 		</member>
 		<member name="internationalization/pseudolocalization/double_vowels" type="bool" setter="" getter="" default="false">
 			Double vowels in strings during pseudolocalization to simulate the lengthening of text due to localization.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Since `Test` property was also used in non-editor builds, i think an better solution would be to rename it to `Override`.