### PR TITLE
Editor Feature Profile: Only rebuild selected TreeItem and all children when a property is edited

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -497,8 +497,8 @@ void EditorFeatureProfileManager::_hide_requested() {
 	_cancel_pressed(); // From AcceptDialog.
 }
 
-void EditorFeatureProfileManager::_fill_classes_from(TreeItem *p_parent, const String &p_class, const String &p_selected) {
-	TreeItem *class_item = class_list->create_item(p_parent);
+void EditorFeatureProfileManager::_fill_classes_from(TreeItem *p_parent, const String &p_class, const String &p_selected, int p_class_insert_index) {
+	TreeItem *class_item = class_list->create_item(p_parent, p_class_insert_index);
 	class_item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 	class_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_class));
 	String text = p_class;
@@ -647,7 +647,7 @@ void EditorFeatureProfileManager::_class_list_item_edited() {
 		String class_selected = md;
 		edited->set_disable_class(class_selected, !checked);
 		_save_and_update();
-		_update_selected_profile();
+		_update_profile_tree_from(item);
 	} else if (md.get_type() == Variant::INT) {
 		int feature_selected = md;
 		edited->set_disable_feature(EditorFeatureProfile::Feature(feature_selected), !checked);
@@ -703,17 +703,27 @@ void EditorFeatureProfileManager::_property_item_edited() {
 		String property_selected = md;
 		edited->set_disable_class_property(class_name, property_selected, !checked);
 		_save_and_update();
-		_update_selected_profile();
+		_update_profile_tree_from(class_list->get_selected());
 	} else if (md.get_type() == Variant::INT) {
 		int feature_selected = md;
 		switch (feature_selected) {
 			case CLASS_OPTION_DISABLE_EDITOR: {
 				edited->set_disable_class_editor(class_name, !checked);
 				_save_and_update();
-				_update_selected_profile();
+				_update_profile_tree_from(class_list->get_selected());
 			} break;
 		}
 	}
+}
+
+void EditorFeatureProfileManager::_update_profile_tree_from(TreeItem *p_edited) {
+	String edited_class = p_edited->get_metadata(0);
+
+	TreeItem *edited_parent = p_edited->get_parent();
+	int class_insert_index = p_edited->get_index();
+	p_edited->get_parent()->remove_child(p_edited);
+
+	_fill_classes_from(edited_parent, edited_class, edited_class, class_insert_index);
 }
 
 void EditorFeatureProfileManager::_update_selected_profile() {

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -147,7 +147,8 @@ class EditorFeatureProfileManager : public AcceptDialog {
 	String current_profile;
 	void _update_profile_list(const String &p_select_profile = String());
 	void _update_selected_profile();
-	void _fill_classes_from(TreeItem *p_parent, const String &p_class, const String &p_selected);
+	void _update_profile_tree_from(TreeItem *p_edited);
+	void _fill_classes_from(TreeItem *p_parent, const String &p_class, const String &p_selected, int p_class_insert_index = -1);
 
 	Ref<EditorFeatureProfile> current;
 	Ref<EditorFeatureProfile> edited;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/92132

Before, the whole `Tree` was rebuild when a property was changed. 
This is not just a bad idea for performance reasons, but also does not retain any folds that were previously done by the user on any other `TreeItem`.

This PR improves that by only rebuilding the selected class `TreeItem` and all children, which improves the performance but also retain any folds that were previously done to other `TreeItem`s.

For that, we now always call `_update_profile_tree_from` when something was edited instead of `_update_selected_profile`, which does a full rebuild.


https://github.com/godotengine/godot/assets/66004280/2523a2a5-185f-45e1-85fb-7e707f701ec9