### PR TITLE
Change param name of AStar's `_estimate_cost` method

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -391,9 +391,9 @@ bool AStar3D::_solve(Point *begin_point, Point *end_point) {
 	return found_route;
 }
 
-real_t AStar3D::_estimate_cost(int64_t p_from_id, int64_t p_to_id) {
+real_t AStar3D::_estimate_cost(int64_t p_from_id, int64_t p_end_id) {
 	real_t scost;
-	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_to_id, scost)) {
+	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_end_id, scost)) {
 		return scost;
 	}
 
@@ -401,11 +401,11 @@ real_t AStar3D::_estimate_cost(int64_t p_from_id, int64_t p_to_id) {
 	bool from_exists = points.lookup(p_from_id, from_point);
 	ERR_FAIL_COND_V_MSG(!from_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_from_id));
 
-	Point *to_point = nullptr;
-	bool to_exists = points.lookup(p_to_id, to_point);
-	ERR_FAIL_COND_V_MSG(!to_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_to_id));
+	Point *end_point = nullptr;
+	bool end_exists = points.lookup(p_end_id, end_point);
+	ERR_FAIL_COND_V_MSG(!end_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_end_id));
 
-	return from_point->pos.distance_to(to_point->pos);
+	return from_point->pos.distance_to(end_point->pos);
 }
 
 real_t AStar3D::_compute_cost(int64_t p_from_id, int64_t p_to_id) {
@@ -579,7 +579,7 @@ void AStar3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStar3D::get_point_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStar3D::get_id_path, DEFVAL(false));
 
-	GDVIRTUAL_BIND(_estimate_cost, "from_id", "to_id")
+	GDVIRTUAL_BIND(_estimate_cost, "from_id", "end_id")
 	GDVIRTUAL_BIND(_compute_cost, "from_id", "to_id")
 }
 
@@ -675,9 +675,9 @@ Vector2 AStar2D::get_closest_position_in_segment(const Vector2 &p_point) const {
 	return Vector2(p.x, p.y);
 }
 
-real_t AStar2D::_estimate_cost(int64_t p_from_id, int64_t p_to_id) {
+real_t AStar2D::_estimate_cost(int64_t p_from_id, int64_t p_end_id) {
 	real_t scost;
-	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_to_id, scost)) {
+	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_end_id, scost)) {
 		return scost;
 	}
 
@@ -685,11 +685,11 @@ real_t AStar2D::_estimate_cost(int64_t p_from_id, int64_t p_to_id) {
 	bool from_exists = astar.points.lookup(p_from_id, from_point);
 	ERR_FAIL_COND_V_MSG(!from_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_from_id));
 
-	AStar3D::Point *to_point = nullptr;
-	bool to_exists = astar.points.lookup(p_to_id, to_point);
-	ERR_FAIL_COND_V_MSG(!to_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_to_id));
+	AStar3D::Point *end_point = nullptr;
+	bool to_exists = astar.points.lookup(p_end_id, end_point);
+	ERR_FAIL_COND_V_MSG(!to_exists, 0, vformat("Can't estimate cost. Point with id: %d doesn't exist.", p_end_id));
 
-	return from_point->pos.distance_to(to_point->pos);
+	return from_point->pos.distance_to(end_point->pos);
 }
 
 real_t AStar2D::_compute_cost(int64_t p_from_id, int64_t p_to_id) {
@@ -918,6 +918,6 @@ void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStar2D::get_point_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStar2D::get_id_path, DEFVAL(false));
 
-	GDVIRTUAL_BIND(_estimate_cost, "from_id", "to_id")
+	GDVIRTUAL_BIND(_estimate_cost, "from_id", "end_id")
 	GDVIRTUAL_BIND(_compute_cost, "from_id", "to_id")
 }

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -120,7 +120,7 @@ class AStar3D : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	virtual real_t _estimate_cost(int64_t p_from_id, int64_t p_to_id);
+	virtual real_t _estimate_cost(int64_t p_from_id, int64_t p_end_id);
 	virtual real_t _compute_cost(int64_t p_from_id, int64_t p_to_id);
 
 	GDVIRTUAL2RC(real_t, _estimate_cost, int64_t, int64_t)
