### PR TITLE
Fix log rebuilding crashing when there's no messages

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -273,6 +273,10 @@ void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
 }
 
 void EditorLog::_rebuild_log() {
+	if (messages.is_empty()) {
+		return;
+	}
+
 	log->clear();
 
 	int line_count = 0;


### PR DESCRIPTION
Fixes the editor crashing on any action that rebuilds the log display (filtering, searching, theme change etc) while there's no messages in it.

Example: Clearing the log manually with the button and then clicking on one of the filter buttons would cause a crash.
