### PR TITLE
Update Add Scene button after TabBar resizes

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -405,7 +405,7 @@ EditorSceneTabs::EditorSceneTabs() {
 	scene_tabs->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorSceneTabs::_scene_tab_exit));
 	scene_tabs->connect(SceneStringName(gui_input), callable_mp(this, &EditorSceneTabs::_scene_tab_input));
 	scene_tabs->connect("active_tab_rearranged", callable_mp(this, &EditorSceneTabs::_reposition_active_tab));
-	scene_tabs->connect(SceneStringName(resized), callable_mp(this, &EditorSceneTabs::_scene_tabs_resized));
+	scene_tabs->connect(SceneStringName(resized), callable_mp(this, &EditorSceneTabs::_scene_tabs_resized), CONNECT_DEFERRED);
 
 	scene_tabs_context_menu = memnew(PopupMenu);
 	tabbar_container->add_child(scene_tabs_context_menu);


### PR DESCRIPTION
When toggling distraction-free mode and there are enough scenes to scroll, the Add Scene button moves to the wrong position.

![image](https://github.com/godotengine/godot/assets/10054226/40514a2a-ea7e-46fe-b209-65afb73494e6)

This happened because it was moved before the tabs resized.