### PR TITLE
Implement Panini projection in Forward+ renderer

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -131,6 +131,15 @@
 				Sets the camera projection to orthogonal mode (see [constant PROJECTION_ORTHOGONAL]), by specifying a [param size], and the [param z_near] and [param z_far] clip planes in world space units. (As a hint, 2D games often use this projection, with values specified in pixels.)
 			</description>
 		</method>
+		<method name="set_panini">
+			<return type="void" />
+			<param index="0" name="panini_fov" type="float" />
+			<param index="1" name="z_near" type="float" />
+			<param index="2" name="z_far" type="float" />
+			<description>
+				Sets the camera projection to panini mode (see [constant PROJECTION_PANINI]), by specifying a [param panini_fov] (field of view) angle in degrees, and the [param z_near] and [param z_far] clip planes in world space units.
+			</description>
+		</method>
 		<method name="set_perspective">
 			<return type="void" />
 			<param index="0" name="fov" type="float" />
@@ -202,6 +211,9 @@
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis. Lower values allow the camera to see objects more up close to its origin, at the cost of lower precision across the [i]entire[/i] range. Values lower than the default can lead to increased Z-fighting.
 		</member>
+		<member name="panini_fov" type="float" setter="set_panini_fov" getter="get_panini_fov" default="150.0">
+			The camera's field of view angle (in degrees) when in panini mode.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>
@@ -221,6 +233,9 @@
 		</constant>
 		<constant name="PROJECTION_FRUSTUM" value="2" enum="ProjectionType">
 			Frustum projection. This mode allows adjusting [member frustum_offset] to create "tilted frustum" effects.
+		</constant>
+		<constant name="PROJECTION_PANINI" value="3" enum="ProjectionType">
+			Panini projection. Supports higher FOV values than perspective, but has a large performance cost due to having to render multiple views.
 		</constant>
 		<constant name="KEEP_WIDTH" value="0" enum="KeepAspect">
 			Preserves the horizontal aspect ratio; also known as Vert- scaling. This is usually the best option for projects running in portrait mode, as taller aspect ratios will benefit from a wider vertical FOV.

--- a/doc/classes/CameraAttributesPhysical.xml
+++ b/doc/classes/CameraAttributesPhysical.xml
@@ -19,6 +19,12 @@
 				Returns the vertical field of view that corresponds to the [member frustum_focal_length]. This value is calculated internally whenever [member frustum_focal_length] is changed.
 			</description>
 		</method>
+		<method name="get_panini_fov" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the spherical field of view used for Panini projection, corresponding to the maximum latidude/longitude visible on the sphere.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="auto_exposure_max_exposure_value" type="float" setter="set_auto_exposure_max_exposure_value" getter="get_auto_exposure_max_exposure_value" default="10.0">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -163,6 +163,16 @@
 				Sets camera to use orthogonal projection, also known as orthographic projection. Objects remain the same size on the screen no matter how far away they are.
 			</description>
 		</method>
+		<method name="camera_set_panini">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="panini_fovy_degrees" type="float" />
+			<param index="2" name="z_near" type="float" />
+			<param index="3" name="z_far" type="float" />
+			<description>
+				Sets camera to use panini projection. Supports higher FOV values than perspective, but has a large performance cost due to having to render multiple views.
+			</description>
+		</method>
 		<method name="camera_set_perspective">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -253,6 +253,28 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector3 tup(0, up.y + hsize / 2, side.z);
 			ADD_TRIANGLE(tup + offset, side + up + offset, nside + up + offset);
 		} break;
+
+		case Camera3D::PROJECTION_PANINI: {
+			// Panini isn't linear, show the front view
+			float fov = 100.0f / 2.0;
+
+			const float hsize = Math::sin(Math::deg_to_rad(fov));
+			const float depth = -Math::cos(Math::deg_to_rad(fov));
+			Vector3 side = Vector3(hsize * size_factor.x, 0, depth);
+			Vector3 nside = Vector3(-side.x, side.y, side.z);
+			Vector3 up = Vector3(0, hsize * size_factor.y, 0);
+
+			ADD_TRIANGLE(Vector3(), side + up, side - up);
+			ADD_TRIANGLE(Vector3(), nside + up, nside - up);
+			ADD_TRIANGLE(Vector3(), side + up, nside + up);
+			ADD_TRIANGLE(Vector3(), side - up, nside - up);
+
+			handles.push_back(side);
+			side.x = MIN(side.x, hsize * 0.25);
+			nside.x = -side.x;
+			Vector3 tup(0, up.y + hsize / 2, side.z);
+			ADD_TRIANGLE(tup, side + up, nside + up);
+		} break;
 	}
 
 #undef ADD_TRIANGLE

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -44,7 +44,8 @@ public:
 	enum ProjectionType {
 		PROJECTION_PERSPECTIVE,
 		PROJECTION_ORTHOGONAL,
-		PROJECTION_FRUSTUM
+		PROJECTION_FRUSTUM,
+		PROJECTION_PANINI
 	};
 
 	enum KeepAspect {
@@ -66,6 +67,7 @@ private:
 	ProjectionType mode = PROJECTION_PERSPECTIVE;
 
 	real_t fov = 75.0;
+	real_t panini_fov = 150.0;
 	real_t size = 1.0;
 	Vector2 frustum_offset;
 	// _ prefix to avoid conflict with Windows defines.
@@ -98,6 +100,10 @@ private:
 	RID pyramid_shape;
 	Vector<Vector3> pyramid_shape_points;
 
+	Vector2 _panini_forward(Vector2 latlon) const;
+	Vector3 _panini_ray(Vector2 p) const;
+	Vector2 _panini_inverse_ray(Vector3 p_pos) const;
+
 protected:
 	void _update_camera();
 	virtual void _request_camera_update();
@@ -119,6 +125,7 @@ public:
 	void set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
 	void set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
 	void set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far);
