### PR TITLE
Make editor builds deterministic

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -1,5 +1,6 @@
 """Functions used to generate source files during build time"""
 
+import hashlib
 import os
 import os.path
 import shutil
@@ -30,11 +31,14 @@ def make_doc_header(target, source, env):
         # Use maximum zlib compression level to further reduce file size
         # (at the cost of initial build times).
         buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+        md5 = hashlib.md5()
+        md5.update(buf)
+        doc_data_hash = md5.hexdigest()
 
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef _DOC_DATA_RAW_H\n")
         g.write("#define _DOC_DATA_RAW_H\n")
-        g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
+        g.write('static const char *_doc_data_hash = "' + doc_data_hash + '";\n')
         g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
         g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
         g.write("static const unsigned char _doc_data_compressed[] = {\n")

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -31,9 +31,7 @@ def make_doc_header(target, source, env):
         # Use maximum zlib compression level to further reduce file size
         # (at the cost of initial build times).
         buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
-        md5 = hashlib.md5()
-        md5.update(buf)
-        doc_data_hash = md5.hexdigest()
+        doc_data_hash = hashlib.md5(buf).hexdigest()
 
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef _DOC_DATA_RAW_H\n")


### PR DESCRIPTION
## The issue

The Godot engine build process is not deterministic if building the editor target.  This conclusion can be taken if one makes two identical copies of the Godot source code on the same machine, builds one after the other with the same parameters and then does a `diff` of the resulting binaries. For me, `diffoscope` said that the difference was fairly minor:
```diffoscope
--- godot.linuxbsd.editor.x86_64
+++ godot.linuxbsd.editor.x86_64-b
│┄ File has been modified after NT_GNU_BUILD_ID has been applied.
├── readelf --wide --notes {}
│┄ error from `readelf --wide --notes {}`:
│┄ readelf: godot.linuxbsd.editor.x86_64: Warning: Gap in build notes detected from 0x48a417 to 0x48a424
│┄ readelf: godot.linuxbsd.editor.x86_64: Warning: Gap in build notes detected from 0x48a4d7 to 0x3f2939f
│┄ readelf: godot.linuxbsd.editor.x86_64: Warning: Gap in build notes detected from 0x47eac2 to 0x3f2cedf
│┄ readelf: godot.linuxbsd.editor.x86_64: Warning: Gap in build notes detected from 0x47eba9 to 0x3f2feef
│ @@ -1,15 +1,15 @@
│  
│  Displaying notes found in: .note.gnu.property
│    Owner                Data size 	Description
│    GNU                  0x00000030	NT_GNU_PROPERTY_TYPE_0	      Properties: x86 ISA needed: x86-64-baseline, x86 feature used: x86, x87, XMM, x86 ISA used: x86-64-baseline
│  
│  Displaying notes found in: .note.gnu.build-id
│    Owner                Data size 	Description
│ -  GNU                  0x00000014	NT_GNU_BUILD_ID (unique build ID bitstring)	    Build ID: 58b16ae59dea2093f492d5557d6b9bdcd500d520
│ +  GNU                  0x00000014	NT_GNU_BUILD_ID (unique build ID bitstring)	    Build ID: e34b82167073b4e19abefb0922315dbde1fe252c
│  
│  Displaying notes found in: .note.ABI-tag
│    Owner                Data size 	Description
│    GNU                  0x00000010	NT_GNU_ABI_TAG (ABI version tag)	    OS: Linux, ABI: 3.2.0
│  
│  Displaying notes found in: .note.stapsdt
│    Owner                Data size 	Description
├── strings --all --bytes=8 {}
│ @@ -79060,15 +79060,15 @@
│  arrow_collapsed
│  editor/editor_inspector.cpp
│  _resize_array
│  property_array_prefix
│  property_array_element
│  editor_doc_cache.res
│  %d/%d/%d/%s
│ -8601117115514980843
│ +5649390763573855146
│  No return value.
│  BitField
│  Toggle Scripts Panel
│  go_to_help
│  class_method
│  class_enum
│  class_signal
├── readelf --wide --decompress --hex-dump=.rodata {}
│ @@ -432777,16 +432777,16 @@
│    0x045ca860 746f722f 65646974 6f725f69 6e737065 tor/editor_inspe
│    0x045ca870 63746f72 2e637070 005f7265 73697a65 ctor.cpp._resize
│    0x045ca880 5f617272 61790070 726f7065 7274795f _array.property_
│    0x045ca890 61727261 795f7072 65666978 0070726f array_prefix.pro
│    0x045ca8a0 70657274 795f6172 7261795f 656c656d perty_array_elem
│    0x045ca8b0 656e7400 65646974 6f725f64 6f635f63 ent.editor_doc_c
│    0x045ca8c0 61636865 2e726573 0025642f 25642f25 ache.res.%d/%d/%
│ -  0x045ca8d0 642f2573 00383630 31313137 31313535 d/%s.86011171155
│ -  0x045ca8e0 31343938 30383433 004e6f20 72657475 14980843.No retu
│ +  0x045ca8d0 642f2573 00353634 39333930 37363335 d/%s.56493907635
│ +  0x045ca8e0 37333835 35313436 004e6f20 72657475 73855146.No retu
│    0x045ca8f0 726e2076 616c7565 2e002341 72726179 rn value..#Array
│    0x045ca900 00426974 4669656c 6400546f 67676c65 .BitField.Toggle
│    0x045ca910 20536372 69707473 2050616e 656c0067  Scripts Panel.g
│    0x045ca920 6f5f746f 5f68656c 7000636c 6173735f o_to_help.class_
│    0x045ca930 6d657468 6f640063 6c617373 5f656e75 method.class_enu
│    0x045ca940 6d00636c 6173735f 7369676e 616c0063 m.class_signal.c
│    0x045ca950 6c617373 5f636f6e 7374616e 7400636c lass_constant.cl

```
(note that the diff will be larger if the differing string has a different length between the two binaries, in which case one will see a bunch of differing `mov` instructions where the referred addresses have 1 or 2 subtracted or added to them, because the data that follows the differing string will be offset by one or two bytes as a consequence of the string being 1 or 2 bytes smaller or larger)

