### PR TITLE
Don't define `NO_EDITOR_SPLASH` in export templates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -492,14 +492,15 @@ if methods.get_cmdline_bool("fast_unsafe", env.dev_build):
 if env["use_precise_math_checks"]:
     env.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])
 
-if env.editor_build and env["engine_update_check"]:
-    env.Append(CPPDEFINES=["ENGINE_UPDATE_CHECK_ENABLED"])
+if env.editor_build:
+    if env["engine_update_check"]:
+        env.Append(CPPDEFINES=["ENGINE_UPDATE_CHECK_ENABLED"])
 
-if not env.File("#main/splash_editor.png").exists():
-    # Force disabling editor splash if missing.
-    env["no_editor_splash"] = True
-if env["no_editor_splash"]:
-    env.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])
+    if not env.File("#main/splash_editor.png").exists():
+        # Force disabling editor splash if missing.
+        env["no_editor_splash"] = True
+    if env["no_editor_splash"]:
+        env.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])
 
 if not env["deprecated"]:
     env.Append(CPPDEFINES=["DISABLE_DEPRECATED"])

--- a/main/SCsub
+++ b/main/SCsub
@@ -20,7 +20,7 @@ env_main.CommandNoCache(
     env.Run(main_builders.make_splash),
 )
 
-if not env_main["no_editor_splash"]:
+if env_main.editor_build and not env_main["no_editor_splash"]:
     env_main.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
     env_main.CommandNoCache(
         "#main/splash_editor.gen.h",

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -104,7 +104,7 @@
 #include "editor/project_manager.h"
 #include "editor/register_editor_types.h"
 
-#ifndef NO_EDITOR_SPLASH
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
 #include "main/splash_editor.gen.h"
 #endif
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I don't think this is good idea to compile export templates with `NO_EDITOR_SPLASH` on it since it goes unused anyway.

As an bonus, don't generate editor splash header in non-editor builds as well.