### PR TITLE
Improve function and signal parameter highlighting, add shadowing warning

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -423,7 +423,10 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					}
 				}
 			} else if (class_names.has(word)) {
-				col = class_names[word];
+				if (in_declaration_params != 1 && prev_type != SIGNAL && prev_text != GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
+					// Avoid highlighting untyped parameters that might shadow global class names inside function, signal, and lambda declarations.
+					col = class_names[word];
+				}
 			} else if (reserved_keywords.has(word)) {
 				col = reserved_keywords[word];
 				// Don't highlight `list` as a type in `for elem: Type in list`.
@@ -449,10 +452,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			}
 		}
 
-		if (!in_function_name && in_word && !in_keyword) {
+		if (!in_function_name) {
 			if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::SIGNAL)) {
 				in_signal_declaration = true;
-			} else {
+			} else if (is_char && prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC) && str[j - 1] == '(') {
+				// Lambda created without a space next to "func".
+				in_function_declaration = true;
+				in_lambda = true;
+				in_declaration_params = 1;
+			} else if (in_word && !in_keyword) {
 				int k = j;
 				while (k < line_length && !is_symbol(str[k]) && !is_whitespace(str[k])) {
 					k++;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1132,6 +1132,8 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 					if (param->datatype_specifier == nullptr) {
 						parser->push_warning(param, GDScriptWarning::UNTYPED_DECLARATION, "Parameter", param->identifier->name);
 					}
+
+					is_shadowing(param->identifier, "signal parameter", false);
 #endif // DEBUG_ENABLED
 					mi.arguments.push_back(param_type.to_property_info(param->identifier->name));
 					// Signals do not support parameter default values.


### PR DESCRIPTION
I noticed that signal parameters got highlighted as class names if they matched, so it could potentially be confusing to see a signal declared as `signal name(bool)`, since at first glance it might seem like it accepts only booleans, when in fact that's just the parameter name. I also added a warning when any signal parameters shadow global class names, to discourage it.

This led me down a bit of a rabbit hole with regards to syntax highlighting for function parameters in general, which suffered from the same problem, but the fix was similar to the one for signals except lambdas which was a bit more complicated since those were not being flagged properly when there was a space after the `func` token.

I attempted a fix for that as well, although I'm not super familiar with this kind of code so there may be a cleaner fix.

Before:
![signal_highlight_before](https://github.com/godotengine/godot/assets/138269/819ad0d0-bfa8-41db-b37e-f15a66b9c24a)

After:
![signal_highlight_after](https://github.com/godotengine/godot/assets/138269/70d1c13a-52b1-4979-a75e-697a5453bba0)

_Triage edit: Fixes https://github.com/godotengine/godot/issues/98273_
