### PR TITLE
[3.x] Tight shadow culling - increase epsilon to prevent flickering

### DIFF
--- a/servers/visual/visual_server_light_culler.h
+++ b/servers/visual/visual_server_light_culler.h
@@ -164,14 +164,14 @@ private:
 		}
 
 		// Prevent divide by zero.
-		if (lc > 0.00001f) {
+		if (lc > 0.001f) {
 			// If the summed length of the smaller two
 			// sides is close to the length of the longest side,
 			// the points are colinear, and the triangle is near degenerate.
 			float ld = ((la + lb) - lc) / lc;
 
 			// ld will be close to zero for colinear tris.
-			return ld < 0.00001f;
+			return ld < 0.001f;
 		}
 
 		// Don't create planes from tiny triangles,


### PR DESCRIPTION
Near colinear triangles were still causing inaccuracy in culling planes, so the threshold for colinearity is bumped up.

Fixes #91976
3.x version of #92078

## Notes
* In the MRP in the issue, the spotlight was placed on the exact boundary of the top and bottom frustum planes, this was causing sometimes frustum places to be added and sometimes not (due to float error). This in itself was not a problem.
* The triangles formed between the light position and the edges however were proving too close to colinear, which as before when converted to a `Plane` caused inaccurate normal and d values.
* Originally I set the epsilon for colinearity deliberately very low, to see what we could get away with. It turns out it needs to be higher so I've gone for quite a conservative value here.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
