### PR TITLE
C#: Move GodotSharp to .NET8

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -229,7 +229,7 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
 
         core_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharp", "bin", build_config))
         editor_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharpEditor", "bin", build_config))
-        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net7.0"))
+        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net8.0"))
 
         if not os.path.isdir(editor_api_dir):
             assert not os.path.isfile(editor_api_dir)

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -229,7 +229,7 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
 
         core_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharp", "bin", build_config))
         editor_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharpEditor", "bin", build_config))
-        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net6.0"))
+        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net7.0"))
 
         if not os.path.isdir(editor_api_dir):
             assert not os.path.isfile(editor_api_dir)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>11</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>11</LangVersion>
   </PropertyGroup>
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
@@ -21,7 +21,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            ReferenceAssemblies = Constants.Net80;
 
             SolutionTransforms.Add((Solution solution, ProjectId projectId) =>
             {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Godot.SourceGenerators.Tests;
@@ -17,7 +16,7 @@ public static class CSharpCodeFixVerifier<TCodeFix, TAnalyzer>
     {
         public Test()
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            ReferenceAssemblies = Constants.Net80;
             SolutionTransforms.Add((Solution solution, ProjectId projectId) =>
             {
                 Project project = solution.GetProject(projectId)!

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -18,7 +18,7 @@ where TSourceGenerator : ISourceGenerator, new()
     {
         public Test()
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            ReferenceAssemblies = Constants.Net80;
 
             SolutionTransforms.Add((Solution solution, ProjectId projectId) =>
             {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Constants.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Constants.cs
@@ -1,11 +1,19 @@
 using System.IO;
 using System.Reflection;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Godot.SourceGenerators.Tests;
 
 public static class Constants
 {
     public static Assembly GodotSharpAssembly => typeof(GodotObject).Assembly;
+
+    // Can't find what needs updating to be able to access ReferenceAssemblies.Net.Net80, so we're making our own one.
+    public static ReferenceAssemblies Net80 => new ReferenceAssemblies(
+        "net8.0",
+        new PackageIdentity("Microsoft.NETCore.App.Ref", "8.0.0"),
+        Path.Combine("ref", "net8.0")
+    );
 
     public static string ExecutingAssemblyPath { get; }
     public static string SourceFolderPath { get; }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
-    <LangVersion>11</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Core C# source generator for Godot projects.</Description>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{639E48BD-44E5-4091-8EDD-22D36DC0768D}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{639E48BD-44E5-4091-8EDD-22D36DC0768D}</ProjectGuid>
-    <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{A8CDAD94-C6D4-4B19-A7E7-76C53CC92984}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -1,17 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{A8CDAD94-C6D4-4B19-A7E7-76C53CC92984}</ProjectGuid>
-    <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\GodotTools.Core\GodotTools.Core.csproj" />
     <ProjectReference Include="..\GodotTools.Shared\GodotTools.Shared.csproj" />
   </ItemGroup>
+
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -22,13 +22,7 @@ namespace GodotTools.ProjectEditor
             root.Sdk = GodotSdkAttrValue;
 
             var mainGroup = root.AddPropertyGroup();
-            mainGroup.AddProperty("TargetFramework", "net6.0");
-
-            var net7 = mainGroup.AddProperty("TargetFramework", "net7.0");
-            net7.Condition = " '$(GodotTargetPlatform)' == 'android' ";
-
-            var net8 = mainGroup.AddProperty("TargetFramework", "net8.0");
-            net8.Condition = " '$(GodotTargetPlatform)' == 'ios' ";
+            mainGroup.AddProperty("TargetFramework", "net8.0");
 
             mainGroup.AddProperty("EnableDynamicLoading", "true");
 

--- a/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
@@ -1,8 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <!-- Specify compile items manually to avoid including dangling generated items. -->
-        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+      <TargetFramework>net8.0</TargetFramework>
+      <LangVersion>12</LangVersion>
+      <!-- Specify compile items manually to avoid including dangling generated items. -->
+      <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
+
     <Import Project="GenerateGodotNupkgsVersions.targets" />
+
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <!-- Specify compile items manually to avoid including dangling generated items. -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-  </PropertyGroup>
-  <Import Project="GenerateGodotNupkgsVersions.targets" />
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <!-- Specify compile items manually to avoid including dangling generated items. -->
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    </PropertyGroup>
+    <Import Project="GenerateGodotNupkgsVersions.targets" />
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{27B00618-A6F2-4828-B922-05CAEB08C286}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{27B00618-A6F2-4828-B922-05CAEB08C286}</ProjectGuid>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <!-- The Godot editor uses the Debug Godot API assemblies -->
     <GodotApiConfiguration>Debug</GodotApiConfiguration>
@@ -13,13 +14,16 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <!-- Needed for our source generators to work despite this not being a Godot game project -->
   <PropertyGroup>
     <IsGodotToolsProject>true</IsGodotToolsProject>
   </PropertyGroup>
+
   <ItemGroup>
     <CompilerVisibleProperty Include="IsGodotToolsProject" />
   </ItemGroup>
+
   <PropertyGroup Condition=" Exists('$(GodotApiAssembliesDir)/GodotSharp.dll') ">
     <!-- The project is part of the Godot source tree -->
     <!-- Use the Godot source tree output folder instead of '$(ProjectDir)/bin' -->
@@ -27,6 +31,7 @@
     <!-- Must not append '$(TargetFramework)' to the output path in this case -->
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3.0" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="JetBrains.Rider.PathLocator" Version="1.0.9" />
@@ -41,14 +46,17 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Godot.NET.Sdk\Godot.SourceGenerators\Godot.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\..\glue\GodotSharp\Godot.SourceGenerators.Internal\Godot.SourceGenerators.Internal.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\GodotTools.BuildLogger\GodotTools.BuildLogger.csproj" />
     <ProjectReference Include="..\GodotTools.IdeMessaging\GodotTools.IdeMessaging.csproj" />
     <ProjectReference Include="..\GodotTools.ProjectEditor\GodotTools.ProjectEditor.csproj" />
     <ProjectReference Include="..\GodotTools.Core\GodotTools.Core.csproj" />
   </ItemGroup>
+
 </Project>

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Godot.SourceGenerators.Internal.csproj
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Godot.SourceGenerators.Internal.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
+
 </Project>

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
@@ -172,11 +172,7 @@ using Godot.NativeInterop;
             {
                 var parameter = callback.Parameters[i];
 
-                AppendRefKind(source, parameter.RefKind);
-                source.Append(' ');
-                source.Append(parameter.Type.FullQualifiedNameIncludeGlobal());
-                source.Append(' ');
-                source.Append(parameter.Name);
+                source.Append(parameter.DeclaringSyntaxReferences[0].GetSyntax().ToString());
 
                 if (parameter.RefKind == RefKind.Out)
                 {

--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -50,8 +50,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array(IEnumerable<Variant> collection) : this()
         {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
+            ArgumentNullException.ThrowIfNull(collection);
 
             foreach (Variant element in collection)
                 Add(element);
@@ -67,8 +66,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array(Variant[] array)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
+            ArgumentNullException.ThrowIfNull(array);
 
             NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
@@ -1056,7 +1054,7 @@ namespace Godot.Collections
         IEnumerable<T>,
         IGenericGodotArray
     {
-        private static godot_variant ToVariantFunc(in Array<T> godotArray) =>
+        private static godot_variant ToVariantFunc(scoped in Array<T> godotArray) =>
             VariantUtils.CreateFromArray(godotArray);
 
         private static Array<T> FromVariantFunc(in godot_variant variant) =>
@@ -1080,8 +1078,8 @@ namespace Godot.Collections
 
         static unsafe Array()
         {
-            VariantUtils.GenericConversion<Array<T>>.ToVariantCb = &ToVariantFunc;
-            VariantUtils.GenericConversion<Array<T>>.FromVariantCb = &FromVariantFunc;
+            VariantUtils.GenericConversion<Array<T>>.ToVariantCb = ToVariantFunc;
+            VariantUtils.GenericConversion<Array<T>>.FromVariantCb = FromVariantFunc;
         }
 
         private readonly Array _underlyingArray;
@@ -1114,8 +1112,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array(IEnumerable<T> collection)
         {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
+            ArgumentNullException.ThrowIfNull(collection);
 
             _underlyingArray = new Array();
             SetTypedForUnderlyingArray();
@@ -1134,8 +1131,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array(T[] array)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
+            ArgumentNullException.ThrowIfNull(array);
 
             _underlyingArray = new Array();
             SetTypedForUnderlyingArray();
@@ -1154,8 +1150,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array(Array array)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
+            ArgumentNullException.ThrowIfNull(array);
 
             _underlyingArray = array;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -90,8 +90,7 @@ namespace Godot.Bridge
         }
 
         [UnmanagedCallersOnly]
-        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName,
-            IntPtr godotObject)
+        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName, IntPtr godotObject)
         {
             try
             {
@@ -143,7 +142,7 @@ namespace Godot.Bridge
                     }
                 }
 
-                var obj = (GodotObject)FormatterServices.GetUninitializedObject(scriptType);
+                var obj = (GodotObject)RuntimeHelpers.GetUninitializedObject(scriptType);
 
                 var parameters = ctor.GetParameters();
                 int paramCount = parameters.Length;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
@@ -87,8 +87,8 @@ namespace Godot
 
             public void Resize(int size)
             {
-                if (size < 0)
-                    throw new ArgumentOutOfRangeException(nameof(size));
+                ArgumentOutOfRangeException.ThrowIfNegative(size);
+
                 var err = NativeFuncs.godotsharp_stack_info_vector_resize(ref this, size);
                 if (err != Error.Ok)
                     throw new InvalidOperationException("Failed to resize vector. Error code is: " + err.ToString());

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -492,7 +492,7 @@ namespace Godot.Collections
         IReadOnlyDictionary<TKey, TValue>,
         IGenericGodotDictionary
     {
-        private static godot_variant ToVariantFunc(in Dictionary<TKey, TValue> godotDictionary) =>
+        private static godot_variant ToVariantFunc(scoped in Dictionary<TKey, TValue> godotDictionary) =>
             VariantUtils.CreateFromDictionary(godotDictionary);
 
         private static Dictionary<TKey, TValue> FromVariantFunc(in godot_variant variant) =>
@@ -521,8 +521,8 @@ namespace Godot.Collections
 
         static unsafe Dictionary()
         {
-            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.ToVariantCb = &ToVariantFunc;
-            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.FromVariantCb = &FromVariantFunc;
+            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.ToVariantCb = ToVariantFunc;
+            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.FromVariantCb = FromVariantFunc;
         }
 
         private readonly Dictionary _underlyingDict;
@@ -555,8 +555,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(IDictionary<TKey, TValue> dictionary)
         {
-            if (dictionary == null)
-                throw new ArgumentNullException(nameof(dictionary));
+            ArgumentNullException.ThrowIfNull(dictionary);
 
             _underlyingDict = new Dictionary();
             SetTypedForUnderlyingDictionary();
@@ -575,8 +574,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(Dictionary dictionary)
         {
-            if (dictionary == null)
-                throw new ArgumentNullException(nameof(dictionary));
+            ArgumentNullException.ThrowIfNull(dictionary);
 
             _underlyingDict = dictionary;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -90,8 +90,7 @@ namespace Godot
             // NativePtr is assigned, that would result in UB or crashes when calling
             // native functions that receive the pointer, which can happen because the
             // debugger calls ToString() and tries to get the value of properties.
-            if (instance._disposed || instance.NativePtr == IntPtr.Zero)
-                throw new ObjectDisposedException(instance.GetType().FullName);
+            ObjectDisposedException.ThrowIf(instance._disposed || instance.NativePtr == IntPtr.Zero, instance);
 
             return instance.NativePtr;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -88,7 +88,7 @@ namespace Godot
 
                 lock (_tasks)
                 {
-                    if (_tasks.Any())
+                    if (_tasks.Count > 0)
                     {
                         task = _tasks.First.Value;
                         _tasks.RemoveFirst();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -173,7 +173,7 @@ namespace Godot.NativeInterop
         internal readonly unsafe godot_variant* GetUnsafeAddress()
             => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
 
-        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
+        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits. (the native enum actually has no fixed underlying type so it is only at least 6 bits long)
         private int _typeField;
 
         // There's padding here

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -173,7 +173,8 @@ namespace Godot.NativeInterop
         internal readonly unsafe godot_variant* GetUnsafeAddress()
             => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
 
-        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits. (the native enum actually has no fixed underlying type so it is only at least 6 bits long)
+        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
+        // The native enum actually has no fixed underlying type, so it is only at least 6 bits long.
         private int _typeField;
 
         // There's padding here
@@ -481,8 +482,10 @@ namespace Godot.NativeInterop
             Type = Variant.Type.Nil;
         }
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
         [StructLayout(LayoutKind.Explicit)]
         internal struct movable
+#pragma warning restore CS8981
         {
             // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
             [FieldOffset(0)] private int _typeField;
@@ -588,8 +591,10 @@ namespace Godot.NativeInterop
             return _data.GetHashCode();
         }
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
         [StructLayout(LayoutKind.Sequential)]
         internal struct movable
+#pragma warning restore CS8981
         {
             private IntPtr _data;
 
@@ -634,8 +639,10 @@ namespace Godot.NativeInterop
             get => _data == IntPtr.Zero;
         }
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
         [StructLayout(LayoutKind.Sequential)]
         internal struct movable
+#pragma warning restore CS8981
         {
             private IntPtr _data;
 
@@ -809,8 +816,10 @@ namespace Godot.NativeInterop
             _p = null;
         }
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
         [StructLayout(LayoutKind.Sequential)]
         internal struct movable
+#pragma warning restore CS8981
         {
             private unsafe ArrayPrivate* _p;
 
@@ -876,8 +885,10 @@ namespace Godot.NativeInterop
             _p = null;
         }
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
         [StructLayout(LayoutKind.Sequential)]
         internal struct movable
+#pragma warning restore CS8981
         {
             private unsafe DictionaryPrivate* _p;
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -268,7 +268,7 @@ namespace Godot.NativeInterop
 
         // Callable
 
-        public static godot_callable ConvertCallableToNative(in Callable p_managed_callable)
+        public static godot_callable ConvertCallableToNative(scoped in Callable p_managed_callable)
         {
             if (p_managed_callable.Delegate != null)
             {
@@ -333,7 +333,7 @@ namespace Godot.NativeInterop
 
         // Signal
 
-        public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
+        public static godot_signal ConvertSignalToNative(scoped in Signal p_managed_signal)
         {
             ulong ownerId = p_managed_signal.Owner.GetInstanceId();
             godot_string_name name;
@@ -432,12 +432,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
+        public static godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(scoped Span<byte> p_array)
         {
             return ConvertSystemArrayToNativePackedByteArray((ReadOnlySpan<byte>)p_array);
         }
 
-        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(ReadOnlySpan<byte> p_array)
+        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(scoped ReadOnlySpan<byte> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_byte_array();
@@ -460,12 +460,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
+        public static godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(scoped Span<int> p_array)
         {
             return ConvertSystemArrayToNativePackedInt32Array((ReadOnlySpan<int>)p_array);
         }
 
-        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(ReadOnlySpan<int> p_array)
+        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(scoped ReadOnlySpan<int> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int32_array();
@@ -488,12 +488,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
+        public static godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(scoped Span<long> p_array)
         {
             return ConvertSystemArrayToNativePackedInt64Array((ReadOnlySpan<long>)p_array);
         }
 
-        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(ReadOnlySpan<long> p_array)
+        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(scoped ReadOnlySpan<long> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int64_array();
@@ -516,13 +516,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(Span<float> p_array)
+        public static godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(scoped Span<float> p_array)
         {
             return ConvertSystemArrayToNativePackedFloat32Array((ReadOnlySpan<float>)p_array);
         }
 
-        public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
-            ReadOnlySpan<float> p_array)
+        public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(scoped ReadOnlySpan<float> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float32_array();
@@ -545,13 +544,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(Span<double> p_array)
+        public static godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(scoped Span<double> p_array)
         {
             return ConvertSystemArrayToNativePackedFloat64Array((ReadOnlySpan<double>)p_array);
         }
 
-        public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
-            ReadOnlySpan<double> p_array)
+        public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(scoped ReadOnlySpan<double> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float64_array();
@@ -573,12 +571,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
+        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(scoped Span<string> p_array)
         {
             return ConvertSystemArrayToNativePackedStringArray((ReadOnlySpan<string>)p_array);
         }
 
-        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(ReadOnlySpan<string> p_array)
+        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(scoped ReadOnlySpan<string> p_array)
         {
             godot_packed_string_array dest = new godot_packed_string_array();
 
@@ -612,13 +610,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(Span<Vector2> p_array)
+        public static godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(scoped Span<Vector2> p_array)
         {
             return ConvertSystemArrayToNativePackedVector2Array((ReadOnlySpan<Vector2>)p_array);
         }
 
-        public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
-            ReadOnlySpan<Vector2> p_array)
+        public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(scoped ReadOnlySpan<Vector2> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector2_array();
@@ -641,13 +638,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(Span<Vector3> p_array)
+        public static godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(scoped Span<Vector3> p_array)
         {
             return ConvertSystemArrayToNativePackedVector3Array((ReadOnlySpan<Vector3>)p_array);
         }
 
-        public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
-            ReadOnlySpan<Vector3> p_array)
+        public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(scoped ReadOnlySpan<Vector3> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector3_array();
@@ -670,13 +666,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(Span<Vector4> p_array)
+        public static godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(scoped Span<Vector4> p_array)
         {
             return ConvertSystemArrayToNativePackedVector4Array((ReadOnlySpan<Vector4>)p_array);
         }
 
-        public static unsafe godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(
-            ReadOnlySpan<Vector4> p_array)
+        public static unsafe godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(scoped ReadOnlySpan<Vector4> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector4_array();
@@ -699,12 +694,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
+        public static godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(scoped Span<Color> p_array)
         {
             return ConvertSystemArrayToNativePackedColorArray((ReadOnlySpan<Color>)p_array);
         }
 
-        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(ReadOnlySpan<Color> p_array)
+        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(scoped ReadOnlySpan<Color> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_color_array();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -101,10 +101,10 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_internal_reload_registered_script(IntPtr scriptPtr);
 
-        internal static partial void godotsharp_array_filter_godot_objects_by_native(in godot_string_name p_native_name,
-            in godot_array p_input, out godot_array r_output);
+        internal static partial void godotsharp_array_filter_godot_objects_by_native(scoped in godot_string_name p_native_name,
+            scoped in godot_array p_input, out godot_array r_output);
 
-        internal static partial void godotsharp_array_filter_godot_objects_by_non_native(in godot_array p_input,
+        internal static partial void godotsharp_array_filter_godot_objects_by_non_native(scoped in godot_array p_input,
             out godot_array r_output);
 
         public static partial void godotsharp_ref_new_from_ref_counted_ptr(out godot_ref r_dest,
@@ -113,15 +113,15 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
 
         public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
-            in godot_string p_name);
+            scoped in godot_string p_name);
 
         public static partial void godotsharp_node_path_new_from_string(out godot_node_path r_dest,
-            in godot_string p_name);
+            scoped in godot_string p_name);
 
         public static partial void
-            godotsharp_string_name_as_string(out godot_string r_dest, in godot_string_name p_name);
+            godotsharp_string_name_as_string(out godot_string r_dest, scoped in godot_string_name p_name);
 
-        public static partial void godotsharp_node_path_as_string(out godot_string r_dest, in godot_node_path p_np);
+        public static partial void godotsharp_node_path_as_string(out godot_string r_dest, scoped in godot_node_path p_np);
 
         public static partial godot_packed_byte_array godotsharp_packed_byte_array_new_mem_copy(byte* p_src,
             int p_length);
@@ -156,10 +156,10 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
             IntPtr p_object, out godot_callable r_callable);
 
-        internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(in godot_callable p_callable,
+        internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(scoped in godot_callable p_callable,
             out IntPtr r_delegate_handle, out IntPtr r_trampoline, out IntPtr r_object, out godot_string_name r_name);
 
-        internal static partial godot_variant godotsharp_callable_call(in godot_callable p_callable,
+        internal static partial godot_variant godotsharp_callable_call(scoped in godot_callable p_callable,
             godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
 
         internal static partial void godotsharp_callable_call_deferred(in godot_callable p_callable,
@@ -180,58 +180,58 @@ namespace Godot.NativeInterop
         // variant.h
 
         public static partial void
-            godotsharp_variant_new_string_name(out godot_variant r_dest, in godot_string_name p_s);
+            godotsharp_variant_new_string_name(out godot_variant r_dest, scoped in godot_string_name p_s);
 
-        public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, in godot_variant p_src);
+        public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, scoped in godot_variant p_src);
 
-        public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, in godot_node_path p_np);
+        public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, scoped in godot_node_path p_np);
 
         public static partial void godotsharp_variant_new_object(out godot_variant r_dest, IntPtr p_obj);
 
-        public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
+        public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, scoped in Transform2D p_t2d);
 
-        public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
+        public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, scoped in Basis p_basis);
 
-        public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);
+        public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, scoped in Transform3D p_trans);
 
-        public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, in Projection p_proj);
+        public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, scoped in Projection p_proj);
 
-        public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, in Aabb p_aabb);
+        public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, scoped in Aabb p_aabb);
 
         public static partial void godotsharp_variant_new_dictionary(out godot_variant r_dest,
-            in godot_dictionary p_dict);
+            scoped in godot_dictionary p_dict);
 
-        public static partial void godotsharp_variant_new_array(out godot_variant r_dest, in godot_array p_arr);
+        public static partial void godotsharp_variant_new_array(out godot_variant r_dest, scoped in godot_array p_arr);
 
         public static partial void godotsharp_variant_new_packed_byte_array(out godot_variant r_dest,
-            in godot_packed_byte_array p_pba);
+            scoped in godot_packed_byte_array p_pba);
 
         public static partial void godotsharp_variant_new_packed_int32_array(out godot_variant r_dest,
-            in godot_packed_int32_array p_pia);
+            scoped in godot_packed_int32_array p_pia);
 
         public static partial void godotsharp_variant_new_packed_int64_array(out godot_variant r_dest,
-            in godot_packed_int64_array p_pia);
+            scoped in godot_packed_int64_array p_pia);
 
         public static partial void godotsharp_variant_new_packed_float32_array(out godot_variant r_dest,
-            in godot_packed_float32_array p_pra);
+            scoped in godot_packed_float32_array p_pra);
 
         public static partial void godotsharp_variant_new_packed_float64_array(out godot_variant r_dest,
-            in godot_packed_float64_array p_pra);
+            scoped in godot_packed_float64_array p_pra);
 
         public static partial void godotsharp_variant_new_packed_string_array(out godot_variant r_dest,
-            in godot_packed_string_array p_psa);
+            scoped in godot_packed_string_array p_psa);
 
         public static partial void godotsharp_variant_new_packed_vector2_array(out godot_variant r_dest,
-            in godot_packed_vector2_array p_pv2a);
+            scoped in godot_packed_vector2_array p_pv2a);
 
         public static partial void godotsharp_variant_new_packed_vector3_array(out godot_variant r_dest,
-            in godot_packed_vector3_array p_pv3a);
+            scoped in godot_packed_vector3_array p_pv3a);
 
         public static partial void godotsharp_variant_new_packed_vector4_array(out godot_variant r_dest,
-            in godot_packed_vector4_array p_pv4a);
+            scoped in godot_packed_vector4_array p_pv4a);
 
         public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
-            in godot_packed_color_array p_pca);
+            scoped in godot_packed_color_array p_pca);
 
         public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
 
@@ -239,7 +239,7 @@ namespace Godot.NativeInterop
 
         public static partial double godotsharp_variant_as_float(in godot_variant p_self);
 
-        public static partial godot_string godotsharp_variant_as_string(in godot_variant p_self);
+        public static partial godot_string godotsharp_variant_as_string(scoped in godot_variant p_self);
 
         public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
 
@@ -273,45 +273,45 @@ namespace Godot.NativeInterop
 
         public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
 
-        public static partial godot_string_name godotsharp_variant_as_string_name(in godot_variant p_self);
+        public static partial godot_string_name godotsharp_variant_as_string_name(scoped in godot_variant p_self);
 
-        public static partial godot_node_path godotsharp_variant_as_node_path(in godot_variant p_self);
+        public static partial godot_node_path godotsharp_variant_as_node_path(scoped in godot_variant p_self);
 
         public static partial Rid godotsharp_variant_as_rid(in godot_variant p_self);
 
-        public static partial godot_callable godotsharp_variant_as_callable(in godot_variant p_self);
+        public static partial godot_callable godotsharp_variant_as_callable(scoped in godot_variant p_self);
 
-        public static partial godot_signal godotsharp_variant_as_signal(in godot_variant p_self);
+        public static partial godot_signal godotsharp_variant_as_signal(scoped in godot_variant p_self);
 
-        public static partial godot_dictionary godotsharp_variant_as_dictionary(in godot_variant p_self);
+        public static partial godot_dictionary godotsharp_variant_as_dictionary(scoped in godot_variant p_self);
 
-        public static partial godot_array godotsharp_variant_as_array(in godot_variant p_self);
+        public static partial godot_array godotsharp_variant_as_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(in godot_variant p_self);
+        public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(in godot_variant p_self);
+        public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(in godot_variant p_self);
+        public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(scoped in godot_variant p_self);
 
         public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_vector4_array godotsharp_variant_as_packed_vector4_array(
             in godot_variant p_self);
 
-        public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(in godot_variant p_self);
+        public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(scoped in godot_variant p_self);
 
         public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
 
@@ -322,17 +322,17 @@ namespace Godot.NativeInterop
         // string_name.h
 
         public static partial void godotsharp_string_name_new_copy(out godot_string_name r_dest,
-            in godot_string_name p_src);
+            scoped in godot_string_name p_src);
 
         // node_path.h
 
-        public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, in godot_node_path p_src);
+        public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, scoped in godot_node_path p_src);
 
         // array.h
 
         public static partial void godotsharp_array_new(out godot_array r_dest);
 
-        public static partial void godotsharp_array_new_copy(out godot_array r_dest, in godot_array p_src);
+        public static partial void godotsharp_array_new_copy(out godot_array r_dest, scoped in godot_array p_src);
 
         public static partial godot_variant* godotsharp_array_ptrw(ref godot_array p_self);
 
@@ -341,7 +341,7 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_dictionary_new(out godot_dictionary r_dest);
 
         public static partial void godotsharp_dictionary_new_copy(out godot_dictionary r_dest,
-            in godot_dictionary p_src);
+            scoped in godot_dictionary p_src);
 
         // destroy functions
 
