### PR TITLE
Reduce code duplication in FileAccess

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -223,59 +223,44 @@ String FileAccess::fix_path(const String &p_path) const {
 }
 
 /* these are all implemented for ease of porting, then can later be optimized */
+uint8_t FileAccess::get_8() const {
+	uint8_t data = 0;
+	get_buffer(&data, sizeof(uint8_t));
+
+	return data;
+}
 
 uint16_t FileAccess::get_16() const {
-	uint16_t res;
-	uint8_t a, b;
-
-	a = get_8();
-	b = get_8();
+	uint16_t data = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint16_t));
 
 	if (big_endian) {
-		SWAP(a, b);
+		data = BSWAP16(data);
 	}
 
-	res = b;
-	res <<= 8;
-	res |= a;
-
-	return res;
+	return data;
 }
 
 uint32_t FileAccess::get_32() const {
-	uint32_t res;
-	uint16_t a, b;
-
-	a = get_16();
-	b = get_16();
+	uint32_t data = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint32_t));
 
 	if (big_endian) {
-		SWAP(a, b);
+		data = BSWAP32(data);
 	}
 
-	res = b;
-	res <<= 16;
-	res |= a;
-
-	return res;
+	return data;
 }
 
 uint64_t FileAccess::get_64() const {
-	uint64_t res;
-	uint32_t a, b;
-
-	a = get_32();
-	b = get_32();
+	uint64_t data = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint64_t));
 
 	if (big_endian) {
-		SWAP(a, b);
+		data = BSWAP64(data);
 	}
 
-	res = b;
-	res <<= 32;
-	res |= a;
-
-	return res;
+	return data;
 }
 
 float FileAccess::get_float() const {
@@ -465,17 +450,6 @@ String FileAccess::get_as_text(bool p_skip_cr) const {
 	return text;
 }
 
-uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-
-	uint64_t i = 0;
-	for (i = 0; i < p_length && !eof_reached(); i++) {
-		p_dst[i] = get_8();
-	}
-
-	return i;
-}
-
 Vector<uint8_t> FileAccess::get_buffer(int64_t p_length) const {
 	Vector<uint8_t> data;
 
@@ -488,7 +462,7 @@ Vector<uint8_t> FileAccess::get_buffer(int64_t p_length) const {
 	ERR_FAIL_COND_V_MSG(err != OK, data, "Can't resize data to " + itos(p_length) + " elements.");
 
 	uint8_t *w = data.ptrw();
-	int64_t len = get_buffer(&w[0], p_length);
+	int64_t len = get_buffer(w, p_length);
 
 	if (len < p_length) {
 		data.resize(len);
@@ -512,46 +486,32 @@ String FileAccess::get_as_utf8_string(bool p_skip_cr) const {
 	return s;
 }
 
+void FileAccess::store_8(uint8_t p_dest) {
+	store_buffer(&p_dest, sizeof(uint8_t));
+}
+
 void FileAccess::store_16(uint16_t p_dest) {
-	uint8_t a, b;
-
-	a = p_dest & 0xFF;
-	b = p_dest >> 8;
-
 	if (big_endian) {
-		SWAP(a, b);
+		p_dest = BSWAP16(p_dest);
 	}
 
-	store_8(a);
-	store_8(b);
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), sizeof(uint16_t));
 }
 
 void FileAccess::store_32(uint32_t p_dest) {
-	uint16_t a, b;
-
-	a = p_dest & 0xFFFF;
-	b = p_dest >> 16;
-
 	if (big_endian) {
-		SWAP(a, b);
+		p_dest = BSWAP32(p_dest);
 	}
 
-	store_16(a);
-	store_16(b);
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), sizeof(uint32_t));
 }
 
 void FileAccess::store_64(uint64_t p_dest) {
-	uint32_t a, b;
-
-	a = p_dest & 0xFFFFFFFF;
-	b = p_dest >> 32;
-
 	if (big_endian) {
-		SWAP(a, b);
+		p_dest = BSWAP64(p_dest);
 	}
 
-	store_32(a);
-	store_32(b);
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), sizeof(uint64_t));
 }
 
 void FileAccess::store_real(real_t p_real) {
@@ -708,22 +668,11 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	store_line(line);
 }
 
