### PR TITLE
Add methods for tracking memory allocations at a global level.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -466,6 +466,14 @@ uint64_t OS::get_static_memory_peak_usage() const {
 	return ::OS::get_singleton()->get_static_memory_peak_usage();
 }
 
+uint64_t OS::get_memory_allocations_count() const {
+	return ::OS::get_singleton()->get_memory_allocations_count();
+}
+
+uint64_t OS::get_memory_allocations_performed() const {
+	return ::OS::get_singleton()->get_memory_allocations_performed();
+}
+
 Dictionary OS::get_memory_info() const {
 	return ::OS::get_singleton()->get_memory_info();
 }
@@ -637,6 +645,8 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_static_memory_usage"), &OS::get_static_memory_usage);
 	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &OS::get_static_memory_peak_usage);
+	ClassDB::bind_method(D_METHOD("get_memory_allocations_count"), &OS::get_memory_allocations_count);
+	ClassDB::bind_method(D_METHOD("get_memory_allocations_performed"), &OS::get_memory_allocations_performed);
 	ClassDB::bind_method(D_METHOD("get_memory_info"), &OS::get_memory_info);
 
 	ClassDB::bind_method(D_METHOD("move_to_trash", "path"), &OS::move_to_trash);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -201,6 +201,8 @@ public:
 
 	uint64_t get_static_memory_usage() const;
 	uint64_t get_static_memory_peak_usage() const;
+	uint64_t get_memory_allocations_count() const;
+	uint64_t get_memory_allocations_performed() const;
 	Dictionary get_memory_info() const;
 
 	void delay_usec(int p_usec) const;

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -64,6 +64,7 @@ SafeNumeric<uint64_t> Memory::max_usage;
 #endif
 
 SafeNumeric<uint64_t> Memory::alloc_count;
+SafeNumeric<uint64_t> Memory::alloc_performed;
 
 void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 #ifdef DEBUG_ENABLED
@@ -77,6 +78,7 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 	ERR_FAIL_NULL_V(mem, nullptr);
 
 	alloc_count.increment();
+	alloc_performed.increment();
 
 	if (prepad) {
 		uint8_t *s8 = (uint8_t *)mem;
@@ -189,6 +191,14 @@ uint64_t Memory::get_mem_max_usage() {
 #else
 	return 0;
 #endif
+}
+
+uint64_t Memory::get_mem_alloc_count() {
+	return alloc_count.get();
+}
+
+uint64_t Memory::get_mem_alloc_performed() {
+	return alloc_performed.get();
 }
 
 _GlobalNil::_GlobalNil() {

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -45,6 +45,7 @@ class Memory {
 #endif
 
 	static SafeNumeric<uint64_t> alloc_count;
+	static SafeNumeric<uint64_t> alloc_performed;
 
 public:
 	// Alignment:  ↓ max_align_t        ↓ uint64_t          ↓ max_align_t
@@ -65,6 +66,8 @@ public:
 	static uint64_t get_mem_available();
 	static uint64_t get_mem_usage();
 	static uint64_t get_mem_max_usage();
+	static uint64_t get_mem_alloc_count();
+	static uint64_t get_mem_alloc_performed();
 };
 
 class DefaultAllocator {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -323,6 +323,14 @@ uint64_t OS::get_static_memory_peak_usage() const {
 	return Memory::get_mem_max_usage();
 }
 
+uint64_t OS::get_memory_allocations_count() const {
+	return Memory::get_mem_alloc_count();
+}
+
+uint64_t OS::get_memory_allocations_performed() const {
+	return Memory::get_mem_alloc_performed();
+}
+
 Error OS::set_cwd(const String &p_cwd) {
 	return ERR_CANT_OPEN;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -256,6 +256,8 @@ public:
 
 	virtual uint64_t get_static_memory_usage() const;
 	virtual uint64_t get_static_memory_peak_usage() const;
+	virtual uint64_t get_memory_allocations_count() const;
+	virtual uint64_t get_memory_allocations_performed() const;
 	virtual Dictionary get_memory_info() const;
 
 	RenderThreadMode get_render_thread_mode() const { return _render_thread_mode; }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -331,6 +331,18 @@
 				[b]Note:[/b] Thread IDs are not deterministic and may be reused across application restarts.
 			</description>
 		</method>
+		<method name="get_memory_allocations_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the current amount of memory allocations.
+			</description>
+		</method>
+		<method name="get_memory_allocations_performed" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of memory allocations performed during the application's lifetime. By comparing this value at different points in time, it is possible to detect if the application is performing unnecessary allocations.
+			</description>
+		</method>
 		<method name="get_memory_info" qualifiers="const">
 			<return type="Dictionary" />
 			<description>


### PR DESCRIPTION
Currently the Memory class performs some form of allocation tracking but doesn't expose methods to query the counter. On top of that, we also lack a way to track which allocations were performed between different points of time, which hides pretty much any sign that there might be unnecessary allocations going on per frame.

I'm submitting this as a basic PR to use as my basis for reviewing any changes I make and tracking the impact with accurate numbers, as memory allocations are a heavy source of performance issues when they're in hot paths. For example, running the TPS demo and comparing the allocations reported by these indicators gives me about ~2000 per frame.

I'm leaving this as a draft since there's a bit of wiggle room in the design for this that we might want to discuss.