### PR TITLE
Add range hint for `SubViewportContainer.stretch_shrink`

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -287,7 +287,7 @@ void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stretch_shrink"), &SubViewportContainer::get_stretch_shrink);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink"), "set_stretch_shrink", "get_stretch_shrink");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), "set_stretch_shrink", "get_stretch_shrink");
 
 	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }


### PR DESCRIPTION
Avoid potential error spamming when dragging this property in the inspector.

`set_stretch_shrink()` errors when the parameter is less than 1.