### PR TITLE
Fix 3d editor left mouse stuck

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3052,6 +3052,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 				_remove_preview_node();
 			}
 		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			DisplayServer::get_singleton()->mouse_clear_button_flag(MouseButtonMask::LEFT);
+		} break;
 	}
 }
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -505,6 +505,14 @@ BitField<MouseButtonMask> DisplayServerX11::mouse_get_button_state() const {
 	return last_button_state;
 }
 
+void DisplayServerX11::mouse_set_button_flag(const MouseButtonMask p_mouse_mask) {
+	last_button_state.set_flag(p_mouse_mask);
+}
+
+void DisplayServerX11::mouse_clear_button_flag(const MouseButtonMask p_mouse_mask) {
+	last_button_state.clear_flag(p_mouse_mask);
+}
+
 void DisplayServerX11::clipboard_set(const String &p_text) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -413,6 +413,8 @@ public:
 	virtual void warp_mouse(const Point2i &p_position) override;
 	virtual Point2i mouse_get_position() const override;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
+	virtual void mouse_set_button_flag(const MouseButtonMask p_mouse_mask) override;
+	virtual void mouse_clear_button_flag(const MouseButtonMask p_mouse_mask) override;
 
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -663,6 +663,14 @@ BitField<MouseButtonMask> DisplayServerWindows::mouse_get_button_state() const {
 	return last_button_state;
 }
 
+void DisplayServerWindows::mouse_set_button_flag(const MouseButtonMask p_mouse_mask) {
+	last_button_state.set_flag(p_mouse_mask);
+}
+
+void DisplayServerWindows::mouse_clear_button_flag(const MouseButtonMask p_mouse_mask) {
+	last_button_state.clear_flag(p_mouse_mask);
+}
+
 void DisplayServerWindows::clipboard_set(const String &p_text) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -555,6 +555,8 @@ public:
 	virtual void warp_mouse(const Point2i &p_position) override;
 	virtual Point2i mouse_get_position() const override;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
+	virtual void mouse_set_button_flag(const MouseButtonMask p_mouse_mask) override;
+	virtual void mouse_clear_button_flag(const MouseButtonMask p_mouse_mask) override;
 
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -502,6 +502,14 @@ BitField<MouseButtonMask> DisplayServer::mouse_get_button_state() const {
 	ERR_FAIL_V_MSG(0, "Mouse is not supported by this display server.");
 }
 
+void DisplayServer::mouse_set_button_flag(const MouseButtonMask p_mouse_mask) {
+	ERR_FAIL_MSG("Mouse is not supported by this display server.");
+}
+
+void DisplayServer::mouse_clear_button_flag(const MouseButtonMask p_mouse_mask) {
+	ERR_FAIL_MSG("Mouse is not supported by this display server.");
+}
+
 void DisplayServer::clipboard_set(const String &p_text) {
 	WARN_PRINT("Clipboard is not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -278,6 +278,8 @@ public:
 	virtual void warp_mouse(const Point2i &p_position);
 	virtual Point2i mouse_get_position() const;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const;
+	virtual void mouse_set_button_flag(const MouseButtonMask p_mouse_mask);
+	virtual void mouse_clear_button_flag(const MouseButtonMask p_mouse_mask);
 
 	virtual void clipboard_set(const String &p_text);
 	virtual String clipboard_get() const;


### PR DESCRIPTION
1. Press left mouse to start selection
2. Alt Tab out of editor while still holding mouse button
3. Release left mouse button *outside editor window*
4. Right click in 3D editor while window is still unfocused

The free look will be frozen until you left-click.

_Originally posted by @KoBeWi in https://github.com/godotengine/godot/issues/90090#issuecomment-2110970287_
            
before

https://github.com/godotengine/godot/assets/94742489/ccce38fe-f1f1-4d50-a710-f5025ec80b8f

after 

https://github.com/godotengine/godot/assets/94742489/8b416793-630e-414b-b19f-7dfac493cc07

I'm not sure if this work on other platform other than window.