### PR TITLE
Fix crash during code editor folding and LSP

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3050,7 +3050,7 @@ void CodeEdit::_update_delimiter_cache(int p_from_line, int p_to_line) {
 }
 
 int CodeEdit::_is_in_delimiter(int p_line, int p_column, DelimiterType p_type) const {
-	if (delimiters.size() == 0) {
+	if (delimiters.size() == 0 || p_line >= delimiter_cache.size()) {
 		return -1;
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), 0);


### PR DESCRIPTION
closes #76447 

Adding a bounds check on `delimiter_cache` which in my repro has size `1` but `p_line` is also `1`

# Repro Steps
1. open Godot
2. open script editor in Godot (important)
3. open VSCode, use and connect godot-tools to LSP
4. edit different file then step 3, add a function, delete function, save
5. crash

### Tested On:
- [x] Win 10 22H2; VSCode; godot-tools 2.0.0; 4.2.2-stable reproduce crash: ✅ (crashes with above steps)
- [x] Win 10 22H2; VSCode; godot-tools 2.0.0; this branch: repro steps pass ✅--test success ✅
- [x] Win 10 22H2; VSCode; godot-tools 2.0.0; ([cherry picked on](https://github.com/robert-wallis/godot/tree/fix-delimiter-crash-4.2)) Godot 4.2.2 15073af: repro steps pass ✅--test success ✅
- [ ] MacOS 14.5 Intel: VSCode; godot-tools 2.0.0; 4.2.2-stable reproduce crash: ❌ (doesn't crash)
- [x] MacOS 14.5 Intel; VSCode; godot-tools 2.0.0; this branch: repro steps pass ✅ --test success ✅
- [x] MacOS 14.5 Intel; VSCode; godot-tools 2.0.0; ([cherry picked on](https://github.com/robert-wallis/godot/tree/fix-delimiter-crash-4.2)) Godot 4.2.2 15073af: repro steps pass ✅ --test success ✅