### PR TITLE
Allow editing `NavigationObstacle2D` shape vertices

### DIFF
--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
@@ -41,6 +41,14 @@ void NavigationObstacle2DEditor::_set_node(Node *p_polygon) {
 	node = Object::cast_to<NavigationObstacle2D>(p_polygon);
 }
 
+Variant NavigationObstacle2DEditor::_get_polygon(int p_idx) const {
+	return node->get_vertices();
+}
+
+void NavigationObstacle2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
+	node->set_vertices(p_polygon);
+}
+
 void NavigationObstacle2DEditor::_action_add_polygon(const Variant &p_polygon) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->add_do_method(node, "set_vertices", p_polygon);

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.h
@@ -43,6 +43,9 @@ protected:
 	virtual Node2D *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
 
+	virtual Variant _get_polygon(int p_idx) const override;
+	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const override;
+
 	virtual void _action_add_polygon(const Variant &p_polygon) override;
 	virtual void _action_remove_polygon(int p_idx) override;
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;


### PR DESCRIPTION
Add `_get_polygon` and `_set_polygon` overrides for `NavigationObstacle2DEditor`, so `AbstractPolygon2DEditor` can access the vertex information.

Fixes #91795

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
