### PR TITLE
Fix Light3D BakeMode enum documentation

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -199,7 +199,7 @@
 		</constant>
 		<constant name="BAKE_DISABLED" value="0" enum="BakeMode">
 			Light is ignored when baking. This is the fastest mode, but the light will be taken into account when baking global illumination. This mode should generally be used for dynamic lights that change quickly, as the effect of global illumination is less noticeable on those lights.
-			[b]Note:[/b] Hiding a light does [i]not[/i] affect baking [LightmapGI]. Hiding a light will still affect baking [VoxelGI] and SDFGI (see [member Environment.sdfgi_enabled).
+			[b]Note:[/b] Hiding a light does [i]not[/i] affect baking [LightmapGI]. Hiding a light will still affect baking [VoxelGI] and SDFGI (see [member Environment.sdfgi_enabled]).
 		</constant>
 		<constant name="BAKE_STATIC" value="1" enum="BakeMode">
 			Light is taken into account in static baking ([VoxelGI], [LightmapGI], SDFGI ([member Environment.sdfgi_enabled])). The light can be moved around or modified, but its global illumination will not update in real-time. This is suitable for subtle changes (such as flickering torches), but generally not large changes such as toggling a light on and off.


### PR DESCRIPTION
Missing bracket was causing the tooltip to break

![image](https://github.com/godotengine/godot/assets/138269/bb727b7c-3e95-4d6a-b147-e44a33e62470)
