### PR TITLE
Add Autocompletion Filtering as an editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1076,6 +1076,12 @@
 		<member name="text_editor/completion/auto_brace_complete" type="bool" setter="" getter="">
 			If [code]true[/code], automatically completes braces when making use of code completion.
 		</member>
+		<member name="text_editor/completion/autocompletion_filtering" type="int" setter="" getter="">
+			Filters autocompletion results.
+			- [b]Default[/b] will show all results that feature the input characters in the given order, but not necessarily grouped as a substring.
+			- [b]Beginning Matching Only[/b] will only show results that start with given input.
+			- [b]Any Substring Matching[/b] will show all results that feature the given input as a substring.
+		</member>
 		<member name="text_editor/completion/code_complete_delay" type="float" setter="" getter="">
 			The delay in seconds after which autocompletion suggestions should be displayed when the user stops typing.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1058,6 +1058,7 @@ void CodeTextEditor::update_editor_settings() {
 	// Completion
 	text_editor->set_auto_brace_completion_enabled(EDITOR_GET("text_editor/completion/auto_brace_complete"));
 	text_editor->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
+	text_editor->set_code_autocompletion_type(EDITOR_GET("text_editor/completion/autocompletion_filtering"));
 	code_complete_enabled = EDITOR_GET("text_editor/completion/code_complete_enabled");
 	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -659,6 +659,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false);
 
 	// Completion
+	String autocompletion_filtering_options = "Default,Beginning Matching Only,Any Substring Matching";
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/completion/autocompletion_filtering", 0, autocompletion_filtering_options);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 2.0, "0.1,10,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true);
 	_initial_set("text_editor/completion/code_complete_enabled", true);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1631,6 +1631,36 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	code_editor->toggle_inline_comment(delimiter);
 }
 
+void ScriptTextEditor::set_autocompletion_filtering(String p_autocompletion, CodeEdit::CodeAutocompletionType a_type) {
+	ERR_FAIL_COND(p_autocompletion.is_empty());
+	for (String mode : autocompletion_modes) {
+		int autocomletion_index = autocompletion_menu->get_item_idx_from_text(mode);
+		autocompletion_menu->set_item_checked(autocomletion_index, mode == p_autocompletion);
+	}
+
+	CodeEdit *te = code_editor->get_text_editor();
+	te->set_code_autocompletion_type(a_type);
+}
+
+void ScriptTextEditor::_change_autocompletion_filtering(int p_idx) {
+	CodeEdit::CodeAutocompletionType type = CodeEdit::AUTOCOMPLETION_DEFAULT;
+	switch (p_idx) {
+		case 0: {
+			type = CodeEdit::AUTOCOMPLETION_DEFAULT;
+			break;
+		}
+		case 1: {
+			type = CodeEdit::AUTOCOMPLETION_BEGINNING_MATCH;
+			break;
+		}
+		case 2: {
+			type = CodeEdit::AUTOCOMPLETION_SUBSTRING_MATCH;
+			break;
+		}
+	}
+	set_autocompletion_filtering(autocompletion_menu->get_item_text(p_idx), type);
+}
+
 void ScriptTextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
@@ -2319,6 +2349,8 @@ void ScriptTextEditor::_enable_code_editor() {
 	}
 	edit_menu->get_popup()->add_submenu_node_item(TTR("Syntax Highlighter"), highlighter_menu);
 	highlighter_menu->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_change_syntax_highlighter));
+	edit_menu->get_popup()->add_submenu_node_item(TTR("Autocompletion Filtering"), autocompletion_menu);
+	autocompletion_menu->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_change_autocompletion_filtering));
 
 	edit_hb->add_child(search_menu);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
