### PR TITLE
Skeleton rest fixer: Apply orthonormalized scale to anims

### DIFF
--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -204,7 +204,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 								} else {
 									for (int j = 0; j < key_len; j++) {
 										Basis sc = Basis().scaled(static_cast<Vector3>(anim->track_get_key_value(i, j)));
-										anim->track_set_key_value(i, j, (global_transform.basis * sc).get_scale());
+										anim->track_set_key_value(i, j, (global_transform.orthonormalized().basis * sc).get_scale());
 									}
 								}
 							}


### PR DESCRIPTION
Adjust the logic for position and scale animation tracks in the Apply Node Transforms case To match how we adjust bone pose/rest, use basis.orthonormalized() for parentless bones.

Fixes #91893 
Cc @TokageItLab @fire 