### PR TITLE
Fix Polygon2D UVs not available in canvasitem shader materials.

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -232,6 +232,8 @@ void Polygon2D::_notification(int p_what) {
 						uvs.write[i] = texmat.xform(points[i]) / tex_size;
 					}
 				}
+			} else if (points.size() == uv.size()) {
+				uvs = uv;
 			}
 
 			if (skeleton_node && !invert && bone_weights.size()) {


### PR DESCRIPTION
Fixes [#81627](https://github.com/godotengine/godot/issues/81627).

Setting UVs for a Polygon2D without setting a texture result in not taking them into account and thus, ShaderMaterial can't rely on the UV built-in.
