### PR TITLE
Fix broken built-in script reloading

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -987,7 +987,7 @@ bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
 bool GDScript::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == GDScriptLanguage::get_singleton()->strings._script_source) {
 		set_source_code(p_value);
-		reload();
+		reload(true);
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #92157
I have no idea what this changes, I only figured that doing this will fix both the error and reload issue.

If default `reload()` is used, this condition
https://github.com/godotengine/godot/blob/40b4130c93d08235a60996d29e5869a22b6ae53d/modules/gdscript/gdscript.cpp#L741
will prevent properly loading the script for reasons unknown.