### PR TITLE
Allow selecting TileMapLayers by clicking them

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1829,6 +1829,12 @@ void TileMapLayer::_update_self_texture_repeat(RS::CanvasItemTextureRepeat p_tex
 	emit_signal(CoreStringName(changed));
 }
 
+#ifdef TOOLS_ENABLED
+bool TileMapLayer::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	return get_cell_source_id(local_to_map(p_point)) != TileSet::INVALID_SOURCE;
+}
+#endif
+
 void TileMapLayer::set_as_tile_map_internal_node(int p_index) {
 	// Compatibility with TileMap.
 	ERR_FAIL_NULL(get_parent());

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -386,6 +386,10 @@ protected:
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat) override;
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
+#endif
+
 	// TileMap node.
 	void set_as_tile_map_internal_node(int p_index);
 	int get_index_in_tile_map() const {


### PR DESCRIPTION
The new TileMapLayers introduced a workflow problem where selecting a layer for editing is more difficult, depending on scene layout. A common workflow is to put TileMapLayers under a single parent. To select a layer you need to first unfold the parent, which is less convenient. If TileMapLayers are under different parents (and the new system allows for some nice setups), finding the correct layer to edit is even more difficult.

This PR allows selecting a layer by clicking it.

https://github.com/godotengine/godot/assets/2223172/58d9edcf-cd62-4278-867c-615ce23b363f

Although I found a bug 🤔 When you close the bottom editor using shortcut after a layer was selected, it gets glued to the cursor.

https://github.com/godotengine/godot/assets/2223172/edbdceb0-11f2-4de9-98ad-031d1b75e33f
