### PR TITLE
Add MagnifyGesture to Advanced Import dialog zooming

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1224,6 +1224,20 @@ void SceneImportSettingsDialog::_viewport_input(const Ref<InputEvent> &p_input) 
 		}
 		_update_camera();
 	}
+	Ref<InputEventMagnifyGesture> mg = p_input;
+	if (mg.is_valid()) {
+		real_t mg_factor = mg->get_factor();
+		if (mg_factor == 0.0) {
+			mg_factor = 1.0;
+		}
+		(*zoom) /= mg_factor;
+		if ((*zoom) < 0.1) {
+			(*zoom) = 0.1;
+		} else if ((*zoom) > 10.0) {
+			(*zoom) = 10.0;
+		}
+		_update_camera();
+	}
 }
 
 void SceneImportSettingsDialog::_re_import() {


### PR DESCRIPTION
This adds the ability for Macbooks and other devices that use the magnifying gesture to zoom in the advanced import dialog.

### Showcase

https://github.com/godotengine/godot/assets/38077837/2669aa3d-4ec3-4333-8551-75678fa46cdc
