### PR TITLE
Core: Convert simple `math_funcs.h` functions to `constexpr`

### DIFF
--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -47,11 +47,11 @@ inline constexpr double INF = std::numeric_limits<double>::infinity();
 inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 } // namespace Math
 
-#define CMP_EPSILON 0.00001
-#define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
+inline constexpr double CMP_EPSILON = 0.00001;
+inline constexpr double CMP_EPSILON2 = CMP_EPSILON * CMP_EPSILON;
 
-#define CMP_NORMALIZE_TOLERANCE 0.000001
-#define CMP_POINT_IN_PLANE_EPSILON 0.00001
+inline constexpr double CMP_NORMALIZE_TOLERANCE = 0.000001;
+inline constexpr double CMP_POINT_IN_PLANE_EPSILON = 0.00001;
 
 #ifdef DEBUG_ENABLED
 #define MATH_CHECKS
@@ -59,10 +59,10 @@ inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 
 //this epsilon is for values related to a unit size (scalar or vector len)
 #ifdef PRECISE_MATH_CHECKS
-#define UNIT_EPSILON 0.00001
+inline constexpr double UNIT_EPSILON = 0.00001;
 #else
 //tolerate some more floating point error normally
-#define UNIT_EPSILON 0.001
+inline constexpr double UNIT_EPSILON = 0.001;
 #endif
 
 #define USEC_TO_SEC(m_usec) ((m_usec) / 1000000.0)

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -217,62 +217,60 @@ _ALWAYS_INLINE_ float exp(float p_x) {
 	return std::exp(p_x);
 }
 
