### PR TITLE
[3.x] Fix long category name display in Inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -944,16 +944,18 @@ void EditorInspectorCategory::_notification(int p_what) {
 		if (icon.is_valid()) {
 			w += hs + icon->get_width();
 		}
+		w = MIN(w, get_size().width - hs * 2);
 
 		int ofs = (get_size().width - w) / 2;
 
 		if (icon.is_valid()) {
 			draw_texture(icon, Point2(ofs, (get_size().height - icon->get_height()) / 2).floor());
 			ofs += hs + icon->get_width();
+			w -= hs + icon->get_width();
 		}
 
 		Color color = get_color("font_color", "Tree");
-		draw_string(font, Point2(ofs, font->get_ascent() + (get_size().height - font->get_height()) / 2).floor(), label, color, get_size().width);
+		draw_string(font, Point2(ofs, font->get_ascent() + (get_size().height - font->get_height()) / 2).floor(), label, color, w);
 	}
 }
 


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/91820