### PR TITLE
Change scene reimport behaviour to address corruption/crashes

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -661,7 +661,7 @@ private:
 
 	void _begin_first_scan();
 
-	void _notify_scene_updated(Node *p_node);
+	void _notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes);
 
 protected:
 	friend class FileSystemDock;


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/91764

This PR makes an important change to how the dynamic scene reimporting works in order to hopefully prevent the crashing regression.

The issue described seems to have been triggered the introduction of PhysicalBoneSimulator3D node which is created by the Skeleton3D node automatically upon entry to the scene tree. The existing function scans the children of all nodes that require reimporting and will attempt preserve them in the hierarchy as best they can. It will also attempt to preserve ownerless nodes which I believe was the main issue with initial implementation. The PR instead does NOT preserve these ownerless nodes and makes the assumption that they are transient and should be left to the discretion of the nodes which created them.

However, for any nodes (including user's custom editor scripts) which create ownerless nodes for visual feedback purposes, there is currently no direct way to tell these nodes that these will require recreating. Since it was decided that a dedicated NOTIFICATION for this event was undesirable, the system will now recurisvely walk the scene tree and attempt to call a script-facing method called '_nodes_scene_reimported' with a list of nodes which have scenes which were reimported, giving the opportunity to recreate the missing nodes, consistent with other editor behaviours. An example project of this in action is attached to this PR.

To test it, open the test_scene then attempt to reimport xbot.gltf. The editor script will automatically instantiate the xbot scene as an ownerless child but also attach a Sprite3D node to it too. The script uses the _nodes_scene_reimported function to detect if the PackedScene used by the 'model_scene' property has changed and will recache everything according, as well as creating a new Sprite3D node and attach it.

[container_nodes.zip](https://github.com/godotengine/godot/files/15383539/container_nodes.zip)