-_ALWAYS_INLINE_ bool is_nan(double p_val) {
-	return std::isnan(p_val);
+constexpr double abs(double p_value) {
+	return p_value == 0 ? 0.0 : (p_value < 0 ? -p_value : p_value);
+}
+constexpr float abs(float p_value) {
+	return p_value == 0 ? 0.0 : (p_value < 0 ? -p_value : p_value);
+}
+constexpr int8_t abs(int8_t p_value) {
+	return p_value > 0 ? p_value : -p_value;
+}
+constexpr int16_t abs(int16_t p_value) {
+	return p_value > 0 ? p_value : -p_value;
+}
+constexpr int32_t abs(int32_t p_value) {
+	return p_value > 0 ? p_value : -p_value;
+}
+constexpr int64_t abs(int64_t p_value) {
+	return p_value > 0 ? p_value : -p_value;
 }
 
-_ALWAYS_INLINE_ bool is_nan(float p_val) {
-	return std::isnan(p_val);
+constexpr bool is_nan(double p_val) {
+	return p_val != p_val;
+}
+constexpr bool is_nan(float p_val) {
+	return p_val != p_val;
 }
 
-_ALWAYS_INLINE_ bool is_inf(double p_val) {
-	return std::isinf(p_val);
+constexpr bool is_inf(double p_val) {
+	return abs(p_val) == INF;
 }
-
-_ALWAYS_INLINE_ bool is_inf(float p_val) {
-	return std::isinf(p_val);
+constexpr bool is_inf(float p_val) {
+	return abs(p_val) == (float)INF;
 }
 
 // These methods assume (p_num + p_den) doesn't overflow.
-_ALWAYS_INLINE_ int32_t division_round_up(int32_t p_num, int32_t p_den) {
+constexpr int32_t division_round_up(int32_t p_num, int32_t p_den) {
 	int32_t offset = (p_num < 0 && p_den < 0) ? 1 : -1;
 	return (p_num + p_den + offset) / p_den;
 }
-_ALWAYS_INLINE_ uint32_t division_round_up(uint32_t p_num, uint32_t p_den) {
+constexpr uint32_t division_round_up(uint32_t p_num, uint32_t p_den) {
 	return (p_num + p_den - 1) / p_den;
 }
-_ALWAYS_INLINE_ int64_t division_round_up(int64_t p_num, int64_t p_den) {
+constexpr int64_t division_round_up(int64_t p_num, int64_t p_den) {
 	int32_t offset = (p_num < 0 && p_den < 0) ? 1 : -1;
 	return (p_num + p_den + offset) / p_den;
 }
-_ALWAYS_INLINE_ uint64_t division_round_up(uint64_t p_num, uint64_t p_den) {
+constexpr uint64_t division_round_up(uint64_t p_num, uint64_t p_den) {
 	return (p_num + p_den - 1) / p_den;
 }
 
-_ALWAYS_INLINE_ bool is_finite(double p_val) {
-	return std::isfinite(p_val);
+constexpr bool is_finite(double p_val) {
+	return !is_nan(p_val) && !is_inf(p_val);
 }
-_ALWAYS_INLINE_ bool is_finite(float p_val) {
-	return std::isfinite(p_val);
-}
-
-_ALWAYS_INLINE_ double abs(double p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ float abs(float p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ int8_t abs(int8_t p_value) {
-	return p_value > 0 ? p_value : -p_value;
-}
-_ALWAYS_INLINE_ int16_t abs(int16_t p_value) {
-	return p_value > 0 ? p_value : -p_value;
-}
-_ALWAYS_INLINE_ int32_t abs(int32_t p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ int64_t abs(int64_t p_value) {
-	return std::abs(p_value);
+constexpr bool is_finite(float p_val) {
+	return !is_nan(p_val) && !is_inf(p_val);
 }
 
 _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
@@ -318,35 +316,35 @@ _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
 	return value;
 }
 
-_ALWAYS_INLINE_ double deg_to_rad(double p_y) {
+constexpr double deg_to_rad(double p_y) {
 	return p_y * (PI / 180.0);
 }
-_ALWAYS_INLINE_ float deg_to_rad(float p_y) {
+constexpr float deg_to_rad(float p_y) {
 	return p_y * ((float)PI / 180.0f);
 }
 
-_ALWAYS_INLINE_ double rad_to_deg(double p_y) {
+constexpr double rad_to_deg(double p_y) {
 	return p_y * (180.0 / PI);
 }
-_ALWAYS_INLINE_ float rad_to_deg(float p_y) {
+constexpr float rad_to_deg(float p_y) {
 	return p_y * (180.0f / (float)PI);
 }
 
-_ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) {
+constexpr double lerp(double p_from, double p_to, double p_weight) {
 	return p_from + (p_to - p_from) * p_weight;
 }
-_ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) {
+constexpr float lerp(float p_from, float p_to, float p_weight) {
 	return p_from + (p_to - p_from) * p_weight;
 }
 
-_ALWAYS_INLINE_ double cubic_interpolate(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
+constexpr double cubic_interpolate(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
 	return 0.5 *
 			((p_from * 2.0) +
 					(-p_pre + p_to) * p_weight +
 					(2.0 * p_pre - 5.0 * p_from + 4.0 * p_to - p_post) * (p_weight * p_weight) +
 					(-p_pre + 3.0 * p_from - 3.0 * p_to + p_post) * (p_weight * p_weight * p_weight));
 }
-_ALWAYS_INLINE_ float cubic_interpolate(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
+constexpr float cubic_interpolate(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
 	return 0.5f *
 			((p_from * 2.0f) +
 					(-p_pre + p_to) * p_weight +
@@ -384,7 +382,7 @@ _ALWAYS_INLINE_ float cubic_interpolate_angle(float p_from, float p_to, float p_
 	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
 }
 
-_ALWAYS_INLINE_ double cubic_interpolate_in_time(double p_from, double p_to, double p_pre, double p_post, double p_weight,
+constexpr double cubic_interpolate_in_time(double p_from, double p_to, double p_pre, double p_post, double p_weight,
 		double p_to_t, double p_pre_t, double p_post_t) {
 	/* Barry-Goldman method */
 	double t = lerp(0.0, p_to_t, p_weight);
@@ -395,7 +393,7 @@ _ALWAYS_INLINE_ double cubic_interpolate_in_time(double p_from, double p_to, dou
 	double b2 = lerp(a2, a3, p_post_t == 0 ? 1.0 : t / p_post_t);
 	return lerp(b1, b2, p_to_t == 0 ? 0.5 : t / p_to_t);
 }
-_ALWAYS_INLINE_ float cubic_interpolate_in_time(float p_from, float p_to, float p_pre, float p_post, float p_weight,
+constexpr float cubic_interpolate_in_time(float p_from, float p_to, float p_pre, float p_post, float p_weight,
 		float p_to_t, float p_pre_t, float p_post_t) {
 	/* Barry-Goldman method */
 	float t = lerp(0.0f, p_to_t, p_weight);
@@ -438,7 +436,7 @@ _ALWAYS_INLINE_ float cubic_interpolate_angle_in_time(float p_from, float p_to, 
 	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
 }
 
-_ALWAYS_INLINE_ double bezier_interpolate(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
+constexpr double bezier_interpolate(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
 	/* Formula from Wikipedia article on Bezier curves. */
 	double omt = (1.0 - p_t);
 	double omt2 = omt * omt;
@@ -448,7 +446,7 @@ _ALWAYS_INLINE_ double bezier_interpolate(double p_start, double p_control_1, do
 
 	return p_start * omt3 + p_control_1 * omt2 * p_t * 3.0 + p_control_2 * omt * t2 * 3.0 + p_end * t3;
 }
-_ALWAYS_INLINE_ float bezier_interpolate(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
+constexpr float bezier_interpolate(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
 	/* Formula from Wikipedia article on Bezier curves. */
 	float omt = (1.0f - p_t);
 	float omt2 = omt * omt;
@@ -459,7 +457,7 @@ _ALWAYS_INLINE_ float bezier_interpolate(float p_start, float p_control_1, float
 	return p_start * omt3 + p_control_1 * omt2 * p_t * 3.0f + p_control_2 * omt * t2 * 3.0f + p_end * t3;
 }
 
-_ALWAYS_INLINE_ double bezier_derivative(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
+constexpr double bezier_derivative(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
 	/* Formula from Wikipedia article on Bezier curves. */
 	double omt = (1.0 - p_t);
 	double omt2 = omt * omt;
@@ -468,7 +466,7 @@ _ALWAYS_INLINE_ double bezier_derivative(double p_start, double p_control_1, dou
 	double d = (p_control_1 - p_start) * 3.0 * omt2 + (p_control_2 - p_control_1) * 6.0 * omt * p_t + (p_end - p_control_2) * 3.0 * t2;
 	return d;
 }
-_ALWAYS_INLINE_ float bezier_derivative(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
+constexpr float bezier_derivative(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
 	/* Formula from Wikipedia article on Bezier curves. */
 	float omt = (1.0f - p_t);
 	float omt2 = omt * omt;
@@ -494,21 +492,21 @@ _ALWAYS_INLINE_ float lerp_angle(float p_from, float p_to, float p_weight) {
 	return p_from + angle_difference(p_from, p_to) * p_weight;
 }
 
-_ALWAYS_INLINE_ double inverse_lerp(double p_from, double p_to, double p_value) {
+constexpr double inverse_lerp(double p_from, double p_to, double p_value) {
 	return (p_value - p_from) / (p_to - p_from);
 }
-_ALWAYS_INLINE_ float inverse_lerp(float p_from, float p_to, float p_value) {
+constexpr float inverse_lerp(float p_from, float p_to, float p_value) {
 	return (p_value - p_from) / (p_to - p_from);
 }
 
-_ALWAYS_INLINE_ double remap(double p_value, double p_istart, double p_istop, double p_ostart, double p_ostop) {
+constexpr double remap(double p_value, double p_istart, double p_istop, double p_ostart, double p_ostop) {
 	return lerp(p_ostart, p_ostop, inverse_lerp(p_istart, p_istop, p_value));
 }
-_ALWAYS_INLINE_ float remap(float p_value, float p_istart, float p_istop, float p_ostart, float p_ostop) {
+constexpr float remap(float p_value, float p_istart, float p_istop, float p_ostart, float p_ostop) {
 	return lerp(p_ostart, p_ostop, inverse_lerp(p_istart, p_istop, p_value));
 }
 
-_ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right, double p_tolerance) {
+constexpr bool is_equal_approx(double p_left, double p_right, double p_tolerance) {
 	// Check for exact equality first, required to handle "infinity" values.
 	if (p_left == p_right) {
 		return true;
@@ -516,7 +514,7 @@ _ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right, double p_tol
 	// Then check for approximate equality.
 	return abs(p_left - p_right) < p_tolerance;
 }
-_ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right, float p_tolerance) {
+constexpr bool is_equal_approx(float p_left, float p_right, float p_tolerance) {
 	// Check for exact equality first, required to handle "infinity" values.
 	if (p_left == p_right) {
 		return true;
@@ -525,7 +523,7 @@ _ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right, float p_tolera
 	return abs(p_left - p_right) < p_tolerance;
 }
 
-_ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right) {
+constexpr bool is_equal_approx(double p_left, double p_right) {
 	// Check for exact equality first, required to handle "infinity" values.
 	if (p_left == p_right) {
 		return true;
@@ -537,7 +535,7 @@ _ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right) {
 	}
 	return abs(p_left - p_right) < tolerance;
 }
-_ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right) {
+constexpr bool is_equal_approx(float p_left, float p_right) {
 	// Check for exact equality first, required to handle "infinity" values.
 	if (p_left == p_right) {
 		return true;
@@ -550,21 +548,21 @@ _ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right) {
 	return abs(p_left - p_right) < tolerance;
 }
 
-_ALWAYS_INLINE_ bool is_zero_approx(double p_value) {
+constexpr bool is_zero_approx(double p_value) {
 	return abs(p_value) < CMP_EPSILON;
 }
-_ALWAYS_INLINE_ bool is_zero_approx(float p_value) {
+constexpr bool is_zero_approx(float p_value) {
 	return abs(p_value) < (float)CMP_EPSILON;
 }
 
-_ALWAYS_INLINE_ bool is_same(double p_left, double p_right) {
+constexpr bool is_same(double p_left, double p_right) {
 	return (p_left == p_right) || (is_nan(p_left) && is_nan(p_right));
 }
-_ALWAYS_INLINE_ bool is_same(float p_left, float p_right) {
+constexpr bool is_same(float p_left, float p_right) {
 	return (p_left == p_right) || (is_nan(p_left) && is_nan(p_right));
 }
 
-_ALWAYS_INLINE_ double smoothstep(double p_from, double p_to, double p_s) {
+constexpr double smoothstep(double p_from, double p_to, double p_s) {
 	if (is_equal_approx(p_from, p_to)) {
 		if (likely(p_from <= p_to)) {
 			return p_s <= p_from ? 0.0 : 1.0;
@@ -575,7 +573,7 @@ _ALWAYS_INLINE_ double smoothstep(double p_from, double p_to, double p_s) {
 	double s = CLAMP((p_s - p_from) / (p_to - p_from), 0.0, 1.0);
 	return s * s * (3.0 - 2.0 * s);
 }
-_ALWAYS_INLINE_ float smoothstep(float p_from, float p_to, float p_s) {
+constexpr float smoothstep(float p_from, float p_to, float p_s) {
 	if (is_equal_approx(p_from, p_to)) {
 		if (likely(p_from <= p_to)) {
 			return p_s <= p_from ? 0.0f : 1.0f;
@@ -587,10 +585,10 @@ _ALWAYS_INLINE_ float smoothstep(float p_from, float p_to, float p_s) {
 	return s * s * (3.0f - 2.0f * s);
 }
 
-_ALWAYS_INLINE_ double move_toward(double p_from, double p_to, double p_delta) {
+constexpr double move_toward(double p_from, double p_to, double p_delta) {
 	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
 }
-_ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) {
+constexpr float move_toward(float p_from, float p_to, float p_delta) {
 	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
 }
 
@@ -651,7 +649,7 @@ _ALWAYS_INLINE_ float wrapf(float p_value, float p_min, float p_max) {
 	return result;
 }
 
-_ALWAYS_INLINE_ int64_t wrapi(int64_t p_value, int64_t p_min, int64_t p_max) {
+constexpr int64_t wrapi(int64_t p_value, int64_t p_min, int64_t p_max) {
 	int64_t range = p_max - p_min;
 	return range == 0 ? p_min : p_min + ((((p_value - p_min) % range) + range) % range);
 }
@@ -699,15 +697,12 @@ _ALWAYS_INLINE_ int fast_ftoi(float p_value) {
 	return std::rint(p_value);
 }
 
-_ALWAYS_INLINE_ uint32_t halfbits_to_floatbits(uint16_t p_half) {
-	uint16_t h_exp, h_sig;
-	uint32_t f_sgn, f_exp, f_sig;
-
-	h_exp = (p_half & 0x7c00u);
-	f_sgn = ((uint32_t)p_half & 0x8000u) << 16;
+constexpr uint32_t halfbits_to_floatbits(uint16_t p_half) {
+	uint16_t h_exp = (p_half & 0x7c00u);
+	uint32_t f_sgn = ((uint32_t)p_half & 0x8000u) << 16;
 	switch (h_exp) {
-		case 0x0000u: /* 0 or subnormal */
-			h_sig = (p_half & 0x03ffu);
+		case 0x0000u: { /* 0 or subnormal */
+			uint16_t h_sig = (p_half & 0x03ffu);
 			/* Signed zero */
 			if (h_sig == 0) {
 				return f_sgn;
@@ -718,9 +713,10 @@ _ALWAYS_INLINE_ uint32_t halfbits_to_floatbits(uint16_t p_half) {
 				h_sig <<= 1;
 				h_exp++;
 			}
-			f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
-			f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+			uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+			uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
 			return f_sgn + f_exp + f_sig;
+		} break;
 		case 0x7c00u: /* inf or NaN */
 			/* All-ones exponent and a copy of the significand */
 			return f_sgn + 0x7f800000u + (((uint32_t)(p_half & 0x03ffu)) << 13);

--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -36,65 +36,66 @@ TEST_FORCE_LINK(test_math_funcs)
 namespace TestMathFuncs {
 
 TEST_CASE("[Math] C++ macros") {
-	CHECK(MIN(-2, 2) == -2);
-	CHECK(MIN(600, 2) == 2);
+	static_assert(MIN(-2, 2) == -2);
+	static_assert(MIN(600, 2) == 2);
 
-	CHECK(MAX(-2, 2) == 2);
-	CHECK(MAX(600, 2) == 600);
+	static_assert(MAX(-2, 2) == 2);
+	static_assert(MAX(600, 2) == 600);
 
-	CHECK(CLAMP(600, -2, 2) == 2);
-	CHECK(CLAMP(620, 600, 650) == 620);
+	static_assert(CLAMP(600, -2, 2) == 2);
+	static_assert(CLAMP(620, 600, 650) == 620);
 	// `max` is lower than `min`.
-	CHECK(CLAMP(620, 600, 50) == 50);
+	static_assert(CLAMP(620, 600, 50) == 50);
 
-	CHECK(Math::abs(-5) == 5);
-	CHECK(Math::abs(0) == 0);
-	CHECK(Math::abs(5) == 5);
+	static_assert(Math::abs(-5) == 5);
+	static_assert(Math::abs(0) == 0);
+	static_assert(Math::abs(5) == 5);
 
-	CHECK(SIGN(-5) == -1.0);
-	CHECK(SIGN(0) == 0.0);
-	CHECK(SIGN(5) == 1.0);
+	static_assert(SIGN(-5) == -1.0);
+	static_assert(SIGN(0) == 0.0);
+	static_assert(SIGN(5) == 1.0);
 	// Check that SIGN(Math::NaN) returns 0.0.
+	// FIXME: `static_assert` fails on some compilers, substitute with normal `CHECK` instead.
 	CHECK(SIGN(Math::NaN) == 0.0);
 }
 
 TEST_CASE("[Math] Power of two functions") {
-	CHECK(Math::next_power_of_2((uint32_t)0) == 0);
-	CHECK(Math::next_power_of_2((uint32_t)1) == 1);
-	CHECK(Math::next_power_of_2((uint32_t)16) == 16);
-	CHECK(Math::next_power_of_2((uint32_t)17) == 32);
-	CHECK(Math::next_power_of_2((uint32_t)65535) == 65536);
+	static_assert(Math::next_power_of_2((uint32_t)0) == 0);
+	static_assert(Math::next_power_of_2((uint32_t)1) == 1);
+	static_assert(Math::next_power_of_2((uint32_t)16) == 16);
+	static_assert(Math::next_power_of_2((uint32_t)17) == 32);
+	static_assert(Math::next_power_of_2((uint32_t)65535) == 65536);
 
-	CHECK(Math::previous_power_of_2((uint32_t)0) == 0);
-	CHECK(Math::previous_power_of_2((uint32_t)1) == 1);
-	CHECK(Math::previous_power_of_2((uint32_t)16) == 16);
-	CHECK(Math::previous_power_of_2((uint32_t)17) == 16);
-	CHECK(Math::previous_power_of_2((uint32_t)65535) == 32768);
+	static_assert(Math::previous_power_of_2((uint32_t)0) == 0);
+	static_assert(Math::previous_power_of_2((uint32_t)1) == 1);
+	static_assert(Math::previous_power_of_2((uint32_t)16) == 16);
+	static_assert(Math::previous_power_of_2((uint32_t)17) == 16);
+	static_assert(Math::previous_power_of_2((uint32_t)65535) == 32768);
 
-	CHECK(Math::closest_power_of_2((uint32_t)0) == 0);
-	CHECK(Math::closest_power_of_2((uint32_t)1) == 1);
-	CHECK(Math::closest_power_of_2((uint32_t)16) == 16);
-	CHECK(Math::closest_power_of_2((uint32_t)17) == 16);
-	CHECK(Math::closest_power_of_2((uint32_t)65535) == 65536);
+	static_assert(Math::closest_power_of_2((uint32_t)0) == 0);
+	static_assert(Math::closest_power_of_2((uint32_t)1) == 1);
+	static_assert(Math::closest_power_of_2((uint32_t)16) == 16);
+	static_assert(Math::closest_power_of_2((uint32_t)17) == 16);
+	static_assert(Math::closest_power_of_2((uint32_t)65535) == 65536);
 
-	CHECK(Math::get_shift_from_power_of_2((uint32_t)0) == -1);
-	CHECK(Math::get_shift_from_power_of_2((uint32_t)1) == 0);
-	CHECK(Math::get_shift_from_power_of_2((uint32_t)16) == 4);
-	CHECK(Math::get_shift_from_power_of_2((uint32_t)17) == -1);
-	CHECK(Math::get_shift_from_power_of_2((uint32_t)65535) == -1);
+	static_assert(Math::get_shift_from_power_of_2((uint32_t)0) == -1);
+	static_assert(Math::get_shift_from_power_of_2((uint32_t)1) == 0);
+	static_assert(Math::get_shift_from_power_of_2((uint32_t)16) == 4);
+	static_assert(Math::get_shift_from_power_of_2((uint32_t)17) == -1);
+	static_assert(Math::get_shift_from_power_of_2((uint32_t)65535) == -1);
 
-	CHECK(Math::nearest_shift((uint32_t)0) == 0);
-	CHECK(Math::nearest_shift((uint32_t)1) == 1);
-	CHECK(Math::nearest_shift((uint32_t)16) == 5);
-	CHECK(Math::nearest_shift((uint32_t)17) == 5);
-	CHECK(Math::nearest_shift((uint32_t)65535) == 16);
+	static_assert(Math::nearest_shift((uint32_t)0) == 0);
+	static_assert(Math::nearest_shift((uint32_t)1) == 1);
+	static_assert(Math::nearest_shift((uint32_t)16) == 5);
+	static_assert(Math::nearest_shift((uint32_t)17) == 5);
+	static_assert(Math::nearest_shift((uint32_t)65535) == 16);
 }
 
 TEST_CASE_TEMPLATE("[Math] abs", T, int, float, double) {
-	CHECK(Math::abs((T)-1) == (T)1);
-	CHECK(Math::abs((T)0) == (T)0);
-	CHECK(Math::abs((T)1) == (T)1);
-	CHECK(Math::abs((T)0.1) == (T)0.1);
+	static_assert(Math::abs((T)-1) == (T)1);
+	static_assert(Math::abs((T)0) == (T)0);
+	static_assert(Math::abs((T)1) == (T)1);
+	static_assert(Math::abs((T)0.1) == (T)0.1);
 }
 
 TEST_CASE_TEMPLATE("[Math] round/floor/ceil", T, float, double) {
@@ -111,26 +112,26 @@ TEST_CASE_TEMPLATE("[Math] round/floor/ceil", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] integer division round up unsigned", T, uint32_t, uint64_t) {
-	CHECK(Math::division_round_up((T)0, (T)64) == 0);
-	CHECK(Math::division_round_up((T)1, (T)64) == 1);
-	CHECK(Math::division_round_up((T)63, (T)64) == 1);
-	CHECK(Math::division_round_up((T)64, (T)64) == 1);
-	CHECK(Math::division_round_up((T)65, (T)64) == 2);
-	CHECK(Math::division_round_up((T)65, (T)1) == 65);
+	static_assert(Math::division_round_up((T)0, (T)64) == 0);
+	static_assert(Math::division_round_up((T)1, (T)64) == 1);
+	static_assert(Math::division_round_up((T)63, (T)64) == 1);
+	static_assert(Math::division_round_up((T)64, (T)64) == 1);
+	static_assert(Math::division_round_up((T)65, (T)64) == 2);
+	static_assert(Math::division_round_up((T)65, (T)1) == 65);
 }
 
 TEST_CASE_TEMPLATE("[Math] integer division round up signed", T, int32_t, int64_t) {
-	CHECK(Math::division_round_up((T)0, (T)64) == 0);
-	CHECK(Math::division_round_up((T)1, (T)64) == 1);
-	CHECK(Math::division_round_up((T)63, (T)64) == 1);
-	CHECK(Math::division_round_up((T)64, (T)64) == 1);
-	CHECK(Math::division_round_up((T)65, (T)64) == 2);
-	CHECK(Math::division_round_up((T)65, (T)1) == 65);
-	CHECK(Math::division_round_up((T)-1, (T)64) == 0);
-	CHECK(Math::division_round_up((T)-1, (T)-1) == 1);
-	CHECK(Math::division_round_up((T)-1, (T)1) == -1);
-	CHECK(Math::division_round_up((T)-1, (T)-2) == 1);
-	CHECK(Math::division_round_up((T)-4, (T)-2) == 2);
+	static_assert(Math::division_round_up((T)0, (T)64) == 0);
+	static_assert(Math::division_round_up((T)1, (T)64) == 1);
+	static_assert(Math::division_round_up((T)63, (T)64) == 1);
+	static_assert(Math::division_round_up((T)64, (T)64) == 1);
+	static_assert(Math::division_round_up((T)65, (T)64) == 2);
+	static_assert(Math::division_round_up((T)65, (T)1) == 65);
+	static_assert(Math::division_round_up((T)-1, (T)64) == 0);
+	static_assert(Math::division_round_up((T)-1, (T)-1) == 1);
+	static_assert(Math::division_round_up((T)-1, (T)1) == -1);
+	static_assert(Math::division_round_up((T)-1, (T)-2) == 1);
+	static_assert(Math::division_round_up((T)-4, (T)-2) == 2);
 }
 
 TEST_CASE_TEMPLATE("[Math] sin/cos/tan", T, float, double) {
@@ -290,12 +291,24 @@ TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
 	CHECK(Math::sqrt((T)1.5) == doctest::Approx((T)1.224745));
 }
 
-TEST_CASE_TEMPLATE("[Math] is_nan/is_inf", T, float, double) {
-	CHECK(!Math::is_nan((T)0.0));
-	CHECK(Math::is_nan((T)Math::NaN));
+TEST_CASE_TEMPLATE("[Math] is_nan/is_inf/is_finite", T, float, double) {
+	static_assert(!Math::is_nan((T)0.0));
+	static_assert(!Math::is_nan((T)CMP_EPSILON));
+	static_assert(!Math::is_nan((T)Math::INF));
+	static_assert(!Math::is_nan((T)-Math::INF));
+	static_assert(Math::is_nan((T)Math::NaN));
 
-	CHECK(!Math::is_inf((T)0.0));
-	CHECK(Math::is_inf((T)Math::INF));
+	static_assert(!Math::is_inf((T)0.0));
+	static_assert(!Math::is_inf((T)CMP_EPSILON));
+	static_assert(Math::is_inf((T)Math::INF));
+	static_assert(Math::is_inf((T)-Math::INF));
+	static_assert(!Math::is_inf((T)Math::NaN));
+
+	static_assert(Math::is_finite((T)0.0));
+	static_assert(Math::is_finite((T)CMP_EPSILON));
+	static_assert(!Math::is_finite((T)Math::INF));
+	static_assert(!Math::is_finite((T)-Math::INF));
+	static_assert(!Math::is_finite((T)Math::NaN));
 }
 
 TEST_CASE_TEMPLATE("[Math] linear_to_db", T, float, double) {
@@ -338,49 +351,69 @@ TEST_CASE_TEMPLATE("[Math] range_step_decimals", T, float, double) {
 	CHECK(Math::range_step_decimals((T)-0.5) == 16);
 }
 
-TEST_CASE_TEMPLATE("[Math] lerp", T, float, double) {
-	CHECK(Math::lerp((T)2.0, (T)5.0, (T)-0.1) == doctest::Approx((T)1.7));
-	CHECK(Math::lerp((T)2.0, (T)5.0, (T)0.0) == doctest::Approx((T)2.0));
-	CHECK(Math::lerp((T)2.0, (T)5.0, (T)0.1) == doctest::Approx((T)2.3));
-	CHECK(Math::lerp((T)2.0, (T)5.0, (T)1.0) == doctest::Approx((T)5.0));
-	CHECK(Math::lerp((T)2.0, (T)5.0, (T)2.0) == doctest::Approx((T)8.0));
+TEST_CASE_TEMPLATE("[Math] is_equal_approx", T, float, double) {
+	static_assert(Math::is_equal_approx((T)2.0, (T)2.0));
+	static_assert(Math::is_equal_approx((T)2.0, (T)2.0 + (T)CMP_EPSILON));
+	static_assert(!Math::is_equal_approx((T)2.0, (T)2.0 + (T)CMP_EPSILON + (T)CMP_EPSILON));
 
-	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)-0.1) == doctest::Approx((T)-1.7));
-	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)0.0) == doctest::Approx((T)-2.0));
-	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)0.1) == doctest::Approx((T)-2.3));
-	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)1.0) == doctest::Approx((T)-5.0));
-	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)2.0) == doctest::Approx((T)-8.0));
+	static_assert(Math::is_equal_approx((T)-2.0, (T)-2.0));
+	static_assert(Math::is_equal_approx((T)-2.0, (T)-2.0 - (T)CMP_EPSILON));
+	static_assert(!Math::is_equal_approx((T)-2.0, (T)-2.0 - (T)CMP_EPSILON - (T)CMP_EPSILON));
+}
+
+TEST_CASE_TEMPLATE("[Math] is_zero_approx", T, float, double) {
+	static_assert(Math::is_zero_approx((T)0.0));
+	static_assert(Math::is_zero_approx((T)0.0 + ((T)CMP_EPSILON / 2)));
+	static_assert(!Math::is_zero_approx((T)0.0 + (T)CMP_EPSILON));
+
+	static_assert(Math::is_zero_approx((T)-0.0));
+	static_assert(Math::is_zero_approx((T)-0.0 - ((T)CMP_EPSILON / 2)));
+	static_assert(!Math::is_zero_approx((T)-0.0 - (T)-CMP_EPSILON));
+}
+
+TEST_CASE_TEMPLATE("[Math] lerp", T, float, double) {
+	static_assert(Math::is_equal_approx(Math::lerp((T)2.0, (T)5.0, (T)-0.1), (T)1.7));
+	static_assert(Math::is_equal_approx(Math::lerp((T)2.0, (T)5.0, (T)0.0), (T)2.0));
+	static_assert(Math::is_equal_approx(Math::lerp((T)2.0, (T)5.0, (T)0.1), (T)2.3));
+	static_assert(Math::is_equal_approx(Math::lerp((T)2.0, (T)5.0, (T)1.0), (T)5.0));
+	static_assert(Math::is_equal_approx(Math::lerp((T)2.0, (T)5.0, (T)2.0), (T)8.0));
+
+	static_assert(Math::is_equal_approx(Math::lerp((T)-2.0, (T)-5.0, (T)-0.1), (T)-1.7));
+	static_assert(Math::is_equal_approx(Math::lerp((T)-2.0, (T)-5.0, (T)0.0), (T)-2.0));
+	static_assert(Math::is_equal_approx(Math::lerp((T)-2.0, (T)-5.0, (T)0.1), (T)-2.3));
+	static_assert(Math::is_equal_approx(Math::lerp((T)-2.0, (T)-5.0, (T)1.0), (T)-5.0));
+	static_assert(Math::is_equal_approx(Math::lerp((T)-2.0, (T)-5.0, (T)2.0), (T)-8.0));
 }
 
 TEST_CASE_TEMPLATE("[Math] inverse_lerp", T, float, double) {
-	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)1.7) == doctest::Approx((T)-0.1));
-	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.0) == doctest::Approx((T)0.0));
-	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.3) == doctest::Approx((T)0.1));
-	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)5.0) == doctest::Approx((T)1.0));
-	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)8.0) == doctest::Approx((T)2.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)2.0, (T)5.0, (T)1.7), (T)-0.1));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.3), (T)0.1));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)2.0, (T)5.0, (T)5.0), (T)1.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)2.0, (T)5.0, (T)8.0), (T)2.0));
 
-	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-1.7) == doctest::Approx((T)-0.1));
-	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.0) == doctest::Approx((T)0.0));
-	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.3) == doctest::Approx((T)0.1));
-	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-5.0) == doctest::Approx((T)1.0));
-	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-8.0) == doctest::Approx((T)2.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-1.7), (T)-0.1));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.3), (T)0.1));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-5.0), (T)1.0));
+	static_assert(Math::is_equal_approx(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-8.0), (T)2.0));
 }
 
 TEST_CASE_TEMPLATE("[Math] remap", T, float, double) {
-	CHECK(Math::remap((T)50.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)-500.0));
-	CHECK(Math::remap((T)100.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)0.0));
-	CHECK(Math::remap((T)200.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1000.0));
-	CHECK(Math::remap((T)250.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)50.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0), (T)-500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)100.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)200.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0), (T)1000.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)250.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0), (T)1500.0));
 
