### PR TITLE
Fix TextEdit HScroll hiding after wrapping

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -286,6 +286,7 @@ void TextEdit::Text::invalidate_all_lines() {
 	}
 	tab_size_dirty = false;
 
+	max_width = -1;
 	_calculate_max_line_width();
 }
 
@@ -404,10 +405,12 @@ void TextEdit::Text::remove_range(int p_from_line, int p_to_line) {
 	text.resize(text.size() - diff);
 
 	if (dirty_height) {
+		line_height = -1;
 		_calculate_line_height();
 	}
 
 	if (dirty_width) {
+		max_width = -1;
 		_calculate_max_line_width();
 	}
 }


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/84812

Since it only happens in certain scenarios here is more information and reproduction steps:

![godot te hscroll missing](https://github.com/godotengine/godot/assets/10054226/a92c3164-8cdb-4522-819d-323d37455952)

Reproduction:
1. Make a new default script.
2. Change the `TextEdit` width such that the word `previous` will be wrapped but not the word `time.` from the comments on lines 9 and 4.
3. Toggle word wrap on and off (alt+z).
4. The hscrollbar doesn't reappear like it should.

When disabling word wrap, the longest line while wrapped (line 4) doesn't change size so `TextEdit::Text::_calculate_line_height()` exits early, even though there is a new longest line.

This happens because `TextEdit::Text::_calculate_max_line_width()` was assuming it was being called from `TextEdit::Text::invalidate_cache()` only and that lines had only shrunk, but this is not true since it can be called from `TextEdit::Text::invalidate_all_lines()` and other places.
This also applies to `TextEdit::Text::_calculate_line_height()` since it is the same situation.