### PR TITLE
[CI] Fix for jsdoc hook in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,8 +125,18 @@ repos:
         language: node
         entry: jsdoc
         files: ^platform/web/js/engine/(engine|config|features)\.js$
-        args: [--template, platform/web/js/jsdoc2rst/, --destination, '', -d, dry-run]
-        additional_dependencies: ["jsdoc@4.0.2"]
+        args:
+          - --template
+          - platform/web/js/jsdoc2rst/
+          - platform/web/js/engine/engine.js
+          - platform/web/js/engine/config.js
+          - platform/web/js/engine/features.js
+          - --destination
+          - ''
+          - -d
+          - dry-run
+        pass_filenames: false
+        additional_dependencies: ['jsdoc@^4.0.3']
 
       - id: copyright-headers
         name: copyright-headers


### PR DESCRIPTION
# Info

This is a fix for `jsdoc` hook from https://github.com/godotengine/godot/pull/91597

Currently, the hooks in the pre-commit are only triggered if the specified files have been modified. In the case of the jsdoc hook, engine.js, config.js and features.js from the `platform/web/js/engine` directory are checked.

The problem is that jsdoc requires all these 3 files in the parameter line and not, as pre-commit does, only those that were modified in the commit.

When, for example, only `feature.js` is changed in a commit, an error will appear:

```
jsdoc....................................................................Failed
- hook id: jsdoc
- exit code: 1

[...]

Undefined symbol! Engine
/godot/platform/web/js/jsdoc2rst/publish.js:315
				throw new Error('Undefined symbol!');
				^

Error: Undefined symbol!
```

The solution is to permanently add the names of all 3 files to the argument line and disable the automatic addition of modified file names by pre-commit (`pass_filenames: false`).

```yaml
        args:
          - --template
          - platform/web/js/jsdoc2rst/
          - platform/web/js/engine/engine.js
          - platform/web/js/engine/config.js
          - platform/web/js/engine/features.js
          - --destination
          - ''
          - -d
          - dry-run
        pass_filenames: false
```