### PR TITLE
Clarify `velocity_computed` signal description

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -261,7 +261,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector2" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted when [member velocity] is set. Only emitted when [member avoidance_enabled] is true.
+				Notifies when the collision avoidance velocity is calculated. Emitted every update as long as [member avoidance_enabled] is [code]true[/code] and the agent has a navigation map.
 			</description>
 		</signal>
 		<signal name="waypoint_reached">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -271,7 +271,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector3" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted when [member velocity] is set. Only emitted when [member avoidance_enabled] is true.
+				Notifies when the collision avoidance velocity is calculated. Emitted every update as long as [member avoidance_enabled] is [code]true[/code] and the agent has a navigation map.
 			</description>
 		</signal>
 		<signal name="waypoint_reached">


### PR DESCRIPTION
As stated in the issue #81761, the `velocity_computed` signal is no longer triggered by `NavigationAgent.set_velocity()`. I updated the documentation for `NavigationAgent2D` and `NavigationAgent3D` to describe it cleaner since the current description could be misleading.

Current description:
> Notifies when the collision avoidance velocity is calculated. Emitted when [velocity](https://docs.godotengine.org/en/stable/classes/class_navigationagent3d.html#class-navigationagent3d-property-velocity) is set. Only emitted when [avoidance_enabled](https://docs.godotengine.org/en/stable/classes/class_navigationagent3d.html#class-navigationagent3d-property-avoidance-enabled) is true.

Updated description:
> Notifies when the collision avoidance velocity is calculated. Emitted every update as long [avoidance_enabled](https://docs.godotengine.org/en/stable/classes/class_navigationagent3d.html#class-navigationagent3d-property-avoidance-enabled)  is true and the agent has a navigation map.
