### PR TITLE
Add colored header output

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -206,7 +206,7 @@ typedef void(GLAPIENTRY *DEBUGPROCARB)(GLenum source,
 typedef void(GLAPIENTRY *DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userParam);
 
 void RasterizerGLES3::initialize() {
-	Engine::get_singleton()->print_header(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
+	Engine::get_singleton()->print_header_rich(vformat("\u001b[2mOpenGL API %s - \u001b[96mCompatibility\u001b[39;2m - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
 }
 
 void RasterizerGLES3::finalize() {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -283,7 +283,11 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 	int line_count = lines.size();
 
 	for (int i = 0; i < line_count; i++) {
+#ifdef MODULE_REGEX_ENABLED
+		_process_message(strip_ansi_regex->sub(lines[i], "", true), p_type, i == line_count - 1);
+#else
 		_process_message(lines[i], p_type, i == line_count - 1);
+#endif
 	}
 }
 
@@ -512,6 +516,11 @@ EditorLog::EditorLog() {
 	vb_left->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb_left->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(vb_left);
+
+#ifdef MODULE_REGEX_ENABLED
+	strip_ansi_regex.instantiate();
+	strip_ansi_regex->compile("\u001b\\[((?:\\d|;)*)([a-zA-Z])");
+#endif // MODULE_REGEX_ENABLED
 
 	// Log - Rich Text Label.
 	log = memnew(RichTextLabel);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -129,6 +129,10 @@ private:
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	HashMap<MessageType, LogFilter *> type_filter_map;
 
+#ifdef MODULE_REGEX_ENABLED
+	Ref<RegEx> strip_ansi_regex;
+#endif // MODULE_REGEX_ENABLED
+
 	RichTextLabel *log = nullptr;
 
 	Button *clear_button = nullptr;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -426,19 +426,19 @@ void finalize_theme_db() {
 #define MAIN_PRINT(m_txt)
 #endif
 
-void Main::print_header(bool p_rich) {
+void Main::print_header(bool p_help) {
 	if (GODOT_VERSION_TIMESTAMP > 0) {
 		// Version timestamp available.
-		if (p_rich) {
+		if (p_help) {
 			Engine::get_singleton()->print_header_rich("\u001b[38;5;39m" + String(GODOT_VERSION_NAME) + "\u001b[0m v" + get_full_version_string() + " (" + Time::get_singleton()->get_datetime_string_from_unix_time(GODOT_VERSION_TIMESTAMP, true) + " UTC) - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		} else {
-			Engine::get_singleton()->print_header(String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " (" + Time::get_singleton()->get_datetime_string_from_unix_time(GODOT_VERSION_TIMESTAMP, true) + " UTC) - " + String(GODOT_VERSION_WEBSITE));
+			Engine::get_singleton()->print_header_rich("\u001b[2m" + String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " (" + Time::get_singleton()->get_datetime_string_from_unix_time(GODOT_VERSION_TIMESTAMP, true) + " UTC) - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		}
 	} else {
-		if (p_rich) {
+		if (p_help) {
 			Engine::get_singleton()->print_header_rich("\u001b[38;5;39m" + String(GODOT_VERSION_NAME) + "\u001b[0m v" + get_full_version_string() + " - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		} else {
-			Engine::get_singleton()->print_header(String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " - " + String(GODOT_VERSION_WEBSITE));
+			Engine::get_singleton()->print_header_rich("\u001b[2m" + String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		}
 	}
 }
@@ -448,7 +448,7 @@ void Main::print_header(bool p_rich) {
  * automatically added at the end.
  */
 void Main::print_help_copyright(const char *p_notice) {
-	OS::get_singleton()->print("\u001b[90m%s\u001b[0m\n", p_notice);
+	OS::get_singleton()->print("\u001b[2m%s\u001b[0m\n", p_notice);
 }
 
 /**
@@ -509,7 +509,7 @@ void Main::print_help_option(const char *p_option, const char *p_description, CL
 	} else {
 		// Make continuation lines for descriptions faint if the option name is empty.
 		OS::get_singleton()->print(
-				"  \u001b[92m%s   \u001b[0m  \u001b[90m%s",
+				"  \u001b[92m%s   \u001b[0m  \u001b[2m%s\u001b[0m",
 				format_help_option(p_option).utf8().ptr(),
 				p_description);
 	}

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6960,13 +6960,13 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		// Only the singleton instance with a display should print this information.
 		String rendering_method;
 		if (OS::get_singleton()->get_current_rendering_method() == "mobile") {
-			rendering_method = "Forward Mobile";
+			rendering_method = "\u001b[95mMobile";
 		} else {
-			rendering_method = "Forward+";
+			rendering_method = "\u001b[92mForward+";
 		}
 
 		// Output our device version.
-		Engine::get_singleton()->print_header(vformat("%s %s - %s - Using Device #%d: %s - %s", get_device_api_name(), get_device_api_version(), rendering_method, device_index, _get_device_vendor_name(device), device.name));
+		Engine::get_singleton()->print_header_rich(vformat("\u001b[2m%s %s - %s\u001b[39;2m - Using Device #%d: %s - %s", get_device_api_name(), get_device_api_version(), rendering_method, device_index, _get_device_vendor_name(device), device.name));
 	}
 
 	// Pick the main queue family. It is worth noting we explicitly do not request the transfer bit, as apparently the specification defines


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/36252 and
https://github.com/godotengine/godot/pull/90900.

Header messages are now displayed in gray, with the rendering method being colorized in the message.

ANSI escape codes are now stripped in the editor Output panel as well, which allows scripts to use custom ANSI escape codes outside of `print_rich()` while not affecting the Output panel's readability. This change was required for the newly printed ANSI escape codes to avoid affecting the editor Output panel. Message collapsing still works as expected:

![Screenshot_20240521_180956](https://github.com/godotengine/godot/assets/180032/bdcdbe38-1ad9-401d-9700-08d2d98f953f)

Additionally, the dim/faint display mode is now used instead of a "bright black" color for better compatibility across terminals (some themes could be displaying black text on a black background otherwise, or white text on a white background).

The Forward Mobile rendering method is now called Mobile in the startup message, for consistency with the editor display.

cc @Repiteo, as the dim/faint display mode (`[2m`) could be helpful for the SCons build time line where we used a 256-color gray previously to avoid the terminal theming issue.

## Preview

*The exact colors displayed will vary depending on your terminal emulator and its color scheme.*

Before | After
-|-
![Screenshot_20240521_180017](https://github.com/godotengine/godot/assets/180032/7c9f961d-31f1-4185-a916-62b53a55fb0e) | ![Screenshot_20240521_180025](https://github.com/godotengine/godot/assets/180032/874a89e5-dafb-4a63-a910-f614194f6da2)