-void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
-	ERR_FAIL_COND(!p_src && p_length > 0);
-	for (uint64_t i = 0; i < p_length; i++) {
-		store_8(p_src[i]);
-	}
-}
-
 void FileAccess::store_buffer(const Vector<uint8_t> &p_buffer) {
 	uint64_t len = p_buffer.size();
-	if (len == 0) {
-		return;
-	}
-
 	const uint8_t *r = p_buffer.ptr();
 
-	store_buffer(&r[0], len);
+	store_buffer(r, len);
 }
 
 void FileAccess::store_var(const Variant &p_var, bool p_full_objects) {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -137,7 +137,7 @@ public:
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
-	virtual uint8_t get_8() const = 0; ///< get a byte
+	virtual uint8_t get_8() const; ///< get a byte
 	virtual uint16_t get_16() const; ///< get 16 bits uint
 	virtual uint32_t get_32() const; ///< get 32 bits uint
 	virtual uint64_t get_64() const; ///< get 64 bits uint
@@ -148,7 +148,7 @@ public:
 
 	Variant get_var(bool p_allow_objects = false) const;
 
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const = 0; ///< get an array of bytes, needs to be overwritten by children.
 	Vector<uint8_t> get_buffer(int64_t p_length) const;
 	virtual String get_line() const;
 	virtual String get_token() const;
@@ -168,7 +168,7 @@ public:
 
 	virtual Error resize(int64_t p_length) = 0;
 	virtual void flush() = 0;
-	virtual void store_8(uint8_t p_dest) = 0; ///< store a byte
+	virtual void store_8(uint8_t p_dest); ///< store a byte
 	virtual void store_16(uint16_t p_dest); ///< store 16 bits uint
 	virtual void store_32(uint32_t p_dest); ///< store 32 bits uint
 	virtual void store_64(uint64_t p_dest); ///< store 64 bits uint
@@ -184,7 +184,7 @@ public:
 	virtual void store_pascal_string(const String &p_string);
 	virtual String get_pascal_string();
 
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) = 0; ///< store an array of bytes, needs to be overwritten by children.
 	void store_buffer(const Vector<uint8_t> &p_buffer);
 
 	void store_var(const Variant &p_var, bool p_full_objects = false);

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -83,14 +83,13 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -206,26 +206,13 @@ bool FileAccessEncrypted::eof_reached() const {
 	return eofed;
 }
 
-uint8_t FileAccessEncrypted::get_8() const {
-	ERR_FAIL_COND_V_MSG(writing, 0, "File has not been opened in read mode.");
-	if (pos >= get_length()) {
-		eofed = true;
-		return 0;
-	}
-
-	uint8_t b = data[pos];
-	pos++;
-	return b;
-}
-
 uint64_t FileAccessEncrypted::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 
 	uint64_t to_copy = MIN(p_length, get_length() - pos);
