### PR TITLE
Make displayed Web errors more meaningful

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -701,9 +701,14 @@ function startEditor(zip) {
 	editor = new Engine(editorConfig);
 
 	function displayFailureNotice(err) {
-		const msg = err.message || err;
-		console.error(msg);
-		setStatusNotice(msg);
+		console.error(err);
+		if (err instanceof Error) {
+			setStatusNotice(err.message);
+		} else if (typeof err === 'string') {
+			setStatusNotice(err);
+		} else {
+			setStatusNotice('An unknown error occured');
+		}
 		setStatusMode('notice');
 		initializing = false;
 	}

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -134,9 +134,14 @@ const engine = new Engine(GODOT_CONFIG);
 	}
 
 	function displayFailureNotice(err) {
-		const msg = err.message || err;
-		console.error(msg);
-		setStatusNotice(msg);
+		console.error(err);
+		if (err instanceof Error) {
+			setStatusNotice(err.message);
+		} else if (typeof err === 'string') {
+			setStatusNotice(err);
+		} else {
+			setStatusNotice('An unknown error occured');
+		}
 		setStatusMode('notice');
 		initializing = false;
 	}


### PR DESCRIPTION
Updates the code to display an error to not only show the message, but the context as well.

| Before | After |
| :---: | :---: |
| ![Capture d’écran, le 2024-05-30 à 10 58 26](https://github.com/godotengine/godot/assets/270928/0b7e1128-f7cf-4d41-93c3-cc7e4c9782a7) | ![Capture d’écran, le 2024-05-30 à 10 59 21](https://github.com/godotengine/godot/assets/270928/98623e13-a314-4060-97b1-a86d360acc58) |
