### PR TITLE
Fix crash on dictionary initialization after return to default in C#.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -960,6 +960,7 @@ void EditorPropertyDictionary::update_property() {
 			memdelete(container);
 			button_add_item = nullptr;
 			container = nullptr;
+			add_panel = nullptr;
 			slots.clear();
 		}
 		return;


### PR DESCRIPTION
Fixes #92340
There was a missing de-initialization step in one of the two place that closes the bottom editor. I fixed it and put the logic in a function to avoid further de-sync between the two places.