### PR TITLE
CI: Call local python `pre-commit` scripts via shell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,14 +79,17 @@ repos:
       - id: make-rst
         name: make-rst
         language: python
-        entry: python3 doc/tools/make_rst.py doc/classes modules platform --dry-run --color
+        entry: misc/scripts/python.sh doc/tools/make_rst.py
+        args: [doc/classes, modules, platform, --dry-run, --color]
         pass_filenames: false
         files: ^(doc/classes|.*/doc_classes)/.*\.xml$
 
       - id: doc-status
         name: doc-status
         language: python
-        entry: python3 doc/tools/doc_status.py
+        entry: misc/scripts/python.sh doc/tools/doc_status.py
+        args: [doc/classes, modules/*/doc_classes, platform/*/doc_classes]
+        pass_filenames: false
         files: ^(doc/classes|.*/doc_classes)/.*\.xml$
 
       - id: eslint
@@ -126,7 +129,7 @@ repos:
       - id: copyright-headers
         name: copyright-headers
         language: python
-        entry: python3 misc/scripts/copyright_headers.py
+        entry: misc/scripts/python.sh misc/scripts/copyright_headers.py
         files: \.(c|h|cpp|hpp|cc|cxx|m|mm|inc|java)$
         exclude: |
           (?x)^(
@@ -141,7 +144,7 @@ repos:
       - id: header-guards
         name: header-guards
         language: python
-        entry: python3 misc/scripts/header_guards.py
+        entry: misc/scripts/python.sh misc/scripts/header_guards.py
         files: \.(h|hpp)$
         exclude: |
           (?x)^(
@@ -153,7 +156,7 @@ repos:
       - id: file-format
         name: file-format
         language: python
-        entry: python3 misc/scripts/file_format.py
+        entry: misc/scripts/python.sh misc/scripts/file_format.py
         types_or: [text]
         exclude: |
           (?x)^(
@@ -170,7 +173,7 @@ repos:
       - id: dotnet-format
         name: dotnet-format
         language: python
-        entry: python3 misc/scripts/dotnet_format.py
+        entry: misc/scripts/python.sh misc/scripts/dotnet_format.py
         types_or: [c#]
 
 # End of upstream Godot pre-commit hooks.

--- a/misc/scripts/python.sh
+++ b/misc/scripts/python.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 ]; then
+    echo "No arguments provided."
+    exit 1
+fi
+
+PYTHON_ALIASES=("python3" "python" "py")
+
+for alias in "${PYTHON_ALIASES[@]}"
+do
+if command "$alias" --version > /dev/null 2>&1; then
+    exec "$alias" "$@"
+    exit $?
+fi
+done
+
+echo "Python not found." 1>&2
+exit 1


### PR DESCRIPTION
Alternative to #90634 and #90662

This is a slightly hacky but fully-functional workaround for allowing local `pre-commit` python scripts to be fully multi-platform. Because we can only provide a static entry point, this PR converts said entry point to a new shell script wrapper: `misc/scripts/python.sh`. This script's job is to evaluate several Python alias calls to see if they exist on the user's path; if a match is found, that alias is used to call the provided arguments directly.

Also assigns proper arguments for `doc-status`, as I learned in local testing that it required a similar argument setup as `make-rst`. Both of these now call said arguments via `args` instead of extending off `entry`.