### PR TITLE
Fix some arguments being passed as references in virtual functions

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -230,14 +230,12 @@
 			</description>
 		</method>
 		<method name="_import" qualifiers="virtual const">
-			<return type="int" enum="Error" />
+			<return type="Dictionary" />
 			<param index="0" name="source_file" type="String" />
 			<param index="1" name="save_path" type="String" />
 			<param index="2" name="options" type="Dictionary" />
-			<param index="3" name="platform_variants" type="String[]" />
-			<param index="4" name="gen_files" type="String[]" />
 			<description>
-				Imports [param source_file] into [param save_path] with the import [param options] specified. The [param platform_variants] and [param gen_files] arrays will be modified by this function.
+				Imports [param source_file] into [param save_path] with the import [param options] specified.
 				This method must be overridden to do the actual importing work. See this class' description for an example of overriding this method.
 			</description>
 		</method>

--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -17,27 +17,23 @@
 			</description>
 		</method>
 		<method name="_generate" qualifiers="virtual const">
-			<return type="Texture2D" />
+			<return type="Dictionary" />
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="size" type="Vector2i" />
-			<param index="2" name="metadata" type="Dictionary" />
 			<description>
 				Generate a preview from a given resource with the specified size. This must always be implemented.
 				Returning [code]null[/code] is an OK way to fail and let another generator take care.
 				Care must be taken because this function is always called from a thread (not the main thread).
-				[param metadata] dictionary can be modified to store file-specific metadata that can be used in [method EditorResourceTooltipPlugin._make_tooltip_for_path] (like image size, sample length etc.).
 			</description>
 		</method>
 		<method name="_generate_from_path" qualifiers="virtual const">
-			<return type="Texture2D" />
+			<return type="Dictionary" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="size" type="Vector2i" />
-			<param index="2" name="metadata" type="Dictionary" />
 			<description>
 				Generate a preview directly from a path with the specified size. Implementing this is optional, as default code will load and call [method _generate].
 				Returning [code]null[/code] is an OK way to fail and let another generator take care.
 				Care must be taken because this function is always called from a thread (not the main thread).
