### PR TITLE
Fix `ClassDB` not checking for editor classes properly

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -505,7 +505,7 @@ Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require
 		ERR_FAIL_NULL_V_MSG(ti->creation_func, nullptr, "Class '" + String(p_class) + "' or its base class cannot be instantiated.");
 	}
 #ifdef TOOLS_ENABLED
-	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
+	if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
 		ERR_PRINT("Class '" + String(p_class) + "' can only be instantiated by editor.");
 		return nullptr;
 	}
@@ -664,7 +664,7 @@ bool ClassDB::can_instantiate(const StringName &p_class) {
 		return scr.is_valid() && scr->is_valid() && !scr->is_abstract();
 	}
 #ifdef TOOLS_ENABLED
-	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
+	if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
 		return false;
 	}
 #endif
@@ -684,7 +684,7 @@ bool ClassDB::is_virtual(const StringName &p_class) {
 		return scr.is_valid() && scr->is_valid() && scr->is_abstract();
 	}
 #ifdef TOOLS_ENABLED
-	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
+	if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
 		return false;
 	}
 #endif


### PR DESCRIPTION
This fixes the `_instantiate_internal`, `can_instantiate` and `is_virtual` methods of `ClassDB` to not only check whether `ClassInfo::api` is `API_EDITOR` but also whether it's `API_EDITOR_EXTENSION`.

This bug led to a crash when running @qarmin's fuzzer on Godot Jolt, as seen in godot-jolt/godot-jolt#868, as it tried to instantiate an editor-only type that erroneously reported a successful `can_instantiate`.

@dsnopek You wouldn't happen to know if this needs the same change? I couldn't quite figure out what it's for:

https://github.com/godotengine/godot/blob/b7feebefabc2d48b0d4794cd31fc141f1caecc5c/core/object/class_db.cpp#L592