### PR TITLE
Disable remote debug button when there are no runnable presets

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -35,7 +35,6 @@
 #include "editor/export/editor_export.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/resources/image_texture.h"
 
 void EditorRunNative::_notification(int p_what) {
 	switch (p_what) {
@@ -49,17 +48,26 @@ void EditorRunNative::_notification(int p_what) {
 			if (changed) {
 				PopupMenu *popup = remote_debug->get_popup();
 				popup->clear();
-				for (int i = 0; i < EditorExport::get_singleton()->get_export_platform_count(); i++) {
-					Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(i);
+				for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
+					Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_preset(i);
+					Ref<EditorExportPlatform> eep = preset->get_platform();
 					if (eep.is_null()) {
 						continue;
 					}
+					int platform_idx = -1;
+					for (int j = 0; j < EditorExport::get_singleton()->get_export_platform_count(); j++) {
+						if (eep->get_name() == EditorExport::get_singleton()->get_export_platform(j)->get_name()) {
+							platform_idx = j;
+						}
+					}
 					int dc = MIN(eep->get_options_count(), 9000);
-					if (dc > 0) {
+					bool needs_templates;
+					String error;
+					if (dc > 0 && preset->is_runnable() && eep->can_export(preset, error, needs_templates)) {
 						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
 						popup->set_item_disabled(-1, true);
 						for (int j = 0; j < dc; j++) {
-							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), 10000 * i + j);
+							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), 10000 * platform_idx + j);
 							popup->set_item_tooltip(-1, eep->get_option_tooltip(j));
 							popup->set_item_indent(-1, 2);
 						}

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -585,17 +585,20 @@ bool EditorExportPlatformWeb::poll_export() {
 		}
 	}
 
+	int prev = menu_options;
+	menu_options = preset.is_valid();
 	HTTPServerState prev_server_state = server_state;
 	server_state = HTTP_SERVER_STATE_OFF;
 	if (server->is_listening()) {
-		if (preset.is_null()) {
+		if (preset.is_null() || menu_options == 0) {
 			server->stop();
 		} else {
 			server_state = HTTP_SERVER_STATE_ON;
+			menu_options += 1;
 		}
 	}
 
-	return server_state != prev_server_state;
+	return server_state != prev_server_state || menu_options != prev;
 }
 
 Ref<ImageTexture> EditorExportPlatformWeb::get_option_icon(int p_index) const {

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -58,6 +58,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 	HTTPServerState server_state = HTTP_SERVER_STATE_OFF;
 
 	Ref<EditorHTTPServer> server;
+	int menu_options = 0;
 
 	String _get_template_name(bool p_extension, bool p_thread_support, bool p_debug) const {
 		String name = "web";


### PR DESCRIPTION
Fixes #91981

Instead of iterating over the platforms, I changed the code to iterate over the presets , and get the platform from there, while also checking that they are Runnable. So if there are no presets, nothing happens.

Also, once that's fixed, I found another bug, where the `Remote Debug` button does not update when a Web preset is added, modified, or deleted. That was due to the fact that the `poll_export` method does not check the validity of the preset options anymore. So I brought that back in `EditorExportPlatformWeb::poll_export()`