### PR TITLE
[Web] Fix splash screen background color in HTML shell

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -38,7 +38,7 @@ body {
 }
 
 #status {
-	background-color: #38363A;
+	background-color: #242424;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;


### PR DESCRIPTION
# Info
I would like to propose a small amendment to the new splash screen related to the background color. My first version used #38363A which came from the div #status-progress of the previous splash screen, but to be consistent with other exporters, the correct background color should be the same as the default `application/boot_splash/bg_color` from Project Settings, which is #242424.

`main/main_builders.py`
```python
# Use a neutral gray color to better fit various kinds of projects.
g.write("static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);\n")
```

## Difference

Before:

![thumb-p1](https://github.com/godotengine/godot/assets/224215/54197a1e-3577-4939-9b33-ffaa19d3faef)

After:

![thumb-p2](https://github.com/godotengine/godot/assets/224215/96f946a8-ad0e-43c9-bdff-c6ff4abf69cc)

## Notes

In the future, it may be possible to pass information to the HTML shell about user settings such as `application/boot_splash/bg_color` or `application/boot_splash/show_image`. For now, we can add information in the documentation that it is easy to modify the background color by typing CSS in the `Head Include` field:

```html
<style>
#status { background: radial-gradient(circle, rgba(15,15,121,1) 0%, rgba(25,224,56,1) 100%); }
</style>
```

![thumb-p3](https://github.com/godotengine/godot/assets/224215/1027f09e-4d4c-4bbc-ab83-902b1db85dac)

![thumb-p4](https://github.com/godotengine/godot/assets/224215/95213670-6d80-45d4-8f55-3343c2e36745)

Similarly, you can hide the splash image by typing:

```html
<style>
#status-splash { display: none; }
</style>
```