### PR TITLE
SCons: Minor fixes/adjustments for web compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -218,7 +218,7 @@ opts.Add(BoolVariable("brotli", "Enable Brotli for decompresson and WOFF2 fonts 
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add(BoolVariable("vulkan", "Enable the vulkan rendering driver", True))
 opts.Add(BoolVariable("opengl3", "Enable the OpenGL/GLES3 rendering driver", True))
-opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver (Windows only)", False))
+opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver", False))
 opts.Add(BoolVariable("openxr", "Enable the OpenXR driver", True))
 opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
 opts.Add(BoolVariable("disable_exceptions", "Force disabling exception handling code", True))

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3279,7 +3279,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 	if (p_paths.size() == 1) {
 		const String &fpath = p_paths[0];
 
-		bool added_separator = false;
+		[[maybe_unused]] bool added_separator = false;
 
 		if (favorites_list.has(fpath)) {
 			TreeItem *favorites_item = tree->get_root()->get_first_child();

--- a/methods.py
+++ b/methods.py
@@ -531,6 +531,7 @@ def no_verbose(env):
     link_shared_library_message = "{}Linking Shared Library {}$TARGET{} ...{}".format(*colors)
     java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(*colors)
     compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(*colors)
+    zip_archive_message = "{}Archiving {}$TARGET{} ...{}".format(*colors)
     generated_file_message = "{}Generating {}$TARGET{} ...{}".format(*colors)
 
     env["CXXCOMSTR"] = compile_source_message
@@ -544,6 +545,7 @@ def no_verbose(env):
     env["JARCOMSTR"] = java_library_message
     env["JAVACCOMSTR"] = java_compile_source_message
     env["RCCOMSTR"] = compiled_resource_message
+    env["ZIPCOMSTR"] = zip_archive_message
     env["GENCOMSTR"] = generated_file_message
 
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -181,7 +181,7 @@ def configure(env: "SConsEnvironment"):
     # Use TempFileMunge since some AR invocations are too long for cmd.exe.
     # Use POSIX-style paths, required with TempFileMunge.
     env["ARCOM_POSIX"] = env["ARCOM"].replace("$TARGET", "$TARGET.posix").replace("$SOURCES", "$SOURCES.posix")
-    env["ARCOM"] = "${TEMPFILE(ARCOM_POSIX)}"
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_POSIX','$ARCOMSTR')}"
 
     # All intermediate files are just object files.
     env["OBJPREFIX"] = ""

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -123,7 +123,6 @@ def create_template_zip(env, js, wasm, worker, side):
         zip_files,
         ZIPROOT=zip_dir,
         ZIPSUFFIX="${PROGSUFFIX}${ZIPSUFFIX}",
-        ZIPCOMSTR="Archiving $SOURCES as $TARGET",
     )
 
 


### PR DESCRIPTION
Implements a handful of tweaks with web platform builds in mind, particularly when compiling from Windows:
- ~~Warn if `d3d12` is used for non-windows platform & disable the option.~~ Outside of PR scope.
- Added a `[[maybe_unused]]` attribute for an argument that only has guaranteed use behind a conditional.
- Ensure `ARCOM_POSIX` uses `ARCOMSTR` for non-verbose output.
- Add `ZIPCOMSTR` to non-verbose outputs.