### PR TITLE
Core: Write Object variants with `\n` between properties

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1185,7 +1185,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 			}
 
 			String vstr;
-			VariantWriter::write_to_string(value, vstr);
+			VariantWriter::write_to_string(value, vstr, true);
 			file->store_string(F.property_name_encode() + "=" + vstr + "\n");
 		}
 	}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -135,7 +135,7 @@ String ConfigFile::encode_to_text() const {
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;
-			VariantWriter::write_to_string(F.value, vstr);
+			VariantWriter::write_to_string(F.value, vstr, true);
 			sb.append(F.key.property_name_encode() + "=" + vstr + "\n");
 		}
 	}
@@ -202,7 +202,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> p_file) {
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;
-			VariantWriter::write_to_string(F.value, vstr);
+			VariantWriter::write_to_string(F.value, vstr, true);
 			p_file->store_string(F.key.property_name_encode() + "=" + vstr + "\n");
 		}
 	}

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3526,7 +3526,7 @@ void Variant::construct_from_string(const String &p_string, Variant &r_value, Ob
 
 String Variant::get_construct_string() const {
 	String vars;
-	VariantWriter::write_to_string(*this, vars);
+	VariantWriter::write_to_string(*this, vars, false);
 
 	return vars;
 }

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -2009,7 +2009,7 @@ static String encode_resource_reference(const String &p_path) {
 	}
 }
 
-Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count, bool p_compat) {
+Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_pretty_print, int p_recursion_count, bool p_compat) {
 	switch (p_variant.get_type()) {
 		case Variant::NIL: {
 			p_store_string_func(p_store_string_ud, "null");
@@ -2178,7 +2178,6 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, "null");
 				return OK;
 			}
-			p_recursion_count++;
 
 			Object *obj = p_variant.get_validated_object();
 
@@ -2210,29 +2209,32 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 			}
 
-			//store as generic object
+			// pretty print has new lines
+			const String value_prefix = p_pretty_print ? " " : "";
+			const String value_suffix = p_pretty_print ? ",\n" : ",";
+			const String object_start_suffix = p_pretty_print ? "\n" : "";
+			const String object_end_prefix = p_pretty_print ? "\n" : "";
+			const String object_end_suffix = p_pretty_print ? "" : "\n";
 
-			p_store_string_func(p_store_string_ud, "Object(" + obj->get_class() + ",");
+			//store as generic object
+			p_store_string_func(p_store_string_ud, "Object(" + obj->get_class() + "," + object_start_suffix);
 
 			List<PropertyInfo> props;
 			obj->get_property_list(&props);
 			bool first = true;
