### PR TITLE
Avoid crash when importing .glsl in headless

### DIFF
--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -92,6 +92,7 @@ static String _include_function(const String &p_path, void *userpointer) {
 Error ResourceImporterShaderFile::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	/* STEP 1, Read shader code */
 	ERR_FAIL_COND_V_EDMSG((OS::get_singleton()->get_current_rendering_method() == "gl_compatibility"), ERR_UNAVAILABLE, "Cannot import custom .glsl shaders when using the gl_compatibility rendering_method. Please switch to the forward_plus or mobile rendering methods to use custom shaders.");
+	ERR_FAIL_COND_V_EDMSG((DisplayServer::get_singleton()->get_name() == "headless"), ERR_UNAVAILABLE, "Cannot import custom .glsl shaders when running in headless mode.");
 
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_source_file, FileAccess::READ, &err);


### PR DESCRIPTION
First, this is a band-aid for a knife stab.

Given that the import process for `.glsl` files involves querying the currently active rendering driver, via `RenderingDevice`, for its capabilities, it's not possible to perform such an import in headless mode. A crash due to null pointer happens. And that's what this PR patches: you are warned the import couldn't happen instead of geting a crash.

However, the issue is much deeper. Which rendering driver is curently active shouldn't have an impact on how the shader from the `.glsl` file is conditioned since at runtime a different one may be enabled. Re-thinking how that works is required. This PR only takes us so far.