### PR TITLE
Expose `get_cached_ref` from `ResourceCache`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -114,6 +114,11 @@ bool ResourceLoader::has_cached(const String &p_path) {
 	return ResourceCache::has(local_path);
 }
 
+Ref<Resource> ResourceLoader::get_cached_ref(const String &p_path) {
+	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+	return ResourceCache::get_ref(local_path);
+}
+
 bool ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
 	return ::ResourceLoader::exists(p_path, p_type_hint);
 }
@@ -134,6 +139,7 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_abort_on_missing_resources", "abort"), &ResourceLoader::set_abort_on_missing_resources);
 	ClassDB::bind_method(D_METHOD("get_dependencies", "path"), &ResourceLoader::get_dependencies);
 	ClassDB::bind_method(D_METHOD("has_cached", "path"), &ResourceLoader::has_cached);
+	ClassDB::bind_method(D_METHOD("get_cached_ref", "path"), &ResourceLoader::get_cached_ref);
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &ResourceLoader::get_resource_uid);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -83,6 +83,7 @@ public:
 	void set_abort_on_missing_resources(bool p_abort);
 	PackedStringArray get_dependencies(const String &p_path);
 	bool has_cached(const String &p_path);
+	Ref<Resource> get_cached_ref(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");
 	ResourceUID::ID get_resource_uid(const String &p_path);
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -31,6 +31,14 @@
 				[b]Note:[/b] If you use [method Resource.take_over_path], this method will return [code]true[/code] for the taken path even if the resource wasn't saved (i.e. exists only in resource cache).
 			</description>
 		</method>
+		<method name="get_cached_ref">
+			<return type="Resource" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the cached resource reference for the given [param path].
+				[b]Note:[/b] If the resource is not cached, the returned [Resource] will be invalid.
+			</description>
+		</method>
 		<method name="get_dependencies">
 			<return type="PackedStringArray" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
This allows custom resource loaders to safely access existing cached resources in the `ResourceCache` like the standard Godot resource loaders work.