### PR TITLE
Fix 2d sdf collision for TileMapLayer Occluders

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -603,6 +603,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 						rs->canvas_light_occluder_set_polygon(occluder, tile_data->get_occluder(occlusion_layer_index, flip_h, flip_v, transpose)->get_rid());
 						rs->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
 						rs->canvas_light_occluder_set_light_mask(occluder, tile_set->get_occlusion_layer_light_mask(occlusion_layer_index));
+						rs->canvas_light_occluder_set_as_sdf_collision(occluder, tile_set->get_occlusion_layer_sdf_collision(occlusion_layer_index));
 					} else {
 						// Clear occluder.
 						if (occluder.is_valid()) {


### PR DESCRIPTION
Proposed fix for #91907 and #92052.

Before [this PR](https://github.com/godotengine/godot/pull/90883) went in, the 2d rendering system ignored the sdf collision flag on 2d light occluder instances and always drew light occluder polygons to the sdf texture. Now, occluders aren't drawn to the texture when sdf collision is false.

Apparently, `TileMap` and now `TileMapLayer` have both been impacted by this fix, as setting the sdf collision flag for their occlusion layers doesn't actually update the underlying light occluder instance (even though it should). This change fixes that, so now the sdf collision field of a `TileMapLayer`'s occlusion layer dictates whether or not it's drawn to the sdf texture:

<img src="https://github.com/godotengine/godot/assets/20360622/282856c5-7398-4dec-8c31-8f374501528f" width="400">

closes #91907
closes #92052.