+	void set_panini(real_t p_panini_fovy_degrees, real_t p_z_near, real_t p_z_far);
 	void set_projection(Camera3D::ProjectionType p_mode);
 
 	void make_current();
@@ -129,6 +136,7 @@ public:
 	RID get_camera() const;
 
 	real_t get_fov() const;
+	real_t get_panini_fov() const;
 	real_t get_size() const;
 	real_t get_far() const;
 	real_t get_near() const;
@@ -137,6 +145,7 @@ public:
 	ProjectionType get_projection() const;
 
 	void set_fov(real_t p_fov);
+	void set_panini_fov(real_t p_panini_fov);
 	void set_size(real_t p_size);
 	void set_far(real_t p_far);
 	void set_near(real_t p_near);

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -373,6 +373,10 @@ real_t CameraAttributesPhysical::get_fov() const {
 	return frustum_fov;
 }
 
+real_t CameraAttributesPhysical::get_panini_fov() const {
+	return panini_fov;
+}
+
 void CameraAttributesPhysical::_update_frustum() {
 	//https://en.wikipedia.org/wiki/Circle_of_confusion#Circle_of_confusion_diameter_limit_based_on_d/1500
 	Vector2i sensor_size = Vector2i(36, 24); // Matches high-end DSLR, could be made variable if there is demand.
@@ -468,6 +472,7 @@ void CameraAttributesPhysical::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_far", "far"), &CameraAttributesPhysical::set_far);
 	ClassDB::bind_method(D_METHOD("get_far"), &CameraAttributesPhysical::get_far);
 	ClassDB::bind_method(D_METHOD("get_fov"), &CameraAttributesPhysical::get_fov);
+	ClassDB::bind_method(D_METHOD("get_panini_fov"), &CameraAttributesPhysical::get_panini_fov);
 
 	ClassDB::bind_method(D_METHOD("set_auto_exposure_max_exposure_value", "exposure_value_max"), &CameraAttributesPhysical::set_auto_exposure_max_exposure_value);
 	ClassDB::bind_method(D_METHOD("get_auto_exposure_max_exposure_value"), &CameraAttributesPhysical::get_auto_exposure_max_exposure_value);

--- a/scene/resources/camera_attributes.h
+++ b/scene/resources/camera_attributes.h
@@ -140,6 +140,7 @@ private:
 	real_t frustum_near = 0.05;
 	real_t frustum_far = 4000.0;
 	real_t frustum_fov = 75.0;
+	real_t panini_fov = 150.0;
 	void _update_frustum();
 
 	virtual void _update_auto_exposure() override;
@@ -168,6 +169,8 @@ public:
 	real_t get_far() const;
 
 	real_t get_fov() const;
+
+	real_t get_panini_fov() const;
 
 	void set_auto_exposure_min_exposure_value(float p_min);
 	float get_auto_exposure_min_exposure_value() const;

--- a/servers/rendering/renderer_rd/effects/panini.cpp
+++ b/servers/rendering/renderer_rd/effects/panini.cpp
@@ -51,7 +51,7 @@ Panini::~Panini() {
 	shader.version_free(shader_version);
 }
 
-void Panini::panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx) {
+void Panini::panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx, bool keep_width) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -60,6 +60,7 @@ void Panini::panini(RID p_source_color_0, RID p_source_color_1, RID p_source_col
 	memset(&push_constant, 0, sizeof(PaniniPushConstant));
 
 	push_constant.fovx = fovx;
+	push_constant.keep_width = keep_width;
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 

--- a/servers/rendering/renderer_rd/effects/panini.cpp
+++ b/servers/rendering/renderer_rd/effects/panini.cpp
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  panini.cpp                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "panini.h"
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
+#include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
+
+using namespace RendererRD;
+
+Panini::Panini() {
+	{
+		Vector<String> modes;
+		modes.push_back("\n");
+		shader.initialize(modes);
+
+		shader_version = shader.version_create();
+
+		pipeline.setup(shader.version_get_shader(shader_version, 0), RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), RD::PipelineColorBlendState::create_disabled(), 0);
+	}
+}
+
+Panini::~Panini() {
+	shader.version_free(shader_version);
+}
+
+void Panini::panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx) {
+	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
+	ERR_FAIL_NULL(uniform_set_cache);
+	MaterialStorage *material_storage = MaterialStorage::get_singleton();
+	ERR_FAIL_NULL(material_storage);
+
+	memset(&push_constant, 0, sizeof(PaniniPushConstant));
+
+	push_constant.fovx = fovx;
+
+	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+
+	RD::Uniform u_source_color_0(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_0 }));
+	RD::Uniform u_source_color_1(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_1 }));
+	RD::Uniform u_source_color_2(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_2 }));
+	RD::Uniform u_source_color_3(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_3 }));
+	RD::Uniform u_source_color_4(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_4 }));
+	RD::Uniform u_source_color_5(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color_5 }));
+
+	RID shader_rid = shader.version_get_shader(shader_version, 0);
+	ERR_FAIL_COND(shader_rid.is_null());
+
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dst_framebuffer, RD::INITIAL_ACTION_DISCARD, RD::FINAL_ACTION_STORE, RD::INITIAL_ACTION_DISCARD, RD::FINAL_ACTION_DISCARD);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, pipeline.get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dst_framebuffer), false, RD::get_singleton()->draw_list_get_current_pass()));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 0, u_source_color_0), 0);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 1, u_source_color_1), 1);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 2, u_source_color_2), 2);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 3, u_source_color_3), 3);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 4, u_source_color_4), 4);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader_rid, 5, u_source_color_5), 5);
+	RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(PaniniPushConstant));
+	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
+	RD::get_singleton()->draw_list_end();
+}

