### PR TITLE
Move some debugger code out of Window file

### DIFF
--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -31,6 +31,7 @@
 #ifndef ENGINE_DEBUGGER_H
 #define ENGINE_DEBUGGER_H
 
+#include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
@@ -38,7 +39,9 @@
 #include "core/variant/array.h"
 #include "core/variant/variant.h"
 
+class InputEvent;
 class RemoteDebuggerPeer;
+class Shortcut;
 class ScriptDebugger;
 
 class EngineDebugger {
@@ -92,6 +95,8 @@ private:
 
 	uint32_t poll_every = 0;
 
+	Ref<Shortcut> stop_shortcut;
+
 protected:
 	static EngineDebugger *singleton;
 	static ScriptDebugger *script_debugger;
@@ -125,6 +130,8 @@ public:
 	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
+
+	void check_stop_shortcut(const Ref<InputEvent> &p_ev);
 
 	void line_poll() {
 		// The purpose of this is just processing events every now and then when the script might get too busy otherwise bugs like infinite loops can't be caught.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -33,9 +33,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
-#include "core/input/shortcut.h"
 #include "core/string/translation.h"
-#include "core/variant/variant_parser.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
@@ -1611,33 +1609,7 @@ bool Window::_can_consume_input_events() const {
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	ERR_MAIN_THREAD_GUARD;
 	if (EngineDebugger::is_active()) {
-		// Quit from game window using the stop shortcut (F8 by default).
-		// The custom shortcut is provided via environment variable when running from the editor.
-		if (debugger_stop_shortcut.is_null()) {
-			String shortcut_str = OS::get_singleton()->get_environment("__GODOT_EDITOR_STOP_SHORTCUT__");
-			if (!shortcut_str.is_empty()) {
-				Variant shortcut_var;
-
-				VariantParser::StreamString ss;
-				ss.s = shortcut_str;
-
-				String errs;
-				int line;
-				VariantParser::parse(&ss, shortcut_var, errs, line);
-				debugger_stop_shortcut = shortcut_var;
-			}
-
-			if (debugger_stop_shortcut.is_null()) {
-				// Define a default shortcut if it wasn't provided or is invalid.
-				debugger_stop_shortcut.instantiate();
-				debugger_stop_shortcut->set_events({ (Variant)InputEventKey::create_reference(Key::F8) });
-			}
-		}
-
-		Ref<InputEventKey> k = p_ev;
-		if (k.is_valid() && k->is_pressed() && !k->is_echo() && debugger_stop_shortcut->matches_event(k)) {
-			EngineDebugger::get_singleton()->send_message("request_quit", Array());
-		}
+		EngineDebugger::get_singleton()->check_stop_shortcut(p_ev);
 	}
 
 	if (exclusive_child != nullptr) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -35,7 +35,6 @@
 #include "scene/resources/theme.h"
 
 class Font;
-class Shortcut;
 class StyleBox;
 class ThemeOwner;
 class ThemeContext;
@@ -232,8 +231,6 @@ private:
 	bool mouse_in_window = false;
 	void _update_mouse_over(Vector2 p_pos) override;
 	void _mouse_leave_viewport() override;
-
-	Ref<Shortcut> debugger_stop_shortcut;
 
 	static int root_layout_direction;
 


### PR DESCRIPTION
Originally mentioned here: https://github.com/godotengine/godot/pull/47744#pullrequestreview-1090181236
Unfortunately adding a node is not possible, because debugger is `core/`. Handling it would still require some hook in scene.