### PR TITLE
Increase coverage of VRAM debugger and add support to RD backends

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1391,7 +1391,7 @@ void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
 		tinfo.format = t->format;
 		tinfo.width = t->alloc_width;
 		tinfo.height = t->alloc_height;
-		tinfo.depth = 0;
+		tinfo.depth = t->depth;
 		tinfo.bytes = t->total_data_size;
 		r_info->push_back(tinfo);
 	}

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -119,6 +119,7 @@ void NoiseTexture2D::_set_texture_image(const Ref<Image> &p_image) {
 		} else {
 			texture = RS::get_singleton()->texture_2d_create(p_image);
 		}
+		RS::get_singleton()->texture_set_path(texture, get_path());
 	}
 	emit_changed();
 }

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -137,6 +137,7 @@ void GradientTexture1D::_update() {
 			texture = RS::get_singleton()->texture_2d_create(image);
 		}
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 }
 
 void GradientTexture1D::set_width(int p_width) {
@@ -276,6 +277,7 @@ void GradientTexture2D::_update() {
 	} else {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 }
 
 float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1457,6 +1457,23 @@ void TextureStorage::texture_set_detect_roughness_callback(RID p_texture, RS::Te
 }
 
 void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
+	List<RID> textures;
+	texture_owner.get_owned_list(&textures);
+
+	for (List<RID>::Element *E = textures.front(); E; E = E->next()) {
+		Texture *t = texture_owner.get_or_null(E->get());
+		if (!t) {
+			continue;
+		}
+		RS::TextureInfo tinfo;
+		tinfo.path = t->path;
+		tinfo.format = t->format;
+		tinfo.width = t->width;
+		tinfo.height = t->height;
+		tinfo.depth = t->depth;
+		tinfo.bytes = Image::get_image_data_size(t->width, t->height, t->format, t->mipmaps);
+		r_info->push_back(tinfo);
+	}
 }
 
 void TextureStorage::texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) {
@@ -3043,6 +3060,7 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 		texture_2d_placeholder_initialize(rt->texture);
 		Texture *tex = get_texture(rt->texture);
 		tex->is_render_target = true;
+		tex->path = "Render Target (Internal)";
 	}
 
 	_clear_render_target(rt);


### PR DESCRIPTION
This is the first step in improving the VRAM debugger. It was already working in the Compatibility renderer, but now it is supported in the RD renderers too. 

The system was only designed to cover RenderingServer::Texture so it misses a lot of internal resources (i.e. all internal textures used for 3D rendering, all buffers, meshes, etc.).

For now it makes sense to bring back basic support and then overhaul the debugger at a later date to include more information

<img width="889" alt="Screenshot 2024-05-15 at 4 28 52 PM" src="https://github.com/godotengine/godot/assets/16521339/8d4b5b73-feb2-4f3c-96f3-0c66a3835c8d">