@@ -2415,6 +2447,17 @@ ScriptTextEditor::ScriptTextEditor() {
 	highlighter.instantiate();
 	add_syntax_highlighter(highlighter);
 	set_syntax_highlighter(highlighter);
+
+	autocompletion_menu = memnew(PopupMenu);
+
+	autocompletion_menu->add_radio_check_item("Default");
+	autocompletion_modes.push_back("Default");
+	autocompletion_menu->add_radio_check_item("Beginning Matching Only");
+	autocompletion_modes.push_back("Beginning Matching Only");
+	autocompletion_menu->add_radio_check_item("Any Substring Matching");
+	autocompletion_modes.push_back("Any Substring Matching");
+
+	set_autocompletion_filtering("Default", CodeEdit::AUTOCOMPLETION_DEFAULT);
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_text(TTR("Search"));

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -84,6 +84,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	PopupMenu *breakpoints_menu = nullptr;
 	PopupMenu *highlighter_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
+	PopupMenu *autocompletion_menu = nullptr;
 
 	GotoLineDialog *goto_line_dialog = nullptr;
 	ScriptEditorQuickOpen *quick_open = nullptr;
@@ -207,12 +208,17 @@ protected:
 
 	String _get_absolute_path(const String &rel_path);
 
+	List<String> autocompletion_modes;
+	void _change_autocompletion_filtering(int p_idx);
+
 public:
 	void _update_connected_methods();
 
 	virtual void add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
 	virtual void set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
 	void update_toggle_scripts_button() override;
+
+	void set_autocompletion_filtering(String p_autocompletion, CodeEdit::CodeAutocompletionType a_type);
 
 	virtual void apply_code() override;
 	virtual Ref<Resource> get_edited_resource() const override;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -61,6 +61,36 @@ void TextEditor::_change_syntax_highlighter(int p_idx) {
 	set_syntax_highlighter(highlighters[highlighter_menu->get_item_text(p_idx)]);
 }
 
+void TextEditor::set_autocompletion_filtering(String p_autocompletion, CodeEdit::CodeAutocompletionType a_type) {
+	ERR_FAIL_COND(p_autocompletion.is_empty());
+	for (String mode : autocompletion_modes) {
+		int autocomletion_index = autocompletion_menu->get_item_idx_from_text(mode);
+		autocompletion_menu->set_item_checked(autocomletion_index, mode == p_autocompletion);
+	}
+
+	CodeEdit *te = code_editor->get_text_editor();
+	te->set_code_autocompletion_type(a_type);
+}
+
+void TextEditor::_change_autocompletion_filtering(int p_idx) {
+	CodeEdit::CodeAutocompletionType type = CodeEdit::AUTOCOMPLETION_DEFAULT;
+	switch (p_idx) {
+		case 0: {
+			type = CodeEdit::AUTOCOMPLETION_DEFAULT;
+			break;
+		}
+		case 1: {
+			type = CodeEdit::AUTOCOMPLETION_BEGINNING_MATCH;
+			break;
+		}
+		case 2: {
+			type = CodeEdit::AUTOCOMPLETION_SUBSTRING_MATCH;
+			break;
+		}
+	}
+	set_autocompletion_filtering(autocompletion_menu->get_item_text(p_idx), type);
+}
+
 void TextEditor::_load_theme_settings() {
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
 }
@@ -664,6 +694,19 @@ TextEditor::TextEditor() {
 	highlighter.instantiate();
 	add_syntax_highlighter(highlighter);
 	set_syntax_highlighter(plain_highlighter);
+
+	autocompletion_menu = memnew(PopupMenu);
+	edit_menu->get_popup()->add_submenu_node_item(TTR("Autocompletion Filtering"), autocompletion_menu);
+	autocompletion_menu->connect("id_pressed", callable_mp(this, &TextEditor::_change_autocompletion_filtering));
+
+	autocompletion_menu->add_radio_check_item("Default");
+	autocompletion_modes.push_back("Default");
+	autocompletion_menu->add_radio_check_item("Beginning Matching Only");
+	autocompletion_modes.push_back("Beginning Matching Only");
+	autocompletion_menu->add_radio_check_item("Any Substring Matching");
+	autocompletion_modes.push_back("Any Substring Matching");
+
+	set_autocompletion_filtering("Default", CodeEdit::AUTOCOMPLETION_DEFAULT);
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_shortcut_context(this);

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -52,6 +52,7 @@ private:
 	MenuButton *search_menu = nullptr;
 	PopupMenu *bookmarks_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
+	PopupMenu *autocompletion_menu = nullptr;
 
 	GotoLineDialog *goto_line_dialog = nullptr;
 
@@ -109,9 +110,14 @@ protected:
 	void _update_bookmark_list();
 	void _bookmark_item_pressed(int p_idx);
 
+	List<String> autocompletion_modes;
+	void _change_autocompletion_filtering(int p_idx);
+
 public:
 	virtual void add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
 	virtual void set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
+
+	void set_autocompletion_filtering(String p_autocompletion, CodeEdit::CodeAutocompletionType a_type);
 
 	virtual String get_name() override;
 	virtual Ref<Texture2D> get_theme_icon() override;

--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -25,6 +25,7 @@ The config file contains two section:
 
 - `cs: boolean = false`: If `true`, the test will be skipped when running a non C# build.
 - `use_single_quotes: boolean = false`: Configures the corresponding editor setting for the test.
+- `autocompletion_filtering: int = 0`: Configures the corresponding editor setting for the test (0 for "Default", 1 for "Beginning Matching Only", 2 for "Any Substring Matching").
 - `scene: String`: Allows to specify a scene which is opened while autocompletion is performed. If this is not set the test runner will search for a `.tscn` file with the same basename as the GDScript file. If that isn't found either, autocompletion will behave as if no scene was opened.
 - `node_path: String`: The node path of the node which holds the current script inside of the scene. Defaults to the scene root node.
 

--- a/modules/gdscript/tests/scripts/completion/completion_options/beginning_option.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/beginning_option.cfg
@@ -1,0 +1,15 @@
+[input]
+autocompletion_filtering=1
+
+[output]
+include=[
+    {"display": "assert"},
+]
+exclude=[
+    {"display": "myAssertion"},
+    {"display": "aqsqsqeqrqt"},
+    {"display": "has_user_signal"},
+    {"display": "JavaClassWrapper"},
+    {"display": "MIDI_MESSAGE_SYSTEM_RESET"},
+    {"display": "GodotPhysicsServer2D"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/beginning_option.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/beginning_option.gd
@@ -1,0 +1,8 @@
+extends Node
+
+func _ready():
+    var myAssertion
+    var aqsqsqeqrqt
+
+    asse➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/completion_options/beginning_option_attributes.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/beginning_option_attributes.cfg
@@ -1,0 +1,16 @@
+[input]
+autocompletion_filtering=1
+
+[output]
+include=[
+    {"display": "ProcessThreadMessages"},
+    {"display": "PROCESS_THREAD_GROUP_INHERIT"},
+    {"display": "PROCESS_MODE_PAUSABLE"},
+]
+exclude=[
+    {"display": "NOTIFICATION_PROCESS"},
+    {"display": "FLAG_PROCESS_THREAD_MESSAGES"},
+    {"display": "print_orphan_nodes"},
+    {"display": "LayoutPresetMode"},
+    {"display": "DUPLICATE_GROUPS"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/beginning_option_attributes.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/beginning_option_attributes.gd
@@ -1,0 +1,5 @@
+extends Node
+
+func _ready():
+    var t = Control.pro➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/completion_options/default_option.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/default_option.cfg
@@ -1,0 +1,13 @@
+[input]
+autocompletion_filtering=0
+
+[output]
+include=[
+    {"display": "myAssertion"},
+    {"display": "assert"},
+    {"display": "aqsqsqeqrqt"},
+    {"display": "has_user_signal"},
+    {"display": "JavaClassWrapper"},
+    {"display": "MIDI_MESSAGE_SYSTEM_RESET"},
+    {"display": "GodotPhysicsServer2D"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/default_option.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/default_option.gd
@@ -1,0 +1,8 @@
+extends Node
+
+func _ready():
+    var myAssertion
+    var aqsqsqeqrqt
+
+    sser➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/completion_options/default_option_attributes.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/default_option_attributes.cfg
@@ -1,0 +1,14 @@
+[input]
+autocompletion_filtering=0
+
+[output]
+include=[
+    {"display": "ProcessThreadMessages"},
+    {"display": "PROCESS_THREAD_GROUP_INHERIT"},
+    {"display": "NOTIFICATION_PROCESS"},
+    {"display": "FLAG_PROCESS_THREAD_MESSAGES"},
+    {"display": "PROCESS_MODE_PAUSABLE"},
+    {"display": "print_orphan_nodes"},
+    {"display": "LayoutPresetMode"},
+    {"display": "DUPLICATE_GROUPS"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/default_option_attributes.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/default_option_attributes.gd
@@ -1,0 +1,5 @@
+extends Node
+
+func _ready():
+    var t = Control.pro➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/completion_options/substring_option.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/substring_option.cfg
@@ -1,0 +1,15 @@
+[input]
+autocompletion_filtering=2
+
+[output]
+include=[
+    {"display": "myAssertion"},
+    {"display": "assert"},
+    {"display": "GodotPhysicsServer2D"},
+]
+exclude=[
+    {"display": "aqsqsqeqrqt"},
+    {"display": "has_user_signal"},
+    {"display": "JavaClassWrapper"},
+    {"display": "MIDI_MESSAGE_SYSTEM_RESET"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/substring_option.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/substring_option.gd
@@ -1,0 +1,8 @@
+extends Node
+
+func _ready():
+    var myAssertion
+    var aqsqsqeqrqt
+
+    sser➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/completion_options/substring_option_attributes.cfg
+++ b/modules/gdscript/tests/scripts/completion/completion_options/substring_option_attributes.cfg
@@ -1,0 +1,16 @@
+[input]
+autocompletion_filtering=2
+
+[output]
+include=[
+    {"display": "ProcessThreadMessages"},
+    {"display": "PROCESS_THREAD_GROUP_INHERIT"},
+    {"display": "PROCESS_MODE_PAUSABLE"},
+    {"display": "NOTIFICATION_PROCESS"},
+    {"display": "FLAG_PROCESS_THREAD_MESSAGES"},
+]
+exclude=[
+    {"display": "print_orphan_nodes"},
+    {"display": "LayoutPresetMode"},
+    {"display": "DUPLICATE_GROUPS"},
+]

--- a/modules/gdscript/tests/scripts/completion/completion_options/substring_option_attributes.gd
+++ b/modules/gdscript/tests/scripts/completion/completion_options/substring_option_attributes.gd
@@ -1,0 +1,5 @@
+extends Node
+
+func _ready():
+    var t = Control.pro➡
+    pass

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -61,6 +61,12 @@ public:
 		LOCATION_OTHER = 1 << 10,
 	};
 
+	enum CodeAutocompletionType {
+		AUTOCOMPLETION_DEFAULT,
+		AUTOCOMPLETION_SUBSTRING_MATCH,
+		AUTOCOMPLETION_BEGINNING_MATCH,
+	};
+
 private:
 	/* Indent management */
 	int indent_size = 4;
@@ -214,6 +220,7 @@ private:
 	int code_completion_longest_line = 0;
 	Rect2i code_completion_rect;
 	Rect2i code_completion_scroll_rect;
+	CodeAutocompletionType autocompletion_type = AUTOCOMPLETION_DEFAULT;
 
 	HashSet<char32_t> code_completion_prefixes;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_submitted;
@@ -478,6 +485,9 @@ public:
 
 	void confirm_code_completion(bool p_replace = false);
 	void cancel_code_completion();
+
+	void set_code_autocompletion_type(CodeAutocompletionType p_type);
+	void set_code_autocompletion_type(int p_idx);
 
 	/* Line length guidelines */
 	void set_line_length_guidelines(TypedArray<int> p_guideline_columns);


### PR DESCRIPTION
Based on godot proposal #9182 (https://github.com/godotengine/godot-proposals/issues/9182)
This feature may be useful for less experienced users, as it may help them feel less overwhelmed by the number of suggestions, but it can also be timesaving for more experienced developers, as it makes autocompletion more focused.

Me and my partner implemented a way for the user to choose what kind of suggestions appear in the autocompletion window while coding in gdscript. We implemented 3 modes: "Default", "Beginning Matching Only" and "Any substring matching".
They work as follows for the string example "asse":
- **"Default"** corresponds to the previously implemented mode in Godot, where suggestions like "has_user_signal" and "JavaClassWrapper" are made;
- **"Begining Matching Only"** only shows suggestions whose begining matches with the user input, and so the only option that appears is "assert";
- **"Any Substring Matching"** shows all options that have a substring that matches with the user input somewhere, as such "assert" appears too and variables with names like "myAssertion" appear as well.

The user can change the setting in the "Edit" tab in the editor itself or in Editor Settings, in the "Completion" section. The results may be inconsistent tho, so any additional advice that may help us solve this issue is greatly appreciated!

In order to test this feature, we also implemented a new input parameter in test_completion tests that allows the test creator to choose which filtering setting they want to use (similar to use_single_quotes). Additional unit tests were provided as well.

Once again, every aditional feedback or advice is welcome!

![photo-collage png](https://github.com/godotengine/godot/assets/105984468/dbc655db-d40b-4f53-944d-40650fcbfa3f)
On the left, the location of the switch. On the right, from top to bottom, the different results for the same input for modes "Default", "Beginning Matching Only" and "Any Substring Matching", respectively. (The typo seen in the picture has been fixed)