### PR TITLE
Avoid editor error reporting using resource loader thread's call queues

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -226,7 +226,7 @@ public:
 	// Loaders can safely use this regardless which thread they are running on.
 	static void notify_load_error(const String &p_err) {
 		if (err_notify) {
-			callable_mp_static(err_notify).call_deferred(p_err);
+			MessageQueue::get_main_singleton()->push_callable(callable_mp_static(err_notify).bind(p_err));
 		}
 	}
 	static void set_error_notify_func(ResourceLoadErrorNotify p_err_notify) {
@@ -239,7 +239,7 @@ public:
 			if (Thread::get_caller_id() == Thread::get_main_id()) {
 				dep_err_notify(p_path, p_dependency, p_type);
 			} else {
-				callable_mp_static(dep_err_notify).call_deferred(p_path, p_dependency, p_type);
+				MessageQueue::get_main_singleton()->push_callable(callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type));
 			}
 		}
 	}

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -164,6 +164,7 @@ class MessageQueue : public CallQueue {
 
 public:
 	_FORCE_INLINE_ static CallQueue *get_singleton() { return thread_singleton ? thread_singleton : main_singleton; }
+	_FORCE_INLINE_ static CallQueue *get_main_singleton() { return main_singleton; }
 
 	static void set_thread_singleton_override(CallQueue *p_thread_singleton);
 

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -406,7 +406,7 @@ void EditorToaster::popup_str(const String &p_message, Severity p_severity, cons
 	// Since "_popup_str" adds nodes to the tree, and since the "add_child" method is not
 	// thread-safe, it's better to defer the call to the next cycle to be thread-safe.
 	is_processing_error = true;
-	callable_mp(this, &EditorToaster::_popup_str).call_deferred(p_message, p_severity, p_tooltip);
+	MessageQueue::get_main_singleton()->push_callable(callable_mp(this, &EditorToaster::_popup_str).bind(p_message, p_severity, p_tooltip));
 	is_processing_error = false;
 }
 


### PR DESCRIPTION
After #91630, deferred calls happening during a resource load going on a non-main thread, are flushed on that very thread. As a result, the mesaures in place for thread-safety so that the editor UI is not updated from a non-main thread need an update, which this PR performs.

Formerly, it was enough for those pieces of code to defer the call in case the caller thread wasn't the main one. However, given the potential flush-on-non-main-thread situation, that second-hand call must explicitly be pushed to the main call queue so it eventually happend on the main thread.

In a way, this requirement introduced by #91630 is a compat breakage. However, I'd say the surface is very small and it seems to be fully solvable in the editor code itself. Maybe some extensions or plugins need to be aware of this as well and perform the appropriate changes, though.

Fixes EditorToaster deadlock in https://github.com/godotengine/godot/issues/85255#issuecomment-2130237839.

**NOTE:** I haven't tested this myself.