### PR TITLE
SCons: Convert platform `get_flags` to dictionary

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -122,6 +122,8 @@ for x in sorted(glob.glob("platform/*")):
         platform_list += [x]
         platform_opts[x] = detect.get_opts()
         platform_flags[x] = detect.get_flags()
+        if isinstance(platform_flags[x], list):  # backwards compatibility
+            platform_flags[x] = {flag[0]: flag[1] for flag in platform_flags[x]}
     sys.path.remove(tmppath)
     sys.modules.pop("detect")
 
@@ -569,9 +571,9 @@ if env["build_profile"] != "":
 # Platform specific flags.
 # These can sometimes override default options.
 flag_list = platform_flags[env["platform"]]
-for f in flag_list:
-    if f[0] not in ARGUMENTS or ARGUMENTS[f[0]] == "auto":  # Allow command line to override platform flags
-        env[f[0]] = f[1]
+for key, value in flag_list.items():
+    if key not in ARGUMENTS or ARGUMENTS[key] == "auto":  # Allow command line to override platform flags
+        env[key] = value
 
 # 'dev_mode' and 'production' are aliases to set default options if they haven't been
 # set manually by the user.

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -67,11 +67,11 @@ def get_min_target_api():
 
 
 def get_flags():
-    return [
-        ("arch", "arm64"),  # Default for convenience.
-        ("target", "template_debug"),
-        ("supported", ["mono"]),
-    ]
+    return {
+        "arch": "arm64",  # Default for convenience.
+        "target": "template_debug",
+        "supported": ["mono"],
+    }
 
 
 # Check if Android NDK version is installed

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -47,13 +47,13 @@ def get_doc_path():
 
 
 def get_flags():
-    return [
-        ("arch", "arm64"),  # Default for convenience.
-        ("target", "template_debug"),
-        ("use_volk", False),
-        ("supported", ["mono"]),
-        ("builtin_pcre2_with_jit", False),
-    ]
+    return {
+        "arch": "arm64",  # Default for convenience.
+        "target": "template_debug",
+        "use_volk": False,
+        "supported": ["mono"],
+        "builtin_pcre2_with_jit": False,
+    }
 
 
 def configure(env: "SConsEnvironment"):

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -65,10 +65,10 @@ def get_doc_path():
 
 
 def get_flags():
-    return [
-        ("arch", detect_arch()),
-        ("supported", ["mono"]),
-    ]
+    return {
+        "arch": detect_arch(),
+        "supported": ["mono"],
+    }
 
 
 def configure(env: "SConsEnvironment"):

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -53,11 +53,11 @@ def get_doc_path():
 
 
 def get_flags():
-    return [
-        ("arch", detect_arch()),
-        ("use_volk", False),
-        ("supported", ["mono"]),
-    ]
+    return {
+        "arch": detect_arch(),
+        "use_volk": False,
+        "supported": ["mono"],
+    }
 
 
 def configure(env: "SConsEnvironment"):

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -65,21 +65,21 @@ def get_doc_path():
 
 
 def get_flags():
-    return [
-        ("arch", "wasm32"),
-        ("target", "template_debug"),
-        ("builtin_pcre2_with_jit", False),
-        ("vulkan", False),
+    return {
+        "arch": "wasm32",
+        "target": "template_debug",
+        "builtin_pcre2_with_jit": False,
+        "vulkan": False,
         # Embree is heavy and requires too much memory (GH-70621).
-        ("module_raycast_enabled", False),
+        "module_raycast_enabled": False,
         # Use -Os to prioritize optimizing for reduced file size. This is
         # particularly valuable for the web platform because it directly
         # decreases download time.
         # -Os reduces file size by around 5 MiB over -O3. -Oz only saves about
         # 100 KiB over -Os, which does not justify the negative impact on
         # run-time performance.
-        ("optimize", "size"),
-    ]
+        "optimize": "size",
+    }
 
 
 def configure(env: "SConsEnvironment"):

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -248,10 +248,10 @@ def get_doc_path():
 def get_flags():
     arch = detect_build_env_arch() or detect_arch()
 
-    return [
-        ("arch", arch),
-        ("supported", ["mono"]),
-    ]
+    return {
+        "arch": arch,
+        "supported": ["mono"],
+    }
 
 
 def build_res_file(target, source, env: "SConsEnvironment"):


### PR DESCRIPTION
Minor formatting update to make `get_flags` return a dictionary instead of a tuple array, as it's already being parsed as if it were a dictionary.