### PR TITLE
Replace List with LocalVector on Skeleton3D's bone transform update.

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -847,12 +847,13 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 	ERR_FAIL_INDEX(p_bone_idx, bone_size);
 
 	Bone *bonesptr = bones.ptrw();
-	List<int> bones_to_process = List<int>();
+	thread_local LocalVector<int> bones_to_process;
+	bones_to_process.clear();
 	bones_to_process.push_back(p_bone_idx);
 
-	while (bones_to_process.size() > 0) {
-		int current_bone_idx = bones_to_process.front()->get();
-		bones_to_process.erase(current_bone_idx);
+	uint32_t index = 0;
+	while (index < bones_to_process.size()) {
+		int current_bone_idx = bones_to_process[index];
 
 		Bone &b = bonesptr[current_bone_idx];
 		bool bone_enabled = b.enabled && !show_rest_only;
@@ -905,6 +906,8 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 		for (int i = 0; i < child_bone_size; i++) {
 			bones_to_process.push_back(b.child_bones[i]);
 		}
+
+		index++;
 	}
 }
 


### PR DESCRIPTION
Along the lines of https://github.com/godotengine/godot/pull/91989, this is a CPU-oriented optimization around removing allocations from a hot path detected in Nuku Warriors that led to around 2000+ allocations per frame due to the usage of a linked list to do a pre-order traversal.

The alternative implementation is fairly minimal and reuses a LocalVector across frames. I'm coming up with a reliable way to benchmark these, but if @Calinou perhaps already has something that causes this same hot path to be hit, that could be ideal to prove the result in an open benchmark.

No behavior differences are expected.