### PR TITLE
Fix reimporting assets with csv in the project

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -118,8 +118,20 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 	}
 #endif
 
-	if (r_path_and_type.path.is_empty() || r_path_and_type.type.is_empty()) {
+	if (r_path_and_type.type.is_empty()) {
 		return ERR_FILE_CORRUPT;
+	}
+	if (r_path_and_type.path.is_empty()) {
+		// Some importers may not write files to the .godot folder, so the path can be empty.
+		if (r_path_and_type.importer.is_empty()) {
+			return ERR_FILE_CORRUPT;
+		}
+
+		// It's only invalid if the extension for the importer is not empty.
+		Ref<ResourceImporter> importer = get_importer_by_name(r_path_and_type.importer);
+		if (importer.is_null() || !importer->get_save_extension().is_empty()) {
+			return ERR_FILE_CORRUPT;
+		}
 	}
 	return OK;
 }

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2398,18 +2398,23 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	int from = 0;
 	for (int i = 0; i < reimport_files.size(); i++) {
 		if (groups_to_reimport.has(reimport_files[i].path)) {
+			from = i + 1;
 			continue;
 		}
 
 		if (use_multiple_threads && reimport_files[i].threaded) {
-			if (i + 1 == reimport_files.size() || reimport_files[i + 1].importer != reimport_files[from].importer) {
+			if (i + 1 == reimport_files.size() || reimport_files[i + 1].importer != reimport_files[from].importer || groups_to_reimport.has(reimport_files[i + 1].path)) {
 				if (from - i == 0) {
 					// Single file, do not use threads.
 					pr.step(reimport_files[i].path.get_file(), i);
 					_reimport_file(reimport_files[i].path);
 				} else {
 					Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(reimport_files[from].importer);
-					ERR_CONTINUE(!importer.is_valid());
+					if (importer.is_null()) {
+						ERR_PRINT(vformat("Invalid importer for \"%s\".", reimport_files[from].importer));
+						from = i + 1;
+						continue;
+					}
 
 					importer->import_threaded_begin();
 
@@ -2439,6 +2444,10 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 		} else {
 			pr.step(reimport_files[i].path.get_file(), i);
 			_reimport_file(reimport_files[i].path);
+
+			// We need to increment the counter, maybe the next file is multithreaded
+			// and doesn't have the same importer.
+			from = i + 1;
 		}
 	}
 


### PR DESCRIPTION
This should fix #83200

The problem was that the `DebugDialogue.csv.import` is invalid according to Godot because it’s missing the `path` line. Because of this the importer was not mark multithread and a counter was not incremented between threaded and non threaded reimportation. I fixed the increment problem in `editor_file_system._reimport_file`.

The problem with the invalid `.import file` was caused because `ResourceImporterCSVTranslation` is the only importer that has no extension. It does not write any file in the .godot folder. I fixed that adding a check in `_get_path_and_type` before returning ERR_FILE_CORRUPT.
