### PR TITLE
Improve NavigationRegion2D debug performance

### DIFF
--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -52,6 +52,12 @@ class NavigationRegion2D : public Node2D {
 
 #ifdef DEBUG_ENABLED
 private:
+	RID debug_mesh_rid;
+	RID debug_instance_rid;
+
+	bool debug_mesh_dirty = true;
+
+	void _free_debug();
 	void _update_debug_mesh();
 	void _update_debug_edge_connections_mesh();
 	void _update_debug_baking_rect();


### PR DESCRIPTION
Improves NavigationRegion2D debug performance by replacing the canvas polygon and line commands with a static mesh.

This largely copies from the NavigationRegion3D debug mesh creation. The result is a whooping performance jump from ~100 fps to ~1400 fps in my test project with a 10.000+ polygon mesh and an unoptimized dev build.

Like most 2D nodes the NavigationRegion2D used the canvas draw functions for lines and polygons to draw its debug. This caused significant performance issues on complex navigation meshes as the rendering could not keep up with so many inefficient draw commands. This PR changes the debug and turns the entire region debug visuals to a single static mesh used for the rendering.

Note: That the mesh uses an array of vertex colors for everything is not a mistake. This was done due to issues with the 2D canvas rendering api not rendering colors correctly when using meshes without textures. With textures the materials and node canvas modulate did not play nice together and created weird color combinations.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
