### PR TITLE
Add tab for custom nodes

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -38,6 +38,10 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
 
+class TabContainer;
+class JSON;
+class EditorChecklistDialog;
+
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
 
@@ -48,6 +52,8 @@ class CreateDialog : public ConfirmationDialog {
 	};
 
 	LineEdit *search_box = nullptr;
+	LineEdit *category_box = nullptr;
+	TabContainer *tabs = nullptr;
 	Tree *search_options = nullptr;
 
 	String base_type;
@@ -61,15 +67,19 @@ class CreateDialog : public ConfirmationDialog {
 	ItemList *recent = nullptr;
 	EditorHelpBit *help_bit = nullptr;
 
+	Button *add_category = nullptr;
+	Ref<JSON> json;
 	HashMap<String, TreeItem *> search_options_types;
 	HashMap<String, String> custom_type_parents;
 	HashMap<String, int> custom_type_indices;
 	List<StringName> type_list;
 	HashSet<StringName> type_blacklist;
 
+	EditorChecklistDialog *checklist_dialog = nullptr;
+
 	void _update_search();
 	bool _should_hide_type(const StringName &p_type) const;
-	void _add_type(const StringName &p_type, TypeCategory p_type_category);
+	void _add_type(const StringName &p_type, TypeCategory p_type_category, Tree *current_tree, Array current_metadata);
 	void _configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category);
 	float _score_type(const String &p_type, const String &p_search) const;
 	bool _is_type_preferred(const String &p_type) const;
@@ -81,12 +91,24 @@ class CreateDialog : public ConfirmationDialog {
 	void _text_changed(const String &p_newtext);
 	void select_type(const String &p_type, bool p_center_on_item = true);
 	void _item_selected();
+	void _custom_item_selected();
 	void _hide_requested();
 
 	void _confirmed();
+	void _custom_confirmed();
 	virtual void cancel_pressed() override;
 
 	void _favorite_toggled();
+
+	Variant _create_tab_metadata(const Dictionary &p_node_names = Dictionary()) const;
+	void _add_tab(const String &p_name, const Dictionary &p_node_names = Dictionary());
+	void _add_category_pressed();
+	void _add_node_pressed();
+	void _remove_node_pressed();
+	void _checklist_confirmed();
+	void _tab_changed(int p_idx);
+	void _tab_closed(int p_idx);
+	void _tab_rearranged(int p_idx_to);
 
 	void _history_selected(int p_idx);
 	void _favorite_selected();
@@ -99,13 +121,14 @@ class CreateDialog : public ConfirmationDialog {
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	bool _is_class_disabled_by_feature_profile(const StringName &p_class) const;
-	void _load_favorites_and_history();
+	void _load_favorites_and_history_and_tabs();
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 	void _save_and_update_favorite_list();
+	void _save_and_update_tabs();
 
 public:
 	Variant instantiate_selected();

--- a/editor/gui/editor_checklist_dialog.cpp
+++ b/editor/gui/editor_checklist_dialog.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  editor_checklist_dialog.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_checklist_dialog.h"
+
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/tree.h"
+
+void EditorChecklistDialog::_visibility_changed() {
+	if (!is_visible()) {
+		tree = nullptr;
+
+		int child_count = get_child_count(false);
+
+		while (--child_count > -1) {
+			get_child(child_count, false)->queue_free();
+		}
+	}
+}
+
+void EditorChecklistDialog::reload(Tree *p_tree, const String &p_title, const String &p_label_text) {
+	set_title(p_title);
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
+	vb->add_margin_child(p_label_text, p_tree, true);
+	tree = p_tree;
+}
+
+Vector<TreeItem*> EditorChecklistDialog::get_all_checked() const {
+	Vector<TreeItem *> result;
+
+	if (!tree || !tree->get_root()) {
+		return result;
+	}
+
+	Array stack;
+	stack.push_back(tree->get_root());
+
+	// Iterative DFS preorder traversal
+	while (!stack.is_empty()) {
+		TreeItem *item = Object::cast_to<TreeItem>(stack.pop_back());
+
+		if (item->is_checked(0)) {
+			result.append(item);
+		}
+
+		TypedArray<TreeItem> children = item->get_children();
+
+		for (int i = children.size() - 1; i > -1; --i) {
+			stack.push_back(item->get_child(i));
+		}
+	}
+
+	return result;
+}
+
+EditorChecklistDialog::EditorChecklistDialog() {
+	set_size(Size2(0, 400) * EDSCALE);
+
+	callable_mp((Object *)this, &Object::connect).bind("visibility_changed", callable_mp(this, &EditorChecklistDialog::_visibility_changed), Object::CONNECT_DEFERRED).call_deferred();
+}

--- a/editor/gui/editor_checklist_dialog.h
+++ b/editor/gui/editor_checklist_dialog.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  editor_checklist_dialog.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_CHECKLIST_DIALOG_H
+#define EDITOR_CHECKLIST_DIALOG_H
+
+#include "scene/gui/dialogs.h"
+
+class Tree;
+class TreeItem;
+
+class EditorChecklistDialog : public ConfirmationDialog {
+	GDCLASS(EditorChecklistDialog, ConfirmationDialog);
+
+	Tree *tree = nullptr;
+
+	void _visibility_changed();
+
+public:
+	void reload(Tree *p_tree, const String &p_title = TTR("Checklist"), const String &p_label_text = TTR("Select all that apply:"));
+
+	Vector<TreeItem *> get_all_checked() const;
+
+	EditorChecklistDialog();
+};
+
+#endif // EDITOR_CHECKLIST_DIALOG_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds a new tab dedicated to displaying the nodes accessible by the editor through "class_name" so as not to mix with the built-in nodes.

To avoid affecting the logic of the dialog, I copied the custom nodes to the new tab and hid them from the main tab.

![Example](https://github.com/godotengine/godot/assets/37383316/99cea013-7b7a-4c9e-983d-60f50d05d52a)
