### PR TITLE
Fix Tree and FileSystemList edit popup double events and ESC behavior.

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -79,6 +79,15 @@ Control *FileSystemList::make_custom_tooltip(const String &p_text) const {
 }
 
 void FileSystemList::_line_editor_submit(const String &p_text) {
+	if (popup_edit_commited) {
+		return; // Already processed by _text_editor_popup_modal_close
+	}
+
+	if (popup_editor->get_hide_reason() == Popup::HIDE_REASON_CANCELED) {
+		return; // ESC pressed, app focus lost, or forced close from code.
+	}
+
+	popup_edit_commited = true; // End edit popup processing.
 	popup_editor->hide();
 
 	emit_signal(SNAME("item_edited"));
@@ -127,6 +136,7 @@ bool FileSystemList::edit_selected() {
 	line_editor->set_text(name);
 	line_editor->select(0, name.rfind("."));
 
+	popup_edit_commited = false; // Start edit popup processing.
 	popup_editor->popup();
 	popup_editor->child_controls_changed();
 	line_editor->grab_focus();
@@ -138,8 +148,12 @@ String FileSystemList::get_edit_text() {
 }
 
 void FileSystemList::_text_editor_popup_modal_close() {
+	if (popup_edit_commited) {
+		return; // Already processed by _text_editor_popup_modal_close
+	}
+
 	if (popup_editor->get_hide_reason() == Popup::HIDE_REASON_CANCELED) {
-		return;
+		return; // ESC pressed, app focus lost, or forced close from code.
 	}
 
 	_line_editor_submit(line_editor->get_text());

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -59,6 +59,7 @@ class FileSystemTree : public Tree {
 class FileSystemList : public ItemList {
 	GDCLASS(FileSystemList, ItemList);
 
+	bool popup_edit_commited = true;
 	VBoxContainer *popup_editor_vb = nullptr;
 	Popup *popup_editor = nullptr;
 	LineEdit *line_editor = nullptr;

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -37,6 +37,7 @@
 
 void Popup::_input_from_window(const Ref<InputEvent> &p_event) {
 	if (get_flag(FLAG_POPUP) && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+		hide_reason = HIDE_REASON_CANCELED; // ESC pressed, mark as canceled unconditionally.
 		_close_pressed();
 	}
 	Window::_input_from_window(p_event);
@@ -104,13 +105,18 @@ void Popup::_notification(int p_what) {
 
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			if (!is_in_edited_scene_root()) {
-				hide_reason = HIDE_REASON_UNFOCUSED;
+				if (hide_reason == HIDE_REASON_NONE) {
+					hide_reason = HIDE_REASON_UNFOCUSED;
+				}
 				_close_pressed();
 			}
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
 			if (!is_in_edited_scene_root() && get_flag(FLAG_POPUP)) {
+				if (hide_reason == HIDE_REASON_NONE) {
+					hide_reason = HIDE_REASON_UNFOCUSED;
+				}
 				_close_pressed();
 			}
 		} break;
@@ -119,7 +125,9 @@ void Popup::_notification(int p_what) {
 
 void Popup::_parent_focused() {
 	if (popped_up && get_flag(FLAG_POPUP)) {
-		hide_reason = HIDE_REASON_UNFOCUSED;
+		if (hide_reason == HIDE_REASON_NONE) {
+			hide_reason = HIDE_REASON_UNFOCUSED;
+		}
 		_close_pressed();
 	}
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -479,6 +479,7 @@ private:
 
 	VBoxContainer *popup_editor_vb = nullptr;
 
+	bool popup_edit_commited = true;
 	Popup *popup_editor = nullptr;
 	LineEdit *line_editor = nullptr;
 	TextEdit *text_editor = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/90473

Fixes canceling edit with ESC, popup behavior should now be (I have taken Finder file rename behavior as example, bot sure if all apps be the same):
- Pressing ESC cancels edit and closes the popup.
- Pressing Enter applies edit and closes the popup.
- Clicking outside popup (in the app or on the other app window) applies edit and closes the popup.

TODO - Testing:

- [x] Single window mode (should be the same on all platforms)
  - [x] On macOS
  - [x] On Windows
  - [x] Linux/X11
  - [x] Linux/Wayland
- [x] macOS
- [x] Linux/X11 on X11
- [x] Linux/X11 on Wayland
- [x] Windows
