### PR TITLE
Fix tooltip content being cut off at some display scales

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1501,6 +1501,7 @@ void Viewport::_gui_show_tooltip() {
 		r.size *= win_scale;
 		vr = window->get_usable_parent_rect();
 	}
+	r.size = r.size.ceil();
 	r.size = r.size.min(panel->get_max_size());
 
 	if (r.size.x + r.position.x > vr.size.x + vr.position.x) {


### PR DESCRIPTION
When getting the minimum size for a tooltip, we get the value as a `Vector2`.  `Window::set_size()` takes a `Vector2i`, so this size was getting truncated.  At certain display scales, this could be enough to cut off part of the tooltip.  Updated to call `Vector2::ceil()` to round up before calling `Window::set_size()`

Fixes #91958

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