Reproducible builds are important due to the reasons pointed out at: https://reproducible-builds.org/

I noticed this while working with the Godot package on Guix. I noticed that running `guix build --rounds=2 godot` failed due to a hash mismatch of the final outputs. `guix challenge` also failed.

Note I only tested with gcc and ld on linux and I didn't build most bundled software. So there may be more determinism-related issues if one compiles with the software bundled by godot. (ie. I'm using most of the `builtin_*` options).

I also only tested with the godot 4.2.1, 4.2.2 and commit aaa4560729b.

### Steps to reproduce
1. `scons platform=linuxbsd builtin_enet=no builtin_freetype=no builtin_graphite=no builtin_harfbuzz=no builtin_libogg=no builtin_libpng=no builtin_libtheora=no builtin_libvorbis=no builtin_libwebp=no builtin_mbedtls=no builtin_miniupnpc=no builtin_pcre2=no builtin_zlib=no builtin_zstd=no target=editor`
2. Rename resulting binary
3. Delete `editor/doc_data_compressed.gen.h` or do `scons --clean`
4. Run the scons command mentioned in step 1 again
5. Run `diff` on the two files you now have and see how it says that the binary files differ.

## The cause

`grep`ing the string that appears to differ in the diff gives us the `doc_data_hash` definition at `editor/doc_data_compressed.gen.h`, which is a file generated by `editor/editor_builders.py`. The problematic line is:
```python
g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
```

This line is problematic, because it uses Python's `hash` function which for security reasons (see note at the bottom of [https://docs.python.org/3/reference/datamodel.html#object.\_\_hash\_\_](https://docs.python.org/3/reference/datamodel.html#object.__hash__) to understand what those reasons are) since 3.3 has a randomized seed, which makes it so that hashes of datatypes like strings do not give the same hash accross different python runs when given the same data.

## The solution

I changed the code to use `hashlib`'s implementation of md5 to generate the editor docs hash. This will give the same result for the same data across different runs. After this fix the binaries built in the situation I mentioned are identical (as can by asserted by running `diff`).

Python also has a `PYTHONHASHSEED` environment variable, but using that seemed kind of hacky to me. I used md5, because it is provided by `hashlib` without needing any additional libraries and was the simplest among all the other hashing algorithms in hashlib (we aren't using the hash in a security context, so any hashing algorithm which doesn't have too many collisions is fine).

As a side effect, this also prevents some unnecessary regeneration of the editor doc cache (I think the only place where that hash is used is to check whether Godot can use the cached docs). But the case where one has two identical binaries built with the same docs and runs each after one another is pretty rare (at least I deduce it is, since there is not much point in doing that), so I think that effect is quite insignificant.