### PR TITLE
Fix confusing descriptions of ConfirmationDialog.

### DIFF
--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -8,10 +8,10 @@
 		To get cancel action, you can use:
 		[codeblocks]
 		[gdscript]
-		get_cancel_button().pressed.connect(self.canceled)
+		get_cancel_button().pressed.connect(_on_canceled)
 		[/gdscript]
 		[csharp]
-		GetCancelButton().Pressed += Canceled;
+		GetCancelButton().Pressed += OnCanceled;
 		[/csharp]
 		[/codeblocks]
 	</description>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The previous code example `get_cancel_button().pressed.connect(self.canceled)` is confusing, Because `canceled` is a signal of base class `AcceptDialog`. Connect a signal to signal is incorrect obviously. 