--- a/servers/rendering/renderer_rd/effects/panini.h
+++ b/servers/rendering/renderer_rd/effects/panini.h
@@ -1,0 +1,63 @@
+/**************************************************************************/
+/*  panini.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PANINI_RD_H
+#define PANINI_RD_H
+
+#include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shaders/effects/panini.glsl.gen.h"
+#include "servers/rendering/renderer_scene_render.h"
+
+#include "servers/rendering_server.h"
+
+namespace RendererRD {
+
+class Panini {
+private:
+public:
+	Panini();
+	~Panini();
+
+	struct PaniniPushConstant {
+		float fovx;
+		float pad[3];
+	};
+
+	PaniniPushConstant push_constant;
+	PaniniShaderRD shader;
+	RID shader_version;
+	PipelineCacheRD pipeline;
+
+	void panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx);
+};
+
+} // namespace RendererRD
+
+#endif // PANINI_RD_H

--- a/servers/rendering/renderer_rd/effects/panini.h
+++ b/servers/rendering/renderer_rd/effects/panini.h
@@ -47,7 +47,8 @@ public:
 
 	struct PaniniPushConstant {
 		float fovx;
-		float pad[3];
+		bool keep_width;
+		float pad[2];
 	};
 
 	PaniniPushConstant push_constant;
@@ -55,7 +56,7 @@ public:
 	RID shader_version;
 	PipelineCacheRD pipeline;
 
-	void panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx);
+	void panini(RID p_source_color_0, RID p_source_color_1, RID p_source_color_2, RID p_source_color_3, RID p_source_color_4, RID p_source_color_5, RID p_dst_framebuffer, float fovx, bool keep_width);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2324,7 +2324,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 					rb->get_panini_texture(4, v),
 					rb->get_panini_texture(5, v),
 					rb_data->get_post_panini_fb(),
-					p_render_data->scene_data->cam_panini_fov);
+					p_render_data->scene_data->cam_panini_fov,
+					p_render_data->scene_data->cam_keep_width);
 		}
 
 		if (use_msaa) {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1637,6 +1637,25 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	Transform3D orig_cam_transform = p_render_data->scene_data->cam_transform;
 	for (int panini_i = 0; panini_i < (p_render_data->scene_data->cam_panini ? 6 : 1); panini_i++) {
+		{
+			float fovx, fovy;
+			if (p_render_data->scene_data->cam_keep_width) {
+				fovx = p_render_data->scene_data->cam_panini_fov;
+				fovy = 360.0f;
+			} else {
+				fovy = p_render_data->scene_data->cam_panini_fov / 2.0f;
+				fovx = 360.0f;
+			}
+			if (fovx < 270.0f) {
+				if (panini_i == 5)
+					break;
+				if (fovx < 90.0f && (panini_i == 1 || panini_i == 2))
+					break;
+			}
+			if (fovy < 90.0f && (panini_i == 3 || panini_i == 4))
+				break;
+		}
+
 		RENDER_TIMESTAMP("Prepare 3D Scene");
 
 		// set camera transform

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -34,6 +34,7 @@
 #include "core/templates/paged_allocator.h"
 #include "servers/rendering/renderer_rd/cluster_builder_rd.h"
 #include "servers/rendering/renderer_rd/effects/fsr2.h"
+#include "servers/rendering/renderer_rd/effects/panini.h"
 #include "servers/rendering/renderer_rd/effects/resolve.h"
 #include "servers/rendering/renderer_rd/effects/ss_effects.h"
 #include "servers/rendering/renderer_rd/effects/taa.h"
@@ -146,8 +147,9 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 		void ensure_fsr2(RendererRD::FSR2Effect *p_effect);
 		RendererRD::FSR2Context *get_fsr2_context() const { return fsr2_context; }
 
-		RID get_color_only_fb();
-		RID get_color_pass_fb(uint32_t p_color_pass_flags);
+		RID get_color_only_fb(bool cam_panini, int panini_i);
+		RID get_color_pass_fb(uint32_t p_color_pass_flags, bool cam_panini, int panini_i);
+		RID get_post_panini_fb();
 		RID get_depth_fb(DepthFrameBufferType p_type = DEPTH_FB);
 		RID get_specular_only_fb();
 		RID get_velocity_only_fb();
@@ -578,6 +580,7 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 	RendererRD::TAA *taa = nullptr;
 	RendererRD::FSR2Effect *fsr2_effect = nullptr;
 	RendererRD::SSEffects *ss_effects = nullptr;
+	RendererRD::Panini *panini = nullptr;
 
 	/* Cluster builder */
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1072,6 +1072,7 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 		scene_data.cam_orthogonal = p_camera_data->is_orthogonal;
 		scene_data.cam_panini = p_camera_data->is_panini;
 		scene_data.cam_panini_fov = p_camera_data->panini_fov;
