### PR TITLE
Add PCF25 shadow filtering option in the Compatibility rendering method

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2587,6 +2587,7 @@
 			Quality setting for shadows cast by [DirectionalLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
 			[b]Note:[/b] The Soft Very Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
 			[b]Note:[/b] The Soft High and Soft Ultra settings will automatically multiply [i]constant[/i] shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
+			[b]Note:[/b] When using the Compatibility rendering method, a different shadow filtering technique is used. The Hard and Soft Very Low settings only apply standard bilinear filtering. The Low and Medium settings apply PCF5 shadow filtering. The High setting applies PCF13 shadow filtering, and the Ultra setting applies PCF25 shadow filtering.
 		</member>
 		<member name="rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality] on mobile devices, due to performance concerns or driver support.
@@ -2616,6 +2617,8 @@
 			Quality setting for shadows cast by [OmniLight3D]s and [SpotLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
 			[b]Note:[/b] The Soft Very Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
 			[b]Note:[/b] The Soft High and Soft Ultra settings will automatically multiply shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
+			[b]Note:[/b] When using the Compatibility rendering method, a different shadow filtering technique is used. The Hard and Soft Very Low settings only apply standard bilinear filtering. The Low and Medium settings apply PCF5 shadow filtering. The High setting applies PCF13 shadow filtering, and the Ultra setting applies PCF25 shadow filtering.
+			[b]Note:[/b] When using the Compatibility rendering method, [OmniLight3D] shadows always use standard bilinear filtering regardless of this setting.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality] on mobile devices, due to performance concerns or driver support.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4611,19 +4611,19 @@
 			[b]Note:[/b] The variable shadow blur performed by [member Light3D.light_size] and [member Light3D.light_angular_distance] is still effective when using hard shadow filtering. In this case, [member Light3D.shadow_blur] [i]is[/i] taken into account. However, the results will not be blurred, instead the blur amount is treated as a maximum radius for the penumbra.
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_VERY_LOW" value="1" enum="ShadowQuality">
-			Very low shadow filtering quality (faster). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 0.75× to avoid introducing too much noise. This division only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+			Very low shadow filtering quality (faster). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 0.75× to avoid introducing too much noise. This division only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]). When using the Compatibility rendering method, this is identical to [constant SHADOW_QUALITY_HARD].
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_LOW" value="2" enum="ShadowQuality">
-			Low shadow filtering quality (fast).
+			Low shadow filtering quality (fast). When using the Compatibility rendering method, this uses PCF5 shadow filtering.
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_MEDIUM" value="3" enum="ShadowQuality">
-			Medium low shadow filtering quality (average).
+			Medium low shadow filtering quality (average). When using the Compatibility rendering method, this is identical to [constant SHADOW_QUALITY_SOFT_LOW].
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_HIGH" value="4" enum="ShadowQuality">
-			High low shadow filtering quality (slow). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 1.5× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+			High low shadow filtering quality (slow). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 1.5× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]). When using the Compatibility rendering method, this uses PCF13 shadow filtering.
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_ULTRA" value="5" enum="ShadowQuality">
-			Highest low shadow filtering quality (slowest). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 2× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+			Highest low shadow filtering quality (slowest). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 2× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]). When using the Compatibility rendering method, this uses PCF25 shadow filtering.
 		</constant>
 		<constant name="SHADOW_QUALITY_MAX" value="6" enum="ShadowQuality">
 			Represents the size of the [enum ShadowQuality] enum.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3219,10 +3219,15 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							spec_constants |= SceneShaderGLES3::ADDITIVE_SPOT;
 						}
 
-						if (scene_state.positional_shadow_quality >= RS::SHADOW_QUALITY_SOFT_HIGH) {
-							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_13;
+						if (scene_state.positional_shadow_quality == RS::SHADOW_QUALITY_SOFT_ULTRA) {
+							// PCF25 is used at Ultra quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_LOW | SceneShaderGLES3::SHADOW_MODE_PCF_HIGH;
+						} else if (scene_state.positional_shadow_quality == RS::SHADOW_QUALITY_SOFT_HIGH) {
+							// PCF13 is used at High quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_HIGH;
 						} else if (scene_state.positional_shadow_quality >= RS::SHADOW_QUALITY_SOFT_LOW) {
-							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_5;
+							// PCF5 is used at Low and Medium quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_LOW;
 						}
 					} else {
 						// Render directional lights.
@@ -3244,10 +3249,15 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							spec_constants |= SceneShaderGLES3::LIGHT_USE_PSSM_BLEND;
 						}
 
-						if (scene_state.directional_shadow_quality >= RS::SHADOW_QUALITY_SOFT_HIGH) {
-							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_13;
+						if (scene_state.directional_shadow_quality == RS::SHADOW_QUALITY_SOFT_ULTRA) {
+							// PCF25 is used at Ultra quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_LOW | SceneShaderGLES3::SHADOW_MODE_PCF_HIGH;
+						} else if (scene_state.directional_shadow_quality == RS::SHADOW_QUALITY_SOFT_HIGH) {
+							// PCF13 is used at High quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_HIGH;
 						} else if (scene_state.directional_shadow_quality >= RS::SHADOW_QUALITY_SOFT_LOW) {
-							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_5;
+							// PCF5 is used at Low and Medium quality.
+							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_LOW;
 						}
 					}
 				}


### PR DESCRIPTION
- 4.x version of https://github.com/godotengine/godot/pull/54355.

This is a high-quality shadow filter which results in smooth, stable shadows even for dynamic objects.

Thanks to early bailing, PCF25 is faster than the old PCF13 implementation while looking better. It's also not that much slower compared to the new PCF13 implementation.

PCF25 is used when the soft shadow quality setting is set to Ultra.

## Preview

Hard | Soft Low (PCF5) | Soft High (PCF13) | Soft Ultra (PCF25)
-|-|-|-
![Screenshot_20240517_142333_hard](https://github.com/godotengine/godot/assets/180032/00167c8f-0611-4427-85ba-ed93cc65faaa) | ![Screenshot_20240517_142328_pcf5](https://github.com/godotengine/godot/assets/180032/ca675e2a-fdb2-44d6-9d41-5c2ecd32a0dc) | ![Screenshot_20240517_142323_pcf13](https://github.com/godotengine/godot/assets/180032/2e30c086-9bbd-4628-8498-b3b08f7b3c15) | ![Screenshot_20240517_142312_pcf25](https://github.com/godotengine/godot/assets/180032/1245ff98-c02e-462f-b9fe-c0652ec076d6)
