### PR TITLE
Add `get_node_list()` to animation roots with child nodes

### DIFF
--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -44,6 +44,12 @@
 				Returns the sub animation node with the specified [param name].
 			</description>
 		</method>
+		<method name="get_node_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the names of all nodes in this sub-tree.
+			</description>
+		</method>
 		<method name="get_node_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -51,6 +51,12 @@
 				Returns the animation node with the given name.
 			</description>
 		</method>
+		<method name="get_node_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the names of all nodes in this sub-tree.
+			</description>
+		</method>
 		<method name="get_node_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="node" type="AnimationNode" />

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1618,7 +1618,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendTree::_process(const AnimationMixe
 	return _blend_node(output, "output", this, pi, FILTER_IGNORE, true, p_test_only, nullptr);
 }
 
-void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) {
+void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) const {
 	for (const KeyValue<StringName, Node> &E : nodes) {
 		r_list->push_back(E.key);
 	}
@@ -1738,6 +1738,16 @@ void AnimationNodeBlendTree::_animation_node_removed(const ObjectID &p_oid, cons
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
+Vector<String> AnimationNodeBlendTree::_get_node_list() const {
+	List<StringName> node_list;
+	get_node_list(&node_list);
+	Vector<String> ret;
+	for (const StringName &node : node_list) {
+		ret.push_back(node);
+	}
+	return ret;
+}
+
 void AnimationNodeBlendTree::reset_state() {
 	graph_offset = Vector2();
 	nodes.clear();
@@ -1773,6 +1783,7 @@ void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, 
 void AnimationNodeBlendTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeBlendTree::add_node, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("get_node", "name"), &AnimationNodeBlendTree::get_node);
+	ClassDB::bind_method(D_METHOD("get_node_list"), &AnimationNodeBlendTree::_get_node_list);
 	ClassDB::bind_method(D_METHOD("remove_node", "name"), &AnimationNodeBlendTree::remove_node);
 	ClassDB::bind_method(D_METHOD("rename_node", "name", "new_name"), &AnimationNodeBlendTree::rename_node);
 	ClassDB::bind_method(D_METHOD("has_node", "name"), &AnimationNodeBlendTree::has_node);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -414,6 +414,8 @@ protected:
 	virtual void _animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) override;
 	virtual void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node) override;
 
+	Vector<String> _get_node_list() const;
+
 	virtual void reset_state() override;
 
 public:
@@ -455,7 +457,7 @@ public:
 	virtual String get_caption() const override;
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
 
-	void get_node_list(List<StringName> *r_list);
+	void get_node_list(List<StringName> *r_list) const;
 
 	void set_graph_offset(const Vector2 &p_graph_offset);
 	Vector2 get_graph_offset() const;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1781,6 +1781,16 @@ void AnimationNodeStateMachine::_animation_node_removed(const ObjectID &p_oid, c
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
+Vector<String> AnimationNodeStateMachine::_get_node_list() const {
+	List<StringName> node_list;
+	get_node_list(&node_list);
+	Vector<String> ret;
+	for (const StringName &node : node_list) {
+		ret.push_back(node);
+	}
+	return ret;
+}
+
 #ifdef TOOLS_ENABLED
 void AnimationNodeStateMachine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
@@ -1803,6 +1813,7 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeStateMachine::add_node, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("replace_node", "name", "node"), &AnimationNodeStateMachine::replace_node);
 	ClassDB::bind_method(D_METHOD("get_node", "name"), &AnimationNodeStateMachine::get_node);
+	ClassDB::bind_method(D_METHOD("get_node_list"), &AnimationNodeStateMachine::_get_node_list);
 	ClassDB::bind_method(D_METHOD("remove_node", "name"), &AnimationNodeStateMachine::remove_node);
 	ClassDB::bind_method(D_METHOD("rename_node", "name", "new_name"), &AnimationNodeStateMachine::rename_node);
 	ClassDB::bind_method(D_METHOD("has_node", "name"), &AnimationNodeStateMachine::has_node);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -164,6 +164,8 @@ protected:
 	virtual void _animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) override;
 	virtual void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node) override;
 
+	Vector<String> _get_node_list() const;
+
 	virtual void reset_state() override;
 
 public:


### PR DESCRIPTION
Animation trees `AnimationNodeBlendTree` and `AnimationNodeStateMachine` have a `get_node(name: StringName)` method but no method to get the list of all node names in the graph making it impossible to get them without hard coding names.
This PR adds `get_node_list()` for them.

* Closes: https://github.com/godotengine/godot-proposals/issues/9845