-	for (uint64_t i = 0; i < to_copy; i++) {
-		p_dst[i] = data[pos++];
-	}
+	memcpy(p_dst, data.ptr() + pos, to_copy);
+	pos += to_copy;
 
 	if (to_copy < p_length) {
 		eofed = true;
@@ -242,35 +229,18 @@ void FileAccessEncrypted::store_buffer(const uint8_t *p_src, uint64_t p_length) 
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 	ERR_FAIL_COND(!p_src && p_length > 0);
 
-	if (pos < get_length()) {
-		for (uint64_t i = 0; i < p_length; i++) {
-			store_8(p_src[i]);
-		}
-	} else if (pos == get_length()) {
+	if (pos + p_length >= get_length()) {
 		data.resize(pos + p_length);
-		for (uint64_t i = 0; i < p_length; i++) {
-			data.write[pos + i] = p_src[i];
-		}
-		pos += p_length;
 	}
+
+	memcpy(data.ptrw() + pos, p_src, p_length);
+	pos += p_length;
 }
 
 void FileAccessEncrypted::flush() {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
 	// encrypted files keep data in memory till close()
-}
-
-void FileAccessEncrypted::store_8(uint8_t p_dest) {
-	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
-
-	if (pos < get_length()) {
-		data.write[pos] = p_dest;
-		pos++;
-	} else if (pos == get_length()) {
-		data.push_back(p_dest);
-		pos++;
-	}
 }
 
 bool FileAccessEncrypted::file_exists(const String &p_name) {

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -73,14 +73,12 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -122,16 +122,6 @@ bool FileAccessMemory::eof_reached() const {
 	return pos >= length;
 }
 
-uint8_t FileAccessMemory::get_8() const {
-	uint8_t ret = 0;
-	if (pos < length) {
-		ret = data[pos];
-	}
-	++pos;
-
-	return ret;
-}
-
 uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V(data, -1);
@@ -157,16 +147,12 @@ void FileAccessMemory::flush() {
 	ERR_FAIL_NULL(data);
 }
 
-void FileAccessMemory::store_8(uint8_t p_byte) {
-	ERR_FAIL_NULL(data);
-	ERR_FAIL_COND(pos >= length);
-	data[pos++] = p_byte;
-}
-
 void FileAccessMemory::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND(!p_src && p_length > 0);
+
 	uint64_t left = length - pos;
 	uint64_t write = MIN(p_length, left);
+
 	if (write < p_length) {
 		WARN_PRINT("Writing less data than requested");
 	}

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -55,15 +55,12 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
-
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override; ///< get an array of bytes
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_byte) override; ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -313,17 +313,6 @@ bool FileAccessPack::eof_reached() const {
 	return eof;
 }
 
-uint8_t FileAccessPack::get_8() const {
-	ERR_FAIL_COND_V_MSG(f.is_null(), 0, "File must be opened before use.");
-	if (pos >= pf.size) {
-		eof = true;
-		return 0;
-	}
-
-	pos++;
-	return f->get_8();
-}
-
 uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V_MSG(f.is_null(), -1, "File must be opened before use.");
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
@@ -363,10 +352,6 @@ Error FileAccessPack::get_error() const {
 }
 
 void FileAccessPack::flush() {
-	ERR_FAIL();
-}
-
-void FileAccessPack::store_8(uint8_t p_dest) {
 	ERR_FAIL();
 }
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -169,8 +169,6 @@ public:
 
 	virtual bool eof_reached() const override;
 
-	virtual uint8_t get_8() const override;
-
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual void set_big_endian(bool p_big_endian) override;
@@ -179,8 +177,6 @@ public:
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override;
-
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_name) override;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -291,12 +291,6 @@ bool FileAccessZip::eof_reached() const {
 	return at_eof;
 }
 
-uint8_t FileAccessZip::get_8() const {
-	uint8_t ret = 0;
-	get_buffer(&ret, 1);
-	return ret;
-}
-
 uint64_t FileAccessZip::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V(zfile, -1);
@@ -328,7 +322,7 @@ void FileAccessZip::flush() {
 	ERR_FAIL();
 }
 
-void FileAccessZip::store_8(uint8_t p_dest) {
+void FileAccessZip::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL();
 }
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -95,14 +95,13 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -218,67 +218,13 @@ bool FileAccessUnix::eof_reached() const {
 	return last_error == ERR_FILE_EOF;
 }
 
-uint8_t FileAccessUnix::get_8() const {
-	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
-	uint8_t b;
-	if (fread(&b, 1, 1, f) == 0) {
-		check_errors();
-		b = '\0';
-	}
-	return b;
-}
-
-uint16_t FileAccessUnix::get_16() const {
-	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
-
-	uint16_t b = 0;
-	if (fread(&b, 1, 2, f) != 2) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP16(b);
-	}
-
-	return b;
-}
-
-uint32_t FileAccessUnix::get_32() const {
-	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
-
-	uint32_t b = 0;
-	if (fread(&b, 1, 4, f) != 4) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP32(b);
-	}
-
-	return b;
-}
-
-uint64_t FileAccessUnix::get_64() const {
-	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
-
-	uint64_t b = 0;
-	if (fread(&b, 1, 8, f) != 8) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP64(b);
-	}
-
-	return b;
-}
-
 uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V_MSG(f, -1, "File must be opened before use.");
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
+
 	return read;
 }
 
