### PR TITLE
Only update the EditorInspector tree when the property list changes.

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -490,6 +490,7 @@ class EditorInspector : public ScrollContainer {
 	void _clear(bool p_hide_plugins = true);
 	Object *object = nullptr;
 	Object *next_object = nullptr;
+	Object *last_object = nullptr;
 
 	//
 
@@ -513,9 +514,11 @@ class EditorInspector : public ScrollContainer {
 	bool deletable_properties = false;
 
 	float refresh_countdown;
-	bool update_tree_pending = false;
+	bool update_tree_pending = false; // Only updates the tree if new property list is different from the last. Use `last_object = nullptr` to force update.
 	StringName _prop_edited;
 	StringName property_selected;
+	List<PropertyInfo> property_list;
+
 	int property_focusable;
 	int update_scroll_request;
 


### PR DESCRIPTION
I have confirmed that this fixes the issue, I can drag the slider which updates the Resource's ArrayMesh in real time. This is achieved by keeping a copy of the last property list and the last inspected object and only updating the complete tree when there is a change. 

Unsure if there are any negative consequences to this approach, would appreciate feedback from somebody with more understanding of the domain.

Please review carefully, as I primarily work in GC languages and I am not as familar with C++ best practises, allocations etc.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/92348*


https://github.com/godotengine/godot/assets/2015791/9c1a8909-172e-43b6-ac6e-e2ffb07afbe0

