### PR TITLE
Cleanup unused/underused singleton StringNames

### DIFF
--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -42,10 +42,8 @@ CoreStringNames::CoreStringNames() :
 		_iter_get(StaticCString::create("_iter_get")),
 		get_rid(StaticCString::create("get_rid")),
 		_to_string(StaticCString::create("_to_string")),
-#ifdef TOOLS_ENABLED
-		_sections_unfolded(StaticCString::create("_sections_unfolded")),
-#endif
 		_custom_features(StaticCString::create("_custom_features")),
+
 		x(StaticCString::create("x")),
 		y(StaticCString::create("y")),
 		z(StaticCString::create("z")),
@@ -68,11 +66,10 @@ CoreStringNames::CoreStringNames() :
 		g8(StaticCString::create("g8")),
 		b8(StaticCString::create("b8")),
 		a8(StaticCString::create("a8")),
+
 		call(StaticCString::create("call")),
 		call_deferred(StaticCString::create("call_deferred")),
 		bind(StaticCString::create("bind")),
-		unbind(StaticCString::create("unbind")),
-		emit(StaticCString::create("emit")),
 		notification(StaticCString::create("notification")),
 		property_list_changed(StaticCString::create("property_list_changed")) {
 }

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -59,9 +59,6 @@ public:
 	StringName _iter_get;
 	StringName get_rid;
 	StringName _to_string;
-#ifdef TOOLS_ENABLED
-	StringName _sections_unfolded;
-#endif
 	StringName _custom_features;
 
 	StringName x;
@@ -90,8 +87,6 @@ public:
 	StringName call;
 	StringName call_deferred;
 	StringName bind;
-	StringName unbind;
-	StringName emit;
 	StringName notification;
 	StringName property_list_changed;
 };

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -192,7 +192,7 @@ void Node3D::_notification(int p_what) {
 			ERR_FAIL_NULL(data.viewport);
 
 			if (get_script_instance()) {
-				get_script_instance()->call(SceneStringName(_enter_world));
+				get_script_instance()->call(SNAME("_enter_world"));
 			}
 
 #ifdef TOOLS_ENABLED
@@ -210,7 +210,7 @@ void Node3D::_notification(int p_what) {
 #endif
 
 			if (get_script_instance()) {
-				get_script_instance()->call(SceneStringName(_exit_world));
+				get_script_instance()->call(SNAME("_exit_world"));
 			}
 
 			data.viewport = nullptr;
@@ -582,7 +582,7 @@ void Node3D::set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, Transfor
 	}
 
 	if (is_part_of_edited_scene()) {
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SceneStringName(_set_subgizmo_selection), this, p_gizmo, p_id, p_transform);
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SNAME("_set_subgizmo_selection"), this, p_gizmo, p_id, p_transform);
 	}
 #endif
 }
@@ -599,7 +599,7 @@ void Node3D::clear_subgizmo_selection() {
 	}
 
 	if (is_part_of_edited_scene()) {
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SceneStringName(_clear_subgizmo_selection), this);
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SNAME("_clear_subgizmo_selection"), this);
 	}
 #endif
 }

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -276,12 +276,12 @@ bool GeometryInstance3D::_set(const StringName &p_name, const Variant &p_value) 
 		return true;
 	}
 #ifndef DISABLE_DEPRECATED
