### PR TITLE
SCons: Bump min version to 3.1.2, test it on CI with one Linux job

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -13,10 +13,10 @@ inputs:
   sconsflags:
     default: ""
   scons-cache:
-    description: The scons cache path.
+    description: The SCons cache path.
     default: "${{ github.workspace }}/.scons-cache/"
   scons-cache-limit:
-    description: The scons cache size limit.
+    description: The SCons cache size limit.
     # actions/cache has 10 GiB limit, and GitHub runners have a 14 GiB disk.
     # Limit to 7 GiB to avoid having the extracted cache fill the disk.
     default: 7168

--- a/.github/actions/godot-cache/action.yml
+++ b/.github/actions/godot-cache/action.yml
@@ -5,13 +5,13 @@ inputs:
     description: The cache base name (job name by default).
     default: "${{github.job}}"
   scons-cache:
-    description: The scons cache path.
+    description: The SCons cache path.
     default: "${{github.workspace}}/.scons-cache/"
 runs:
   using: "composite"
   steps:
-    # Upload cache on completion and check it out now
-    - name: Load .scons_cache directory
+    # Upload cache on completion and check it out now.
+    - name: Load SCons cache directory
       uses: actions/cache@v4
       with:
         path: ${{inputs.scons-cache}}

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -1,27 +1,30 @@
-name: Setup python and scons
-description: Setup python, install the pip version of scons.
+name: Setup Python and SCons
+description: Setup Python, install the pip version of SCons.
 inputs:
   python-version:
-    description: The python version to use.
+    description: The Python version to use.
     default: "3.x"
   python-arch:
-    description: The python architecture.
+    description: The Python architecture.
     default: "x64"
+  scons-version:
+    description: The SCons version to use.
+    default: "4.7.0"
 runs:
   using: "composite"
   steps:
-    # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
       uses: actions/setup-python@v5
       with:
-        # Semantic version range syntax or exact version of a Python version
+        # Semantic version range syntax or exact version of a Python version.
         python-version: ${{ inputs.python-version }}
-        # Optional - x64 or x86 architecture, defaults to x64
+        # Optional - x64 or x86 architecture, defaults to x64.
         architecture: ${{ inputs.python-arch }}
 
-    - name: Setup scons
+    - name: Setup SCons
       shell: bash
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install scons==4.7.0
+        python -m pip install wheel
+        python -m pip install scons==${{ inputs.scons-version }}
         scons --version

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/godot-cache
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       - name: Compilation (arm32)

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       # Checkout godot-cpp
@@ -47,7 +47,7 @@ jobs:
           cp -f godot-api/gdextension_interface.h godot-cpp/gdextension/
           cp -f godot-api/extension_api.json godot-cpp/gdextension/
 
-      # TODO: Add caching to the scons build and store it for CI via the godot-cache
+      # TODO: Add caching to the SCons build and store it for CI via the godot-cache
       # action.
 
       # Build godot-cpp test extension

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/godot-cache
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       - name: Compilation (arm64)

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -58,6 +58,8 @@ jobs:
             tests: true
             # Skip 2GiB artifact speeding up action.
             artifact: false
+            # Test our oldest supported SCons/Python versions on one arbitrary editor build.
+            legacy-scons: true
 
           - name: Editor with ThreadSanitizer (target=editor, tests=yes, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
@@ -115,8 +117,17 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
+        if: ${{ ! matrix.legacy-scons }}
         uses: ./.github/actions/godot-deps
+
+      - name: Setup Python and SCons (legacy versions)
+        if: ${{ matrix.legacy-scons }}
+        uses: ./.github/actions/godot-deps
+        with:
+          # Sync with Ensure*Version in SConstruct.
+          python-version: 3.6
+          scons-version: 3.1.2
 
       - name: Setup GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -43,7 +43,7 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       - name: Setup Vulkan SDK

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -58,7 +58,7 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       - name: Compilation

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -48,7 +48,7 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Setup python and scons
+      - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
       - name: Download Direct3D 12 SDK components

--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-EnsureSConsVersion(3, 0, 0)
+EnsureSConsVersion(3, 1, 2)
 EnsurePythonVersion(3, 6)
 
 # System


### PR DESCRIPTION
The min SCons version had to be bumped as SCons 3.0 before 3.0.3 seems broken (see below), and there's little gain from supporting 3.0.3-3.0.5.

3.1.2 is also the first version to avoid ambiguities between Python 2 and Python 3 usage, so we finally use it as the minimum baseline.
    
Also test against Python 3.6 which is also our minimum supported version.
This should help prevent regressions whenever we modernize the build scripts.

Also a bunch of cosmetic changes, got carried away :P

~This should fail initially because of #91986, so I will rebase after #92041 is merged.~
Confirmed, so #92041 is now included in this PR.

CC @Repiteo @AThousandShips 