### PR TITLE
GDScript: Do not produce `INFERRED_DECLARATION` on type import

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1971,7 +1971,12 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 		const bool is_parameter = p_assignable->type == GDScriptParser::Node::PARAMETER;
 		const String declaration_type = is_constant ? "Constant" : (is_parameter ? "Parameter" : "Variable");
 		if (p_assignable->infer_datatype || is_constant) {
-			parser->push_warning(p_assignable, GDScriptWarning::INFERRED_DECLARATION, declaration_type, p_assignable->identifier->name);
+			// Do not produce the `INFERRED_DECLARATION` warning on type import because there is no way to specify the true type.
+			// And removing the metatype makes it impossible to use the constant as a type hint (especially for enums).
+			const bool is_type_import = is_constant && p_assignable->initializer != nullptr && p_assignable->initializer->datatype.is_meta_type;
+			if (!is_type_import) {
+				parser->push_warning(p_assignable, GDScriptWarning::INFERRED_DECLARATION, declaration_type, p_assignable->identifier->name);
+			}
 		} else {
 			parser->push_warning(p_assignable, GDScriptWarning::UNTYPED_DECLARATION, declaration_type, p_assignable->identifier->name);
 		}


### PR DESCRIPTION
* Resolves (partially) #89077.

It's a very small change, so I think we could include it for 4.3. See also #92544 for context.
