### PR TITLE
Release Engine after unregistering GDExtensions

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4295,9 +4295,6 @@ void Main::cleanup(bool p_force) {
 	if (globals) {
 		memdelete(globals);
 	}
-	if (engine) {
-		memdelete(engine);
-	}
 
 	if (OS::get_singleton()->is_restart_on_exit_set()) {
 		//attempt to restart with arguments
@@ -4314,6 +4311,10 @@ void Main::cleanup(bool p_force) {
 	unregister_core_extensions();
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	unregister_core_types();
+
+	if (engine) {
+		memdelete(engine);
+	}
 
 	OS::get_singleton()->benchmark_end_measure("Shutdown", "Total");
 	OS::get_singleton()->benchmark_dump();


### PR DESCRIPTION
The Engine is used to retrieve singletons, and GDExtensions may try to retrieve a singleton (e.g.: `OS`) in their deinitialization.

**MRP**: [GDExtensionSingletonCrash.zip](https://github.com/user-attachments/files/15599010/GDExtensionSingletonCrash-master.zip)


The MRP shows the following errors and then crashes:

```
ERROR: Failed to retrieve non-existent singleton 'OS'.
   at: get_singleton_object (core/config/engine.cpp:294)
ERROR: Parameter "singleton_obj" is null.
   at: get_singleton (godot-cpp/gen/src/classes/os.cpp:47)
```