### PR TITLE
[Tests] Expand tests for `Curve2D/3D`

### DIFF
--- a/tests/scene/test_curve_2d.h
+++ b/tests/scene/test_curve_2d.h
@@ -147,13 +147,19 @@ TEST_CASE("[Curve2D] Sampling") {
 		CHECK(curve->samplef(1) == Vector2(0, 50));
 	}
 
-	SUBCASE("sample_baked") {
+	SUBCASE("sample_baked, cubic = false") {
 		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 0))) == Vector2(0, 0));
 		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 25))) == Vector2(0, 25));
 		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 50))) == Vector2(0, 50));
 	}
 
-	SUBCASE("sample_baked_with_rotation") {
+	SUBCASE("sample_baked, cubic = true") {
+		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 0)), true) == Vector2(0, 0));
+		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 25)), true) == Vector2(0, 25));
+		CHECK(curve->sample_baked(curve->get_closest_offset(Vector2(0, 50)), true) == Vector2(0, 50));
+	}
+
+	SUBCASE("sample_baked_with_rotation, cubic = false") {
 		const real_t pi = 3.14159;
 		const real_t half_pi = pi * 0.5;
 		Ref<Curve2D> rot_curve = memnew(Curve2D);
@@ -184,6 +190,41 @@ TEST_CASE("[Curve2D] Sampling") {
 		rot_curve->add_point(Vector2());
 		rot_curve->add_point(Vector2(0, -50));
 		t = rot_curve->sample_baked_with_rotation(25);
+		CHECK(t.get_origin() == Vector2(0, -25));
+		CHECK(Math::is_equal_approx(t.get_rotation(), -half_pi));
+	}
+
+	SUBCASE("sample_baked_with_rotation, cubic = true") {
+		const real_t pi = 3.14159;
+		const real_t half_pi = pi * 0.5;
+		Ref<Curve2D> rot_curve = memnew(Curve2D);
+		Transform2D t;
+
+		rot_curve->clear_points();
+		rot_curve->add_point(Vector2());
+		rot_curve->add_point(Vector2(50, 0));
+		t = rot_curve->sample_baked_with_rotation(25, true);
+		CHECK(t.get_origin() == Vector2(25, 0));
+		CHECK(Math::is_equal_approx(t.get_rotation(), 0));
+
+		rot_curve->clear_points();
+		rot_curve->add_point(Vector2());
+		rot_curve->add_point(Vector2(0, 50));
+		t = rot_curve->sample_baked_with_rotation(25, true);
+		CHECK(t.get_origin() == Vector2(0, 25));
+		CHECK(Math::is_equal_approx(t.get_rotation(), half_pi));
+
+		rot_curve->clear_points();
+		rot_curve->add_point(Vector2());
+		rot_curve->add_point(Vector2(-50, 0));
+		t = rot_curve->sample_baked_with_rotation(25, true);
+		CHECK(t.get_origin() == Vector2(-25, 0));
+		CHECK(Math::is_equal_approx(t.get_rotation(), pi));
+
+		rot_curve->clear_points();
+		rot_curve->add_point(Vector2());
+		rot_curve->add_point(Vector2(0, -50));
+		t = rot_curve->sample_baked_with_rotation(25, true);
 		CHECK(t.get_origin() == Vector2(0, -25));
 		CHECK(Math::is_equal_approx(t.get_rotation(), -half_pi));
 	}

--- a/tests/scene/test_curve_3d.h
+++ b/tests/scene/test_curve_3d.h
@@ -177,10 +177,28 @@ TEST_CASE("[Curve3D] Sampling") {
 		CHECK(curve->sample_baked(curve->get_closest_offset(Vector3(0, 50, 0)), true) == Vector3(0, 50, 0));
 	}
 
-	SUBCASE("sample_baked_with_rotation") {
+	SUBCASE("sample_baked_with_rotation, cubic = false, p_apply_tilt = false") {
 		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 0, 0))) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 0, 0)));
 		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 25, 0))) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 25, 0)));
 		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 50, 0))) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 50, 0)));
+	}
+
+	SUBCASE("sample_baked_with_rotation, cubic = false, p_apply_tilt = true") {
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 0, 0)), false, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 0, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 25, 0)), false, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 25, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 50, 0)), false, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 50, 0)));
+	}
+
+	SUBCASE("sample_baked_with_rotation, cubic = true, p_apply_tilt = false") {
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 0, 0)), true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 0, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 25, 0)), true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 25, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 50, 0)), true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 50, 0)));
+	}
+
+	SUBCASE("sample_baked_with_rotation, cubic = true, p_apply_tilt = true") {
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 0, 0)), true, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 0, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 25, 0)), true, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 25, 0)));
+		CHECK(curve->sample_baked_with_rotation(curve->get_closest_offset(Vector3(0, 50, 0)), true, true) == Transform3D(Basis(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(0, -1, 0)), Vector3(0, 50, 0)));
 	}
 
 	SUBCASE("sample_baked_tilt") {


### PR DESCRIPTION
Some simple cases for parity and covering cases, some of these cases might be expanded with more complex curves to get better coverage but just added some cases for now

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
