### PR TITLE
Improve button min. size calculation.

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -50,6 +50,83 @@ void Button::_set_internal_margin(Side p_side, float p_value) {
 void Button::_queue_update_size_cache() {
 }
 
+void Button::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	const bool rtl = is_layout_rtl();
+	if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
+		theme_cache.max_style_size = theme_cache.normal_mirrored->get_minimum_size();
+		theme_cache.style_margin_left = theme_cache.normal_mirrored->get_margin(SIDE_LEFT);
+		theme_cache.style_margin_right = theme_cache.normal_mirrored->get_margin(SIDE_RIGHT);
+		theme_cache.style_margin_top = theme_cache.normal_mirrored->get_margin(SIDE_TOP);
+		theme_cache.style_margin_bottom = theme_cache.normal_mirrored->get_margin(SIDE_BOTTOM);
+	} else {
+		theme_cache.max_style_size = theme_cache.normal->get_minimum_size();
+		theme_cache.style_margin_left = theme_cache.normal->get_margin(SIDE_LEFT);
+		theme_cache.style_margin_right = theme_cache.normal->get_margin(SIDE_RIGHT);
+		theme_cache.style_margin_top = theme_cache.normal->get_margin(SIDE_TOP);
+		theme_cache.style_margin_bottom = theme_cache.normal->get_margin(SIDE_BOTTOM);
+	}
+	if (has_theme_stylebox("hover_pressed")) {
+		if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
+			theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.hover_pressed_mirrored->get_minimum_size());
+			theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.hover_pressed_mirrored->get_margin(SIDE_LEFT));
+			theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.hover_pressed_mirrored->get_margin(SIDE_RIGHT));
+			theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.hover_pressed_mirrored->get_margin(SIDE_TOP));
+			theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.hover_pressed_mirrored->get_margin(SIDE_BOTTOM));
+		} else {
+			theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.hover_pressed->get_minimum_size());
+			theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.hover_pressed->get_margin(SIDE_LEFT));
+			theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.hover_pressed->get_margin(SIDE_RIGHT));
+			theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.hover_pressed->get_margin(SIDE_TOP));
+			theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.hover_pressed->get_margin(SIDE_BOTTOM));
+		}
+	}
+	if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.pressed_mirrored->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.pressed_mirrored->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.pressed_mirrored->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.pressed_mirrored->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.pressed_mirrored->get_margin(SIDE_BOTTOM));
+	} else {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.pressed->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.pressed->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.pressed->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.pressed->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.pressed->get_margin(SIDE_BOTTOM));
+	}
+	if (rtl && has_theme_stylebox(SNAME("hover_mirrored"))) {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.hover_mirrored->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.hover_mirrored->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.hover_mirrored->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.hover_mirrored->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.hover_mirrored->get_margin(SIDE_BOTTOM));
+	} else {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.hover->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.hover->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.hover->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.hover->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.hover->get_margin(SIDE_BOTTOM));
+	}
+	if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.disabled_mirrored->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.disabled_mirrored->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.disabled_mirrored->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.disabled_mirrored->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.disabled_mirrored->get_margin(SIDE_BOTTOM));
+	} else {
+		theme_cache.max_style_size = theme_cache.max_style_size.max(theme_cache.disabled->get_minimum_size());
+		theme_cache.style_margin_left = MAX(theme_cache.style_margin_left, theme_cache.disabled->get_margin(SIDE_LEFT));
+		theme_cache.style_margin_right = MAX(theme_cache.style_margin_right, theme_cache.disabled->get_margin(SIDE_RIGHT));
+		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.disabled->get_margin(SIDE_TOP));
+		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.disabled->get_margin(SIDE_BOTTOM));
+	}
+}
+
+Size2 Button::_get_largest_stylebox_size() const {
+	return theme_cache.max_style_size;
+}
+
 Ref<StyleBox> Button::_get_current_stylebox() const {
 	Ref<StyleBox> stylebox = theme_cache.normal;
 	const bool rtl = is_layout_rtl();
@@ -137,16 +214,13 @@ void Button::_notification(int p_what) {
 			const RID ci = get_canvas_item();
 			const Size2 size = get_size();
 
-			const Ref<StyleBox> style = _get_current_stylebox();
-			{ // Draws the stylebox in the current state.
-				if (!flat) {
-					style->draw(ci, Rect2(Point2(), size));
-				}
+			// Draws the stylebox in the current state.
+			if (!flat) {
+				_get_current_stylebox()->draw(ci, Rect2(Point2(), size));
+			}
 
-				if (has_focus()) {
-					Ref<StyleBox> style2 = theme_cache.focus;
-					style2->draw(ci, Rect2(Point2(), size));
-				}
+			if (has_focus()) {
+				theme_cache.focus->draw(ci, Rect2(Point2(), size));
 			}
 
 			Ref<Texture2D> _icon = icon;
@@ -158,16 +232,11 @@ void Button::_notification(int p_what) {
 				break;
 			}
 
-			const float style_margin_left = style->get_margin(SIDE_LEFT);
-			const float style_margin_right = style->get_margin(SIDE_RIGHT);
-			const float style_margin_top = style->get_margin(SIDE_TOP);
-			const float style_margin_bottom = style->get_margin(SIDE_BOTTOM);
-
 			Size2 drawable_size_remained = size;
 
 			{ // The size after the stelybox is stripped.
-				drawable_size_remained.width -= style_margin_left + style_margin_right;
-				drawable_size_remained.height -= style_margin_top + style_margin_bottom;
+				drawable_size_remained.width -= theme_cache.style_margin_left + theme_cache.style_margin_right;
+				drawable_size_remained.height -= theme_cache.style_margin_top + theme_cache.style_margin_bottom;
 			}
 
 			const int h_separation = MAX(0, theme_cache.h_separation);
@@ -312,12 +381,12 @@ void Button::_notification(int p_what) {
 							[[fallthrough]];
 						case HORIZONTAL_ALIGNMENT_FILL:
 						case HORIZONTAL_ALIGNMENT_LEFT: {
-							icon_ofs.x += style_margin_left;
+							icon_ofs.x += theme_cache.style_margin_left;
 							icon_ofs.x += left_internal_margin_with_h_separation;
 						} break;
 
 						case HORIZONTAL_ALIGNMENT_RIGHT: {
-							icon_ofs.x = size.x - style_margin_right;
+							icon_ofs.x = size.x - theme_cache.style_margin_right;
 							icon_ofs.x -= right_internal_margin_with_h_separation;
 							icon_ofs.x -= icon_size.width;
 						} break;
@@ -330,11 +399,11 @@ void Button::_notification(int p_what) {
 							[[fallthrough]];
 						case VERTICAL_ALIGNMENT_FILL:
 						case VERTICAL_ALIGNMENT_TOP: {
-							icon_ofs.y += style_margin_top;
+							icon_ofs.y += theme_cache.style_margin_top;
 						} break;
 
 						case VERTICAL_ALIGNMENT_BOTTOM: {
-							icon_ofs.y = size.y - style_margin_bottom - icon_size.height;
+							icon_ofs.y = size.y - theme_cache.style_margin_bottom - icon_size.height;
 						} break;
 					}
 					icon_ofs = icon_ofs.floor();
@@ -373,7 +442,7 @@ void Button::_notification(int p_what) {
 					case HORIZONTAL_ALIGNMENT_FILL:
 					case HORIZONTAL_ALIGNMENT_LEFT:
 					case HORIZONTAL_ALIGNMENT_RIGHT: {
-						text_ofs.x += style_margin_left;
+						text_ofs.x += theme_cache.style_margin_left;
 						text_ofs.x += left_internal_margin_with_h_separation;
 						if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 							// Offset by the space's width that occupied by icon and h_separation together.
@@ -382,7 +451,7 @@ void Button::_notification(int p_what) {
 					} break;
 				}
 
-				text_ofs.y = (drawable_size_remained.height - text_buf->get_size().height) / 2.0f + style_margin_top;
+				text_ofs.y = (drawable_size_remained.height - text_buf->get_size().height) / 2.0f + theme_cache.style_margin_top;
 				if (vertical_icon_alignment == VERTICAL_ALIGNMENT_TOP) {
 					text_ofs.y += custom_element_size.height - drawable_size_remained.height; // Offset by the icon's height.
 				}
@@ -452,7 +521,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		}
 	}
 
-	return _get_current_stylebox()->get_minimum_size() + minsize;
+	return _get_largest_stylebox_size() + minsize;
 }
 
 void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -69,6 +69,12 @@ private:
 		Ref<StyleBox> disabled_mirrored;
 		Ref<StyleBox> focus;
 
+		Size2 max_style_size;
+		float style_margin_left = 0;
+		float style_margin_right = 0;
+		float style_margin_top = 0;
+		float style_margin_bottom = 0;
+
 		Color font_color;
 		Color font_focus_color;
 		Color font_pressed_color;
@@ -100,10 +106,13 @@ private:
 	void _texture_changed();
 
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _set_internal_margin(Side p_side, float p_value);
 	virtual void _queue_update_size_cache();
 
 	Ref<StyleBox> _get_current_stylebox() const;
+	Size2 _get_largest_stylebox_size() const;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -66,7 +66,7 @@ Size2 CheckBox::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
 	const Size2 tex_size = get_icon_size();
 	if (tex_size.width > 0 || tex_size.height > 0) {
-		const Size2 padding = _get_current_stylebox()->get_minimum_size();
+		const Size2 padding = _get_largest_stylebox_size();
 		Size2 content_size = minsize - padding;
 		if (content_size.width > 0 && tex_size.width > 0) {
 			content_size.width += MAX(0, theme_cache.h_separation);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -70,7 +70,7 @@ Size2 CheckButton::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
 	const Size2 tex_size = get_icon_size();
 	if (tex_size.width > 0 || tex_size.height > 0) {
-		const Size2 padding = _get_current_stylebox()->get_minimum_size();
+		const Size2 padding = _get_largest_stylebox_size();
 		Size2 content_size = minsize - padding;
 		if (content_size.width > 0 && tex_size.width > 0) {
 			content_size.width += MAX(0, theme_cache.h_separation);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -60,7 +60,7 @@ Size2 OptionButton::get_minimum_size() const {
 	}
 
 	if (has_theme_icon(SNAME("arrow"))) {
-		const Size2 padding = _get_current_stylebox()->get_minimum_size();
+		const Size2 padding = _get_largest_stylebox_size();
 		const Size2 arrow_size = theme_cache.arrow_icon->get_size();
 
 		Size2 content_size = minsize - padding;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91022

Changes button min. size calculation to take into account all stiles and use the largest possible margin. `_get_current_stylebox()` can't be used for the min. size calculation, since min. size is not recalculated on hover.