### PR TITLE
Fix Texture3D import not working

### DIFF
--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -310,8 +310,6 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 		Vector<Ref<Image>> mipmap_images;
 		uint64_t total_size = 0;
 
-		bool first = true;
-
 		for (uint32_t i = 0; i < mipmaps + 1; i++) {
 			uint32_t size = f->get_32();
 
@@ -340,14 +338,17 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 			if (img.is_null() || img->is_empty()) {
 				ERR_FAIL_COND_V(img.is_null() || img->is_empty(), Ref<Image>());
 			}
+			// If the image is compressed and its format doesn't match the desired format, return an empty reference.
+			// This is done to avoid recompressing the image on load.
+			ERR_FAIL_COND_V(img->is_compressed() && format != img->get_format(), Ref<Image>());
 
-			if (first) {
-				//format will actually be the format of the first image,
-				//as it may have changed on compression
-				format = img->get_format();
-				first = false;
-			} else if (img->get_format() != format) {
-				img->convert(format); //all needs to be the same format
+			// The format will actually be the format of the header,
+			// as it may have changed on compression.
+			if (format != img->get_format()) {
+				// Convert the image to the desired format.
+				// Note: We are not decompressing the image here, just changing its format.
+				// It's important that all images in the texture array share the same format for correct rendering.
+				img->convert(format);
 			}
 
 			total_size += img->get_data().size();


### PR DESCRIPTION
Fix Texture3D import not working when texture has fully opaque and (partly or fully) transparent slices.

Fixes: https://github.com/godotengine/godot/issues/92315

The idea behind this pr is all Texture3D and Texture2DLayered must match the format in the header which may not be the format of the first image.

~~The idea behind this pr is all Texture3D and Texture2DLayered must match the first image in format. We enforce this, since the RD and the gpu does.~~


~~This feels vaguely wrong though.. because we're being strict on the load and forcing it to match the first image rather than rejecting the CompressedTexture2D but the advantage is this is both valid and allows failing files to load.~~

~~Somehow when saving LayeredTexture (TextureArray or Texture3D) the image goes from rgba -> rgb randomly in some of the layers. There probably should be a future pr for that but this also solves it in a less clean way.~~

https://github.com/godotengine/godot/files/15439250/Archive.zip has a series of failure cases that are fixed. Remember to convert them to Texture3D at 8x8 slices.


See also `Ref<Image> _validate_texture_format(const Ref<Image> &p_image, TextureToRDFormat &r_format);`