### PR TITLE
[iOS] Implement raw mouse input support and captured mouse mode.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -782,7 +782,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			touch_velocity_track.erase(st->get_index());
 		}
 
-		if (emulate_mouse_from_touch) {
+		if (emulate_mouse_from_touch && get_mouse_mode() != MouseMode::MOUSE_MODE_CAPTURED) {
 			bool translate = false;
 			if (st->is_pressed()) {
 				if (mouse_from_touch_index == -1) {
@@ -830,7 +830,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 		sd->set_velocity(track.velocity);
 		sd->set_screen_velocity(track.screen_velocity);
 
-		if (emulate_mouse_from_touch && sd->get_index() == mouse_from_touch_index) {
+		if (emulate_mouse_from_touch && sd->get_index() == mouse_from_touch_index && get_mouse_mode() != MouseMode::MOUSE_MODE_CAPTURED) {
 			Ref<InputEventMouseMotion> motion_event;
 			motion_event.instantiate();
 

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -58,6 +58,9 @@
 	</array>
 	$additional_plist_content
 	$plist_launch_screen_name
-	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	$ui_indirect_events
 </dict>
 </plist>

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -82,6 +82,8 @@ class DisplayServerIOS : public DisplayServer {
 
 	int virtual_keyboard_height = 0;
 
+	MouseMode mouse_mode = MOUSE_MODE_VISIBLE;
+
 	void perform_event(const Ref<InputEvent> &p_event);
 
 	DisplayServerIOS(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error);
@@ -221,6 +223,11 @@ public:
 
 	virtual void virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect, VirtualKeyboardType p_type, int p_max_length, int p_cursor_start, int p_cursor_end) override;
 	virtual void virtual_keyboard_hide() override;
+
+	virtual void mouse_set_mode(MouseMode p_mode) override;
+	virtual MouseMode mouse_get_mode() const override;
+
+	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
 
 	void virtual_keyboard_set_height(int height);
 	virtual int virtual_keyboard_get_height() const override;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -773,6 +773,30 @@ bool DisplayServerIOS::has_hardware_keyboard() const {
 	}
 }
 
+void DisplayServerIOS::mouse_set_mode(DisplayServer::MouseMode p_mode) {
+	if (mouse_mode == p_mode) {
+		return;
+	}
+	ERR_FAIL_COND_MSG(p_mode == DisplayServer::MouseMode::MOUSE_MODE_HIDDEN || p_mode == DisplayServer::MouseMode::MOUSE_MODE_CONFINED || p_mode == DisplayServer::MouseMode::MOUSE_MODE_CONFINED_HIDDEN, "Confined and hidden mouse modes not supported.");
+
+	mouse_mode = p_mode;
+	if (@available(iOS 14, *)) {
+		[AppDelegate.viewController setNeedsUpdateOfPrefersPointerLocked];
+	}
+}
+
+DisplayServer::MouseMode DisplayServerIOS::mouse_get_mode() const {
+	return mouse_mode;
+}
+
+BitField<MouseButtonMask> DisplayServerIOS::mouse_get_button_state() const {
+	if (@available(iOS 14, *)) {
+		return [AppDelegate.viewController mouseGetButtonState];
+	} else {
+		return 0;
+	}
+}
+
 void DisplayServerIOS::clipboard_set(const String &p_text) {
 	[UIPasteboard generalPasteboard].string = [NSString stringWithUTF8String:p_text.utf8()];
 }

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -72,6 +72,9 @@
 		<member name="application/signature" type="String" setter="" getter="">
 			A four-character creator code that is specific to the bundle. Optional.
 		</member>
+		<member name="application/supports_indirect_input" type="bool" setter="" getter="">
+			If [code]true[/code], raw mouse/touchpad input is always used. Otherwise, it's only used in captured mode.
+		</member>
 		<member name="application/targeted_device_family" type="int" setter="" getter="">
 			Supported device family.
 		</member>

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -304,6 +304,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/export_project_only"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/delete_old_export_files_unconditionally"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/generate_simulator_library_if_missing"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/supports_indirect_input"), true));
 
 	Vector<PluginConfigIOS> found_plugins = get_plugins();
 	for (int i = 0; i < found_plugins.size(); i++) {
@@ -850,6 +851,9 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 				}
 			}
 			strnew += "\t</array>\n";
+		} else if (lines[i].contains("$ui_indirect_events")) {
+			bool ind = p_preset->get("application/supports_indirect_input");
+			strnew += lines[i].replace("$ui_indirect_events", ind ? "<true/>" : "<false/>") + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -30,9 +30,11 @@
 
 #import "godot_view.h"
 
+#import "app_delegate.h"
 #import "display_layer.h"
 #import "display_server_ios.h"
 #import "godot_view_renderer.h"
+#import "view_controller.h"
 
 #include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
@@ -355,6 +357,9 @@ static const float earth_gravity = 9.80665;
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
 	for (UITouch *touch in touches) {
+		if (touch.type != UITouchTypeDirect && touch.type != UITouchTypePencil && AppDelegate.viewController.hasMouse) {
+			continue;
+		}
 		int tid = [self getTouchIDForTouch:touch];
 		ERR_FAIL_COND(tid == -1);
 		CGPoint touchPoint = [touch locationInView:self];
@@ -364,6 +369,9 @@ static const float earth_gravity = 9.80665;
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
 	for (UITouch *touch in touches) {
+		if (touch.type != UITouchTypeDirect && touch.type != UITouchTypePencil && AppDelegate.viewController.hasMouse) {
+			continue;
+		}
 		int tid = [self getTouchIDForTouch:touch];
 		ERR_FAIL_COND(tid == -1);
 		CGPoint touchPoint = [touch locationInView:self];
@@ -376,6 +384,10 @@ static const float earth_gravity = 9.80665;
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
 	for (UITouch *touch in touches) {
+		if (touch.type != UITouchTypeDirect && touch.type != UITouchTypePencil && AppDelegate.viewController.hasMouse) {
+			[self removeTouch:touch];
+			continue;
+		}
 		int tid = [self getTouchIDForTouch:touch];
 		ERR_FAIL_COND(tid == -1);
 		[self removeTouch:touch];
@@ -386,6 +398,9 @@ static const float earth_gravity = 9.80665;
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
 	for (UITouch *touch in touches) {
+		if (touch.type != UITouchTypeDirect && touch.type != UITouchTypePencil && AppDelegate.viewController.hasMouse) {
+			continue;
+		}
 		int tid = [self getTouchIDForTouch:touch];
 		ERR_FAIL_COND(tid == -1);
 		DisplayServerIOS::get_singleton()->touches_canceled(tid);

--- a/platform/ios/view_controller.h
+++ b/platform/ios/view_controller.h
@@ -30,6 +30,8 @@
 
 #import <UIKit/UIKit.h>
 
+#include "core/input/input.h"
+
 @class GodotView;
 @class GodotNativeVideoView;
 @class GodotKeyboardInputView;
@@ -38,5 +40,8 @@
 
 @property(nonatomic, readonly, strong) GodotView *godotView;
 @property(nonatomic, readonly, strong) GodotKeyboardInputView *keyboardView;
+@property(nonatomic) bool hasMouse;
+
+- (BitField<MouseButtonMask>)mouseGetButtonState;
 
 @end


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/92255

- Adds support far raw mouse input handling (iOS 14+), now mouse/touchpad will generate full set of input events: motion (with relative values), all buttons, h/v scroll. Previously, was generating only left click events and drag (as simulated touch events).
- Adds support for captured mouse mode (confined and hidden mode is not supported, there's no way to hide cursor without locking).