### PR TITLE
Add macros for accessing project metadata

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -226,7 +226,7 @@ void ActionMapEditor::_tree_item_activated() {
 void ActionMapEditor::set_show_builtin_actions(bool p_show) {
 	show_builtin_actions = p_show;
 	show_builtin_actions_checkbutton->set_pressed(p_show);
-	EditorSettings::get_singleton()->set_project_metadata("project_settings", "show_builtin_actions", show_builtin_actions);
+	SET_PROJECT_META("project_settings", "show_builtin_actions", show_builtin_actions);
 
 	// Prevent unnecessary updates of action list when cache is empty.
 	if (!actions_cache.is_empty()) {
@@ -586,7 +586,7 @@ ActionMapEditor::ActionMapEditor() {
 	show_builtin_actions_checkbutton->connect("toggled", callable_mp(this, &ActionMapEditor::set_show_builtin_actions));
 	add_hbox->add_child(show_builtin_actions_checkbutton);
 
-	show_builtin_actions = EditorSettings::get_singleton()->get_project_metadata("project_settings", "show_builtin_actions", false);
+	show_builtin_actions = GET_PROJECT_META("project_settings", "show_builtin_actions", false);
 	show_builtin_actions_checkbutton->set_pressed(show_builtin_actions);
 
 	main_vbox->add_child(add_hbox);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -397,9 +397,9 @@ void ConnectDialog::_update_method_tree() {
 
 void ConnectDialog::_method_check_button_pressed(const CheckButton *p_button) {
 	if (p_button == script_methods_only) {
-		EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "show_script_methods_only", p_button->is_pressed());
+		SET_PROJECT_META("editor_metadata", "show_script_methods_only", p_button->is_pressed());
 	} else if (p_button == compatible_methods_only) {
-		EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "show_compatible_methods_only", p_button->is_pressed());
+		SET_PROJECT_META("editor_metadata", "show_compatible_methods_only", p_button->is_pressed());
 	}
 	_update_method_tree();
 }
@@ -681,7 +681,7 @@ void ConnectDialog::_advanced_pressed() {
 		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
 	}
 
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "use_advanced_connections", advanced->is_pressed());
+	SET_PROJECT_META("editor_metadata", "use_advanced_connections", advanced->is_pressed());
 
 	popup_centered();
 }
@@ -767,13 +767,13 @@ ConnectDialog::ConnectDialog() {
 	script_methods_only = memnew(CheckButton(TTR("Script Methods Only")));
 	method_vbc->add_child(script_methods_only);
 	script_methods_only->set_h_size_flags(Control::SIZE_SHRINK_END);
-	script_methods_only->set_pressed(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "show_script_methods_only", true));
+	script_methods_only->set_pressed(GET_PROJECT_META("editor_metadata", "show_script_methods_only", true));
 	script_methods_only->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_method_check_button_pressed).bind(script_methods_only));
 
 	compatible_methods_only = memnew(CheckButton(TTR("Compatible Methods Only")));
 	method_vbc->add_child(compatible_methods_only);
 	compatible_methods_only->set_h_size_flags(Control::SIZE_SHRINK_END);
-	compatible_methods_only->set_pressed(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "show_compatible_methods_only", true));
+	compatible_methods_only->set_pressed(GET_PROJECT_META("editor_metadata", "show_compatible_methods_only", true));
 	compatible_methods_only->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_method_check_button_pressed).bind(compatible_methods_only));
 
 	vbc_right = memnew(VBoxContainer);
@@ -839,7 +839,7 @@ ConnectDialog::ConnectDialog() {
 	advanced = memnew(CheckButton(TTR("Advanced")));
 	vbc_left->add_child(advanced);
 	advanced->set_h_size_flags(Control::SIZE_SHRINK_BEGIN | Control::SIZE_EXPAND);
-	advanced->set_pressed(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "use_advanced_connections", false));
+	advanced->set_pressed(GET_PROJECT_META("editor_metadata", "use_advanced_connections", false));
 	advanced->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_advanced_pressed));
 
 	HBoxContainer *hbox = memnew(HBoxContainer);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -69,7 +69,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	_save_and_update_favorite_list();
 
 	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2());
+	Rect2 saved_size = GET_PROJECT_META("dialog_bounds", "create_new_node", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
@@ -459,7 +459,7 @@ void CreateDialog::_notification(int p_what) {
 				callable_mp((Control *)search_box, &Control::grab_focus).call_deferred(); // Still not visible.
 				search_box->select_all();
 			} else {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
+				SET_PROJECT_META("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
 			}
 		} break;
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -537,14 +537,14 @@ void EditorDebuggerNode::_menu_option(int p_id) {
 			debug_with_external_editor = !ischecked;
 			script_menu->get_popup()->set_item_checked(script_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "debug_with_external_editor", !ischecked);
+				SET_PROJECT_META("debug_options", "debug_with_external_editor", !ischecked);
 			}
 		} break;
 	}
 }
 
 void EditorDebuggerNode::_update_debug_options() {
-	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "debug_with_external_editor", false).operator bool()) {
+	if (GET_PROJECT_META("debug_options", "debug_with_external_editor", false).operator bool()) {
 		_menu_option(DEBUG_WITH_EXTERNAL_EDITOR);
 	}
 }

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -365,7 +365,7 @@ EditorBuildProfile::EditorBuildProfile() {
 void EditorBuildProfileManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			String last_file = EditorSettings::get_singleton()->get_project_metadata("build_profile", "last_file_path", "");
+			String last_file = GET_PROJECT_META("build_profile", "last_file_path", "");
 			if (!last_file.is_empty()) {
 				_import_profile(last_file);
 			}
@@ -777,7 +777,7 @@ void EditorBuildProfileManager::_import_profile(const String &p_path) {
 	}
 
 	profile_path->set_text(p_path);
-	EditorSettings::get_singleton()->set_project_metadata("build_profile", "last_file_path", p_path);
+	SET_PROJECT_META("build_profile", "last_file_path", p_path);
 
 	edited = profile;
 	_update_edited_profile();
@@ -790,7 +790,7 @@ void EditorBuildProfileManager::_export_profile(const String &p_path) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving profile to path: '%s'."), p_path));
 	} else {
 		profile_path->set_text(p_path);
-		EditorSettings::get_singleton()->set_project_metadata("build_profile", "last_file_path", p_path);
+		SET_PROJECT_META("build_profile", "last_file_path", p_path);
 	}
 }
 

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -262,7 +262,7 @@ void EditorCommandPalette::_add_command(String p_command_name, String p_key_name
 	command.shortcut_text = p_shortcut_text;
 
 	// Commands added from plugins don't exist yet when the history is loaded, so we assign the last use time here if it was recorded.
-	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
+	Dictionary command_history = GET_PROJECT_META("command_palette", "command_history", Dictionary());
 	if (command_history.has(p_key_name)) {
 		command.last_used = command_history[p_key_name];
 	}
@@ -297,7 +297,7 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 	unregistered_shortcuts.clear();
 
 	// Load command use history.
-	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
+	Dictionary command_history = GET_PROJECT_META("command_palette", "command_history", Dictionary());
 	Array history_entries = command_history.keys();
 	for (int i = 0; i < history_entries.size(); i++) {
 		const String &history_key = history_entries[i];
@@ -330,7 +330,7 @@ void EditorCommandPalette::_save_history() const {
 			command_history[E.key] = E.value.last_used;
 		}
 	}
-	EditorSettings::get_singleton()->set_project_metadata("command_palette", "command_history", command_history);
+	SET_PROJECT_META("command_palette", "command_history", command_history);
 }
 
 EditorCommandPalette *EditorCommandPalette::get_singleton() {

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -207,7 +207,7 @@ void EditorHelpSearch::_notification(int p_what) {
 				tree_cache.clear();
 				callable_mp(results_tree, &Tree::clear).call_deferred(); // Wait for the Tree's mouse event propagation.
 				get_ok_button()->set_disabled(true);
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "search_help", Rect2(get_position(), get_size()));
+				SET_PROJECT_META("dialog_bounds", "search_help", Rect2(get_position(), get_size()));
 			}
 		} break;
 
