### PR TITLE
Fix TextureButton's click mask texture size ignored if missing normal texture

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -178,13 +178,14 @@ void TextureButton::_notification(int p_what) {
 				texdraw = focused;
 			}
 
-			if (texdraw.is_valid()) {
-				size = texdraw->get_size();
-				_texture_region = Rect2(Point2(), texdraw->get_size());
+			if (texdraw.is_valid() || click_mask.is_valid()) {
+				const Size2 texdraw_size = texdraw.is_valid() ? texdraw->get_size() : Size2(click_mask->get_size());
+
+				size = texdraw_size;
+				_texture_region = Rect2(Point2(), texdraw_size);
 				_tile = false;
 				switch (stretch_mode) {
 					case STRETCH_KEEP:
-						size = texdraw->get_size();
 						break;
 					case STRETCH_SCALE:
 						size = get_size();
@@ -194,18 +195,17 @@ void TextureButton::_notification(int p_what) {
 						_tile = true;
 						break;
 					case STRETCH_KEEP_CENTERED:
-						ofs = (get_size() - texdraw->get_size()) / 2;
-						size = texdraw->get_size();
+						ofs = (get_size() - texdraw_size) / 2;
 						break;
 					case STRETCH_KEEP_ASPECT_CENTERED:
 					case STRETCH_KEEP_ASPECT: {
 						Size2 _size = get_size();
-						float tex_width = texdraw->get_width() * _size.height / texdraw->get_height();
+						float tex_width = texdraw_size.width * _size.height / texdraw_size.height;
 						float tex_height = _size.height;
 
 						if (tex_width > _size.width) {
 							tex_width = _size.width;
-							tex_height = texdraw->get_height() * tex_width / texdraw->get_width();
+							tex_height = texdraw_size.height * tex_width / texdraw_size.width;
 						}
 
 						if (stretch_mode == STRETCH_KEEP_ASPECT_CENTERED) {
@@ -217,10 +217,9 @@ void TextureButton::_notification(int p_what) {
 					} break;
 					case STRETCH_KEEP_ASPECT_COVERED: {
 						size = get_size();
-						Size2 tex_size = texdraw->get_size();
-						Size2 scale_size(size.width / tex_size.width, size.height / tex_size.height);
+						Size2 scale_size = size / texdraw_size;
 						float scale = scale_size.width > scale_size.height ? scale_size.width : scale_size.height;
-						Size2 scaled_tex_size = tex_size * scale;
+						Size2 scaled_tex_size = texdraw_size * scale;
 						Point2 ofs2 = ((scaled_tex_size - size) / scale).abs() / 2.0f;
 						_texture_region = Rect2(ofs2, size / scale);
 					} break;
@@ -233,10 +232,12 @@ void TextureButton::_notification(int p_what) {
 
 				if (draw_focus_only) {
 					// Do nothing, we only needed to calculate the rectangle.
-				} else if (_tile) {
-					draw_texture_rect(texdraw, Rect2(ofs, size), _tile);
-				} else {
-					draw_texture_rect_region(texdraw, Rect2(ofs, size), _texture_region);
+				} else if (texdraw.is_valid()) {
+					if (_tile) {
+						draw_texture_rect(texdraw, Rect2(ofs, size), _tile);
+					} else {
+						draw_texture_rect_region(texdraw, Rect2(ofs, size), _texture_region);
+					}
 				}
 			} else {
 				_position_rect = Rect2();


### PR DESCRIPTION
* fixes #91898

~~although click/hover now works correctly, precisely detecting expected borders, it logs error for abscent "normal" texture.~~
```
scene\main\canvas_item.cpp:785 - Condition "p_texture.is_null()" is true
```
~~not sure what to do with that message yet, and if it needs to be fixed or not. is error message in case of missing normal texture expected?~~
fixed error log message https://github.com/godotengine/godot/pull/92222/files#diff-d9ffa969dbdabac1b846bcdcddd360802270fcabb040bae52bde2a3ab549c423#241:~:text=%7D%20else%20if%20(texdraw.is_valid())%20%7B