@@ -306,41 +252,6 @@ Error FileAccessUnix::resize(int64_t p_length) {
 void FileAccessUnix::flush() {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
 	fflush(f);
-}
-
-void FileAccessUnix::store_8(uint8_t p_dest) {
-	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
-	ERR_FAIL_COND(fwrite(&p_dest, 1, 1, f) != 1);
-}
-
-void FileAccessUnix::store_16(uint16_t p_dest) {
-	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
-
-	if (big_endian) {
-		p_dest = BSWAP16(p_dest);
-	}
-
-	ERR_FAIL_COND(fwrite(&p_dest, 1, 2, f) != 2);
-}
-
-void FileAccessUnix::store_32(uint32_t p_dest) {
-	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
-
-	if (big_endian) {
-		p_dest = BSWAP32(p_dest);
-	}
-
-	ERR_FAIL_COND(fwrite(&p_dest, 1, 4, f) != 4);
-}
-
-void FileAccessUnix::store_64(uint64_t p_dest) {
-	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
-
-	if (big_endian) {
-		p_dest = BSWAP64(p_dest);
-	}
-
-	ERR_FAIL_COND(fwrite(&p_dest, 1, 8, f) != 8);
 }
 
 void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -67,20 +67,12 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
-	virtual uint16_t get_16() const override;
-	virtual uint32_t get_32() const override;
-	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override;
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
-	virtual void store_16(uint16_t p_dest) override;
-	virtual void store_32(uint32_t p_dest) override;
-	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -125,22 +125,9 @@ String FileAccessUnixPipe::get_path_absolute() const {
 	return path_src;
 }
 
-uint8_t FileAccessUnixPipe::get_8() const {
-	ERR_FAIL_COND_V_MSG(fd[0] < 0, 0, "Pipe must be opened before use.");
-
-	uint8_t b;
-	if (::read(fd[0], &b, 1) == 0) {
-		last_error = ERR_FILE_CANT_READ;
-		b = '\0';
-	} else {
-		last_error = OK;
-	}
-	return b;
-}
-
 uint64_t FileAccessUnixPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(fd[0] < 0, -1, "Pipe must be opened before use.");
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	uint64_t read = ::read(fd[0], p_dst, p_length);
 	if (read == p_length) {
@@ -155,18 +142,10 @@ Error FileAccessUnixPipe::get_error() const {
 	return last_error;
 }
 
-void FileAccessUnixPipe::store_8(uint8_t p_src) {
-	ERR_FAIL_COND_MSG(fd[1] < 0, "Pipe must be opened before use.");
-	if (::write(fd[1], &p_src, 1) != 1) {
-		last_error = ERR_FILE_CANT_WRITE;
-	} else {
-		last_error = OK;
-	}
-}
-
 void FileAccessUnixPipe::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(fd[1] < 0, "Pipe must be opened before use.");
 	ERR_FAIL_COND(!p_src && p_length > 0);
+
 	if (::write(fd[1], p_src, p_length) != (ssize_t)p_length) {
 		last_error = ERR_FILE_CANT_WRITE;
 	} else {

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -65,14 +65,12 @@ public:
 
 	virtual bool eof_reached() const override { return false; }
 
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override {}
-	virtual void store_8(uint8_t p_src) override; ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path) override { return false; }

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -323,93 +323,9 @@ bool FileAccessWindows::eof_reached() const {
 	return last_error == ERR_FILE_EOF;
 }
 
-uint8_t FileAccessWindows::get_8() const {
-	ERR_FAIL_NULL_V(f, 0);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == WRITE) {
-			fflush(f);
-		}
-		prev_op = READ;
-	}
-	uint8_t b;
-	if (fread(&b, 1, 1, f) == 0) {
-		check_errors();
-		b = '\0';
-	}
-
-	return b;
-}
-
-uint16_t FileAccessWindows::get_16() const {
-	ERR_FAIL_NULL_V(f, 0);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == WRITE) {
-			fflush(f);
-		}
-		prev_op = READ;
-	}
-
-	uint16_t b = 0;
-	if (fread(&b, 1, 2, f) != 2) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP16(b);
-	}
-
-	return b;
-}
-
-uint32_t FileAccessWindows::get_32() const {
-	ERR_FAIL_NULL_V(f, 0);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == WRITE) {
-			fflush(f);
-		}
-		prev_op = READ;
-	}
-
-	uint32_t b = 0;
-	if (fread(&b, 1, 4, f) != 4) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP32(b);
-	}
-
-	return b;
-}
-
-uint64_t FileAccessWindows::get_64() const {
-	ERR_FAIL_NULL_V(f, 0);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == WRITE) {
-			fflush(f);
-		}
-		prev_op = READ;
-	}
-
-	uint64_t b = 0;
-	if (fread(&b, 1, 8, f) != 8) {
-		check_errors();
-	}
-
-	if (big_endian) {
-		b = BSWAP64(b);
-	}
-
-	return b;
-}
-
 uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V(f, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == WRITE) {
@@ -417,8 +333,10 @@ uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 		}
 		prev_op = READ;
 	}
