### PR TITLE
Add camera perspective projection mode for advanced import

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -669,19 +669,20 @@ void SceneImportSettingsDialog::_update_camera() {
 	Vector3 center = camera_aabb.get_center();
 	float camera_size = camera_aabb.get_longest_axis_size();
 
-	const int view = GLOBAL_GET("editor/import/camera_view");
-
+	current_camera_view = GLOBAL_GET("editor/import/camera_view");
 	Transform3D xf;
-	if (view == 0) {
+	if (current_camera_view == 0) {
+		WARN_PRINT("Camera set to orthogonal");
 		camera->set_orthogonal(camera_size * zoom, 0.0001, camera_size * 2);
 		xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
 		xf.origin = center;
 		xf.translate_local(0, 0, camera_size);
 	} else {
+		WARN_PRINT("Camera set to perspective");
 		camera->set_perspective(camera_size * 2, 0.0001, camera_size * zoom * 12);
 		xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
 		xf.origin = center;
-		xf.translate_local(0, 0, camera_size * zoom * 10);
+		xf.translate_local(0, 0, camera_size * zoom * 5);
 	}
 
 	camera->set_transform(xf);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -669,12 +669,20 @@ void SceneImportSettingsDialog::_update_camera() {
 	Vector3 center = camera_aabb.get_center();
 	float camera_size = camera_aabb.get_longest_axis_size();
 
-	camera->set_orthogonal(camera_size * zoom, 0.0001, camera_size * 2);
+	const int view = GLOBAL_GET("editor/import/camera_view");
 
 	Transform3D xf;
-	xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
-	xf.origin = center;
-	xf.translate_local(0, 0, camera_size);
+	if (view == 0) {
+		camera->set_orthogonal(camera_size * zoom, 0.0001, camera_size * 2);
+		xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
+		xf.origin = center;
+		xf.translate_local(0, 0, camera_size);
+	} else {
+		camera->set_perspective(camera_size * 2, 0.0001, camera_size * zoom * 12);
+		xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
+		xf.origin = center;
+		xf.translate_local(0, 0, camera_size * zoom * 10);
+	}
 
 	camera->set_transform(xf);
 }

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -71,6 +71,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 		VIEW_PERSPECTIVE,
 		VIEW_ORTHOGONAL,
 		VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL,
+		VIEW_AUTO_ORTHOGONAL,
 		VIEW_MAX
 	};
 
@@ -107,7 +108,9 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	ViewType view_type;
 	void _view_menu_option(int p_option);
+	void _set_auto_orthogonal();
 	bool orthogonal;
+	bool auto_orthogonal;
 	MenuButton *view_display_menu = nullptr;
 
 	Button *light_1_switch = nullptr;
@@ -225,7 +228,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	void _on_light_2_switch_pressed();
 	void _on_light_rotate_switch_pressed();
 
-	void _viewport_input(const Ref<InputEvent> &p_input);
+	void _sinput(const Ref<InputEvent> &p_input);
 
 	HashMap<StringName, Variant> defaults;
 

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -220,6 +220,8 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	int current_action = 0;
 
+	int current_camera_view = 0;
+
 	Vector<TreeItem *> save_path_items;
 
 	TreeItem *save_path_item = nullptr;

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -61,6 +61,29 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 		ACTION_CHOOSE_ANIMATION_SAVE_PATHS,
 	};
 
+	enum {
+		VIEW_TOP,
+		VIEW_BOTTOM,
+		VIEW_LEFT,
+		VIEW_RIGHT,
+		VIEW_FRONT,
+		VIEW_REAR,
+		VIEW_PERSPECTIVE,
+		VIEW_ORTHOGONAL,
+		VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL,
+		VIEW_MAX
+	};
+
+	enum ViewType {
+		VIEW_TYPE_USER,
+		VIEW_TYPE_TOP,
+		VIEW_TYPE_BOTTOM,
+		VIEW_TYPE_LEFT,
+		VIEW_TYPE_RIGHT,
+		VIEW_TYPE_FRONT,
+		VIEW_TYPE_REAR,
+	};
+
 	Node *scene = nullptr;
 
 	HSplitContainer *tree_split = nullptr;
@@ -81,6 +104,11 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	Ref<ProceduralSkyMaterial> procedural_sky_material;
 	bool first_aabb = false;
 	AABB contents_aabb;
+
+	ViewType view_type;
+	void _view_menu_option(int p_option);
+	bool orthogonal;
+	MenuButton *view_display_menu = nullptr;
 
 	Button *light_1_switch = nullptr;
 	Button *light_2_switch = nullptr;
@@ -177,6 +205,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	bool selecting = false;
 
 	void _update_view_gizmos();
+	void _update_view_type_name();
 	void _update_camera();
 	void _select(Tree *p_from, const String &p_type, const String &p_id);
 	void _inspector_property_edited(const String &p_name);

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -241,6 +241,11 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum CameraView {
+		CAMERA_VIEW_ORTHOGRAPHIC,
+		CAMERA_VIEW_PERSPECTIVE,
+	};
+
 	bool is_editing_animation() const { return editing_animation; }
 	void request_generate_collider();
 	void update_view();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -56,6 +56,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/import/3d/resource_importer_obj.h"
 #include "editor/import/3d/resource_importer_scene.h"
+#include "editor/import/3d/scene_import_settings.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
@@ -284,6 +285,7 @@ void register_editor_types() {
 
 	GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
 	GLOBAL_DEF("editor/import/use_multiple_threads", true);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/import/camera_view", PROPERTY_HINT_ENUM, "Orthographic,Perspective"), SceneImportSettingsDialog::CameraView::CAMERA_VIEW_PERSPECTIVE);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/import/atlas_max_width", PROPERTY_HINT_RANGE, "128,8192,1,or_greater"), 2048);
 


### PR DESCRIPTION
This PR adds the possibility to switch between the perspective and orthographic camera projection modes. It also adds a setting in `Editor/Import` with `Perspective` being the default.

Closes https://github.com/godotengine/godot-proposals/issues/6692

### Showcase 

https://github.com/godotengine/godot/assets/38077837/603af83a-e129-4778-abd9-5180673f01c5

