### PR TITLE
Node3D: Only set rotation & scale to dirty if they changed

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -304,8 +304,10 @@ void Node3D::set_global_rotation_degrees(const Vector3 &p_euler_degrees) {
 
 void Node3D::set_transform(const Transform3D &p_transform) {
 	ERR_THREAD_GUARD;
+	if (!data.local_transform.basis.is_equal_approx(p_transform.basis)) {
+		_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // Make rot/scale dirty.
+	}
 	data.local_transform = p_transform;
-	_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // Make rot/scale dirty.
 
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {


### PR DESCRIPTION
This small check fixes many issues relating to 3D transforms.

Without this fix, the following code results in a Node3D stuttering due to the euler angles flipping. With this patch, the issue is fixed and it moves and rotates as expected.
```gdscript
func _process(delta):
	rotation_degrees.x += 360 * delta
	global_position.x += 1 * delta
```

Edit: Adding some more context to the issue. Whenever a Node3D has its local transform set, the rotation and scale are marked as dirty which leads to them being recomputed from the basis whenever they are read from again. The problem with this is there are several transform methods that lead to `set_transform` calls that haven't actually modified the rotation or scale of the object. This PR avoids recomputing the rotation and scale if the basis hasn't changed and fixes euler angle issues that occur because of it.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/92211*