### PR TITLE
Fix Multiplayer Spawner freeing node after client disconnected Issue

### DIFF
--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -76,7 +76,7 @@ void SceneCacheInterface::on_peer_change(int p_id, bool p_connected) {
 		for (KeyValue<int, ObjectID> E : pinfo->recv_nodes) {
 			NodeCache *nc = nodes_cache.getptr(E.value);
 			ERR_CONTINUE(!nc);
-			nc->recv_ids.erase(E.key);
+			nc->recv_ids.erase(p_id);
 		}
 		for (const ObjectID &oid : pinfo->sent_nodes) {
 			NodeCache *nc = nodes_cache.getptr(oid);


### PR DESCRIPTION
Fixes an error that happens when freeing a node that was synced using a MultiplayerSpawner after a client disconnects. Closes #92358 

When a client disconnects on `on_peer_change` it looks like the intention of the code was to remove the peer ID from the list of received ids of that node with `nc->recv_ids.erase(p_id);` but what is actually in the code today is `nc->recv_ids.erase(E.key);` which in this case is trying to erase the `remote cache id` of the node from the list of received ids of the node, which doesn't really make sense since that is a list of peer ids that received that node.

I'm assuming it was a mistake, this one line fix fixes it.

The error happens because since the id wasn't being removed from the list of recv_ids when the node was eventually freed it tried to get the peer_info for that id and failed since the peer at this point no longer exists, showing the error.