### PR TITLE
Fix Capture and Record AudioEffect bugs for surround systems

### DIFF
--- a/doc/classes/AudioEffect.xml
+++ b/doc/classes/AudioEffect.xml
@@ -12,6 +12,12 @@
 		<link title="Audio Microphone Record Demo">https://godotengine.org/asset-library/asset/2760</link>
 	</tutorials>
 	<methods>
+		<method name="_finalize" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to do any finalization in the [AudioEffect] after all [AudioEffectInstance]s have been created.
+			</description>
+		</method>
 		<method name="_instantiate" qualifiers="virtual required">
 			<return type="AudioEffectInstance" />
 			<description>

--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -4,9 +4,10 @@
 		Captures audio from an audio bus in real-time.
 	</brief_description>
 	<description>
-		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
-		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating-point PCM.
-		Unlike [AudioEffectRecord], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
+		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer(s). Processing is done per channel by [AudioEffectCaptureInstance]. The parent AudioEffectCapture allows accessing data per-channel via the channel parameter on the get methods, or it can be accessed directly from [AudioEffectCaptureInstance] using [method AudioServer.get_bus_effect_instance].
+		Application code should consume audio frames from the ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating-point PCM.
+		Unlike [AudioEffectRecord] or [AudioEffectRecordInstance], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
+		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
@@ -15,54 +16,61 @@
 		<method name="can_get_buffer" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="frames" type="int" />
+			<param index="1" name="channel" type="int" default="0" />
 			<description>
-				Returns [code]true[/code] if at least [param frames] audio frames are available to read in the internal ring buffer.
+				Returns [code]true[/code] if at least [param frames] audio frames are available to read in the internal ring buffer of the given [param channel]'s [AudioEffectCaptureInstance].
 			</description>
 		</method>
 		<method name="clear_buffer">
 			<return type="void" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Clears the internal ring buffer.
+				Clears the internal ring buffer for the given [param channel]'s [AudioEffectCaptureInstance].
 				[b]Note:[/b] Calling this during a capture can cause the loss of samples which causes popping in the playback.
 			</description>
 		</method>
 		<method name="get_buffer">
 			<return type="PackedVector2Array" />
 			<param index="0" name="frames" type="int" />
+			<param index="1" name="channel" type="int" default="0" />
 			<description>
-				Gets the next [param frames] audio samples from the internal ring buffer.
+				Gets the next [param frames] audio samples from the internal ring buffer on the given [param channel]'s [AudioEffectCaptureInstance].
 				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
 				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
 			</description>
 		</method>
 		<method name="get_buffer_length_frames" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns the total size of the internal ring buffer in frames.
+				Returns the total size of the internal ring buffer in frames on the given [param channel]'s [AudioEffectCaptureInstance].
 			</description>
 		</method>
 		<method name="get_discarded_frames" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns the number of audio frames discarded from the audio bus due to full buffer.
+				Returns the number of audio frames discarded from the audio bus due to full buffer on the given [param channel]'s [AudioEffectCaptureInstance].
 			</description>
 		</method>
 		<method name="get_frames_available" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns the number of frames available to read using [method get_buffer].
+				Returns the number of frames available to read using [method get_buffer], for the given [param channel]'s [AudioEffectCaptureInstance].
 			</description>
 		</method>
 		<method name="get_pushed_frames" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns the number of audio frames inserted from the audio bus.
+				Returns the number of audio frames inserted from the audio bus, for the given [param channel]'s [AudioEffectCaptureInstance].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length" default="0.1">
-			Length of the internal ring buffer, in seconds. Setting the buffer length will have no effect if already initialized.
+			Length of the internal ring buffer(s), in seconds. Setting the buffer length will have no effect if already initialized.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectCaptureInstance.xml
+++ b/doc/classes/AudioEffectCaptureInstance.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectCaptureInstance" inherits="AudioEffectInstance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Captures audio from an audio bus, on a specific channel, in real-time.
+	</brief_description>
+	<description>
+		AudioEffectCaptureInstance is an instance of AudioEffectCapture which copies all audio frames from a specific channel of the attached audio effect bus into its internal ring buffer.
+		Access to instances of this class can be obtained with [method AudioServer.get_bus_effect_instance]. The parent AudioEffectCapture object mirrors the AudioEffectCaptureInstance created for channel 0, so method calls on the parent are passed straight through to the channel 0 instance.
+		Application code may consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating-point PCM.
+		Unlike [AudioEffectRecord] or [AudioEffectRecordInstance], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
+		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
+	</description>
+	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+	</tutorials>
+	<methods>
+		<method name="can_get_buffer" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Returns [code]true[/code] if at least [param frames] audio frames are available to read in the internal ring buffer.
+			</description>
+		</method>
+		<method name="clear_buffer">
+			<return type="void" />
+			<description>
+				Clears the internal ring buffer.
+				[b]Note:[/b] Calling this during a capture can cause the loss of samples which causes popping in the playback.
+			</description>
+		</method>
+		<method name="get_buffer">
+			<return type="PackedVector2Array" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Gets the next [param frames] audio samples from the internal ring buffer.
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
+			</description>
+		</method>
+		<method name="get_buffer_length_frames" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total size of the internal ring buffer in frames.
+			</description>
+		</method>
+		<method name="get_discarded_frames" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of audio frames discarded from the audio bus due to full buffer.
+			</description>
+		</method>
+		<method name="get_frames_available" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of frames available to read using [method get_buffer].
+			</description>
+		</method>
+		<method name="get_pushed_frames" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of audio frames inserted from the audio bus.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length">
+			Length of the internal ring buffer, in seconds. Initialized to buffer length of parent [AudioEffectCapture]. Setting the buffer length will have no effect if already initialized.
+		</member>
+	</members>
+</class>

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -4,7 +4,7 @@
 		Manipulates the audio it receives for a given effect.
 	</brief_description>
 	<description>
-		An audio effect instance manipulates the audio it receives for a given effect. This instance is automatically created by an [AudioEffect] when it is added to a bus, and should usually not be created directly. If necessary, it can be fetched at run-time with [method AudioServer.get_bus_effect_instance].
+		An audio effect instance manipulates the audio it receives for a given effect. This instance is automatically created by an [AudioEffect] when it is added to a bus, once for each channel on the bus, and should usually not be created directly. If necessary, it can be fetched at run-time with [method AudioServer.get_bus_effect_instance].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>

--- a/doc/classes/AudioEffectRecord.xml
+++ b/doc/classes/AudioEffectRecord.xml
@@ -4,8 +4,8 @@
 		Audio effect used for recording the sound from an audio bus.
 	</brief_description>
 	<description>
