### PR TITLE
[C#] Remove useless `isFirstEntry` and useless `source.Append("else ")`

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
@@ -33,15 +33,15 @@ partial class AllReadOnly
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyAutoProperty);
             return true;
         }
-        else if (name == PropertyName.ReadOnlyProperty) {
+        if (name == PropertyName.ReadOnlyProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyProperty);
             return true;
         }
-        else if (name == PropertyName.InitOnlyAutoProperty) {
+        if (name == PropertyName.InitOnlyAutoProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.InitOnlyAutoProperty);
             return true;
         }
-        else if (name == PropertyName.ReadOnlyField) {
+        if (name == PropertyName.ReadOnlyField) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyField);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
@@ -25,7 +25,7 @@ partial class AllWriteOnly
             this.WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }
-        else if (name == PropertyName._writeOnlyBackingField) {
+        if (name == PropertyName._writeOnlyBackingField) {
             this._writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -257,239 +257,239 @@ partial class ExportedFields
             this._fieldBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }
-        else if (name == PropertyName._fieldChar) {
+        if (name == PropertyName._fieldChar) {
             this._fieldChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
             return true;
         }
-        else if (name == PropertyName._fieldSByte) {
+        if (name == PropertyName._fieldSByte) {
             this._fieldSByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
             return true;
         }
-        else if (name == PropertyName._fieldInt16) {
+        if (name == PropertyName._fieldInt16) {
             this._fieldInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
             return true;
         }
-        else if (name == PropertyName._fieldInt32) {
+        if (name == PropertyName._fieldInt32) {
             this._fieldInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
             return true;
         }
-        else if (name == PropertyName._fieldInt64) {
+        if (name == PropertyName._fieldInt64) {
             this._fieldInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
             return true;
         }
-        else if (name == PropertyName._fieldByte) {
+        if (name == PropertyName._fieldByte) {
             this._fieldByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
             return true;
         }
-        else if (name == PropertyName._fieldUInt16) {
+        if (name == PropertyName._fieldUInt16) {
             this._fieldUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
             return true;
         }
-        else if (name == PropertyName._fieldUInt32) {
+        if (name == PropertyName._fieldUInt32) {
             this._fieldUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
             return true;
         }
-        else if (name == PropertyName._fieldUInt64) {
+        if (name == PropertyName._fieldUInt64) {
             this._fieldUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
             return true;
         }
-        else if (name == PropertyName._fieldSingle) {
+        if (name == PropertyName._fieldSingle) {
             this._fieldSingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
-        else if (name == PropertyName._fieldDouble) {
+        if (name == PropertyName._fieldDouble) {
             this._fieldDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
             return true;
         }
-        else if (name == PropertyName._fieldString) {
+        if (name == PropertyName._fieldString) {
             this._fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector2) {
+        if (name == PropertyName._fieldVector2) {
             this._fieldVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector2I) {
+        if (name == PropertyName._fieldVector2I) {
             this._fieldVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
             return true;
         }
-        else if (name == PropertyName._fieldRect2) {
+        if (name == PropertyName._fieldRect2) {
             this._fieldRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
             return true;
         }
-        else if (name == PropertyName._fieldRect2I) {
+        if (name == PropertyName._fieldRect2I) {
             this._fieldRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
             return true;
         }
-        else if (name == PropertyName._fieldTransform2D) {
+        if (name == PropertyName._fieldTransform2D) {
             this._fieldTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector3) {
+        if (name == PropertyName._fieldVector3) {
             this._fieldVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector3I) {
+        if (name == PropertyName._fieldVector3I) {
             this._fieldVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
             return true;
         }
-        else if (name == PropertyName._fieldBasis) {
+        if (name == PropertyName._fieldBasis) {
             this._fieldBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
             return true;
         }
-        else if (name == PropertyName._fieldQuaternion) {
+        if (name == PropertyName._fieldQuaternion) {
             this._fieldQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
             return true;
         }
-        else if (name == PropertyName._fieldTransform3D) {
+        if (name == PropertyName._fieldTransform3D) {
             this._fieldTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector4) {
+        if (name == PropertyName._fieldVector4) {
             this._fieldVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector4I) {
+        if (name == PropertyName._fieldVector4I) {
             this._fieldVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
             return true;
         }
-        else if (name == PropertyName._fieldProjection) {
+        if (name == PropertyName._fieldProjection) {
             this._fieldProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
             return true;
         }
-        else if (name == PropertyName._fieldAabb) {
+        if (name == PropertyName._fieldAabb) {
             this._fieldAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
             return true;
         }
-        else if (name == PropertyName._fieldColor) {
+        if (name == PropertyName._fieldColor) {
             this._fieldColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
             return true;
         }
-        else if (name == PropertyName._fieldPlane) {
+        if (name == PropertyName._fieldPlane) {
             this._fieldPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
             return true;
         }
-        else if (name == PropertyName._fieldCallable) {
+        if (name == PropertyName._fieldCallable) {
             this._fieldCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
             return true;
         }
-        else if (name == PropertyName._fieldSignal) {
+        if (name == PropertyName._fieldSignal) {
             this._fieldSignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
             return true;
         }
-        else if (name == PropertyName._fieldEnum) {
+        if (name == PropertyName._fieldEnum) {
             this._fieldEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
             return true;
         }
-        else if (name == PropertyName._fieldFlagsEnum) {
+        if (name == PropertyName._fieldFlagsEnum) {
             this._fieldFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
             return true;
         }
-        else if (name == PropertyName._fieldByteArray) {
+        if (name == PropertyName._fieldByteArray) {
             this._fieldByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldInt32Array) {
+        if (name == PropertyName._fieldInt32Array) {
             this._fieldInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldInt64Array) {
+        if (name == PropertyName._fieldInt64Array) {
             this._fieldInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldSingleArray) {
+        if (name == PropertyName._fieldSingleArray) {
             this._fieldSingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldDoubleArray) {
+        if (name == PropertyName._fieldDoubleArray) {
             this._fieldDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldStringArray) {
+        if (name == PropertyName._fieldStringArray) {
             this._fieldStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldStringArrayEnum) {
+        if (name == PropertyName._fieldStringArrayEnum) {
             this._fieldStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector2Array) {
+        if (name == PropertyName._fieldVector2Array) {
             this._fieldVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVector3Array) {
+        if (name == PropertyName._fieldVector3Array) {
             this._fieldVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldColorArray) {
+        if (name == PropertyName._fieldColorArray) {
             this._fieldColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotObjectOrDerivedArray) {
+        if (name == PropertyName._fieldGodotObjectOrDerivedArray) {
             this._fieldGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
             return true;
         }
-        else if (name == PropertyName._fieldStringNameArray) {
+        if (name == PropertyName._fieldStringNameArray) {
             this._fieldStringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldNodePathArray) {
+        if (name == PropertyName._fieldNodePathArray) {
             this._fieldNodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldRidArray) {
+        if (name == PropertyName._fieldRidArray) {
             this._fieldRidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldEmptyInt32Array) {
+        if (name == PropertyName._fieldEmptyInt32Array) {
             this._fieldEmptyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldArrayFromList) {
+        if (name == PropertyName._fieldArrayFromList) {
             this._fieldArrayFromList = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
             return true;
         }
-        else if (name == PropertyName._fieldVariant) {
+        if (name == PropertyName._fieldVariant) {
             this._fieldVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotObjectOrDerived) {
+        if (name == PropertyName._fieldGodotObjectOrDerived) {
             this._fieldGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotResourceTexture) {
+        if (name == PropertyName._fieldGodotResourceTexture) {
             this._fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
             return true;
         }
-        else if (name == PropertyName._fieldStringName) {
+        if (name == PropertyName._fieldStringName) {
             this._fieldStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
             return true;
         }
-        else if (name == PropertyName._fieldNodePath) {
+        if (name == PropertyName._fieldNodePath) {
             this._fieldNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
             return true;
         }
-        else if (name == PropertyName._fieldRid) {
+        if (name == PropertyName._fieldRid) {
             this._fieldRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotDictionary) {
+        if (name == PropertyName._fieldGodotDictionary) {
             this._fieldGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotArray) {
+        if (name == PropertyName._fieldGodotArray) {
             this._fieldGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotGenericDictionary) {
+        if (name == PropertyName._fieldGodotGenericDictionary) {
             this._fieldGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
             return true;
         }
-        else if (name == PropertyName._fieldGodotGenericArray) {
+        if (name == PropertyName._fieldGodotGenericArray) {
             this._fieldGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
             return true;
         }
-        else if (name == PropertyName._fieldEmptyInt64Array) {
+        if (name == PropertyName._fieldEmptyInt64Array) {
             this._fieldEmptyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
             return true;
         }
@@ -503,239 +503,239 @@ partial class ExportedFields
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this._fieldBoolean);
             return true;
         }
-        else if (name == PropertyName._fieldChar) {
+        if (name == PropertyName._fieldChar) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this._fieldChar);
             return true;
         }
-        else if (name == PropertyName._fieldSByte) {
+        if (name == PropertyName._fieldSByte) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this._fieldSByte);
             return true;
         }
-        else if (name == PropertyName._fieldInt16) {
+        if (name == PropertyName._fieldInt16) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this._fieldInt16);
             return true;
         }
-        else if (name == PropertyName._fieldInt32) {
+        if (name == PropertyName._fieldInt32) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this._fieldInt32);
             return true;
         }
-        else if (name == PropertyName._fieldInt64) {
+        if (name == PropertyName._fieldInt64) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this._fieldInt64);
             return true;
         }
-        else if (name == PropertyName._fieldByte) {
+        if (name == PropertyName._fieldByte) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this._fieldByte);
             return true;
         }
-        else if (name == PropertyName._fieldUInt16) {
+        if (name == PropertyName._fieldUInt16) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this._fieldUInt16);
             return true;
         }
-        else if (name == PropertyName._fieldUInt32) {
+        if (name == PropertyName._fieldUInt32) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this._fieldUInt32);
             return true;
         }
-        else if (name == PropertyName._fieldUInt64) {
+        if (name == PropertyName._fieldUInt64) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this._fieldUInt64);
             return true;
         }
-        else if (name == PropertyName._fieldSingle) {
+        if (name == PropertyName._fieldSingle) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this._fieldSingle);
             return true;
         }
-        else if (name == PropertyName._fieldDouble) {
+        if (name == PropertyName._fieldDouble) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this._fieldDouble);
             return true;
         }
-        else if (name == PropertyName._fieldString) {
+        if (name == PropertyName._fieldString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._fieldString);
             return true;
         }
-        else if (name == PropertyName._fieldVector2) {
+        if (name == PropertyName._fieldVector2) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this._fieldVector2);
             return true;
         }
-        else if (name == PropertyName._fieldVector2I) {
+        if (name == PropertyName._fieldVector2I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this._fieldVector2I);
             return true;
         }
-        else if (name == PropertyName._fieldRect2) {
+        if (name == PropertyName._fieldRect2) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this._fieldRect2);
             return true;
         }
-        else if (name == PropertyName._fieldRect2I) {
+        if (name == PropertyName._fieldRect2I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this._fieldRect2I);
             return true;
         }
-        else if (name == PropertyName._fieldTransform2D) {
+        if (name == PropertyName._fieldTransform2D) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this._fieldTransform2D);
             return true;
         }
-        else if (name == PropertyName._fieldVector3) {
+        if (name == PropertyName._fieldVector3) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this._fieldVector3);
             return true;
         }
-        else if (name == PropertyName._fieldVector3I) {
+        if (name == PropertyName._fieldVector3I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this._fieldVector3I);
             return true;
         }
-        else if (name == PropertyName._fieldBasis) {
+        if (name == PropertyName._fieldBasis) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this._fieldBasis);
             return true;
         }
-        else if (name == PropertyName._fieldQuaternion) {
+        if (name == PropertyName._fieldQuaternion) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this._fieldQuaternion);
             return true;
         }
-        else if (name == PropertyName._fieldTransform3D) {
+        if (name == PropertyName._fieldTransform3D) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this._fieldTransform3D);
             return true;
         }
-        else if (name == PropertyName._fieldVector4) {
+        if (name == PropertyName._fieldVector4) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this._fieldVector4);
             return true;
         }
-        else if (name == PropertyName._fieldVector4I) {
+        if (name == PropertyName._fieldVector4I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this._fieldVector4I);
             return true;
         }
-        else if (name == PropertyName._fieldProjection) {
+        if (name == PropertyName._fieldProjection) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this._fieldProjection);
             return true;
         }
-        else if (name == PropertyName._fieldAabb) {
+        if (name == PropertyName._fieldAabb) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this._fieldAabb);
             return true;
         }
-        else if (name == PropertyName._fieldColor) {
+        if (name == PropertyName._fieldColor) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this._fieldColor);
             return true;
         }
-        else if (name == PropertyName._fieldPlane) {
+        if (name == PropertyName._fieldPlane) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this._fieldPlane);
             return true;
         }
-        else if (name == PropertyName._fieldCallable) {
+        if (name == PropertyName._fieldCallable) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this._fieldCallable);
             return true;
         }
-        else if (name == PropertyName._fieldSignal) {
+        if (name == PropertyName._fieldSignal) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this._fieldSignal);
             return true;
         }
-        else if (name == PropertyName._fieldEnum) {
+        if (name == PropertyName._fieldEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(this._fieldEnum);
             return true;
         }
-        else if (name == PropertyName._fieldFlagsEnum) {
+        if (name == PropertyName._fieldFlagsEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(this._fieldFlagsEnum);
             return true;
         }
-        else if (name == PropertyName._fieldByteArray) {
+        if (name == PropertyName._fieldByteArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this._fieldByteArray);
             return true;
         }
-        else if (name == PropertyName._fieldInt32Array) {
+        if (name == PropertyName._fieldInt32Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this._fieldInt32Array);
             return true;
         }
-        else if (name == PropertyName._fieldInt64Array) {
+        if (name == PropertyName._fieldInt64Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this._fieldInt64Array);
             return true;
         }
-        else if (name == PropertyName._fieldSingleArray) {
+        if (name == PropertyName._fieldSingleArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this._fieldSingleArray);
             return true;
         }
-        else if (name == PropertyName._fieldDoubleArray) {
+        if (name == PropertyName._fieldDoubleArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this._fieldDoubleArray);
             return true;
         }
-        else if (name == PropertyName._fieldStringArray) {
+        if (name == PropertyName._fieldStringArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this._fieldStringArray);
             return true;
         }
-        else if (name == PropertyName._fieldStringArrayEnum) {
+        if (name == PropertyName._fieldStringArrayEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this._fieldStringArrayEnum);
             return true;
         }
-        else if (name == PropertyName._fieldVector2Array) {
+        if (name == PropertyName._fieldVector2Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this._fieldVector2Array);
             return true;
         }
-        else if (name == PropertyName._fieldVector3Array) {
+        if (name == PropertyName._fieldVector3Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this._fieldVector3Array);
             return true;
         }
-        else if (name == PropertyName._fieldColorArray) {
+        if (name == PropertyName._fieldColorArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this._fieldColorArray);
             return true;
         }
-        else if (name == PropertyName._fieldGodotObjectOrDerivedArray) {
+        if (name == PropertyName._fieldGodotObjectOrDerivedArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this._fieldGodotObjectOrDerivedArray);
             return true;
         }
-        else if (name == PropertyName._fieldStringNameArray) {
+        if (name == PropertyName._fieldStringNameArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this._fieldStringNameArray);
             return true;
         }
-        else if (name == PropertyName._fieldNodePathArray) {
+        if (name == PropertyName._fieldNodePathArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this._fieldNodePathArray);
             return true;
         }
-        else if (name == PropertyName._fieldRidArray) {
+        if (name == PropertyName._fieldRidArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this._fieldRidArray);
             return true;
         }
-        else if (name == PropertyName._fieldEmptyInt32Array) {
+        if (name == PropertyName._fieldEmptyInt32Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this._fieldEmptyInt32Array);
             return true;
         }
-        else if (name == PropertyName._fieldArrayFromList) {
+        if (name == PropertyName._fieldArrayFromList) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this._fieldArrayFromList);
             return true;
         }
-        else if (name == PropertyName._fieldVariant) {
+        if (name == PropertyName._fieldVariant) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this._fieldVariant);
             return true;
         }
-        else if (name == PropertyName._fieldGodotObjectOrDerived) {
+        if (name == PropertyName._fieldGodotObjectOrDerived) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this._fieldGodotObjectOrDerived);
             return true;
         }
-        else if (name == PropertyName._fieldGodotResourceTexture) {
+        if (name == PropertyName._fieldGodotResourceTexture) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this._fieldGodotResourceTexture);
             return true;
         }
-        else if (name == PropertyName._fieldStringName) {
+        if (name == PropertyName._fieldStringName) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this._fieldStringName);
             return true;
         }
-        else if (name == PropertyName._fieldNodePath) {
+        if (name == PropertyName._fieldNodePath) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this._fieldNodePath);
             return true;
         }
-        else if (name == PropertyName._fieldRid) {
+        if (name == PropertyName._fieldRid) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this._fieldRid);
             return true;
         }
-        else if (name == PropertyName._fieldGodotDictionary) {
+        if (name == PropertyName._fieldGodotDictionary) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this._fieldGodotDictionary);
             return true;
         }
-        else if (name == PropertyName._fieldGodotArray) {
+        if (name == PropertyName._fieldGodotArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this._fieldGodotArray);
             return true;
         }
-        else if (name == PropertyName._fieldGodotGenericDictionary) {
+        if (name == PropertyName._fieldGodotGenericDictionary) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this._fieldGodotGenericDictionary);
             return true;
         }
-        else if (name == PropertyName._fieldGodotGenericArray) {
+        if (name == PropertyName._fieldGodotGenericArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this._fieldGodotGenericArray);
             return true;
         }
-        else if (name == PropertyName._fieldEmptyInt64Array) {
+        if (name == PropertyName._fieldEmptyInt64Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this._fieldEmptyInt64Array);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -293,275 +293,275 @@ partial class ExportedProperties
             this.NotGenerateComplexLamdaProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.NotGenerateLamdaNoFieldProperty) {
+        if (name == PropertyName.NotGenerateLamdaNoFieldProperty) {
             this.NotGenerateLamdaNoFieldProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.NotGenerateComplexReturnProperty) {
+        if (name == PropertyName.NotGenerateComplexReturnProperty) {
             this.NotGenerateComplexReturnProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.NotGenerateReturnsProperty) {
+        if (name == PropertyName.NotGenerateReturnsProperty) {
             this.NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.FullPropertyString) {
+        if (name == PropertyName.FullPropertyString) {
             this.FullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.FullPropertyString_Complex) {
+        if (name == PropertyName.FullPropertyString_Complex) {
             this.FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.LamdaPropertyString) {
+        if (name == PropertyName.LamdaPropertyString) {
             this.LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyBoolean) {
+        if (name == PropertyName.PropertyBoolean) {
             this.PropertyBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyChar) {
+        if (name == PropertyName.PropertyChar) {
             this.PropertyChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
             return true;
         }
-        else if (name == PropertyName.PropertySByte) {
+        if (name == PropertyName.PropertySByte) {
             this.PropertySByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyInt16) {
+        if (name == PropertyName.PropertyInt16) {
             this.PropertyInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyInt32) {
+        if (name == PropertyName.PropertyInt32) {
             this.PropertyInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyInt64) {
+        if (name == PropertyName.PropertyInt64) {
             this.PropertyInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyByte) {
+        if (name == PropertyName.PropertyByte) {
             this.PropertyByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt16) {
+        if (name == PropertyName.PropertyUInt16) {
             this.PropertyUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt32) {
+        if (name == PropertyName.PropertyUInt32) {
             this.PropertyUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt64) {
+        if (name == PropertyName.PropertyUInt64) {
             this.PropertyUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
             return true;
         }
-        else if (name == PropertyName.PropertySingle) {
+        if (name == PropertyName.PropertySingle) {
             this.PropertySingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyDouble) {
+        if (name == PropertyName.PropertyDouble) {
             this.PropertyDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyString) {
+        if (name == PropertyName.PropertyString) {
             this.PropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2) {
+        if (name == PropertyName.PropertyVector2) {
             this.PropertyVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2I) {
+        if (name == PropertyName.PropertyVector2I) {
             this.PropertyVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyRect2) {
+        if (name == PropertyName.PropertyRect2) {
             this.PropertyRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyRect2I) {
+        if (name == PropertyName.PropertyRect2I) {
             this.PropertyRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyTransform2D) {
+        if (name == PropertyName.PropertyTransform2D) {
             this.PropertyTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3) {
+        if (name == PropertyName.PropertyVector3) {
             this.PropertyVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3I) {
+        if (name == PropertyName.PropertyVector3I) {
             this.PropertyVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyBasis) {
+        if (name == PropertyName.PropertyBasis) {
             this.PropertyBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyQuaternion) {
+        if (name == PropertyName.PropertyQuaternion) {
             this.PropertyQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyTransform3D) {
+        if (name == PropertyName.PropertyTransform3D) {
             this.PropertyTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector4) {
+        if (name == PropertyName.PropertyVector4) {
             this.PropertyVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector4I) {
+        if (name == PropertyName.PropertyVector4I) {
             this.PropertyVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyProjection) {
+        if (name == PropertyName.PropertyProjection) {
             this.PropertyProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyAabb) {
+        if (name == PropertyName.PropertyAabb) {
             this.PropertyAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyColor) {
+        if (name == PropertyName.PropertyColor) {
             this.PropertyColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyPlane) {
+        if (name == PropertyName.PropertyPlane) {
             this.PropertyPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyCallable) {
+        if (name == PropertyName.PropertyCallable) {
             this.PropertyCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
             return true;
         }
-        else if (name == PropertyName.PropertySignal) {
+        if (name == PropertyName.PropertySignal) {
             this.PropertySignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyEnum) {
+        if (name == PropertyName.PropertyEnum) {
             this.PropertyEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyFlagsEnum) {
+        if (name == PropertyName.PropertyFlagsEnum) {
             this.PropertyFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyByteArray) {
+        if (name == PropertyName.PropertyByteArray) {
             this.PropertyByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyInt32Array) {
+        if (name == PropertyName.PropertyInt32Array) {
             this.PropertyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyInt64Array) {
+        if (name == PropertyName.PropertyInt64Array) {
             this.PropertyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertySingleArray) {
+        if (name == PropertyName.PropertySingleArray) {
             this.PropertySingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyDoubleArray) {
+        if (name == PropertyName.PropertyDoubleArray) {
             this.PropertyDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyStringArray) {
+        if (name == PropertyName.PropertyStringArray) {
             this.PropertyStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyStringArrayEnum) {
+        if (name == PropertyName.PropertyStringArrayEnum) {
             this.PropertyStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2Array) {
+        if (name == PropertyName.PropertyVector2Array) {
             this.PropertyVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3Array) {
+        if (name == PropertyName.PropertyVector3Array) {
             this.PropertyVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyColorArray) {
+        if (name == PropertyName.PropertyColorArray) {
             this.PropertyColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotObjectOrDerivedArray) {
+        if (name == PropertyName.PropertyGodotObjectOrDerivedArray) {
             this.PropertyGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
             return true;
         }
-        else if (name == PropertyName.field_StringNameArray) {
+        if (name == PropertyName.field_StringNameArray) {
             this.field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
             return true;
         }
-        else if (name == PropertyName.field_NodePathArray) {
+        if (name == PropertyName.field_NodePathArray) {
             this.field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
             return true;
         }
-        else if (name == PropertyName.field_RidArray) {
+        if (name == PropertyName.field_RidArray) {
             this.field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyVariant) {
+        if (name == PropertyName.PropertyVariant) {
             this.PropertyVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotObjectOrDerived) {
+        if (name == PropertyName.PropertyGodotObjectOrDerived) {
             this.PropertyGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotResourceTexture) {
+        if (name == PropertyName.PropertyGodotResourceTexture) {
             this.PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyStringName) {
+        if (name == PropertyName.PropertyStringName) {
             this.PropertyStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyNodePath) {
+        if (name == PropertyName.PropertyNodePath) {
             this.PropertyNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyRid) {
+        if (name == PropertyName.PropertyRid) {
             this.PropertyRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotDictionary) {
+        if (name == PropertyName.PropertyGodotDictionary) {
             this.PropertyGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotArray) {
+        if (name == PropertyName.PropertyGodotArray) {
             this.PropertyGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotGenericDictionary) {
+        if (name == PropertyName.PropertyGodotGenericDictionary) {
             this.PropertyGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotGenericArray) {
+        if (name == PropertyName.PropertyGodotGenericArray) {
             this.PropertyGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
             return true;
         }
-        else if (name == PropertyName._notGeneratePropertyString) {
+        if (name == PropertyName._notGeneratePropertyString) {
             this._notGeneratePropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName._notGeneratePropertyInt) {
+        if (name == PropertyName._notGeneratePropertyInt) {
             this._notGeneratePropertyInt = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
             return true;
         }
-        else if (name == PropertyName._fullPropertyString) {
+        if (name == PropertyName._fullPropertyString) {
             this._fullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName._fullPropertyStringComplex) {
+        if (name == PropertyName._fullPropertyStringComplex) {
             this._fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
-        else if (name == PropertyName._lamdaPropertyString) {
+        if (name == PropertyName._lamdaPropertyString) {
             this._lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
@@ -575,275 +575,275 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerateComplexLamdaProperty);
             return true;
         }
-        else if (name == PropertyName.NotGenerateLamdaNoFieldProperty) {
+        if (name == PropertyName.NotGenerateLamdaNoFieldProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerateLamdaNoFieldProperty);
             return true;
         }
-        else if (name == PropertyName.NotGenerateComplexReturnProperty) {
+        if (name == PropertyName.NotGenerateComplexReturnProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerateComplexReturnProperty);
             return true;
         }
-        else if (name == PropertyName.NotGenerateReturnsProperty) {
+        if (name == PropertyName.NotGenerateReturnsProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerateReturnsProperty);
             return true;
         }
-        else if (name == PropertyName.FullPropertyString) {
+        if (name == PropertyName.FullPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.FullPropertyString);
             return true;
         }
-        else if (name == PropertyName.FullPropertyString_Complex) {
+        if (name == PropertyName.FullPropertyString_Complex) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.FullPropertyString_Complex);
             return true;
         }
-        else if (name == PropertyName.LamdaPropertyString) {
+        if (name == PropertyName.LamdaPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.LamdaPropertyString);
             return true;
         }
-        else if (name == PropertyName.PropertyBoolean) {
+        if (name == PropertyName.PropertyBoolean) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.PropertyBoolean);
             return true;
         }
-        else if (name == PropertyName.PropertyChar) {
+        if (name == PropertyName.PropertyChar) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.PropertyChar);
             return true;
         }
-        else if (name == PropertyName.PropertySByte) {
+        if (name == PropertyName.PropertySByte) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.PropertySByte);
             return true;
         }
-        else if (name == PropertyName.PropertyInt16) {
+        if (name == PropertyName.PropertyInt16) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.PropertyInt16);
             return true;
         }
-        else if (name == PropertyName.PropertyInt32) {
+        if (name == PropertyName.PropertyInt32) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.PropertyInt32);
             return true;
         }
-        else if (name == PropertyName.PropertyInt64) {
+        if (name == PropertyName.PropertyInt64) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.PropertyInt64);
             return true;
         }
-        else if (name == PropertyName.PropertyByte) {
+        if (name == PropertyName.PropertyByte) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.PropertyByte);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt16) {
+        if (name == PropertyName.PropertyUInt16) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.PropertyUInt16);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt32) {
+        if (name == PropertyName.PropertyUInt32) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.PropertyUInt32);
             return true;
         }
-        else if (name == PropertyName.PropertyUInt64) {
+        if (name == PropertyName.PropertyUInt64) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.PropertyUInt64);
             return true;
         }
-        else if (name == PropertyName.PropertySingle) {
+        if (name == PropertyName.PropertySingle) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.PropertySingle);
             return true;
         }
-        else if (name == PropertyName.PropertyDouble) {
+        if (name == PropertyName.PropertyDouble) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.PropertyDouble);
             return true;
         }
-        else if (name == PropertyName.PropertyString) {
+        if (name == PropertyName.PropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.PropertyString);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2) {
+        if (name == PropertyName.PropertyVector2) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.PropertyVector2);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2I) {
+        if (name == PropertyName.PropertyVector2I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.PropertyVector2I);
             return true;
         }
-        else if (name == PropertyName.PropertyRect2) {
+        if (name == PropertyName.PropertyRect2) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.PropertyRect2);
             return true;
         }
-        else if (name == PropertyName.PropertyRect2I) {
+        if (name == PropertyName.PropertyRect2I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.PropertyRect2I);
             return true;
         }
-        else if (name == PropertyName.PropertyTransform2D) {
+        if (name == PropertyName.PropertyTransform2D) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.PropertyTransform2D);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3) {
+        if (name == PropertyName.PropertyVector3) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.PropertyVector3);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3I) {
+        if (name == PropertyName.PropertyVector3I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.PropertyVector3I);
             return true;
         }
-        else if (name == PropertyName.PropertyBasis) {
+        if (name == PropertyName.PropertyBasis) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.PropertyBasis);
             return true;
         }
-        else if (name == PropertyName.PropertyQuaternion) {
+        if (name == PropertyName.PropertyQuaternion) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.PropertyQuaternion);
             return true;
         }
-        else if (name == PropertyName.PropertyTransform3D) {
+        if (name == PropertyName.PropertyTransform3D) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.PropertyTransform3D);
             return true;
         }
-        else if (name == PropertyName.PropertyVector4) {
+        if (name == PropertyName.PropertyVector4) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.PropertyVector4);
             return true;
         }
-        else if (name == PropertyName.PropertyVector4I) {
+        if (name == PropertyName.PropertyVector4I) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.PropertyVector4I);
             return true;
         }
-        else if (name == PropertyName.PropertyProjection) {
+        if (name == PropertyName.PropertyProjection) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.PropertyProjection);
             return true;
         }
-        else if (name == PropertyName.PropertyAabb) {
+        if (name == PropertyName.PropertyAabb) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.PropertyAabb);
             return true;
         }
-        else if (name == PropertyName.PropertyColor) {
+        if (name == PropertyName.PropertyColor) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.PropertyColor);
             return true;
         }
-        else if (name == PropertyName.PropertyPlane) {
+        if (name == PropertyName.PropertyPlane) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.PropertyPlane);
             return true;
         }
-        else if (name == PropertyName.PropertyCallable) {
+        if (name == PropertyName.PropertyCallable) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.PropertyCallable);
             return true;
         }
-        else if (name == PropertyName.PropertySignal) {
+        if (name == PropertyName.PropertySignal) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.PropertySignal);
             return true;
         }
-        else if (name == PropertyName.PropertyEnum) {
+        if (name == PropertyName.PropertyEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(this.PropertyEnum);
             return true;
         }
-        else if (name == PropertyName.PropertyFlagsEnum) {
+        if (name == PropertyName.PropertyFlagsEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(this.PropertyFlagsEnum);
             return true;
         }
-        else if (name == PropertyName.PropertyByteArray) {
+        if (name == PropertyName.PropertyByteArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.PropertyByteArray);
             return true;
         }
-        else if (name == PropertyName.PropertyInt32Array) {
+        if (name == PropertyName.PropertyInt32Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.PropertyInt32Array);
             return true;
         }
-        else if (name == PropertyName.PropertyInt64Array) {
+        if (name == PropertyName.PropertyInt64Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.PropertyInt64Array);
             return true;
         }
-        else if (name == PropertyName.PropertySingleArray) {
+        if (name == PropertyName.PropertySingleArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.PropertySingleArray);
             return true;
         }
-        else if (name == PropertyName.PropertyDoubleArray) {
+        if (name == PropertyName.PropertyDoubleArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.PropertyDoubleArray);
             return true;
         }
-        else if (name == PropertyName.PropertyStringArray) {
+        if (name == PropertyName.PropertyStringArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.PropertyStringArray);
             return true;
         }
-        else if (name == PropertyName.PropertyStringArrayEnum) {
+        if (name == PropertyName.PropertyStringArrayEnum) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.PropertyStringArrayEnum);
             return true;
         }
-        else if (name == PropertyName.PropertyVector2Array) {
+        if (name == PropertyName.PropertyVector2Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.PropertyVector2Array);
             return true;
         }
-        else if (name == PropertyName.PropertyVector3Array) {
+        if (name == PropertyName.PropertyVector3Array) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.PropertyVector3Array);
             return true;
         }
-        else if (name == PropertyName.PropertyColorArray) {
+        if (name == PropertyName.PropertyColorArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.PropertyColorArray);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotObjectOrDerivedArray) {
+        if (name == PropertyName.PropertyGodotObjectOrDerivedArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.PropertyGodotObjectOrDerivedArray);
             return true;
         }
-        else if (name == PropertyName.field_StringNameArray) {
+        if (name == PropertyName.field_StringNameArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.field_StringNameArray);
             return true;
         }
-        else if (name == PropertyName.field_NodePathArray) {
+        if (name == PropertyName.field_NodePathArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.field_NodePathArray);
             return true;
         }
-        else if (name == PropertyName.field_RidArray) {
+        if (name == PropertyName.field_RidArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.field_RidArray);
             return true;
         }
-        else if (name == PropertyName.PropertyVariant) {
+        if (name == PropertyName.PropertyVariant) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.PropertyVariant);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotObjectOrDerived) {
+        if (name == PropertyName.PropertyGodotObjectOrDerived) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.PropertyGodotObjectOrDerived);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotResourceTexture) {
+        if (name == PropertyName.PropertyGodotResourceTexture) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.PropertyGodotResourceTexture);
             return true;
         }
-        else if (name == PropertyName.PropertyStringName) {
+        if (name == PropertyName.PropertyStringName) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.PropertyStringName);
             return true;
         }
-        else if (name == PropertyName.PropertyNodePath) {
+        if (name == PropertyName.PropertyNodePath) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.PropertyNodePath);
             return true;
         }
-        else if (name == PropertyName.PropertyRid) {
+        if (name == PropertyName.PropertyRid) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.PropertyRid);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotDictionary) {
+        if (name == PropertyName.PropertyGodotDictionary) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.PropertyGodotDictionary);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotArray) {
+        if (name == PropertyName.PropertyGodotArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.PropertyGodotArray);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotGenericDictionary) {
+        if (name == PropertyName.PropertyGodotGenericDictionary) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.PropertyGodotGenericDictionary);
             return true;
         }
-        else if (name == PropertyName.PropertyGodotGenericArray) {
+        if (name == PropertyName.PropertyGodotGenericArray) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.PropertyGodotGenericArray);
             return true;
         }
-        else if (name == PropertyName._notGeneratePropertyString) {
+        if (name == PropertyName._notGeneratePropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._notGeneratePropertyString);
             return true;
         }
-        else if (name == PropertyName._notGeneratePropertyInt) {
+        if (name == PropertyName._notGeneratePropertyInt) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this._notGeneratePropertyInt);
             return true;
         }
-        else if (name == PropertyName._fullPropertyString) {
+        if (name == PropertyName._fullPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._fullPropertyString);
             return true;
         }
-        else if (name == PropertyName._fullPropertyStringComplex) {
+        if (name == PropertyName._fullPropertyStringComplex) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._fullPropertyStringComplex);
             return true;
         }
-        else if (name == PropertyName._lamdaPropertyString) {
+        if (name == PropertyName._lamdaPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._lamdaPropertyString);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
@@ -41,7 +41,7 @@ partial class MixedReadOnlyWriteOnly
             this.WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }
-        else if (name == PropertyName._writeOnlyBackingField) {
+        if (name == PropertyName._writeOnlyBackingField) {
             this._writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
             return true;
         }
@@ -55,19 +55,19 @@ partial class MixedReadOnlyWriteOnly
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyAutoProperty);
             return true;
         }
-        else if (name == PropertyName.ReadOnlyProperty) {
+        if (name == PropertyName.ReadOnlyProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyProperty);
             return true;
         }
-        else if (name == PropertyName.InitOnlyAutoProperty) {
+        if (name == PropertyName.InitOnlyAutoProperty) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.InitOnlyAutoProperty);
             return true;
         }
-        else if (name == PropertyName.ReadOnlyField) {
+        if (name == PropertyName.ReadOnlyField) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.ReadOnlyField);
             return true;
         }
-        else if (name == PropertyName._writeOnlyBackingField) {
+        if (name == PropertyName._writeOnlyBackingField) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this._writeOnlyBackingField);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
@@ -54,7 +54,7 @@ partial class ScriptBoilerplate
         if (method == MethodName._Process) {
            return true;
         }
-        else if (method == MethodName.Bazz) {
+        if (method == MethodName.Bazz) {
            return true;
         }
         return base.HasGodotClassMethod(method);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
@@ -25,7 +25,7 @@ partial class ScriptBoilerplate
             this._nodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
             return true;
         }
-        else if (name == PropertyName._velocity) {
+        if (name == PropertyName._velocity) {
             this._velocity = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
             return true;
         }
@@ -39,7 +39,7 @@ partial class ScriptBoilerplate
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this._nodePath);
             return true;
         }
-        else if (name == PropertyName._velocity) {
+        if (name == PropertyName._velocity) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this._velocity);
             return true;
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -253,11 +253,9 @@ namespace Godot.SourceGenerators
                 source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
                 source.Append("    protected override bool HasGodotClassMethod(in godot_string_name method)\n    {\n");
 
-                bool isFirstEntry = true;
                 foreach (string methodName in distinctMethodNames)
                 {
-                    GenerateHasMethodEntry(methodName, source, isFirstEntry);
-                    isFirstEntry = false;
+                    GenerateHasMethodEntry(methodName, source);
                 }
 
                 source.Append("        return base.HasGodotClassMethod(method);\n");
@@ -412,13 +410,10 @@ namespace Godot.SourceGenerators
 
         private static void GenerateHasMethodEntry(
             string methodName,
-            StringBuilder source,
-            bool isFirstEntry
+            StringBuilder source
         )
         {
             source.Append("        ");
-            if (!isFirstEntry)
-                source.Append("else ");
             source.Append("if (method == MethodName.");
             source.Append(methodName);
             source.Append(") {\n           return true;\n        }\n");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -172,7 +172,6 @@ namespace Godot.SourceGenerators
 
             if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
             {
-                bool isFirstEntry;
 
                 // Generate SetGodotClassPropertyValue
 
@@ -186,15 +185,13 @@ namespace Godot.SourceGenerators
                     source.Append("    protected override bool SetGodotClassPropertyValue(in godot_string_name name, ");
                     source.Append("in godot_variant value)\n    {\n");
 
-                    isFirstEntry = true;
                     foreach (var property in godotClassProperties)
                     {
                         if (property.PropertySymbol.IsReadOnly || property.PropertySymbol.SetMethod!.IsInitOnly)
                             continue;
 
                         GeneratePropertySetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source, isFirstEntry);
-                        isFirstEntry = false;
+                            property.PropertySymbol.Type, property.Type, source);
                     }
 
                     foreach (var field in godotClassFields)
@@ -203,8 +200,7 @@ namespace Godot.SourceGenerators
                             continue;
 
                         GeneratePropertySetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source, isFirstEntry);
-                        isFirstEntry = false;
+                            field.FieldSymbol.Type, field.Type, source);
                     }
 
                     source.Append("        return base.SetGodotClassPropertyValue(name, value);\n");
@@ -222,22 +218,19 @@ namespace Godot.SourceGenerators
                     source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
                     source.Append("out godot_variant value)\n    {\n");
 
-                    isFirstEntry = true;
                     foreach (var property in godotClassProperties)
                     {
                         if (property.PropertySymbol.IsWriteOnly)
                             continue;
 
                         GeneratePropertyGetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source, isFirstEntry);
-                        isFirstEntry = false;
+                            property.PropertySymbol.Type, property.Type, source);
                     }
 
                     foreach (var field in godotClassFields)
                     {
                         GeneratePropertyGetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source, isFirstEntry);
-                        isFirstEntry = false;
+                            field.FieldSymbol.Type, field.Type, source);
                     }
 
                     source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
@@ -318,14 +311,10 @@ namespace Godot.SourceGenerators
             string propertyMemberName,
             ITypeSymbol propertyTypeSymbol,
             MarshalType propertyMarshalType,
-            StringBuilder source,
-            bool isFirstEntry
+            StringBuilder source
         )
         {
             source.Append("        ");
-
-            if (!isFirstEntry)
-                source.Append("else ");
 
             source.Append("if (name == PropertyName.")
                 .Append(propertyMemberName)
@@ -343,14 +332,10 @@ namespace Godot.SourceGenerators
             string propertyMemberName,
             ITypeSymbol propertyTypeSymbol,
             MarshalType propertyMarshalType,
-            StringBuilder source,
-            bool isFirstEntry
+            StringBuilder source
         )
         {
             source.Append("        ");
-
-            if (!isFirstEntry)
-                source.Append("else ");
 
             source.Append("if (name == PropertyName.")
                 .Append(propertyMemberName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -319,11 +319,9 @@ namespace Godot.SourceGenerators
                 source.Append(
                     "    protected override bool HasGodotClassSignal(in godot_string_name signal)\n    {\n");
 
-                bool isFirstEntry = true;
                 foreach (var signal in godotSignalDelegates)
                 {
-                    GenerateHasSignalEntry(signal.Name, source, isFirstEntry);
-                    isFirstEntry = false;
+                    GenerateHasSignalEntry(signal.Name, source);
                 }
 
                 source.Append("        return base.HasGodotClassSignal(signal);\n");
@@ -473,13 +471,10 @@ namespace Godot.SourceGenerators
 
         private static void GenerateHasSignalEntry(
             string signalName,
-            StringBuilder source,
-            bool isFirstEntry
+            StringBuilder source
         )
         {
             source.Append("        ");
-            if (!isFirstEntry)
-                source.Append("else ");
             source.Append("if (signal == SignalName.");
             source.Append(signalName);
             source.Append(") {\n           return true;\n        }\n");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
PR https://github.com/godotengine/godot/pull/90687#issuecomment-2073792331

Even removing the else keyword does not affect program execution.