### PR TITLE
Add Mesh metadata to MeshLibrary/GridMap

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -234,6 +234,53 @@
 				This is for editors that edit script-based objects. You can return a list of breakpoints in the format ([code]script:line[/code]), for example: [code]res://path_to_script.gd:25[/code].
 			</description>
 		</method>
+		<method name="_get_meshlib_item_metadata_list" qualifiers="virtual">
+			<return type="Dictionary[]" />
+			<param index="0" name="object" type="MeshInstance3D" />
+			<description>
+				Override this method to implement application-specific metadata in a [MeshLibrary].
+				It is called once for each [MeshInstance3D] when generating a [MeshLibrary] from a scene.
+				Metadata can be added this way by returning a [Dictionary] list where each entry contains the [code]name[/code] and [code]value[/code] keys.
+				This example assumes that there is a [Node] type named [code]MeshTerrainTypeDefiner[/code] which contains a [code]terrain_type[/code] property:
+				[codeblocks]
+				[gdscript]
+				func _get_meshlib_item_metadata_list(object):
+				    var metadata_list = []
+				    
+				    for child in object.get_children():
+				        if child is MeshTerrainTypeDefiner:
+				            metadata_list.append({
+				                "name": "terrain_type",
+				                "value": child.terrain_type,
+				            })
+				            break
+				    
+				    return metadata_list
+				[/gdscript]
+				[csharp]
+				public override Godot.Collections.Array&lt;Godot.Collections.Dictionary&gt; _GetMeshlibItemMetadataList(MeshInstance3D @object)
+				{
+				    var metadataList = new Godot.Collections.Array&lt;Godot.Collections.Dictionary&gt;();
+				
+				    foreach (Node child in @object.GetChildren())
+				    {
+				        if (child is MeshTerrainTypeDefiner terrainTypeDefiner)
+				        {
+				            metadataList.Add(new Godot.Collections.Dictionary()
+				            {
+				                { "name", "TerrainType" },
+				                { "value", terrainTypeDefiner.TerrainType },
+				            });
+				            break;
+				        }
+				    }
+				    
+				    return metadataList;
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="_get_plugin_icon" qualifiers="virtual const">
 			<return type="Texture2D" />
 			<description>

--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -52,6 +52,14 @@
 				Returns the transform applied to the item's mesh.
 			</description>
 		</method>
+		<method name="get_item_metadata" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Returns the item's metadata corresponding to [param key].
+			</description>
+		</method>
 		<method name="get_item_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="id" type="int" />
@@ -101,11 +109,34 @@
 				Gets an unused ID for a new item.
 			</description>
 		</method>
+		<method name="has_item" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns [code]true[/code] if an item exists at [param id].
+			</description>
+		</method>
+		<method name="has_item_metadata" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Returns [code]true[/code] if the item has metadata corresponding to [param key].
+			</description>
+		</method>
 		<method name="remove_item">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
 				Removes the item.
+			</description>
+		</method>
+		<method name="remove_item_metadata">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="key" type="String" />
+			<description>
+				Removes the item's metadata corresponding to [param key].
 			</description>
 		</method>
 		<method name="set_item_mesh">
@@ -122,6 +153,15 @@
 			<param index="1" name="mesh_transform" type="Transform3D" />
 			<description>
 				Sets the transform to apply to the item's mesh.
+			</description>
+		</method>
+		<method name="set_item_metadata">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="key" type="String" />
+			<param index="2" name="value" type="Variant" />
+			<description>
+				Assigns [param value] to the item's metadata.
 			</description>
 		</method>
 		<method name="set_item_name">

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -507,6 +507,30 @@ bool EditorPlugin::build() {
 	return success;
 }
 
+void EditorPlugin::get_meshlib_item_metadata_list(MeshInstance3D *p_object, List<MeshLibrary::PluginGeneratedMetadata> *p_list) {
+	TypedArray<Dictionary> virtual_list;
+	if (GDVIRTUAL_CALL(_get_meshlib_item_metadata_list, p_object, virtual_list)) {
+		for (int i = 0; i < virtual_list.size(); i++) {
+			Dictionary virtual_entry = virtual_list.get(i);
+			if (!virtual_entry.has("name") || !virtual_entry.has("value")) {
+				continue;
+			}
+			Variant var_name = virtual_entry["name"];
+			Variant var_metadata = virtual_entry["value"];
+
+			if (var_name.get_type() != Variant::STRING) {
+				continue;
+			}
+			String name = var_name;
+			if (name.is_empty()) {
+				continue;
+			}
+			MeshLibrary::PluginGeneratedMetadata meta = MeshLibrary::PluginGeneratedMetadata(name, var_metadata);
+			p_list->push_back(meta);
+		}
+	}
+}
+
 void EditorPlugin::queue_save_layout() {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
@@ -637,6 +661,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_set_window_layout, "configuration");
 	GDVIRTUAL_BIND(_get_window_layout, "configuration");
 	GDVIRTUAL_BIND(_build);
+	GDVIRTUAL_BIND(_get_meshlib_item_metadata_list, "object");
 	GDVIRTUAL_BIND(_enable_plugin);
 	GDVIRTUAL_BIND(_disable_plugin);
 

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -33,6 +33,8 @@
 
 #include "core/io/config_file.h"
 #include "scene/3d/camera_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/resources/3d/mesh_library.h"
 #include "scene/gui/control.h"
 
 class Node3D;
@@ -132,6 +134,7 @@ protected:
 	GDVIRTUAL1(_set_window_layout, Ref<ConfigFile>)
 	GDVIRTUAL1(_get_window_layout, Ref<ConfigFile>)
 	GDVIRTUAL0R(bool, _build)
+	GDVIRTUAL1R(TypedArray<Dictionary>, _get_meshlib_item_metadata_list, MeshInstance3D *)
 	GDVIRTUAL0(_enable_plugin)
 	GDVIRTUAL0(_disable_plugin)
 
@@ -201,6 +204,7 @@ public:
 	virtual void get_window_layout(Ref<ConfigFile> p_layout);
 	virtual void edited_scene_changed() {} // if changes are pending in editor, apply them
 	virtual bool build(); // builds with external tools. Returns true if safe to continue running scene.
+	virtual void get_meshlib_item_metadata_list(MeshInstance3D *p_object, List<MeshLibrary::PluginGeneratedMetadata> *p_list); // While generating a MeshLibrary from a scene, metadata may be added to any item. Useful for game-specific data, like terrain types.
 
 	EditorInterface *get_editor_interface();
 	ScriptCreateDialog *get_script_create_dialog();

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -206,6 +206,16 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 			break;
 		}
 	}
