### PR TITLE
Add new column related methods regarding visibility and mobility to Tree, Add Unit Tree tests

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -250,6 +250,21 @@
 				Returns [code]true[/code] if the column has enabled expanding (see [method set_column_expand]).
 			</description>
 		</method>
+		<method name="is_column_visible">
+			<return type="bool" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns [code]true[/code] if the column is visible (see [method set_column_visible]).
+			</description>
+		</method>
+		<method name="move_column">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="index" type="int" />
+			<description>
+				Moves the given [param column] to the given [param index], and reorders the columns accordingly for the root item and all of its descendants.
+			</description>
+		</method>
 		<method name="scroll_to_item">
 			<return type="void" />
 			<param index="0" name="item" type="TreeItem" />
@@ -322,12 +337,28 @@
 				Sets language code of column title used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 			</description>
 		</method>
+		<method name="set_column_visible">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="visible" type="bool" />
+			<description>
+				Sets the visibility for the given [param column] with the given [param visible] value.
+			</description>
+		</method>
 		<method name="set_selected">
 			<return type="void" />
 			<param index="0" name="item" type="TreeItem" />
 			<param index="1" name="column" type="int" />
 			<description>
 				Selects the specified [TreeItem] and column.
+			</description>
+		</method>
+		<method name="swap_columns">
+			<return type="void" />
+			<param index="0" name="column1" type="int" />
+			<param index="1" name="column2" type="int" />
+			<description>
+				Swaps the given [param column1] with the given [param column2], for the root item and all of its descendants.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -441,6 +441,13 @@
 				Returns [code]true[/code] if the given [param column] is selected.
 			</description>
 		</method>
+		<method name="is_tooltip_visible" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns [code]true[/code] if the tooltip for the given [param column] is visible.
+			</description>
+		</method>
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -785,6 +792,14 @@
 			<param index="1" name="tooltip" type="String" />
 			<description>
 				Sets the given column's tooltip text.
+			</description>
+		</method>
+		<method name="set_tooltip_visible">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets the given column's tooltip visibility.
 			</description>
 		</method>
 		<method name="uncollapse_tree">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -99,6 +99,7 @@ private:
 
 		Variant meta;
 		String tooltip;
+		bool tooltip_visible = true;
 
 		Callable custom_draw_callback;
 
@@ -317,6 +318,9 @@ public:
 	void deselect(int p_column);
 	void set_as_cursor(int p_column);
 
+	void move_column(int p_column, int p_index);
+	void swap_columns(int p_column1, int p_column2);
+
 	void set_editable(int p_column, bool p_editable);
 	bool is_editable(int p_column);
 
@@ -339,6 +343,9 @@ public:
 
 	void set_tooltip_text(int p_column, const String &p_tooltip);
 	String get_tooltip_text(int p_column) const;
+
+	void set_tooltip_visible(int p_column, bool p_visible);
+	bool is_tooltip_visible(int p_column) const;
 
 	void set_text_alignment(int p_column, HorizontalAlignment p_alignment);
 	HorizontalAlignment get_text_alignment(int p_column) const;
@@ -460,6 +467,7 @@ private:
 		int expand_ratio = 1;
 		bool expand = true;
 		bool clip_content = false;
+		bool visible = true;
 		String title;
 		String xl_title;
 		HorizontalAlignment title_alignment = HORIZONTAL_ALIGNMENT_CENTER;
@@ -775,6 +783,12 @@ public:
 	bool is_h_scroll_enabled() const;
 	void set_v_scroll_enabled(bool p_enable);
 	bool is_v_scroll_enabled() const;
+
+	void set_column_visible(int p_column, bool p_visible);
+	bool is_column_visible(int p_column);
+
+	void move_column(int p_column, int p_index);
+	void swap_columns(int p_column1, int p_column2);
 
 	void set_cursor_can_exit_tree(bool p_enable);
 

