### PR TITLE
Fix loading of cyclic scenes from GDScript

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -454,6 +454,25 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 	return res;
 }
 
+// Returns a shallow reference of the loading resource.
+// Will fail if the resource is not loading.
+Ref<Resource> ResourceLoader::get_loading_resource(const String &p_path, Error *r_error) {
+	ERR_FAIL_COND_V(r_error == nullptr, nullptr);
+	*r_error = OK;
+
+	String local_path = _validate_local_path(p_path);
+	{
+		MutexLock thread_load_lock(thread_load_mutex);
+
+		if (!thread_load_tasks.has(local_path)) {
+			*r_error = FAILED;
+			return nullptr;
+		}
+
+		return thread_load_tasks[local_path].resource;
+	}
+}
+
 Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode) {
 	String local_path = _validate_local_path(p_path);
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -204,6 +204,7 @@ public:
 	static bool is_within_load() { return load_nesting > 0; };
 
 	static Ref<Resource> load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
+	static Ref<Resource> get_loading_resource(const String &p_path, Error *r_error);
 	static bool exists(const String &p_path, const String &p_type_hint = "");
 
 	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);


### PR DESCRIPTION
Makes it possible for ClassA of SceneA to refer to ClassB of SceneB that refers to ClassA back.

This PR creates `Ref<Resource> ResourceLoader::get_loading_resource(const String &p_path, Error *r_error)`. This function returns a (shallow) resource that is currently being loaded. If not, it returns `nullptr` and the `FAILED` error. This is important, because most of the time, the returned reference will be not valid, but will still point later to the loaded resource.

This allows `GDScriptAnalyzer` to "load" a `PackedScene` when analyzing a script file even if the scene is currently loading, preventing a cyclic load error.

Fixes #70985
Fixes #90362
Fixes #90954