### PR TITLE
Allow `OpenXRCompositionLayer` property `layer_viewport` to always be assigned `nullptr`

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -165,7 +165,9 @@ void OpenXRCompositionLayer::set_layer_viewport(SubViewport *p_viewport) {
 		return;
 	}
 
-	ERR_FAIL_COND_EDMSG(is_viewport_in_use(p_viewport), RTR("Cannot use the same SubViewport with multiple OpenXR composition layers. Clear it from its current layer first."));
+	if (p_viewport != nullptr) {
+		ERR_FAIL_COND_EDMSG(is_viewport_in_use(p_viewport), RTR("Cannot use the same SubViewport with multiple OpenXR composition layers. Clear it from its current layer first."));
+	}
 
 	layer_viewport = p_viewport;
 


### PR DESCRIPTION
If you have multiple `OpenXRCompositionLayer` nodes and at least one of them does not have a viewport assigned, users are not able to return an assigned `layer_viewport` property to its default value (`nullptr`). This fixes that.