### PR TITLE
Prevent static XCFramework bundles from being embedded on iOS

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1332,7 +1332,12 @@ void EditorExportPlatformIOS::_add_assets_to_project(const String &p_out_dir, co
 
 			type = "wrapper.framework";
 		} else if (asset.exported_path.ends_with(".xcframework")) {
-			if (asset.should_embed) {
+			int total_libs = 0;
+			int static_libs = 0;
+			int dylibs = 0;
+			int frameworks = 0;
+			_check_xcframework_content(p_out_dir.path_join(asset.exported_path), total_libs, static_libs, dylibs, frameworks);
+			if (asset.should_embed && static_libs != total_libs) {
 				additional_asset_info_format += "$framework_id = {isa = PBXBuildFile; fileRef = $ref_id; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };\n";
 				framework_id = (++current_id).str();
 				pbx_embeded_frameworks += framework_id + ",\n";


### PR DESCRIPTION
Currently when archiving/distributing iOS apps that utilize extensions that have been built with the XCFramework approach, as seen in godot-cpp's `test` project [here](https://github.com/godotengine/godot-cpp/blob/21b86b67700a8d097d7ba09afb7adcd74380255e/test/generate_xcframework.sh), you will currently run into errors when you try to validate said app, due to the `.a` files of the two XCFramework bundles (godot-cpp and the extension) being bundled within the `.app`.

This PR fixes this by checking to see whether the XCFramework only contains static libraries before respecting `IOSExportAsset::should_embed`, same as what regular frameworks already do as of #86288, as seen a few lines above this change.

CC @bruvzg 