+		scene_data.cam_keep_width = p_camera_data->vaspect;
 		scene_data.camera_visible_layers = p_camera_data->visible_layers;
 		scene_data.taa_jitter = p_camera_data->taa_jitter;
 		scene_data.main_cam_transform = p_camera_data->main_transform;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1070,6 +1070,8 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 		scene_data.cam_transform = p_camera_data->main_transform;
 		scene_data.cam_projection = p_camera_data->main_projection;
 		scene_data.cam_orthogonal = p_camera_data->is_orthogonal;
+		scene_data.cam_panini = p_camera_data->is_panini;
+		scene_data.cam_panini_fov = p_camera_data->panini_fov;
 		scene_data.camera_visible_layers = p_camera_data->visible_layers;
 		scene_data.taa_jitter = p_camera_data->taa_jitter;
 		scene_data.main_cam_transform = p_camera_data->main_transform;

--- a/servers/rendering/renderer_rd/shaders/effects/panini.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/panini.glsl
@@ -66,15 +66,15 @@ vec3 panini_ray(vec2 p) {
 
 void main() {
 	vec2 viewport_size = vec2(textureSize(source_color_0, 0));
-    vec3 albedo = vec3(0.0);
+	vec3 albedo = vec3(0.0);
 
 	float view_ratio = viewport_size.x / viewport_size.y;
-	vec2 uv = uv_interp*viewport_size / min(viewport_size.x, viewport_size.y);
+	vec2 uv = uv_interp * viewport_size / min(viewport_size.x, viewport_size.y);
 	vec3 pos = vec3(0.0, 0.0, 0.0);
 	if (view_ratio > 1.0) {
 		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
 	} else {
-		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
+		pos = panini_ray(vec2(uv.x - 0.5, uv.y - 0.5 / view_ratio) * 1.0);
 	}
 	if (pos == vec3(0.0, 0.0, 0.0)) {
 		albedo = pos;
@@ -112,5 +112,5 @@ void main() {
 			albedo = vec3(0.0, 0.0, 0.0);
 		}
 	}
-    frag_color = vec4(albedo, 1.0);
+	frag_color = vec4(albedo, 1.0);
 }

--- a/servers/rendering/renderer_rd/shaders/effects/panini.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/panini.glsl
@@ -61,7 +61,16 @@ vec2 panini_forward(vec2 latlon) {
 	return vec2(x, y);
 }
 vec3 panini_ray(vec2 p) {
-	float scale = panini_forward(vec2(0.0, radians(params.fovx) / 2.0)).x;
+	float scale;
+	if (params.keep_width) {
+		// horizontal FOV
+		scale = panini_forward(vec2(0.0, radians(params.fovx) / 2.0)).x;
+	} else {
+		// vertical FOV
+		// further divide FOV by 2 because it's a cylindrical projection
+		// (actual FOV range is up to 180 degrees, half of horizontal FOV)
+		scale = panini_forward(vec2(radians(params.fovx) / 4.0, 0.0)).y;
+	}
 	return panini_inverse(p * scale);
 }
 

--- a/servers/rendering/renderer_rd/shaders/effects/panini.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/panini.glsl
@@ -1,0 +1,116 @@
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(location = 0) out vec2 uv_interp;
+
+void main() {
+	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
+	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+}
+
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(location = 0) in vec2 uv_interp;
+
+layout(set = 0, binding = 0) uniform sampler2D source_color_0;
+layout(set = 1, binding = 0) uniform sampler2D source_color_1;
+layout(set = 2, binding = 0) uniform sampler2D source_color_2;
+layout(set = 3, binding = 0) uniform sampler2D source_color_3;
+layout(set = 4, binding = 0) uniform sampler2D source_color_4;
+layout(set = 5, binding = 0) uniform sampler2D source_color_5;
+
+layout(push_constant, std430) uniform Params {
+	float fovx;
+}
+params;
+
+layout(location = 0) out vec4 frag_color;
+
+const float subcamera_fov = 100.0f;
+
+vec3 latlon_to_ray(vec2 latlon) {
+	float lat = latlon.x;
+	float lon = latlon.y;
+	return vec3(sin(lon) * cos(lat), sin(lat), -cos(lon) * cos(lat));
+}
+
+vec3 panini_inverse(vec2 p) {
+	float d = 1.0;
+	float k = p.x * p.x / ((d + 1.0) * (d + 1.0));
+	float dscr = k * k * d * d - (k + 1.0) * (k * d * d - 1.0);
+	float clon = (-k * d + sqrt(dscr)) / (k + 1.0);
+	float s = (d + 1.0) / (d + clon);
+	float lon = atan(p.x, (s * clon));
+	float lat = atan(p.y, s);
+	return latlon_to_ray(vec2(lat, lon));
+}
+vec2 panini_forward(vec2 latlon) {
+	float d = 1.0;
+	float s = (d + 1.0) / (d + cos(latlon.y));
+	float x = s * sin(latlon.y);
+	float y = s * tan(latlon.x);
+	return vec2(x, y);
+}
+vec3 panini_ray(vec2 p) {
+	float scale = panini_forward(vec2(0.0, radians(params.fovx) / 2.0)).x;
+	return panini_inverse(p * scale);
+}
+
+void main() {
+	vec2 viewport_size = vec2(textureSize(source_color_0, 0));
+    vec3 albedo = vec3(0.0);
+
+	float view_ratio = viewport_size.x / viewport_size.y;
+	vec2 uv = uv_interp*viewport_size / min(viewport_size.x, viewport_size.y);
+	vec3 pos = vec3(0.0, 0.0, 0.0);
+	if (view_ratio > 1.0) {
+		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
+	} else {
+		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
+	}
+	if (pos == vec3(0.0, 0.0, 0.0)) {
+		albedo = pos;
+	} else {
+		float ax = abs(pos.x);
+		float ay = abs(pos.y);
+		float az = abs(pos.z);
+
+		float fov_fix = 1.0 / tan(radians(subcamera_fov / 2.0));
+		if (az >= ax && az >= ay) {
+			if (pos.z < 0.0) {
+				uv = vec2(fov_fix * 0.5 * (vec2(pos.x / az, pos.y / az)) + 0.5);
+				albedo = (texture(source_color_0, uv).rgb);
+			} else {
+				uv = vec2(fov_fix * 0.5 * (vec2(-pos.x / az, pos.y / az)) + 0.5);
+				albedo = (texture(source_color_5, uv).rgb);
+			}
+		} else if (ax >= ay && ax >= az) {
+			if (pos.x < 0.0) {
+				uv = vec2(fov_fix * 0.5 * (vec2(-pos.z / ax, pos.y / ax)) + 0.5);
+				albedo = (texture(source_color_1, uv).rgb);
+			} else {
+				uv = vec2(fov_fix * 0.5 * (vec2(pos.z / ax, pos.y / ax)) + 0.5);
+				albedo = (texture(source_color_2, uv).rgb);
+			}
+		} else if (ay >= ax && ay >= az) {
+			if (pos.y > 0.0) {
+				uv = vec2(fov_fix * 0.5 * (vec2(pos.x / ay, pos.z / ay)) + 0.5);
+				albedo = (texture(source_color_3, uv).rgb);
+			} else {
+				uv = vec2(fov_fix * 0.5 * (vec2(pos.x / ay, -pos.z / ay)) + 0.5);
+				albedo = (texture(source_color_4, uv).rgb);
+			}
+		} else {
+			albedo = vec3(0.0, 0.0, 0.0);
+		}
+	}
+    frag_color = vec4(albedo, 1.0);
+}

--- a/servers/rendering/renderer_rd/shaders/effects/panini.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/panini.glsl
@@ -63,12 +63,12 @@ vec2 panini_forward(vec2 latlon) {
 vec3 panini_ray(vec2 p) {
 	float scale;
 	if (params.keep_width) {
-		// horizontal FOV
+		// Horizontal FOV.
 		scale = panini_forward(vec2(0.0, radians(params.fovx) / 2.0)).x;
 	} else {
-		// vertical FOV
-		// further divide FOV by 2 because it's a cylindrical projection
-		// (actual FOV range is up to 180 degrees, half of horizontal FOV)
+		// Vertical FOV.
+		// Further divide FOV by 2 because it's a cylindrical projection
+		// (actual FOV range is up to 180 degrees, half of horizontal FOV).
 		scale = panini_forward(vec2(radians(params.fovx) / 4.0, 0.0)).y;
 	}
 	return panini_inverse(p * scale);
@@ -82,10 +82,10 @@ void main() {
 	vec2 uv = uv_interp * viewport_size / (params.keep_width ? viewport_size.x : viewport_size.y);
 	vec3 pos = vec3(0.0, 0.0, 0.0);
 	if (params.keep_width) {
-		// adjust height
+		// Adjust height.
 		pos = panini_ray(vec2(uv.x - 0.5, uv.y - 0.5 / view_ratio) * 1.0);
 	} else {
-		// adjust width
+		// Adjust width.
 		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
 	}
 	if (pos == vec3(0.0, 0.0, 0.0)) {

--- a/servers/rendering/renderer_rd/shaders/effects/panini.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/panini.glsl
@@ -29,6 +29,7 @@ layout(set = 5, binding = 0) uniform sampler2D source_color_5;
 
 layout(push_constant, std430) uniform Params {
 	float fovx;
+	bool keep_width;
 }
 params;
 
@@ -69,12 +70,14 @@ void main() {
 	vec3 albedo = vec3(0.0);
 
 	float view_ratio = viewport_size.x / viewport_size.y;
-	vec2 uv = uv_interp * viewport_size / min(viewport_size.x, viewport_size.y);
+	vec2 uv = uv_interp * viewport_size / (params.keep_width ? viewport_size.x : viewport_size.y);
 	vec3 pos = vec3(0.0, 0.0, 0.0);
-	if (view_ratio > 1.0) {
-		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
-	} else {
+	if (params.keep_width) {
+		// adjust height
 		pos = panini_ray(vec2(uv.x - 0.5, uv.y - 0.5 / view_ratio) * 1.0);
+	} else {
+		// adjust width
+		pos = panini_ray(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
 	}
 	if (pos == vec3(0.0, 0.0, 0.0)) {
 		albedo = pos;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -181,6 +181,12 @@ void RenderSceneBuffersRD::configure(const RenderSceneBuffersConfiguration *p_co
 		}
 
 		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_0, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_1, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_2, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_3, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_4, base_data_format, usage_bits);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_5, base_data_format, usage_bits);
 	}
 
 	// Create our depth buffer
@@ -218,6 +224,12 @@ void RenderSceneBuffersRD::configure(const RenderSceneBuffersConfiguration *p_co
 		texture_samples = ts[msaa_3d];
 
 		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_0, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_1, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_2, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_3, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_4, format, usage_bits, texture_samples);
+		create_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_5, format, usage_bits, texture_samples);
 
 		usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
 		format = RD::get_singleton()->texture_is_format_supported_for_usage(preferred_format[0], usage_bits) ? preferred_format[0] : preferred_format[1];

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -47,7 +47,19 @@
 
 #define RB_TEXTURE SNAME("texture")
 #define RB_TEX_COLOR SNAME("color")
+#define RB_TEX_COLOR_PANINI_0 SNAME("color_panini_0")
+#define RB_TEX_COLOR_PANINI_1 SNAME("color_panini_1")
+#define RB_TEX_COLOR_PANINI_2 SNAME("color_panini_2")
+#define RB_TEX_COLOR_PANINI_3 SNAME("color_panini_3")
+#define RB_TEX_COLOR_PANINI_4 SNAME("color_panini_4")
+#define RB_TEX_COLOR_PANINI_5 SNAME("color_panini_5")
 #define RB_TEX_COLOR_MSAA SNAME("color_msaa")
+#define RB_TEX_COLOR_MSAA_PANINI_0 SNAME("color_msaa_panini_0")
+#define RB_TEX_COLOR_MSAA_PANINI_1 SNAME("color_msaa_panini_1")
+#define RB_TEX_COLOR_MSAA_PANINI_2 SNAME("color_msaa_panini_2")
+#define RB_TEX_COLOR_MSAA_PANINI_3 SNAME("color_msaa_panini_3")
+#define RB_TEX_COLOR_MSAA_PANINI_4 SNAME("color_msaa_panini_4")
+#define RB_TEX_COLOR_MSAA_PANINI_5 SNAME("color_msaa_panini_5")
 #define RB_TEX_COLOR_UPSCALED SNAME("color_upscaled")
 #define RB_TEX_DEPTH SNAME("depth")
 #define RB_TEX_DEPTH_MSAA SNAME("depth_msaa")
@@ -254,6 +266,76 @@ public:
 	}
 	_FORCE_INLINE_ RID get_color_msaa(uint32_t p_layer) {
 		return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA, p_layer, 0);
+	}
+
+	RID get_panini_texture(int i) const {
+		switch (i) {
+			case 1:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_1);
+			case 2:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_2);
+			case 3:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_3);
+			case 4:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_4);
+			case 5:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_5);
+
+			default:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_0);
+		}
+	}
+	RID get_panini_texture(int i, const uint32_t p_layer) {
+		switch (i) {
+			case 1:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_1, p_layer, 0);
+			case 2:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_2, p_layer, 0);
+			case 3:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_3, p_layer, 0);
+			case 4:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_4, p_layer, 0);
+			case 5:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_5, p_layer, 0);
+
+			default:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_PANINI_0, p_layer, 0);
+		}
+	}
+
+	RID get_panini_msaa_texture(int i) const {
+		switch (i) {
+			case 1:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_1);
+			case 2:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_2);
+			case 3:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_3);
+			case 4:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_4);
+			case 5:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_5);
+
+			default:
+				return get_texture(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_0);
+		}
+	}
+	RID get_panini_msaa_texture(int i, const uint32_t p_layer) {
+		switch (i) {
+			case 1:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_1, p_layer, 0);
+			case 2:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_2, p_layer, 0);
+			case 3:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_3, p_layer, 0);
+			case 4:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_4, p_layer, 0);
+			case 5:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_5, p_layer, 0);
+
+			default:
+				return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_PANINI_0, p_layer, 0);
+		}
 	}
 
 	bool has_depth_texture();

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -52,6 +52,7 @@ public:
 	bool cam_orthogonal = false;
 	bool cam_panini = false;
 	float cam_panini_fov;
