### PR TITLE
[3.x] Fix Viewport interpolation mode

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -246,6 +246,7 @@
 		<member name="own_world" type="bool" setter="set_use_own_world" getter="is_using_own_world" default="false">
 			If [code]true[/code], the viewport will use a unique copy of the [World] defined in [member world].
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 		<member name="physics_object_picking" type="bool" setter="set_physics_object_picking" getter="get_physics_object_picking" default="false">
 			If [code]true[/code], the objects rendered by viewport become subjects of mouse picking process.
 		</member>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3681,6 +3681,13 @@ Viewport::Viewport() {
 	local_input_handled = false;
 	handle_input_locally = true;
 	physics_last_id = 0; //ensures first time there will be a check
+
+	// Physics interpolation mode for viewports is a special case.
+	// Typically viewports will be housed within Controls,
+	// and Controls default to PHYSICS_INTERPOLATION_MODE_OFF.
+	// Viewports can thus inherit physics interpolation OFF, which is unexpected.
+	// Setting to ON allows each viewport to have a fresh interpolation state.
+	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_ON);
 }
 
 Viewport::~Viewport() {


### PR DESCRIPTION
Viewport interpolation mode is a special case, which should be set to ON instead of INHERIT.

Fixes #92150
Fixes #91918

## Notes
* Controls defaulting to OFF is a trade off - it makes adding controls easy to a physics interpolated game, but users need to be aware that nodes below the control will usually inherit this OFF setting.
* Viewports are typically children of Controls, and previously would inherit OFF, which could be unexpected for physics interpolated games.
* The simplest and most sensible solution seems to be to reset the physics interpolation mode and consider the `Viewport` as a new root of each subscene.
* This is something that can eventually be added to the physics interpolation docs, along with other special cases. But it should now work in a more expected manner for most users.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