@@ -271,7 +271,7 @@ void EditorHelpSearch::popup_dialog() {
 
 void EditorHelpSearch::popup_dialog(const String &p_term) {
 	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "search_help", Rect2());
+	Rect2 saved_size = GET_PROJECT_META("dialog_bounds", "search_help", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -735,7 +735,7 @@ void EditorNode::_notification(int p_what) {
 			_titlebar_resized();
 
 			// Set up a theme context for the 2D preview viewport using the stored preview theme.
-			CanvasItemEditor::ThemePreviewMode theme_preview_mode = (CanvasItemEditor::ThemePreviewMode)(int)EditorSettings::get_singleton()->get_project_metadata("2d_editor", "theme_preview", CanvasItemEditor::THEME_PREVIEW_PROJECT);
+			CanvasItemEditor::ThemePreviewMode theme_preview_mode = (CanvasItemEditor::ThemePreviewMode)(int)GET_PROJECT_META("2d_editor", "theme_preview", CanvasItemEditor::THEME_PREVIEW_PROJECT);
 			update_preview_themes(theme_preview_mode);
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
@@ -3879,8 +3879,8 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 
 void EditorNode::setup_color_picker(ColorPicker *p_picker) {
 	p_picker->set_editor_settings(EditorSettings::get_singleton());
-	int default_color_mode = EditorSettings::get_singleton()->get_project_metadata("color_picker", "color_mode", EDITOR_GET("interface/inspector/default_color_picker_mode"));
-	int picker_shape = EditorSettings::get_singleton()->get_project_metadata("color_picker", "picker_shape", EDITOR_GET("interface/inspector/default_color_picker_shape"));
+	int default_color_mode = GET_PROJECT_META("color_picker", "color_mode", EDITOR_GET("interface/inspector/default_color_picker_mode"));
+	int picker_shape = GET_PROJECT_META("color_picker", "picker_shape", EDITOR_GET("interface/inspector/default_color_picker_shape"));
 
 	p_picker->set_color_mode((ColorPicker::ColorModeType)default_color_mode);
 	p_picker->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
@@ -4348,7 +4348,7 @@ void EditorNode::_show_messages() {
 }
 
 void EditorNode::_add_to_recent_scenes(const String &p_scene) {
-	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
+	Array rc = GET_PROJECT_META("recent_files", "scenes", Array());
 	if (rc.has(p_scene)) {
 		rc.erase(p_scene);
 	}
@@ -4357,28 +4357,28 @@ void EditorNode::_add_to_recent_scenes(const String &p_scene) {
 		rc.resize(10);
 	}
 
-	EditorSettings::get_singleton()->set_project_metadata("recent_files", "scenes", rc);
+	SET_PROJECT_META("recent_files", "scenes", rc);
 	_update_recent_scenes();
 }
 
 void EditorNode::_open_recent_scene(int p_idx) {
 	if (p_idx == recent_scenes->get_item_count() - 1) {
-		EditorSettings::get_singleton()->set_project_metadata("recent_files", "scenes", Array());
+		SET_PROJECT_META("recent_files", "scenes", Array());
 		callable_mp(this, &EditorNode::_update_recent_scenes).call_deferred();
 	} else {
-		Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
+		Array rc = GET_PROJECT_META("recent_files", "scenes", Array());
 		ERR_FAIL_INDEX(p_idx, rc.size());
 
 		if (load_scene(rc[p_idx]) != OK) {
 			rc.remove_at(p_idx);
-			EditorSettings::get_singleton()->set_project_metadata("recent_files", "scenes", rc);
+			SET_PROJECT_META("recent_files", "scenes", rc);
 			_update_recent_scenes();
 		}
 	}
 }
 
 void EditorNode::_update_recent_scenes() {
-	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
+	Array rc = GET_PROJECT_META("recent_files", "scenes", Array());
 	recent_scenes->clear();
 
 	String path;
@@ -6311,7 +6311,7 @@ EditorNode::EditorNode() {
 
 	// Warm up the surface upgrade tool as early as possible.
 	surface_upgrade_tool = memnew(SurfaceUpgradeTool);
-	run_surface_upgrade_tool = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "run_on_restart", false);
+	run_surface_upgrade_tool = GET_PROJECT_META("surface_upgrade_tool", "run_on_restart", false);
 	if (run_surface_upgrade_tool) {
 		SurfaceUpgradeTool::get_singleton()->begin_upgrade();
 	}
@@ -7467,7 +7467,7 @@ EditorNode::EditorNode() {
 
 	String exec = OS::get_singleton()->get_executable_path();
 	// Save editor executable path for third-party tools.
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "executable_path", exec);
+	SET_PROJECT_META("editor_metadata", "executable_path", exec);
 
 	follow_system_theme = EDITOR_GET("interface/theme/follow_system_theme");
 	use_system_accent_color = EDITOR_GET("interface/theme/use_system_accent_color");

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -114,7 +114,7 @@ void EditorPropertyVectorN::_store_link(bool p_linked) {
 		return;
 	}
 	const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
-	EditorSettings::get_singleton()->set_project_metadata("linked_properties", key, p_linked);
+	SET_PROJECT_META("linked_properties", key, p_linked);
 }
 
 void EditorPropertyVectorN::_grab_changed(bool p_grab) {
@@ -129,7 +129,7 @@ void EditorPropertyVectorN::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			if (linked->is_visible()) {
 				const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
-				linked->set_pressed_no_signal(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
+				linked->set_pressed_no_signal(GET_PROJECT_META("linked_properties", key, true));
 				_update_ratio();
 			}
 		} break;

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -68,11 +68,11 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	args.push_back("--editor-pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
-	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
-	bool debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);
-	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
-	bool debug_avoidance = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_avoidance", false);
-	bool debug_canvas_redraw = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
+	bool debug_collisions = GET_PROJECT_META("debug_options", "run_debug_collisions", false);
+	bool debug_paths = GET_PROJECT_META("debug_options", "run_debug_paths", false);
+	bool debug_navigation = GET_PROJECT_META("debug_options", "run_debug_navigation", false);
+	bool debug_avoidance = GET_PROJECT_META("debug_options", "run_debug_avoidance", false);
+	bool debug_canvas_redraw = GET_PROJECT_META("debug_options", "run_debug_canvas_redraw", false);
 
 	if (debug_collisions) {
 		args.push_back("--debug-collisions");

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -144,9 +144,9 @@ Error EditorRunNative::start_run_native(int p_id) {
 	int flags = 0;
 
 	bool deploy_debug_remote = is_deploy_debug_remote_enabled();
-	bool deploy_dumb = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
-	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
-	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
+	bool deploy_dumb = GET_PROJECT_META("debug_options", "run_file_server", false);
+	bool debug_collisions = GET_PROJECT_META("debug_options", "run_debug_collisions", false);
+	bool debug_navigation = GET_PROJECT_META("debug_options", "run_debug_navigation", false);
 
 	if (deploy_debug_remote) {
 		flags |= EditorExportPlatform::DEBUG_FLAG_REMOTE_DEBUG;
@@ -181,7 +181,7 @@ void EditorRunNative::_bind_methods() {
 }
 
 bool EditorRunNative::is_deploy_debug_remote_enabled() const {
-	return EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
+	return GET_PROJECT_META("debug_options", "run_deploy_remote_debug", false);
 }
 
 EditorRunNative::EditorRunNative() {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -212,4 +212,7 @@ void ED_SHORTCUT_OVERRIDE(const String &p_path, const String &p_feature, Key p_k
 void ED_SHORTCUT_OVERRIDE_ARRAY(const String &p_path, const String &p_feature, const PackedInt32Array &p_keycodes, bool p_physical = false);
 Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path);
 
+#define SET_PROJECT_META(m_section, m_key, m_data) EditorSettings::get_singleton()->set_project_metadata(m_section, m_key, m_data)
+#define GET_PROJECT_META(m_section, m_key, m_default) EditorSettings::get_singleton()->get_project_metadata(m_section, m_key, m_default)
+
 #endif // EDITOR_SETTINGS_H

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -104,7 +104,7 @@ void EditorSettingsDialog::popup_edit_settings() {
 	set_process_shortcut_input(true);
 
 	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "editor_settings", Rect2());
+	Rect2 saved_size = GET_PROJECT_META("dialog_bounds", "editor_settings", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
@@ -132,7 +132,7 @@ void EditorSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
+				SET_PROJECT_META("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
 				set_process_shortcut_input(false);
 			}
 		} break;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -95,7 +95,7 @@ void ProjectExportDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "export", Rect2(get_position(), get_size()));
+				SET_PROJECT_META("dialog_bounds", "export", Rect2(get_position(), get_size()));
 			}
 		} break;
 
@@ -127,7 +127,7 @@ void ProjectExportDialog::popup_export() {
 	}
 
 	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "export", Rect2());
+	Rect2 saved_size = GET_PROJECT_META("dialog_bounds", "export", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
@@ -1120,7 +1120,7 @@ void ProjectExportDialog::_export_project() {
 void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 	// Save this name for use in future exports (but drop the file extension)
 	default_filename = p_path.get_file().get_basename();
-	EditorSettings::get_singleton()->set_project_metadata("export_options", "default_filename", default_filename);
+	SET_PROJECT_META("export_options", "default_filename", default_filename);
 
 	Ref<EditorExportPreset> current = get_current_preset();
 	ERR_FAIL_COND_MSG(current.is_null(), "Failed to start the export: current preset is invalid.");
@@ -1583,7 +1583,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	set_hide_on_ok(false);
 
-	default_filename = EditorSettings::get_singleton()->get_project_metadata("export_options", "default_filename", "");
+	default_filename = GET_PROJECT_META("export_options", "default_filename", "");
 	// If no default set, use project name
 	if (default_filename.is_empty()) {
 		// If no project name defined, use a sane default

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1616,7 +1616,7 @@ void SceneTreeDialog::popup_scenetree_dialog(Node *p_selected_node, Node *p_mark
 }
 
 void SceneTreeDialog::_show_all_nodes_changed(bool p_button_pressed) {
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "show_all_nodes_for_node_selection", p_button_pressed);
+	SET_PROJECT_META("editor_metadata", "show_all_nodes_for_node_selection", p_button_pressed);
 	tree->set_show_all_nodes(p_button_pressed);
 }
 
@@ -1758,7 +1758,7 @@ SceneTreeDialog::SceneTreeDialog() {
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));
 	// Initialize button state, must be done after the tree has been created to update its 'show_all_nodes' flag.
 	// This is also done before adding the tree to the content to avoid triggering unnecessary tree filtering.
-	show_all_nodes->set_pressed(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "show_all_nodes_for_node_selection", false));
+	show_all_nodes->set_pressed(GET_PROJECT_META("editor_metadata", "show_all_nodes_for_node_selection", false));
 	content->add_child(tree);
 
 	// Disable the OK button when no node is selected.

--- a/editor/history_dock.cpp
+++ b/editor/history_dock.cpp
@@ -221,8 +221,8 @@ void HistoryDock::_notification(int p_notification) {
 }
 
 void HistoryDock::save_options() {
-	EditorSettings::get_singleton()->set_project_metadata("history", "include_scene", current_scene_checkbox->is_pressed());
-	EditorSettings::get_singleton()->set_project_metadata("history", "include_global", global_history_checkbox->is_pressed());
+	SET_PROJECT_META("history", "include_scene", current_scene_checkbox->is_pressed());
+	SET_PROJECT_META("history", "include_global", global_history_checkbox->is_pressed());
 }
 
 HistoryDock::HistoryDock() {
@@ -235,8 +235,8 @@ HistoryDock::HistoryDock() {
 	HBoxContainer *mode_hb = memnew(HBoxContainer);
 	add_child(mode_hb);
 
-	bool include_scene = EditorSettings::get_singleton()->get_project_metadata("history", "include_scene", true);
-	bool include_global = EditorSettings::get_singleton()->get_project_metadata("history", "include_global", true);
+	bool include_scene = GET_PROJECT_META("history", "include_scene", true);
+	bool include_global = GET_PROJECT_META("history", "include_global", true);
 
 	current_scene_checkbox = memnew(CheckBox);
 	mode_hb->add_child(current_scene_checkbox);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -902,12 +902,12 @@ void CanvasItemEditor::_commit_canvas_item_state(const List<CanvasItem *> &p_can
 void CanvasItemEditor::_snap_changed() {
 	static_cast<SnapDialog *>(snap_dialog)->get_fields(grid_offset, grid_step, primary_grid_step, snap_rotation_offset, snap_rotation_step, snap_scale_step);
 
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_offset", grid_offset);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_step", grid_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "primary_grid_step", primary_grid_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_offset", snap_rotation_offset);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_step", snap_rotation_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_scale_step", snap_scale_step);
+	SET_PROJECT_META("2d_editor", "grid_offset", grid_offset);
+	SET_PROJECT_META("2d_editor", "grid_step", grid_step);
+	SET_PROJECT_META("2d_editor", "primary_grid_step", primary_grid_step);
+	SET_PROJECT_META("2d_editor", "snap_rotation_offset", snap_rotation_offset);
+	SET_PROJECT_META("2d_editor", "snap_rotation_step", snap_rotation_step);
+	SET_PROJECT_META("2d_editor", "snap_scale_step", snap_scale_step);
 
 	grid_step_multiplier = 0;
 	viewport->queue_redraw();
@@ -1047,7 +1047,7 @@ void CanvasItemEditor::_switch_theme_preview(int p_mode) {
 		return;
 	}
 	theme_preview = (ThemePreviewMode)p_mode;
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "theme_preview", theme_preview);
+	SET_PROJECT_META("2d_editor", "theme_preview", theme_preview);
 
 	for (int i = 0; i < THEME_PREVIEW_MAX; i++) {
 		theme_menu->set_item_checked(i, i == theme_preview);
@@ -5064,12 +5064,12 @@ void CanvasItemEditor::clear() {
 	previous_update_view_offset = view_offset; // Moves the view a little bit to the left so that (0,0) is visible. The values a relative to a 16/10 screen.
 	_update_scrollbars();
 
-	grid_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_offset", Vector2());
-	grid_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_step", Vector2(8, 8));
-	primary_grid_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "primary_grid_step", Vector2i(8, 8));
-	snap_rotation_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_step", Math::deg_to_rad(15.0));
-	snap_rotation_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_offset", 0.0);
-	snap_scale_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_scale_step", 0.1);
+	grid_offset = GET_PROJECT_META("2d_editor", "grid_offset", Vector2());
+	grid_step = GET_PROJECT_META("2d_editor", "grid_step", Vector2(8, 8));
+	primary_grid_step = GET_PROJECT_META("2d_editor", "primary_grid_step", Vector2i(8, 8));
+	snap_rotation_step = GET_PROJECT_META("2d_editor", "snap_rotation_step", Math::deg_to_rad(15.0));
+	snap_rotation_offset = GET_PROJECT_META("2d_editor", "snap_rotation_offset", 0.0);
+	snap_scale_step = GET_PROJECT_META("2d_editor", "snap_scale_step", 0.1);
 }
 
 void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
@@ -5529,7 +5529,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	theme_menu->add_radio_check_item(TTR("Default theme"), THEME_PREVIEW_DEFAULT);
 	p->add_submenu_node_item(TTR("Preview Theme"), theme_menu);
 
-	theme_preview = (ThemePreviewMode)(int)EditorSettings::get_singleton()->get_project_metadata("2d_editor", "theme_preview", THEME_PREVIEW_PROJECT);
+	theme_preview = (ThemePreviewMode)(int)GET_PROJECT_META("2d_editor", "theme_preview", THEME_PREVIEW_PROJECT);
 	for (int i = 0; i < THEME_PREVIEW_MAX; i++) {
 		theme_menu->set_item_checked(i, i == theme_preview);
 	}

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -125,7 +125,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_FILE_SERVER), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
+				SET_PROJECT_META("debug_options", "run_file_server", !ischecked);
 			}
 
 		} break;
@@ -135,7 +135,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_LIVE_DEBUG), !ischecked);
 			EditorDebuggerNode::get_singleton()->set_live_debugging(!ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
+				SET_PROJECT_META("debug_options", "run_live_debug", !ischecked);
 			}
 
 		} break;
@@ -143,7 +143,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_deploy_remote_debug", !ischecked);
+				SET_PROJECT_META("debug_options", "run_deploy_remote_debug", !ischecked);
 			}
 
 		} break;
