### PR TITLE
Use `OS::delay_usec()` to avoid using deprecated `usleep()` on Linux

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -591,7 +591,7 @@ void FreeDesktopPortalDesktop::_thread_monitor(void *p_ud) {
 			dbus_connection_read_write(portal->monitor_connection, 0);
 		}
 
-		usleep(50000);
+		OS::get_singleton()->delay_usec(50'000);
 	}
 }
 

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -225,7 +225,7 @@ void JoypadLinux::monitor_joypads(udev *p_udev) {
 				udev_device_unref(dev);
 			}
 		}
-		usleep(50000);
+		OS::get_singleton()->delay_usec(50'000);
 	}
 	udev_monitor_unref(mon);
 }
@@ -250,7 +250,7 @@ void JoypadLinux::monitor_joypads() {
 			}
 		}
 		closedir(input_directory);
-		usleep(1000000); // 1s
+		OS::get_singleton()->delay_usec(1'000'000);
 	}
 }
 
@@ -508,7 +508,7 @@ void JoypadLinux::joypad_events_thread_run() {
 			}
 		}
 		if (no_events) {
-			usleep(10000); // 10ms
+			OS::get_singleton()->delay_usec(10'000);
 		}
 	}
 }

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2269,7 +2269,7 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 			break;
 		}
 
-		usleep(10000);
+		OS::get_singleton()->delay_usec(10'000);
 	}
 
 	// Keep rendering context window size in sync
@@ -2544,7 +2544,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 		// Give up after 0.5s, it's not going to happen on this WM.
 		// https://github.com/godotengine/godot/issues/19978
 		for (int attempt = 0; window_get_mode(p_window) != WINDOW_MODE_MAXIMIZED && attempt < 50; attempt++) {
-			usleep(10000);
+			OS::get_singleton()->delay_usec(10'000);
 		}
 	}
 	wd.maximized = p_enabled;


### PR DESCRIPTION
usleep(3) was declared obsolete in POSIX.1-2001 and removed in POSIX.1-2008. nanosleep(2) was recommended to be used instead.

[`OS::delay_usec()` internally uses `nanosleep()`.](https://github.com/Calinou/godot/blob/a008896f70b247f727fa433a9ccf49db05b0bd2c/drivers/unix/os_unix.cpp#L286-L293)

This also uses large number separators for improved readability.

- See https://github.com/ioquake/ioq3/pull/652.
