### PR TITLE
Allow specifying a key when loading resource packs

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -579,10 +579,18 @@ void ProjectSettings::_emit_changed() {
 }
 
 bool ProjectSettings::load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
-	return ProjectSettings::_load_resource_pack(p_pack, p_replace_files, p_offset, false);
+	return ProjectSettings::_load_resource_pack_encrypted(p_pack, PackedByteArray(), p_replace_files, p_offset, false);
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_main_pack) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_main_file) {
+	return ProjectSettings::_load_resource_pack_encrypted(p_pack, PackedByteArray(), p_replace_files, p_offset, p_main_file);
+}
+
+bool ProjectSettings::load_resource_pack_encrypted(const String &p_pack, const PackedByteArray &p_key, bool p_replace_files, int p_offset) {
+	return ProjectSettings::_load_resource_pack_encrypted(p_pack, p_key, p_replace_files, p_offset, false);
+}
+
+bool ProjectSettings::_load_resource_pack_encrypted(const String &p_pack, const PackedByteArray &p_key, bool p_replace_files, int p_offset, bool p_main_pack) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
@@ -596,12 +604,12 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 		// Add the project's resource file system to PackedData so directory access keeps working when
 		// the game is running without a main pack, like in the editor or on Android.
 		PackedData::get_singleton()->add_pack_source(memnew(PackedSourceDirectory));
-		PackedData::get_singleton()->add_pack("res://", false, 0);
+		PackedData::get_singleton()->add_pack("res://", false, 0, p_key);
 		DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
 		using_datapack = true;
 	}
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset, p_key) == OK;
 	if (!ok) {
 		return false;
 	}
@@ -1636,6 +1644,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack_encrypted", "pack", "key", "replace_files", "offset"), &ProjectSettings::load_resource_pack_encrypted, DEFVAL(true), DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -147,6 +147,8 @@ protected:
 
 	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset);
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
+	bool load_resource_pack_encrypted(const String &p_pack, const PackedByteArray &p_key, bool p_replace_files = true, int p_offset = 0);
+	bool _load_resource_pack_encrypted(const String &p_pack, const PackedByteArray &p_key, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -392,6 +392,7 @@ Ref<FileAccess> PackedSourcePCK::get_file(const String &p_path, PackedData::Pack
 bool PackedSourceDirectory::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
 	// Load with offset feature only supported for PCK files.
 	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with directories.");
+	ERR_FAIL_COND_V_MSG(!p_decryption_key.is_empty(), false, "Invalid PCK data. Note that using a key isn't supported with directories.");
 
 	if (p_path != "res://") {
 		return false;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -147,6 +147,7 @@ unzFile ZipArchive::get_file_handle(const String &p_file) const {
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
 	// load with offset feature only supported for PCK files
 	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
+	ERR_FAIL_COND_V_MSG(!p_decryption_key.is_empty(), false, "Invalid PCK data. Note that using a key isn't supported with ZIP archives.");
 
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -178,6 +178,19 @@
 				[b]Note:[/b] [DirAccess] will not show changes made to the contents of [code]res://[/code] after calling this function.
 			</description>
 		</method>
+		<method name="load_resource_pack_encrypted">
+			<return type="bool" />
+			<param index="0" name="pack" type="String" />
+			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="replace_files" type="bool" default="true" />
+			<param index="3" name="offset" type="int" default="0" />
+			<description>
+				Loads the contents of the encrypted .pck file specified by [param pack] decrypted with [param key] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
+				[b]Note:[/b] If a file from [param pack] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [param pack] unless [param replace_files] is set to [code]false[/code].
+				[b]Note:[/b] The optional [param offset] parameter can be used to specify the offset in bytes to the start of the resource pack.
+				[b]Note:[/b] The provided key must be 32 bytes long.
+			</description>
+		</method>
 		<method name="localize_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
Extends ProjectSettings with `load_resource_pack_encrypted`, allowing a custom decryption key to be specified.

The code could be refactored a bit more nicely, but I wanted to avoid passing around the embedded secret key as much as possible. 

See godotengine/godot-proposals#9726 for rationale.
