### PR TITLE
[3.x] Fix fragcolor write locations in scene shaders

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -2467,6 +2467,12 @@ FRAGMENT_SHADER_CODE
 	frag_color.rgb = mix(pow((frag_color.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), frag_color.rgb * (1.0 / 12.92), vec3(lessThan(frag_color.rgb, vec3(0.04045))));
 #endif
 
+	// Write to the final output once and only once.
+	// Use a temporary in the rest of the shader.
+	// This is for drivers that have a performance drop
+	// when the output is read during the shader.
+	gl_FragColor = frag_color;
+
 #else // not RENDER_DEPTH
 //depth render
 #ifdef USE_RGBA_SHADOWS
@@ -2474,10 +2480,8 @@ FRAGMENT_SHADER_CODE
 	highp float depth = ((position_interp.z / position_interp.w) + 1.0) * 0.5 + 0.0; // bias
 	highp vec4 comp = fract(depth * vec4(255.0 * 255.0 * 255.0, 255.0 * 255.0, 255.0, 1.0));
 	comp -= comp.xxyz * vec4(0.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
-	frag_color = comp;
+	gl_FragColor = comp;
 
 #endif
 #endif
-
-	gl_FragColor = frag_color;
 }

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2453,13 +2453,13 @@ FRAGMENT_SHADER_CODE
 #endif //ubershader-runtime
 #endif //SHADELESS //ubershader-runtime
 
+#endif //USE_MULTIPLE_RENDER_TARGETS //ubershader-runtime
+
 	// Write to the final output once and only once.
 	// Use a temporary in the rest of the shader.
 	// This is for drivers that have a performance drop
 	// when the output is read during the shader.
 	frag_color_final = frag_color;
-
-#endif //USE_MULTIPLE_RENDER_TARGETS //ubershader-runtime
 
 #endif //RENDER_DEPTH //ubershader-runtime
 }


### PR DESCRIPTION
This will need careful checking by @clayjohn as I'm not super familiar with all the parts of the scene shaders.

Fixes #91967

## Discussion
In retrospect, I'm not totally surprised I got these in slightly the wrong place, the `#ifdef` arrangements especially in the scene shaders are very difficult to follow (manually). I would welcome suggestions for glsl editor that will follow them sensibly, geany can identify from opening, but not from closing. Other than that I'm relying on `find_in_files`.

What makes things particularly difficult is that the comments in the scene shaders appear to be out of sync:

```
// scene.glsl line 2464
#endif //RENDER_DEPTH //ubershader-runtime
```
presumably should be `not RENDER_DEPTH`.

This appears to have happened several times in the shaders because files originally contained e.g.
```
#ifdef RENDER_DEPTH
#endif // RENDER_DEPTH
```
then an `#else` was inserted, and the ending comment became incorrect.

I suspect these shaders could do with a second pass PR correcting these comments (I haven't done in the same PR as it seems two different problems).

Additionally, I worked out that `RENDER_DEPTH` seems actually for the z pre-pass and shadow maps. If so perhaps a better define would be `RENDER_DEPTH_ONLY`, because depth is also rendered during normal passes, so the define is confusing.

Also, `//ubershader-runtime` seems to be put on every closing `#endif`, and I have no idea why, perhaps I can figure out from the ubershader PR. :grin: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
