### PR TITLE
Optimize AnimationMixer with new BitSet class.

### DIFF
--- a/core/templates/bit_set.h
+++ b/core/templates/bit_set.h
@@ -1,0 +1,97 @@
+/**************************************************************************/
+/*  bit_set.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BIT_SET_H
+#define BIT_SET_H
+
+#include "core/templates/local_vector.h"
+
+template <typename U = uint64_t, bool tight = false>
+class BitSet {
+private:
+	LocalVector<U, uint32_t, false, tight> values;
+	uint32_t count = 0;
+
+	_FORCE_INLINE_ U _get_value_index(uint32_t p_index) const {
+		return p_index / (sizeof(U) * 8);
+	}
+
+	_FORCE_INLINE_ U _get_value_mask(uint32_t p_index) const {
+		return U(1) << (p_index % (sizeof(U) * 8));
+	}
+
+public:
+	_FORCE_INLINE_ void clear() {
+		values.clear();
+		count = 0;
+	}
+
+	_FORCE_INLINE_ void resize(uint32_t p_size) {
+		uint32_t previous_size = values.size();
+		values.resize((p_size + (sizeof(U) * 8 - 1)) / (sizeof(U) * 8));
+
+		uint32_t count_remainder = count % (sizeof(U) * 8);
+		if (count < p_size && count_remainder != 0) {
+			// The remaining bits of the value should be cleared.
+			values[_get_value_index(count)] &= (U(1) << count_remainder) - U(1);
+		}
+
+		for (uint32_t i = previous_size; i < values.size(); i++) {
+			// All the remaining values should be initialized to zero.
+			values[i] = U(0);
+		}
+
+		count = p_size;
+	}
+
+	_FORCE_INLINE_ void set(uint32_t p_index, bool p_value) {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+
+		if (p_value) {
+			values[_get_value_index(p_index)] |= _get_value_mask(p_index);
+		} else {
+			values[_get_value_index(p_index)] &= ~_get_value_mask(p_index);
+		}
+	}
+
+	_FORCE_INLINE_ bool get(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+
+		return (values[_get_value_index(p_index)] & _get_value_mask(p_index)) != 0;
+	}
+
+	_FORCE_INLINE_ uint32_t size() const {
+		return count;
+	}
+
+	_FORCE_INLINE_ BitSet() {}
+};
+
+#endif // BIT_SET_H

--- a/tests/core/templates/test_bit_set.h
+++ b/tests/core/templates/test_bit_set.h
@@ -1,0 +1,131 @@
+/**************************************************************************/
+/*  test_bit_set.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_BIT_SET_H
+#define TEST_BIT_SET_H
+
+#include "core/templates/bit_set.h"
+
+#include "tests/test_macros.h"
+
+namespace TestBitSet {
+
+TEST_CASE("[BitSet] Set elements") {
+	BitSet set;
+	set.resize(6);
+	set.set(0, true);
+	set.set(3, true);
+	set.set(5, true);
+
+	CHECK(set.size() == 6);
+	CHECK(set.get(0) == true);
+	CHECK(set.get(1) == false);
+	CHECK(set.get(2) == false);
+	CHECK(set.get(3) == true);
+	CHECK(set.get(4) == false);
+	CHECK(set.get(5) == true);
+
+	set.set(0, false);
+	set.set(1, true);
+	set.set(3, false);
+	set.set(4, true);
+
+	CHECK(set.get(0) == false);
+	CHECK(set.get(1) == true);
+	CHECK(set.get(2) == false);
+	CHECK(set.get(3) == false);
+	CHECK(set.get(4) == true);
+	CHECK(set.get(5) == true);
+}
+
+TEST_CASE("[BitSet] Clear and resize defaults") {
+	BitSet set;
+	set.resize(3);
+	set.set(0, true);
+	set.set(1, true);
+	set.set(2, true);
+	set.clear();
+
+	CHECK(set.size() == 0);
+
+	// After resizing, all values should be defaulted to zero.
+	set.resize(3);
+
+	CHECK(set.size() == 3);
+	CHECK(set.get(0) == false);
+	CHECK(set.get(1) == false);
+	CHECK(set.get(2) == false);
+
+	// Special case where the bit set should've cleared the individual bit to simulate
+	// the behavior a vector does when resizing to a bigger size and defaulting to zero,
+	// even if the contents might've been set before.
+	set.set(0, true);
+	set.set(1, true);
+	set.set(2, true);
+	set.resize(2);
+	set.resize(12);
+
+	CHECK(set.get(0) == true);
+	CHECK(set.get(1) == true);
+	CHECK(set.get(2) == false);
+	CHECK(set.get(11) == false);
+}
+
+TEST_CASE("[BitSet] Copy") {
+	BitSet set;
+	set.resize(3);
+	set.set(0, true);
+	set.set(1, false);
+	set.set(2, true);
+
+	BitSet set_copy = set;
+	CHECK(set_copy.size() == 3);
+	CHECK(set_copy.get(0) == true);
+	CHECK(set_copy.get(1) == false);
+	CHECK(set_copy.get(2) == true);
+}
+
+TEST_CASE("[BitSet] Large set") {
+	uint32_t large_count = 10000;
+	BitSet set;
+	set.resize(large_count);
+	set.set(100, true);
+	set.set(350, true);
+	set.set(5000, true);
+	set.set(1234, true);
+
+	CHECK(set.get(100) == true);
+	CHECK(set.get(350) == true);
+	CHECK(set.get(5000) == true);
+	CHECK(set.get(1234) == true);
+}
+} // namespace TestBitSet
+
+#endif // TEST_BIT_SET_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -80,6 +80,7 @@
 #include "tests/core/string/test_string.h"
 #include "tests/core/string/test_translation.h"
 #include "tests/core/string/test_translation_server.h"
+#include "tests/core/templates/test_bit_set.h"
 #include "tests/core/templates/test_command_queue.h"
 #include "tests/core/templates/test_hash_map.h"
 #include "tests/core/templates/test_hash_set.h"


### PR DESCRIPTION
This optimization went a bit out of scope as it adds a new BitSet class we've recognized we could use in different places. For example, the D3D12 driver currently relies on implementing this structure manually (@RandomShaper will recall that we needed to fix it in his PR as well).

The optimization is fairly straightforward and shouldn't cause any behavior differences as long as the BitSet class is implemented correctly, which I added some tests to verify that (although they might not be very extensive). 

There's two problems with the function and it causes a non-negligible amount of allocations if the project uses a lot of animation trackers:
- It uses a CoW Vector which always must be allocated from scratch and gets elements added as they're processed.
- It uses a linear search on the vector to find if an index was added to the Vector.

Both of these are pretty straightforward to solve by using the BitSet instead on TLS so allocation is only performed when it needs to increase the capacity once and retains the contents across multiple function calls. The second problem is resolved by decreasing the complexity of the linear lookup to a single index and mask check by using the BitSet.

I do believe we should benchmark this one properly, so I'm interested in hearing if @Calinou or someone else in charge of benchmarks has a good test case for this.