-			for (const PropertyInfo &E : props) {
-				if (E.usage & PROPERTY_USAGE_STORAGE || E.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
-					//must be serialized
-
-					if (first) {
-						first = false;
-					} else {
-						p_store_string_func(p_store_string_ud, ",");
+			for (const PropertyInfo &prop : props) {
+				if (prop.usage & PROPERTY_USAGE_STORAGE || prop.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
+					if (!first) {
+						p_store_string_func(p_store_string_ud, value_suffix);
 					}
+					first = false;
+					p_store_string_func(p_store_string_ud, "\"" + prop.name + "\":" + value_prefix);
 
-					p_store_string_func(p_store_string_ud, "\"" + E.name + "\":");
-					write(obj->get(E.name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+					write(obj->get(prop.name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_pretty_print, p_recursion_count + 1, p_compat);
 				}
 			}
 
-			p_store_string_func(p_store_string_ud, ")\n");
+			p_store_string_func(p_store_string_ud, object_end_prefix + ")" + object_end_suffix);
 		} break;
 
 		case Variant::DICTIONARY: {
@@ -2311,15 +2313,13 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 					// Avoid unnecessary line break.
 					p_store_string_func(p_store_string_ud, "{}");
 				} else {
-					p_recursion_count++;
-
 					p_store_string_func(p_store_string_ud, "{\n");
 
 					for (uint32_t i = 0; i < keys.size(); i++) {
 						const Variant &key = keys[i];
-						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_pretty_print, p_recursion_count + 1, p_compat);
 						p_store_string_func(p_store_string_ud, ": ");
-						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_pretty_print, p_recursion_count + 1, p_compat);
 						if (i + 1 < keys.size()) {
 							p_store_string_func(p_store_string_ud, ",\n");
 						} else {
@@ -2374,8 +2374,6 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				ERR_PRINT("Max recursion reached");
 				p_store_string_func(p_store_string_ud, "[]");
 			} else {
-				p_recursion_count++;
-
 				p_store_string_func(p_store_string_ud, "[");
 
 				bool first = true;
@@ -2385,7 +2383,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 					} else {
 						p_store_string_func(p_store_string_ud, ", ");
 					}
-					write(var, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+					write(var, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_pretty_print, p_recursion_count + 1, p_compat);
 				}
 
 				p_store_string_func(p_store_string_ud, "]");
@@ -2568,8 +2566,8 @@ static Error _write_to_str(void *p_ud, const String &p_string) {
 	return OK;
 }
 
-Error VariantWriter::write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_compat) {
+Error VariantWriter::write_to_string(const Variant &p_variant, String &r_string, bool p_pretty_print, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_compat) {
 	r_string = String();
 
-	return write(p_variant, _write_to_str, &r_string, p_encode_res_func, p_encode_res_ud, 0, p_compat);
+	return write(p_variant, _write_to_str, &r_string, p_encode_res_func, p_encode_res_ud, p_pretty_print, 0, p_compat);
 }

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -159,6 +159,6 @@ public:
 	typedef Error (*StoreStringFunc)(void *p_ud, const String &p_string);
 	typedef String (*EncodeResourceFunc)(void *p_ud, const Ref<Resource> &p_resource);
 
-	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0, bool p_compat = true);
-	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr, bool p_compat = true);
+	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_pretty_print = true, int p_recursion_count = 0, bool p_compat = true);
+	static Error write_to_string(const Variant &p_variant, String &r_string, bool p_pretty_print = true, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr, bool p_compat = true);
 };

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1036,7 +1036,7 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 
 String VariantUtilityFunctions::var_to_str(const Variant &p_var) {
 	String vars;
-	VariantWriter::write_to_string(p_var, vars);
+	VariantWriter::write_to_string(p_var, vars, false);
 	return vars;
 }
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2735,7 +2735,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 					v = source_file_options[file][base];
 				}
 				String value;
-				VariantWriter::write_to_string(v, value);
+				VariantWriter::write_to_string(v, value, true);
 				f->store_line(base + "=" + value);
 			}
 		}
@@ -2973,11 +2973,15 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 
 		if (meta != Variant()) {
-			f->store_line("metadata=" + meta.get_construct_string());
+			String value;
+			VariantWriter::write_to_string(meta, value, true);
+			f->store_line("metadata=" + value);
 		}
 
 		if (generator_parameters != Variant()) {
-			f->store_line("generator_parameters=" + generator_parameters.get_construct_string());
+			String value;
+			VariantWriter::write_to_string(generator_parameters, value, true);
+			f->store_line("generator_parameters=" + value);
 		}
 
 		f->store_line("");
@@ -2992,7 +2996,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 			}
 
 			String value;
-			VariantWriter::write_to_string(genf, value);
+			VariantWriter::write_to_string(genf, value, true);
 			f->store_line("files=" + value);
 			f->store_line("");
 		}
@@ -3016,7 +3020,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		for (const ResourceImporter::ImportOption &E : opts) {
 			String base = E.option.name;
 			String value;
-			VariantWriter::write_to_string(params[base], value);
+			VariantWriter::write_to_string(params[base], value, true);
 			f->store_line(base + "=" + value);
 		}
 	}

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1994,7 +1994,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 				}
 
 				String vars;
-				VariantWriter::write_to_string(value, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(value, vars, true, _write_resources, this, use_compat);
 				f->store_string(name.property_name_encode() + " = " + vars + "\n");
 			}
 		}
@@ -2072,14 +2072,14 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			if (!instance_placeholder.is_empty()) {
 				String vars;
 				f->store_string(" instance_placeholder=");
-				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(instance_placeholder, vars, true, _write_resources, this, use_compat);
 				f->store_string(vars);
 			}
 
 			if (instance.is_valid()) {
 				String vars;
 				f->store_string(" instance=");
-				VariantWriter::write_to_string(instance, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(instance, vars, true, _write_resources, this, use_compat);
 				f->store_string(vars);
 			}
 
@@ -2087,7 +2087,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
 				String vars;
-				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, true, _write_resources, this, use_compat);
 
 				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
 			}