+	bool cam_keep_width;
 
 	// For billboards to cast correct shadows.
 	Transform3D main_cam_transform;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -50,6 +50,8 @@ public:
 	Vector2 taa_jitter;
 	uint32_t camera_visible_layers;
 	bool cam_orthogonal = false;
+	bool cam_panini = false;
+	float cam_panini_fov;
 
 	// For billboards to cast correct shadows.
 	Transform3D main_cam_transform;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3050,7 +3050,7 @@ void RendererSceneCull::_render_scene(RendererSceneRender::CameraData *p_camera_
 	Projection orig_cam_projection;
 	Transform3D orig_cam_transform;
 	if (p_camera_data->is_panini) {
-		// Cull on a cube
+		// Cull on a cube.
 		orig_cam_projection = p_camera_data->main_projection;
 		orig_cam_transform = p_camera_data->main_transform;
 		real_t z_far = p_camera_data->main_projection.get_z_far();

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -90,6 +90,15 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->zfar = p_z_far;
 }
 
+void RendererSceneCull::camera_set_panini(RID p_camera, float p_panini_fovy_degrees, float p_z_near, float p_z_far) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->type = Camera::PANINI;
+	camera->panini_fov = p_panini_fovy_degrees;
+	camera->znear = p_z_near;
+	camera->zfar = p_z_far;
+}
+
 void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
 	Camera *camera = camera_owner.get_or_null(p_camera);
 	ERR_FAIL_NULL(camera);
