### PR TITLE
Fix for Exported typed variables in a tool script have wrong initial value if not initialized

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -192,6 +192,16 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 			ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance: " + error_text);
 		}
 	}
+
+#ifdef TOOLS_ENABLED
+	// Update exports to have the correct default values for tool scripts on editor startup.
+	// Should be called in the editor only, otherwise it crashes macOS unit tests
+	// with a 'Segmentation violation signal' because of missing instance state support.
+	if (Engine::get_singleton()->is_editor_hint()) {
+		_update_exports(nullptr, false, nullptr);
+	}
+#endif
+
 	//@TODO make thread safe
 	return instance;
 }


### PR DESCRIPTION
This should fix #62363 

The problem was caused by `member_default_values_cache` not initialized for tool scripts. When not a tool script, a PlaceHolder is created and `_update_exports` was called. But `_update_exports` was not called on the creation of GDScriptInstance. Later when the scene or the script is saved, `_update_exports` is called fixing the issue after the first save. So to fix the problem, I added a call to `_update_exports` when the GDScriptInstance is created.

