### PR TITLE
Core: Add `constexpr` constructors to math structs

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -129,8 +129,8 @@ struct [[nodiscard]] AABB {
 
 	operator String() const;
 
-	_FORCE_INLINE_ AABB() {}
-	inline AABB(const Vector3 &p_pos, const Vector3 &p_size) :
+	constexpr AABB() {}
+	constexpr AABB(const Vector3 &p_pos, const Vector3 &p_size) :
 			position(p_pos),
 			size(p_size) {
 	}

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -53,6 +53,7 @@ static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear_to_db(AUDIO_PEAK_OFFSE
 struct AudioFrame {
 	// Left and right samples.
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			float left;
 			float right;
@@ -64,6 +65,7 @@ struct AudioFrame {
 		};
 #endif
 		float levels[2] = { 0.0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_ALWAYS_INLINE_ const float &operator[](int p_idx) const {
@@ -133,14 +135,12 @@ struct AudioFrame {
 		return res;
 	}
 
-	_ALWAYS_INLINE_ AudioFrame(float p_left, float p_right) {
-		left = p_left;
-		right = p_right;
-	}
-	_ALWAYS_INLINE_ AudioFrame(const AudioFrame &p_frame) {
-		left = p_frame.left;
-		right = p_frame.right;
-	}
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+	constexpr AudioFrame(float p_left, float p_right) :
+			left(p_left), right(p_right) {}
+	constexpr AudioFrame(const AudioFrame &p_frame) :
+			left(p_frame.left), right(p_frame.right) {}
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 	_ALWAYS_INLINE_ void operator=(const AudioFrame &p_frame) {
 		left = p_frame.left;
@@ -151,11 +151,12 @@ struct AudioFrame {
 		return Vector2(left, right);
 	}
 
-	_ALWAYS_INLINE_ AudioFrame(const Vector2 &p_v2) {
-		left = p_v2.x;
-		right = p_v2.y;
-	}
-	_ALWAYS_INLINE_ AudioFrame() {}
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+	constexpr AudioFrame(const Vector2 &p_v2) :
+			left(p_v2.x), right(p_v2.y) {}
+	constexpr AudioFrame() :
+			left(0), right(0) {}
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 _ALWAYS_INLINE_ AudioFrame operator*(float p_scalar, const AudioFrame &p_frame) {

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -204,9 +204,12 @@ struct [[nodiscard]] Basis {
 				rows[0].z * p_m[0].y + rows[1].z * p_m[1].y + rows[2].z * p_m[2].y,
 				rows[0].z * p_m[0].z + rows[1].z * p_m[1].z + rows[2].z * p_m[2].z);
 	}
-	Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) {
-		set(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	}
+	constexpr Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) :
+			rows{
+				{ p_xx, p_xy, p_xz },
+				{ p_yx, p_yy, p_yz },
+				{ p_zx, p_zy, p_zz },
+			} {}
 
 	void orthonormalize();
 	Basis orthonormalized() const;
@@ -230,11 +233,14 @@ struct [[nodiscard]] Basis {
 	Basis(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_angle, p_scale); }
 	static Basis from_scale(const Vector3 &p_scale);
 
-	_FORCE_INLINE_ Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) {
-		set_columns(p_x_axis, p_y_axis, p_z_axis);
-	}
+	constexpr Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) :
+			rows{
+				{ p_x_axis.x, p_y_axis.x, p_z_axis.x },
+				{ p_x_axis.y, p_y_axis.y, p_z_axis.y },
+				{ p_x_axis.z, p_y_axis.z, p_z_axis.z },
+			} {}
 
-	_FORCE_INLINE_ Basis() {}
+	constexpr Basis() {}
 
 private:
 	// Helper method.

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -435,8 +435,6 @@ private:
 			return;
 		}
 
-		BOUNDS bb;
-
 		typename BVHTREE_CLASS::CullParams params;
 
 		params.result_count_overall = 0;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -37,6 +37,7 @@ class String;
 
 struct [[nodiscard]] Color {
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			float r;
 			float g;
@@ -44,6 +45,7 @@ struct [[nodiscard]] Color {
 			float a;
 		};
 		float components[4] = { 0, 0, 0, 1.0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	uint32_t to_rgba32() const;
@@ -234,39 +236,29 @@ struct [[nodiscard]] Color {
 	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
 
-	_FORCE_INLINE_ Color() {}
+	constexpr Color() :
+			r(0), g(0), b(0), a(1) {}
 
 	/**
 	 * RGBA construct parameters.
 	 * Alpha is not optional as otherwise we can't bind the RGB version for scripting.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b, float p_a) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = p_a;
-	}
+	constexpr Color(float p_r, float p_g, float p_b, float p_a) :
+			r(p_r), g(p_g), b(p_b), a(p_a) {}
 
 	/**
 	 * RGB construct parameters.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = 1.0f;
-	}
+	constexpr Color(float p_r, float p_g, float p_b) :
+			r(p_r), g(p_g), b(p_b), a(1) {}
 
 	/**
 	 * Construct a Color from another Color, but with the specified alpha value.
 	 */
-	_FORCE_INLINE_ Color(const Color &p_c, float p_a) {
-		r = p_c.r;
-		g = p_c.g;
-		b = p_c.b;
-		a = p_a;
-	}
+	constexpr Color(const Color &p_c, float p_a) :
+			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
 
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 	Color(const String &p_code) {
 		if (html_is_valid(p_code)) {
 			*this = html(p_code);
@@ -279,6 +271,7 @@ struct [[nodiscard]] Color {
 		*this = Color(p_code);
 		a = p_a;
 	}
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 bool Color::operator<(const Color &p_color) const {

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -79,12 +79,9 @@ struct [[nodiscard]] Face3 {
 	_FORCE_INLINE_ bool intersects_aabb2(const AABB &p_aabb) const;
 	operator String() const;
 
-	inline Face3() {}
-	inline Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) {
-		vertex[0] = p_v1;
-		vertex[1] = p_v2;
-		vertex[2] = p_v3;
-	}
+	constexpr Face3() {}
+	constexpr Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) :
+			vertex{ p_v1, p_v2, p_v3 } {}
 };
 
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -80,12 +80,12 @@ struct [[nodiscard]] Plane {
 	_FORCE_INLINE_ bool operator!=(const Plane &p_plane) const;
 	operator String() const;
 
-	_FORCE_INLINE_ Plane() {}
-	_FORCE_INLINE_ Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
+	constexpr Plane() {}
+	constexpr Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
 			normal(p_a, p_b, p_c),
 			d(p_d) {}
 
-	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d = 0.0);
+	constexpr Plane(const Vector3 &p_normal, real_t p_d = 0.0);
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
@@ -104,7 +104,7 @@ bool Plane::has_point(const Vector3 &p_point, real_t p_tolerance) const {
 	return (dist <= p_tolerance);
 }
 
-Plane::Plane(const Vector3 &p_normal, real_t p_d) :
+constexpr Plane::Plane(const Vector3 &p_normal, real_t p_d) :
 		normal(p_normal),
 		d(p_d) {
 }

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -827,10 +827,6 @@ void Projection::flip_y() {
 	}
 }
 
-Projection::Projection() {
-	set_identity();
-}
-
 Projection Projection::operator*(const Projection &p_matrix) const {
 	Projection new_matrix;
 
@@ -1032,13 +1028,6 @@ Projection::operator Transform3D() const {
 	return tr;
 }
 
-Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) {
-	columns[0] = p_x;
-	columns[1] = p_y;
-	columns[2] = p_z;
-	columns[3] = p_w;
-}
-
 Projection::Projection(const Transform3D &p_transform) {
 	const Transform3D &tr = p_transform;
 	real_t *m = &columns[0][0];
@@ -1059,7 +1048,4 @@ Projection::Projection(const Transform3D &p_transform) {
 	m[13] = tr.origin.y;
 	m[14] = tr.origin.z;
 	m[15] = 1.0;
-}
-
-Projection::~Projection() {
 }

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -150,10 +150,16 @@ struct [[nodiscard]] Projection {
 
 	real_t get_lod_multiplier() const;
 
-	Projection();
-	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
+	constexpr Projection() :
+			columns{
+				{ 1, 0, 0, 0 },
+				{ 0, 1, 0, 0 },
+				{ 0, 0, 1, 0 },
+				{ 0, 0, 0, 1 },
+			} {}
+	constexpr Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) :
+			columns{ p_x, p_y, p_z, p_w } {}
 	Projection(const Transform3D &p_transform);
-	~Projection();
 };
 
 Vector3 Projection::xform(const Vector3 &p_vec3) const {

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -37,6 +37,7 @@
 
 struct [[nodiscard]] Quaternion {
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			real_t x;
 			real_t y;
@@ -44,6 +45,7 @@ struct [[nodiscard]] Quaternion {
 			real_t w;
 		};
 		real_t components[4] = { 0, 0, 0, 1.0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_idx) {
@@ -115,23 +117,16 @@ struct [[nodiscard]] Quaternion {
 
 	operator String() const;
 
-	_FORCE_INLINE_ Quaternion() {}
+	constexpr Quaternion() :
+			x(0), y(0), z(0), w(1) {}
 
-	_FORCE_INLINE_ Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
-			x(p_x),
-			y(p_y),
-			z(p_z),
-			w(p_w) {
-	}
+	constexpr Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 
 	Quaternion(const Vector3 &p_axis, real_t p_angle);
 
-	Quaternion(const Quaternion &p_q) :
-			x(p_q.x),
-			y(p_q.y),
-			z(p_q.z),
-			w(p_q.w) {
-	}
+	constexpr Quaternion(const Quaternion &p_q) :
+			x(p_q.x), y(p_q.y), z(p_q.z), w(p_q.w) {}
 
 	void operator=(const Quaternion &p_q) {
 		x = p_q.x;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -361,12 +361,12 @@ struct [[nodiscard]] Rect2 {
 	operator String() const;
 	operator Rect2i() const;
 
-	Rect2() {}
-	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
+	constexpr Rect2() {}
+	constexpr Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
 			position(Point2(p_x, p_y)),
 			size(Size2(p_width, p_height)) {
 	}
-	Rect2(const Point2 &p_pos, const Size2 &p_size) :
+	constexpr Rect2(const Point2 &p_pos, const Size2 &p_size) :
 			position(p_pos),
 			size(p_size) {
 	}

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -227,12 +227,12 @@ struct [[nodiscard]] Rect2i {
 	operator String() const;
 	operator Rect2() const;
 
-	Rect2i() {}
-	Rect2i(int p_x, int p_y, int p_width, int p_height) :
+	constexpr Rect2i() {}
+	constexpr Rect2i(int p_x, int p_y, int p_width, int p_height) :
 			position(Point2i(p_x, p_y)),
 			size(Size2i(p_width, p_height)) {
 	}
-	Rect2i(const Point2i &p_pos, const Size2i &p_size) :
+	constexpr Rect2i(const Point2i &p_pos, const Size2i &p_size) :
 			position(p_pos),
 			size(p_size) {
 	}

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -128,29 +128,26 @@ struct [[nodiscard]] Transform2D {
 
 	operator String() const;
 
-	Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) {
-		columns[0][0] = p_xx;
-		columns[0][1] = p_xy;
-		columns[1][0] = p_yx;
-		columns[1][1] = p_yy;
-		columns[2][0] = p_ox;
-		columns[2][1] = p_oy;
-	}
+	constexpr Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) :
+			columns{
+				{ p_xx, p_xy },
+				{ p_yx, p_yy },
+				{ p_ox, p_oy },
+			} {}
 
-	Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) {
-		columns[0] = p_x;
-		columns[1] = p_y;
-		columns[2] = p_origin;
-	}
+	constexpr Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) :
+			columns{ p_x, p_y, p_origin } {}
 
 	Transform2D(real_t p_rot, const Vector2 &p_pos);
 
 	Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos);
 
-	Transform2D() {
-		columns[0][0] = 1.0;
-		columns[1][1] = 1.0;
-	}
+	constexpr Transform2D() :
+			columns{
+				{ 1, 0 },
+				{ 0, 1 },
+				{ 0, 0 },
+			} {}
 };
 
 Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -225,20 +225,3 @@ Transform3D::operator String() const {
 			", Z: " + basis.get_column(2).operator String() +
 			", O: " + origin.operator String() + "]";
 }
-
-Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :
-		basis(p_basis),
-		origin(p_origin) {
-}
-
-Transform3D::Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
-		origin(p_origin) {
-	basis.set_column(0, p_x);
-	basis.set_column(1, p_y);
-	basis.set_column(2, p_z);
-}
-
-Transform3D::Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) {
-	basis = Basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	origin = Vector3(p_ox, p_oy, p_oz);
-}

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -124,10 +124,16 @@ struct [[nodiscard]] Transform3D {
 
 	operator String() const;
 
-	Transform3D() {}
-	Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3());
-	Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin);
-	Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz);
+	constexpr Transform3D() {}
+	constexpr Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3()) :
+			basis(p_basis),
+			origin(p_origin) {}
+	constexpr Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
+			basis(p_x, p_y, p_z),
+			origin(p_origin) {}
+	constexpr Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) :
+			basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz),
+			origin(p_ox, p_oy, p_oz) {}
 };
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -46,18 +46,19 @@ struct [[nodiscard]] Vector2 {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
-			union {
-				real_t x;
-				real_t width;
-			};
-			union {
-				real_t y;
-				real_t height;
-			};
+			real_t x;
+			real_t y;
+		};
+
+		struct {
+			real_t width;
+			real_t height;
 		};
 
 		real_t coord[2] = { 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
@@ -184,11 +185,12 @@ struct [[nodiscard]] Vector2 {
 	operator String() const;
 	operator Vector2i() const;
 
-	_FORCE_INLINE_ Vector2() {}
-	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+	constexpr Vector2() :
+			x(0), y(0) {}
+	constexpr Vector2(real_t p_x, real_t p_y) :
+			x(p_x), y(p_y) {}
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -46,18 +46,19 @@ struct [[nodiscard]] Vector2i {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
-			union {
-				int32_t x;
-				int32_t width;
-			};
-			union {
-				int32_t y;
-				int32_t height;
-			};
+			int32_t x;
+			int32_t y;
+		};
+
+		struct {
+			int32_t width;
+			int32_t height;
 		};
 
 		int32_t coord[2] = { 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
@@ -142,11 +143,12 @@ struct [[nodiscard]] Vector2i {
 	operator String() const;
 	operator Vector2() const;
 
-	inline Vector2i() {}
-	inline Vector2i(int32_t p_x, int32_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+	constexpr Vector2i() :
+			x(0), y(0) {}
+	constexpr Vector2i(int32_t p_x, int32_t p_y) :
+			x(p_x), y(p_y) {}
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -49,6 +49,7 @@ struct [[nodiscard]] Vector3 {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			real_t x;
 			real_t y;
@@ -56,6 +57,7 @@ struct [[nodiscard]] Vector3 {
 		};
 
 		real_t coord[3] = { 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
@@ -186,12 +188,10 @@ struct [[nodiscard]] Vector3 {
 	operator String() const;
 	operator Vector3i() const;
 
-	_FORCE_INLINE_ Vector3() {}
-	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3() :
+			x(0), y(0), z(0) {}
+	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :
+			x(p_x), y(p_y), z(p_z) {}
 };
 
 Vector3 Vector3::cross(const Vector3 &p_with) const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -47,6 +47,7 @@ struct [[nodiscard]] Vector3i {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			int32_t x;
 			int32_t y;
@@ -54,6 +55,7 @@ struct [[nodiscard]] Vector3i {
 		};
 
 		int32_t coord[3] = { 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
@@ -132,12 +134,10 @@ struct [[nodiscard]] Vector3i {
 	operator String() const;
 	operator Vector3() const;
 
-	_FORCE_INLINE_ Vector3i() {}
-	_FORCE_INLINE_ Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3i() :
+			x(0), y(0), z(0) {}
+	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
+			x(p_x), y(p_y), z(p_z) {}
 };
 
 int64_t Vector3i::length_squared() const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -49,6 +49,7 @@ struct [[nodiscard]] Vector4 {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			real_t x;
 			real_t y;
@@ -56,6 +57,7 @@ struct [[nodiscard]] Vector4 {
 			real_t w;
 		};
 		real_t coord[4] = { 0, 0, 0, 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
@@ -144,13 +146,10 @@ struct [[nodiscard]] Vector4 {
 	operator String() const;
 	operator Vector4i() const;
 
-	_FORCE_INLINE_ Vector4() {}
-	_FORCE_INLINE_ Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
+	constexpr Vector4() :
+			x(0), y(0), z(0), w(0) {}
+	constexpr Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -48,6 +48,7 @@ struct [[nodiscard]] Vector4i {
 	};
 
 	union {
+		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
 			int32_t x;
 			int32_t y;
@@ -56,6 +57,7 @@ struct [[nodiscard]] Vector4i {
 		};
 
 		int32_t coord[4] = { 0 };
+		// NOLINTEND(modernize-use-default-member-init)
 	};
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
@@ -134,14 +136,11 @@ struct [[nodiscard]] Vector4i {
 	operator String() const;
 	operator Vector4() const;
 
-	_FORCE_INLINE_ Vector4i() {}
+	constexpr Vector4i() :
+			x(0), y(0), z(0), w(0) {}
 	Vector4i(const Vector4 &p_vec4);
-	_FORCE_INLINE_ Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
+	constexpr Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
 
 int64_t Vector4i::length_squared() const {

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -208,7 +208,6 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) const {
 
 				Vector<float> ret;
 				ret.resize(16);
-				Transform3D tr;
 				// i wonder why collada matrices are transposed, given that's opposed to opengl..
 				ret.write[0] = interp.basis.rows[0][0];
 				ret.write[1] = interp.basis.rows[0][1];

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4826,7 +4826,6 @@ void CanvasItemEditor::_set_owner_for_node_and_children(Node *p_node, Node *p_ow
 }
 
 void CanvasItemEditor::_focus_selection(int p_op) {
-	Vector2 center(0.f, 0.f);
 	Rect2 rect;
 	int count = 0;
 

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -223,7 +223,6 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			Vector3 right, up;
 			Vector3 back(0, 0, -1.0);
-			Vector3 front(0, 0, 0);
 
 			if (aspect == Camera3D::KeepAspect::KEEP_WIDTH) {
 				right = Vector3(keep_size, 0, 0);

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -477,7 +477,7 @@ void Polygon3DEditor::_polygon_draw() {
 		va.resize(poly.size());
 		Vector3 *w = va.ptrw();
 		for (int i = 0; i < poly.size(); i++) {
-			Vector2 p, p2;
+			Vector2 p;
 			p = i == edited_point ? edited_point_pos : poly[i];
 
 			Vector3 point = Vector3(p.x, p.y, depth);

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -112,7 +112,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	}
 
 	Vector3 b1Axis1, b1Axis2, b1Axis3;
-	Vector3 b2Axis1, b2Axis2;
+	Vector3 b2Axis1;
 
 	b1Axis1 = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(0));
 	b2Axis1 = B->get_transform().basis.xform(m_rbBFrame.basis.get_column(0));

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -135,7 +135,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	// few things we need
 	Input *input = Input::get_singleton();
 	Vector3 down(0.0, -1.0, 0.0); // Down is Y negative
-	Vector3 north(0.0, 0.0, 1.0); // North is Z positive
+	//Vector3 north(0.0, 0.0, 1.0); // North is Z positive
 
 	// make copies of our inputs
 	bool has_grav = false;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2689,8 +2689,6 @@ Transform3D OpenXRAPI::transform_from_pose(const XrPosef &p_pose) {
 
 template <typename T>
 XRPose::TrackingConfidence _transform_from_location(const T &p_location, Transform3D &r_transform) {
-	Basis basis;
-	Vector3 origin;
 	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
 	const XrPosef &pose = p_location.pose;
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -79,7 +79,6 @@ enum StartupStep {
 
 static SafeNumeric<int> step; // Shared between UI and render threads
 
-static Size2 new_size;
 static Vector3 accelerometer;
 static Vector3 gravity;
 static Vector3 magnetometer;

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -534,7 +534,6 @@ void Label::_notification(int p_what) {
 
 			bool has_settings = settings.is_valid();
 
-			Size2 string_size;
 			Ref<StyleBox> style = theme_cache.normal_style;
 			Color font_color = has_settings ? settings->get_font_color() : theme_cache.font_color;
 			Color font_shadow_color = has_settings ? settings->get_shadow_color() : theme_cache.font_shadow_color;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -524,7 +524,6 @@ static void fill_bits(const BitMap *p_src, Ref<BitMap> &p_map, const Point2i &p_
 Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2i &p_rect, float p_epsilon) const {
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 
-	Point2i from;
 	Ref<BitMap> fill;
 	fill.instantiate();
 	fill->create(get_size());


### PR DESCRIPTION
Subsection of #91992

I quickly realized the scope of adding `constexpr` to math structs, even at a reduced scope, made for a pretty daunting and exhaustive changelog overall. So instead, this aims to be a *significantly* reduced version of the original commit by focusing **exclusively** on constructors. In the interest of keeping the changecount as low as possible, no attempts were made to reorganize the structs from how they are now. Absolutely *no* other functions were made `constexpr`; if a constructor relied on other functions in their constructors, they simply weren't converted.

The **only** changes outside of constructors were:
- Removing redundant variables (would cause warnings/errors in GCC).
- Removing Projection's empty destructor.
- Changing Vector2/Vector2i's union struct layout from 2 layers of nesting to 1 (intellisense throws a fit otherwise).
- Added `NOLINT` sections for `clang-tidy` to union struts (parsing logic gets confused otherwise).