### PR TITLE
Add missing space around the ratio lock button

### DIFF
--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -31,7 +31,9 @@
 #include "editor_properties_vector.h"
 
 #include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/texture_button.h"
 
@@ -135,8 +137,11 @@ void EditorPropertyVectorN::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
+			int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+
 			linked->set_texture_normal(get_editor_theme_icon(SNAME("Unlinked")));
 			linked->set_texture_pressed(get_editor_theme_icon(SNAME("Instance")));
+			linked->set_custom_minimum_size(Size2(icon_size + 8 * EDSCALE, 0));
 
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < component_count; i++) {


### PR DESCRIPTION
**Before:**

![1](https://github.com/godotengine/godot/assets/60579014/78ebbc3f-bae7-48d9-8fa9-4ee1e10b2111)

**After:**

![2](https://github.com/godotengine/godot/assets/60579014/84370899-ec29-48b3-a8ce-92df8e968321)
