### PR TITLE
Fix error when dropping image onto the scene dock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3333,9 +3333,9 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 	// Either instantiate scenes or create AudioStreamPlayers.
 	int to_pos = -1;
 	_normalize_drop(node, to_pos, p_type);
-	if (res_type == "PackedScene") {
+	if (ClassDB::is_parent_class(res_type, "PackedScene")) {
 		_perform_instantiate_scenes(p_files, node, to_pos);
-	} else {
+	} else if (ClassDB::is_parent_class(res_type, "AudioStream")) {
 		_perform_create_audio_stream_players(p_files, node, to_pos);
 	}
 }


### PR DESCRIPTION
Fixes a regression described in https://github.com/godotengine/godot/pull/92004#issuecomment-2134836842.

Dropping files onto the scene dock has 3 situations:

1. Any single resource file: Set type-matching property of that node.
2. One or more scene files: Instantiate the scene.
3. One or more audio files: Create an AudioStreamPlayer.

#92004 first tries to do the property drop (1 above). 2 and 3 will be tried if the resource file does not have any matching property, so that audio stream players are easier to create. But I did not check the "single file, not audio stream" situation, thus the error message.

CC @patwork