@@ -2135,7 +2135,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			f->store_string(connstr);
 			if (binds.size()) {
 				String vars;
-				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(binds, vars, true, _write_resources, this, use_compat);
 				f->store_string(" binds= " + vars);
 			}
 

--- a/tests/core/io/test_config_file.cpp
+++ b/tests/core/io/test_config_file.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_config_file)
 
+#include "core/input/input_event.h"
 #include "core/io/config_file.h"
 
 #ifdef WINDOWS_ENABLED
@@ -160,6 +161,45 @@ antiAliasing=false
 	Ref<FileAccess> file = FileAccess::open(config_path, FileAccess::READ);
 	CHECK_MESSAGE(file->get_as_utf8_string() == contents,
 			"The saved configuration file should match the expected format.");
+}
+
+TEST_CASE("[ConfigFile] Saving pretty printed Objects") {
+	ConfigFile config_file;
+
+	Ref<InputEventKey> key;
+	key.instantiate();
+	key->set_keycode(Key::SPACE);
+
+	Dictionary d_ui_accept({ { "deadzone", 0.5 }, { "events", Array({ key }) } });
+
+	config_file.set_value("input", "ui_accept", d_ui_accept);
+
+	const String expected = R"([input]
+
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,
+"resource_local_to_scene": false,
+"resource_name": "",
+"device": 16,
+"window_id": 0,
+"alt_pressed": false,
+"shift_pressed": false,
+"ctrl_pressed": false,
+"meta_pressed": false,
+"pressed": false,
+"keycode": 32,
+"physical_keycode": 0,
+"key_label": 0,
+"unicode": 0,
+"location": 0,
+"echo": false,
+"script": null
+)]
+}
+)";
+
+	CHECK_MESSAGE(config_file.encode_to_text() == expected, "Object properties should be on new lines.");
 }
 
 } // namespace TestConfigFile

