### PR TITLE
Add a string replace method to handle multiple search keys efficiently.

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -415,7 +415,8 @@ Color Color::named(const String &p_name, const Color &p_default) {
 int Color::find_named_color(const String &p_name) {
 	String name = p_name;
 	// Normalize name.
-	name = name.replace(Vector<String>({ " ", "-", "_", "'", "." }), "");
+	static Vector<String> to_replace({ " ", "-", "_", "'", "." });
+	name = name.replace(to_replace, "");
 	name = name.to_upper();
 
 	static HashMap<String, int> named_colors_hashmap;

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -415,11 +415,7 @@ Color Color::named(const String &p_name, const Color &p_default) {
 int Color::find_named_color(const String &p_name) {
 	String name = p_name;
 	// Normalize name.
-	name = name.replace(" ", "");
-	name = name.replace("-", "");
-	name = name.replace("_", "");
-	name = name.replace("'", "");
-	name = name.replace(".", "");
+	name = name.replace(Vector<String>({ " ", "-", "_", "'", "." }), "");
 	name = name.to_upper();
 
 	static HashMap<String, int> named_colors_hashmap;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -243,10 +243,7 @@ String OS::get_safe_dir_name(const String &p_dir_name, bool p_allow_paths) const
 			safe_dir_name = "twodots";
 		}
 	}
-
-	for (int i = 0; i < invalid_chars.size(); i++) {
-		safe_dir_name = safe_dir_name.replace(invalid_chars[i], "-");
-	}
+	safe_dir_name = safe_dir_name.replace(invalid_chars, "-");
 	return safe_dir_name;
 }
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4103,8 +4103,9 @@ String String::replace(const Vector<String> &p_keys, const String &p_with) const
 
 		for (const String &key : p_keys) {
 			const int key_len = key.length();
-			if (src_pos + key_len > len || key_len == 0)
+			if (src_pos + key_len > len || key_len == 0) {
 				continue;
+			}
 
 			bool found = true;
 			for (int k = 0; k < key_len; k++) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4103,7 +4103,7 @@ String String::replace(const Vector<String> &p_keys, const String &p_with) const
 
 		for (const String &key : p_keys) {
 			const int key_len = key.length();
-			if (src_pos + key_len > len)
+			if (src_pos + key_len > len || key_len == 0)
 				continue;
 
 			bool found = true;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4117,7 +4117,7 @@ String String::replace(const Vector<String> &p_keys, const String &p_with) const
 			if (found) {
 				replaced = true;
 				new_string += p_with;
-				src_pos += key_len;
+				src_pos += key_len - 1;
 				break;
 			}
 		}

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4093,6 +4093,43 @@ String String::replacen(const char *p_key, const char *p_with) const {
 	return new_string;
 }
 
+String String::replace(const Vector<String> &p_keys, const String &p_with) const {
+	String new_string;
+
+	const int len = length();
+	for (int src_pos = 0; src_pos < len; src_pos++) {
+		bool replaced = false;
+		const char32_t *src = &operator[](src_pos);
+
+		for (const String &key : p_keys) {
+			const int key_len = key.length();
+			if (src_pos + key_len > len)
+				continue;
+
+			bool found = true;
+			for (int k = 0; k < key_len; k++) {
+				if (key[k] != src[k]) {
+					found = false;
+					break;
+				}
+			}
+
+			if (found) {
+				replaced = true;
+				new_string += p_with;
+				src_pos += key_len;
+				break;
+			}
+		}
+
+		if (!replaced) {
+			new_string += src[0];
+		}
+	}
+
+	return new_string;
+}
+
 String String::repeat(int p_count) const {
 	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
 
@@ -5048,9 +5085,7 @@ bool String::is_valid_filename() const {
 String String::validate_filename() const {
 	Vector<String> chars = String(invalid_filename_characters).split(" ");
 	String name = strip_edges();
-	for (int i = 0; i < chars.size(); i++) {
-		name = name.replace(chars[i], "_");
-	}
+	name = name.replace(chars, "_");
 	return name;
 }
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -312,6 +312,7 @@ public:
 	String replace_first(const char *p_key, const char *p_with) const;
 	String replace(const String &p_key, const String &p_with) const;
 	String replace(const char *p_key, const char *p_with) const;
+	String replace(const Vector<String> &p_keys, const String &p_with) const;
 	String replacen(const String &p_key, const String &p_with) const;
 	String replacen(const char *p_key, const char *p_with) const;
 	String repeat(int p_count) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1668,6 +1668,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(format, sarray("values", "placeholder"), varray("{_}"));
 	bind_string_methodv(replace, static_cast<String (String::*)(const String &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());
 	bind_string_methodv(replacen, static_cast<String (String::*)(const String &, const String &) const>(&String::replacen), sarray("what", "forwhat"), varray());
+	bind_string_methodv(replace_all, static_cast<String (String::*)(const Vector<String> &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());
 	bind_string_method(repeat, sarray("count"), varray());
 	bind_string_method(reverse, sarray(), varray());
 	bind_string_method(insert, sarray("position", "what"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -744,6 +744,14 @@
 				Replaces all occurrences of [param what] inside the string with the given [param forwhat].
 			</description>
 		</method>
+		<method name="replace_all" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="what" type="PackedStringArray" />
+			<param index="1" name="forwhat" type="String" />
+			<description>
+				Replaces all occurrences of all [param what] entries inside the string with the given [param forwhat]. This is more efficient than calling [code skip-lint]replace[/code] multiple times with different [param what] and the same [param forwhat].
+			</description>
+		</method>
 		<method name="replacen" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="what" type="String" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -645,6 +645,14 @@
 				Replaces all occurrences of [param what] inside the string with the given [param forwhat].
 			</description>
 		</method>
+		<method name="replace_all" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="what" type="PackedStringArray" />
+			<param index="1" name="forwhat" type="String" />
+			<description>
+				Replaces all occurrences of all [param what] entries inside the string with the given [param forwhat]. This is more efficient than calling [code skip-lint]replace[/code] multiple times with different [param what] and the same [param forwhat].
+			</description>
+		</method>
 		<method name="replacen" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="what" type="String" />

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2098,7 +2098,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			switch (expression_pattern) {
 				case RGBA_PARAMETER: {
 					color_args = line.substr(begin, end - begin);
-					String stripped = color_args.replace(Vector<String>({ " ", "\t", "(", ")" }), "");
+					static Vector<String> to_replace({ " ", "\t", "(", ")" });
+					String stripped = color_args.replace(to_replace, "");
 					PackedFloat64Array color = stripped.split_floats(",");
 					if (color.size() > 2) {
 						float alpha = color.size() > 3 ? color[3] : 1.0f;
@@ -2110,7 +2111,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 						end = line.length();
 					}
 					color_args = line.substr(begin, end - begin);
-					const String color_name = color_args.replace(Vector<String>({ " ", "\t", "." }), "");
+					static Vector<String> to_replace({ " ", "\t", "." });
+					const String color_name = color_args.replace(to_replace, "");
 					const int color_index = Color::find_named_color(color_name);
 					if (0 <= color_index) {
 						const Color color_constant = Color::get_named_color(color_index);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2098,7 +2098,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			switch (expression_pattern) {
 				case RGBA_PARAMETER: {
 					color_args = line.substr(begin, end - begin);
-					String stripped = color_args.replace(" ", "").replace("\t", "").replace("(", "").replace(")", "");
+					String stripped = color_args.replace(Vector<String>({ " ", "\t", "(", ")" }), "");
 					PackedFloat64Array color = stripped.split_floats(",");
 					if (color.size() > 2) {
 						float alpha = color.size() > 3 ? color[3] : 1.0f;
@@ -2110,7 +2110,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 						end = line.length();
 					}
 					color_args = line.substr(begin, end - begin);
-					const String color_name = color_args.replace(" ", "").replace("\t", "").replace(".", "");
+					const String color_name = color_args.replace(Vector<String>({ " ", "\t", "." }), "");
 					const int color_index = Color::find_named_color(color_name);
 					if (0 <= color_index) {
 						const Color color_constant = Color::get_named_color(color_index);

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -293,8 +293,7 @@ String FBXDocument::_sanitize_animation_name(const String &p_name) {
 
 	// TODO: Consider adding invalid_characters or a validate_animation_name to animation_player to mirror Node.
 	String anim_name = p_name.validate_node_name();
-	anim_name = anim_name.replace(",", "");
-	anim_name = anim_name.replace("[", "");
+	anim_name = anim_name.replace(Vector<String>({ ",", "[" }), "");
 	return anim_name;
 }
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -293,7 +293,8 @@ String FBXDocument::_sanitize_animation_name(const String &p_name) {
 
 	// TODO: Consider adding invalid_characters or a validate_animation_name to animation_player to mirror Node.
 	String anim_name = p_name.validate_node_name();
-	anim_name = anim_name.replace(Vector<String>({ ",", "[" }), "");
+	static Vector<String> to_replace({ ",", "[" });
+	anim_name = anim_name.replace(to_replace, "");
 	return anim_name;
 }
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -79,22 +79,22 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	type_hints = EDITOR_GET("text_editor/completion/add_type_hints");
 #endif
 	if (!type_hints) {
-		processed_template = processed_template.replace(Vector<String>({ ": int",
-																": Shader.Mode",
-																": VisualShader.Type",
-																": float",
-																": String",
-																": Array[String]",
-																": Node",
-																": CharFXTransform",
-																":=",
-																" -> void",
-																" -> bool",
-																" -> int",
-																" -> PortType",
-																" -> String",
-																" -> Object" }),
-				"");
+		static Vector<String> to_replace({ ": int",
+				": Shader.Mode",
+				": VisualShader.Type",
+				": float",
+				": String",
+				": Array[String]",
+				": Node",
+				": CharFXTransform",
+				":=",
+				" -> void",
+				" -> bool",
+				" -> int",
+				" -> PortType",
+				" -> String",
+				" -> Object" });
+		processed_template = processed_template.replace(to_replace, "");
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -79,21 +79,22 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	type_hints = EDITOR_GET("text_editor/completion/add_type_hints");
 #endif
 	if (!type_hints) {
-		processed_template = processed_template.replace(": int", "")
-									 .replace(": Shader.Mode", "")
-									 .replace(": VisualShader.Type", "")
-									 .replace(": float", "")
-									 .replace(": String", "")
-									 .replace(": Array[String]", "")
-									 .replace(": Node", "")
-									 .replace(": CharFXTransform", "")
-									 .replace(":=", "=")
-									 .replace(" -> void", "")
-									 .replace(" -> bool", "")
-									 .replace(" -> int", "")
-									 .replace(" -> PortType", "")
-									 .replace(" -> String", "")
-									 .replace(" -> Object", "");
+		processed_template = processed_template.replace(Vector<String>({ ": int",
+																": Shader.Mode",
+																": VisualShader.Type",
+																": float",
+																": String",
+																": Array[String]",
+																": Node",
+																": CharFXTransform",
+																":=",
+																" -> void",
+																" -> bool",
+																" -> int",
+																" -> PortType",
+																" -> String",
+																" -> Object" }),
+				"");
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -695,7 +695,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 
 			} else {
 				ScriptLanguage::LookupResult ret;
-				if (symbol_identifier == "new" && parser->get_lines()[p_doc_pos.position.line].replace(" ", "").replace("\t", "").contains("new(")) {
+				if (symbol_identifier == "new" && parser->get_lines()[p_doc_pos.position.line].replace(Vector<String>({ " ", "\t" }), "").contains("new(")) {
 					symbol_identifier = "_init";
 				}
 				if (OK == GDScriptLanguage::get_singleton()->lookup_code(parser->get_text_for_lookup_symbol(pos, symbol_identifier, p_func_required), symbol_identifier, path, nullptr, ret)) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -695,7 +695,8 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 
 			} else {
 				ScriptLanguage::LookupResult ret;
-				if (symbol_identifier == "new" && parser->get_lines()[p_doc_pos.position.line].replace(Vector<String>({ " ", "\t" }), "").contains("new(")) {
+				static Vector<String> to_replace({ " ", "\t" });
+				if (symbol_identifier == "new" && parser->get_lines()[p_doc_pos.position.line].replace(to_replace, "").contains("new(")) {
 					symbol_identifier = "_init";
 				}
 				if (OK == GDScriptLanguage::get_singleton()->lookup_code(parser->get_text_for_lookup_symbol(pos, symbol_identifier, p_func_required), symbol_identifier, path, nullptr, ret)) {

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -246,9 +246,7 @@ String get_csharp_project_name() {
 				// Other chars that have been found to break assembly loading.
 				";", "'", "=", "," });
 		name = name.strip_edges();
-		for (int i = 0; i < invalid_chars.size(); i++) {
-			name = name.replace(invalid_chars[i], "-");
-		}
+		name = name.replace(invalid_chars, "-");
 	}
 
 	if (name.is_empty()) {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1400,7 +1400,8 @@ Error EditorExportPlatformIOS::_copy_asset(const Ref<EditorExportPreset> &p_pres
 		return ERR_FILE_NOT_FOUND;
 	}
 
-	String base_dir = p_asset.get_base_dir().replace(Vector<String>({ "res://", ".godot/mono/temp/bin/" }), "");
+	static Vector<String> to_replace({ "res://", ".godot/mono/temp/bin/" });
+	String base_dir = p_asset.get_base_dir().replace(to_replace, "");
 	String asset = p_asset.ends_with("/") ? p_asset.left(p_asset.length() - 1) : p_asset;
 	String destination_dir;
 	String destination;

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1400,7 +1400,7 @@ Error EditorExportPlatformIOS::_copy_asset(const Ref<EditorExportPreset> &p_pres
 		return ERR_FILE_NOT_FOUND;
 	}
 
-	String base_dir = p_asset.get_base_dir().replace("res://", "").replace(".godot/mono/temp/bin/", "");
+	String base_dir = p_asset.get_base_dir().replace(Vector<String>({ "res://", ".godot/mono/temp/bin/" }), "");
 	String asset = p_asset.ends_with("/") ? p_asset.left(p_asset.length() - 1) : p_asset;
 	String destination_dir;
 	String destination;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -427,6 +427,7 @@ TEST_CASE("[String] Find and replace") {
 	MULTICHECK_STRING_STRING_EQ(s, replace, "Birthday", "Halloween", "Happy Halloween, Anna!");
 	MULTICHECK_STRING_STRING_EQ(s, replace_first, "y", "Y", "HappY Birthday, Anna!");
 	MULTICHECK_STRING_STRING_EQ(s, replacen, "Y", "Y", "HappY BirthdaY, Anna!");
+	CHECK(s.replace(Vector<String>({ " ", ",", "Anna!" }), "") == "HappyBirthday");
 }
 
 TEST_CASE("[String] Insertion") {


### PR DESCRIPTION
There are multiple places where we want to replace multiple characters or strings with one character (e.g. cleaning up paths), and calling replace for every source string is wasteful, we can do it all in one go.

_Contributed with ❤️ by W4Games_