### PR TITLE
 Fix POT generation failing on some scripts with class_name. 

### DIFF
--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -52,10 +52,16 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 	ids = r_ids;
 	ids_ctx_plural = r_ids_ctx_plural;
 	Ref<GDScript> gdscript = loaded_res;
+	ERR_FAIL_COND_V_MSG(!gdscript->is_valid(), ERR_FILE_CANT_OPEN, "Failed to load GDScript.");
 	String source_code = gdscript->get_source_code();
 
+	String path_res = p_path;
+	if (!path_res.begins_with("res://")) {
+		path_res = "res://" + path_res;
+	}
+
 	GDScriptParser parser;
-	err = parser.parse(source_code, p_path, false);
+	err = parser.parse(source_code, path_res, false);
 	ERR_FAIL_COND_V_MSG(err, err, "Failed to parse GDScript with GDScriptParser.");
 
 	GDScriptAnalyzer analyzer(&parser);


### PR DESCRIPTION


Previously, it would fail with the error "Class "<class>" hides a global script class"

Original error at line: 

https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript_analyzer.cpp#L364

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
