### PR TITLE
GDScript: Fix `STANDALONE_EXPRESSION` warning for `preload()`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -554,10 +554,10 @@
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when defining a local or subclass member variable that would shadow a variable that is inherited from a parent class.
 		</member>
 		<member name="debug/gdscript/warnings/standalone_expression" type="int" setter="" getter="" default="1">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling an expression that has no effect on the surrounding code, such as writing [code]2 + 2[/code] as a statement.
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling an expression that may have no effect on the surrounding code, such as writing [code]2 + 2[/code] as a statement.
 		</member>
 		<member name="debug/gdscript/warnings/standalone_ternary" type="int" setter="" getter="" default="1">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a ternary expression that has no effect on the surrounding code, such as writing [code]42 if active else 0[/code] as a statement.
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a ternary expression that may have no effect on the surrounding code, such as writing [code]42 if active else 0[/code] as a statement.
 		</member>
 		<member name="debug/gdscript/warnings/static_called_on_instance" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a static method from an instance of a class instead of from the class directly.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3394,6 +3394,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 
 #ifdef DEBUG_ENABLED
+		// FIXME: No warning for built-in constructors and utilities due to early return.
 		if (p_is_root && return_type.kind != GDScriptParser::DataType::UNRESOLVED && return_type.builtin_type != Variant::NIL &&
 				!(p_call->is_super && p_call->function_name == GDScriptLanguage::get_singleton()->strings._init)) {
 			parser->push_warning(p_call, GDScriptWarning::RETURN_VALUE_DISCARDED, p_call->function_name);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1877,6 +1877,10 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 					case Node::CALL:
 						// Fine.
 						break;
+					case Node::PRELOAD:
+						// `preload` is a function-like keyword.
+						push_warning(expression, GDScriptWarning::RETURN_VALUE_DISCARDED, "preload");
+						break;
 					case Node::LAMBDA:
 						// Standalone lambdas can't be used, so make this an error.
 						push_error("Standalone lambdas cannot be accessed. Consider assigning it to a variable.", expression);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -74,7 +74,7 @@ String GDScriptWarning::get_message() const {
 		case UNREACHABLE_PATTERN:
 			return "Unreachable pattern (pattern after wildcard or bind).";
 		case STANDALONE_EXPRESSION:
-			return "Standalone expression (the line has no effect).";
+			return "Standalone expression (the line may have no effect).";
 		case STANDALONE_TERNARY:
 			return "Standalone ternary operator: the return value is being discarded.";
 		case INCOMPATIBLE_TERNARY:

--- a/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.gd
@@ -4,3 +4,4 @@ func i_return_int() -> int:
 
 func test():
 	i_return_int()
+	preload("../../utils.notest.gd") # `preload` is a function-like keyword.

--- a/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
@@ -3,3 +3,7 @@ GDTEST_OK
 >> Line: 6
 >> RETURN_VALUE_DISCARDED
 >> The function "i_return_int()" returns a value that will be discarded if not used.
+>> WARNING
+>> Line: 7
+>> RETURN_VALUE_DISCARDED
+>> The function "preload()" returns a value that will be discarded if not used.

--- a/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.gd
@@ -6,3 +6,16 @@ func test():
 	Vector3.ZERO
 	[true, false]
 	float(125)
+	# The following statements should not produce `STANDALONE_EXPRESSION`:
+	var _a = 1
+	_a = 2 # Assignment is a local (or global) side effect.
+	@warning_ignore("redundant_await")
+	await 3 # The `await` operand is usually a coroutine or a signal.
+	absi(4) # A call (in general) can have side effects.
+	@warning_ignore("return_value_discarded")
+	preload("../../utils.notest.gd") # A static initializer may have side effects.
+	"""
+	Python-like "comment".
+	"""
+	@warning_ignore("standalone_ternary")
+	1 if 2 else 3 # Produces `STANDALONE_TERNARY` instead.

--- a/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.out
@@ -2,16 +2,16 @@ GDTEST_OK
 >> WARNING
 >> Line: 3
 >> STANDALONE_EXPRESSION
->> Standalone expression (the line has no effect).
+>> Standalone expression (the line may have no effect).
 >> WARNING
 >> Line: 4
 >> STANDALONE_EXPRESSION
->> Standalone expression (the line has no effect).
+>> Standalone expression (the line may have no effect).
 >> WARNING
 >> Line: 6
 >> STANDALONE_EXPRESSION
->> Standalone expression (the line has no effect).
+>> Standalone expression (the line may have no effect).
 >> WARNING
 >> Line: 7
 >> STANDALONE_EXPRESSION
->> Standalone expression (the line has no effect).
+>> Standalone expression (the line may have no effect).


### PR DESCRIPTION
* Fixes #92022.
* `preload()` is a function-like keyword. This is a different type of node, but we often expect the same behavior as from `CallNode`. For example `assert()` and `preload()` are listed in `@GDScript` functions.
* Instead, `RETURN_VALUE_DISCARDED` is now generated (which is disabled by default).
* Warning message changed: `the line has no effect` -> `the line may have no effect`. See also https://github.com/godotengine/godot/pull/83037#discussion_r1479339901.
* Added more tests.