### PR TITLE
Prevent label width from flickering rapidly in editor frametime panel

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -255,6 +255,8 @@ private:
 	ViewportNavigationControl *look_control = nullptr;
 	ViewportRotationControl *rotation_control = nullptr;
 	Gradient *frame_time_gradient = nullptr;
+	PanelContainer *frame_time_panel = nullptr;
+	VBoxContainer *frame_time_vbox = nullptr;
 	Label *cpu_time_label = nullptr;
 	Label *gpu_time_label = nullptr;
 	Label *fps_label = nullptr;


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/91586.

## Preview

*Using the [Inter](https://rsms.me/inter/) font.*

### Before

https://github.com/godotengine/godot/assets/180032/0a234bfb-9579-473b-a7d2-3ddd55ad19c4

### After

https://github.com/godotengine/godot/assets/180032/2e1e007b-a06b-498e-ac28-53146807bebe

