### PR TITLE
[Viewport] Close and reopen windows when changing `Viewport::set_embedding_subwindows`.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1657,6 +1657,24 @@
 				[b]Note:[/b] Setting the window to full screen forcibly sets the borderless flag to [code]true[/code], so make sure to set it back to [code]false[/code] when not wanted.
 			</description>
 		</method>
+		<method name="window_set_mode_changed_callback">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets the [param callback] that will be called after the window mode is changed.
+				[b]Warning:[/b] Advanced users only! Adding such a callback to a [Window] node will override its default implementation, which can introduce bugs.
+			</description>
+		</method>
+		<method name="window_set_mode_will_change_callback">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets the [param callback] that will be called before the window mode is changed.
+				[b]Warning:[/b] Advanced users only! Adding such a callback to a [Window] node will override its default implementation, which can introduce bugs.
+			</description>
+		</method>
 		<method name="window_set_mouse_passthrough">
 			<return type="void" />
 			<param index="0" name="region" type="PackedVector2Array" />

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -183,6 +183,8 @@ class DisplayServerX11 : public DisplayServer {
 		Callable input_event_callback;
 		Callable input_text_callback;
 		Callable drop_files_callback;
+		Callable mode_will_change_callback;
+		Callable mode_changed_callback;
 
 		Vector<Vector2> mpath;
 
@@ -207,6 +209,7 @@ class DisplayServerX11 : public DisplayServer {
 		bool is_popup = false;
 		bool layered_window = false;
 		bool mpass = false;
+		bool temp_mode_change = false;
 
 		Rect2i parent_safe_rect;
 
@@ -458,6 +461,10 @@ public:
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_mode_will_change_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mode_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -105,6 +105,8 @@ public:
 		Callable input_event_callback;
 		Callable input_text_callback;
 		Callable drop_files_callback;
+		Callable mode_will_change_callback;
+		Callable mode_changed_callback;
 
 		ObjectID instance_id;
 		bool fs_transition = false;
@@ -126,6 +128,7 @@ public:
 		bool focused = false;
 		bool is_visible = true;
 		bool extend_to_title = false;
+		bool temp_mode_change = false;
 
 		Rect2i parent_safe_rect;
 	};
@@ -337,6 +340,10 @@ public:
 	virtual Rect2i window_get_popup_safe_rect(WindowID p_window) const override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_mode_will_change_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mode_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -97,6 +97,12 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	wd.fs_transition = false;
+
+	if (!wd.temp_mode_change) {
+		if (wd.mode_changed_callback.is_valid()) {
+			wd.mode_changed_callback.call(wd.exclusive_fullscreen ? DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN : DisplayServer::WINDOW_MODE_FULLSCREEN);
+		}
+	}
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification *)notification {
@@ -122,6 +128,12 @@
 
 	// Force window resize event and redraw.
 	[self windowDidResize:notification];
+
+	if (!wd.temp_mode_change) {
+		if (wd.mode_changed_callback.is_valid()) {
+			wd.mode_changed_callback.call(ds->window_get_mode(window_id));
+		}
+	}
 }
 
 - (void)windowWillExitFullScreen:(NSNotification *)notification {
@@ -132,6 +144,12 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	wd.fs_transition = true;
+
+	if (!wd.temp_mode_change) {
+		if (wd.mode_will_change_callback.is_valid()) {
+			wd.mode_will_change_callback.call(DisplayServer::WINDOW_MODE_WINDOWED);
+		}
+	}
 
 	// Restore custom window buttons.
 	if ([wd.window_object styleMask] & NSWindowStyleMaskFullSizeContentView) {
@@ -200,6 +218,12 @@
 
 	// Force window resize event and redraw.
 	[self windowDidResize:notification];
+
+	if (!wd.temp_mode_change) {
+		if (wd.mode_changed_callback.is_valid()) {
+			wd.mode_changed_callback.call(ds->window_get_mode(window_id));
+		}
+	}
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -396,6 +396,7 @@ class DisplayServerWindows : public DisplayServer {
 		bool exclusive = false;
 		bool context_created = false;
 		bool mpass = false;
+		bool temp_mode_change = false;
 
 		// Used to transfer data between events using timer.
 		WPARAM saved_wparam;
@@ -441,6 +442,8 @@ class DisplayServerWindows : public DisplayServer {
 		Callable input_event_callback;
 		Callable input_text_callback;
 		Callable drop_files_callback;
+		Callable mode_will_change_callback;
+		Callable mode_changed_callback;
 
 		WindowID transient_parent = INVALID_WINDOW_ID;
 		HashSet<WindowID> transient_children;
@@ -595,6 +598,9 @@ public:
 	virtual void gl_window_make_current(DisplayServer::WindowID p_window_id) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_mode_will_change_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mode_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -123,6 +123,8 @@ private:
 	bool focused = false;
 	WindowInitialPosition initial_position = WINDOW_INITIAL_POSITION_ABSOLUTE;
 	bool force_native = false;
+	bool was_in_exfs = false;
+	bool prev_embed_subwindows = false;
 
 	bool use_font_oversampling = false;
 	bool transient = false;
@@ -227,6 +229,8 @@ private:
 	void _window_drop_files(const Vector<String> &p_files);
 	void _rect_changed_callback(const Rect2i &p_callback);
 	void _event_callback(DisplayServer::WindowEvent p_event);
+	void _mode_will_change_callback(DisplayServer::WindowMode p_mode);
+	void _mode_changed_callback(DisplayServer::WindowMode p_mode);
 	virtual bool _can_consume_input_events() const override;
 
 	bool mouse_in_window = false;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -909,6 +909,9 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_set_input_text_callback", "callback", "window_id"), &DisplayServer::window_set_input_text_callback, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_drop_files_callback", "callback", "window_id"), &DisplayServer::window_set_drop_files_callback, DEFVAL(MAIN_WINDOW_ID));
 
+	ClassDB::bind_method(D_METHOD("window_set_mode_will_change_callback", "callback", "window_id"), &DisplayServer::window_set_mode_will_change_callback, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_mode_changed_callback", "callback", "window_id"), &DisplayServer::window_set_mode_changed_callback, DEFVAL(MAIN_WINDOW_ID));
+
 	ClassDB::bind_method(D_METHOD("window_get_attached_instance_id", "window_id"), &DisplayServer::window_get_attached_instance_id, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_max_size", "window_id"), &DisplayServer::window_get_max_size, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -411,6 +411,9 @@ public:
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) = 0;
 
+	virtual void window_set_mode_will_change_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) {}
+	virtual void window_set_mode_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) {}
+
 	enum WindowEvent {
 		WINDOW_EVENT_MOUSE_ENTER,
 		WINDOW_EVENT_MOUSE_EXIT,


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/90242

- Adds option to set `DisplayServer` callbacks for mode change.
- Changes `Viewport::set_embedding_subwindows` to reopen windows instead of returning error.
- Adds callbacks to the `Window` to auto sets `embedding_subwindows` when entering exclusive full-screen and restore previous value when exiting.

TODO Test on:
- [x] macOS
- [ ] Windows
- [ ] Linux