### PR TITLE
GDScript: Add support for `atr` and `atr_n` to POT generator

### DIFF
--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -276,8 +276,8 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 	id_ctx_plural.resize(3);
 	bool extract_id_ctx_plural = true;
 
-	if (function_name == tr_func) {
-		// Extract from tr(id, ctx).
+	if (function_name == tr_func || function_name == atr_func) {
+		// Extract from `tr(id, ctx)` or `atr(id, ctx)`.
 		for (int i = 0; i < p_call->arguments.size(); i++) {
 			if (_is_constant_string(p_call->arguments[i])) {
 				id_ctx_plural.write[i] = p_call->arguments[i]->reduced_value;
@@ -289,8 +289,8 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 		if (extract_id_ctx_plural) {
 			ids_ctx_plural->push_back(id_ctx_plural);
 		}
-	} else if (function_name == trn_func) {
-		// Extract from tr_n(id, plural, n, ctx).
+	} else if (function_name == trn_func || function_name == atrn_func) {
+		// Extract from `tr_n(id, plural, n, ctx)` or `atr_n(id, plural, n, ctx)`.
 		Vector<int> indices;
 		indices.push_back(0);
 		indices.push_back(3);

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -45,6 +45,8 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 	// List of patterns used for extracting translation strings.
 	StringName tr_func = "tr";
 	StringName trn_func = "tr_n";
+	StringName atr_func = "atr";
+	StringName atrn_func = "atr_n";
 	HashSet<StringName> assignment_patterns;
 	HashSet<StringName> first_arg_patterns;
 	HashSet<StringName> second_arg_patterns;


### PR DESCRIPTION
* See #87530.