-				[param metadata] dictionary can be modified to store file-specific metadata that can be used in [method EditorResourceTooltipPlugin._make_tooltip_for_path] (like image size, sample length etc.).
 			</description>
 		</method>
 		<method name="_generate_small_preview_automatically" qualifiers="virtual const">

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -53,18 +53,45 @@ bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 }
 
 Ref<Texture2D> EditorResourcePreviewGenerator::generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const {
+	Dictionary ret;
+	if (GDVIRTUAL_CALL(_generate, p_from, p_size, ret)) {
+		if (!ret.has("result")) {
+			return Ref<Texture2D>();
+		}
+		if (ret.has("metadata")) {
+			p_metadata = ret["metadata"];
+		}
+		return ret["result"];
+	}
+
+#ifndef DISABLE_DEPRECATED
 	Ref<Texture2D> preview;
-	if (GDVIRTUAL_CALL(_generate, p_from, p_size, p_metadata, preview)) {
+	if (GDVIRTUAL_CALL(_generate_bind_compat_92175, p_from, p_size, p_metadata, preview)) {
 		return preview;
 	}
+#endif // DISABLE_DEPRECATED
+
 	ERR_FAIL_V_MSG(Ref<Texture2D>(), "EditorResourcePreviewGenerator::_generate needs to be overridden.");
 }
 
 Ref<Texture2D> EditorResourcePreviewGenerator::generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const {
+	Dictionary ret;
+	if (GDVIRTUAL_CALL(_generate_from_path, p_path, p_size, ret)) {
+		if (!ret.has("result")) {
+			return Ref<Texture2D>();
+		}
+		if (ret.has("metadata")) {
+			p_metadata = ret["metadata"];
+		}
+		return ret["result"];
+	}
+
+#ifndef DISABLE_DEPRECATED
 	Ref<Texture2D> preview;
-	if (GDVIRTUAL_CALL(_generate_from_path, p_path, p_size, p_metadata, preview)) {
+	if (GDVIRTUAL_CALL(_generate_from_path_bind_compat_92175, p_path, p_size, p_metadata, preview)) {
 		return preview;
 	}
+#endif // DISABLE_DEPRECATED
 
 	Ref<Resource> res = ResourceLoader::load(p_path);
 	if (res.is_null()) {
@@ -87,10 +114,15 @@ bool EditorResourcePreviewGenerator::can_generate_small_preview() const {
 
 void EditorResourcePreviewGenerator::_bind_methods() {
 	GDVIRTUAL_BIND(_handles, "type");
-	GDVIRTUAL_BIND(_generate, "resource", "size", "metadata");
-	GDVIRTUAL_BIND(_generate_from_path, "path", "size", "metadata");
+	GDVIRTUAL_BIND(_generate, "resource", "size");
+	GDVIRTUAL_BIND(_generate_from_path, "path", "size");
 	GDVIRTUAL_BIND(_generate_small_preview_automatically);
 	GDVIRTUAL_BIND(_can_generate_small_preview);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_generate_bind_compat_92175, "resource", "size", "metadata");
+	GDVIRTUAL_BIND_COMPAT(_generate_from_path_bind_compat_92175, "path", "size", "metadata");
+#endif // DISABLE_DEPRECATED
 }
 
 void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) {

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -45,10 +45,15 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL1RC(bool, _handles, String)
-	GDVIRTUAL3RC(Ref<Texture2D>, _generate, Ref<Resource>, Vector2i, Dictionary)
-	GDVIRTUAL3RC(Ref<Texture2D>, _generate_from_path, String, Vector2i, Dictionary)
+	GDVIRTUAL2RC(Dictionary, _generate, Ref<Resource>, Vector2i)
+	GDVIRTUAL2RC(Dictionary, _generate_from_path, String, Vector2i)
 	GDVIRTUAL0RC(bool, _generate_small_preview_automatically)
 	GDVIRTUAL0RC(bool, _can_generate_small_preview)
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL3RC_COMPAT(_generate_bind_compat_92175, Ref<Texture2D>, _generate, Ref<Resource>, Vector2i, Dictionary)
+	GDVIRTUAL3RC_COMPAT(_generate_from_path_bind_compat_92175, Ref<Texture2D>, _generate_from_path, String, Vector2i, Dictionary)
+#endif
 
 	class DrawRequester : public Object {
 		Semaphore semaphore;

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -170,7 +170,6 @@ bool EditorImportPlugin::get_option_visibility(const String &p_path, const Strin
 
 Error EditorImportPlugin::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Dictionary options;
-	TypedArray<String> platform_variants, gen_files;
 
 	HashMap<StringName, Variant>::ConstIterator E = p_options.begin();
 	while (E) {
@@ -178,8 +177,40 @@ Error EditorImportPlugin::import(ResourceUID::ID p_source_id, const String &p_so
 		++E;
 	}
 
+	Dictionary ret;
+	if (GDVIRTUAL_CALL(_import, p_source_file, p_save_path, options, ret)) {
+		if (!ret.has("result")) {
+			return ERR_UNAVAILABLE;
+		}
+
+		if (r_platform_variants != nullptr && ret.has("platform_variants")) {
+			TypedArray<String> platform_variants = ret["platform_variants"];
+			for (const String platform_variant : platform_variants) {
+				r_platform_variants->push_back(platform_variant);
+			}
+		}
+
+		if (r_gen_files != nullptr && ret.has("gen_files")) {
+			TypedArray<String> gen_files = ret["gen_files"];
+			for (const String gen_file : gen_files) {
+				r_gen_files->push_back(gen_file);
+			}
+		}
+
+		if (r_metadata != nullptr && ret.has("metadata")) {
+			*r_metadata = ret["metadata"];
+		}
+
+		Error result = Error(int(ret["result"]));
+
+		return result;
+	}
+
+#ifndef DISABLE_DEPRECATED
+	TypedArray<String> platform_variants, gen_files;
+
 	Error err = OK;
-	if (GDVIRTUAL_CALL(_import, p_source_file, p_save_path, options, platform_variants, gen_files, err)) {
+	if (GDVIRTUAL_CALL(_inport_bind_compat_92175, p_source_file, p_save_path, options, platform_variants, gen_files, err)) {
 		for (int i = 0; i < platform_variants.size(); i++) {
 			r_platform_variants->push_back(platform_variants[i]);
 		}
@@ -188,6 +219,8 @@ Error EditorImportPlugin::import(ResourceUID::ID p_source_id, const String &p_so
 		}
 		return err;
 	}
+#endif // DISABLE_DEPRECATED
+
 	ERR_FAIL_V_MSG(ERR_METHOD_NOT_FOUND, "Unimplemented _import in add-on.");
 }
 
@@ -226,7 +259,11 @@ void EditorImportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_import_order)
 	GDVIRTUAL_BIND(_get_format_version)
 	GDVIRTUAL_BIND(_get_option_visibility, "path", "option_name", "options")
-	GDVIRTUAL_BIND(_import, "source_file", "save_path", "options", "platform_variants", "gen_files");
+	GDVIRTUAL_BIND(_import, "source_file", "save_path", "options");
 	GDVIRTUAL_BIND(_can_import_threaded);
 	ClassDB::bind_method(D_METHOD("append_import_external_resource", "path", "custom_options", "custom_importer", "generator_parameters"), &EditorImportPlugin::_append_import_external_resource, DEFVAL(Dictionary()), DEFVAL(String()), DEFVAL(Variant()));
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_inport_bind_compat_92175, "source_file", "save_path", "options", "platform_variants", "gen_files");
+#endif
 }

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -51,8 +51,12 @@ protected:
 	GDVIRTUAL0RC(int, _get_import_order)
 	GDVIRTUAL0RC(int, _get_format_version)
 	GDVIRTUAL3RC(bool, _get_option_visibility, String, StringName, Dictionary)
-	GDVIRTUAL5RC(Error, _import, String, String, Dictionary, TypedArray<String>, TypedArray<String>)
+	GDVIRTUAL3RC(Dictionary, _import, String, String, Dictionary)
 	GDVIRTUAL0RC(bool, _can_import_threaded)
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL5RC_COMPAT(_inport_bind_compat_92175, Error, _import, String, String, Dictionary, TypedArray<String>, TypedArray<String>)
+#endif
 
 	Error _append_import_external_resource(const String &p_file, const Dictionary &p_custom_options = Dictionary(), const String &p_custom_importer = String(), Variant p_generator_parameters = Variant());
 

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -24,3 +24,15 @@ Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/regist
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 
 Switched from `OpenXRExtensionWrapperExtension` to parent `OpenXRExtensionWrapper`. Compatibility methods registered.
+
+
+GH-92175
+--------
+Validate extension JSON: Error: Field 'classes/EditorImportPlugin/methods/_import/arguments': size changed value in new API, from 5 to 3.
+Validate extension JSON: Error: Field 'classes/EditorImportPlugin/methods/_import/return_value': type changed value in new API, from "enum::Error" to "Dictionary".
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate/arguments': size changed value in new API, from 3 to 2.
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate/return_value': type changed value in new API, from "Texture2D" to "Dictionary".
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate_from_path/arguments': size changed value in new API, from 3 to 2.
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate_from_path/return_value': type changed value in new API, from "Texture2D" to "Dictionary".
+
+Return values were passed in constant reference arguments. Changed to using a return Dictionary. Compatibility methods registered.


### PR DESCRIPTION
These can't be used safely in extensions, replaced with `Dictionary` returns

A few cases could do with this improvement, like `EditorSceneFormatImporter::_import_scene` but focused on cases that had arguments that were unusable, at least generally

This is patterned on the way `ScriptLanguageExtension::_validate` and similar are written, alternatively this could pass `GDExtensionPtr` but that would make these methods inaccessible from scripting, which considering some of them have documentation showing how to use them in GDScript and C# feels like the wrong way to go. Those cases do work (as far as I know, haven't tested the unchanged code) in at least GDScript (don't know if the passed references are useable in C#) but they use constant references in at least godot-cpp, which couldn't be changed without making broad changes there without handling other cases as there's no way to distinguish the cases.

This might be considered too significant a breakage, but it feels unsafe and strange if users have to use `const_cast` to be able to use these, and it might not be guaranteed that these passed arguments remain linked in the future since they aren't intended to be mutable based on the interface

Edit: the ability to modify these values seems to be unreliable, and might not work correctly at least in godot-cpp, so this change appears more necessary, this could be this issue surfacing in godot-cpp (so would be specific to typed arrays):
* https://github.com/godotengine/godot/issues/89191 

Todo:
- [ ] Update documentation (will update these once the approach has been decided on, as it involves example code)
- [ ] Consider additional cases

* Closes: https://github.com/godotengine/godot-cpp/issues/1471

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