+
 	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
+
 	return read;
 }
 
@@ -453,77 +371,6 @@ void FileAccessWindows::flush() {
 	}
 }
 
-void FileAccessWindows::store_8(uint8_t p_dest) {
-	ERR_FAIL_NULL(f);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == READ) {
-			if (last_error != ERR_FILE_EOF) {
-				fseek(f, 0, SEEK_CUR);
-			}
-		}
-		prev_op = WRITE;
-	}
-	fwrite(&p_dest, 1, 1, f);
-}
-
-void FileAccessWindows::store_16(uint16_t p_dest) {
-	ERR_FAIL_NULL(f);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == READ) {
-			if (last_error != ERR_FILE_EOF) {
-				fseek(f, 0, SEEK_CUR);
-			}
-		}
-		prev_op = WRITE;
-	}
-
-	if (big_endian) {
-		p_dest = BSWAP16(p_dest);
-	}
-
-	fwrite(&p_dest, 1, 2, f);
-}
-
-void FileAccessWindows::store_32(uint32_t p_dest) {
-	ERR_FAIL_NULL(f);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == READ) {
-			if (last_error != ERR_FILE_EOF) {
-				fseek(f, 0, SEEK_CUR);
-			}
-		}
-		prev_op = WRITE;
-	}
-
-	if (big_endian) {
-		p_dest = BSWAP32(p_dest);
-	}
-
-	fwrite(&p_dest, 1, 4, f);
-}
-
-void FileAccessWindows::store_64(uint64_t p_dest) {
-	ERR_FAIL_NULL(f);
-
-	if (flags == READ_WRITE || flags == WRITE_READ) {
-		if (prev_op == READ) {
-			if (last_error != ERR_FILE_EOF) {
-				fseek(f, 0, SEEK_CUR);
-			}
-		}
-		prev_op = WRITE;
-	}
-
-	if (big_endian) {
-		p_dest = BSWAP64(p_dest);
-	}
-
-	fwrite(&p_dest, 1, 8, f);
-}
-
 void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_NULL(f);
 	ERR_FAIL_COND(!p_src && p_length > 0);
@@ -536,6 +383,7 @@ void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 		}
 		prev_op = WRITE;
 	}
