### PR TITLE
Separate linear and sRGB uniform buffers in RD rendering backends

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -746,8 +746,10 @@ MaterialStorage::MaterialData::~MaterialData() {
 		material_storage->global_shader_uniforms.materials_using_texture.erase(global_texture_E);
 	}
 
-	if (uniform_buffer.is_valid()) {
-		RD::get_singleton()->free(uniform_buffer);
+	for (int i = 0; i < 2; i++) {
+		if (uniform_buffer[i].is_valid()) {
+			RD::get_singleton()->free(uniform_buffer[i]);
+		}
 	}
 }
 
@@ -987,17 +989,17 @@ void MaterialStorage::MaterialData::free_parameters_uniform_set(RID p_uniform_se
 }
 
 bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const HashMap<StringName, HashMap<int, RID>> &p_default_texture_params, uint32_t p_ubo_size, RID &uniform_set, RID p_shader, uint32_t p_shader_uniform_set, bool p_use_linear_color, bool p_3d_material) {
-	if ((uint32_t)ubo_data.size() != p_ubo_size) {
+	if ((uint32_t)ubo_data[p_use_linear_color].size() != p_ubo_size) {
 		p_uniform_dirty = true;
-		if (uniform_buffer.is_valid()) {
-			RD::get_singleton()->free(uniform_buffer);
-			uniform_buffer = RID();
+		if (uniform_buffer[p_use_linear_color].is_valid()) {
+			RD::get_singleton()->free(uniform_buffer[p_use_linear_color]);
+			uniform_buffer[p_use_linear_color] = RID();
 		}
 
-		ubo_data.resize(p_ubo_size);
-		if (ubo_data.size()) {
-			uniform_buffer = RD::get_singleton()->uniform_buffer_create(ubo_data.size());
-			memset(ubo_data.ptrw(), 0, ubo_data.size()); //clear
+		ubo_data[p_use_linear_color].resize(p_ubo_size);
+		if (ubo_data[p_use_linear_color].size()) {
+			uniform_buffer[p_use_linear_color] = RD::get_singleton()->uniform_buffer_create(ubo_data[p_use_linear_color].size());
+			memset(ubo_data[p_use_linear_color].ptrw(), 0, ubo_data[p_use_linear_color].size()); //clear
 		}
 
 		//clear previous uniform set
@@ -1009,9 +1011,9 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 	}
 
 	//check whether buffer changed
-	if (p_uniform_dirty && ubo_data.size()) {
-		update_uniform_buffer(p_uniforms, p_uniform_offsets, p_parameters, ubo_data.ptrw(), ubo_data.size(), p_use_linear_color);
-		RD::get_singleton()->buffer_update(uniform_buffer, 0, ubo_data.size(), ubo_data.ptrw());
+	if (p_uniform_dirty && ubo_data[p_use_linear_color].size()) {
+		update_uniform_buffer(p_uniforms, p_uniform_offsets, p_parameters, ubo_data[p_use_linear_color].ptrw(), ubo_data[p_use_linear_color].size(), p_use_linear_color);
+		RD::get_singleton()->buffer_update(uniform_buffer[p_use_linear_color], 0, ubo_data[p_use_linear_color].size(), ubo_data[p_use_linear_color].ptrw());
 	}
 
 	uint32_t tex_uniform_count = 0U;
@@ -1053,7 +1055,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 0;
-			u.append_id(uniform_buffer);
+			u.append_id(uniform_buffer[p_use_linear_color]);
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -100,8 +100,8 @@ public:
 		HashMap<StringName, uint64_t> used_global_textures;
 
 		//internally by update_parameters_uniform_set
-		Vector<uint8_t> ubo_data;
-		RID uniform_buffer;
+		Vector<uint8_t> ubo_data[2]; // 0: linear buffer; 1: sRGB buffer.
+		RID uniform_buffer[2]; // 0: linear buffer; 1: sRGB buffer.
 		Vector<RID> texture_cache;
 	};
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84989

We had a separate uniform set for sRGB vs linear versions of the uniform buffer. When turning on HDR_2D we would use the linear uniform set. Since the same material can be used in both a regular viewport and one with HDR_2D, we have to generate both sets. 

Previously, we had one data array and one uniform buffer for both sets. That resulted in the sRGB version of the uniform set overwriting the values in the linear set and the shader effectively always using sRGB values. 

This separates out the buffer so the two versions can co-exist.

_Before: Note the difference between the version on the right and the one on the left_
![Screenshot from 2024-05-27 13-36-34](https://github.com/godotengine/godot/assets/16521339/36e990a2-55c6-4f04-a0bf-c486b72cdbbf)
_After: Note how the color is consistent now_
![Screenshot from 2024-05-27 13-35-51](https://github.com/godotengine/godot/assets/16521339/cbf1f4be-3735-4148-b7f0-5959512d9cd1)
