### PR TITLE
Add support for setting fixed fps at runtime

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -74,6 +74,14 @@ int Engine::get_max_fps() const {
 	return _max_fps;
 }
 
+void Engine::set_fixed_fps(int p_fps) {
+	fixed_fps = p_fps;
+}
+
+int Engine::get_fixed_fps() const {
+	return fixed_fps;
+}
+
 void Engine::set_audio_output_latency(int p_msec) {
 	_audio_output_latency = p_msec > 1 ? p_msec : 1;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -70,6 +70,7 @@ private:
 	int max_physics_steps_per_frame = 8;
 	double _physics_interpolation_fraction = 0.0f;
 	bool abort_on_gpu_errors = false;
+	int fixed_fps = -1;
 	bool use_validation_layers = false;
 	bool generate_spirv_debug_info = false;
 	int32_t gpu_idx = -1;
@@ -109,6 +110,9 @@ public:
 
 	virtual void set_max_fps(int p_fps);
 	virtual int get_max_fps() const;
+
+	virtual void set_fixed_fps(int p_fps);
+	virtual int get_fixed_fps() const;
 
 	virtual void set_audio_output_latency(int p_msec);
 	virtual int get_audio_output_latency() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1652,6 +1652,14 @@ int Engine::get_max_fps() const {
 	return ::Engine::get_singleton()->get_max_fps();
 }
 
+void Engine::set_fixed_fps(int p_fps) {
+	::Engine::get_singleton()->set_fixed_fps(p_fps);
+}
+
+int Engine::get_fixed_fps() const {
+	return ::Engine::get_singleton()->get_fixed_fps();
+}
+
 double Engine::get_frames_per_second() const {
 	return ::Engine::get_singleton()->get_frames_per_second();
 }
@@ -1806,6 +1814,8 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &Engine::get_physics_interpolation_fraction);
 	ClassDB::bind_method(D_METHOD("set_max_fps", "max_fps"), &Engine::set_max_fps);
 	ClassDB::bind_method(D_METHOD("get_max_fps"), &Engine::get_max_fps);
+	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fixed_fps"), &Engine::set_fixed_fps);
+	ClassDB::bind_method(D_METHOD("get_fixed_fps"), &Engine::get_fixed_fps);
 
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
@@ -1851,6 +1861,7 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_ticks_per_second"), "set_physics_ticks_per_second", "get_physics_ticks_per_second");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_physics_steps_per_frame"), "set_max_physics_steps_per_frame", "get_max_physics_steps_per_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps"), "set_max_fps", "get_max_fps");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
 }

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -499,6 +499,8 @@ public:
 
 	void set_max_fps(int p_fps);
 	int get_max_fps() const;
+	void set_fixed_fps(int p_fps);
+	int get_fixed_fps() const;
 
 	double get_frames_per_second() const;
 	uint64_t get_physics_frames() const;

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -310,6 +310,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="-1">
+			When fixed_fps is greater than [code]-1[/code], the engine will process at this fps regardless of what the actual fps is. This is useful for doing things such as recording movies where realtime updates do not matter, but the images captured should appear smooth once being encoded together.
+		</member>
 		<member name="max_fps" type="int" setter="set_max_fps" getter="get_max_fps" default="0">
 			The maximum number of frames that can be rendered every second (FPS). A value of [code]0[/code] means the framerate is uncapped.
 			Limiting the FPS can be useful to reduce the host machine's power consumption, which reduces heat, noise emissions, and improves battery life.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -228,7 +228,6 @@ static int max_fps = -1;
 static int frame_delay = 0;
 static int audio_output_latency = 0;
 static bool disable_render_loop = false;
-static int fixed_fps = -1;
 static MovieWriter *movie_writer = nullptr;
 static bool disable_vsync = false;
 static bool print_fps = false;
@@ -1640,7 +1639,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			disable_render_loop = true;
 		} else if (arg == "--fixed-fps") {
 			if (N) {
-				fixed_fps = N->get().to_int();
+				Engine::get_singleton()->set_fixed_fps(N->get().to_int());
 				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing fixed-fps argument, aborting.\n");
@@ -1650,8 +1649,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (N) {
 				Engine::get_singleton()->set_write_movie_path(N->get());
 				N = N->next();
-				if (fixed_fps == -1) {
-					fixed_fps = 60;
+				if (Engine::get_singleton()->get_fixed_fps() == -1) {
+					Engine::get_singleton()->set_fixed_fps(60);
 				}
 				OS::get_singleton()->_writing_movie = true;
 			} else {
@@ -3893,7 +3892,7 @@ int Main::start() {
 	}
 
 	if (movie_writer) {
-		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
+		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), Engine::get_singleton()->get_fixed_fps(), Engine::get_singleton()->get_write_movie_path());
 	}
 
 	if (minimum_time_msec) {
@@ -3944,6 +3943,7 @@ bool Main::iteration() {
 	iterating++;
 
 	const uint64_t ticks = OS::get_singleton()->get_ticks_usec();
+	const int fixed_fps = Engine::get_singleton()->get_fixed_fps();
 	Engine::get_singleton()->_frame_ticks = ticks;
 	main_timer_sync.set_cpu_ticks_usec(ticks);
 	main_timer_sync.set_fixed_fps(fixed_fps);


### PR DESCRIPTION
This exposes the static fixed_fps field so that it can set at runtime.  Currently the only way to modify it is from the command line or by starting a movie recorder from the editor.  By exposing it publicly, we can now add movie recording functionality to our games such as what I did with Blocky Ball! :)  Here's a preview of how we are using it in our game:

This is the replay / record interface that users can use to watch replays and or make recordings of their previous games:

![image](https://github.com/godotengine/godot/assets/24307049/49ea399c-e740-4e37-bcb2-09d3b04cb6ef)

And then putting it all together, we can end of with a beautiful video like so!

[2024-05-28_16:18:09.webm](https://github.com/godotengine/godot/assets/24307049/c3c6a65b-fea9-49ad-84b0-4a1ddef0564e)

It even works impressively well on mobile!  I've tested on both my samsung and iphone so far.  The framerate goes down significantly while recording but the video still comes out completely smooth!

Let me know if you need any changes to this before it can be pushed through.

* *Bugsquad edit, see also: #60284*