### PR TITLE
GDScript: Fix subscript resolution on constant non-metatype GDScript base

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4342,15 +4342,45 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 
 		GDScriptParser::DataType base_type = p_subscript->base->get_datatype();
 		bool valid = false;
+
 		// If the base is a metatype, use the analyzer instead.
-		if (p_subscript->base->is_constant && !base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::CLASS) {
-			// Just try to get it.
-			Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
-			if (valid) {
-				p_subscript->is_constant = true;
-				p_subscript->reduced_value = value;
-				result_type = type_from_variant(value, p_subscript);
+		if (p_subscript->base->is_constant && !base_type.is_meta_type) {
+			// GH-92534. If the base is a GDScript, use the analyzer instead.
+			bool base_is_gdscript = false;
+			if (p_subscript->base->reduced_value.get_type() == Variant::OBJECT) {
+				Ref<GDScript> gdscript = Object::cast_to<GDScript>(p_subscript->base->reduced_value.get_validated_object());
+				if (gdscript.is_valid()) {
+					base_is_gdscript = true;
+					// Makes a metatype from a constant GDScript, since `base_type` is not a metatype.
+					GDScriptParser::DataType base_type_meta = type_from_variant(gdscript, p_subscript);
+					// First try to reduce the attribute from the metatype.
+					reduce_identifier_from_base(p_subscript->attribute, &base_type_meta);
+					GDScriptParser::DataType attr_type = p_subscript->attribute->get_datatype();
+					if (attr_type.is_set()) {
+						valid = !attr_type.is_pseudo_type || p_can_be_pseudo_type;
+						result_type = attr_type;
+						p_subscript->is_constant = p_subscript->attribute->is_constant;
+						p_subscript->reduced_value = p_subscript->attribute->reduced_value;
+					}
+					if (!valid) {
+						// If unsuccessful, reset and return to the normal route.
+						p_subscript->attribute->set_datatype(GDScriptParser::DataType());
+					}
+				}
 			}
+			if (!base_is_gdscript) {
+				// Just try to get it.
+				Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
+				if (valid) {
+					p_subscript->is_constant = true;
+					p_subscript->reduced_value = value;
+					result_type = type_from_variant(value, p_subscript);
+				}
+			}
+		}
+
+		if (valid) {
+			// Do nothing.
 		} else if (base_type.is_variant() || !base_type.is_hard_type()) {
 			valid = !base_type.is_pseudo_type || p_can_be_pseudo_type;
 			result_type.kind = GDScriptParser::DataType::VARIANT;
@@ -4388,6 +4418,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				mark_node_unsafe(p_subscript);
 			}
 		}
+
 		if (!valid) {
 			GDScriptParser::DataType attr_type = p_subscript->attribute->get_datatype();
 			if (!p_can_be_pseudo_type && (attr_type.is_pseudo_type || result_type.is_pseudo_type)) {
@@ -4406,6 +4437,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 		if (p_subscript->base->is_constant && p_subscript->index->is_constant) {
 			// Just try to get it.
 			bool valid = false;
+			// TODO: Check if `p_subscript->base->reduced_value` is GDScript.
 			Variant value = p_subscript->base->reduced_value.get(p_subscript->index->reduced_value, &valid);
 			if (!valid) {
 				push_error(vformat(R"(Cannot get index "%s" from "%s".)", p_subscript->index->reduced_value, p_subscript->base->reduced_value), p_subscript->index);

--- a/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
@@ -25,12 +25,24 @@ func test():
 		if str(property.name).begins_with("test_"):
 			print(Utils.get_property_signature(property))
 
+	print("---")
 	check_gdscript_native_class(test_native)
 	check_gdscript(test_script)
 	check_gdscript(test_class)
 	check_enum(test_enum)
 
+	print("---")
 	print(test_native.stringify([]))
 	print(test_script.TEST)
 	print(test_class.TEST)
 	print(test_enum.keys())
+
+	print("---")
+	# Some users add unnecessary type hints to `const`-`preload`, which removes metatypes.
+	# For **constant** `GDScript` we still check the class members, despite the wider type.
+	const ScriptNoMeta: GDScript = Other
+	const ClassNoMeta: GDScript = MyClass
+	var a := ScriptNoMeta.TEST
+	var b := ClassNoMeta.TEST
+	print(a)
+	print(b)

--- a/modules/gdscript/tests/scripts/runtime/features/metatypes.out
+++ b/modules/gdscript/tests/scripts/runtime/features/metatypes.out
@@ -3,11 +3,16 @@ var test_native: GDScriptNativeClass
 var test_script: GDScript
 var test_class: GDScript
 var test_enum: Dictionary
+---
 GDScriptNativeClass
 GDScript
 GDScript
 { "A": 0, "B": 1, "C": 2 }
+---
 []
 100
 10
 ["A", "B", "C"]
+---
+100
+10


### PR DESCRIPTION
* Fixes #92534.
* Resolves (partially) #89077.

#92035 exposed a bug with the static analyzer tries to get `GDScript` properties when they might be invalid (now there is [a guard](https://github.com/godotengine/godot/blob/e7dd6f11ed1ed4d72186d3a90d5f4ef42e79c4d0/modules/gdscript/gdscript.cpp#L934-L936) against it). This is due to the fact that when reducing subscript on a constant base, we use `Variant::get_named()`, while we should use the analyzer. In #79510, I fixed a related bug, but I didn't take into account that a constant value could have a broader type due to type hints and casting.

We also have a quirk that GDScript classes are both types and values. What causes collisions (#75392, #76414) is whether you mean a static class member or a non-static member of the `GDScript` resource (for instance, `resource_path`). Also, we don't have first class types and the `is_meta_type` flag sometimes leads to strange bugs.

Some users add unnecessary type hints to `const`-`preload`, which removes metatypes.

```gdscript
const MyClass: GDScript = preload("./my_class.gd")
var test := MyClass.InnerClass.new()
#                   ^^^^^^^^^^
# The specified type `GDScript` has no member `InnerClass`,
# but the value has and this is known in advance.
```

It might make sense to distinguish between a GDScript class as a type and as a value, but we proceed from the current state of affairs and strive to maintain backward compatibility. Now, for a constant `GDScript` base without the `is_meta_type` flag, the static members of the class are checked first, and then the non-static members of the `GDScript` class. For `GDScript` with the `is_meta_type` flag, only static class members are still checked.