### PR TITLE
[DAP] Add `--dap-port` as a command line argument

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_server.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_server.cpp
@@ -35,6 +35,8 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 
+int DebugAdapterServer::port_override = -1;
+
 DebugAdapterServer::DebugAdapterServer() {
 	_EDITOR_DEF("network/debug_adapter/remote_port", remote_port);
 	_EDITOR_DEF("network/debug_adapter/request_timeout", protocol._request_timeout);
@@ -67,7 +69,7 @@ void DebugAdapterServer::_notification(int p_what) {
 			}
 			protocol._request_timeout = EDITOR_GET("network/debug_adapter/request_timeout");
 			protocol._sync_breakpoints = EDITOR_GET("network/debug_adapter/sync_breakpoints");
-			int port = _EDITOR_GET("network/debug_adapter/remote_port");
+			int port = (DebugAdapterServer::port_override > -1) ? DebugAdapterServer::port_override : (int)_EDITOR_GET("network/debug_adapter/remote_port");
 			if (port != remote_port) {
 				stop();
 				start();
@@ -77,9 +79,9 @@ void DebugAdapterServer::_notification(int p_what) {
 }
 
 void DebugAdapterServer::start() {
-	remote_port = (int)_EDITOR_GET("network/debug_adapter/remote_port");
+	remote_port = (DebugAdapterServer::port_override > -1) ? DebugAdapterServer::port_override : (int)_EDITOR_GET("network/debug_adapter/remote_port");
 	if (protocol.start(remote_port, IPAddress("127.0.0.1")) == OK) {
-		EditorNode::get_log()->add_message("--- Debug adapter server started ---", EditorLog::MSG_TYPE_EDITOR);
+		EditorNode::get_log()->add_message("--- Debug adapter server started on port " + itos(remote_port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 		set_process_internal(true);
 		started = true;
 	}

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -49,6 +49,7 @@ private:
 	void _notification(int p_what);
 
 public:
+	static int port_override;
 	DebugAdapterServer();
 	void start();
 	void stop();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -90,6 +90,7 @@
 #endif
 
 #ifdef TOOLS_ENABLED
+#include "editor/debugger/debug_adapter/debug_adapter_server.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc_data_class_path.gen.h"
 #include "editor/doc_tools.h"
@@ -518,8 +519,9 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("-e, --editor", "Start the editor instead of running the scene.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("-p, --project-manager", "Start the project manager, even if a project is auto-detected.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--debug-server <uri>", "Start the editor debug server (<protocol>://<host/IP>[:port], e.g. tcp://127.0.0.1:6007)\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--dap-port <port>", "Use the specified port for the GDScript Debugger Adaptor protocol. Recommended port range [1024, 49151].\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #if defined(MODULE_GDSCRIPT_ENABLED) && !defined(GDSCRIPT_NO_LSP)
-	print_help_option("--lsp-port <port>", "Use the specified port for the GDScript language server protocol. The port should be between 1025 and 49150.\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--lsp-port <port>", "Use the specified port for the GDScript language server protocol. Recommended port range [1024, 49151].\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #endif // MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
 #endif
 	print_help_option("--quit", "Quit after the first iteration.\n");
@@ -1714,6 +1716,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 #endif // TOOLS_ENABLED && MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
+#if defined(TOOLS_ENABLED)
+		} else if (arg == "--dap-port") {
+			if (N) {
+				int port_override = N->get().to_int();
+				if (port_override < 0 || port_override > 65535) {
+					OS::get_singleton()->print("<port> argument for --dap-port <port> must be between 0 and 65535.\n");
+					goto error;
+				}
+				DebugAdapterServer::port_override = port_override;
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing <port> argument for --dap-port <port>.\n");
+				goto error;
+			}
+#endif // TOOLS_ENABLED
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
 		} else {


### PR DESCRIPTION
This is very similar to --lsp-port, which was added in https://github.com/godotengine/godot/pull/81844

I have started a conversation in https://chat.godotengine.org/channel/devel?msg=qEJuhGNKqXKsxmjZr, however haven't got responses so far.

The PR solves a case, when 2 GodotEditors are opened with projects and external editor tries to use one of the editors for debugging via DAP via Godot Editor (DebugAdapterServer, default port 6006).
In Rider already can start GodotEditor with LSP server in a headless mode, and this PR would help to use such GodotEditor also for debugging. Other external editors, which use DAP may also benefit from the PR.