+
 	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != (size_t)p_length);
 }
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -69,20 +69,12 @@ public:
 
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const override; ///< get a byte
-	virtual uint16_t get_16() const override;
-	virtual uint32_t get_32() const override;
-	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override;
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
-	virtual void store_16(uint16_t p_dest) override;
-	virtual void store_32(uint32_t p_dest) override;
-	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -96,22 +96,9 @@ String FileAccessWindowsPipe::get_path_absolute() const {
 	return path_src;
 }
 
-uint8_t FileAccessWindowsPipe::get_8() const {
-	ERR_FAIL_COND_V_MSG(fd[0] == 0, 0, "Pipe must be opened before use.");
-
-	uint8_t b;
-	if (!ReadFile(fd[0], &b, 1, nullptr, nullptr)) {
-		last_error = ERR_FILE_CANT_READ;
-		b = '\0';
-	} else {
-		last_error = OK;
-	}
-	return b;
-}
-
 uint64_t FileAccessWindowsPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(fd[0] == 0, -1, "Pipe must be opened before use.");
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	DWORD read = -1;
 	if (!ReadFile(fd[0], p_dst, p_length, &read, nullptr) || read != p_length) {
@@ -124,15 +111,6 @@ uint64_t FileAccessWindowsPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) co
 
 Error FileAccessWindowsPipe::get_error() const {
 	return last_error;
-}
-
-void FileAccessWindowsPipe::store_8(uint8_t p_src) {
-	ERR_FAIL_COND_MSG(fd[1] == 0, "Pipe must be opened before use.");
-	if (!WriteFile(fd[1], &p_src, 1, nullptr, nullptr)) {
-		last_error = ERR_FILE_CANT_WRITE;
-	} else {
-		last_error = OK;
-	}
 }
 
 void FileAccessWindowsPipe::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -64,14 +64,12 @@ public:
 
 	virtual bool eof_reached() const override { return false; }
 
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override {}
-	virtual void store_8(uint8_t p_src) override; ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override { return false; }

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -113,87 +113,6 @@ bool FileAccessAndroid::eof_reached() const {
 	return eof;
 }
 
-uint8_t FileAccessAndroid::get_8() const {
-	if (pos >= len) {
-		eof = true;
-		return 0;
-	}
-
-	uint8_t byte;
-	AAsset_read(asset, &byte, 1);
-	pos++;
-	return byte;
-}
-
-uint16_t FileAccessAndroid::get_16() const {
-	if (pos >= len) {
-		eof = true;
-		return 0;
-	}
-
-	uint16_t bytes = 0;
-	int r = AAsset_read(asset, &bytes, 2);
-
-	if (r >= 0) {
-		pos += r;
-		if (pos >= len) {
-			eof = true;
-		}
-	}
-
-	if (big_endian) {
-		bytes = BSWAP16(bytes);
-	}
-
-	return bytes;
-}
-
-uint32_t FileAccessAndroid::get_32() const {
-	if (pos >= len) {
-		eof = true;
-		return 0;
-	}
-
-	uint32_t bytes = 0;
-	int r = AAsset_read(asset, &bytes, 4);
-
-	if (r >= 0) {
-		pos += r;
-		if (pos >= len) {
-			eof = true;
-		}
-	}
-
-	if (big_endian) {
-		bytes = BSWAP32(bytes);
-	}
-
-	return bytes;
-}
-
-uint64_t FileAccessAndroid::get_64() const {
-	if (pos >= len) {
-		eof = true;
-		return 0;
-	}
-
-	uint64_t bytes = 0;
-	int r = AAsset_read(asset, &bytes, 8);
-
-	if (r >= 0) {
-		pos += r;
-		if (pos >= len) {
-			eof = true;
-		}
-	}
-
-	if (big_endian) {
-		bytes = BSWAP64(bytes);
-	}
-
-	return bytes;
-}
-
 uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
@@ -209,6 +128,7 @@ uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 			pos = len;
 		}
 	}
+
 	return r;
 }
 
@@ -220,19 +140,7 @@ void FileAccessAndroid::flush() {
 	ERR_FAIL();
 }
 
