### PR TITLE
[3.x] Physics interpolation - Zero server side multimesh data

### DIFF
--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -313,6 +313,10 @@ void RasterizerStorage::multimesh_allocate(RID p_multimesh, int p_instances, VS:
 		mmi->_data_curr.resize(size_in_floats);
 		mmi->_data_prev.resize(size_in_floats);
 		mmi->_data_interpolated.resize(size_in_floats);
+
+		mmi->_data_curr.fill(0);
+		mmi->_data_prev.fill(0);
+		mmi->_data_interpolated.fill(0);
 	}
 
 	return _multimesh_allocate(p_multimesh, p_instances, p_transform_format, p_color_format, p_data);


### PR DESCRIPTION
To prevent possibility of use of uninitialized data.

## Notes
* Noticed by @rburing in #91818
* I can't remember whether this problem can occur in the wild, but seems worth zeroing just in case. :+1: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