@@ -389,8 +389,7 @@ namespace Godot.NativeInterop
 
         public static partial int godotsharp_array_binary_search(ref godot_array p_self, int p_index, int p_count, in godot_variant p_value);
 
-        public static partial void
-            godotsharp_array_duplicate(ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
+        public static partial void godotsharp_array_duplicate(scoped ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
 
         public static partial void godotsharp_array_fill(ref godot_array p_self, in godot_variant p_value);
 
@@ -410,11 +409,11 @@ namespace Godot.NativeInterop
 
         public static partial godot_bool godotsharp_array_is_typed(ref godot_array p_self);
 
-        public static partial void godotsharp_array_max(ref godot_array p_self, out godot_variant r_value);
+        public static partial void godotsharp_array_max(scoped ref godot_array p_self, out godot_variant r_value);
 
-        public static partial void godotsharp_array_min(ref godot_array p_self, out godot_variant r_value);
+        public static partial void godotsharp_array_min(scoped ref godot_array p_self, out godot_variant r_value);
 
-        public static partial void godotsharp_array_pick_random(ref godot_array p_self, out godot_variant r_value);
+        public static partial void godotsharp_array_pick_random(scoped ref godot_array p_self, out godot_variant r_value);
 
         public static partial godot_bool godotsharp_array_recursive_equal(ref godot_array p_self, in godot_array p_other);
 
@@ -426,7 +425,7 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_array_shuffle(ref godot_array p_self);
 
-        public static partial void godotsharp_array_slice(ref godot_array p_self, int p_start, int p_end,
+        public static partial void godotsharp_array_slice(scoped ref godot_array p_self, int p_start, int p_end,
             int p_step, godot_bool p_deep, out godot_array r_dest);
 
         public static partial void godotsharp_array_sort(ref godot_array p_self);
@@ -435,20 +434,20 @@ namespace Godot.NativeInterop
 
         // Dictionary
 
-        public static partial godot_bool godotsharp_dictionary_try_get_value(ref godot_dictionary p_self,
-            in godot_variant p_key,
+        public static partial godot_bool godotsharp_dictionary_try_get_value(scoped ref godot_dictionary p_self,
+            scoped in godot_variant p_key,
             out godot_variant r_value);
 
         public static partial void godotsharp_dictionary_set_value(ref godot_dictionary p_self, in godot_variant p_key,
             in godot_variant p_value);
 
-        public static partial void godotsharp_dictionary_keys(ref godot_dictionary p_self, out godot_array r_dest);
+        public static partial void godotsharp_dictionary_keys(scoped ref godot_dictionary p_self, out godot_array r_dest);
 
-        public static partial void godotsharp_dictionary_values(ref godot_dictionary p_self, out godot_array r_dest);
+        public static partial void godotsharp_dictionary_values(scoped ref godot_dictionary p_self, out godot_array r_dest);
 
         public static partial int godotsharp_dictionary_count(ref godot_dictionary p_self);
 
-        public static partial void godotsharp_dictionary_key_value_pair_at(ref godot_dictionary p_self, int p_index,
+        public static partial void godotsharp_dictionary_key_value_pair_at(scoped ref godot_dictionary p_self, int p_index,
             out godot_variant r_key, out godot_variant r_value);
 
         public static partial void godotsharp_dictionary_add(ref godot_dictionary p_self, in godot_variant p_key,
@@ -459,7 +458,7 @@ namespace Godot.NativeInterop
         public static partial godot_bool godotsharp_dictionary_contains_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 
-        public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
+        public static partial void godotsharp_dictionary_duplicate(scoped ref godot_dictionary p_self, godot_bool p_deep,
             out godot_dictionary r_dest);
 
         public static partial void godotsharp_dictionary_merge(ref godot_dictionary p_self, in godot_dictionary p_dictionary, godot_bool p_overwrite);
@@ -496,20 +495,20 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_dictionary_get_typed_value_script(ref godot_dictionary p_self, out godot_variant r_dest);
 
-        public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
+        public static partial void godotsharp_dictionary_to_string(scoped ref godot_dictionary p_self, out godot_string r_str);
 
         // StringExtensions
 
-        public static partial void godotsharp_string_simplify_path(in godot_string p_self,
+        public static partial void godotsharp_string_simplify_path(scoped in godot_string p_self,
             out godot_string r_simplified_path);
 
-        public static partial void godotsharp_string_to_camel_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_camel_case(scoped in godot_string p_self,
             out godot_string r_camel_case);
 
-        public static partial void godotsharp_string_to_pascal_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_pascal_case(scoped in godot_string p_self,
             out godot_string r_pascal_case);
 
-        public static partial void godotsharp_string_to_snake_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_snake_case(scoped in godot_string p_self,
             out godot_string r_snake_case);
 
         // NodePath
@@ -517,18 +516,18 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,
             ref godot_node_path r_dest);
 
-        public static partial void godotsharp_node_path_get_concatenated_names(in godot_node_path p_self,
+        public static partial void godotsharp_node_path_get_concatenated_names(scoped in godot_node_path p_self,
             out godot_string r_names);
 
-        public static partial void godotsharp_node_path_get_concatenated_subnames(in godot_node_path p_self,
+        public static partial void godotsharp_node_path_get_concatenated_subnames(scoped in godot_node_path p_self,
             out godot_string r_subnames);
 
-        public static partial void godotsharp_node_path_get_name(in godot_node_path p_self, int p_idx,
+        public static partial void godotsharp_node_path_get_name(scoped in godot_node_path p_self, int p_idx,
             out godot_string r_name);
 
         public static partial int godotsharp_node_path_get_name_count(in godot_node_path p_self);
 
-        public static partial void godotsharp_node_path_get_subname(in godot_node_path p_self, int p_idx,
+        public static partial void godotsharp_node_path_get_subname(scoped in godot_node_path p_self, int p_idx,
             out godot_string r_subname);
 
         public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
@@ -541,11 +540,11 @@ namespace Godot.NativeInterop
 
         // GD, etc
 
-        internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,
+        internal static partial void godotsharp_bytes_to_var(scoped in godot_packed_byte_array p_bytes,
             godot_bool p_allow_objects,
             out godot_variant r_ret);
 
-        internal static partial void godotsharp_convert(in godot_variant p_what, int p_type,
+        internal static partial void godotsharp_convert(scoped in godot_variant p_what, int p_type,
             out godot_variant r_ret);
 
         internal static partial int godotsharp_hash(in godot_variant p_var);
@@ -582,12 +581,12 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
 
-        internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
+        internal static partial void godotsharp_str_to_var(scoped in godot_string p_str, out godot_variant r_ret);
 
-        internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
+        internal static partial void godotsharp_var_to_bytes(scoped in godot_variant p_what, godot_bool p_full_objects,
             out godot_packed_byte_array r_bytes);
 
-        internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
+        internal static partial void godotsharp_var_to_str(scoped in godot_variant p_var, out godot_string r_ret);
 
         internal static partial void godotsharp_err_print_error(in godot_string p_function, in godot_string p_file, int p_line, in godot_string p_error, in godot_string p_message = default, godot_bool p_editor_notify = godot_bool.False, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -233,51 +233,51 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
             scoped in godot_packed_color_array p_pca);
 
-        public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
+        public static partial godot_bool godotsharp_variant_as_bool(scoped in godot_variant p_self);
 
-        public static partial Int64 godotsharp_variant_as_int(in godot_variant p_self);
+        public static partial Int64 godotsharp_variant_as_int(scoped in godot_variant p_self);
 
-        public static partial double godotsharp_variant_as_float(in godot_variant p_self);
+        public static partial double godotsharp_variant_as_float(scoped in godot_variant p_self);
 
         public static partial godot_string godotsharp_variant_as_string(scoped in godot_variant p_self);
 
-        public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
+        public static partial Vector2 godotsharp_variant_as_vector2(scoped in godot_variant p_self);
 
-        public static partial Vector2I godotsharp_variant_as_vector2i(in godot_variant p_self);
+        public static partial Vector2I godotsharp_variant_as_vector2i(scoped in godot_variant p_self);
 
-        public static partial Rect2 godotsharp_variant_as_rect2(in godot_variant p_self);
+        public static partial Rect2 godotsharp_variant_as_rect2(scoped in godot_variant p_self);
 
-        public static partial Rect2I godotsharp_variant_as_rect2i(in godot_variant p_self);
+        public static partial Rect2I godotsharp_variant_as_rect2i(scoped in godot_variant p_self);
 
-        public static partial Vector3 godotsharp_variant_as_vector3(in godot_variant p_self);
+        public static partial Vector3 godotsharp_variant_as_vector3(scoped in godot_variant p_self);
 
-        public static partial Vector3I godotsharp_variant_as_vector3i(in godot_variant p_self);
+        public static partial Vector3I godotsharp_variant_as_vector3i(scoped in godot_variant p_self);
 
-        public static partial Transform2D godotsharp_variant_as_transform2d(in godot_variant p_self);
+        public static partial Transform2D godotsharp_variant_as_transform2d(scoped in godot_variant p_self);
 
-        public static partial Vector4 godotsharp_variant_as_vector4(in godot_variant p_self);
+        public static partial Vector4 godotsharp_variant_as_vector4(scoped in godot_variant p_self);
 
-        public static partial Vector4I godotsharp_variant_as_vector4i(in godot_variant p_self);
+        public static partial Vector4I godotsharp_variant_as_vector4i(scoped in godot_variant p_self);
 
-        public static partial Plane godotsharp_variant_as_plane(in godot_variant p_self);
+        public static partial Plane godotsharp_variant_as_plane(scoped in godot_variant p_self);
 
-        public static partial Quaternion godotsharp_variant_as_quaternion(in godot_variant p_self);
+        public static partial Quaternion godotsharp_variant_as_quaternion(scoped in godot_variant p_self);
 
-        public static partial Aabb godotsharp_variant_as_aabb(in godot_variant p_self);
+        public static partial Aabb godotsharp_variant_as_aabb(scoped in godot_variant p_self);
 
-        public static partial Basis godotsharp_variant_as_basis(in godot_variant p_self);
+        public static partial Basis godotsharp_variant_as_basis(scoped in godot_variant p_self);
 
-        public static partial Transform3D godotsharp_variant_as_transform3d(in godot_variant p_self);
+        public static partial Transform3D godotsharp_variant_as_transform3d(scoped in godot_variant p_self);
 
-        public static partial Projection godotsharp_variant_as_projection(in godot_variant p_self);
+        public static partial Projection godotsharp_variant_as_projection(scoped in godot_variant p_self);
 
-        public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
+        public static partial Color godotsharp_variant_as_color(scoped in godot_variant p_self);
 
         public static partial godot_string_name godotsharp_variant_as_string_name(scoped in godot_variant p_self);
 
         public static partial godot_node_path godotsharp_variant_as_node_path(scoped in godot_variant p_self);
 
-        public static partial Rid godotsharp_variant_as_rid(in godot_variant p_self);
+        public static partial Rid godotsharp_variant_as_rid(scoped in godot_variant p_self);
 
         public static partial godot_callable godotsharp_variant_as_callable(scoped in godot_variant p_self);
 
@@ -293,27 +293,22 @@ namespace Godot.NativeInterop
 
         public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
-            scoped in godot_variant p_self);
+        public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
-            scoped in godot_variant p_self);
+        public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
-            scoped in godot_variant p_self);
+        public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
-            scoped in godot_variant p_self);
+        public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
-            scoped in godot_variant p_self);
+        public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(scoped in godot_variant p_self);
 
         public static partial godot_packed_vector4_array godotsharp_variant_as_packed_vector4_array(
             in godot_variant p_self);
 
         public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(scoped in godot_variant p_self);
 
-        public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
+        public static partial godot_bool godotsharp_variant_equals(scoped in godot_variant p_a, scoped in godot_variant p_b);
 
         // string.h
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -6,7 +6,7 @@ namespace Godot.NativeInterop
 {
     public static partial class NativeFuncs
     {
-        public static godot_variant godotsharp_variant_new_copy(in godot_variant src)
+        public static godot_variant godotsharp_variant_new_copy(scoped in godot_variant src)
         {
             switch (src.Type)
             {
@@ -48,7 +48,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_string_name godotsharp_string_name_new_copy(in godot_string_name src)
+        public static godot_string_name godotsharp_string_name_new_copy(scoped in godot_string_name src)
         {
             if (src.IsEmpty)
                 return default;
@@ -56,7 +56,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_node_path godotsharp_node_path_new_copy(in godot_node_path src)
+        public static godot_node_path godotsharp_node_path_new_copy(scoped in godot_node_path src)
         {
             if (src.IsEmpty)
                 return default;
@@ -70,7 +70,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_array godotsharp_array_new_copy(in godot_array src)
+        public static godot_array godotsharp_array_new_copy(scoped in godot_array src)
         {
             godotsharp_array_new_copy(out godot_array ret, src);
             return ret;
@@ -82,7 +82,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_dictionary godotsharp_dictionary_new_copy(in godot_dictionary src)
+        public static godot_dictionary godotsharp_dictionary_new_copy(scoped in godot_dictionary src)
         {
             godotsharp_dictionary_new_copy(out godot_dictionary ret, src);
             return ret;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -248,13 +248,28 @@ namespace Godot.NativeInterop
         }
 
         public static godot_variant CreateFromSystemArrayOfStringName(scoped Span<StringName> from)
-            => CreateFromArray(new Collections.Array(from));
+        {
+            if (from == null)
+                return default;
+            using var fromGodot = new Collections.Array(from);
+            return CreateFromArray((godot_array)fromGodot.NativeValue);
+        }
 
         public static godot_variant CreateFromSystemArrayOfNodePath(scoped Span<NodePath> from)
-            => CreateFromArray(new Collections.Array(from));
+        {
+            if (from == null)
+                return default;
+            using var fromGodot = new Collections.Array(from);
+            return CreateFromArray((godot_array)fromGodot.NativeValue);
+        }
 
         public static godot_variant CreateFromSystemArrayOfRid(scoped Span<Rid> from)
-            => CreateFromArray(new Collections.Array(from));
+        {
+            if (from == null)
+                return default;
+            using var fromGodot = new Collections.Array(from);
+            return CreateFromArray((godot_array)fromGodot.NativeValue);
+        }
 
         public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -117,159 +117,144 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromString(string? from)
             => CreateFromStringTakingOwnershipOfDisposableValue(Marshaling.ConvertStringToNative(from));
 
-        public static godot_variant CreateFromPackedByteArray(in godot_packed_byte_array from)
+        public static godot_variant CreateFromPackedByteArray(scoped in godot_packed_byte_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_byte_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedInt32Array(in godot_packed_int32_array from)
+        public static godot_variant CreateFromPackedInt32Array(scoped in godot_packed_int32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int32_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedInt64Array(in godot_packed_int64_array from)
+        public static godot_variant CreateFromPackedInt64Array(scoped in godot_packed_int64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int64_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedFloat32Array(in godot_packed_float32_array from)
+        public static godot_variant CreateFromPackedFloat32Array(scoped in godot_packed_float32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float32_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedFloat64Array(in godot_packed_float64_array from)
+        public static godot_variant CreateFromPackedFloat64Array(scoped in godot_packed_float64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float64_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedStringArray(in godot_packed_string_array from)
+        public static godot_variant CreateFromPackedStringArray(scoped in godot_packed_string_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_string_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedVector2Array(in godot_packed_vector2_array from)
+        public static godot_variant CreateFromPackedVector2Array(scoped in godot_packed_vector2_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector2_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedVector3Array(in godot_packed_vector3_array from)
+        public static godot_variant CreateFromPackedVector3Array(scoped in godot_packed_vector3_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector3_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedVector4Array(in godot_packed_vector4_array from)
+        public static godot_variant CreateFromPackedVector4Array(scoped in godot_packed_vector4_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector4_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedColorArray(in godot_packed_color_array from)
+        public static godot_variant CreateFromPackedColorArray(scoped in godot_packed_color_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_color_array(out godot_variant ret, from);
             return ret;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedByteArray(Span<byte> from)
+        public static godot_variant CreateFromPackedByteArray(scoped Span<byte> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedByteArray(from);
             return CreateFromPackedByteArray(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt32Array(Span<int> from)
+        public static godot_variant CreateFromPackedInt32Array(scoped Span<int> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt32Array(from);
             return CreateFromPackedInt32Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt64Array(Span<long> from)
+        public static godot_variant CreateFromPackedInt64Array(scoped Span<long> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt64Array(from);
             return CreateFromPackedInt64Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat32Array(Span<float> from)
+        public static godot_variant CreateFromPackedFloat32Array(scoped Span<float> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat32Array(from);
             return CreateFromPackedFloat32Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat64Array(Span<double> from)
+        public static godot_variant CreateFromPackedFloat64Array(scoped Span<double> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat64Array(from);
             return CreateFromPackedFloat64Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedStringArray(Span<string> from)
+        public static godot_variant CreateFromPackedStringArray(scoped Span<string> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedStringArray(from);
             return CreateFromPackedStringArray(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector2Array(Span<Vector2> from)
+        public static godot_variant CreateFromPackedVector2Array(scoped Span<Vector2> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector2Array(from);
             return CreateFromPackedVector2Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector3Array(Span<Vector3> from)
+        public static godot_variant CreateFromPackedVector3Array(scoped Span<Vector3> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector3Array(from);
             return CreateFromPackedVector3Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector4Array(Span<Vector4> from)
+        public static godot_variant CreateFromPackedVector4Array(scoped Span<Vector4> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector4Array(from);
             return CreateFromPackedVector4Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedColorArray(Span<Color> from)
+        public static godot_variant CreateFromPackedColorArray(scoped Span<Color> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedColorArray(from);
             return CreateFromPackedColorArray(nativePackedArray);
         }
 
-        public static godot_variant CreateFromSystemArrayOfStringName(Span<StringName> from)
-        {
-            if (from == null)
-                return default;
-            using var fromGodot = new Collections.Array(from);
-            return CreateFromArray((godot_array)fromGodot.NativeValue);
-        }
+        public static godot_variant CreateFromSystemArrayOfStringName(scoped Span<StringName> from)
+            => CreateFromArray(new Collections.Array(from));
 
-        public static godot_variant CreateFromSystemArrayOfNodePath(Span<NodePath> from)
-        {
-            if (from == null)
-                return default;
-            using var fromGodot = new Collections.Array(from);
-            return CreateFromArray((godot_array)fromGodot.NativeValue);
-        }
+        public static godot_variant CreateFromSystemArrayOfNodePath(scoped Span<NodePath> from)
+            => CreateFromArray(new Collections.Array(from));
 
-        public static godot_variant CreateFromSystemArrayOfRid(Span<Rid> from)
-        {
-            if (from == null)
-                return default;
-            using var fromGodot = new Collections.Array(from);
-            return CreateFromArray((godot_array)fromGodot.NativeValue);
-        }
+        public static godot_variant CreateFromSystemArrayOfRid(scoped Span<Rid> from)
+            => CreateFromArray(new Collections.Array(from));
 
         public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
         {
@@ -279,7 +264,7 @@ namespace Godot.NativeInterop
             return CreateFromArray((godot_array)fromGodot.NativeValue);
         }
 
-        public static godot_variant CreateFromArray(godot_array from)
+        public static godot_variant CreateFromArray(scoped in godot_array from)
         {
             NativeFuncs.godotsharp_variant_new_array(out godot_variant ret, from);
             return ret;
@@ -293,7 +278,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromArray<[MustBeVariant] T>(Array<T>? from)
             => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
 
-        public static godot_variant CreateFromDictionary(godot_dictionary from)
+        public static godot_variant CreateFromDictionary(scoped in godot_dictionary from)
         {
             NativeFuncs.godotsharp_variant_new_dictionary(out godot_variant ret, from);
             return ret;
@@ -307,7 +292,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? from)
             => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
 
-        public static godot_variant CreateFromStringName(godot_string_name from)
+        public static godot_variant CreateFromStringName(scoped in godot_string_name from)
         {
             NativeFuncs.godotsharp_variant_new_string_name(out godot_variant ret, from);
             return ret;
@@ -317,7 +302,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromStringName(StringName? from)
             => from != null ? CreateFromStringName((godot_string_name)from.NativeValue) : default;
 
-        public static godot_variant CreateFromNodePath(godot_node_path from)
+        public static godot_variant CreateFromNodePath(scoped in godot_node_path from)
         {
             NativeFuncs.godotsharp_variant_new_node_path(out godot_variant ret, from);
             return ret;
@@ -510,7 +495,7 @@ namespace Godot.NativeInterop
             }
         }
 
-        public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
+        public static godot_string_name ConvertToNativeStringName(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.StringName ?
                 NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
                 NativeFuncs.godotsharp_variant_as_string_name(p_var);
@@ -519,7 +504,7 @@ namespace Godot.NativeInterop
         public static StringName ConvertToStringName(in godot_variant p_var)
             => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
 
-        public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
+        public static godot_node_path ConvertToNativeNodePath(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.NodePath ?
                 NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
                 NativeFuncs.godotsharp_variant_as_node_path(p_var);
@@ -529,7 +514,7 @@ namespace Godot.NativeInterop
             => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
+        public static godot_callable ConvertToNativeCallable(scoped in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_callable(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -540,7 +525,7 @@ namespace Godot.NativeInterop
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
+        public static godot_signal ConvertToNativeSignal(scoped in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -550,7 +535,7 @@ namespace Godot.NativeInterop
             return Marshaling.ConvertSignalToManaged(signal);
         }
 
-        public static godot_array ConvertToNativeArray(in godot_variant p_var)
+        public static godot_array ConvertToNativeArray(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.Array ?
                 NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
                 NativeFuncs.godotsharp_variant_as_array(p_var);
@@ -563,7 +548,7 @@ namespace Godot.NativeInterop
         public static Array<T> ConvertToArray<[MustBeVariant] T>(in godot_variant p_var)
             => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
-        public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
+        public static godot_dictionary ConvertToNativeDictionary(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.Dictionary ?
                 NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
                 NativeFuncs.godotsharp_variant_as_dictionary(p_var);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -12,8 +12,10 @@ public partial class VariantUtils
 
     internal static class GenericConversion<T>
     {
-        public static unsafe godot_variant ToVariant(in T from) =>
+        public static unsafe godot_variant ToVariant(scoped in T from) =>
+#pragma warning disable CS9088 // the delegate pointer cannot be marked scoped, but it should be
             ToVariantCb != null ? ToVariantCb(from) : throw UnsupportedType<T>();
+#pragma warning restore CS9088
 
         public static unsafe T FromVariant(in godot_variant variant) =>
             FromVariantCb != null ? FromVariantCb(variant) : throw UnsupportedType<T>();
@@ -31,7 +33,7 @@ public partial class VariantUtils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static godot_variant CreateFrom<[MustBeVariant] T>(in T from)
+    public static godot_variant CreateFrom<[MustBeVariant] T>(scoped in T from)
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static TTo UnsafeAs<TTo>(in T f) => Unsafe.As<T, TTo>(ref Unsafe.AsRef(f));

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1581,7 +1581,7 @@ namespace Godot
                 if (end < 0)
                     end = len;
                 if (allowEmpty || end > from)
-                    ret.Add(float.Parse(instance.Substring(from), CultureInfo.InvariantCulture));
+                    ret.Add(float.Parse(instance.AsSpan(from), CultureInfo.InvariantCulture));
                 if (end == len)
                     break;
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{AEBF0036-DA76-4341-B651-A3F2856AB2FA}</ProjectGuid>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>11</LangVersion>
 
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
+
   <PropertyGroup>
     <Description>Godot C# Core API.</Description>
     <Authors>Godot Engine contributors</Authors>
@@ -28,23 +30,28 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
   <ItemGroup>
     <!-- SdkPackageVersions.props for easy access -->
     <None Include="$(GodotSdkPackageVersionsFilePath)">
       <Link>SdkPackageVersions.props</Link>
     </None>
   </ItemGroup>
+
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GODOT</DefineConstants>
     <DefineConstants Condition=" '$(GodotFloat64)' == 'true' ">REAL_T_IS_DOUBLE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="ReflectionAnalyzers" Version="0.1.22-dev" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <!--PackageReference Include="IDisposableAnalyzers" Version="3.4.13" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" /-->
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Godot.SourceGenerators.Internal\Godot.SourceGenerators.Internal.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="Core\Aabb.cs" />
@@ -135,10 +142,12 @@
     <Compile Include="GlobalUsings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <!-- Compat Sources -->
   <ItemGroup Condition=" '$(GodotNoDeprecated)' == '' ">
     <Compile Include="Compat.cs" />
   </ItemGroup>
+
   <!--
   We import a props file with auto-generated includes. This works well with Rider.
   However, Visual Studio and MonoDevelop won't list them in the solution explorer.

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -4,11 +4,11 @@
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
 
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -4,7 +4,7 @@
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{8FBEC238-D944-4074-8548-B3B524305905}</ProjectGuid>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Godot C# Editor API.</Description>


### PR DESCRIPTION
This is to prepare the EOS of .NET6 in November.

Would need to be more thoroughly tested. There are probably a bunch of other spots where we could mark things as `scoped`. 

- Supersedes #71241