@@ -2575,6 +2584,8 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		Projection projection;
 		bool vaspect = camera->vaspect;
 		bool is_orthogonal = false;
+		bool is_panini = false;
+		float panini_fov = 150.0f;
 
 		switch (camera->type) {
 			case Camera::ORTHOGONAL: {
@@ -2604,9 +2615,19 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 						camera->zfar,
 						camera->vaspect);
 			} break;
+			case Camera::PANINI: {
+				projection.set_perspective(
+						100.0f,
+						1.0f,
+						camera->znear,
+						camera->zfar,
+						camera->vaspect);
+				is_panini = true;
+				panini_fov = camera->panini_fov;
+			} break;
 		}
 
-		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, camera->visible_layers);
+		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, camera->visible_layers, is_panini, panini_fov);
 	} else {
 		// Setup our camera for our XR interface.
 		// We can support multiple views here each with their own camera
@@ -2628,9 +2649,9 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		}
 
 		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, camera->visible_layers);
+			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, camera->visible_layers, false);
 		} else if (view_count == 2) {
-			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect);
+			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect, false, camera->panini_fov);
 		} else {
 			// this won't be called (see fail check above) but keeping this comment to indicate we may support more then 2 views in the future...
 		}
@@ -3023,8 +3044,24 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 	}
 }
 
