### PR TITLE
Don't translate preview in node batch rename dialog

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -289,6 +289,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	vbc->add_child(lbl_preview_title);
 
 	lbl_preview = memnew(Label);
+	lbl_preview->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	lbl_preview->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	vbc->add_child(lbl_preview);
 


### PR DESCRIPTION
Node name rename preview was translated :joy: 