### PR TITLE
[3.x] Physics Interpolation - 3D shifting origin support

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -484,9 +484,7 @@
 			<argument index="0" name="item" type="RID" />
 			<argument index="1" name="xform" type="Transform2D" />
 			<description>
-				Transforms both the current and previous stored transform for a canvas item.
-				This allows transforming a canvas item without creating a "glitch" in the interpolation.
-				This is particularly useful for large worlds utilising a shifting origin.
+				Transforms both the current and previous stored transform for a canvas item. This allows transforming a canvas item without creating a "glitch" in the interpolation. This is particularly useful for large worlds utilising a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_light_attach_to_canvas">
@@ -572,9 +570,7 @@
 			<argument index="0" name="occluder" type="RID" />
 			<argument index="1" name="xform" type="Transform2D" />
 			<description>
-				Transforms both the current and previous stored transform for an occluder.
-				This allows transforming an occluder without creating a "glitch" in the interpolation.
-				This is particularly useful for large worlds utilising a shifting origin.
+				Transforms both the current and previous stored transform for an occluder. This allows transforming an occluder without creating a "glitch" in the interpolation. This is particularly useful for large worlds utilising a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_light_reset_physics_interpolation">
@@ -752,9 +748,7 @@
 			<argument index="0" name="light" type="RID" />
 			<argument index="1" name="xform" type="Transform2D" />
 			<description>
-				Transforms both the current and previous stored transform for a light.
-				This allows transforming a light without creating a "glitch" in the interpolation.
-				This is particularly useful for large worlds utilising a shifting origin.
+				Transforms both the current and previous stored transform for a light. This allows transforming a light without creating a "glitch" in the interpolation. This is particularly useful for large worlds utilising a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_occluder_polygon_create">
@@ -1602,6 +1596,14 @@
 			<argument index="1" name="visible" type="bool" />
 			<description>
 				Sets whether an instance is drawn or not. Equivalent to [member Spatial.visible].
+			</description>
+		</method>
+		<method name="instance_transform_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="instance" type="RID" />
+			<argument index="1" name="transform" type="Transform" />
+			<description>
+				Transforms both the current and previous stored transform for an instance. This allows transforming an instance without creating a "glitch" in the interpolation. This is particularly useful for large worlds utilising a shifting origin.
 			</description>
 		</method>
 		<method name="instances_cull_aabb" qualifiers="const">

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -576,6 +576,7 @@ public:
 	BIND2(instance_set_transform, RID, const Transform &)
 	BIND2(instance_set_interpolated, RID, bool)
 	BIND1(instance_reset_physics_interpolation, RID)
+	BIND2(instance_transform_physics_interpolation, RID, const Transform &)
 	BIND2(instance_attach_object_instance_id, RID, ObjectID)
 	BIND3(instance_set_blend_shape_weight, RID, int, float)
 	BIND3(instance_set_surface_material, RID, int, RID)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -832,6 +832,19 @@ void VisualServerScene::instance_reset_physics_interpolation(RID p_instance) {
 	}
 }
 
+void VisualServerScene::instance_transform_physics_interpolation(RID p_instance, const Transform &p_transform) {
+	Instance *instance = instance_owner.get(p_instance);
+	ERR_FAIL_COND(!instance);
+
+	if (_interpolation_data.interpolation_enabled && instance->interpolated && instance->scenario) {
+		instance->transform_prev = p_transform * instance->transform_prev;
+		instance->transform_curr = p_transform * instance->transform_curr;
+
+		instance->transform_checksum_prev = TransformInterpolator::checksum_transform(instance->transform_prev);
+		instance->transform_checksum_curr = TransformInterpolator::checksum_transform(instance->transform_curr);
+	}
+}
+
 void VisualServerScene::instance_set_interpolated(RID p_instance, bool p_interpolated) {
 	Instance *instance = instance_owner.get(p_instance);
 	ERR_FAIL_COND(!instance);

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -684,6 +684,7 @@ public:
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform);
 	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated);
 	virtual void instance_reset_physics_interpolation(RID p_instance);
+	virtual void instance_transform_physics_interpolation(RID p_instance, const Transform &p_transform);
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id);
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -484,6 +484,7 @@ public:
 	FUNC2(instance_set_transform, RID, const Transform &)
 	FUNC2(instance_set_interpolated, RID, bool)
 	FUNC1(instance_reset_physics_interpolation, RID)
+	FUNC2(instance_transform_physics_interpolation, RID, const Transform &)
 	FUNC2(instance_attach_object_instance_id, RID, ObjectID)
 	FUNC3(instance_set_blend_shape_weight, RID, int, float)
 	FUNC3(instance_set_surface_material, RID, int, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2175,6 +2175,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_transform", "instance", "transform"), &VisualServer::instance_set_transform);
 	ClassDB::bind_method(D_METHOD("instance_set_interpolated", "instance", "interpolated"), &VisualServer::instance_set_interpolated);
 	ClassDB::bind_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &VisualServer::instance_reset_physics_interpolation);
+	ClassDB::bind_method(D_METHOD("instance_transform_physics_interpolation", "instance", "transform"), &VisualServer::instance_transform_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("instance_attach_object_instance_id", "instance", "id"), &VisualServer::instance_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("instance_set_blend_shape_weight", "instance", "shape", "weight"), &VisualServer::instance_set_blend_shape_weight);
 	ClassDB::bind_method(D_METHOD("instance_set_surface_material", "instance", "surface", "material"), &VisualServer::instance_set_surface_material);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -881,6 +881,7 @@ public:
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform) = 0;
 	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated) = 0;
 	virtual void instance_reset_physics_interpolation(RID p_instance) = 0;
+	virtual void instance_transform_physics_interpolation(RID p_instance, const Transform &p_transform) = 0;
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material) = 0;


### PR DESCRIPTION
* Adds support for moving origin via `instance_transform_physics_interpolation()`.

## Discussion
Once auto-resets are added for 3D, it becomes necessary to add explicit support for moving origins, as moving origin worlds (for large world support) cannot be achieved easily without this.

## ToDo
Still need to add support to call the `VisualServer` functions from `VisualInstance`, and support `Cameras` (which will work differently as of #92784).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