--- a/tests/core/variant/test_variant.cpp
+++ b/tests/core/variant/test_variant.cpp
@@ -1821,9 +1821,10 @@ TEST_CASE("[Variant] Writer and parser dictionary") {
 	// d = {{1: 2}: 3, 4: "hello", 5: {null: []}}
 	Dictionary d = { { Dictionary({ { 1, 2 } }), 3 }, { 4, String("hello") }, { 5, Dictionary({ { Variant(), Array() } }) } };
 	String d_str;
-	VariantWriter::write_to_string(d, d_str);
+	VariantWriter::write_to_string(d, d_str, false);
 
-	CHECK_EQ(d_str, "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}");
+	const String expected = "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}";
+	CHECK_EQ(d_str, expected);
 
 	VariantParser::StreamString ss;
 	String errs;
@@ -1833,13 +1834,137 @@ TEST_CASE("[Variant] Writer and parser dictionary") {
 	ss.s = d_str;
 	VariantParser::parse(&ss, d_parsed, errs, line);
 
-	CHECK_MESSAGE(d_parsed == Variant(d), "Should parse back.");
+	CHECK_MESSAGE(d_parsed == Variant(d), "Should parse what it writes.");
+	CHECK_EQ(d_parsed.get_type(), Variant::DICTIONARY);
+
+	// Must be able to write the same string it parsed.
+	String d_parsed_str;
+	VariantWriter::write_to_string(d_parsed, d_parsed_str, false);
+	CHECK_EQ(d_parsed_str, expected);
+}
+
+TEST_CASE("[Variant] Pretty print dictionaries and arrays") {
+	String o_str;
+
+	// Dictionary of arrays
+	Dictionary d = {
+		{ 1, Array({ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29 }) },
+		{ 2, Array({ 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 46, 47, 49 }) },
+	};
+	VariantWriter::write_to_string(d, o_str, true);
+	String expected_str = "{\n"
+						  "1: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],\n"
+						  "2: [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 46, 47, 49]\n"
+						  "}";
+	CHECK_EQ(o_str, expected_str);
+
+	// example metadata from image resource
+	d = { { "vram_texture", false } };
+	expected_str = "{\n\"vram_texture\": false\n}";
+
+	VariantWriter::write_to_string(d, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(d, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Dictionary prints pretty and non-pretty the same way");
+
+	// Array of dictionaries
+	Array a = {
+		Dictionary({ { 1, String("A") }, { 2, String("B") } }),
+		Dictionary({ { 3, Array({ 3, 33, 333 }) } }),
+	};
+	VariantWriter::write_to_string(a, o_str, true);
+	expected_str = "[{\n"
+				   "1: \"A\",\n"
+				   "2: \"B\"\n"
+				   "}, {\n"
+				   "3: [3, 33, 333]\n"
+				   "}]";
+	CHECK_EQ(o_str, expected_str);
+}
+
+TEST_CASE("[Variant] Pretty print empty variants") {
+	String o_str;
+
+	Array a = {};
+	String expected_str = "[]";
+	VariantWriter::write_to_string(a, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(a, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Empty Array prints pretty and non-pretty the same way");
+
+	Dictionary d = {};
+	expected_str = "{}";
+	VariantWriter::write_to_string(d, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(d, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Empty Dictionary prints pretty and non-pretty the same way");
+}
+
+TEST_CASE("[Variant] Pretty print single element variants") {
+	String o_str;
+
+	Array a = { 65535 };
+	String expected_str = "[65535]";
+	VariantWriter::write_to_string(a, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(a, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Single element Array prints pretty and non-pretty the same way");
+
+	Dictionary d = { { 123, String("one two three") } };
+	expected_str = "{\n"
+				   "123: \"one two three\"\n"
+				   "}";
+
+	VariantWriter::write_to_string(d, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+
+	VariantWriter::write_to_string(d, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Dictionary prints pretty and non-pretty the same way");
+}
+
+TEST_CASE("[Variant] Pretty print common variants") {
+	String o_str;
+
+	Transform2D t2d = Transform2D(1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f);
+	String expected_str = "Transform2D(1.1, 1.2, 2.1, 2.2, 3.1, 3.2)";
+	VariantWriter::write_to_string(t2d, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(t2d, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Transform2D prints pretty and non-pretty the same way");
+
+	Transform3D t3d = Transform3D(1.1f, 1.2f, 1.3f, 2.1f, 2.2f, 2.3f, 3.1f, 3.2f, 3.3f, 4.1f, 4.2f, 4.3f);
+	expected_str = "Transform3D(1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3)";
+	VariantWriter::write_to_string(t3d, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(t3d, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Transform3D prints pretty and non-pretty the same way");
+
+	Vector3 v3 = Vector3(1, 2, 3);
+	expected_str = "Vector3(1, 2, 3)";
+	VariantWriter::write_to_string(v3, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(v3, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "Vector3 prints pretty and non-pretty the same way");
+
+	PackedByteArray pba = { 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x21 }; // Hello there!
+	expected_str = "PackedByteArray(72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 33)";
+	VariantWriter::write_to_string(pba, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(pba, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "PackedByteArray prints pretty and non-pretty the same way");
+
+	PackedInt32Array pi32a = { 0x48656c6c, 0x6f207468, 0x65726521 }; // Hello there!
+	expected_str = "PackedInt32Array(1214606444, 1864397928, 1701995809)";
+	VariantWriter::write_to_string(pi32a, o_str, true);
+	CHECK_EQ(o_str, expected_str);
+	VariantWriter::write_to_string(pi32a, o_str, false);
+	CHECK_MESSAGE(o_str == expected_str, "PackedInt32Array prints pretty and non-pretty the same way");
 }
 
 TEST_CASE("[Variant] Writer key sorting") {
 	Dictionary d = { { StringName("C"), 3 }, { "A", 1 }, { StringName("B"), 2 }, { "D", 4 } };
 	String d_str;
-	VariantWriter::write_to_string(d, d_str);
+	VariantWriter::write_to_string(d, d_str, true);
 
 	CHECK_EQ(d_str, "{\n\"A\": 1,\n&\"B\": 2,\n&\"C\": 3,\n\"D\": 4\n}");
 }
@@ -1909,6 +2034,101 @@ TEST_CASE("[Variant] Writer recursive dictionary on keys") {
 	d2.clear();
 }
 #endif
+
+TEST_CASE("[Variant] Object non-pretty prints with correct newlines") {
+	Object *o1 = memnew(Object);
+	Variant v1 = o1;
+
+	String o_str;
+	VariantWriter::write_to_string(v1, o_str, false);
+
+	String expected_str = "Object(Object,\"script\":null)\n";
+
+	CHECK(o_str == expected_str);
+
+	memdelete(o1);
+}
+
+TEST_CASE("[Variant] Object pretty prints with correct newlines") {
+	Object *o1 = memnew(Object);
+	Variant v1 = o1;
+
+	String o_str;
+	VariantWriter::write_to_string(v1, o_str, true);
+
+	String expected_str = "Object(Object,\n\"script\": null\n)";
+
+	CHECK(o_str == expected_str);
+
+	memdelete(o1);
+}
+
+TEST_CASE("[Variant] Nested Objects non-pretty print without spacing") {
+	Object *o1 = memnew(Object);
+	Object *o2 = memnew(Object);
+	Object *o3 = memnew(Object);
+
+	o1->set_meta("o2", o2);
+	o2->set_meta("o3", o3);
+
+	Variant v1 = o1;
+
+	String o_str;
+	VariantWriter::write_to_string(v1, o_str, false);
+
+	String expected_str = "Object(Object,\"script\":null,\"metadata/o2\":Object(Object,\"script\":null,\"metadata/o3\":Object(Object,\"script\":null)\n)\n)\n";
+
+	CHECK(o_str == expected_str);
+
+	memdelete(o1);
+	memdelete(o2);
+	memdelete(o3);
+}
+
+TEST_CASE("[Variant] Nested Objects pretty print with correct newlines") {
+	Object *o1 = memnew(Object);
+	Object *o2 = memnew(Object);
+	Object *o3 = memnew(Object);
+
+	o1->set_meta("o2", o2);
+	o2->set_meta("o3", o3);
+
+	Variant v1 = o1;
+
+	String o_str;
+	VariantWriter::write_to_string(v1, o_str, true);
+
+	String expected_str = "Object(Object,\n"
+						  "\"script\": null,\n"
+						  "\"metadata/o2\": Object(Object,\n"
+						  "\"script\": null,\n"
+						  "\"metadata/o3\": Object(Object,\n"
+						  "\"script\": null\n"
+						  ")\n"
+						  ")\n"
+						  ")";
+
+	CHECK(o_str == expected_str);
+
+	memdelete(o1);
+	memdelete(o2);
+	memdelete(o3);
+}
+
+TEST_CASE("[Variant] Dictionary propagates pretty_print flag to nested Objects") {
+	Object *o1 = memnew(Object);
+	Dictionary d = { { 1, o1 } };
+
+	String o_str;
+	VariantWriter::write_to_string(d, o_str, true);
+	CHECK_EQ(o_str, "{\n1: Object(Object,\n\"script\": null\n)\n}");
+
+	VariantWriter::write_to_string(d, o_str, false);
+	// non-pretty printed Object has \n and Dictionary also has \n for a double \n\n
+	CHECK_EQ(o_str, "{\n1: Object(Object,\"script\":null)\n\n}");
+
+	memdelete(o1);
+}
 
 TEST_CASE("[Variant] Basic comparison") {
 	CHECK_EQ(Variant(1), Variant(1));


### PR DESCRIPTION
Adds line feeds '\n' after commas for each property in an `Object`.

This mirroring the format for `Dictionary` variants in `core/variant/variant_parser.cpp` [lines 2054-2066](https://github.com/robert-wallis/godot/commit/eebdc3b9ca283ad826b76e423ad8e91b487acaaf#diff-8fa43a0158f72fe267697c83f42d65e567c538c003320e7a9417faffd51f8bfeL2054-L2066)

## Before
![before diff](https://github.com/godotengine/godot/assets/145938/b29549b2-c0ca-4644-8174-4d259700fd66)
## After
![after diff](https://github.com/godotengine/godot/assets/145938/ac22485a-4ae3-45d2-bbd3-9898c9efc803)

This makes reading the diff easier.  It also [lets VCS auto-merge conflicts](https://github.com/godotengine/godot-proposals/issues/9774#issuecomment-2123260188) during a diff, when a different properties in an `Object` are changed at the same time.

# Proposal
* _Bugsquad edit:_ Closes https://github.com/godotengine/godot-proposals/issues/9774