### PR TITLE
Fix albedo value wraparound in Compatibility render mode

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1523,6 +1523,9 @@ void main() {
 #CODE : FRAGMENT
 	}
 
+	// Keep albedo values in positive number range as negative values "wraparound" into positive numbers resulting in wrong colors
+	albedo = max(albedo, vec3(0.0));
+
 #ifdef LIGHT_VERTEX_USED
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW


### PR DESCRIPTION
Using the Compatibility renderer results in wrapped albedo values if a custom shader returns albedo values outside the expected range of [0,1].

This commit fixed this issue by clamping the albedo value to [0,1] right after the custom shader is executed.

Fixes #91919