### PR TITLE
Clean `Input::frame_parsed_events` before de-initialising scripting languages to ensure no script created events exist at the exit.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1029,6 +1029,14 @@ void Input::parse_input_event(const Ref<InputEvent> &p_event) {
 	}
 }
 
+#ifdef DEBUG_ENABLED
+void Input::flush_frame_parsed_events() {
+	_THREAD_SAFE_METHOD_
+
+	frame_parsed_events.clear();
+}
+#endif
+
 void Input::flush_buffered_events() {
 	_THREAD_SAFE_METHOD_
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -363,6 +363,9 @@ public:
 	Dictionary get_joy_info(int p_device) const;
 	void set_fallback_mapping(const String &p_guid);
 
+#ifdef DEBUG_ENABLED
+	void flush_frame_parsed_events();
+#endif
 	void flush_buffered_events();
 	bool is_using_input_buffering();
 	void set_use_input_buffering(bool p_enable);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4182,6 +4182,12 @@ void Main::cleanup(bool p_force) {
 		ERR_FAIL_COND(!_start_success);
 	}
 
+#ifdef DEBUG_ENABLED
+	if (input) {
+		input->flush_frame_parsed_events();
+	}
+#endif
+
 	for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 		TextServerManager::get_singleton()->get_interface(i)->cleanup();
 	}


### PR DESCRIPTION
A quick fix for https://github.com/godotengine/godot/issues/83973, should address the crash reason, but C# object cleanup probably should be investigated further to avoid similar issues.

Fixes https://github.com/godotengine/godot/issues/83973, and probably fixes https://github.com/godotengine/godot/issues/89188 (at least MRP in the first comment).