### PR TITLE
Pre-commit: Allow adding downstream hooks without (less) risk of conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,7 @@ repos:
         exclude: |
           (?x)^(
             core/math/bvh_.*\.inc$|
+            platform/(?!android|ios|linuxbsd|macos|web|windows)\w+/.*|
             platform/android/java/lib/src/com/.*|
             platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView\.java$|
             platform/android/java/lib/src/org/godotengine/godot/gl/EGLLogWrapper\.java$|
@@ -186,3 +187,15 @@ repos:
         language: python
         entry: python3 misc/scripts/dotnet_format.py
         types_or: [c#]
+
+# End of upstream Godot pre-commit hooks.
+#
+# Keep this separation to let downstream forks add their own hooks to this file,
+# without running into merge conflicts when rebasing on latest upstream.
+#
+# Start of downstream pre-commit hooks.
+#
+# This is still the "repo: local" scope, so new local hooks can be defined directly at this indentation:
+#     - id: new-local-hook
+# To add external repo hooks, bring the indentation back to:
+# - repo: my-remote-hook


### PR DESCRIPTION
Apply Godot copyright header only on the platform folders that we maintain upstream. This lets downstream forks decide what to do with their potential proprietary platforms.

This is a proof of concept for the simplest approach to allow this kind of downstream changes.

We discussed other options on RC in https://chat.godotengine.org/channel/buildsystem?msg=5xaykgLZdDincTDjY which may still be worth exploring, either now or in the future.

While this works, this is limited in how flexible things can be. For example we may want to similar add logic to only apply the Godot copyright header to modules present in this repo, and not new modules added in downstream forks.

In general, there might be a need for bypassing part of the `.pre-commit-config.yaml` if it's not relevant to a downstream fork, or outright replacing it. But I don't think `pre-commit` gives us much flexibility there.