### PR TITLE
Fix detecting when Gradle is invoked from Studio

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -330,8 +330,7 @@ ext.getReleaseKeyAlias = { ->
 }
 
 ext.isAndroidStudio = { ->
-    def sysProps = System.getProperties()
-    return sysProps != null && sysProps['idea.platform.prefix'] != null
+    return project.hasProperty('android.injected.invoked.from.ide')
 }
 
 ext.shouldZipAlign = { ->

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -232,11 +232,6 @@ def generateBuildTasks(String flavor = "template") {
     return tasks
 }
 
-def isAndroidStudio() {
-    def sysProps = System.getProperties()
-    return sysProps != null && sysProps['idea.platform.prefix'] != null
-}
-
 task copyEditorReleaseApkToBin(type: Copy) {
     dependsOn ':editor:assembleRelease'
     from('editor/build/outputs/apk/release')


### PR DESCRIPTION
The existing `idea.platform.prefix` system-property approach only worked because of a Android Studio bug that leaks the system properties from Android Studio into Gradle build.
  - https://issuetracker.google.com/201075423

This bug was fixed in Android Studio 2023.3.1 (Jellyfish), which is why Godot fails to build on Jellyfish without this fix.

The correct way of identifying builds from Android Studio is to use the following project property (not system property):
 - `android.injected.invoked.from.ide`

Fixes #92122 