### PR TITLE
Fix TileSet caching wrong collision layer shapes for shapes comprising several polygons.

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6378,7 +6378,7 @@ Ref<ConvexPolygonShape2D> TileData::get_collision_polygon_shape(int p_layer_id, 
 		for (int i = 0; i < size; i++) {
 			Ref<ConvexPolygonShape2D> transformed_polygon;
 			transformed_polygon.instantiate();
-			transformed_polygon->set_points(get_transformed_vertices(shapes_data.shapes[shape_index]->get_points(), p_flip_h, p_flip_v, p_transpose));
+			transformed_polygon->set_points(get_transformed_vertices(shapes_data.shapes[i]->get_points(), p_flip_h, p_flip_v, p_transpose));
 			shapes_data.transformed_shapes[key][i] = transformed_polygon;
 		}
 		return shapes_data.transformed_shapes[key][shape_index];


### PR DESCRIPTION
Fixes an index error occurring when Godot caches transformed collision layer shapes for tiles of a TileSet. 
This happens when a collision shape comprises several convex polygons: instead of transforming **each** member polygon, only the requested member polygon is transformed, and all other member polygons of the transformed shape are overwritten with that polygon.