-	if (p_name == SceneStringName(use_in_baked_light) && bool(p_value)) {
+	if (p_name == SNAME("use_in_baked_light") && bool(p_value)) {
 		set_gi_mode(GI_MODE_STATIC);
 		return true;
 	}
 
-	if (p_name == SceneStringName(use_dynamic_gi) && bool(p_value)) {
+	if (p_name == SNAME("use_dynamic_gi") && bool(p_value)) {
 		set_gi_mode(GI_MODE_DYNAMIC);
 		return true;
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1736,12 +1736,10 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 		StringName name = p_path.get_name(i);
 		Node *next = nullptr;
 
-		if (name == SceneStringName(dot)) { // .
-
+		if (name == SNAME(".")) {
 			next = current;
 
-		} else if (name == SceneStringName(doubledot)) { // ..
-
+		} else if (name == SNAME("..")) {
 			if (current == nullptr || !current->data.parent) {
 				return nullptr;
 			}

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -33,20 +33,12 @@
 SceneStringNames *SceneStringNames::singleton = nullptr;
 
 SceneStringNames::SceneStringNames() {
-	_estimate_cost = StaticCString::create("_estimate_cost");
-	_compute_cost = StaticCString::create("_compute_cost");
-
 	resized = StaticCString::create("resized");
-	dot = StaticCString::create(".");
-	doubledot = StaticCString::create("..");
 	draw = StaticCString::create("draw");
-	_draw = StaticCString::create("_draw");
 	hidden = StaticCString::create("hidden");
 	visibility_changed = StaticCString::create("visibility_changed");
 	input_event = StaticCString::create("input_event");
 	shader = StaticCString::create("shader");
-	shader_unshaded = StaticCString::create("shader/unshaded");
-	shading_mode = StaticCString::create("shader/shading_mode");
 	tree_entered = StaticCString::create("tree_entered");
 	tree_exiting = StaticCString::create("tree_exiting");
 	tree_exited = StaticCString::create("tree_exited");
@@ -86,98 +78,33 @@ SceneStringNames::SceneStringNames() {
 	area_shape_entered = StaticCString::create("area_shape_entered");
 	area_shape_exited = StaticCString::create("area_shape_exited");
 
-	_body_inout = StaticCString::create("_body_inout");
-	_area_inout = StaticCString::create("_area_inout");
-
-	idle = StaticCString::create("idle");
-	iteration = StaticCString::create("iteration");
 	update = StaticCString::create("update");
 	updated = StaticCString::create("updated");
 
-	_physics_process = StaticCString::create("_physics_process");
-	_process = StaticCString::create("_process");
-
-	_enter_tree = StaticCString::create("_enter_tree");
-	_exit_tree = StaticCString::create("_exit_tree");
-	_enter_world = StaticCString::create("_enter_world");
-	_exit_world = StaticCString::create("_exit_world");
 	_ready = StaticCString::create("_ready");
-
-	_update_scroll = StaticCString::create("_update_scroll");
-	_update_xform = StaticCString::create("_update_xform");
-
-	_structured_text_parser = StaticCString::create("_structured_text_parser");
-
-	_proxgroup_add = StaticCString::create("_proxgroup_add");
-	_proxgroup_remove = StaticCString::create("_proxgroup_remove");
-
-	grouped = StaticCString::create("grouped");
-	ungrouped = StaticCString::create("ungrouped");
 
 	screen_entered = StaticCString::create("screen_entered");
 	screen_exited = StaticCString::create("screen_exited");
 
-	viewport_entered = StaticCString::create("viewport_entered");
-	viewport_exited = StaticCString::create("viewport_exited");
-
-	camera_entered = StaticCString::create("camera_entered");
-	camera_exited = StaticCString::create("camera_exited");
-
-	_input = StaticCString::create("_input");
-	_input_event = StaticCString::create("_input_event");
-
 	gui_input = StaticCString::create("gui_input");
-	_gui_input = StaticCString::create("_gui_input");
-
-	_unhandled_input = StaticCString::create("_unhandled_input");
-	_unhandled_key_input = StaticCString::create("_unhandled_key_input");
-
-	_shader_changed = StaticCString::create("_shader_changed");
 
 	_spatial_editor_group = StaticCString::create("_spatial_editor_group");
 	_request_gizmo = StaticCString::create("_request_gizmo");
-	_set_subgizmo_selection = StaticCString::create("_set_subgizmo_selection");
-	_clear_subgizmo_selection = StaticCString::create("_clear_subgizmo_selection");
 
 	offset = StaticCString::create("offset");
-	unit_offset = StaticCString::create("unit_offset");
 	rotation_mode = StaticCString::create("rotation_mode");
 	rotate = StaticCString::create("rotate");
 	h_offset = StaticCString::create("h_offset");
 	v_offset = StaticCString::create("v_offset");
 
-	_update_remote = StaticCString::create("_update_remote");
-	_update_pairs = StaticCString::create("_update_pairs");
-
-	_get_minimum_size = StaticCString::create("_get_minimum_size");
-
 	area_entered = StaticCString::create("area_entered");
 	area_exited = StaticCString::create("area_exited");
 
-	_has_point = StaticCString::create("_has_point");
-
 	line_separation = StaticCString::create("line_separation");
-
-	_get_drag_data = StaticCString::create("_get_drag_data");
-	_drop_data = StaticCString::create("_drop_data");
-	_can_drop_data = StaticCString::create("_can_drop_data");
-
-	baked_light_changed = StaticCString::create("baked_light_changed");
-	_baked_light_changed = StaticCString::create("_baked_light_changed");
-
-	_mouse_enter = StaticCString::create("_mouse_enter");
-	_mouse_exit = StaticCString::create("_mouse_exit");
-	_mouse_shape_enter = StaticCString::create("_mouse_shape_enter");
-	_mouse_shape_exit = StaticCString::create("_mouse_shape_exit");
-
-	_pressed = StaticCString::create("_pressed");
-	_toggled = StaticCString::create("_toggled");
 
 	frame_changed = StaticCString::create("frame_changed");
 	texture_changed = StaticCString::create("texture_changed");
 
-	playback_speed = StaticCString::create("playback/speed");
-	playback_active = StaticCString::create("playback/active");
 	autoplay = StaticCString::create("autoplay");
 	blend_times = StaticCString::create("blend_times");
 	speed = StaticCString::create("speed");
@@ -193,11 +120,7 @@ SceneStringNames::SceneStringNames() {
 
 	default_ = StaticCString::create("default");
 
-	_window_group = StaticCString::create("_window_group");
-	_window_input = StaticCString::create("_window_input");
 	window_input = StaticCString::create("window_input");
-	_window_unhandled_input = StaticCString::create("_window_unhandled_input");
-	_get_contents_minimum_size = StaticCString::create("_get_contents_minimum_size");
 
 	theme_changed = StaticCString::create("theme_changed");
 	parameters_base_path = "parameters/";
@@ -206,9 +129,4 @@ SceneStringNames::SceneStringNames() {
 	shader_overrides_group_active = StaticCString::create("_shader_overrides_group_active_");
 
 	pressed = StaticCString::create("pressed");
-
-#ifndef DISABLE_DEPRECATED
-	use_in_baked_light = StaticCString::create("use_in_baked_light");
-	use_dynamic_gi = StaticCString::create("use_dynamic_gi");
-#endif
 }

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -51,23 +51,14 @@ class SceneStringNames {
 public:
 	_FORCE_INLINE_ static SceneStringNames *get_singleton() { return singleton; }
 
-	StringName _estimate_cost;
-	StringName _compute_cost;
-
 	StringName resized;
-	StringName dot;
-	StringName doubledot;
 	StringName draw;
 	StringName hidden;
 	StringName visibility_changed;
 	StringName input_event;
-	StringName _input_event;
 	StringName gui_input;
-	StringName _gui_input;
 	StringName item_rect_changed;
 	StringName shader;
-	StringName shader_unshaded;
-	StringName shading_mode;
 	StringName tree_entered;
 	StringName tree_exiting;
 	StringName tree_exited;
@@ -75,8 +66,6 @@ public:
 	StringName size_flags_changed;
 	StringName minimum_size_changed;
 	StringName sleeping_state_changed;
-	StringName idle;
-	StringName iteration;
 	StringName update;
 	StringName updated;
 
@@ -111,82 +100,26 @@ public:
 	StringName area_shape_entered;
 	StringName area_shape_exited;
 
-	StringName _body_inout;
-	StringName _area_inout;
-
-	StringName _physics_process;
-	StringName _process;
-	StringName _enter_world;
-	StringName _exit_world;
-	StringName _enter_tree;
-	StringName _exit_tree;
-	StringName _draw;
-	StringName _input;
 	StringName _ready;
-	StringName _unhandled_input;
-	StringName _unhandled_key_input;
-
-	StringName _pressed;
-	StringName _toggled;
-
-	StringName _update_scroll;
-	StringName _update_xform;
-
-	StringName _structured_text_parser;
-
-	StringName _proxgroup_add;
-	StringName _proxgroup_remove;
-
-	StringName grouped;
-	StringName ungrouped;
-
-	StringName _has_point;
-	StringName _get_drag_data;
-	StringName _can_drop_data;
-	StringName _drop_data;
 
 	StringName screen_entered;
 	StringName screen_exited;
-	StringName viewport_entered;
-	StringName viewport_exited;
-	StringName camera_entered;
-	StringName camera_exited;
-
-	StringName _shader_changed;
 
 	StringName _spatial_editor_group;
 	StringName _request_gizmo;
-	StringName _set_subgizmo_selection;
-	StringName _clear_subgizmo_selection;
 
 	StringName offset;
-	StringName unit_offset;
 	StringName rotation_mode;
 	StringName rotate;
 	StringName v_offset;
 	StringName h_offset;
 
-	StringName _update_remote;
-	StringName _update_pairs;
-
 	StringName area_entered;
 	StringName area_exited;
-
-	StringName _get_minimum_size;
-
-	StringName baked_light_changed;
-	StringName _baked_light_changed;
-
-	StringName _mouse_enter;
-	StringName _mouse_exit;
-	StringName _mouse_shape_enter;
-	StringName _mouse_shape_exit;
 
 	StringName frame_changed;
 	StringName texture_changed;
 
-	StringName playback_speed;
-	StringName playback_active;
 	StringName autoplay;
 	StringName blend_times;
 	StringName speed;
@@ -202,23 +135,13 @@ public:
 	StringName Master;
 
 	StringName parameters_base_path;
-
-	StringName _window_group;
-	StringName _window_input;
-	StringName _window_unhandled_input;
 	StringName window_input;
-	StringName _get_contents_minimum_size;
 
 	StringName theme_changed;
 	StringName shader_overrides_group;
 	StringName shader_overrides_group_active;
 
 	StringName pressed;
-
-#ifndef DISABLE_DEPRECATED
-	StringName use_in_baked_light;
-	StringName use_dynamic_gi;
-#endif
 };
 
 #define SceneStringName(m_name) SceneStringNames::get_singleton()->m_name


### PR DESCRIPTION
Follow-up to #91909 (likely final one)
Removes many unused names from core/scene string names. If a name was used exactly once, it's replaced with SNAME (for single use they are pretty much equivalent).
Most of the removed names are few-year-old leftovers obsoleted after GDVIRTUAL was added.

EDIT:
I forgot to mention, but this does not handle 1-2 character-long names, because they are difficult to track.