### PR TITLE
Disable all sources of ambient light when `ambient_light_disabled` render mode is used

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1604,6 +1604,7 @@ void main() {
 #ifdef BASE_PASS
 	/////////////////////// LIGHTING //////////////////////////////
 
+#ifndef AMBIENT_LIGHT_DISABLED
 	// IBL precalculations
 	float ndotv = clamp(dot(normal, view), 0.0, 1.0);
 	vec3 F = f0 + (max(vec3(1.0 - roughness), f0) - f0) * pow(1.0 - ndotv, 5.0);
@@ -1741,18 +1742,14 @@ void main() {
 #endif // USE_LIGHTMAP_CAPTURE
 #endif // !DISABLE_LIGHTMAP
 
-	{
-#if defined(AMBIENT_LIGHT_DISABLED)
-		ambient_light = vec3(0.0, 0.0, 0.0);
-#else
-		ambient_light *= albedo.rgb;
-		ambient_light *= ao;
-#endif // AMBIENT_LIGHT_DISABLED
-	}
+	ambient_light *= albedo.rgb;
+	ambient_light *= ao;
+
+#endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
 	ao = mix(1.0, ao, ao_light_affect);
-
+#ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
 		//simplify for toon, as
@@ -1773,6 +1770,8 @@ void main() {
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
 #endif
 	}
+
+#endif // !AMBIENT_LIGHT_DISABLED
 
 #ifndef DISABLE_LIGHT_DIRECTIONAL
 	for (uint i = uint(0); i < scene_data.directional_light_count; i++) {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1310,6 +1310,8 @@ void fragment_shader(in SceneData scene_data) {
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
+#ifndef AMBIENT_LIGHT_DISABLED
+
 	if (scene_data.use_reflection_cubemap) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1397,14 +1399,15 @@ void fragment_shader(in SceneData scene_data) {
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
-#endif
+#endif // LIGHT_CLEARCOAT_USED
+#endif // !AMBIENT_LIGHT_DISABLED
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 	//radiance
 
 /// GI ///
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
-
+#ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
 	//lightmap
@@ -1698,9 +1701,6 @@ void fragment_shader(in SceneData scene_data) {
 
 	//finalize ambient light here
 	{
-#if defined(AMBIENT_LIGHT_DISABLED)
-		ambient_light = vec3(0.0, 0.0, 0.0);
-#else
 		ambient_light *= albedo.rgb;
 		ambient_light *= ao;
 
@@ -1713,15 +1713,14 @@ void fragment_shader(in SceneData scene_data) {
 			ambient_light *= 1.0 - ssil.a;
 			ambient_light += ssil.rgb * albedo.rgb;
 		}
-#endif // AMBIENT_LIGHT_DISABLED
 	}
-
+#endif // AMBIENT_LIGHT_DISABLED
 	// convert ao to direct light ao
 	ao = mix(1.0, ao, ao_light_affect);
 
 	//this saves some VGPRs
 	vec3 f0 = F0(metallic, specular, albedo);
-
+#ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
 		//simplify for toon, as
@@ -1743,6 +1742,7 @@ void fragment_shader(in SceneData scene_data) {
 #endif
 	}
 
+#endif // !AMBIENT_LIGHT_DISABLED
 #endif //GI !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #if !defined(MODE_RENDER_DEPTH)

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1069,6 +1069,8 @@ void main() {
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
+#ifndef AMBIENT_LIGHT_DISABLED
+
 	if (scene_data.use_reflection_cubemap) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1156,13 +1158,14 @@ void main() {
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
-#endif
+#endif // LIGHT_CLEARCOAT_USED
+#endif // !AMBIENT_LIGHT_DISABLED
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 	//radiance
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
-
+#ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
 	//lightmap
@@ -1272,14 +1275,11 @@ void main() {
 	} //Reflection probes
 
 	// finalize ambient light here
-	{
-#if defined(AMBIENT_LIGHT_DISABLED)
-		ambient_light = vec3(0.0, 0.0, 0.0);
-#else
-		ambient_light *= albedo.rgb;
-		ambient_light *= ao;
-#endif // AMBIENT_LIGHT_DISABLED
-	}
+
+	ambient_light *= albedo.rgb;
+	ambient_light *= ao;
+
+#endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
 	ao = mix(1.0, ao, ao_light_affect);
@@ -1287,6 +1287,7 @@ void main() {
 	//this saves some VGPRs
 	vec3 f0 = F0(metallic, specular, albedo);
 
+#ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
 		//simplify for toon, as
@@ -1308,6 +1309,7 @@ void main() {
 #endif
 	}
 
+#endif // !AMBIENT_LIGHT_DISABLED
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #if !defined(MODE_RENDER_DEPTH)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/83593

In https://github.com/godotengine/godot/pull/66107 we agreed to reinstate the `ambient_light_disabled` render mode and use it to disable all ambient light contributions. However, the actual code only disabled diffuse ambient light and not specular ambient light. This led to it doing essentially nothing on metallic materials and running the full ambient light calculations for all materials. 

I noticed this issue while debugging performance in a 3D scene with @RPicster. A transparent object was doing the full VoxelGI calculation in the forward pass, even when ambient light was disabled. 

This change will technically change behaviour as it will disable specular ambient light in addition to diffuse. IMO this is an acceptable change in behaviour because the previous behaviour was unexpected, bad for performance, and ultimately the result of a bug. That being said, I am tagging it for 4.4 as we are too late in the 4.3 dev cycle to introduce a change in behaviour. 