### PR TITLE
Increase the project manager's default window size

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -150,8 +150,8 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 // Main layout.
 
 void ProjectManager::_update_size_limits() {
-	const Size2 minimum_size = Size2(680, 450) * EDSCALE;
-	const Size2 default_size = Size2(1024, 600) * EDSCALE;
+	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
+	const Size2 default_size = Size2(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT) * EDSCALE;
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
@@ -159,8 +159,12 @@ void ProjectManager::_update_size_limits() {
 		// Calling Window methods this early doesn't sync properties with DS.
 		w->set_min_size(minimum_size);
 		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
-		w->set_size(default_size);
-		DisplayServer::get_singleton()->window_set_size(default_size);
+		if (DisplayServer::get_singleton()->window_get_size() == default_size) {
+			// Only set window size if it currently matches the default, which is defined in `main/main.cpp`.
+			// This allows CLI arguments to override the window size.
+			w->set_size(default_size);
+			DisplayServer::get_singleton()->window_set_size(default_size);
+		}
 	}
 
 	Rect2i screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServer::get_singleton()->window_get_current_screen());

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -250,6 +250,9 @@ protected:
 public:
 	static ProjectManager *get_singleton() { return singleton; }
 
+	static constexpr int DEFAULT_WINDOW_WIDTH = 1152;
+	static constexpr int DEFAULT_WINDOW_HEIGHT = 800;
+
 	// Project list.
 
 	bool is_initialized() const { return initialized; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2459,6 +2459,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
 	OS::get_singleton()->set_current_rendering_method(rendering_method);
 
+#ifdef TOOLS_ENABLED
+	if (!force_res && project_manager) {
+		// Ensure splash screen size matches the project manager window size
+		// (see `editor/project_manager.cpp` for defaults).
+		window_size.width = ProjectManager::DEFAULT_WINDOW_WIDTH;
+		window_size.height = ProjectManager::DEFAULT_WINDOW_HEIGHT;
+	}
+#endif
+
 	if (use_custom_res) {
 		if (!force_res) {
 			window_size.width = GLOBAL_GET("display/window/size/viewport_width");


### PR DESCRIPTION
This makes the project manager feel less cramped when many projects are imported, or when browsing templates in the asset library.

On displays smaller than 1152×800 (e.g. 1366×768), window height is automatically limited by DisplayServer when setting the window size.

This also tweaks splash screen size when starting the project manager to match the project manager's default window size, and allows the `--resolution` and `--position` CLI arguments to affect the project manager.

Lastly, this increases the minimum width slightly to prevent the UI from being cut off with the default theme.

## Preview

Before | After
-|-
![Screenshot_20240513_000907](https://github.com/godotengine/godot/assets/180032/16aa33a7-d376-44ad-92e5-335e78e364da) | ![Screenshot_20240512_235619](https://github.com/godotengine/godot/assets/180032/0f406a5f-8098-48f4-bbbb-621cfb962d4f)

Before | After
-|-
![Screenshot_20240513_000912](https://github.com/godotengine/godot/assets/180032/729252d4-9e2a-452a-9090-e98ef2679d32) | ![Screenshot_20240512_235626](https://github.com/godotengine/godot/assets/180032/8bfcf87a-a372-4e37-8240-2fb56cc3304b)