### PR TITLE
Improve dragging in editor properties

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -656,6 +656,7 @@ class EditorPropertyNodePath : public EditorProperty {
 	NodePath base_hint;
 	bool use_path_from_scene_root = false;
 	bool editing_node = false;
+	bool dropping = false;
 
 	Vector<StringName> valid_types;
 	void _node_selected(const NodePath &p_path);
@@ -670,6 +671,7 @@ class EditorPropertyNodePath : public EditorProperty {
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 	bool is_drop_valid(const Dictionary &p_drag_data) const;
+	void _button_draw();
 
 	virtual Variant _get_cache_value(const StringName &p_prop, bool &r_valid) const override;
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -565,8 +565,6 @@ bool EditorPropertyArray::can_drop_data_fw(const Point2 &p_point, const Variant 
 }
 
 void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	ERR_FAIL_COND(!_is_drop_valid(p_data));
-
 	Dictionary drag_data = p_data;
 	const String drop_type = drag_data.get("type", "");
 	Variant array = object->get_array();
@@ -645,11 +643,9 @@ void EditorPropertyArray::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
-			if (is_visible_in_tree()) {
-				if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
-					dropping = true;
-					edit->queue_redraw();
-				}
+			if (is_visible_in_tree() && _is_drop_valid(get_viewport()->gui_get_drag_data())) {
+				dropping = true;
+				edit->queue_redraw();
 			}
 		} break;
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -696,8 +696,6 @@ bool EditorResourcePicker::can_drop_data_fw(const Point2 &p_point, const Variant
 }
 
 void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	ERR_FAIL_COND(!_is_drop_valid(p_data));
-
 	Dictionary drag_data = p_data;
 
 	Ref<Resource> dropped_resource;


### PR DESCRIPTION
- removes redundant calls to `is_drop_valid()` inside `drop_data()` (already checked by the Viewport)
- adds drop highlight to NodePath property, similar to what EditorResourcePicker already does

https://github.com/godotengine/godot/assets/2223172/7e213417-152e-4692-88cb-eb95dc7afd7f

