### PR TITLE
Add methods to simulate input events.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1174,6 +1174,41 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, macOS, Windows, and Linux (X11/Wayland).
 			</description>
 		</method>
+		<method name="simulate_keypress">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<param index="1" name="modifiers" type="int" enum="KeyModifierMask" is_bitfield="true" />
+			<param index="2" name="pressed" type="bool" />
+			<description>
+				Simulates a key press event which can be handled by the operating system, not just Godot (as opposed to [method Input.parse_input_event]). The key press event is typically sent to the currently focused window, but some apps may have global shortcuts active.
+				[b]Note:[/b] The key press does not change based on keyboard layout, so if you are using this to input text, use [method DisplayServer.keyboard_get_keycode_from_physical] to convert the key to the user's keyboard layout.
+				[b]Note:[/b] Simulated input events are ignored by login screen, and other security related OS UI elements.
+				[b]Note:[/b] On macOS, this method requires "Accessibility" permission.
+				[b]Note:[/b] This method is implemented on macOS, Windows, and Linux (X11).
+			</description>
+		</method>
+		<method name="simulate_mouse_click">
+			<return type="bool" />
+			<param index="0" name="button" type="int" enum="MouseButton" />
+			<param index="1" name="modifiers" type="int" enum="KeyModifierMask" is_bitfield="true" />
+			<param index="2" name="pressed" type="bool" />
+			<description>
+				Simulates a mouse button or wheel event which can be handled by the operating system, not just Godot (as opposed to [method Input.parse_input_event]).
+				[b]Note:[/b] Simulated input events are ignored by login screen, and other security related OS UI elements.
+				[b]Note:[/b] On macOS, this method requires "Accessibility" permission.
+				[b]Note:[/b] This method is implemented on macOS, Windows, and Linux (X11).
+			</description>
+		</method>
+		<method name="simulate_unicode_input">
+			<return type="bool" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Simulates an Unicode string input which can be handled by the operating system, not just Godot (as opposed to [method Input.parse_input_event]). The key press event is typically sent to the currently focused window.
+				[b]Note:[/b] Simulated input events are ignored by login screen, and other security related OS UI elements.
+				[b]Note:[/b] On macOS, this method requires "Accessibility" permission.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="status_indicator_get_rect" qualifiers="const">
 			<return type="Rect2" />
 			<param index="0" name="id" type="int" />
@@ -1859,6 +1894,9 @@
 		</constant>
 		<constant name="FEATURE_NATIVE_DIALOG_FILE" value="25" enum="Feature">
 			Display server supports spawning dialogs for selecting files or directories using the operating system's native look-and-feel. See [method file_dialog_show] and [method file_dialog_with_options_show]. [b]Windows, macOS, Linux (X11/Wayland)[/b]