-		Allows the user to record the sound from an audio bus into an [AudioStreamWAV]. When used on the "Master" audio bus, this includes all audio output by Godot.
-		Unlike [AudioEffectCapture], this effect encodes the recording with the given format (8-bit, 16-bit, or compressed) instead of giving access to the raw audio samples.
+		Allows the user to record the sound from an audio bus into an [AudioStreamWAV]. When used on the "Master" audio bus, this includes all audio output by Godot. Recording is done per channel by [AudioEffectRecordInstance]. The parent AudioEffectRecord allows accessing data per-channel via the channel parameter on the get methods, or it can be accessed directly from [AudioEffectRecordInstance] using [method AudioServer.get_bus_effect_instance].
+		Unlike [AudioEffectCapture] or [AudioEffectCaptureInstance], this effect encodes the recording with the given format (8-bit, 16-bit, or compressed) instead of giving access to the raw audio samples.
 		Can be used (with an [AudioStreamMicrophone]) to record from a microphone.
 		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 	</description>
@@ -16,21 +16,24 @@
 	<methods>
 		<method name="get_recording" qualifiers="const">
 			<return type="AudioStreamWAV" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns the recorded sample.
+				Returns the recorded sample for the given [param channel]'s [AudioEffectRecordInstance].
 			</description>
 		</method>
 		<method name="is_recording_active" qualifiers="const">
 			<return type="bool" />
+			<param index="0" name="channel" type="int" default="0" />
 			<description>
-				Returns whether the recording is active or not.
+				Returns whether the recording is active or not on the given [param channel]'s [AudioEffectRecordInstance].
 			</description>
 		</method>
 		<method name="set_recording_active">
 			<return type="void" />
 			<param index="0" name="record" type="bool" />
+			<param index="1" name="channel" type="int" default="0" />
 			<description>
-				If [code]true[/code], the sound will be recorded. Note that restarting the recording will remove the previously recorded sample.
+				If [code]true[/code], the sound will be recorded on the given [param channel]'s [AudioEffectRecordInstance]. Note that restarting the recording will remove the previously recorded sample.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioEffectRecordInstance.xml
+++ b/doc/classes/AudioEffectRecordInstance.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectRecordInstance" inherits="AudioEffectInstance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Audio effect instance used for recording the sound from an audio bus from a particular audio channel.
+	</brief_description>
+	<description>
+		Allows the user to record the sound from an individual channel of an audio bus into an [AudioStreamWAV]. When used on the "Master" audio bus, this includes all audio output for that channel by Godot.
+		Unlike [AudioEffectCapture] or [AudioEffectCaptureInstance], this effect encodes the recording with the given format (8-bit, 16-bit, or compressed) instead of giving access to the raw audio samples.
+		Can be used (with an [AudioStreamMicrophone]) to record from a microphone.
+		An instance of this class can be obtained with [method AudioServer.get_bus_effect_instance].
+		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
+	</description>
+	<tutorials>
+		<link title="Recording with microphone">$DOCS_URL/tutorials/audio/recording_with_microphone.html</link>
+		<link title="Audio Microphone Record Demo">https://godotengine.org/asset-library/asset/2760</link>
+	</tutorials>
+	<methods>
+		<method name="get_recording" qualifiers="const">
+			<return type="AudioStreamWAV" />
+			<description>
+				Returns the recorded sample.
+			</description>
+		</method>
+		<method name="is_recording_active" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the recording is active or not.
+			</description>
+		</method>
+		<method name="set_recording_active">
+			<return type="void" />
+			<param index="0" name="record" type="bool" />
+			<description>
+				If [code]true[/code], the sound will be recorded. Note that restarting the recording will remove the previously recorded sample.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="format" type="int" setter="set_format" getter="get_format" enum="AudioStreamWAV.Format">
+			Specifies the format in which the sample will be recorded. Initialized to format of parent [AudioEffectRecord]. See [enum AudioStreamWAV.Format] for available formats.
+		</member>
+	</members>
+</class>

--- a/misc/extension_api_validation/4.5-stable/GH-92532.txt
+++ b/misc/extension_api_validation/4.5-stable/GH-92532.txt
@@ -1,0 +1,14 @@
+GH-92532
+--------
+Validate extension JSON: Error: Field 'classes/AudioEffectCapture/methods/can_get_buffer/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/AudioEffectCapture/methods/get_buffer/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/AudioEffectRecord/methods/set_recording_active/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectCapture/methods/clear_buffer': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectCapture/methods/get_buffer_length_frames': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectCapture/methods/get_discarded_frames': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectCapture/methods/get_frames_available': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectCapture/methods/get_pushed_frames': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectRecord/methods/get_recording': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/AudioEffectRecord/methods/is_recording_active': arguments
+
+Optional argument added. Compatibility methods registered.

--- a/servers/audio/audio_effect.cpp
+++ b/servers/audio/audio_effect.cpp
@@ -38,7 +38,6 @@ bool AudioEffectInstance::process_silence() const {
 	GDVIRTUAL_CALL(_process_silence, ret);
 	return ret;
 }
