### PR TITLE
[3.x] Don't define `NO_EDITOR_SPLASH` in export templates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -363,11 +363,12 @@ if methods.get_cmdline_bool("fast_unsafe", env_base["target"] == "debug"):
 if env_base["use_precise_math_checks"]:
     env_base.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])
 
-if not env_base.File("#main/splash_editor.png").exists():
-    # Force disabling editor splash if missing.
-    env_base["no_editor_splash"] = True
-if env_base["no_editor_splash"]:
-    env_base.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])
+if env_base["tools"]:
+    if not env_base.File("#main/splash_editor.png").exists():
+        # Force disabling editor splash if missing.
+        env_base["no_editor_splash"] = True
+    if env_base["no_editor_splash"]:
+        env_base.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])
 
 if not env_base["deprecated"]:
     env_base.Append(CPPDEFINES=["DISABLE_DEPRECATED"])

--- a/main/SCsub
+++ b/main/SCsub
@@ -23,7 +23,7 @@ env.add_source_files(env.main_sources, gensource)
 env.Depends("#main/splash.gen.h", "#main/splash.png")
 env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))
 
-if not env["no_editor_splash"]:
+if env["tools"] and not env["no_editor_splash"]:
     env.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
     env.CommandNoCache(
         "#main/splash_editor.gen.h", "#main/splash_editor.png", run_in_subprocess(main_builders.make_splash_editor)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -81,7 +81,7 @@
 #include "editor/progress_dialog.h"
 #include "editor/project_manager.h"
 #include "editor/script_editor_debugger.h"
-#ifndef NO_EDITOR_SPLASH
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
 #include "main/splash_editor.gen.h"
 #endif
 #endif


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Same as before but for `3.x` instead.