### PR TITLE
Clarify `is_polygon_clockwise()` coordinate system

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -350,6 +350,8 @@ public:
 		return triangles;
 	}
 
+	// Assumes cartesian coordinate system with +x to the right, +y up.
+	// If using screen coordinates (+x to the right, +y down) the result will need to be flipped.
 	static bool is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
 		int c = p_polygon.size();
 		if (c < 3) {

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -116,6 +116,7 @@
 			<param index="0" name="polygon" type="PackedVector2Array" />
 			<description>
 				Returns [code]true[/code] if [param polygon]'s vertices are ordered in clockwise order, otherwise returns [code]false[/code].
+				[b]Note:[/b] Assumes a Cartesian coordinate system where [code]+x[/code] is right and [code]+y[/code] is up. If using screen coordinates ([code]+y[/code] is down), the result will need to be flipped (i.e. a [code]true[/code] result will indicate counter-clockwise).
 			</description>
 		</method>
 		<method name="line_intersects_line">


### PR DESCRIPTION
The function assumes a normal Cartesian coordinate system.

Fixes #49716

## Notes
* Alternative would be to add a parameter to do the flip as in #89635, but that may be controversial, and is taking a while to be decided on, so this doc change will do the job either as the final solution, or until we decide on another solution.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
