### PR TITLE
Minor UI tweaks

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -435,7 +435,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/code_font_contextual_ligatures", 1, "Enabled,Disable Contextual Alternates (Coding Ligatures),Use Custom OpenType Feature Set")
 	_initial_set("interface/editor/code_font_custom_opentype_features", "");
 	_initial_set("interface/editor/code_font_custom_variations", "");
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/font_antialiasing", 1, "None,Grayscale,LCD Subpixel")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/font_antialiasing", 2, "None,Grayscale,LCD Subpixel")
 #ifdef MACOS_ENABLED
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/font_hinting", 0, "Auto (None),None,Light,Normal")
 #else

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -881,6 +881,7 @@ ProjectDialog::ProjectDialog() {
 	l->set_text(TTR("Renderer:"));
 	renderer_container->add_child(l);
 	HBoxContainer *rshc = memnew(HBoxContainer);
+	rshc->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	renderer_container->add_child(rshc);
 	renderer_button_group.instantiate();
 
@@ -952,6 +953,7 @@ ProjectDialog::ProjectDialog() {
 	renderer_container->add_child(l);
 
 	default_files_container = memnew(HBoxContainer);
+	default_files_container->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	vb->add_child(default_files_container);
 	l = memnew(Label);
 	l->set_text(TTR("Version Control Metadata:"));


### PR DESCRIPTION
1. Fix default font antialiasing method: Change the default antialiasing method to LCD subpixel, as the majority of users are not on HiDPI screens: [source](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam).

2. Fix create project dialog UI. Center some options to make the project creation dialog look more appealing.

## Before
![Screenshot 2024-05-16 201213](https://github.com/godotengine/godot/assets/33201674/6064e65a-4f67-4283-a764-85427f877c81)

## After
![Screenshot 2024-05-16 204641](https://github.com/godotengine/godot/assets/33201674/c905d113-7a41-4402-81df-0ca43a257318)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
