### PR TITLE
Implement key-value pair iteration of dictionaries

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1493,6 +1493,13 @@ void GDScriptByteCodeGenerator::write_for_assignment(const Address &p_list) {
 	append(p_list);
 }
 
+void GDScriptByteCodeGenerator::write_for_value_assignment(const Address &p_value) {
+	const Address &counter = for_counter_variables.back()->get();
+	const Address &container = for_container_variables.back()->get();
+
+	write_get(p_value, counter, container);
+}
+
 void GDScriptByteCodeGenerator::write_for(const Address &p_variable, bool p_use_conversion) {
 	const Address &counter = for_counter_variables.back()->get();
 	const Address &container = for_container_variables.back()->get();

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -537,6 +537,7 @@ public:
 	virtual void write_end_jump_if_shared() override;
 	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) override;
 	virtual void write_for_assignment(const Address &p_list) override;
+	virtual void write_for_value_assignment(const Address &p_value) override;
 	virtual void write_for(const Address &p_variable, bool p_use_conversion) override;
 	virtual void write_endfor() override;
 	virtual void start_while_condition() override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -150,6 +150,7 @@ public:
 	virtual void write_end_jump_if_shared() = 0;
 	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) = 0;
 	virtual void write_for_assignment(const Address &p_list) = 0;
+	virtual void write_for_value_assignment(const Address &p_value) = 0;
 	virtual void write_for(const Address &p_variable, bool p_use_conversion) = 0;
 	virtual void write_endfor() = 0;
 	virtual void start_while_condition() = 0; // Used to allow a jump to the expression evaluation.

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2013,6 +2013,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				codegen.start_block(); // Add an extra block, since the iterator and @special variables belong to the loop scope.
 
 				GDScriptCodeGenerator::Address iterator = codegen.add_local(for_n->variable->name, _gdtype_from_datatype(for_n->variable->get_datatype(), codegen.script));
+				GDScriptCodeGenerator::Address iterator_value;
 
 				gen->start_for(iterator.type, _gdtype_from_datatype(for_n->list->get_datatype(), codegen.script));
 
@@ -2032,6 +2033,10 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				// Loop variables must be cleared even when `break`/`continue` is used.
 				List<GDScriptCodeGenerator::Address> loop_locals = _add_block_locals(codegen, for_n->loop);
 
+				if (for_n->pair_variable) {
+					iterator_value = codegen.add_local(for_n->pair_variable->name, _gdtype_from_datatype(for_n->pair_variable->get_datatype(), codegen.script));
+					gen->write_for_value_assignment(iterator_value);
+				}
 				//_clear_block_locals(codegen, loop_locals); // Inside loop, before block - for `continue`. // TODO
 
 				err = _parse_block(codegen, for_n->loop, false); // Don't add locals again.

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -832,7 +832,9 @@ public:
 
 	struct ForNode : public Node {
 		IdentifierNode *variable = nullptr;
+		IdentifierNode *pair_variable = nullptr;
 		TypeNode *datatype_specifier = nullptr;
+		TypeNode *value_datatype_specifier = nullptr;
 		bool use_conversion_assign = false;
 		ExpressionNode *list = nullptr;
 		SuiteNode *loop = nullptr;

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_key_value_not_dictionary.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_key_value_not_dictionary.gd
@@ -1,0 +1,3 @@
+func test():
+    for u, v in ["test1", "test2", "test3"]:
+        print(u, " ", v)

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_key_value_not_dictionary.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_key_value_not_dictionary.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Unable to iterate with key-value pair on iteration of type "Array" (not a dictionary).

--- a/modules/gdscript/tests/scripts/parser/features/for_key_value_pair.gd
+++ b/modules/gdscript/tests/scripts/parser/features/for_key_value_pair.gd
@@ -1,0 +1,3 @@
+func test():
+	for u, v in { "key1" : "value1", "key2" : "value2", "key3" : "value3"}:
+		print(u, " ", v)

--- a/modules/gdscript/tests/scripts/parser/features/for_key_value_pair.out
+++ b/modules/gdscript/tests/scripts/parser/features/for_key_value_pair.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+key1 value1
+key2 value2
+key3 value3

--- a/modules/gdscript/tests/scripts/parser/features/for_key_value_pair_with_type_specifiers.gd
+++ b/modules/gdscript/tests/scripts/parser/features/for_key_value_pair_with_type_specifiers.gd
@@ -1,0 +1,3 @@
+func test():
+	for u, v : String, String in { "key1" : "value1", "key2" : "value2", "key3" : "value3"}:
+		print(u, " ", v)

--- a/modules/gdscript/tests/scripts/parser/features/for_key_value_pair_with_type_specifiers.out
+++ b/modules/gdscript/tests/scripts/parser/features/for_key_value_pair_with_type_specifiers.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+key1 value1
+key2 value2
+key3 value3

--- a/modules/gdscript/tests/scripts/runtime/features/for_key_value_multiple_types.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/for_key_value_multiple_types.gd
@@ -1,0 +1,3 @@
+func test():
+    for u, v in {"key1" : "value1", 2 : "value2", "key3" : 3, 4 : 4, 5.01 : 5.01}:
+        print(u, " ", v)

--- a/modules/gdscript/tests/scripts/runtime/features/for_key_value_multiple_types.out
+++ b/modules/gdscript/tests/scripts/runtime/features/for_key_value_multiple_types.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+key1 value1
+2 value2
+key3 3
+4 4
+5.01 5.01


### PR DESCRIPTION
Implementation includes parsing of both variables, type hints, static analysis and type checking, and compiling. The implementation writes an implicit assignment from the key index of the container to the value variable before the suite, within the compilation and code generation stages.

Example grammar:
forStmt = "for" IDENTIFIER [“,” IDENTIFIER] [“:” typeHint [“,” typeHint]] "in" expression ":" stmtOrSuite ;

Unit tests added (.gd and .out):
* parser/features/for_key_value_pair_with_type_specifiers : successful key-value pair iteration on dictionary with type specifiers for both key and value variables
* runtime/features/for_key_value_multiple_types : successful key-value pair iteration on dictionary with multiple types
* analyzer/errors/for_key_value_not_dictionary : error on key-value pair iteration on non-dictionary container
* parser/features/for_key_value_pair : basic success test

Closes: godotengine/godot-proposals#3457

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
