### PR TITLE
SCons: Bump minimum supported GCC version to GCC 9

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -621,22 +621,12 @@ if methods.using_gcc(env):
             "Couldn't detect compiler version, skipping version checks. "
             "Build may fail if the compiler doesn't support C++17 fully."
         )
-    # GCC 8 before 8.4 has a regression in the support of guaranteed copy elision
-    # which causes a build failure: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521
-    elif cc_version_major == 8 and cc_version_minor < 4:
+    elif cc_version_major < 9:
         print_error(
-            "Detected GCC 8 version < 8.4, which is not supported due to a "
-            "regression in its C++17 guaranteed copy elision support. Use a "
-            'newer GCC version, or Clang 6 or later by passing "use_llvm=yes" '
-            "to the SCons command line."
-        )
-        Exit(255)
-    elif cc_version_major < 7:
-        print_error(
-            "Detected GCC version older than 7, which does not fully support "
-            "C++17. Supported versions are GCC 7, 9 and later. Use a newer GCC "
-            'version, or Clang 6 or later by passing "use_llvm=yes" to the '
-            "SCons command line."
+            "Detected GCC version older than 9, which does not fully support "
+            "C++17, or has bugs when compiling Godot. Supported versions are 9 "
+            "and later. Use a newer GCC version, or Clang 6 or later by passing "
+            '"use_llvm=yes" to the SCons command line.'
         )
         Exit(255)
     elif cc_version_metadata1 == "win32":


### PR DESCRIPTION
- GCC 7 supports C++17 but seems to have breaking regressions, see #79352.
- GCC 8 broke C++17 guaranteed copy elision support, fixed in 8.4, but...
- GCC 9 is old enough (2022) to use as a baseline and stop dealing with unmaintained and less efficient compiler versions.

---

- Fixes https://github.com/godotengine/godot/issues/79352.

Note: From the oldest Linux distros we might aim to support, it seems all of them include GCC 9 or newer.
- Ubuntu 20.04 has GCC 9.3.0: https://packages.ubuntu.com/focal/gcc
- Debian 11 has GCC 10.2.1: https://packages.debian.org/bullseye/gcc
- Debian 10 only has GCC 8.3.0, but it reached EOL in 2022
- RHEL 8 seems to have both GCC 8 and GCC 9 available out of the box