### PR TITLE
Skip unnecessary updates to scene groups and scripts

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -197,6 +197,7 @@ class EditorFileSystem : public Node {
 	};
 
 	HashMap<String, FileCache> file_cache;
+	HashSet<String> dep_update_list;
 
 	struct ScanProgress {
 		float low = 0;


### PR DESCRIPTION
Fixes #91418

Projects have `filesystem_update4` file that gets populated with paths to every scene/resource you have saved in your editor session. According to a comment, it's required to update dependencies when editor is restarted. I did not question that (but IMO it's sus), however it causes the project opening to be much slower the longer you were editing your project (as more files are saved and stored in that file).

The problem was that this caused not only file rescan, but also update of scene groups in affected scenes, which is pointless. When a file gets updated from update4, it's safe to assume that non-dependency cache is up-to-date, because the file was already cached - we just force some FileSystem update. Thus my fix just skips unnecessary updates of files from update4 list. This includes scene group cache and script update.

I also fixed a bug where update4 file was not getting removed, which made the issue appear on every rescan. Also, apparently checking that file on every rescan is wrong, so I fixed it too.