-	CHECK(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)-500.0));
-	CHECK(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)0.0));
-	CHECK(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1000.0));
-	CHECK(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0), (T)-500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0), (T)1000.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0), (T)1500.0));
 
-	CHECK(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)500.0));
-	CHECK(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)0.0));
-	CHECK(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1000.0));
-	CHECK(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0), (T)500.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0), (T)-1000.0));
+	static_assert(Math::is_equal_approx(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0), (T)-1500.0));
 
 	// Note: undefined behavior can happen when `p_istart == p_istop`. We don't bother testing this as it will
 	// vary between hardware and compilers properly implementing IEEE 754.
@@ -554,10 +587,10 @@ TEST_CASE("[Math] posmod") {
 }
 
 TEST_CASE("[Math] wrapi") {
-	CHECK(Math::wrapi(-30, -20, 160) == 150);
-	CHECK(Math::wrapi(30, -20, 160) == 30);
-	CHECK(Math::wrapi(300, -20, 160) == 120);
-	CHECK(Math::wrapi(300'000'000'000, -20, 160) == 120);
+	static_assert(Math::wrapi(-30, -20, 160) == 150);
+	static_assert(Math::wrapi(30, -20, 160) == 30);
+	static_assert(Math::wrapi(300, -20, 160) == 120);
+	static_assert(Math::wrapi(300'000'000'000, -20, 160) == 120);
 }
 
 TEST_CASE_TEMPLATE("[Math] wrapf", T, float, double) {
@@ -586,25 +619,25 @@ TEST_CASE_TEMPLATE("[Math] pingpong", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] deg_to_rad/rad_to_deg", T, float, double) {
-	CHECK(Math::deg_to_rad((T)180.0) == doctest::Approx((T)Math::PI));
-	CHECK(Math::deg_to_rad((T)-27.0) == doctest::Approx((T)-0.471239));
+	static_assert(Math::is_equal_approx(Math::deg_to_rad((T)180.0), (T)Math::PI));
+	static_assert(Math::is_equal_approx(Math::deg_to_rad((T)-27.0), (T)-0.471239));
 
-	CHECK(Math::rad_to_deg((T)Math::PI) == doctest::Approx((T)180.0));
-	CHECK(Math::rad_to_deg((T)-1.5) == doctest::Approx((T)-85.94366927));
+	static_assert(Math::is_equal_approx(Math::rad_to_deg((T)Math::PI), (T)180.0));
+	static_assert(Math::is_equal_approx(Math::rad_to_deg((T)-1.5), (T)-85.94366927));
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate", T, float, double) {
-	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0) == doctest::Approx((T)0.2));
-	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25) == doctest::Approx((T)0.33125));
-	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5) == doctest::Approx((T)0.5));
-	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75) == doctest::Approx((T)0.66875));
-	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0) == doctest::Approx((T)0.8));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0), (T)0.2));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25), (T)0.33125));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5), (T)0.5));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75), (T)0.66875));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0), (T)0.8));
 
