### PR TITLE
Move "Add a new scene" button when Scene Tabs settings change

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -63,6 +63,7 @@ void EditorSceneTabs::_notification(int p_what) {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/scene_tabs")) {
 				scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
 				scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
+				_scene_tabs_resized();
 			}
 		} break;
 	}


### PR DESCRIPTION
Updating "Display Close Button" setting (interface/scene_tabs/display_close_button) in Editor Settings changes the size of scene tabs, but the add button at the end of the tabs was not being moved until the next update, causing gaps/overlaps between the controls.  Adding call to `_scene_tabs_resized()` after getting the new settings to update the add button position.

Fixes #91850

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
