### PR TITLE
SCons: Fix generation of `disabled_classes.gen.h` after #91624

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -166,7 +166,7 @@ def disabled_class_builder(target, source, env):
         for c in source[0].read():
             cs = c.strip()
             if cs != "":
-                file.write(f"#define ClassDB_Disable_{cs} 1")
+                file.write(f"#define ClassDB_Disable_{cs} 1\n")
 
 
 env.CommandNoCache("disabled_classes.gen.h", env.Value(env.disabled_classes), env.Run(disabled_class_builder))


### PR DESCRIPTION
Before:
![图片](https://github.com/godotengine/godot/assets/52148221/d816e79c-3b1f-4658-9a47-62d1bc3bfc4c)
After:
![图片](https://github.com/godotengine/godot/assets/52148221/f455def1-fc89-4559-a0cd-74f34c0ab066)

*Bugsquad edit:*
- Fixes #91844