-	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-50.0) == doctest::Approx((T)-6662732.3));
-	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-5.0) == doctest::Approx((T)-9356.3));
-	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)0.0) == doctest::Approx((T)20.2));
-	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)1.0) == doctest::Approx((T)30.1));
-	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)4.0) == doctest::Approx((T)1853.2));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-50.0), (T)-6662732.3));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-5.0), (T)-9356.3));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)0.0), (T)20.2));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)1.0), (T)30.1));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)4.0), (T)1853.2));
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle", T, float, double) {
@@ -616,11 +649,11 @@ TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_in_time", T, float, double) {
-	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.0));
-	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.1625));
-	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.4));
-	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.6375));
-	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.8));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0, (T)0.5, (T)0.0, (T)1.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25, (T)0.5, (T)0.0, (T)1.0), (T)0.1625));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5, (T)0.5, (T)0.0, (T)1.0), (T)0.4));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75, (T)0.5, (T)0.0, (T)1.0), (T)0.6375));
+	static_assert(Math::is_equal_approx(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0, (T)0.5, (T)0.0, (T)1.0), (T)0.8));
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle_in_time", T, float, double) {
@@ -632,11 +665,11 @@ TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle_in_time", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {
-	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.0) == doctest::Approx((T)0.0));
-	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.25) == doctest::Approx((T)0.2125));
-	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.5) == doctest::Approx((T)0.5));
-	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.75) == doctest::Approx((T)0.7875));
-	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0) == doctest::Approx((T)1.0));
+	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.0), (T)0.0));
+	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.25), (T)0.2125));
+	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.5), (T)0.5));
+	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.75), (T)0.7875));
+	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0), (T)1.0));
 }
 
 } // namespace TestMathFuncs


### PR DESCRIPTION
Depends on #90499

Takes a handful of the `math_funcs` functions & converts them to `constexpr` equivalents. The majority were able to be converted over with no further changes, while some were refactored to take advantage of the above `math_defs.h` PR. Intended to be as non-disruptive as possible to the existing codebase, excluding the 4 refactored funcs (`is_inf`, `is_nan`, `is_finite`, `abs`); no other extraneous variables or functions were modified whatsoever.

_Bugsquad edit: Closes https://github.com/godotengine/godot/issues/118097_