### PR TITLE
SCons: Restore compatibility with SCons < 4.0.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -365,7 +365,7 @@ if env["platform"] in platform_opts:
         opts.Add(opt)
 
 # Update the environment to take platform-specific options into account.
-opts.Update(env, {**ARGUMENTS, **env})
+opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
 
 # Detect modules.
 modules_detected = OrderedDict()
@@ -425,7 +425,7 @@ for name, path in modules_detected.items():
 env.modules_detected = modules_detected
 
 # Update the environment again after all the module options are added.
-opts.Update(env, {**ARGUMENTS, **env})
+opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
 Help(opts.GenerateHelpText(env))
 
 # add default include paths


### PR DESCRIPTION
- Follow-up to #91792.
- Fixes #91986.

I'm not familiar with the Python semantics of `{**a, **b}` (I literally learned about it when working on #91792), but it seems like SCons Environment before 4.0.0 doesn't automatically expose its internal dictionary to this operator.

Calling `SubstitutionEnvironment.Dictionary()` explicitly seems to do the trick and it still works for the following versions I could test:
- 3.0.0
- 3.1.0
- 3.1.1
- 3.1.2
- 4.0.0
- 4.1.0
- 4.7.0

I couldn't test 3.0.x because this version requires the `imp` module, which has been removed in Python 3.12. I'll see if I can add a CI build using SCons 3.0.0 on Python 3.11 so we can properly test its support, until we eventually decide to bump our minimum required version.

*Edit:* I could test 3.0.0 in a `python:3.6` podman container, works fine with this PR.
*Edit 2:* On the other hand, testing on CI showed that SCons 3.0.0 still has breaking issues, so we're bumping the min version to ~3.1.0~ 3.1.2 in #92043.

CC @Repiteo @AThousandShips 