### PR TITLE
Revert "GDScript: Implement `get_dependencies()`"

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2919,7 +2919,7 @@ String ResourceFormatLoaderGDScript::get_resource_type(const String &p_path) con
 	return "";
 }
 
-void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<String> *r_dependencies, bool p_add_types) {
+void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_MSG(file.is_null(), "Cannot open file '" + p_path + "'.");
 
@@ -2933,13 +2933,8 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 		return;
 	}
 
-	GDScriptAnalyzer analyzer(&parser);
-	if (OK != analyzer.analyze()) {
-		return;
-	}
-
 	for (const String &E : parser.get_dependencies()) {
-		r_dependencies->push_back(E);
+		p_dependencies->push_back(E);
 	}
 }
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -638,7 +638,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
-	virtual void get_dependencies(const String &p_path, List<String> *r_dependencies, bool p_add_types = false) override;
+	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1432,8 +1432,6 @@ private:
 	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
 	void reset_extents(Node *p_node, Node *p_from);
 
-	HashSet<String> dependencies;
-
 	template <typename T>
 	T *alloc_node() {
 		T *node = memnew(T);
@@ -1577,11 +1575,9 @@ public:
 	bool annotation_exists(const String &p_annotation_name) const;
 
 	const List<ParserError> &get_errors() const { return errors; }
-	const HashSet<String> &get_dependencies() const {
-		return dependencies;
-	}
-	void add_dependency(const String &p_dependency) {
-		dependencies.insert(p_dependency);
+	const List<String> get_dependencies() const {
+		// TODO: Keep track of deps.
+		return List<String>();
 	}
 #ifdef DEBUG_ENABLED
 	const List<GDScriptWarning> &get_warnings() const { return warnings; }


### PR DESCRIPTION
This reverts commit dc73440f899e6f32de748787e946ad762771fda0 / #90860.

This commit in some form is needed to fix handling of dependencies on export, but as it's also used for import, it's exposing some pre-existing issues which we need to solve first.

So reverting for now to give ourselves time to iron this out for a future Godot release.

- Fixes #91726.
- Reopens #90643.

CC @vnen @dalexeev @adamscott 