-
 void AudioEffectInstance::_bind_methods() {
 	GDVIRTUAL_BIND(_process, "src_buffer", "dst_buffer", "frame_count");
 	GDVIRTUAL_BIND(_process_silence);
@@ -51,8 +50,14 @@ Ref<AudioEffectInstance> AudioEffect::instantiate() {
 	GDVIRTUAL_CALL(_instantiate, ret);
 	return ret;
 }
+
+void AudioEffect::finalize() {
+	GDVIRTUAL_CALL(_finalize);
+}
+
 void AudioEffect::_bind_methods() {
 	GDVIRTUAL_BIND(_instantiate);
+	GDVIRTUAL_BIND(_finalize);
 }
 
 AudioEffect::AudioEffect() {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1097,11 +1097,12 @@ void AudioServer::_update_bus_effects(int p_bus) {
 		buses.write[p_bus]->channels.write[i].effect_instances.resize(buses[p_bus]->effects.size());
 		for (int j = 0; j < buses[p_bus]->effects.size(); j++) {
 			Ref<AudioEffectInstance> fx = buses.write[p_bus]->effects.write[j].effect->instantiate();
-			if (Object::cast_to<AudioEffectCompressorInstance>(*fx)) {
-				Object::cast_to<AudioEffectCompressorInstance>(*fx)->set_current_channel(i);
-			}
+			fx->set_current_channel(i);
 			buses.write[p_bus]->channels.write[i].effect_instances.write[j] = fx;
 		}
+	}
+	for (int j = 0; j < buses[p_bus]->effects.size(); j++) {
+		buses.write[p_bus]->effects.write[j].effect->finalize();
 	}
 }
 

--- a/servers/audio/effects/audio_effect_capture.compat.inc
+++ b/servers/audio/effects/audio_effect_capture.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  audio_effect.h                                                        */
+/*  audio_effect_capture.compat.inc                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,42 +28,44 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/resource.h"
-#include "core/math/audio_frame.h"
-#include "core/object/gdvirtual.gen.inc"
-#include "core/variant/native_ptr.h"
+bool AudioEffectCapture::_can_get_buffer_bind_compat_92532(int p_frames) const {
+	return can_get_buffer(p_frames, 0);
+}
 
-class AudioEffectInstance : public RefCounted {
-	GDCLASS(AudioEffectInstance, RefCounted);
+PackedVector2Array AudioEffectCapture::_get_buffer_bind_compat_92532(int p_len) {
+	return get_buffer(p_len, 0);
+}
 
-protected:
-	GDVIRTUAL3_REQUIRED(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
-	GDVIRTUAL0RC(bool, _process_silence)
-	static void _bind_methods();
+void AudioEffectCapture::_clear_buffer_bind_compat_92532() {
+	clear_buffer(0);
+}
 
-	int current_channel;
+int AudioEffectCapture::_get_frames_available_bind_compat_92532() const {
+	return get_frames_available(0);
+}
 
-public:
-	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
-	virtual bool process_silence() const;
+int64_t AudioEffectCapture::_get_discarded_frames_bind_compat_92532() const {
+	return get_discarded_frames(0);
+}
 
-	void set_current_channel(int p_channel) { current_channel = p_channel; }
-	int get_current_channel() { return current_channel; }
-};
+int AudioEffectCapture::_get_buffer_length_frames_bind_compat_92532() const {
+	return get_buffer_length_frames(0);
+}
 
-class AudioEffect : public Resource {
-	GDCLASS(AudioEffect, Resource);
+int64_t AudioEffectCapture::_get_pushed_frames_bind_compat_92532() const {
+	return get_pushed_frames(0);
+}
 
-protected:
-	GDVIRTUAL0R_REQUIRED(Ref<AudioEffectInstance>, _instantiate)
-	GDVIRTUAL0(_finalize)
-	static void _bind_methods();
+void AudioEffectCapture::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("can_get_buffer", "frames"), &AudioEffectCapture::_can_get_buffer_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_buffer", "frames"), &AudioEffectCapture::_get_buffer_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("clear_buffer"), &AudioEffectCapture::_clear_buffer_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_frames_available"), &AudioEffectCapture::_get_frames_available_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_discarded_frames"), &AudioEffectCapture::_get_discarded_frames_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_buffer_length_frames"), &AudioEffectCapture::_get_buffer_length_frames_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_pushed_frames"), &AudioEffectCapture::_get_pushed_frames_bind_compat_92532);
+}
 
-public:
-	virtual Ref<AudioEffectInstance> instantiate();
-	virtual void finalize();
-
-	AudioEffect();
-};
+#endif // DISABLE_DEPRECATED

--- a/servers/audio/effects/audio_effect_capture.cpp
+++ b/servers/audio/effects/audio_effect_capture.cpp
@@ -29,14 +29,45 @@
 /**************************************************************************/
 
 #include "audio_effect_capture.h"
+#include "audio_effect_capture.compat.inc"
 
 #include "servers/audio/audio_server.h"
 
-bool AudioEffectCapture::can_get_buffer(int p_frames) const {
+void AudioEffectCaptureInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+	for (int i = 0; i < p_frame_count; i++) {
+		p_dst_frames[i] = p_src_frames[i];
+	}
+
+	if (buffer.space_left() >= p_frame_count) {
+		// Add incoming audio frames to the IO ring buffer
+		int32_t ret = buffer.write(p_src_frames, p_frame_count);
+		ERR_FAIL_COND_MSG(ret != p_frame_count, "Failed to add data to effect capture ring buffer despite sufficient space.");
+		pushed_frames.add(p_frame_count);
+	} else {
+		discarded_frames.add(p_frame_count);
+	}
+}
+
+bool AudioEffectCaptureInstance::process_silence() const {
+	return true;
+}
+
+bool AudioEffectCaptureInstance::initialize_buffer() {
+	if (!buffer_initialized) {
+		float target_buffer_size = AudioServer::get_singleton()->get_mix_rate() * buffer_length_seconds;
+		ERR_FAIL_COND_V(target_buffer_size <= 0 || target_buffer_size >= (1 << 27), false);
+		buffer.resize(nearest_shift((uint32_t)target_buffer_size));
+		buffer_initialized = true;
+	}
+	return true;
+}
+
+bool AudioEffectCaptureInstance::can_get_buffer(int p_frames) const {
+	ERR_FAIL_COND_V(!buffer_initialized, false);
 	return buffer.data_left() >= p_frames;
 }
 
-PackedVector2Array AudioEffectCapture::get_buffer(int p_frames) {
+PackedVector2Array AudioEffectCaptureInstance::get_buffer(int p_frames) {
 	ERR_FAIL_COND_V(!buffer_initialized, PackedVector2Array());
 	ERR_FAIL_INDEX_V(p_frames, buffer.size(), PackedVector2Array());
 	int data_left = buffer.data_left();
@@ -56,85 +87,159 @@ PackedVector2Array AudioEffectCapture::get_buffer(int p_frames) {
 	return ret;
 }
 
-void AudioEffectCapture::clear_buffer() {
+void AudioEffectCaptureInstance::clear_buffer() {
 	const int32_t data_left = buffer.data_left();
 	buffer.advance_read(data_left);
 }
 
-void AudioEffectCapture::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("can_get_buffer", "frames"), &AudioEffectCapture::can_get_buffer);
-	ClassDB::bind_method(D_METHOD("get_buffer", "frames"), &AudioEffectCapture::get_buffer);
-	ClassDB::bind_method(D_METHOD("clear_buffer"), &AudioEffectCapture::clear_buffer);
-	ClassDB::bind_method(D_METHOD("set_buffer_length", "buffer_length_seconds"), &AudioEffectCapture::set_buffer_length);
-	ClassDB::bind_method(D_METHOD("get_buffer_length"), &AudioEffectCapture::get_buffer_length);
-	ClassDB::bind_method(D_METHOD("get_frames_available"), &AudioEffectCapture::get_frames_available);
-	ClassDB::bind_method(D_METHOD("get_discarded_frames"), &AudioEffectCapture::get_discarded_frames);
-	ClassDB::bind_method(D_METHOD("get_buffer_length_frames"), &AudioEffectCapture::get_buffer_length_frames);
-	ClassDB::bind_method(D_METHOD("get_pushed_frames"), &AudioEffectCapture::get_pushed_frames);
+void AudioEffectCaptureInstance::set_buffer_length(float p_buffer_length_seconds) {
+	buffer_length_seconds = p_buffer_length_seconds;
+}
+
+float AudioEffectCaptureInstance::get_buffer_length() {
+	return buffer_length_seconds;
+}
+
+int AudioEffectCaptureInstance::get_frames_available() const {
+	ERR_FAIL_COND_V(!buffer_initialized, 0);
+	return buffer.data_left();
+}
+
+int64_t AudioEffectCaptureInstance::get_discarded_frames() const {
+	ERR_FAIL_COND_V(!buffer_initialized, 0);
+	return discarded_frames.get();
+}
+
+int AudioEffectCaptureInstance::get_buffer_length_frames() const {
+	ERR_FAIL_COND_V(!buffer_initialized, 0);
+	return buffer.size();
+}
+
+int64_t AudioEffectCaptureInstance::get_pushed_frames() const {
+	ERR_FAIL_COND_V(!buffer_initialized, 0);
+	return pushed_frames.get();
+}
+
+void AudioEffectCaptureInstance::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("can_get_buffer", "frames"), &AudioEffectCaptureInstance::can_get_buffer);
+	ClassDB::bind_method(D_METHOD("get_buffer", "frames"), &AudioEffectCaptureInstance::get_buffer);
+	ClassDB::bind_method(D_METHOD("clear_buffer"), &AudioEffectCaptureInstance::clear_buffer);
+	ClassDB::bind_method(D_METHOD("set_buffer_length", "buffer_length_seconds"), &AudioEffectCaptureInstance::set_buffer_length);
+	ClassDB::bind_method(D_METHOD("get_buffer_length"), &AudioEffectCaptureInstance::get_buffer_length);
+	ClassDB::bind_method(D_METHOD("get_frames_available"), &AudioEffectCaptureInstance::get_frames_available);
+	ClassDB::bind_method(D_METHOD("get_discarded_frames"), &AudioEffectCaptureInstance::get_discarded_frames);
+	ClassDB::bind_method(D_METHOD("get_buffer_length_frames"), &AudioEffectCaptureInstance::get_buffer_length_frames);
+	ClassDB::bind_method(D_METHOD("get_pushed_frames"), &AudioEffectCaptureInstance::get_pushed_frames);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "buffer_length", PROPERTY_HINT_RANGE, "0.01,10,0.01,suffix:s"), "set_buffer_length", "get_buffer_length");
 }
 
 Ref<AudioEffectInstance> AudioEffectCapture::instantiate() {
-	if (!buffer_initialized) {
-		float target_buffer_size = AudioServer::get_singleton()->get_mix_rate() * buffer_length_seconds;
-		ERR_FAIL_COND_V(target_buffer_size <= 0 || target_buffer_size >= (1 << 27), Ref<AudioEffectInstance>());
-		buffer.resize(nearest_shift((uint32_t)target_buffer_size));
-		buffer_initialized = true;
-	}
-
-	clear_buffer();
-
 	Ref<AudioEffectCaptureInstance> ins;
 	ins.instantiate();
-	ins->base = Ref<AudioEffectCapture>(this);
+	ins->buffer_length_seconds = buffer_length_seconds;
+	ERR_FAIL_COND_V(!ins->initialize_buffer(), Ref<AudioEffectInstance>());
+	temp_instances.push_back(ins);
 
 	return ins;
 }
 
