### PR TITLE
Fix -empty string- console log in web export (cosmetic)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2841,8 +2841,10 @@ Error Main::setup2() {
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Servers");
 
+#ifndef WEB_ENABLED
 	// Add a blank line for readability.
 	Engine::get_singleton()->print_header("");
+#endif // WEB_ENABLED
 
 	register_core_singletons();
 


### PR DESCRIPTION
# Info

While reading the messages displayed by Godot in the browser console, I became interested in what causes the ‘empty string’ message when the engine starts up.

![empty-string](https://github.com/godotengine/godot/assets/224215/c4b5cd83-76f6-408e-9ebc-4545d6dae7fa)

It turned out that the `print_header("")` line, which is supposed to improve readability in the terminal window, displays confusing text in the browser (in my case Firefox).

## Fix

The fix is cosmetic and causes the empty line to display only when WEB_ENABLED is not defined.