### PR TITLE
Improve description of `find_item_by_name()` method in `MeshLibrary` class documentation

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -29,7 +29,7 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the first item with the given name.
+				Returns the first item with the given name, or [code]-1[/code] if no item is found.
 			</description>
 		</method>
 		<method name="get_item_list" qualifiers="const">


### PR DESCRIPTION
## What I Did

- Specified what the `find_item_by_name()` method in the `MeshLibrary` class returns if no item is found.

Closes: https://github.com/godotengine/godot-docs/issues/9219