### PR TITLE
Propagate `reset_physics_interpolation` through `RemoteTransform2D/3D`

### DIFF
--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -114,6 +114,16 @@ void RemoteTransform2D::_notification(int p_what) {
 			_update_cache();
 		} break;
 
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			if (cache.is_valid()) {
+				_update_remote();
+				Node2D *n = Object::cast_to<Node2D>(ObjectDB::get_instance(cache));
+				if (n) {
+					n->reset_physics_interpolation();
+				}
+			}
+		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -113,6 +113,16 @@ void RemoteTransform3D::_notification(int p_what) {
 			_update_cache();
 		} break;
 
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			if (cache.is_valid()) {
+				_update_remote();
+				Node3D *n = Object::cast_to<Node3D>(ObjectDB::get_instance(cache));
+				if (n) {
+					n->reset_physics_interpolation();
+				}
+			}
+		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {


### PR DESCRIPTION
I noticed that when calling `reset_physics_interpolation` on a scene tree that contains a `RemoteTransform2D/3D` node, the RemoteTransform doesn't propagate the `reset_physics_interpolation` call to the remote_path object.

This PR introduce the behavior to both `RemoteTransform2D/3D` nodes, by listening the `NOTIFICATION_RESET_PHYSICS_INTERPOLATION` notification and properly updating the cached object.

I have made a small reproduction project. It uses a low physics ticks per second to highlight the issue. The blue icon is randomly teleporting and uses `reset_physics_interpolation`. The red node is controlled via a `RemoteTransform2D` that is a child of the blue node but with an offset. We can see that the red node interpolates while the blue node doesn't.

Before :
https://github.com/godotengine/godot/assets/11552304/45804993-3ece-4498-adf7-690591cbaa7c

After :
https://github.com/godotengine/godot/assets/11552304/48c1f170-594b-4165-8bb2-8b74f92b3ed8

Reproduction project :
[remotePhysicsInterpolation.zip](https://github.com/godotengine/godot/files/15394613/remotePhysicsInterpolation.zip)

Note : 
A temporary fix is possible in user space by creating a script with the following and attaching it to the RemoteTransform2D, but we need to use a hack to force the re-computation of the transform because `RemoteTransform::_update_remote` is not exposed
```gdscript
extends RemoteTransform2D

func _notification(what: int) -> void:
	if what == NOTIFICATION_RESET_PHYSICS_INTERPOLATION:
		# force re-computation of transform
		use_global_coordinates = !use_global_coordinates;
		use_global_coordinates = !use_global_coordinates;

		var node : Node2D = get_node(remote_path);
		get_node(remote_path).reset_physics_interpolation();
```
