### PR TITLE
Fix build with `vulkan=no` and `d3d12=no` after #91505.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5201,10 +5201,11 @@ bool DisplayServerX11::is_window_transparency_available() const {
 	if (XGetSelectionOwner(x11_display, net_wm_cm) == None) {
 		return false;
 	}
-
+#if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->is_composite_alpha_supported()) {
 		return false;
 	}
+#endif
 	return OS::get_singleton()->is_layered_allowed();
 }
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3315,9 +3315,11 @@ void DisplayServerMacOS::delete_status_indicator(IndicatorID p_id) {
 }
 
 bool DisplayServerMacOS::is_window_transparency_available() const {
+#if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->is_composite_alpha_supported()) {
 		return false;
 	}
+#endif
 	return OS::get_singleton()->is_layered_allowed();
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3408,9 +3408,11 @@ bool DisplayServerWindows::is_window_transparency_available() const {
 			return false;
 		}
 	}
+#if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->is_composite_alpha_supported()) {
 		return false;
 	}
+#endif
 	return OS::get_singleton()->is_layered_allowed();
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92362