### PR TITLE
Add support for compiling with VS clang-cl toolset

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -30,6 +30,14 @@ jobs:
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
             bin: "./bin/godot.windows.editor.x86_64.exe"
+            artifact: true
+
+          - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
+            cache-name: windows-editor-clang
+            target: editor
+            tests: true
+            sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes
+            bin: ./bin/godot.windows.editor.x86_64.llvm.exe
 
           - name: Template (target=template_release)
             cache-name: windows-template
@@ -37,6 +45,7 @@ jobs:
             tests: true
             sconsflags: debug_symbols=no tests=yes
             bin: "./bin/godot.windows.template_release.x86_64.console.exe"
+            artifact: true
 
     steps:
       - uses: actions/checkout@v4
@@ -84,10 +93,12 @@ jobs:
         continue-on-error: true
 
       - name: Prepare artifact
+        if: ${{ matrix.artifact }}
         run: |
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
 
       - name: Upload artifact
+        if: ${{ matrix.artifact }}
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}

--- a/core/io/packed_data_container.h
+++ b/core/io/packed_data_container.h
@@ -36,7 +36,7 @@
 class PackedDataContainer : public Resource {
 	GDCLASS(PackedDataContainer, Resource);
 
-	enum {
+	enum : uint32_t {
 		TYPE_DICT = 0xFFFFFFFF,
 		TYPE_ARRAY = 0xFFFFFFFE,
 	};

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -203,7 +203,7 @@ struct LightmapInstance {
 
 class LightStorage : public RendererLightStorage {
 public:
-	enum ShadowAtlastQuadrant {
+	enum ShadowAtlastQuadrant : uint32_t {
 		QUADRANT_SHIFT = 27,
 		OMNI_LIGHT_FLAG = 1 << 26,
 		SHADOW_INDEX_MASK = OMNI_LIGHT_FLAG - 1,

--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -216,6 +216,7 @@ bool get_default_installation_dir(String &r_dotnet_root) {
 #endif
 }
 
+#ifndef WINDOWS_ENABLED
 bool get_install_location_from_file(const String &p_file_path, String &r_dotnet_root) {
 	Error err = OK;
 	Ref<FileAccess> f = FileAccess::open(p_file_path, FileAccess::READ, &err);
@@ -233,6 +234,7 @@ bool get_install_location_from_file(const String &p_file_path, String &r_dotnet_
 	r_dotnet_root = line;
 	return true;
 }
+#endif
 
 bool get_dotnet_self_registered_dir(String &r_dotnet_root) {
 #if defined(WINDOWS_ENABLED)

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -118,7 +118,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	HANDLE process = GetCurrentProcess();
 	HANDLE hThread = GetCurrentThread();
 	DWORD offset_from_symbol = 0;
-	IMAGEHLP_LINE64 line = { 0 };
+	IMAGEHLP_LINE64 line = {};
 	std::vector<module_data> modules;
 	DWORD cbNeeded;
 	std::vector<HMODULE> module_handles(1);

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -35,9 +35,8 @@
 
 class Voxelizer {
 private:
-	enum {
+	enum : uint32_t {
 		CHILD_EMPTY = 0xFFFFFFFF
-
 	};
 
 	struct Cell {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -49,7 +49,7 @@ namespace RendererRD {
 
 class LightStorage : public RendererLightStorage {
 public:
-	enum ShadowAtlastQuadrant {
+	enum ShadowAtlastQuadrant : uint32_t {
 		QUADRANT_SHIFT = 27,
 		OMNI_LIGHT_FLAG = 1 << 26,
 		SHADOW_INDEX_MASK = OMNI_LIGHT_FLAG - 1,

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -377,7 +377,9 @@ public:
 	// used for the render pipelines.
 
 	struct AttachmentFormat {
-		enum { UNUSED_ATTACHMENT = 0xFFFFFFFF };
+		enum : uint32_t {
+			UNUSED_ATTACHMENT = 0xFFFFFFFF
+		};
 		DataFormat format;
 		TextureSamples samples;
 		uint32_t usage_flags;

--- a/thirdparty/libwebp/patches/godot-clang-cl-fix.patch
+++ b/thirdparty/libwebp/patches/godot-clang-cl-fix.patch
@@ -1,0 +1,19 @@
+diff --git a/thirdparty/libwebp/src/dsp/cpu.h b/thirdparty/libwebp/src/dsp/cpu.h
+index c86540f280..4dbe607aec 100644
+--- a/thirdparty/libwebp/src/dsp/cpu.h
++++ b/thirdparty/libwebp/src/dsp/cpu.h
+@@ -47,12 +47,12 @@
+ // x86 defines.
+ 
+ #if !defined(HAVE_CONFIG_H)
+-#if defined(_MSC_VER) && _MSC_VER > 1310 && \
++#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER > 1310 && \
+     (defined(_M_X64) || defined(_M_IX86))
+ #define WEBP_MSC_SSE2  // Visual C++ SSE2 targets
+ #endif
+ 
+-#if defined(_MSC_VER) && _MSC_VER >= 1500 && \
++#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER >= 1500 && \
+     (defined(_M_X64) || defined(_M_IX86))
+ #define WEBP_MSC_SSE41  // Visual C++ SSE4.1 targets
+ #endif

--- a/thirdparty/libwebp/src/dsp/cpu.h
+++ b/thirdparty/libwebp/src/dsp/cpu.h
@@ -47,12 +47,12 @@
 // x86 defines.
 
 #if !defined(HAVE_CONFIG_H)
-#if defined(_MSC_VER) && _MSC_VER > 1310 && \
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER > 1310 && \
     (defined(_M_X64) || defined(_M_IX86))
 #define WEBP_MSC_SSE2  // Visual C++ SSE2 targets
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500 && \
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER >= 1500 && \
     (defined(_M_X64) || defined(_M_IX86))
 #define WEBP_MSC_SSE41  // Visual C++ SSE4.1 targets
 #endif


### PR DESCRIPTION
Me and the few people using my fork have been using LLVM-based builds for a couple of months, I thought it'd be useful to upstream.

This compiler setup has the benefits of being able to use LLVM compiler optimizations ([which according to documentation seems to be why Godot favors MinGW over MSVC](https://docs.godotengine.org/en/stable/contributing/development/compiling/compiling_for_windows.html)) and ABI compatibility with code compiled with Visual Studio.