### PR TITLE
Fix mouse state persists on display server after app loses focus

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1123,6 +1123,10 @@ void DisplayServerWayland::process_events() {
 			} else if (winev_msg->event == WINDOW_EVENT_FOCUS_OUT) {
 				if (OS::get_singleton()->get_main_loop()) {
 					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+					{
+						MutexLock mutex_lock(wayland_thread.mutex);
+						wayland_thread.pointer_clear_button_mask();
+					}
 				}
 			}
 		}

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3504,7 +3504,7 @@ BitField<MouseButtonMask> WaylandThread::pointer_get_button_mask() const {
 	return BitField<MouseButtonMask>();
 }
 
-void WaylandThread::pointer_get_button_mask() {
+void WaylandThread::pointer_clear_button_mask() {
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 	if (ss) {
 		ss->pointer_data_buffer.pressed_button_mask.clear()

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3504,6 +3504,13 @@ BitField<MouseButtonMask> WaylandThread::pointer_get_button_mask() const {
 	return BitField<MouseButtonMask>();
 }
 
+void WaylandThread::pointer_get_button_mask() {
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+	if (ss) {
+		ss->pointer_data_buffer.pressed_button_mask.clear()
+	}
+}
+
 Error WaylandThread::init() {
 #ifdef SOWRAP_ENABLED
 #ifdef DEBUG_ENABLED

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -918,6 +918,7 @@ public:
 	PointerConstraint pointer_get_constraint() const;
 	DisplayServer::WindowID pointer_get_pointed_window_id() const;
 	BitField<MouseButtonMask> pointer_get_button_mask() const;
+	void pointer_clear_button_mask();
 
 	void cursor_hide();
 	void cursor_set_shape(DisplayServer::CursorShape p_cursor_shape);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4310,6 +4310,7 @@ void DisplayServerX11::process_events() {
 				if (OS::get_singleton()->get_main_loop()) {
 					DEBUG_LOG_X11("All focus lost, triggering NOTIFICATION_APPLICATION_FOCUS_OUT\n");
 					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+					last_button_state.clear();
 				}
 				app_focused = false;
 			}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3774,6 +3774,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			app_focused = new_app_focused;
 			if (OS::get_singleton()->get_main_loop()) {
 				OS::get_singleton()->get_main_loop()->notification(app_focused ? MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN : MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+				if (!app_focused) {
+					last_button_state.clear();
+				}
 			}
 		} break;
 		case WM_ACTIVATE: {


### PR DESCRIPTION
fix for window, x11 and wayland

example of issue
1. Press left mouse to start selection
2. Alt Tab out of editor while still holding mouse button
3. Release left mouse button outside editor window
4. Right click in 3D editor while window is still unfocused