### PR TITLE
Fix theme StyleBox override parameter completion

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -211,17 +211,17 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 		const String pf = p_function;
 		Theme::DataType type = Theme::DATA_TYPE_MAX;
 
-		if (pf == "add_theme_color_override" || pf == "has_theme_color" || pf == "has_theme_color_override" || pf == "get_theme_color") {
+		if (pf == "add_theme_color_override" || pf == "has_theme_color" || pf == "has_theme_color_override" || pf == "get_theme_color" || pf == "remove_theme_color_override") {
 			type = Theme::DATA_TYPE_COLOR;
-		} else if (pf == "add_theme_constant_override" || pf == "has_theme_constant" || pf == "has_theme_constant_override" || pf == "get_theme_constant") {
+		} else if (pf == "add_theme_constant_override" || pf == "has_theme_constant" || pf == "has_theme_constant_override" || pf == "get_theme_constant" || pf == "remove_theme_constant_override") {
 			type = Theme::DATA_TYPE_CONSTANT;
-		} else if (pf == "add_theme_font_override" || pf == "has_theme_font" || pf == "has_theme_font_override" || pf == "get_theme_font") {
+		} else if (pf == "add_theme_font_override" || pf == "has_theme_font" || pf == "has_theme_font_override" || pf == "get_theme_font" || pf == "remove_theme_font_override") {
 			type = Theme::DATA_TYPE_FONT;
-		} else if (pf == "add_theme_font_size_override" || pf == "has_theme_font_size" || pf == "has_theme_font_size_override" || pf == "get_theme_font_size") {
+		} else if (pf == "add_theme_font_size_override" || pf == "has_theme_font_size" || pf == "has_theme_font_size_override" || pf == "get_theme_font_size" || pf == "remove_theme_font_size_override") {
 			type = Theme::DATA_TYPE_FONT_SIZE;
-		} else if (pf == "add_theme_icon_override" || pf == "has_theme_icon" || pf == "has_theme_icon_override" || pf == "get_theme_icon") {
+		} else if (pf == "add_theme_icon_override" || pf == "has_theme_icon" || pf == "has_theme_icon_override" || pf == "get_theme_icon" || pf == "remove_theme_icon_override") {
 			type = Theme::DATA_TYPE_ICON;
-		} else if (pf == "add_theme_style_override" || pf == "has_theme_style" || pf == "has_theme_style_override" || pf == "get_theme_style") {
+		} else if (pf == "add_theme_stylebox_override" || pf == "has_theme_stylebox" || pf == "has_theme_stylebox_override" || pf == "get_theme_stylebox" || pf == "remove_theme_stylebox_override") {
 			type = Theme::DATA_TYPE_STYLEBOX;
 		}
 


### PR DESCRIPTION
There was no parameter completion for methods like `add_theme_stylebox_override()`. It's because the completion code checked for the wrong method names (`*_style_*` instead of `*_stylebox_*`) :P

Also added missing completion for `remove_theme_*_override()`.