-void FileAccessAndroid::store_8(uint8_t p_dest) {
-	ERR_FAIL();
-}
-
-void FileAccessAndroid::store_16(uint16_t p_dest) {
-	ERR_FAIL();
-}
-
-void FileAccessAndroid::store_32(uint32_t p_dest) {
-	ERR_FAIL();
-}
-
-void FileAccessAndroid::store_64(uint64_t p_dest) {
+void FileAccessAndroid::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL();
 }
 

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -68,19 +68,12 @@ public:
 	virtual bool eof_reached() const override; // reading passed EOF
 
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual uint8_t get_8() const override; // get a byte
-	virtual uint16_t get_16() const override;
-	virtual uint32_t get_32() const override;
-	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; // get last error
 
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; // store a byte
-	virtual void store_16(uint16_t p_dest) override;
-	virtual void store_32(uint32_t p_dest) override;
-	virtual void store_64(uint64_t p_dest) override;
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_path) override; // return true if a file exists
 

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -169,43 +169,6 @@ void FileAccessFilesystemJAndroid::_set_eof(bool eof) {
 	}
 }
 
-uint8_t FileAccessFilesystemJAndroid::get_8() const {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
-	uint8_t byte;
-	get_buffer(&byte, 1);
-	return byte;
-}
-
-uint16_t FileAccessFilesystemJAndroid::get_16() const {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
-	uint16_t bytes = 0;
-	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 2);
-	if (big_endian) {
-		bytes = BSWAP16(bytes);
-	}
-	return bytes;
-}
-
-uint32_t FileAccessFilesystemJAndroid::get_32() const {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
-	uint32_t bytes = 0;
-	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 4);
-	if (big_endian) {
-		bytes = BSWAP32(bytes);
-	}
-	return bytes;
-}
-
-uint64_t FileAccessFilesystemJAndroid::get_64() const {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
-	uint64_t bytes = 0;
-	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 8);
-	if (big_endian) {
-		bytes = BSWAP64(bytes);
-	}
-	return bytes;
-}
-
 String FileAccessFilesystemJAndroid::get_line() const {
 	ERR_FAIL_COND_V_MSG(!is_open(), String(), "File must be opened before use.");
 
@@ -269,31 +232,6 @@ uint64_t FileAccessFilesystemJAndroid::get_buffer(uint8_t *p_dst, uint64_t p_len
 	} else {
 		return 0;
 	}
-}
-
-void FileAccessFilesystemJAndroid::store_8(uint8_t p_dest) {
-	store_buffer(&p_dest, 1);
-}
-
-void FileAccessFilesystemJAndroid::store_16(uint16_t p_dest) {
-	if (big_endian) {
-		p_dest = BSWAP16(p_dest);
-	}
-	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 2);
-}
-
-void FileAccessFilesystemJAndroid::store_32(uint32_t p_dest) {
-	if (big_endian) {
-		p_dest = BSWAP32(p_dest);
-	}
-	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 4);
-}
-
-void FileAccessFilesystemJAndroid::store_64(uint64_t p_dest) {
-	if (big_endian) {
-		p_dest = BSWAP64(p_dest);
-	}
-	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 8);
 }
 
 void FileAccessFilesystemJAndroid::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -78,20 +78,12 @@ public:
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
 	virtual Error resize(int64_t p_length) override;
-	virtual uint8_t get_8() const override; ///< get a byte
-	virtual uint16_t get_16() const override;
-	virtual uint32_t get_32() const override;
-	virtual uint64_t get_64() const override;
 	virtual String get_line() const override; ///< get a line
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual void flush() override;
-	virtual void store_8(uint8_t p_dest) override; ///< store a byte
-	virtual void store_16(uint16_t p_dest) override;
-	virtual void store_32(uint32_t p_dest) override;
-	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists


### PR DESCRIPTION
#84107 added a lot of duplicate code to FileAccess classes. This PR moves most of that into the base FileAccess. 
The child classes now only have to override the `get_buffer` and `store_buffer` virtual methods to function properly, while the rest is handled by the base class.

This needs testing on all platforms, but it should work without issues.