-void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, bool p_using_shadows, RenderingMethod::RenderInfo *r_render_info) {
+void RendererSceneCull::_render_scene(RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, bool p_using_shadows, RenderingMethod::RenderInfo *r_render_info) {
 	Instance *render_reflection_probe = instance_owner.get_or_null(p_reflection_probe); //if null, not rendering to it
+
+	Projection orig_cam_projection;
+	Transform3D orig_cam_transform;
+	if (p_camera_data->is_panini) {
+		// Cull on a cube
+		orig_cam_projection = p_camera_data->main_projection;
+		orig_cam_transform = p_camera_data->main_transform;
+		real_t z_far = p_camera_data->main_projection.get_z_far();
+		p_camera_data->main_projection.set_orthogonal(
+				z_far * 2.0f,
+				1.0f,
+				p_camera_data->main_projection.get_z_near(),
+				z_far * 2.0f,
+				false);
+		p_camera_data->main_transform.translate_local(0.0f, 0.0f, z_far);
+	}
 
 	// Prepare the light - camera volume culling system.
 	light_culler->prepare_camera(p_camera_data->main_transform, p_camera_data->main_projection);
@@ -3080,6 +3117,11 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
 	cull.frustum = Frustum(planes);
+
+	if (p_camera_data->is_panini) {
+		p_camera_data->main_projection = orig_cam_projection;
+		p_camera_data->main_transform = orig_cam_transform;
+	}
 
 	Vector<RID> directional_lights;
 	// directional lights

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -72,10 +72,12 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			PANINI
 		};
 		Type type;
 		float fov;
+		float panini_fov;
 		float znear, zfar;
 		float size;
 		Vector2 offset;
@@ -90,6 +92,7 @@ public:
 		Camera() {
 			visible_layers = 0xFFFFFFFF;
 			fov = 75;
+			panini_fov = 150;
 			type = PERSPECTIVE;
 			znear = 0.05;
 			zfar = 4000;
@@ -107,6 +110,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_panini(RID p_camera, float p_panini_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
@@ -1149,7 +1153,7 @@ public:
 	_FORCE_INLINE_ bool _visibility_parent_check(const CullData &p_cull_data, const InstanceData &p_instance_data);
 
 	bool _render_reflection_probe_step(Instance *p_instance, int p_step);
-	void _render_scene(const RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, bool p_using_shadows = true, RenderInfo *r_render_info = nullptr);
+	void _render_scene(RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, bool p_using_shadows = true, RenderInfo *r_render_info = nullptr);
 	void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas);
 
 	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, RenderingMethod::RenderInfo *r_render_info = nullptr);

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -33,9 +33,11 @@
 /////////////////////////////////////////////////////////////////////////////
 // CameraData
 
-void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, const uint32_t p_visible_layers) {
+void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, const uint32_t p_visible_layers, bool p_is_panini, float p_panini_fov) {
 	view_count = 1;
 	is_orthogonal = p_is_orthogonal;
+	is_panini = p_is_panini;
+	panini_fov = p_panini_fov;
 	vaspect = p_vaspect;
 
 	main_transform = p_transform;
@@ -47,12 +49,14 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	taa_jitter = p_taa_jitter;
 }
 
