### PR TITLE
Expose `World3D.compositor`

### DIFF
--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -14,7 +14,7 @@
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>
 		<member name="compositor" type="Compositor" setter="set_compositor" getter="get_compositor">
-			The World3D's [Compositor].
+			The World3D's [Compositor]. Set by [WorldEnvironment] nodes in this World3D.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -13,6 +13,9 @@
 		<member name="camera_attributes" type="CameraAttributes" setter="set_camera_attributes" getter="get_camera_attributes">
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>
+		<member name="compositor" type="Compositor" setter="set_compositor" getter="get_compositor">
+			The World3D's [Compositor].
+		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.
 		</member>

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -14,7 +14,7 @@
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>
 		<member name="compositor" type="Compositor" setter="set_compositor" getter="get_compositor">
-			The default [Compositor] resource to be use if none is set on the [Camera3D]. Will be replaced by the first [WorldEnvironment] registered to this World3D.
+			The default [Compositor] resource to use if none is set on the [Camera3D]. Will be replaced by the first [WorldEnvironment] registered to this World3D.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -14,7 +14,7 @@
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>
 		<member name="compositor" type="Compositor" setter="set_compositor" getter="get_compositor">
-			The World3D's [Compositor]. Set by [WorldEnvironment] nodes in this World3D.
+			The default [Compositor] resource to be use if none is set on the [Camera3D]. Will be replaced by the first [WorldEnvironment] registered to this World3D.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -155,9 +155,12 @@ void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "attributes"), &World3D::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &World3D::get_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
+	ClassDB::bind_method(D_METHOD("set_compositor", "compositor"), &World3D::set_compositor);
+	ClassDB::bind_method(D_METHOD("get_compositor"), &World3D::get_compositor);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_environment", "get_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_fallback_environment", "get_fallback_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "compositor", PROPERTY_HINT_RESOURCE_TYPE, "Compositor"), "set_compositor", "get_compositor");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");


### PR DESCRIPTION
this closes https://github.com/godotengine/godot-proposals/issues/9815

I'm positive this just got missed in the `Compositor` implementation, since i could find no mention of its omission or any reasons for it (and it only makes using `World3D` resources more cumbersome).