--- a/tests/scene/test_tree.h
+++ b/tests/scene/test_tree.h
@@ -1,0 +1,187 @@
+/**************************************************************************/
+/*  test_tree.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_TREE_H
+#define TEST_TREE_H
+
+#include "scene/gui/tree.h"
+
+#include "tests/test_macros.h"
+
+namespace TestTree {
+
+TEST_CASE("[SceneTree][Tree] Check Tree Setters and Getters") {
+	Tree *test_tree = memnew(Tree);
+	int columns = 5;
+	test_tree->create_item();
+	test_tree->set_columns(columns);
+
+	SUBCASE("[Tree] Set visibility and tooltip visibility on all columns") {
+		//CHECK DEFAULT
+		for (int column = 0; column < columns; column++) {
+			CHECK_EQ(test_tree->is_column_visible(column), true);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), true);
+		}
+
+		for (int column = 0; column < columns; column++) {
+			test_tree->set_column_visible(column, false);
+			test_tree->get_root()->set_tooltip_visible(column, false);
+			CHECK_EQ(test_tree->is_column_visible(column), false);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), false);
+		}
+
+		for (int column = 0; column < columns; column++) {
+			test_tree->set_column_visible(column, true);
+			test_tree->get_root()->set_tooltip_visible(column, true);
+			CHECK_EQ(test_tree->is_column_visible(column), true);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), true);
+		}
+	}
+
+	SUBCASE("[Tree] Set visibility and tooltip visibility on alternating columns") {
+		//CHECK DEFAULT
+		for (int column = 0; column < columns; column++) {
+			CHECK_EQ(test_tree->is_column_visible(column), true);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), true);
+		}
+
+		for (int column = 0; column < columns; column += 2) {
+			test_tree->set_column_visible(column, false);
+			test_tree->get_root()->set_tooltip_visible(column, false);
+			CHECK_EQ(test_tree->is_column_visible(column), false);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), false);
+		}
+
+		for (int column = 1; column < columns; column += 2) {
+			CHECK_EQ(test_tree->is_column_visible(column), true);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), true);
+		}
+
+		for (int column = 1; column < columns; column += 2) {
+			test_tree->set_column_visible(column, false);
+			test_tree->get_root()->set_tooltip_visible(column, false);
+			CHECK_EQ(test_tree->is_column_visible(column), false);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), false);
+		}
+
+		for (int column = 0; column < columns; column += 2) {
+			CHECK_EQ(test_tree->is_column_visible(column), false);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), false);
+		}
+
+		for (int column = 0; column < columns; column++) {
+			test_tree->set_column_visible(column, true);
+			test_tree->get_root()->set_tooltip_visible(column, true);
+			CHECK_EQ(test_tree->is_column_visible(column), true);
+			CHECK_EQ(test_tree->get_root()->is_tooltip_visible(column), true);
+		}
+	}
+
+	memdelete(test_tree);
+}
+
+TEST_CASE("[SceneTree][Tree] Check Tree Column Moving and Swapping") {
+	Tree *test_tree = memnew(Tree);
+	int columns = 5;
+	test_tree->create_item();
+	test_tree->set_columns(columns);
+
+	SUBCASE("[Tree] Move columns between all indexes where column position is lower than index") {
+		for (int column = 0; column < columns; column++) {
+			for (int index = column + 1; index < columns; index++) {
+				//Reset text on columns for each test
+				for (int cell = 0; cell < columns; cell++) {
+					test_tree->get_root()->set_text(cell, itos(cell));
+					CHECK_EQ(test_tree->get_root()->get_text(cell), itos(cell));
+				}
+
+				test_tree->move_column(column, index);
+				CHECK_EQ(test_tree->get_root()->get_text(index), itos(column));
+
+				for (int prev_index = index - 1; prev_index >= column; prev_index--) {
+					CHECK_EQ(test_tree->get_root()->get_text(prev_index), itos(prev_index + 1));
+				}
+			}
+		}
+	}
+
+	SUBCASE("[Tree] Move columns between all indexes where column position is greater than index") {
+		for (int column = columns - 1; column >= 0; column--) {
+			for (int index = column - 1; index >= 0; index--) {
+				//Reset text on columns for each test
+				for (int cell = 0; cell < columns; cell++) {
+					test_tree->get_root()->set_text(cell, itos(cell));
+					CHECK_EQ(test_tree->get_root()->get_text(cell), itos(cell));
+				}
+
+				test_tree->move_column(column, index);
+				CHECK_EQ(test_tree->get_root()->get_text(index), itos(column));
+
+				for (int prev_index = index + 1; prev_index <= column; prev_index++) {
+					CHECK_EQ(test_tree->get_root()->get_text(prev_index), itos(prev_index - 1));
+				}
+			}
+		}
+	}
+
+	SUBCASE("[Tree] Swap columns between all indexes") {
+		for (int column1 = 0; column1 < columns; column1++) {
+			for (int column2 = 0; column2 < columns; column2++) {
+				if (column1 == column2) {
+					continue;
+				}
+
+				//Reset text on columns for each test
+				for (int cell = 0; cell < columns; cell++) {
+					test_tree->get_root()->set_text(cell, itos(cell));
+					CHECK_EQ(test_tree->get_root()->get_text(cell), itos(cell));
+				}
+
+				test_tree->swap_columns(column1, column2);
+				CHECK_EQ(test_tree->get_root()->get_text(column2), itos(column1));
+				CHECK_EQ(test_tree->get_root()->get_text(column1), itos(column2));
+
+				for (int cell = 0; cell < columns; cell++) {
+					if (cell == column1 || cell == column2) {
+						continue;
+					}
+
+					CHECK_EQ(test_tree->get_root()->get_text(cell), itos(cell));
+				}
+			}
+		}
+	}
+
+	memdelete(test_tree);
+}
+
+} // namespace TestTree
+
+#endif // TEST_TREE_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -121,6 +121,7 @@
 #include "tests/scene/test_text_edit.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"
+#include "tests/scene/test_tree.h"
 #include "tests/scene/test_viewport.h"
 #include "tests/scene/test_visual_shader.h"
 #include "tests/scene/test_window.h"


### PR DESCRIPTION
As the issue suggests, we added new methods to the tree class, a way to make a column not visible, with the option to toggle on and off its tooltip. 

We initially made a move_column method and we decided to widen the scope of said feature by also being able to directly switch each column. We thought it was the easiest way to differentiate column moving operations, while move_column assigns a new intended position to the chosen column, reordering the other columns accordingly, switch_columns, as implied, only switches the position between two specific columns.

We also added unit tests that tested our feature. As unit tests for the class did not exist, we had to create a new unit test file. That implied that we had to make tests not directly for our feature but also other methods that were used in the creation of our feature, as we believed that was the best practice after talking to other developers.

#43440 - Link to the unit test tracker (https://github.com/godotengine/godot/issues/43440)
2290, 2291 - First time this feature was mentioned (https://github.com/godotengine/godot-proposals/issues/2290, https://github.com/godotengine/godot-proposals/issues/2291)

Closes https://github.com/godotengine/godot-proposals/issues/2290
Closes https://github.com/godotengine/godot-proposals/issues/2291

Co-authored-by: Gustavo Diogo <gustavomanuel30@tecnico.ulisboa.pt>