### PR TITLE
Fix `get_cache_multipass` crash with nullptr rendering device

### DIFF
--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.cpp
@@ -57,6 +57,8 @@ void FramebufferCacheRD::_framebuffer_invalidation_callback(void *p_userdata) {
 }
 
 RID FramebufferCacheRD::get_cache_multipass_array(const TypedArray<RID> &p_textures, const TypedArray<RDFramebufferPass> &p_passes, uint32_t p_views) {
+	ERR_FAIL_NULL_V(RD::get_singleton(), RID());
+
 	Vector<RID> textures;
 	Vector<RD::FramebufferPass> passes;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92412

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
