### PR TITLE
Add `Tween::has_tweeners()`

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -144,6 +144,12 @@
 				[b]Note:[/b] As it results from accumulating frame deltas, the time returned after the [Tween] has finished animating will be slightly greater than the actual [Tween] duration.
 			</description>
 		</method>
+		<method name="has_tweeners" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if any [Tweener] has been added to the [Tween] and the [Tween] is valid. Useful when tweeners are added dynamically and the tween can end up empty. Killing an empty tween before it starts will prevent errors.
+			</description>
+		</method>
 		<method name="interpolate_value" qualifiers="static">
 			<return type="Variant" />
 			<param index="0" name="initial_value" type="Variant" />

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -182,6 +182,10 @@ void Tween::kill() {
 	dead = true;
 }
 
+bool Tween::has_tweeners() const {
+	return !tweeners.is_empty();
+}
+
 bool Tween::is_running() {
 	return running;
 }
@@ -441,6 +445,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("kill"), &Tween::kill);
 	ClassDB::bind_method(D_METHOD("get_total_elapsed_time"), &Tween::get_total_time);
 
+	ClassDB::bind_method(D_METHOD("has_tweeners"), &Tween::has_tweeners);
 	ClassDB::bind_method(D_METHOD("is_running"), &Tween::is_running);
 	ClassDB::bind_method(D_METHOD("is_valid"), &Tween::is_valid);
 	ClassDB::bind_method(D_METHOD("bind_node", "node"), &Tween::bind_node);

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -151,6 +151,7 @@ public:
 	void play();
 	void kill();
 
+	bool has_tweeners() const;
 	bool is_running();
 	bool is_valid();
 	void clear();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Add `Tween::has_tweeners()`.
So we can check and kill a tween if it has not contains any tweener before it step by scene tree and avoid print an error.
