### PR TITLE
Add triangulation partition option to 2D navigation mesh baking

### DIFF
--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -193,6 +193,9 @@
 		<member name="parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" enum="NavigationPolygon.ParsedGeometryType" default="2">
 			Determines which type of nodes will be parsed as geometry. See [enum ParsedGeometryType] for possible values.
 		</member>
+		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" enum="NavigationPolygon.SamplePartitionType" default="0">
+			Partitioning algorithm for creating the navigation mesh polys. See [enum SamplePartitionType] for possible values.
+		</member>
 		<member name="source_geometry_group_name" type="StringName" setter="set_source_geometry_group_name" getter="get_source_geometry_group_name" default="&amp;&quot;navigation_polygon_source_geometry_group&quot;">
 			The group name of nodes that should be parsed for baking source geometry.
 			Only used when [member source_geometry_mode] is [constant SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN] or [constant SOURCE_GEOMETRY_GROUPS_EXPLICIT].
@@ -202,6 +205,15 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="SAMPLE_PARTITION_CONVEX_PARTITION" value="0" enum="SamplePartitionType">
+			Convex partitioning that yields navigation mesh with convex polygons.
+		</constant>
+		<constant name="SAMPLE_PARTITION_TRIANGULATE" value="1" enum="SamplePartitionType">
+			Triangulation partitioning that yields navigation mesh with triangle polygons.
+		</constant>
+		<constant name="SAMPLE_PARTITION_MAX" value="2" enum="SamplePartitionType">
+			Represents the size of the [enum SamplePartitionType] enum.
+		</constant>
 		<constant name="PARSED_GEOMETRY_MESH_INSTANCES" value="0" enum="ParsedGeometryType">
 			Parses mesh instances as obstruction geometry. This includes [Polygon2D], [MeshInstance2D], [MultiMeshInstance2D], and [TileMap] nodes.
 			Meshes are only parsed when they use a 2D vertices surface format.

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -400,6 +400,15 @@ real_t NavigationPolygon::get_border_size() const {
 	return border_size;
 }
 
+void NavigationPolygon::set_sample_partition_type(SamplePartitionType p_value) {
+	ERR_FAIL_INDEX(p_value, SAMPLE_PARTITION_MAX);
+	partition_type = p_value;
+}
+
+NavigationPolygon::SamplePartitionType NavigationPolygon::get_sample_partition_type() const {
+	return partition_type;
+}
+
 void NavigationPolygon::set_parsed_geometry_type(ParsedGeometryType p_geometry_type) {
 	ERR_FAIL_INDEX(p_geometry_type, PARSED_GEOMETRY_MAX);
 	parsed_geometry_type = p_geometry_type;
@@ -514,6 +523,9 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_border_size", "border_size"), &NavigationPolygon::set_border_size);
 	ClassDB::bind_method(D_METHOD("get_border_size"), &NavigationPolygon::get_border_size);
 
+	ClassDB::bind_method(D_METHOD("set_sample_partition_type", "sample_partition_type"), &NavigationPolygon::set_sample_partition_type);
+	ClassDB::bind_method(D_METHOD("get_sample_partition_type"), &NavigationPolygon::get_sample_partition_type);
+
 	ClassDB::bind_method(D_METHOD("set_parsed_geometry_type", "geometry_type"), &NavigationPolygon::set_parsed_geometry_type);
 	ClassDB::bind_method(D_METHOD("get_parsed_geometry_type"), &NavigationPolygon::get_parsed_geometry_type);
 
@@ -543,6 +555,8 @@ void NavigationPolygon::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_outlines", "_get_outlines");
 
+	ADD_GROUP("Sampling", "sample_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sample_partition_type", PROPERTY_HINT_ENUM, "Convex Partition,Triangulate"), "set_sample_partition_type", "get_sample_partition_type");
 	ADD_GROUP("Geometry", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "parsed_geometry_type", PROPERTY_HINT_ENUM, "Mesh Instances,Static Colliders,Meshes and Static Colliders"), "set_parsed_geometry_type", "get_parsed_geometry_type");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "parsed_collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_parsed_collision_mask", "get_parsed_collision_mask");
@@ -558,6 +572,10 @@ void NavigationPolygon::_bind_methods() {
 	ADD_GROUP("Filters", "");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "baking_rect"), "set_baking_rect", "get_baking_rect");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "baking_rect_offset"), "set_baking_rect_offset", "get_baking_rect_offset");
+
+	BIND_ENUM_CONSTANT(SAMPLE_PARTITION_CONVEX_PARTITION);
+	BIND_ENUM_CONSTANT(SAMPLE_PARTITION_TRIANGULATE);
+	BIND_ENUM_CONSTANT(SAMPLE_PARTITION_MAX);
 
 	BIND_ENUM_CONSTANT(PARSED_GEOMETRY_MESH_INSTANCES);
 	BIND_ENUM_CONSTANT(PARSED_GEOMETRY_STATIC_COLLIDERS);

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -74,6 +74,11 @@ public:
 	Rect2 _edit_get_rect() const;
 	bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 #endif
+	enum SamplePartitionType {
+		SAMPLE_PARTITION_CONVEX_PARTITION = 0,
+		SAMPLE_PARTITION_TRIANGULATE,
+		SAMPLE_PARTITION_MAX
+	};
 
 	enum ParsedGeometryType {
 		PARSED_GEOMETRY_MESH_INSTANCES = 0,
@@ -91,6 +96,7 @@ public:
 
 	real_t agent_radius = 10.0f;
 
+	SamplePartitionType partition_type = SAMPLE_PARTITION_CONVEX_PARTITION;
 	ParsedGeometryType parsed_geometry_type = PARSED_GEOMETRY_BOTH;
 	uint32_t parsed_collision_mask = 0xFFFFFFFF;
 
@@ -119,6 +125,9 @@ public:
 	const Vector<Vector<int>> &get_polygons() const;
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
+
+	void set_sample_partition_type(SamplePartitionType p_value);
+	SamplePartitionType get_sample_partition_type() const;
 
 	void set_parsed_geometry_type(ParsedGeometryType p_geometry_type);
 	ParsedGeometryType get_parsed_geometry_type() const;
@@ -161,6 +170,7 @@ public:
 	~NavigationPolygon() {}
 };
 
+VARIANT_ENUM_CAST(NavigationPolygon::SamplePartitionType);
 VARIANT_ENUM_CAST(NavigationPolygon::ParsedGeometryType);
 VARIANT_ENUM_CAST(NavigationPolygon::SourceGeometryMode);
 


### PR DESCRIPTION
Adds triangulation partition option to 2D navigation mesh baking as an alternative to the existing convex partition option.

![partition_options](https://github.com/godotengine/godot/assets/52464204/e5cafc47-e205-4fcf-8de6-7ac984999b02)

Between convex polygons or triangulated polygons there is no "always better" for pathfinding, it all matters on context. This PR provides an alternative and partitions the polygons as triangles similar to how the 3D navmesh baking does.

![convex_vs_triangulated](https://github.com/godotengine/godot/assets/52464204/df4ca3d2-adc2-464e-b9c9-519d23643887)

For most projects convex polygons are preferred because they can cover large surface areas with a single polygon and reduce the total edge count for performance. The problem with convex polygons depends entirely on the project as having a single polygon as a "hub" polygon can result in weird pathing issues on certain map layouts. It also works better in combination with the edge-centered postprocessing on "tile" layouts if they have an edge in the middle.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
