### PR TITLE
Add `_get_custom_preview_node` method for 3D preview

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4997,20 +4997,29 @@ void Node3DEditorViewport::_create_preview_node(const Vector<String> &files) con
 	for (const String &path : files) {
 		Ref<Resource> res = ResourceLoader::load(path);
 		ERR_CONTINUE(res.is_null());
-
-		Ref<PackedScene> scene = res;
+		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
 		if (scene.is_valid()) {
 			Node *instance = scene->instantiate();
 			if (instance) {
-				instance = _sanitize_preview_node(instance);
+				if (instance->has_method("_get_custom_preview_node")) {
+					Node3D *custom_preview = Object::cast_to<Node3D>(instance->call("_get_custom_preview_node"));
+					if (custom_preview) {
+						memdelete(instance);
+						instance = custom_preview;
+					} else {
+						instance = _sanitize_preview_node(instance);
+					}
+				} else {
+					instance = _sanitize_preview_node(instance);
+				}
 				preview_node->add_child(instance);
 				Node3D *node_3d = Object::cast_to<Node3D>(instance);
 				if (node_3d) {
 					node_3d->set_as_top_level(false);
 				}
 			}
-			add_preview = true;
 		}
+		add_preview = true;
 
 		Ref<Mesh> mesh = res;
 		if (mesh.is_valid()) {


### PR DESCRIPTION
Partially implements my proposal here (https://github.com/godotengine/godot-proposals/issues/9796) for customisable drag and drop previews (currently only works for 3D previews, not 2D, but should be trivial to add support.)

You can see a functional example of this in action with this preview project. Drag the instance_scene.tscn into the main scene and note how it still generates a preview in spite of the fact that the scene itself contains no actual child nodes. The nodes are generated as ownerless nodes once formally added to the scene tree. This improves Godot's support for architecting games with a more data-oriented design.

[instance_scenes.zip](https://github.com/godotengine/godot/files/15384804/instance_scenes.zip)