+		</constant>
+		<constant name="FEATURE_INPUT_SIMULATION" value="26" enum="Feature">
+			Display server supports input simulation, see [method simulate_mouse_click], [method simulate_keypress], and [method simulate_unicode_input]. [b]Windows, macOS, Linux (X11)[/b]
 		</constant>
 		<constant name="MOUSE_MODE_VISIBLE" value="0" enum="MouseMode">
 			Makes the mouse cursor visible if it is hidden.

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -371,6 +371,8 @@ class DisplayServerX11 : public DisplayServer {
 	void _poll_events();
 	void _check_pending_events(LocalVector<XEvent> &r_events);
 
+	unsigned int _find_free_keycode() const;
+
 	static Bool _predicate_all_events(Display *display, XEvent *event, XPointer arg);
 	static Bool _predicate_clipboard_selection(Display *display, XEvent *event, XPointer arg);
 	static Bool _predicate_clipboard_incr(Display *display, XEvent *event, XPointer arg);
@@ -522,6 +524,10 @@ public:
 	virtual String keyboard_get_layout_name(int p_index) const override;
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const override;
 	virtual Key keyboard_get_label_from_physical(Key p_keycode) const override;
+
+	virtual bool simulate_mouse_click(MouseButton p_button, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_keypress(Key p_keycode, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_unicode_input(const String &p_text) override;
 
 	virtual void process_events() override;
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -422,6 +422,10 @@ public:
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const override;
 	virtual Key keyboard_get_label_from_physical(Key p_keycode) const override;
 
+	virtual bool simulate_mouse_click(MouseButton p_button, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_keypress(Key p_keycode, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_unicode_input(const String &p_text) override;
+
 	virtual void process_events() override;
 	virtual void force_process_and_drop_events() override;
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -772,6 +772,7 @@ bool DisplayServerMacOS::has_feature(Feature p_feature) const {
 		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_STATUS_INDICATOR:
 		case FEATURE_NATIVE_HELP:
+		case FEATURE_INPUT_SIMULATION:
 			return true;
 		default: {
 		}
@@ -2982,6 +2983,127 @@ Key DisplayServerMacOS::keyboard_get_label_from_physical(Key p_keycode) const {
 	Key keycode_no_mod = p_keycode & KeyModifierMask::CODE_MASK;
 	unsigned int macos_keycode = KeyMappingMacOS::unmap_key(keycode_no_mod);
 	return (Key)(KeyMappingMacOS::remap_key(macos_keycode, 0, true) | modifiers);
+}
+
+bool DisplayServerMacOS::simulate_mouse_click(MouseButton p_button, BitField<KeyModifierMask> p_modifiers, bool p_pressed) {
+	Point2 position_on_screen = mouse_get_position();
+	position_on_screen.y *= -1;
+	position_on_screen += _get_screens_origin();
+	position_on_screen /= screen_get_max_scale();
+	CGPoint mouse_pos = { position_on_screen.x, CGDisplayBounds(CGMainDisplayID()).size.height - position_on_screen.y };
+
+	CGEventType mouse_type = kCGEventNull;
+	CGMouseButton mouse_button = (CGMouseButton)0;
+	Vector2i wheel_factor;
+	switch (p_button) {
+		case MouseButton::LEFT: {
+			mouse_type = p_pressed ? kCGEventLeftMouseDown : kCGEventLeftMouseUp;
+			mouse_button = (CGMouseButton)0;
+		} break;
+		case MouseButton::RIGHT: {
+			mouse_type = p_pressed ? kCGEventRightMouseDown : kCGEventRightMouseUp;
+			mouse_button = (CGMouseButton)1;
+		} break;
+		case MouseButton::MIDDLE: {
+			mouse_type = p_pressed ? kCGEventOtherMouseDown : kCGEventOtherMouseUp;
+			mouse_button = (CGMouseButton)2;
+		} break;
+		case MouseButton::MB_XBUTTON1: {
+			mouse_type = p_pressed ? kCGEventOtherMouseDown : kCGEventOtherMouseUp;
+			mouse_button = (CGMouseButton)3;
+		} break;
+		case MouseButton::MB_XBUTTON2: {
+			mouse_type = p_pressed ? kCGEventOtherMouseDown : kCGEventOtherMouseUp;
+			mouse_button = (CGMouseButton)4;
+		} break;
+		case MouseButton::WHEEL_UP: {
+			mouse_type = kCGEventScrollWheel;
+			wheel_factor = Vector2i(-1, 0);
+		} break;
+		case MouseButton::WHEEL_DOWN: {
+			mouse_type = kCGEventScrollWheel;
+			wheel_factor = Vector2i(1, 0);
+		} break;
+		case MouseButton::WHEEL_LEFT: {
+			mouse_type = kCGEventScrollWheel;
+			wheel_factor = Vector2i(0, -1);
+		} break;
+		case MouseButton::WHEEL_RIGHT: {
+			mouse_type = kCGEventScrollWheel;
+			wheel_factor = Vector2i(0, 1);
+		} break;
+		default:
+			break;
+	}
+	if (mouse_type == kCGEventScrollWheel) {
+		CGEventRef event = CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitLine, 2, wheel_factor.x, wheel_factor.y);
+		CGEventFlags flags = 0;
+		if (p_modifiers.has_flag(KeyModifierMask::SHIFT)) {
+			flags |= kCGEventFlagMaskShift;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::ALT)) {
+			flags |= kCGEventFlagMaskAlternate;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::META) || p_modifiers.has_flag(KeyModifierMask::CMD_OR_CTRL)) {
+			flags |= kCGEventFlagMaskCommand;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::CTRL)) {
+			flags |= kCGEventFlagMaskControl;
+		}
+		CGEventSetFlags(event, flags);
+		CGEventPost(kCGHIDEventTap, event);
+		CFRelease(event);
+	} else {
+		CGEventRef event = CGEventCreateMouseEvent(nullptr, mouse_type, mouse_pos, mouse_button);
+		CGEventFlags flags = 0;
+		if (p_modifiers.has_flag(KeyModifierMask::SHIFT)) {
+			flags |= kCGEventFlagMaskShift;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::ALT)) {
+			flags |= kCGEventFlagMaskAlternate;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::META) || p_modifiers.has_flag(KeyModifierMask::CMD_OR_CTRL)) {
+			flags |= kCGEventFlagMaskCommand;
+		}
+		if (p_modifiers.has_flag(KeyModifierMask::CTRL)) {
+			flags |= kCGEventFlagMaskControl;
+		}
+		CGEventSetFlags(event, flags);
+		CGEventPost(kCGHIDEventTap, event);
+		CFRelease(event);
+	}
+	return true;
+}
+
+bool DisplayServerMacOS::simulate_keypress(Key p_keycode, BitField<KeyModifierMask> p_modifiers, bool p_pressed) {
+	unsigned int macos_keycode = KeyMappingMacOS::unmap_key(p_keycode & KeyModifierMask::CODE_MASK);
+	CGEventRef event = CGEventCreateKeyboardEvent(nullptr, (CGKeyCode)macos_keycode, p_pressed);
+	CGEventFlags flags = 0;
+	if (p_modifiers.has_flag(KeyModifierMask::SHIFT)) {
+		flags |= kCGEventFlagMaskShift;
+	}
+	if (p_modifiers.has_flag(KeyModifierMask::ALT)) {
+		flags |= kCGEventFlagMaskAlternate;
+	}
+	if (p_modifiers.has_flag(KeyModifierMask::META) || p_modifiers.has_flag(KeyModifierMask::CMD_OR_CTRL)) {
+		flags |= kCGEventFlagMaskCommand;
+	}
+	if (p_modifiers.has_flag(KeyModifierMask::CTRL)) {
+		flags |= kCGEventFlagMaskControl;
+	}
+	CGEventSetFlags(event, flags);
+	CGEventPost(kCGHIDEventTap, event);
+	CFRelease(event);
+	return true;
+}
+
+bool DisplayServerMacOS::simulate_unicode_input(const String &p_text) {
+	CGEventRef event = CGEventCreateKeyboardEvent(nullptr, 0, true);
+	Char16String text16 = p_text.utf16();
+	CGEventKeyboardSetUnicodeString(event, text16.length(), (const UniChar *)text16.get_data());
+	CGEventPost(kCGHIDEventTap, event);
+	CFRelease(event);
+	return true;
 }
 
 void DisplayServerMacOS::process_events() {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -521,6 +521,9 @@ class DisplayServerWindows : public DisplayServer {
 
 	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);
 
+	bool _simulate_modifiers_press(BitField<KeyModifierMask> p_modifiers);
+	bool _simulate_modifiers_release(BitField<KeyModifierMask> p_modifiers);
+
 public:
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	LRESULT MouseProc(int code, WPARAM wParam, LPARAM lParam);
@@ -676,6 +679,10 @@ public:
 	virtual String tablet_get_driver_name(int p_driver) const override;
 	virtual String tablet_get_current_driver() const override;
 	virtual void tablet_set_current_driver(const String &p_driver) override;
+
+	virtual bool simulate_mouse_click(MouseButton p_button, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_keypress(Key p_keycode, BitField<KeyModifierMask> p_modifiers, bool p_pressed) override;
+	virtual bool simulate_unicode_input(const String &p_text) override;
 
 	virtual void process_events() override;
 

--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -43,9 +43,12 @@ struct HashMapHasherKeys {
 };
 
 HashMap<unsigned int, Key, HashMapHasherKeys> vk_map;
+HashMap<Key, unsigned int, HashMapHasherKeys> vk_map_inv;
 HashMap<unsigned int, Key, HashMapHasherKeys> scansym_map;
 HashMap<Key, unsigned int, HashMapHasherKeys> scansym_map_inv;
 HashMap<unsigned int, Key, HashMapHasherKeys> scansym_map_ext;
+HashMap<Key, unsigned int, HashMapHasherKeys> scansym_map_ext_inv;
+
 HashMap<unsigned int, KeyLocation, HashMapHasherKeys> location_map;
 
 void KeyMappingWindows::initialize() {
@@ -232,6 +235,10 @@ void KeyMappingWindows::initialize() {
 	// VK_PA1 (0xFD), Old IBM 3270 PA1 key.
 	vk_map[VK_OEM_CLEAR] = Key::CLEAR; // (0xFE), OEM specific clear key. Unclear how it differs from normal clear.
 
+	for (const KeyValue<unsigned int, Key> &E : vk_map) {
+		vk_map_inv[E.value] = E.key;
+	}
+
 	scansym_map[0x00] = Key::PAUSE;
 	scansym_map[0x01] = Key::ESCAPE;
 	scansym_map[0x02] = Key::KEY_1;
@@ -382,6 +389,10 @@ void KeyMappingWindows::initialize() {
 	scansym_map_ext[0x6D] = Key::LAUNCHMEDIA;
 	scansym_map_ext[0x78] = Key::MEDIARECORD;
 
+	for (const KeyValue<unsigned int, Key> &E : scansym_map_ext) {
+		scansym_map_ext_inv[E.value] = E.key;
+	}
+
 	// Scancode to physical location map.
 	// Shift.
 	location_map[0x2A] = KeyLocation::LEFT;
@@ -400,8 +411,24 @@ Key KeyMappingWindows::get_keysym(unsigned int p_code) {
 	return Key::UNKNOWN;
 }
 
+unsigned int KeyMappingWindows::get_vk(Key p_keycode) {
+	const unsigned int *key = vk_map_inv.getptr(p_keycode);
+	if (key) {
+		return *key;
+	}
+	return 0;
+}
+
 unsigned int KeyMappingWindows::get_scancode(Key p_keycode) {
 	const unsigned int *key = scansym_map_inv.getptr(p_keycode);
+	if (key) {
+		return *key;
+	}
+	return 0;
+}
+
+unsigned int KeyMappingWindows::get_scancode_ext(Key p_keycode) {
+	const unsigned int *key = scansym_map_ext_inv.getptr(p_keycode);
 	if (key) {
 		return *key;
 	}

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -44,7 +44,9 @@ public:
 	static void initialize();
 
 	static Key get_keysym(unsigned int p_code);
+	static unsigned int get_vk(Key p_keycode);
 	static unsigned int get_scancode(Key p_keycode);
+	static unsigned int get_scancode_ext(Key p_keycode);
 	static Key get_scansym(unsigned int p_code, bool p_extended);
 	static bool is_extended_key(unsigned int p_code);
 	static KeyLocation get_location(unsigned int p_code, bool p_extended);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -998,6 +998,10 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_window_transparency_available"), &DisplayServer::is_window_transparency_available);
 
+	ClassDB::bind_method(D_METHOD("simulate_mouse_click", "button", "modifiers", "pressed"), &DisplayServer::simulate_mouse_click);
+	ClassDB::bind_method(D_METHOD("simulate_keypress", "keycode", "modifiers", "pressed"), &DisplayServer::simulate_keypress);
+	ClassDB::bind_method(D_METHOD("simulate_unicode_input", "text"), &DisplayServer::simulate_unicode_input);
+
 #ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(FEATURE_GLOBAL_MENU);
 #endif
@@ -1025,6 +1029,7 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_HELP);
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_DIALOG_INPUT);
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_DIALOG_FILE);
+	BIND_ENUM_CONSTANT(FEATURE_INPUT_SIMULATION);
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -148,6 +148,7 @@ public:
 		FEATURE_NATIVE_HELP,
 		FEATURE_NATIVE_DIALOG_INPUT,
 		FEATURE_NATIVE_DIALOG_FILE,
+		FEATURE_INPUT_SIMULATION,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -559,6 +560,10 @@ public:
 	virtual String tablet_get_driver_name(int p_driver) const { return "default"; };
 	virtual String tablet_get_current_driver() const { return "default"; };
 	virtual void tablet_set_current_driver(const String &p_driver){};
+
+	virtual bool simulate_mouse_click(MouseButton p_button, BitField<KeyModifierMask> p_modifiers, bool p_pressed) { return false; };
+	virtual bool simulate_keypress(Key p_keycode, BitField<KeyModifierMask> p_modifiers, bool p_pressed) { return false; };
+	virtual bool simulate_unicode_input(const String &p_text) { return false; };
 
 	virtual void process_events() = 0;
 


### PR DESCRIPTION
Add input event simulation support (on OS level), to allow automated UI (native windows interaction) testing (can be useful for other tasks as well).

Adds the following methods:
- `simulate_keypress`, sends key code with modifiers (macOS, X11 and, Windows).
- `simulate_unicode_input`, sends Unicode string (macOS, and Windows, not sure if it's possible on X11, seems like only characters from current keyboard layout can be sent).
- `simulate_mouse_click`, sends mouse click with modifiers (macOS, X11 and, Windows).
- mouse movement is already possible with `warp_mouse`.
- on Wayland it seems to be only possible to do on low level (using `uinput` kernel interface, not implemented in this PR, since no native window support is currently implemented for Wayland).

Related https://github.com/godotengine/godot-proposals/issues/1760
