### PR TITLE
Disable viewports inputs when dragging and dropping into the viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1614,7 +1614,7 @@ void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
 }
 
 void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
-	if (previewing) {
+	if (previewing || get_viewport()->gui_get_drag_data()) {
 		return; //do NONE
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/90112 and this comment https://github.com/godotengine/godot/issues/90112#issuecomment-2105974359

Having viewport inputs enabled while performing a drag and drop leads to issues especially in different navigation modes as mentioned in the linked issue. In theory the existing behavior sounds good, but in practice I believe it leads to more issues than it's worth. Usually, users put the target location in their viewport before dragging to it.