+
+	List<MeshLibrary::PluginGeneratedMetadata> plugin_meta_list;
+	List<MeshLibrary::PluginGeneratedMetadata> *plugin_meta_list_ptr = &plugin_meta_list;
+	for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
+		EditorPlugin *current_plugin = EditorNode::get_editor_data().get_editor_plugin(i);
+		current_plugin->get_meshlib_item_metadata_list(mesh_instance_node, plugin_meta_list_ptr);
+	}
+	for (const MeshLibrary::PluginGeneratedMetadata &plugin_meta : plugin_meta_list) {
+		p_library->set_item_metadata(item_id, plugin_meta.name, plugin_meta.value);
+	}
 }
 
 Error MeshLibraryEditor::update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge, bool p_apply_xforms) {

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -55,12 +55,26 @@ public:
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+		Dictionary metadata;
+	};
+	struct PluginGeneratedMetadata {
+		String name;
+		Variant value;
+
+		PluginGeneratedMetadata() {}
+
+		PluginGeneratedMetadata(const String &p_name, const Variant &p_value) {
+			name = p_name;
+			value = p_value;
+		}
 	};
 
 	RBMap<int, Item> item_map;
 
 	void _set_item_shapes(int p_item, const Array &p_shapes);
 	Array _get_item_shapes(int p_item) const;
+	void _set_item_metadata_dictionary(int p_item, const Dictionary &p_metadata); // internally, allow dealing with the meta dictionary directly
+	Dictionary _get_item_metadata_dictionary(int p_item) const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -80,6 +94,7 @@ public:
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
+	void set_item_metadata(int p_item, const String &p_key, const Variant &p_value);
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
@@ -88,9 +103,12 @@ public:
 	uint32_t get_item_navigation_layers(int p_item) const;
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 	Ref<Texture2D> get_item_preview(int p_item) const;
+	Variant get_item_metadata(int p_item, const String &p_key) const;
 
 	void remove_item(int p_item);
 	bool has_item(int p_item) const;
+	void remove_item_metadata(int p_item, const String &p_key);
+	bool has_item_metadata(int p_item, const String &p_key) const;
 
 	void clear();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
At the moment, there is no way to associate custom data with a `MeshLibrary`.
For certain types of games which use `GridMap`, this feature saves tons of time!
The example provided is terrain types (like in Fire Emblem) in a 3D grid-based game, though data such as heights, custom tile graphics, grid collisions, etc. are all possible to implement this way.
A method is also added to `EditorPlugin` to facilitate this, with the intention being to add custom data based on the children of the `MeshInstance3D` being scanned like how it's checked for `StaticBody3D` children, but any kind of usage is possible.

A few questions:
- Would it be better to store the metadata as sub-properties rather than a dictionary, eg. `item/0/metadata/terrain_type = 2`
- Should the type passed to `EditorPlugin` be `MeshInstance3D`? If more types are able to be used in generation later for whatever reason, it'd break compatibility with existing plugins which use the feature. Furthermore, it increases compile time in certain cases. Is expecting type casting from the user preferable?
- Should the automatic metadata creation feature instead do something like `if (has_method(SNAME("_get_meshlib_item_metadata_list")))` on the root of the scene that's being scanned and use its result if the type matches? Like, rather than it being part of `EditorPlugin`. It's a niche use case, and primarily game-specific, so maybe this would be better. This is the same approach taken for the visibility button in the scene dock.

___

- *Production edit: See https://github.com/godotengine/godot-proposals/issues/8723.*