### PR TITLE
Use Option+Cmd+Left/Right for script editor history navigation on macOS

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4087,6 +4087,9 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_previous", TTR("History Previous"), KeyModifierMask::ALT | Key::LEFT), WINDOW_PREV);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_next", TTR("History Next"), KeyModifierMask::ALT | Key::RIGHT), WINDOW_NEXT);
+	ED_SHORTCUT_OVERRIDE("script_editor/history_previous", "macos", KeyModifierMask::ALT | KeyModifierMask::META | Key::LEFT);
+	ED_SHORTCUT_OVERRIDE("script_editor/history_next", "macos", KeyModifierMask::ALT | KeyModifierMask::META | Key::RIGHT);
+
 	file_menu->get_popup()->add_separator();
 
 	theme_submenu = memnew(PopupMenu);


### PR DESCRIPTION

fixes a lingering shortcut issue: https://github.com/godotengine/godot-proposals/issues/3754
supersedes https://github.com/godotengine/godot/pull/47618

Macos has a few shortcuts that do not work because they are overridden by default. The history navigation ones were particularly noticeable for me and i stumbled upon these threads. I have updated the pr and tested on latest git and confirmed it is working. 