### PR TITLE
Editor: Fix categories and tooltips in `TileSet` editor

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3699,12 +3699,8 @@ void EditorHelpBit::set_custom_text(const String &p_type, const String &p_name, 
 	}
 }
 
-void EditorHelpBit::prepend_description(const String &p_text) {
-	if (help_data.description.is_empty()) {
-		help_data.description = p_text;
-	} else {
-		help_data.description = p_text + "\n" + help_data.description;
-	}
+void EditorHelpBit::set_description(const String &p_text) {
+	help_data.description = p_text;
 
 	if (is_inside_tree()) {
 		_update_labels();

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -311,7 +311,8 @@ protected:
 public:
 	void parse_symbol(const String &p_symbol);
 	void set_custom_text(const String &p_type, const String &p_name, const String &p_description);
-	void prepend_description(const String &p_text);
+	void set_description(const String &p_text);
+	_FORCE_INLINE_ String get_description() const { return help_data.description; }
 
 	void set_content_height_limits(float p_min, float p_max);
 	void update_content_height();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -494,7 +494,8 @@ class EditorInspector : public ScrollContainer {
 	//
 
 	LineEdit *search_box = nullptr;
-	bool show_categories = false;
+	bool show_standard_categories = false;
+	bool show_custom_categories = false;
 	bool hide_script = true;
 	bool hide_metadata = true;
 	bool use_doc_hints = false;
@@ -610,7 +611,7 @@ public:
 
 	void set_autoclear(bool p_enable);
 
-	void set_show_categories(bool p_show);
+	void set_show_categories(bool p_show_standard, bool p_show_custom);
 	void set_use_doc_hints(bool p_enable);
 	void set_hide_script(bool p_hide);
 	void set_hide_metadata(bool p_hide);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -787,7 +787,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
 	inspector->set_autoclear(true);
-	inspector->set_show_categories(true);
+	inspector->set_show_categories(true, true);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
 	inspector->set_hide_script(false);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2555,7 +2555,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	tile_inspector = memnew(EditorInspector);
 	tile_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
-	tile_inspector->set_show_categories(true);
+	tile_inspector->set_show_categories(false, true);
 	tile_inspector->set_use_doc_hints(true);
 	tile_inspector->set_use_folding(true);
 	tile_inspector->connect("property_selected", callable_mp(this, &TileSetAtlasSourceEditor::_inspector_property_selected));
@@ -2609,7 +2609,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	atlas_source_inspector = memnew(EditorInspector);
 	atlas_source_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
-	atlas_source_inspector->set_show_categories(true);
+	atlas_source_inspector->set_show_categories(false, true);
 	atlas_source_inspector->set_use_doc_hints(true);
 	atlas_source_inspector->add_inspector_plugin(memnew(TileSourceInspectorPlugin));
 	middle_vbox_container->add_child(atlas_source_inspector);


### PR DESCRIPTION
* Hide unnecessary standard category.
  * Regression from #88318.
  * Fixes #91926.
* Fix missing custom descriptions in help tooltips.
  * Regression from #89058.