### PR TITLE
Disallow selection of ownerless nodes

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -296,8 +296,8 @@ private:
 
 	ObjectID clicked;
 	ObjectID material_target;
-	Vector<_RayResult> selection_results;
-	Vector<_RayResult> selection_results_menu;
+	Vector<Node3D *> selection_results;
+	Vector<Node3D *> selection_results_menu;
 	bool clicked_wants_append = false;
 	bool selection_in_progress = false;
 


### PR DESCRIPTION
Closes #92187

This changes the behaviour of node selection when selecting ownerless nodes in the 3D node editor. Now, instead of simply selecting the ownerless node, it will walk its parents and attempt to find the first node which is valid for selection.