### PR TITLE
Fix example for Basis * Vector3 in documentation

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -444,12 +444,14 @@
 				Transforms (multiplies) the [param right] vector by this basis, returning a [Vector3].
 				[codeblocks]
 				[gdscript]
-				var my_basis = Basis(Vector3(1, 1, 1), Vector3(1, 1, 1), Vector3(0, 2, 5))
-				print(my_basis * Vector3(1, 2, 3)) # Prints (7, 3, 16)
+				# Basis that swaps the X/Z axes and doubles the scale.
+				var my_basis = Basis(Vector3(0, 2, 0), Vector3(2, 0, 0), Vector3(0, 0, 2))
+				print(my_basis * Vector3(1, 2, 3)) # Prints (4, 2, 6)
 				[/gdscript]
 				[csharp]
-				var myBasis = new Basis(new Vector3(1, 1, 1), new Vector3(1, 1, 1), new Vector3(0, 2, 5));
-				GD.Print(my_basis * new Vector3(1, 2, 3)); // Prints (7, 3, 16)
+				// Basis that swaps the X/Z axes and doubles the scale.
+				var myBasis = new Basis(new Vector3(0, 2, 0), new Vector3(2, 0, 0), new Vector3(0, 0, 2));
+				GD.Print(myBasis * new Vector3(1, 2, 3)); // Prints (4, 2, 6)
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
## Description
This MR fixes an invalid example in the Basis documentation, fixes https://github.com/godotengine/godot-docs/issues/9394

I opted to change the inputs instead of the outputs, because it seemed strange to have two identical basis vectors. Plus this allows some of the inputs to be negative

## Actions performed
* Cloned both projects, symlinked them together and ran the build both before and after the changes to confirm they show up where expected
* Retested the GDScript example in editor to confirm the new example gives the promised result
* ⚠️ Did not test the C# example. Though I have no reason to believe it should run any different
* Checked the original MR to see if there were any comments about this example to be aware of
* Ran pre-commit hooks (4 passed, rest skipped)
