### PR TITLE
[3.x] Mesh merging - refactor to be backward compatible for CPU / GPU storage

### DIFF
--- a/scene/3d/merge_group.cpp
+++ b/scene/3d/merge_group.cpp
@@ -302,7 +302,7 @@ void MergeGroup::_split_mesh_by_surface(MeshInstance *p_mi, int p_num_surfaces) 
 
 	_node_changed(parent);
 
-	p_mi->split_by_surface(siblings);
+	MergingTool::wrapped_split_by_surface(*p_mi, siblings, Mesh::STORAGE_MODE_CPU);
 
 	// Failed to split.
 	if (parent->get_child_count() <= first_sibling_id) {
@@ -827,7 +827,7 @@ void MergeGroup::_merge_list(const LocalVector<MeshInstance *> &p_mis, bool p_sh
 		varlist.push_back(Variant(p_mis[n]));
 	}
 
-	if (!merged->merge_meshes(varlist, false, false, p_shadows)) {
+	if (!MergingTool::wrapped_merge_meshes(*merged, varlist, false, false, p_shadows, Mesh::STORAGE_MODE_CPU)) {
 		_log("MERGE_MESHES failed.");
 		_delete_node(merged);
 		return;

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -140,7 +140,6 @@ public:
 	// Merging.
 	bool is_mergeable_with(Node *p_other, bool p_shadows_only) const;
 	bool merge_meshes(Vector<Variant> p_list, bool p_use_global_space, bool p_check_compatibility, bool p_shadows_only);
-	bool split_by_surface(Vector<Variant> p_destination_mesh_instances);
 
 	virtual AABB get_aabb() const;
 	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;

--- a/scene/resources/merging_tool.h
+++ b/scene/resources/merging_tool.h
@@ -46,9 +46,19 @@ struct CSGBrush;
 // #define GODOT_MERGING_VERBOSE
 #endif
 
-// NOTE : These merging and joining functions DO NOT move children, or delete source nodes. That is the responsibility of the caller.
+// NOTE : These merging and joining functions DO NOT move children, or delete source nodes.
+// That is the responsibility of the caller.
+
 class MergingTool {
 public:
+	////////////////////////////////////////////////////////////////////////////////////
+	// WRAPPED versions are accessible via script via MeshInstance.
+	// These have to cope with Variants as lists of MeshInstances is not easy from script.
+	static bool wrapped_merge_meshes(MeshInstance &r_dest_mi, Vector<Variant> p_list, bool p_use_global_space, bool p_check_compatibility, bool p_shadows_only, Mesh::StorageMode p_storage_mode);
+	static bool wrapped_split_by_surface(const MeshInstance &p_source_mi, Vector<Variant> p_destination_mesh_instances, Mesh::StorageMode p_storage_mode);
+
+	////////////////////////////////////////////////////////////////////////////////////
+
 	// Are two mesh instances mergeable with each other?
 	static bool is_mergeable_with(const MeshInstance &p_mi, const MeshInstance &p_other, bool p_check_surface_material_match);
 	static bool is_shadow_mergeable_with(const MeshInstance &p_mi, const MeshInstance &p_other);


### PR DESCRIPTION
Allows the old `merge_meshes()` function to work from the editor.

Fixes #91988

Most of the lines changed here are just moving the implementation functions to a new location. The bug fix is allowing them to be called choosing storage CPU or GPU etc, and defaulting the old function to store in GPU (which is the old way in 3.5).

So the PR is actually very simple and doesn't require in depth review or specialist knowledge (it just looks more complex because of moving a bit of code).

## Notes
* `MergeGroups` totally changed the backend for merging, which inadvertently broke the old `merge_meshes()` function in `MeshInstance` when used from the editor.
* The breakage was simply because the new method defaulted to creating the result mesh on the CPU only (as this is significantly faster, as it removes a round trip to the GPU + drivers for any geometry processing).
* This PR moves the wrappers for the `MeshInstance` merging functions to the `MergingTool`, and converts the results from the wrappers to GPU meshes, so they are suitable for use in the editor and rendering.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