@@ -151,7 +151,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_COLLISIONS));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_COLLISIONS), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisions", !ischecked);
+				SET_PROJECT_META("debug_options", "run_debug_collisions", !ischecked);
 			}
 
 		} break;
@@ -159,7 +159,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", !ischecked);
+				SET_PROJECT_META("debug_options", "run_debug_paths", !ischecked);
 			}
 
 		} break;
@@ -167,7 +167,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
+				SET_PROJECT_META("debug_options", "run_debug_navigation", !ischecked);
 			}
 
 		} break;
@@ -175,7 +175,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_AVOIDANCE));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_AVOIDANCE), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_avoidance", !ischecked);
+				SET_PROJECT_META("debug_options", "run_debug_avoidance", !ischecked);
 			}
 
 		} break;
@@ -183,7 +183,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_CANVAS_REDRAW));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_CANVAS_REDRAW), !ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_canvas_redraw", !ischecked);
+				SET_PROJECT_META("debug_options", "run_debug_canvas_redraw", !ischecked);
 			}
 
 		} break;
@@ -193,7 +193,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 
 			ScriptEditor::get_singleton()->set_live_auto_reload_running_scripts(!ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
+				SET_PROJECT_META("debug_options", "run_reload_scripts", !ischecked);
 			}
 
 		} break;