+void AudioEffectCapture::finalize() {
+	int max_channel = -1;
+	for (int i = 0; i < temp_instances.size(); i++) {
+		int current_channel = temp_instances.get(i)->get_current_channel();
+		max_channel = MAX(max_channel, current_channel);
+	}
+	if (max_channel < 0) {
+		instances.clear();
+		temp_instances.clear();
+		return;
+	}
+	instances.resize(max_channel + 1);
+
+	for (int i = 0; i < max_channel; i++) {
+		int temp_index = -1;
+		for (int j = 0; j < temp_instances.size(); j++) {
+			if (i == temp_instances.get(j)->get_current_channel()) {
+				temp_index = j;
+				break;
+			}
+		}
+		if (temp_index < 0) {
+			instances.write[i] = Ref<AudioEffectCaptureInstance>();
+		} else {
+			instances.write[i] = temp_instances.get(temp_index);
+		}
+	}
+
+	temp_instances.clear();
+}
+
 void AudioEffectCapture::set_buffer_length(float p_buffer_length_seconds) {
 	buffer_length_seconds = p_buffer_length_seconds;
+	for (int i = 0; i < instances.size(); i++) {
+		if (instances[i].is_valid()) {
+			instances.write[i]->set_buffer_length(p_buffer_length_seconds);
+		}
+	}
 }
 
 float AudioEffectCapture::get_buffer_length() {
 	return buffer_length_seconds;
 }
 
-int AudioEffectCapture::get_frames_available() const {
-	ERR_FAIL_COND_V(!buffer_initialized, 0);
-	return buffer.data_left();
+int AudioEffectCapture::get_frames_available(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), 0);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), 0);
+	return instances[p_channel]->get_frames_available();
 }
 
-int64_t AudioEffectCapture::get_discarded_frames() const {
-	return discarded_frames.get();
+int64_t AudioEffectCapture::get_discarded_frames(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), 0);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), 0);
+	return instances[p_channel]->get_discarded_frames();
 }
 
-int AudioEffectCapture::get_buffer_length_frames() const {
-	ERR_FAIL_COND_V(!buffer_initialized, 0);
-	return buffer.size();
+int AudioEffectCapture::get_buffer_length_frames(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), 0);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), 0);
+	return instances[p_channel]->get_buffer_length_frames();
 }
 
-int64_t AudioEffectCapture::get_pushed_frames() const {
-	return pushed_frames.get();
+int64_t AudioEffectCapture::get_pushed_frames(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), 0);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), 0);
+	return instances[p_channel]->get_pushed_frames();
 }
 
-void AudioEffectCaptureInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	RingBuffer<AudioFrame> &buffer = base->buffer;
-
-	for (int i = 0; i < p_frame_count; i++) {
-		p_dst_frames[i] = p_src_frames[i];
-	}
-
-	if (buffer.space_left() >= p_frame_count) {
-		// Add incoming audio frames to the IO ring buffer
-		int32_t ret = buffer.write(p_src_frames, p_frame_count);
-		ERR_FAIL_COND_MSG(ret != p_frame_count, "Failed to add data to effect capture ring buffer despite sufficient space.");
-		base->pushed_frames.add(p_frame_count);
-	} else {
-		base->discarded_frames.add(p_frame_count);
-	}
+bool AudioEffectCapture::can_get_buffer(int p_frames, int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), false);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), false);
+	return instances[p_channel]->can_get_buffer(p_frames);
 }
 
