### PR TITLE
Add context getter to RenderingDevice

### DIFF
--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -797,6 +797,8 @@ private:
 #endif
 
 public:
+	RenderingContextDriver *get_context_driver() const { return context; }
+
 	const RDD::Capabilities &get_device_capabilities() const { return driver->get_capabilities(); }
 
 	bool has_feature(const Features p_feature) const;


### PR DESCRIPTION
The classic equivalent was lost in the split of rendering architecture. It's still useful in cases where dealing directly with the driver is desirable.