### PR TITLE
Fix use of undeclared identifier `__cpuidex` error on MinGW

### DIFF
--- a/thirdparty/embree/common/sys/sysinfo.cpp
+++ b/thirdparty/embree/common/sys/sysinfo.cpp
@@ -295,7 +295,7 @@ namespace embree
     if (nIds >= 1) __cpuid (cpuid_leaf_1,0x00000001);
 #if _WIN32
 #if _MSC_VER && (_MSC_FULL_VER < 160040219)
-#else
+#elif defined(_MSC_VER)
     if (nIds >= 7) __cpuidex(cpuid_leaf_7,0x00000007,0);
 #endif
 #else

--- a/thirdparty/embree/patches/mingw-no-cpuidex.patch
+++ b/thirdparty/embree/patches/mingw-no-cpuidex.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/embree/common/sys/sysinfo.cpp b/thirdparty/embree/common/sys/sysinfo.cpp
+index d01eab3c9d..4ecab05265 100644
+--- a/thirdparty/embree/common/sys/sysinfo.cpp
++++ b/thirdparty/embree/common/sys/sysinfo.cpp
+@@ -295,7 +295,7 @@ namespace embree
+     if (nIds >= 1) __cpuid (cpuid_leaf_1,0x00000001);
+ #if _WIN32
+ #if _MSC_VER && (_MSC_FULL_VER < 160040219)
+-#else
++#elif defined(_MSC_VER)
+     if (nIds >= 7) __cpuidex(cpuid_leaf_7,0x00000007,0);
+ #endif
+ #else


### PR DESCRIPTION
This change requires the target to be ``msvc`` in order to reference the method ``__cpuidex``.  The reasoning is due to a breaking change that appears to have come into effect recently across all major c / c++ compilers.  Details are as follows:

LLVM, Zig (which uses LLVM under the hood), and GCC all recently updated their compilers changing what was a warning to an error.  The compiler will now error if attempting to reference ``__cpuidex`` and not targetting msvc.  It will no longer work for MINGW targets.

Here are relevant docs / source code for reference

Discovered by @Rexicon226, here is the LLVM code and how it handles it:

https://github.com/llvm/llvm-project/blob/main/llvm/lib/Support/BLAKE3/blake3_dispatch.c#L46-L60

Another helpful zig dev who's discord username is "random internet person" found: https://github.com/ziglang/zig/blob/master/lib/zig.h#L3902-L3913

Which appears similar to LLVM's new implementation.

And GNU posted a more formal announcement notifying of the warn to error change that appears to have propagated across all major compilers recently: https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors

Shoutout to @paperdave for all the help and guidance along the way! :)