### PR TITLE
[Web] Fix quotes style in HTML shell head include

### DIFF
--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -154,11 +154,11 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 
 	String head_include;
 	if (p_preset->get("html/export_icon")) {
-		head_include += "<link id='-gd-engine-icon' rel='icon' type='image/png' href='" + p_name + ".icon.png' />\n";
-		head_include += "<link rel='apple-touch-icon' href='" + p_name + ".apple-touch-icon.png'/>\n";
+		head_include += "<link id=\"-gd-engine-icon\" rel=\"icon\" type=\"image/png\" href=\"" + p_name + ".icon.png\" />\n";
+		head_include += "<link rel=\"apple-touch-icon\" href=\"" + p_name + ".apple-touch-icon.png\"/>\n";
 	}
 	if (p_preset->get("progressive_web_app/enabled")) {
-		head_include += "<link rel='manifest' href='" + p_name + ".manifest.json'>\n";
+		head_include += "<link rel=\"manifest\" href=\"" + p_name + ".manifest.json\">\n";
 		config["serviceWorker"] = p_name + ".service.worker.js";
 	}
 


### PR DESCRIPTION
# Info

As we use double quotes in the HTML tags, I would like to propose a fix to the `platform/web/export/export_plugin.cpp` code that adds headings related to icons and the PWA manifest.

# Difference

Before:

```html
<link id='-gd-engine-icon' rel='icon' type='image/png' href='mygame.icon.png' />
<link rel='apple-touch-icon' href='mygame.apple-touch-icon.png'/>
<link rel='manifest' href='mygame.manifest.json'>
```

After:

```html
<link id="-gd-engine-icon" rel="icon" type="image/png" href="mygame.icon.png" />
<link rel="apple-touch-icon" href="mygame.apple-touch-icon.png"/>
<link rel="manifest" href="mygame.manifest.json">
```