-bool AudioEffectCaptureInstance::process_silence() const {
-	return true;
+PackedVector2Array AudioEffectCapture::get_buffer(int p_frames, int p_channel) {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), PackedVector2Array());
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), PackedVector2Array());
+	return instances.write[p_channel]->get_buffer(p_frames);
+}
+
+void AudioEffectCapture::clear_buffer(int p_channel) {
+	ERR_FAIL_INDEX(p_channel, instances.size());
+	ERR_FAIL_COND(instances[p_channel].is_null());
+	instances.write[p_channel]->clear_buffer();
+}
+
+void AudioEffectCapture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("can_get_buffer", "frames", "channel"), &AudioEffectCapture::can_get_buffer, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_buffer", "frames", "channel"), &AudioEffectCapture::get_buffer, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("clear_buffer", "channel"), &AudioEffectCapture::clear_buffer, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("set_buffer_length", "buffer_length_seconds"), &AudioEffectCapture::set_buffer_length);
+	ClassDB::bind_method(D_METHOD("get_buffer_length"), &AudioEffectCapture::get_buffer_length);
+	ClassDB::bind_method(D_METHOD("get_frames_available", "channel"), &AudioEffectCapture::get_frames_available, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_discarded_frames", "channel"), &AudioEffectCapture::get_discarded_frames, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_buffer_length_frames", "channel"), &AudioEffectCapture::get_buffer_length_frames, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_pushed_frames", "channel"), &AudioEffectCapture::get_pushed_frames, DEFVAL(0));
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "buffer_length", PROPERTY_HINT_RANGE, "0.01,10,0.01,suffix:s"), "set_buffer_length", "get_buffer_length");
 }

--- a/servers/audio/effects/audio_effect_capture.h
+++ b/servers/audio/effects/audio_effect_capture.h
@@ -34,22 +34,13 @@
 #include "core/object/ref_counted.h"
 #include "core/templates/ring_buffer.h"
 #include "servers/audio/audio_effect.h"
