### PR TITLE
Fix ContextMenu `Copy Error` is off in `MSBuild` Panel

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
@@ -280,7 +280,7 @@ namespace GodotTools.Build
 
             if (_problemsContextMenu.ItemCount > 0)
             {
-                _problemsContextMenu.Position = (Vector2I)(_problemsTree.GlobalPosition + position);
+                _problemsContextMenu.Position = (Vector2I)(GetScreenPosition() + position);
                 _problemsContextMenu.Popup();
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/91995

The fix is to do the same thing that is also done for basically every other `Popup` ContextMenu in Godot.
That is to get the screen position of the `Control` and add the mouse position to it.

![image](https://github.com/godotengine/godot/assets/66004280/f136169e-a9a6-4d9e-a0bc-87ea42c3cf2c)