@@ -203,7 +203,7 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 
 			EditorDebuggerNode::get_singleton()->set_keep_open(!ischecked);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "server_keep_open", !ischecked);
+				SET_PROJECT_META("debug_options", "server_keep_open", !ischecked);
 			}
 
 		} break;
@@ -228,16 +228,16 @@ void DebuggerEditorPlugin::_notification(int p_what) {
 }
 
 void DebuggerEditorPlugin::_update_debug_options() {
-	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
-	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
-	bool check_debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
-	bool check_debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);
-	bool check_debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
-	bool check_debug_avoidance = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_avoidance", false);
-	bool check_debug_canvas_redraw = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
-	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", true);
-	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", true);
-	bool check_server_keep_open = EditorSettings::get_singleton()->get_project_metadata("debug_options", "server_keep_open", false);
+	bool check_deploy_remote = GET_PROJECT_META("debug_options", "run_deploy_remote_debug", false);
+	bool check_file_server = GET_PROJECT_META("debug_options", "run_file_server", false);
+	bool check_debug_collisions = GET_PROJECT_META("debug_options", "run_debug_collisions", false);
+	bool check_debug_paths = GET_PROJECT_META("debug_options", "run_debug_paths", false);
+	bool check_debug_navigation = GET_PROJECT_META("debug_options", "run_debug_navigation", false);
+	bool check_debug_avoidance = GET_PROJECT_META("debug_options", "run_debug_avoidance", false);
+	bool check_debug_canvas_redraw = GET_PROJECT_META("debug_options", "run_debug_canvas_redraw", false);
+	bool check_live_debug = GET_PROJECT_META("debug_options", "run_live_debug", true);
+	bool check_reload_scripts = GET_PROJECT_META("debug_options", "run_reload_scripts", true);
+	bool check_server_keep_open = GET_PROJECT_META("debug_options", "server_keep_open", false);
 
 	if (check_deploy_remote) {
 		_menu_option(RUN_DEPLOY_REMOTE_DEBUG);

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -140,7 +140,7 @@ void MaterialEditor::_on_sphere_switch_pressed() {
 	sphere_instance->show();
 	box_switch->set_pressed(false);
 	sphere_switch->set_pressed(true);
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_on_sphere", true);
+	SET_PROJECT_META("inspector_options", "material_preview_on_sphere", true);
 }
 
 void MaterialEditor::_on_box_switch_pressed() {
@@ -148,7 +148,7 @@ void MaterialEditor::_on_box_switch_pressed() {
 	sphere_instance->hide();
 	box_switch->set_pressed(true);
 	sphere_switch->set_pressed(false);
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_on_sphere", false);
+	SET_PROJECT_META("inspector_options", "material_preview_on_sphere", false);
 }
 
 MaterialEditor::MaterialEditor() {
@@ -270,7 +270,7 @@ MaterialEditor::MaterialEditor() {
 	vb_light->add_child(light_2_switch);
 	light_2_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_light_2_switch_pressed));
 
-	if (EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_on_sphere", true)) {
+	if (GET_PROJECT_META("inspector_options", "material_preview_on_sphere", true)) {
 		box_instance->hide();
 	} else {
 		box_instance->show();

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6230,9 +6230,9 @@ void Node3DEditor::_snap_changed() {
 	snap_rotate_value = snap_rotate->get_text().to_float();
 	snap_scale_value = snap_scale->get_text().to_float();
 
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_translate_value", snap_translate_value);
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_rotate_value", snap_rotate_value);
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_scale_value", snap_scale_value);
+	SET_PROJECT_META("3d_editor", "snap_translate_value", snap_translate_value);
+	SET_PROJECT_META("3d_editor", "snap_rotate_value", snap_rotate_value);
+	SET_PROJECT_META("3d_editor", "snap_scale_value", snap_scale_value);
 }
 
 void Node3DEditor::_snap_update() {
@@ -8214,9 +8214,9 @@ void Node3DEditor::clear() {
 	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
 	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
 
-	snap_translate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_translate_value", 1);
-	snap_rotate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_rotate_value", 15);
-	snap_scale_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_scale_value", 10);
+	snap_translate_value = GET_PROJECT_META("3d_editor", "snap_translate_value", 1);
+	snap_rotate_value = GET_PROJECT_META("3d_editor", "snap_rotate_value", 15);
+	snap_scale_value = GET_PROJECT_META("3d_editor", "snap_scale_value", 10);
 	_snap_update();
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {

--- a/editor/plugins/particle_process_material_editor_plugin.cpp
+++ b/editor/plugins/particle_process_material_editor_plugin.cpp
@@ -271,7 +271,7 @@ void ParticleProcessMaterialMinMaxPropertyEditor::_update_mode() {
 
 void ParticleProcessMaterialMinMaxPropertyEditor::_toggle_mode(bool p_edit_mode) {
 	slider_mode = p_edit_mode ? Mode::MIDPOINT : Mode::RANGE;
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "particle_spin_mode", int(slider_mode));
+	SET_PROJECT_META("editor_metadata", "particle_spin_mode", int(slider_mode));
 	_update_mode();
 }
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -293,7 +293,7 @@ void Polygon2DEditor::_uv_edit_mode_select(int p_mode) {
 }
 
 void Polygon2DEditor::_uv_edit_popup_hide() {
-	EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "uv_editor", Rect2(uv_edit->get_position(), uv_edit->get_size()));
+	SET_PROJECT_META("dialog_bounds", "uv_editor", Rect2(uv_edit->get_position(), uv_edit->get_size()));
 	_cancel_editing();
 }
 
@@ -320,7 +320,7 @@ void Polygon2DEditor::_menu_option(int p_option) {
 				undo_redo->commit_action();
 			}
 
-			const Rect2 bounds = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "uv_editor", Rect2());
+			const Rect2 bounds = GET_PROJECT_META("dialog_bounds", "uv_editor", Rect2());
 			if (bounds.has_area()) {
 				uv_edit->popup(bounds);
 			} else {
@@ -425,36 +425,36 @@ void Polygon2DEditor::_commit_action() {
 
 void Polygon2DEditor::_set_use_snap(bool p_use) {
 	use_snap = p_use;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_enabled", p_use);
+	SET_PROJECT_META("polygon_2d_uv_editor", "snap_enabled", p_use);
 }
 
 void Polygon2DEditor::_set_show_grid(bool p_show) {
 	snap_show_grid = p_show;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "show_grid", p_show);
+	SET_PROJECT_META("polygon_2d_uv_editor", "show_grid", p_show);
 	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_off_x(real_t p_val) {
 	snap_offset.x = p_val;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
+	SET_PROJECT_META("polygon_2d_uv_editor", "snap_offset", snap_offset);
 	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_off_y(real_t p_val) {
 	snap_offset.y = p_val;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
+	SET_PROJECT_META("polygon_2d_uv_editor", "snap_offset", snap_offset);
 	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_step_x(real_t p_val) {
 	snap_step.x = p_val;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
+	SET_PROJECT_META("polygon_2d_uv_editor", "snap_step", snap_step);
 	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_step_y(real_t p_val) {
 	snap_step.y = p_val;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
+	SET_PROJECT_META("polygon_2d_uv_editor", "snap_step", snap_step);
 	uv_edit_draw->queue_redraw();
 }
 
@@ -1292,11 +1292,11 @@ Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
 }
 
 Polygon2DEditor::Polygon2DEditor() {
-	snap_offset = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_offset", Vector2());
+	snap_offset = GET_PROJECT_META("polygon_2d_uv_editor", "snap_offset", Vector2());
 	// A power-of-two value works better as a default grid size.
-	snap_step = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(8, 8));
-	use_snap = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_enabled", false);
-	snap_show_grid = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "show_grid", false);
+	snap_step = GET_PROJECT_META("polygon_2d_uv_editor", "snap_step", Vector2(8, 8));
+	use_snap = GET_PROJECT_META("polygon_2d_uv_editor", "snap_enabled", false);
+	snap_show_grid = GET_PROJECT_META("polygon_2d_uv_editor", "show_grid", false);
 
 	button_uv = memnew(Button);
 	button_uv->set_theme_type_variation("FlatButton");

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -741,7 +741,7 @@ void ScriptEditor::_add_recent_script(const String &p_path) {
 		return;
 	}
 
-	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scripts", Array());
+	Array rc = GET_PROJECT_META("recent_files", "scripts", Array());
 	if (rc.has(p_path)) {
 		rc.erase(p_path);
 	}
@@ -750,12 +750,12 @@ void ScriptEditor::_add_recent_script(const String &p_path) {
 		rc.resize(10);
 	}
 
-	EditorSettings::get_singleton()->set_project_metadata("recent_files", "scripts", rc);
+	SET_PROJECT_META("recent_files", "scripts", rc);
 	_update_recent_scripts();
 }
 
 void ScriptEditor::_update_recent_scripts() {
-	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scripts", Array());
+	Array rc = GET_PROJECT_META("recent_files", "scripts", Array());
 	recent_scripts->clear();
 
 	String path;
@@ -774,12 +774,12 @@ void ScriptEditor::_update_recent_scripts() {
 void ScriptEditor::_open_recent_script(int p_idx) {
 	// clear button
 	if (p_idx == recent_scripts->get_item_count() - 1) {
-		EditorSettings::get_singleton()->set_project_metadata("recent_files", "scripts", Array());
+		SET_PROJECT_META("recent_files", "scripts", Array());
 		callable_mp(this, &ScriptEditor::_update_recent_scripts).call_deferred();
 		return;
 	}
 
-	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scripts", Array());
+	Array rc = GET_PROJECT_META("recent_files", "scripts", Array());
 	ERR_FAIL_INDEX(p_idx, rc.size());
 
 	String path = rc[p_idx];
@@ -825,7 +825,7 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	}
 
 	rc.remove_at(p_idx);
-	EditorSettings::get_singleton()->set_project_metadata("recent_files", "scripts", rc);
+	SET_PROJECT_META("recent_files", "scripts", rc);
 	_update_recent_scripts();
 	_show_error_dialog(path);
 }
@@ -1240,7 +1240,7 @@ TypedArray<Script> ScriptEditor::_get_open_scripts() const {
 
 bool ScriptEditor::toggle_scripts_panel() {
 	list_split->set_visible(!list_split->is_visible());
-	EditorSettings::get_singleton()->set_project_metadata("scripts_panel", "show_scripts_panel", list_split->is_visible());
+	SET_PROJECT_META("scripts_panel", "show_scripts_panel", list_split->is_visible());
 	return list_split->is_visible();
 }
 
@@ -4028,7 +4028,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	list_split->add_child(overview_vbox);
-	list_split->set_visible(EditorSettings::get_singleton()->get_project_metadata("scripts_panel", "show_scripts_panel", true));
+	list_split->set_visible(GET_PROJECT_META("scripts_panel", "show_scripts_panel", true));
 	buttons_hbox = memnew(HBoxContainer);
 	overview_vbox->add_child(buttons_hbox);
 

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -856,10 +856,10 @@ void TextureRegionEditor::_notification(int p_what) {
 			}
 
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_offset", snap_offset);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_step", snap_step);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_separation", snap_separation);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_mode", snap_mode);
+				SET_PROJECT_META("texture_region_editor", "snap_offset", snap_offset);
+				SET_PROJECT_META("texture_region_editor", "snap_step", snap_step);
+				SET_PROJECT_META("texture_region_editor", "snap_separation", snap_separation);
+				SET_PROJECT_META("texture_region_editor", "snap_mode", snap_mode);
 			}
 		} break;
 
@@ -1116,10 +1116,10 @@ TextureRegionEditor::TextureRegionEditor() {
 	set_ok_button_text(TTR("Close"));
 
 	// A power-of-two value works better as a default grid size.
-	snap_offset = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_offset", Vector2());
-	snap_step = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_step", Vector2(8, 8));
-	snap_separation = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_separation", Vector2());
-	snap_mode = (SnapMode)(int)EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_mode", SNAP_NONE);
+	snap_offset = GET_PROJECT_META("texture_region_editor", "snap_offset", Vector2());
+	snap_step = GET_PROJECT_META("texture_region_editor", "snap_step", Vector2(8, 8));
+	snap_separation = GET_PROJECT_META("texture_region_editor", "snap_separation", Vector2());
+	snap_mode = (SnapMode)(int)GET_PROJECT_META("texture_region_editor", "snap_mode", SNAP_NONE);
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &TextureRegionEditor::_pan_callback), callable_mp(this, &TextureRegionEditor::_zoom_callback));

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -689,8 +689,8 @@ void GenericTilePolygonEditor::_set_snap_option(int p_index) {
 }
 
 void GenericTilePolygonEditor::_store_snap_options() {
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_snap_option", current_snap_option);
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_snap_subdiv", snap_subdivision->get_value());
+	SET_PROJECT_META("editor_metadata", "tile_snap_option", current_snap_option);
+	SET_PROJECT_META("editor_metadata", "tile_snap_subdiv", snap_subdivision->get_value());
 }
 
 void GenericTilePolygonEditor::_toggle_expand(bool p_expand) {
@@ -963,8 +963,8 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	button_center_view->set_disabled(true);
 	root->add_child(button_center_view);
 
-	snap_subdivision->set_value_no_signal(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_snap_subdiv", 4));
-	_set_snap_option(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_snap_option", SNAP_NONE));
+	snap_subdivision->set_value_no_signal(GET_PROJECT_META("editor_metadata", "tile_snap_subdiv", 4));
+	_set_snap_option(GET_PROJECT_META("editor_metadata", "tile_snap_option", SNAP_NONE));
 	initializing = false;
 }
 

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -2139,7 +2139,7 @@ void TileMapLayerEditorTilesPlugin::_set_source_sort(int p_sort) {
 	}
 	TilesEditorUtils::get_singleton()->set_sorting_option(p_sort);
 	_update_tile_set_sources_list();
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_source_sort", p_sort);
+	SET_PROJECT_META("editor_metadata", "tile_source_sort", p_sort);
 }
 
 void TileMapLayerEditorTilesPlugin::_bind_methods() {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -359,7 +359,7 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 	_update_sources_list(old_selected);
 
 	if (!first_edit) {
-		EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_source_sort", p_sort);
+		SET_PROJECT_META("editor_metadata", "tile_source_sort", p_sort);
 	}
 }
 
@@ -741,7 +741,7 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 
 		tile_set->connect_changed(callable_mp(this, &TileSetEditor::_tile_set_changed));
 		if (first_edit) {
-			_set_source_sort(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_source_sort", 0));
+			_set_source_sort(GET_PROJECT_META("editor_metadata", "tile_source_sort", 0));
 			first_edit = false;
 		} else {
 			_update_sources_list();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -50,7 +50,7 @@ void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs
 
 void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
+	Rect2 saved_size = GET_PROJECT_META("dialog_bounds", "project_settings", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
@@ -100,7 +100,7 @@ void ProjectSettingsEditor::_update_advanced(bool p_is_advanced) {
 }
 
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
-	EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", p_button_pressed);
+	SET_PROJECT_META("project_settings", "advanced_mode", p_button_pressed);
 	_update_advanced(p_button_pressed);
 	general_settings_inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
@@ -606,7 +606,7 @@ void ProjectSettingsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "project_settings", Rect2(get_position(), get_size()));
+				SET_PROJECT_META("dialog_bounds", "project_settings", Rect2(get_position(), get_size()));
 			}
 		} break;
 
@@ -771,7 +771,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	set_ok_button_text(TTR("Close"));
 	set_hide_on_ok(true);
 
-	bool use_advanced = EditorSettings::get_singleton()->get_project_metadata("project_settings", "advanced_mode", false);
+	bool use_advanced = GET_PROJECT_META("project_settings", "advanced_mode", false);
 
 	if (use_advanced) {
 		advanced->set_pressed(true);

--- a/editor/run_instances_dialog.cpp
+++ b/editor/run_instances_dialog.cpp
@@ -100,8 +100,8 @@ void RunInstancesDialog::_create_instance(InstanceData &p_instance, const Dictio
 void RunInstancesDialog::_save_main_args() {
 	ProjectSettings::get_singleton()->set_setting("editor/run/main_run_args", main_args_edit->get_text());
 	ProjectSettings::get_singleton()->save();
-	EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_main_feature_tags", main_features_edit->get_text());
-	EditorSettings::get_singleton()->set_project_metadata("debug_options", "multiple_instances_enabled", enable_multiple_instances_checkbox->is_pressed());
+	SET_PROJECT_META("debug_options", "run_main_feature_tags", main_features_edit->get_text());
+	SET_PROJECT_META("debug_options", "multiple_instances_enabled", enable_multiple_instances_checkbox->is_pressed());
 }
 
 void RunInstancesDialog::_save_arguments() {
@@ -116,7 +116,7 @@ void RunInstancesDialog::_save_arguments() {
 		dict["features"] = instance.get_feature_tags();
 		stored_data[i] = dict;
 	}
-	EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_instances_config", stored_data);
+	SET_PROJECT_META("debug_options", "run_instances_config", stored_data);
 }
 
 Vector<String> RunInstancesDialog::_split_cmdline_args(const String &p_arg_string) const {
@@ -279,7 +279,7 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	enable_multiple_instances_checkbox = memnew(CheckBox);
 	enable_multiple_instances_checkbox->set_text(TTR("Enable Multiple Instances"));
-	enable_multiple_instances_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "multiple_instances_enabled", false));
+	enable_multiple_instances_checkbox->set_pressed(GET_PROJECT_META("debug_options", "multiple_instances_enabled", false));
 	args_gc->add_child(enable_multiple_instances_checkbox);
 	enable_multiple_instances_checkbox->connect(SceneStringName(pressed), callable_mp(this, &RunInstancesDialog::_start_main_timer));
 
@@ -295,7 +295,7 @@ RunInstancesDialog::RunInstancesDialog() {
 		args_gc->add_child(l);
 	}
 
-	stored_data = TypedArray<Dictionary>(EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_instances_config", TypedArray<Dictionary>()));
+	stored_data = TypedArray<Dictionary>(GET_PROJECT_META("debug_options", "run_instances_config", TypedArray<Dictionary>()));
 
 	instance_count = memnew(SpinBox);
 	instance_count->set_min(1);
@@ -318,7 +318,7 @@ RunInstancesDialog::RunInstancesDialog() {
 	main_features_edit = memnew(LineEdit);
 	main_features_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	main_features_edit->set_placeholder(TTR("Comma-separated tags, example: demo, steam, event"));
-	main_features_edit->set_text(EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_main_feature_tags", ""));
+	main_features_edit->set_text(GET_PROJECT_META("debug_options", "run_main_feature_tags", ""));
 	args_gc->add_child(main_features_edit);
 	main_features_edit->connect("text_changed", callable_mp(this, &RunInstancesDialog::_start_main_timer).unbind(1));
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -120,7 +120,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 				}
 			}
 
-			String last_language = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
+			String last_language = GET_PROJECT_META("script_setup", "last_selected_language", "");
 			if (!last_language.is_empty()) {
 				for (int i = 0; i < language_menu->get_item_count(); i++) {
 					if (language_menu->get_item_text(i) == last_language) {
@@ -292,9 +292,9 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 	if (is_using_templates && !parent_name->get_text().begins_with("\"res:")) {
 		if (sinfo.origin == ScriptLanguage::TemplateLocation::TEMPLATE_PROJECT) {
 			// Save the last used template for this node into the project dictionary.
-			Dictionary dic_templates_project = EditorSettings::get_singleton()->get_project_metadata("script_setup", "templates_dictionary", Dictionary());
+			Dictionary dic_templates_project = GET_PROJECT_META("script_setup", "templates_dictionary", Dictionary());
 			dic_templates_project[parent_name->get_text()] = sinfo.get_hash();
-			EditorSettings::get_singleton()->set_project_metadata("script_setup", "templates_dictionary", dic_templates_project);
+			SET_PROJECT_META("script_setup", "templates_dictionary", dic_templates_project);
 		} else {
 			// Save template info to editor dictionary (not a project template).
 			Dictionary dic_templates;
@@ -304,10 +304,10 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 			dic_templates[parent_name->get_text()] = sinfo.get_hash();
 			EditorSettings::get_singleton()->set_meta("script_setup_templates_dictionary", dic_templates);
 			// Remove template from project dictionary as we last used an editor level template.
-			Dictionary dic_templates_project = EditorSettings::get_singleton()->get_project_metadata("script_setup", "templates_dictionary", Dictionary());
+			Dictionary dic_templates_project = GET_PROJECT_META("script_setup", "templates_dictionary", Dictionary());
 			if (dic_templates_project.has(parent_name->get_text())) {
 				dic_templates_project.erase(parent_name->get_text());
-				EditorSettings::get_singleton()->set_project_metadata("script_setup", "templates_dictionary", dic_templates_project);
+				SET_PROJECT_META("script_setup", "templates_dictionary", dic_templates_project);
 			}
 		}
 	}
@@ -396,7 +396,7 @@ void ScriptCreateDialog::_language_changed(int l) {
 	_path_changed(path);
 	file_path->set_text(path);
 
-	EditorSettings::get_singleton()->set_project_metadata("script_setup", "last_selected_language", language_menu->get_item_text(language_menu->get_selected()));
+	SET_PROJECT_META("script_setup", "last_selected_language", language_menu->get_item_text(language_menu->get_selected()));
 
 	_parent_name_changed(parent_name->get_text());
 	validation_panel->update();
@@ -508,7 +508,7 @@ void ScriptCreateDialog::_update_template_menu() {
 
 	if (is_language_using_templates) {
 		// Get the latest templates used for each type of node from project settings then global settings.
-		Dictionary last_local_templates = EditorSettings::get_singleton()->get_project_metadata("script_setup", "templates_dictionary", Dictionary());
+		Dictionary last_local_templates = GET_PROJECT_META("script_setup", "templates_dictionary", Dictionary());
 		Dictionary last_global_templates;
 		if (EditorSettings::get_singleton()->has_meta("script_setup_templates_dictionary")) {
 			last_global_templates = (Dictionary)EditorSettings::get_singleton()->get_meta("script_setup_templates_dictionary");

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -48,7 +48,7 @@ enum ShaderType {
 void ShaderCreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			String last_lang = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_language", "");
+			String last_lang = GET_PROJECT_META("shader_setup", "last_selected_language", "");
 			if (!last_lang.is_empty()) {
 				for (int i = 0; i < type_menu->get_item_count(); i++) {
 					if (type_menu->get_item_text(i) == last_lang) {
@@ -61,7 +61,7 @@ void ShaderCreateDialog::_notification(int p_what) {
 				type_menu->select(default_type);
 			}
 
-			current_mode = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_mode", 0);
+			current_mode = GET_PROJECT_META("shader_setup", "last_selected_mode", 0);
 			mode_menu->select(current_mode);
 		} break;
 
@@ -118,12 +118,12 @@ void ShaderCreateDialog::_path_hbox_sorted() {
 
 void ShaderCreateDialog::_mode_changed(int p_mode) {
 	current_mode = p_mode;
-	EditorSettings::get_singleton()->set_project_metadata("shader_setup", "last_selected_mode", p_mode);
+	SET_PROJECT_META("shader_setup", "last_selected_mode", p_mode);
 }
 
 void ShaderCreateDialog::_template_changed(int p_template) {
 	current_template = p_template;
-	EditorSettings::get_singleton()->set_project_metadata("shader_setup", "last_selected_template", p_template);
+	SET_PROJECT_META("shader_setup", "last_selected_template", p_template);
 }
 
 void ShaderCreateDialog::ok_pressed() {
@@ -309,7 +309,7 @@ void ShaderCreateDialog::_type_changed(int p_language) {
 	template_menu->clear();
 
 	if (shader_type_data.use_templates) {
-		int last_template = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_template", 0);
+		int last_template = GET_PROJECT_META("shader_setup", "last_selected_template", 0);
 
 		template_menu->add_item(TTR("Default"));
 		template_menu->add_item(TTR("Empty"));
@@ -320,7 +320,7 @@ void ShaderCreateDialog::_type_changed(int p_language) {
 		template_menu->add_item(TTR("N/A"));
 	}
 
-	EditorSettings::get_singleton()->set_project_metadata("shader_setup", "last_selected_language", type_menu->get_item_text(type_menu->get_selected()));
+	SET_PROJECT_META("shader_setup", "last_selected_language", type_menu->get_item_text(type_menu->get_selected()));
 	validation_panel->update();
 }
 

--- a/editor/surface_upgrade_tool.cpp
+++ b/editor/surface_upgrade_tool.cpp
@@ -95,14 +95,14 @@ void SurfaceUpgradeTool::_show_popup() {
 }
 
 void SurfaceUpgradeTool::prepare_upgrade() {
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "run_on_restart", true);
+	SET_PROJECT_META("surface_upgrade_tool", "run_on_restart", true);
 
 	Vector<String> reimport_paths;
 	Vector<String> resave_paths;
 	_add_files(EditorFileSystem::get_singleton()->get_filesystem(), reimport_paths, resave_paths);
 
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "reimport_paths", reimport_paths);
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "resave_paths", resave_paths);
+	SET_PROJECT_META("surface_upgrade_tool", "reimport_paths", reimport_paths);
+	SET_PROJECT_META("surface_upgrade_tool", "resave_paths", resave_paths);
 
 	// Delay to avoid deadlocks, since this dialog can be triggered by loading a scene.
 	callable_mp(EditorNode::get_singleton(), &EditorNode::restart_editor).call_deferred();
@@ -112,7 +112,7 @@ void SurfaceUpgradeTool::prepare_upgrade() {
 void SurfaceUpgradeTool::begin_upgrade() {
 	updating = true;
 
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "run_on_restart", false);
+	SET_PROJECT_META("surface_upgrade_tool", "run_on_restart", false);
 	RS::get_singleton()->set_surface_upgrade_callback(nullptr);
 	RS::get_singleton()->set_warn_on_surface_upgrade(false);
 }
@@ -121,8 +121,8 @@ void SurfaceUpgradeTool::finish_upgrade() {
 	EditorNode::get_singleton()->trigger_menu_option(EditorNode::FILE_CLOSE_ALL, true);
 
 	// Update all meshes here.
-	Vector<String> resave_paths = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "resave_paths", Vector<String>());
-	Vector<String> reimport_paths = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "reimport_paths", Vector<String>());
+	Vector<String> resave_paths = GET_PROJECT_META("surface_upgrade_tool", "resave_paths", Vector<String>());
+	Vector<String> reimport_paths = GET_PROJECT_META("surface_upgrade_tool", "reimport_paths", Vector<String>());
 	EditorProgress ep("surface_upgrade_resave", TTR("Upgrading All Meshes in Project"), resave_paths.size() + reimport_paths.size());
 
 	int step = 0;
@@ -134,7 +134,7 @@ void SurfaceUpgradeTool::finish_upgrade() {
 			ResourceSaver::save(res);
 		}
 	}
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "resave_paths", Vector<String>());
+	SET_PROJECT_META("surface_upgrade_tool", "resave_paths", Vector<String>());
 
 	// Remove the imported scenes/meshes from .import so they will be reimported automatically after this.
 	for (const String &file_path : reimport_paths) {
@@ -160,7 +160,7 @@ void SurfaceUpgradeTool::finish_upgrade() {
 			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + remap_path + "\n");
 		}
 	}
-	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "reimport_paths", Vector<String>());
+	SET_PROJECT_META("surface_upgrade_tool", "reimport_paths", Vector<String>());
 
 	emit_signal(SNAME("upgrade_finished"));
 }


### PR DESCRIPTION
`EditorSettings::get_singleton()->set/get_project_metadata()` is used fairly often, but it's overly verbose.
This PR adds shorthand macros: `SET_PROJECT_META` and `GET_PROJECT_META`.