### PR TITLE
Fix multichar warning in `windows_utils.cpp`

### DIFF
--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -92,7 +92,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 			DWORD Offset;
 		};
 
-		const DWORD nb10_magic = '01BN';
+		const DWORD nb10_magic = 0x3031424e; // "01BN" (little-endian)
 		struct CV_INFO_PDB20 {
 			CV_HEADER CvHeader; // CvHeader.Signature = "NB10"
 			DWORD Signature;
@@ -100,7 +100,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 			BYTE PdbFileName[1];
 		};
 
-		const DWORD rsds_magic = 'SDSR';
+		const DWORD rsds_magic = 0x53445352; // "SDSR" (little-endian)
 		struct CV_INFO_PDB70 {
 			DWORD Signature; // "RSDS"
 			BYTE Guid[16];


### PR DESCRIPTION
# Info

Spiritual followup to https://github.com/godotengine/godot/pull/5787

This fix removes the `multi-character character constant` warning when compiling `platform/windows/windows_utils.cpp`.

The values of the constants were verified with https://llvm.org/doxygen/CVDebugRecord_8h_source.html

## Warning

In this particular case, we do not consider the difference between little endian and big endian systems.