### PR TITLE
Linux: Enable build config `wayland=yes use_sowrap=no`

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -43,6 +43,9 @@
 #else
 #include <wayland-client-core.h>
 #include <wayland-cursor.h>
+#ifdef GLES3_ENABLED
+#include <wayland-egl.h>
+#endif
 #include <xkbcommon/xkbcommon.h>
 #endif // SOWRAP_ENABLED
 


### PR DESCRIPTION
Enables building with `wayland=yes use_sowrap=no`.

If `opengl3=no` then this change is not required.
