### PR TITLE
[3.x] Physics Interpolation - Fix `VisualInstance::set_instance_use_identit…

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -74,10 +74,10 @@ void VisualInstance::set_instance_use_identity_transform(bool p_enable) {
 	if (is_inside_tree()) {
 		if (p_enable) {
 			// want to make sure instance is using identity transform
-			VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
+			VisualServer::get_singleton()->instance_set_transform(instance, Transform());
 		} else {
 			// want to make sure instance is up to date
-			VisualServer::get_singleton()->instance_set_transform(instance, Transform());
+			VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
 		}
 	}
 }


### PR DESCRIPTION
…y_transform()`

The logic for updating the `VisualServer` with the transform was the wrong way around.

## Notes
* Thanks to @rburing for spotting this.
* I tested this out in a small project toggling the `local_coords` at runtime, and sure enough I got it completely the wrong way around. :blush: 
* This was unlikely to show up in most situations because people generally only change this in the editor.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
