### PR TITLE
Add PropertyListHelper to TileSet (part 1)

### DIFF
--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -37,6 +37,7 @@
 #include "core/templates/rb_set.h"
 #include "scene/2d/light_occluder_2d.h"
 #include "scene/main/canvas_item.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/2d/convex_polygon_shape_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"
 #include "scene/resources/image_texture.h"
@@ -187,6 +188,16 @@ private:
 		int z_index = 0;
 	};
 
+	static inline PropertyListHelper base_occlusion_layer_property_helper;
+	static inline PropertyListHelper base_physics_layer_property_helper;
+	static inline PropertyListHelper base_navigation_layer_property_helper;
+	static inline PropertyListHelper base_custom_data_property_helper;
+
+	PropertyListHelper occlusion_layer_property_helper;
+	PropertyListHelper physics_layer_property_helper;
+	PropertyListHelper navigation_layer_property_helper;
+	PropertyListHelper custom_data_property_helper;
+
 	enum CompatibilityTileMode {
 		COMPATIBILITY_TILE_MODE_SINGLE_TILE = 0,
 		COMPATIBILITY_TILE_MODE_AUTO_TILE,
@@ -297,6 +308,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 	void _validate_property(PropertyInfo &p_property) const;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Adds PropertyListHelper to TileSet, though it doesn't cover all properties. Missing are terrain sources, sources and patterns. They would require modifications to the helper code. Also helpers can be added to other classes too.

Putting as draft due to a problem. TileSet defines array properties with `ADD_ARRAY` instead of `ADD_ARRAY_COUNT`, which means there is no e.g. `physics_layers_count` property, which means that if a layer has all default values, it's not saved. The fix is simple (adding layer count property), but I'm not sure if it's worth it overall. TileSet requires multiple helpers to handle all properties and the code is not as simpler as in other classes, so the benefit is questionable. I already implemented these changes before realizing the problem, so I might as well open this 🤷‍♂️