### PR TITLE
Fix wrong usage of `parameters_base_path` StringName

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -118,7 +118,7 @@ String AnimationNodeStateMachineEditor::_get_root_playback_path(String &r_node_d
 		if (node_directory_path.size()) {
 			r_node_directory += "/";
 		}
-		base_path = !edited_path.size() ? String(SceneStringName(parameters_base_path)) + "playback" : String(SceneStringName(parameters_base_path)) + base_path + "/playback";
+		base_path = !edited_path.size() ? Animation::PARAMETERS_BASE_PATH + "playback" : Animation::PARAMETERS_BASE_PATH + base_path + "/playback";
 	} else {
 		// Hmmm, we have to return Grouped state machine playback...
 		// It will give the user the error that Root/Nested state machine should be retrieved, that would be kind :-)

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -220,7 +220,7 @@ void AnimationTreeEditor::remove_plugin(AnimationTreeNodeEditorPlugin *p_editor)
 }
 
 String AnimationTreeEditor::get_base_path() {
-	String path = SceneStringName(parameters_base_path);
+	String path = Animation::PARAMETERS_BASE_PATH;
 	for (int i = 0; i < edited_path.size(); i++) {
 		path += edited_path[i] + "/";
 	}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -626,7 +626,7 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 		for (int i = 0; i < p_track_count; i++) {
 			src_blendsw[i] = 1.0; // By default all go to 1 for the root input.
 		}
-		root_animation_node->node_state.base_path = SceneStringName(parameters_base_path);
+		root_animation_node->node_state.base_path = SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data());
 		root_animation_node->node_state.parent = nullptr;
 	}
 
@@ -787,7 +787,7 @@ void AnimationTree::_update_properties() {
 	input_activity_map_get.clear();
 
 	if (root_animation_node.is_valid()) {
-		_update_properties_for_node(SceneStringName(parameters_base_path), root_animation_node);
+		_update_properties_for_node(Animation::PARAMETERS_BASE_PATH, root_animation_node);
 	}
 
 	properties_dirty = false;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -43,6 +43,8 @@ class Animation : public Resource {
 public:
 	typedef uint32_t TypeHash;
 
+	static inline String PARAMETERS_BASE_PATH = "parameters/";
+
 	enum TrackType {
 		TYPE_VALUE, // Set a value in a property, can be interpolated.
 		TYPE_POSITION_3D, // Position 3D track, can be compressed.

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -123,7 +123,6 @@ SceneStringNames::SceneStringNames() {
 	window_input = StaticCString::create("window_input");
 
 	theme_changed = StaticCString::create("theme_changed");
-	parameters_base_path = "parameters/";
 
 	shader_overrides_group = StaticCString::create("_shader_overrides_group_");
 	shader_overrides_group_active = StaticCString::create("_shader_overrides_group_active_");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -134,7 +134,6 @@ public:
 
 	StringName Master;
 
-	StringName parameters_base_path;
 	StringName window_input;
 
 	StringName theme_changed;


### PR DESCRIPTION
`parameters_base_path` was registered as a scene string name, but all of its usages, except 1, converted it to String. I changed it to a constant String in Animation and the single StringName usage was converted to SNAME.