@@ -176,7 +176,7 @@ class AStar2D : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	virtual real_t _estimate_cost(int64_t p_from_id, int64_t p_to_id);
+	virtual real_t _estimate_cost(int64_t p_from_id, int64_t p_end_id);
 	virtual real_t _compute_cost(int64_t p_from_id, int64_t p_to_id);
 
 	GDVIRTUAL2RC(real_t, _estimate_cost, int64_t, int64_t)

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -531,12 +531,12 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point) {
 	return found_route;
 }
 
-real_t AStarGrid2D::_estimate_cost(const Vector2i &p_from_id, const Vector2i &p_to_id) {
+real_t AStarGrid2D::_estimate_cost(const Vector2i &p_from_id, const Vector2i &p_end_id) {
 	real_t scost;
-	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_to_id, scost)) {
+	if (GDVIRTUAL_CALL(_estimate_cost, p_from_id, p_end_id, scost)) {
 		return scost;
 	}
-	return heuristics[default_estimate_heuristic](p_from_id, p_to_id);
+	return heuristics[default_estimate_heuristic](p_from_id, p_end_id);
 }
 
 real_t AStarGrid2D::_compute_cost(const Vector2i &p_from_id, const Vector2i &p_to_id) {
@@ -697,7 +697,7 @@ void AStarGrid2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_point_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_id_path, DEFVAL(false));
 
-	GDVIRTUAL_BIND(_estimate_cost, "from_id", "to_id")
+	GDVIRTUAL_BIND(_estimate_cost, "from_id", "end_id")
 	GDVIRTUAL_BIND(_compute_cost, "from_id", "to_id")
 
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2I, "region"), "set_region", "get_region");

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -151,7 +151,7 @@ private: // Internal routines.
 protected:
 	static void _bind_methods();
 
-	virtual real_t _estimate_cost(const Vector2i &p_from_id, const Vector2i &p_to_id);
+	virtual real_t _estimate_cost(const Vector2i &p_from_id, const Vector2i &p_end_id);
 	virtual real_t _compute_cost(const Vector2i &p_from_id, const Vector2i &p_to_id);
 
 	GDVIRTUAL2RC(real_t, _estimate_cost, Vector2i, Vector2i)

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -22,7 +22,7 @@
 		<method name="_estimate_cost" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="from_id" type="int" />
-			<param index="1" name="to_id" type="int" />
+			<param index="1" name="end_id" type="int" />
 			<description>
 				Called when estimating the cost between a point and the path's ending point.
 				Note that this function is hidden in the default [AStar2D] class.

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -51,7 +51,7 @@
 		<method name="_estimate_cost" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="from_id" type="int" />
-			<param index="1" name="to_id" type="int" />
+			<param index="1" name="end_id" type="int" />
 			<description>
 				Called when estimating the cost between a point and the path's ending point.
 				Note that this function is hidden in the default [AStar3D] class.

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -41,7 +41,7 @@
 		<method name="_estimate_cost" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="from_id" type="Vector2i" />
-			<param index="1" name="to_id" type="Vector2i" />
+			<param index="1" name="end_id" type="Vector2i" />
 			<description>
 				Called when estimating the cost between a point and the path's ending point.
 				Note that this function is hidden in the default [AStarGrid2D] class.


### PR DESCRIPTION
A* classes all have two similar cost functions:

- `_estimate_cost(from, to)`
- `_compute_cost(from, to)`

It's easy to misunderstand that their second parameters are the same. But in fact, `_estimate_cost()` receives the end point of the search query, while `_compute_cost()` receives a connected (neighbour) point.