### PR TITLE
Core: Re-add Variant class initializer, fix comment

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -165,10 +165,12 @@ private:
 
 	friend struct _VariantCall;
 	friend class VariantInternal;
-	// Variant takes 20 bytes when real_t is float, and 36 if double
-	// it only allocates extra memory for aabb/matrix.
+	// Variant takes 24 bytes when real_t is float, and 40 bytes if double.
+	// It only allocates extra memory for AABB/Transform2D (24, 48 if double),
+	// Basis/Transform3D (48, 96 if double), Projection (64, 128 if double),
+	// and PackedArray/Array/Dictionary (platform-dependent).
 
-	Type type;
+	Type type = NIL;
 
 	struct ObjData {
 		ObjectID id;


### PR DESCRIPTION
Fixes two minor issues in `variant.h`:
- Readded the class initalizer for `type` (#90866 regression).
- Updated the comment that specifies Variant's byte allocation & when it allocates extra memory.