### PR TITLE
Fix `Window.wrap_controls` does not account for the `content_scale_factor`

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1602,7 +1602,7 @@ Size2 Window::_get_contents_minimum_size() const {
 		}
 	}
 
-	return max;
+	return max * content_scale_factor;
 }
 
 void Window::child_controls_changed() {


### PR DESCRIPTION
### Previously

`wrap_controls` allows a window to self-determine its best minimum size for displaying its children Controls, however, such calculation forgot to include the `content_scale_factor`, which leads the window too big (if the scale factor is less than one) or too small (if the scale factor is larger than one) for its `content_scale_factor` applied children.

https://github.com/godotengine/godot/assets/71481700/107aac42-9d17-469e-a605-bbea91124e08

### In this PR

I multiplied the results of the `Window::_get_contents_minimum_size()` with `content_scale_factor`, which results in the correct size.

https://github.com/godotengine/godot/assets/71481700/9e3bf86d-f724-459f-97da-022862019203

Closes #91960 