### PR TITLE
Revert "Enable `EditorPlugin` added by modules and GDExtensions"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3533,7 +3533,6 @@ void EditorNode::add_extension_editor_plugin(const StringName &p_class_name) {
 	EditorPlugin *plugin = Object::cast_to<EditorPlugin>(ClassDB::instantiate(p_class_name));
 	singleton->editor_data.add_extension_editor_plugin(p_class_name, plugin);
 	add_editor_plugin(plugin);
-	plugin->enable_plugin();
 }
 
 void EditorNode::remove_extension_editor_plugin(const StringName &p_class_name) {
@@ -7273,9 +7272,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
-		EditorPlugin *plugin = EditorPlugins::create(i);
-		add_editor_plugin(plugin);
-		plugin->enable_plugin();
+		add_editor_plugin(EditorPlugins::create(i));
 	}
 
 	for (const StringName &extension_class_name : GDExtensionEditorPlugins::get_extension_classes()) {


### PR DESCRIPTION
- Reverts godotengine/godot#90608

The PR was incorrect, it was a misunderstanding on my part regarding the behavior of EditorPlugins :disappointed:. See https://github.com/godotengine/godot/pull/90608#discussion_r1590203153.