+#include "servers/audio/audio_server.h"
 
 class AudioEffectCapture;
 
 class AudioEffectCaptureInstance : public AudioEffectInstance {
 	GDCLASS(AudioEffectCaptureInstance, AudioEffectInstance);
 	friend class AudioEffectCapture;
-	Ref<AudioEffectCapture> base;
-
-public:
-	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
-	virtual bool process_silence() const override;
-};
-
-class AudioEffectCapture : public AudioEffect {
-	GDCLASS(AudioEffectCapture, AudioEffect)
-	friend class AudioEffectCaptureInstance;
 
 	RingBuffer<AudioFrame> buffer;
 	SafeNumeric<uint64_t> discarded_frames;
@@ -57,11 +48,14 @@ class AudioEffectCapture : public AudioEffect {
 	float buffer_length_seconds = 0.1f;
 	bool buffer_initialized = false;
 
+	bool initialize_buffer();
+
 protected:
 	static void _bind_methods();
 
 public:
-	virtual Ref<AudioEffectInstance> instantiate() override;
+	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
+	virtual bool process_silence() const override;
 
 	void set_buffer_length(float p_buffer_length_seconds);
 	float get_buffer_length();
@@ -74,4 +68,45 @@ public:
 	int64_t get_discarded_frames() const;
 	int get_buffer_length_frames() const;
 	int64_t get_pushed_frames() const;
+};
+
+class AudioEffectCapture : public AudioEffect {
+	GDCLASS(AudioEffectCapture, AudioEffect)
+	friend class AudioEffectCaptureInstance;
+
+	float buffer_length_seconds = 0.1f;
+	Vector<Ref<AudioEffectCaptureInstance>> instances;
+	List<Ref<AudioEffectCaptureInstance>> temp_instances;
+
+protected:
+	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	bool _can_get_buffer_bind_compat_92532(int p_frames) const;
+	PackedVector2Array _get_buffer_bind_compat_92532(int p_len);
+	void _clear_buffer_bind_compat_92532();
+
+	int _get_frames_available_bind_compat_92532() const;
+	int64_t _get_discarded_frames_bind_compat_92532() const;
+	int _get_buffer_length_frames_bind_compat_92532() const;
+	int64_t _get_pushed_frames_bind_compat_92532() const;
+
+	static void _bind_compatibility_methods();
+#endif
+
+public:
+	virtual Ref<AudioEffectInstance> instantiate() override;
+	virtual void finalize() override;
+
+	void set_buffer_length(float p_buffer_length_seconds);
+	float get_buffer_length();
+
+	bool can_get_buffer(int p_frames, int p_channel = 0) const;
+	PackedVector2Array get_buffer(int p_len, int p_channel = 0);
+	void clear_buffer(int p_channel = 0);
+
+	int get_frames_available(int p_channel = 0) const;
+	int64_t get_discarded_frames(int p_channel = 0) const;
+	int get_buffer_length_frames(int p_channel = 0) const;
+	int64_t get_pushed_frames(int p_channel = 0) const;
 };

--- a/servers/audio/effects/audio_effect_compressor.h
+++ b/servers/audio/effects/audio_effect_compressor.h
@@ -40,10 +40,8 @@ class AudioEffectCompressorInstance : public AudioEffectInstance {
 	Ref<AudioEffectCompressor> base;
 
 	float rundb, averatio, runratio, runmax, maxover, gr_meter;
-	int current_channel;
 
 public:
-	void set_current_channel(int p_channel) { current_channel = p_channel; }
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 };
 

--- a/servers/audio/effects/audio_effect_record.compat.inc
+++ b/servers/audio/effects/audio_effect_record.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  audio_effect.h                                                        */
+/*  audio_effect_record.compat.inc                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,42 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/resource.h"
-#include "core/math/audio_frame.h"
-#include "core/object/gdvirtual.gen.inc"
-#include "core/variant/native_ptr.h"
+void AudioEffectRecord::_set_recording_active_bind_compat_92532(bool p_record) {
+	set_recording_active(p_record, 0);
+}
 
-class AudioEffectInstance : public RefCounted {
-	GDCLASS(AudioEffectInstance, RefCounted);
+bool AudioEffectRecord::_is_recording_active_bind_compat_92532() const {
+	return is_recording_active(0);
+}
 
-protected:
-	GDVIRTUAL3_REQUIRED(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
-	GDVIRTUAL0RC(bool, _process_silence)
-	static void _bind_methods();
+Ref<AudioStreamWAV> AudioEffectRecord::_get_recording_bind_compat_92532() const {
+	return get_recording(0);
+}
 
-	int current_channel;
+void AudioEffectRecord::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_recording_active", "frames"), &AudioEffectRecord::_set_recording_active_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("is_recording_active"), &AudioEffectRecord::_is_recording_active_bind_compat_92532);
+	ClassDB::bind_compatibility_method(D_METHOD("get_recording"), &AudioEffectRecord::_get_recording_bind_compat_92532);
+}
 
-public:
-	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
-	virtual bool process_silence() const;
-
-	void set_current_channel(int p_channel) { current_channel = p_channel; }
-	int get_current_channel() { return current_channel; }
-};
-
-class AudioEffect : public Resource {
-	GDCLASS(AudioEffect, Resource);
-
-protected:
-	GDVIRTUAL0R_REQUIRED(Ref<AudioEffectInstance>, _instantiate)
-	GDVIRTUAL0(_finalize)
-	static void _bind_methods();
-
-public:
-	virtual Ref<AudioEffectInstance> instantiate();
-	virtual void finalize();
-
-	AudioEffect();
-};
+#endif // DISABLE_DEPRECATED

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_effect_record.h"
+#include "audio_effect_record.compat.inc"
 
 #include "core/io/marshalls.h"
 
@@ -117,10 +118,126 @@ void AudioEffectRecordInstance::finish() {
 	}
 }
 
+void AudioEffectRecordInstance::set_recording_active(bool p_record) {
+	if (p_record) {
+		finish();
+		init();
+	} else {
+		is_recording = false;
+	}
+}
+
+bool AudioEffectRecordInstance::is_recording_active() const {
+	return is_recording;
+}
+
+void AudioEffectRecordInstance::set_format(AudioStreamWAV::Format p_format) {
+	format = p_format;
+}
+
+AudioStreamWAV::Format AudioEffectRecordInstance::get_format() const {
+	return format;
+}
+
+Ref<AudioStreamWAV> AudioEffectRecordInstance::get_recording() const {
+	ERR_FAIL_COND_V(recording_data.is_empty(), Ref<AudioStreamWAV>());
+
+	AudioStreamWAV::Format dst_format = format;
+	bool stereo = true; //forcing mono is not implemented
+
+	Vector<uint8_t> dst_data;
+
+	if (dst_format == AudioStreamWAV::FORMAT_8_BITS) {
+		int data_size = recording_data.size();
+		dst_data.resize(data_size);
+		uint8_t *w = dst_data.ptrw();
+
+		for (int i = 0; i < data_size; i++) {
+			int8_t v = CLAMP(recording_data[i] * 128, -128, 127);
+			w[i] = v;
+		}
+	} else if (dst_format == AudioStreamWAV::FORMAT_16_BITS) {
+		int data_size = recording_data.size();
+		dst_data.resize(data_size * 2);
+		uint8_t *w = dst_data.ptrw();
+
+		for (int i = 0; i < data_size; i++) {
+			int16_t v = CLAMP(recording_data[i] * 32768, -32768, 32767);
+			encode_uint16(v, &w[i * 2]);
+		}
+	} else if (dst_format == AudioStreamWAV::FORMAT_IMA_ADPCM) {
+		//byte interleave
+		Vector<float> left;
+		Vector<float> right;
+
+		int tframes = recording_data.size() / 2;
+		left.resize(tframes);
+		right.resize(tframes);
+
+		for (int i = 0; i < tframes; i++) {
+			left.set(i, recording_data[i * 2 + 0]);
+			right.set(i, recording_data[i * 2 + 1]);
+		}
+
+		Vector<uint8_t> bleft;
+		Vector<uint8_t> bright;
+
+		AudioStreamWAV::_compress_ima_adpcm(left, bleft);
+		AudioStreamWAV::_compress_ima_adpcm(right, bright);
+
+		int dl = bleft.size();
+		dst_data.resize(dl * 2);
+
+		uint8_t *w = dst_data.ptrw();
+		const uint8_t *rl = bleft.ptr();
+		const uint8_t *rr = bright.ptr();
+
+		for (int i = 0; i < dl; i++) {
+			w[i * 2 + 0] = rl[i];
+			w[i * 2 + 1] = rr[i];
+		}
+	} else if (dst_format == AudioStreamWAV::FORMAT_QOA) {
+		qoa_desc desc = {};
+		desc.samples = recording_data.size() / 2;
+		desc.samplerate = AudioServer::get_singleton()->get_mix_rate();
+		desc.channels = 2;
+		AudioStreamWAV::_compress_qoa(recording_data, dst_data, &desc);
+	} else {
+		ERR_PRINT("Format not implemented.");
+	}
+
+	Ref<AudioStreamWAV> sample;
+	sample.instantiate();
+	sample->set_data(dst_data);
+	sample->set_format(dst_format);
+	sample->set_mix_rate(AudioServer::get_singleton()->get_mix_rate());
+	sample->set_loop_mode(AudioStreamWAV::LOOP_DISABLED);
+	sample->set_loop_begin(0);
+	sample->set_loop_end(0);
+	sample->set_stereo(stereo);
+
+	return sample;
+}
+
+void AudioEffectRecordInstance::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_recording_active", "record"), &AudioEffectRecordInstance::set_recording_active);
+	ClassDB::bind_method(D_METHOD("is_recording_active"), &AudioEffectRecordInstance::is_recording_active);
+	ClassDB::bind_method(D_METHOD("set_format", "format"), &AudioEffectRecordInstance::set_format);
+	ClassDB::bind_method(D_METHOD("get_format"), &AudioEffectRecordInstance::get_format);
+	ClassDB::bind_method(D_METHOD("get_recording"), &AudioEffectRecordInstance::get_recording);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "format", PROPERTY_HINT_ENUM, "8-Bit,16-Bit,IMA ADPCM,Quite OK Audio"), "set_format", "get_format");
+}
+
+AudioEffectRecordInstance::~AudioEffectRecordInstance() {
+	finish();
+}
+
 Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 	Ref<AudioEffectRecordInstance> ins;
 	ins.instantiate();
 	ins->is_recording = false;
+	ins->format = format;
 
 	// Reusing the buffer size calculations from audio_effect_delay.cpp.
 	float ring_buffer_max_size = IO_BUFFER_SIZE_MS;
@@ -144,151 +261,92 @@ Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 
 	ins->ring_buffer_read_pos = 0;
 
-	ensure_thread_stopped();
-	bool is_currently_recording = false;
-	if (current_instance.is_valid()) {
-		is_currently_recording = current_instance->is_recording;
-	}
-	if (is_currently_recording) {
-		ins->init();
-	}
-	current_instance = ins;
-
+	temp_instances.push_back(ins);
 	return ins;
 }
 
-void AudioEffectRecord::ensure_thread_stopped() {
-	if (current_instance.is_valid()) {
-		current_instance->finish();
-	}
-}
+void AudioEffectRecord::finalize() {
+	int max_channel = -1;
+	for (int i = 0; i < temp_instances.size(); i++) {
+		int current_channel = temp_instances.get(i)->get_current_channel();
+		max_channel = MAX(max_channel, current_channel);
 
-void AudioEffectRecord::set_recording_active(bool p_record) {
-	if (p_record) {
-		if (current_instance.is_null()) {
-			WARN_PRINT("Recording should not be set as active before Godot has initialized.");
-			return;
+		bool is_currently_recording = false;
+		if (instances[current_channel].is_valid()) {
+			is_currently_recording = instances[current_channel]->is_recording;
+			instances.write[current_channel]->finish();
 		}
-		ensure_thread_stopped();
-		current_instance->init();
-	} else {
-		if (current_instance.is_valid()) {
-			current_instance->is_recording = false;
+
+		if (is_currently_recording && temp_instances.get(i).is_valid()) {
+			temp_instances.get(i)->init();
 		}
 	}
+	if (max_channel < 0) {
+		instances.clear();
+		temp_instances.clear();
+		return;
+	}
+	instances.resize(max_channel + 1);
+
+	for (int i = 0; i < max_channel; i++) {
+		int temp_index = -1;
+		for (int j = 0; j < temp_instances.size(); j++) {
+			if (i == temp_instances.get(j)->get_current_channel()) {
+				temp_index = j;
+				break;
+			}
+		}
+		if (temp_index < 0) {
+			instances.write[i] = Ref<AudioEffectRecordInstance>();
+		} else {
+			instances.write[i] = temp_instances.get(temp_index);
+		}
+	}
+
+	temp_instances.clear();
 }
 
-bool AudioEffectRecord::is_recording_active() const {
-	if (current_instance.is_null()) {
-		return false;
-	} else {
-		return current_instance->is_recording;
-	}
+void AudioEffectRecord::set_recording_active(bool p_record, int p_channel) {
+	ERR_FAIL_INDEX(p_channel, instances.size());
+	ERR_FAIL_COND(instances[p_channel].is_null());
+	instances.write[p_channel]->set_recording_active(p_record);
+}
+
+bool AudioEffectRecord::is_recording_active(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), false);
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), false);
+	return instances[p_channel]->is_recording_active();
 }
 
 void AudioEffectRecord::set_format(AudioStreamWAV::Format p_format) {
 	format = p_format;
+	for (int i = 0; i < instances.size(); i++) {
+		if (instances[i].is_valid()) {
+			instances.write[i]->set_format(p_format);
+		}
+	}
 }
 
 AudioStreamWAV::Format AudioEffectRecord::get_format() const {
 	return format;
 }
 
-Ref<AudioStreamWAV> AudioEffectRecord::get_recording() const {
-	AudioStreamWAV::Format dst_format = format;
-	bool stereo = true; //forcing mono is not implemented
-
-	Vector<uint8_t> dst_data;
-
-	ERR_FAIL_COND_V(current_instance.is_null(), nullptr);
-	ERR_FAIL_COND_V(current_instance->recording_data.is_empty(), nullptr);
-
-	if (dst_format == AudioStreamWAV::FORMAT_8_BITS) {
-		int data_size = current_instance->recording_data.size();
-		dst_data.resize(data_size);
-		uint8_t *w = dst_data.ptrw();
-
-		for (int i = 0; i < data_size; i++) {
-			int8_t v = CLAMP(current_instance->recording_data[i] * 128, -128, 127);
-			w[i] = v;
-		}
-	} else if (dst_format == AudioStreamWAV::FORMAT_16_BITS) {
-		int data_size = current_instance->recording_data.size();
-		dst_data.resize(data_size * 2);
-		uint8_t *w = dst_data.ptrw();
-
-		for (int i = 0; i < data_size; i++) {
-			int16_t v = CLAMP(current_instance->recording_data[i] * 32768, -32768, 32767);
-			encode_uint16(v, &w[i * 2]);
-		}
-	} else if (dst_format == AudioStreamWAV::FORMAT_IMA_ADPCM) {
-		//byte interleave
-		Vector<float> left;
-		Vector<float> right;
-
-		int tframes = current_instance->recording_data.size() / 2;
-		left.resize(tframes);
-		right.resize(tframes);
-
-		for (int i = 0; i < tframes; i++) {
-			left.set(i, current_instance->recording_data[i * 2 + 0]);
-			right.set(i, current_instance->recording_data[i * 2 + 1]);
-		}
-
-		Vector<uint8_t> bleft;
-		Vector<uint8_t> bright;
-
-		AudioStreamWAV::_compress_ima_adpcm(left, bleft);
-		AudioStreamWAV::_compress_ima_adpcm(right, bright);
-
-		int dl = bleft.size();
-		dst_data.resize(dl * 2);
-
-		uint8_t *w = dst_data.ptrw();
-		const uint8_t *rl = bleft.ptr();
-		const uint8_t *rr = bright.ptr();
-
-		for (int i = 0; i < dl; i++) {
-			w[i * 2 + 0] = rl[i];
-			w[i * 2 + 1] = rr[i];
-		}
-	} else if (dst_format == AudioStreamWAV::FORMAT_QOA) {
-		qoa_desc desc = {};
-		desc.samples = current_instance->recording_data.size() / 2;
-		desc.samplerate = AudioServer::get_singleton()->get_mix_rate();
-		desc.channels = 2;
-		AudioStreamWAV::_compress_qoa(current_instance->recording_data, dst_data, &desc);
-	} else {
-		ERR_PRINT("Format not implemented.");
-	}
-
-	Ref<AudioStreamWAV> sample;
-	sample.instantiate();
-	sample->set_data(dst_data);
-	sample->set_format(dst_format);
-	sample->set_mix_rate(AudioServer::get_singleton()->get_mix_rate());
-	sample->set_loop_mode(AudioStreamWAV::LOOP_DISABLED);
-	sample->set_loop_begin(0);
-	sample->set_loop_end(0);
-	sample->set_stereo(stereo);
-
-	return sample;
+Ref<AudioStreamWAV> AudioEffectRecord::get_recording(int p_channel) const {
+	ERR_FAIL_INDEX_V(p_channel, instances.size(), Ref<AudioStreamWAV>());
+	ERR_FAIL_COND_V(instances[p_channel].is_null(), Ref<AudioStreamWAV>());
+	return instances[p_channel]->get_recording();
 }
 
 void AudioEffectRecord::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_recording_active", "record"), &AudioEffectRecord::set_recording_active);
-	ClassDB::bind_method(D_METHOD("is_recording_active"), &AudioEffectRecord::is_recording_active);
+	ClassDB::bind_method(D_METHOD("set_recording_active", "record", "channel"), &AudioEffectRecord::set_recording_active, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_recording_active", "channel"), &AudioEffectRecord::is_recording_active, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("set_format", "format"), &AudioEffectRecord::set_format);
 	ClassDB::bind_method(D_METHOD("get_format"), &AudioEffectRecord::get_format);
-	ClassDB::bind_method(D_METHOD("get_recording"), &AudioEffectRecord::get_recording);
+	ClassDB::bind_method(D_METHOD("get_recording", "channel"), &AudioEffectRecord::get_recording, DEFVAL(0));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "format", PROPERTY_HINT_ENUM, "8-Bit,16-Bit,IMA ADPCM,Quite OK Audio"), "set_format", "get_format");
 }
 
 AudioEffectRecord::AudioEffectRecord() {
 	format = AudioStreamWAV::FORMAT_16_BITS;
-}
-
-AudioEffectRecord::~AudioEffectRecord() {
-	ensure_thread_stopped();
 }

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -41,6 +41,8 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 	GDCLASS(AudioEffectRecordInstance, AudioEffectInstance);
 	friend class AudioEffectRecord;
 
+	AudioStreamWAV::Format format;
+
 	bool is_recording;
 	Thread io_thread;
 
@@ -58,11 +60,22 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 	void _update_buffer();
 	static void _update(void *userdata);
 
+protected:
+	static void _bind_methods();
+
 public:
-	void init();
-	void finish();
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 	virtual bool process_silence() const override;
+
+	void init();
+	void finish();
+
+	void set_recording_active(bool p_record);
+	bool is_recording_active() const;
+	void set_format(AudioStreamWAV::Format p_format);
+	AudioStreamWAV::Format get_format() const;
+	Ref<AudioStreamWAV> get_recording() const;
+	~AudioEffectRecordInstance();
 };
 
 class AudioEffectRecord : public AudioEffect {
@@ -74,22 +87,30 @@ class AudioEffectRecord : public AudioEffect {
 		IO_BUFFER_SIZE_MS = 1500
 	};
 
-	Ref<AudioEffectRecordInstance> current_instance;
+	Vector<Ref<AudioEffectRecordInstance>> instances;
+	List<Ref<AudioEffectRecordInstance>> temp_instances;
 
 	AudioStreamWAV::Format format;
-
-	void ensure_thread_stopped();
 
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _set_recording_active_bind_compat_92532(bool p_record);
+	bool _is_recording_active_bind_compat_92532() const;
+	Ref<AudioStreamWAV> _get_recording_bind_compat_92532() const;
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	Ref<AudioEffectInstance> instantiate() override;
-	void set_recording_active(bool p_record);
-	bool is_recording_active() const;
+	virtual void finalize() override;
+
+	void set_recording_active(bool p_record, int p_channel = 0);
+	bool is_recording_active(int p_channel = 0) const;
 	void set_format(AudioStreamWAV::Format p_format);
 	AudioStreamWAV::Format get_format() const;
-	Ref<AudioStreamWAV> get_recording() const;
+	Ref<AudioStreamWAV> get_recording(int p_channel = 0) const;
 	AudioEffectRecord();
-	~AudioEffectRecord();
 };

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -209,10 +209,12 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectPitchShift);
 		GDREGISTER_CLASS(AudioEffectPhaser);
 		GDREGISTER_CLASS(AudioEffectRecord);
+		GDREGISTER_ABSTRACT_CLASS(AudioEffectRecordInstance);
 		GDREGISTER_CLASS(AudioEffectSpectrumAnalyzer);
 		GDREGISTER_ABSTRACT_CLASS(AudioEffectSpectrumAnalyzerInstance);
 
 		GDREGISTER_CLASS(AudioEffectCapture);
+		GDREGISTER_ABSTRACT_CLASS(AudioEffectCaptureInstance);
 
 #ifndef DISABLE_DEPRECATED
 		GDREGISTER_CLASS(AudioEffectLimiter);


### PR DESCRIPTION
The `AudioEffectCapture` and `AudioEffectRecord` classes do not work properly when there is more than one audio channel active. This PR makes some changes to several `AudioEffect` classes to fix these bugs. Fixes #91133. 

I added a `channel` variable to `AudioEffect`, which is set when audio bus effects are updated, for each channel right before `AudioEffect::instantiate()` is called, so that channel specific configuration can be done. It's not exposed as a property, but is accessible with a read-only `get_channel()`.

Also added to `AudioEffect` is a new virtual function `set_channel_count` that an effect can override if they want access to channel count (this will match `AudioServer::get_channel_count()`). It gets called when audio bus effects are updated, before the `AudioEffectInstance`s are instantiated.

Using these two changes, the `AudioEffectCapture` and `AudioEffectRecord` have been refactored. All of the core recording/capturing logic has been moved from the base `AudioEffect` classes into the respective `AudioEffectInstance` classes, along with the public interface methods. The base effects keep a vector of the instances, keyed by the channel number. 

The `AudioEffectCapture`/`AudioEffectRecord` interface methods have been changed to take a new optional `channel` parameter (defaults to 0), which is used to pass the calls through to the requested `AudioEffectInstance` methods. However, `AudioEffect` properties (`buffer_length` for capture, and `format` for record) are not instance specific: they keep local copies of the values, and pass the set value on to all instances.

**Update** (2025/12/30): I didn't like the previous solution, which used a `virtual init_instance()` method on `AudioEffect` to do extra channel specific configuration to an `AudioEffectInstance`. I removed `set_current_channel` from `AudioEffectInstance`, and `init_instance` from `AudioEffect`, and instead have a `channel` variable on `AudioEffect`, set before `instantiate()` gets called.

Added a virtual function `set_channel_count` to `AudioEffect` that can be overridden if an effect wants the total number of channels in the system at runtime.

Also changed the capture/record `instances` arrays to vectors, which get resized by `set_channel_count` to avoid the edge case where some instance refs were sitting in there after the number of channels changed.

Updated the description above, and removed all the deprecated notes.