### PR TITLE
Fix array variable with `@export_multiline` not registering changes.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -235,6 +235,9 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 	Variant array = object->get_array().duplicate();
 	array.set(index, p_value);
 	emit_changed(get_edited_property(), array, p_name, p_changing);
+	if (p_changing) {
+		object->set_array(array);
+	}
 }
 
 void EditorPropertyArray::_change_type(Object *p_button, int p_slot_index) {


### PR DESCRIPTION
Fixes #89288 
In case the nested editor was sending updates with `changing= true` update_property is not called which is expected but this means the new value was not set which meant new changes wouldn't take into consideration previous ones until update_property was called. 