-void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect) {
+void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, bool p_is_panini, float p_panini_fov) {
 	ERR_FAIL_COND_MSG(p_view_count != 2, "Incorrect view count for stereoscopic view");
 
 	visible_layers = 0xFFFFFFFF;
 	view_count = p_view_count;
 	is_orthogonal = p_is_orthogonal;
+	is_panini = p_is_panini;
+	panini_fov = p_panini_fov;
 	vaspect = p_vaspect;
 	Vector<Plane> planes[2];
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -297,19 +297,21 @@ public:
 		// flags
 		uint32_t view_count;
 		bool is_orthogonal;
+		bool is_panini;
 		uint32_t visible_layers;
 		bool vaspect;
 
 		// Main/center projection
 		Transform3D main_transform;
 		Projection main_projection;
+		float panini_fov;
 
 		Transform3D view_offset[RendererSceneRender::MAX_RENDER_VIEWS];
 		Projection view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
 		Vector2 taa_jitter;
 
-		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), uint32_t p_visible_layers = 0xFFFFFFFF);
-		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect);
+		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), uint32_t p_visible_layers = 0xFFFFFFFF, bool p_is_panini = false, float p_panini_fov = 150.0f);
+		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, bool p_is_panini, float p_panini_fov);
 	};
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_render_info = nullptr) = 0;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -50,6 +50,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_panini(RID p_camera, float p_panini_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -582,6 +582,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC4(camera_set_panini, RID, float, float, float)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2755,6 +2755,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_panini", "camera", "panini_fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_panini);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -842,6 +842,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_panini(RID p_camera, float p_panini_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;


### PR DESCRIPTION
Implements Panini projection as a built-in feature in Forward+ renderer, along with a new PROJECTION_PANINI enum value in Camera3D to enable this projection.

When enabled, the renderer draws 6 frames with different camera orientations to form a 360 degrees view. These frames are then merged by an extra render step performed before screen-space effects.

Implements (partially) godotengine/godot-proposals#3779.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
