### PR TITLE
Implement a "Recovery Mode" for recovering crashing projects during initialization

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -87,6 +87,7 @@ private:
 	bool project_manager_hint = false;
 	bool extension_reloading = false;
 	bool embedded_in_editor = false;
+	bool recovery_mode_hint = false;
 
 	bool _print_header = true;
 
@@ -162,6 +163,9 @@ public:
 
 	_FORCE_INLINE_ void set_extension_reloading_enabled(bool p_enabled) { extension_reloading = p_enabled; }
 	_FORCE_INLINE_ bool is_extension_reloading_enabled() const { return extension_reloading; }
+
+	_FORCE_INLINE_ void set_recovery_mode_hint(bool p_enabled) { recovery_mode_hint = p_enabled; }
+	_FORCE_INLINE_ bool is_recovery_mode_hint() const { return recovery_mode_hint; }
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
@@ -171,6 +175,9 @@ public:
 
 	_FORCE_INLINE_ void set_extension_reloading_enabled(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_extension_reloading_enabled() const { return false; }
+
+	_FORCE_INLINE_ void set_recovery_mode_hint(bool p_enabled) {}
+	_FORCE_INLINE_ bool is_recovery_mode_hint() const { return false; }
 #endif
 
 	Dictionary get_version_info() const;

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -84,6 +84,10 @@ GDExtensionManager::LoadStatus GDExtensionManager::_unload_extension_internal(co
 }
 
 GDExtensionManager::LoadStatus GDExtensionManager::load_extension(const String &p_path) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return LOAD_STATUS_FAILED;
+	}
+
 	Ref<GDExtensionLibraryLoader> loader;
 	loader.instantiate();
 	return GDExtensionManager::get_singleton()->load_extension_with_loader(p_path, loader);
@@ -118,6 +122,10 @@ GDExtensionManager::LoadStatus GDExtensionManager::reload_extension(const String
 	ERR_FAIL_V_MSG(LOAD_STATUS_FAILED, "GDExtensions can only be reloaded in an editor build.");
 #else
 	ERR_FAIL_COND_V_MSG(!Engine::get_singleton()->is_extension_reloading_enabled(), LOAD_STATUS_FAILED, "GDExtension reloading is disabled.");
+
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return LOAD_STATUS_FAILED;
+	}
 
 	if (!gdextension_map.has(p_path)) {
 		return LOAD_STATUS_NOT_LOADED;
@@ -161,6 +169,10 @@ GDExtensionManager::LoadStatus GDExtensionManager::reload_extension(const String
 }
 
 GDExtensionManager::LoadStatus GDExtensionManager::unload_extension(const String &p_path) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return LOAD_STATUS_FAILED;
+	}
+
 	if (!gdextension_map.has(p_path)) {
 		return LOAD_STATUS_NOT_LOADED;
 	}
@@ -207,6 +219,10 @@ String GDExtensionManager::class_get_icon_path(const String &p_class) const {
 }
 
 void GDExtensionManager::initialize_extensions(GDExtension::InitializationLevel p_level) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	ERR_FAIL_COND(int32_t(p_level) - 1 != level);
 	for (KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
 		E.value->initialize_library(p_level);
@@ -221,6 +237,10 @@ void GDExtensionManager::initialize_extensions(GDExtension::InitializationLevel 
 }
 
 void GDExtensionManager::deinitialize_extensions(GDExtension::InitializationLevel p_level) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	ERR_FAIL_COND(int32_t(p_level) != level);
 	for (KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
 		E.value->deinitialize_library(p_level);
@@ -259,6 +279,10 @@ void GDExtensionManager::_reload_all_scripts() {
 #endif // TOOLS_ENABLED
 
 void GDExtensionManager::load_extensions() {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	Ref<FileAccess> f = FileAccess::open(GDExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f.is_valid() && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
@@ -273,6 +297,9 @@ void GDExtensionManager::load_extensions() {
 
 void GDExtensionManager::reload_extensions() {
 #ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
 	bool reloaded = false;
 	for (const KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
 		if (!E.value->is_reloadable()) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -285,6 +285,7 @@ public:
 	virtual String get_bundle_resource_dir() const;
 	virtual String get_bundle_icon_path() const;
 
+	virtual String get_user_data_dir(const String &p_user_dir) const;
 	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;
 
@@ -302,6 +303,9 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const;
 
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }
+
+	void create_lock_file();
+	void remove_lock_file();
 
 	virtual int get_exit_code() const;
 	// `set_exit_code` should only be used from `SceneTree` (or from a similar

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -959,22 +959,8 @@ void OS_Unix::unset_environment(const String &p_var) const {
 	unsetenv(p_var.utf8().get_data());
 }
 
-String OS_Unix::get_user_data_dir() const {
-	String appname = get_safe_dir_name(GLOBAL_GET("application/config/name"));
-	if (!appname.is_empty()) {
-		bool use_custom_dir = GLOBAL_GET("application/config/use_custom_user_dir");
-		if (use_custom_dir) {
-			String custom_dir = get_safe_dir_name(GLOBAL_GET("application/config/custom_user_dir_name"), true);
-			if (custom_dir.is_empty()) {
-				custom_dir = appname;
-			}
-			return get_data_path().path_join(custom_dir);
-		} else {
-			return get_data_path().path_join(get_godot_dir_name()).path_join("app_userdata").path_join(appname);
-		}
-	}
-
-	return get_data_path().path_join(get_godot_dir_name()).path_join("app_userdata").path_join("[unnamed project]");
+String OS_Unix::get_user_data_dir(const String &p_user_dir) const {
+	return get_data_path().path_join(p_user_dir);
 }
 
 String OS_Unix::get_executable_path() const {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -106,7 +106,7 @@ public:
 	virtual void initialize_debugging() override;
 
 	virtual String get_executable_path() const override;
-	virtual String get_user_data_dir() const override;
+	virtual String get_user_data_dir(const String &p_user_dir) const override;
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -91,6 +91,10 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	remote_scene_tree_timeout = EDITOR_GET("debugger/remote_scene_tree_refresh_interval");
 	inspect_edited_object_timeout = EDITOR_GET("debugger/remote_inspect_refresh_interval");
 
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	EditorRunBar::get_singleton()->get_pause_button()->connect(SceneStringName(pressed), callable_mp(this, &EditorDebuggerNode::_paused));
 }
 
@@ -263,6 +267,10 @@ void EditorDebuggerNode::set_keep_open(bool p_keep_open) {
 }
 
 Error EditorDebuggerNode::start(const String &p_uri) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return ERR_UNAVAILABLE;
+	}
+
 	ERR_FAIL_COND_V(!p_uri.contains("://"), ERR_INVALID_PARAMETER);
 	if (keep_open && current_uri == p_uri && server.is_valid()) {
 		return OK;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -730,6 +730,10 @@ void EditorNode::_notification(int p_what) {
 			CanvasItemEditor::ThemePreviewMode theme_preview_mode = (CanvasItemEditor::ThemePreviewMode)(int)EditorSettings::get_singleton()->get_project_metadata("2d_editor", "theme_preview", CanvasItemEditor::THEME_PREVIEW_PROJECT);
 			update_preview_themes(theme_preview_mode);
 
+			if (Engine::get_singleton()->is_recovery_mode_hint()) {
+				EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Editor functionality has been restricted."), EditorToaster::SEVERITY_WARNING);
+			}
+
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
 
@@ -1152,7 +1156,13 @@ void EditorNode::_sources_changed(bool p_exist) {
 		if (!singleton->cmdline_export_mode) {
 			EditorResourcePreview::get_singleton()->start();
 		}
+
+		get_tree()->create_timer(1.0f)->connect("timeout", callable_mp(this, &EditorNode::_remove_lock_file));
 	}
+}
+
+void EditorNode::_remove_lock_file() {
+	OS::get_singleton()->remove_lock_file();
 }
 
 void EditorNode::_scan_external_changes() {
@@ -5382,6 +5392,10 @@ void EditorNode::_save_window_settings_to_config(Ref<ConfigFile> p_layout, const
 }
 
 void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	if (!bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
 		return;
 	}
@@ -6613,7 +6627,9 @@ void EditorNode::_feature_profile_changed() {
 
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_3D, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_SCRIPT, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
-		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME));
+		if (!Engine::get_singleton()->is_recovery_mode_hint()) {
+			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME));
+		}
 		if (AssetLibraryEditorPlugin::is_available()) {
 			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_ASSETLIB, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_ASSET_LIB));
 		}
@@ -6624,7 +6640,9 @@ void EditorNode::_feature_profile_changed() {
 		editor_dock_manager->set_dock_enabled(history_dock, true);
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_3D, true);
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_SCRIPT, true);
-		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, true);
+		if (!Engine::get_singleton()->is_recovery_mode_hint()) {
+			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, true);
+		}
 		if (AssetLibraryEditorPlugin::is_available()) {
 			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_ASSETLIB, true);
 		}
@@ -7761,7 +7779,10 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(CanvasItemEditorPlugin));
 	add_editor_plugin(memnew(Node3DEditorPlugin));
 	add_editor_plugin(memnew(ScriptEditorPlugin));
-	add_editor_plugin(memnew(GameViewPlugin));
+
+	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
+		add_editor_plugin(memnew(GameViewPlugin));
+	}
 
 	EditorAudioBuses *audio_bus_editor = EditorAudioBuses::register_editor();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -132,20 +132,6 @@ public:
 		ACTION_ON_STOP_CLOSE_BUTTOM_PANEL,
 	};
 
-	struct ExecuteThreadArgs {
-		String path;
-		List<String> args;
-		String output;
-		Thread execute_output_thread;
-		Mutex execute_output_mutex;
-		int exitcode = 0;
-		SafeFlag done;
-	};
-
-private:
-	friend class EditorSceneTabs;
-	friend class SurfaceUpgradeTool;
-
 	enum MenuOptions {
 		FILE_NEW_SCENE,
 		FILE_NEW_INHERITED_SCENE,
@@ -234,6 +220,20 @@ private:
 
 		TOOL_MENU_BASE = 1000
 	};
+
+	struct ExecuteThreadArgs {
+		String path;
+		List<String> args;
+		String output;
+		Thread execute_output_thread;
+		Mutex execute_output_mutex;
+		int exitcode = 0;
+		SafeFlag done;
+	};
+
+private:
+	friend class EditorSceneTabs;
+	friend class SurfaceUpgradeTool;
 
 	enum {
 		MAX_INIT_CALLBACKS = 128,
@@ -548,6 +548,7 @@ private:
 	void _resources_reimporting(const Vector<String> &p_resources);
 	void _resources_reimported(const Vector<String> &p_resources);
 	void _sources_changed(bool p_exist);
+	void _remove_lock_file();
 
 	void _node_renamed();
 	void _save_editor_states(const String &p_file, int p_idx = -1);

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -40,6 +40,8 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_quick_open_dialog.h"
+#include "editor/gui/editor_toaster.h"
+#include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/panel_container.h"
@@ -52,7 +54,35 @@ void EditorRunBar::_notification(int p_what) {
 			_reset_play_buttons();
 		} break;
 
+		case NOTIFICATION_READY: {
+			if (Engine::get_singleton()->is_recovery_mode_hint()) {
+				recovery_mode_show_dialog();
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
+			if (Engine::get_singleton()->is_recovery_mode_hint()) {
+				main_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("LaunchPadRecoveryMode"), EditorStringName(EditorStyles)));
+				recovery_mode_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("RecoveryModeButton"), EditorStringName(EditorStyles)));
+				recovery_mode_button->add_theme_style_override("hover", get_theme_stylebox(SNAME("RecoveryModeButton"), EditorStringName(EditorStyles)));
+
+				recovery_mode_button->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
+				recovery_mode_reload_button->set_button_icon(get_editor_theme_icon(SNAME("Reload")));
+
+				recovery_mode_button->begin_bulk_theme_override();
+				recovery_mode_button->add_theme_color_override("icon_normal_color", Color(0.3, 0.3, 0.3, 1));
+				recovery_mode_button->add_theme_color_override("icon_pressed_color", Color(0.4, 0.4, 0.4, 1));
+				recovery_mode_button->add_theme_color_override("icon_hover_color", Color(0.6, 0.6, 0.6, 1));
+				Color dark_color = get_theme_color("recovery_mode_text_color", EditorStringName(Editor));
+				recovery_mode_button->add_theme_color_override(SceneStringName(font_color), dark_color);
+				recovery_mode_button->add_theme_color_override("font_pressed_color", dark_color.lightened(0.2));
+				recovery_mode_button->add_theme_color_override("font_hover_color", dark_color.lightened(0.4));
+				recovery_mode_button->add_theme_color_override("font_hover_pressed_color", dark_color.lightened(0.2));
+				recovery_mode_button->end_bulk_theme_override();
+
+				return;
+			}
+
 			_update_play_buttons();
 			profiler_autostart_indicator->set_button_icon(get_editor_theme_icon(SNAME("ProfilerAutostartWarning")));
 			pause_button->set_button_icon(get_editor_theme_icon(SNAME("Pause")));
@@ -79,6 +109,10 @@ void EditorRunBar::_notification(int p_what) {
 }
 
 void EditorRunBar::_reset_play_buttons() {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	play_button->set_pressed(false);
 	play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
 	play_button->set_tooltip_text(TTR("Play the project."));
@@ -93,6 +127,10 @@ void EditorRunBar::_reset_play_buttons() {
 }
 
 void EditorRunBar::_update_play_buttons() {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
 	_reset_play_buttons();
 	if (!is_playing()) {
 		return;
@@ -278,7 +316,20 @@ void EditorRunBar::_profiler_autostart_indicator_pressed() {
 	}
 }
 
+void EditorRunBar::recovery_mode_show_dialog() {
+	recovery_mode_popup->popup_centered();
+}
+
+void EditorRunBar::recovery_mode_reload_project() {
+	EditorNode::get_singleton()->trigger_menu_option(EditorNode::RELOAD_CURRENT_PROJECT, false);
+}
+
 void EditorRunBar::play_main_scene(bool p_from_native) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+
 	if (p_from_native) {
 		run_native->resume_run_native();
 	} else {
@@ -290,6 +341,11 @@ void EditorRunBar::play_main_scene(bool p_from_native) {
 }
 
 void EditorRunBar::play_current_scene(bool p_reload) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+
 	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
 
 	EditorNode::get_singleton()->save_default_environment();
@@ -304,6 +360,11 @@ void EditorRunBar::play_current_scene(bool p_reload) {
 }
 
 void EditorRunBar::play_custom_scene(const String &p_custom) {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+
 	stop_playing();
 
 	current_mode = RunMode::RUN_CUSTOM;
@@ -378,6 +439,7 @@ void EditorRunBar::update_profiler_autostart_indicator() {
 	bool visual_profiler_active = EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false);
 	bool network_profiler_active = EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_network_profiler", false);
 	bool any_profiler_active = profiler_active | visual_profiler_active | network_profiler_active;
+	any_profiler_active &= !Engine::get_singleton()->is_recovery_mode_hint();
 	profiler_autostart_indicator->set_visible(any_profiler_active);
 	if (any_profiler_active) {
 		String tooltip = TTR("Autostart is enabled for the following profilers, which can have a performance impact:");
@@ -424,6 +486,42 @@ EditorRunBar::EditorRunBar() {
 
 	main_hbox = memnew(HBoxContainer);
 	main_panel->add_child(main_hbox);
+
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		recovery_mode_popup = memnew(AcceptDialog);
+		recovery_mode_popup->set_min_size(Size2(550, 70) * EDSCALE);
+		recovery_mode_popup->set_title(TTR("Recovery Mode"));
+		recovery_mode_popup->set_text(
+				TTR("Godot opened the project in Recovery Mode, which is a special mode that can help recover projects that crash the engine upon initialization. The following features have been temporarily disabled:") +
+				String::utf8("\n\n•  ") + TTR("Tool scripts") +
+				String::utf8("\n•  ") + TTR("Editor plugins") +
+				String::utf8("\n•  ") + TTR("GDExtension addons") +
+				String::utf8("\n•  ") + TTR("Automatic scene restoring") +
+				String::utf8("\n\n") + TTR("If the project cannot be opened outside of this mode, then it's very likely any of these components is preventing this project from launching. This mode is intended only for basic editing to troubleshoot such issues, and therefore it is not possible to run a project in this mode.") +
+				String::utf8("\n\n") + TTR("To disable Recovery Mode, reload the project by pressing the Reload button next to the Recovery Mode banner, or by reopening the project normally."));
+		recovery_mode_popup->set_autowrap(true);
+		add_child(recovery_mode_popup);
+
+		recovery_mode_reload_button = memnew(Button);
+		main_hbox->add_child(recovery_mode_reload_button);
+		recovery_mode_reload_button->set_theme_type_variation("RunBarButton");
+		recovery_mode_reload_button->set_focus_mode(Control::FOCUS_NONE);
+		recovery_mode_reload_button->set_tooltip_text(TTR("Disable recovery mode and reload the project."));
+		recovery_mode_reload_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::recovery_mode_reload_project));
+
+		recovery_mode_panel = memnew(PanelContainer);
+		main_hbox->add_child(recovery_mode_panel);
+
+		recovery_mode_button = memnew(Button);
+		recovery_mode_panel->add_child(recovery_mode_button);
+		recovery_mode_button->set_theme_type_variation("RunBarButton");
+		recovery_mode_button->set_focus_mode(Control::FOCUS_NONE);
+		recovery_mode_button->set_text(TTR("Recovery Mode"));
+		recovery_mode_button->set_tooltip_text(TTR("Recovery Mode is enabled. Click for more details."));
+		recovery_mode_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::recovery_mode_show_dialog));
+
+		return;
+	}
 
 	play_button = memnew(Button);
 	main_hbox->add_child(play_button);

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -39,6 +39,7 @@ class Button;
 class EditorRunNative;
 class PanelContainer;
 class HBoxContainer;
+class AcceptDialog;
 
 class EditorRunBar : public MarginContainer {
 	GDCLASS(EditorRunBar, MarginContainer);
@@ -57,6 +58,11 @@ class EditorRunBar : public MarginContainer {
 	HBoxContainer *outer_hbox = nullptr;
 
 	Button *profiler_autostart_indicator = nullptr;
+
+	PanelContainer *recovery_mode_panel = nullptr;
+	Button *recovery_mode_button = nullptr;
+	Button *recovery_mode_reload_button = nullptr;
+	AcceptDialog *recovery_mode_popup = nullptr;
 
 	Button *play_button = nullptr;
 	Button *pause_button = nullptr;
@@ -94,6 +100,9 @@ protected:
 
 public:
 	static EditorRunBar *get_singleton() { return singleton; }
+
+	void recovery_mode_show_dialog();
+	void recovery_mode_reload_project();
 
 	void play_main_scene(bool p_from_native = false);
 	void play_current_scene(bool p_reload = false);

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -570,8 +570,13 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			Color button_color = Color(1, 1, 1);
 			// Can't set tooltip after adding button, need to do it before.
 			if (scr->is_tool()) {
-				additional_notes += "\n" + TTR("This script is currently running in the editor.");
-				button_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				if (Engine::get_singleton()->is_recovery_mode_hint()) {
+					additional_notes += "\n" + TTR("This script can run in the editor.\nIt is currently disabled due to recovery mode.");
+					button_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+				} else {
+					additional_notes += "\n" + TTR("This script is currently running in the editor.");
+					button_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				}
 			}
 			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr) {
 				additional_notes += "\n" + TTR("This script is a custom type.");

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1782,7 +1782,7 @@ bool AssetLibraryEditorPlugin::is_available() {
 	// directly from GitHub which does not set CORS.
 	return false;
 #else
-	return StreamPeerTLS::is_available();
+	return StreamPeerTLS::is_available() && !Engine::get_singleton()->is_recovery_mode_hint();
 #endif
 }
 

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -37,6 +37,9 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/margin_container.h"
+#include "scene/gui/separator.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 
 void EditorPluginSettings::_notification(int p_what) {
@@ -48,6 +51,12 @@ void EditorPluginSettings::_notification(int p_what) {
 		case Node::NOTIFICATION_READY: {
 			plugin_config_dialog->connect("plugin_ready", callable_mp(EditorNode::get_singleton(), &EditorNode::_on_plugin_ready));
 			plugin_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			if (Engine::get_singleton()->is_recovery_mode_hint()) {
+				recovery_mode_icon->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
+			}
 		} break;
 	}
 }
@@ -203,6 +212,23 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_config_dialog = memnew(PluginConfigDialog);
 	plugin_config_dialog->config("");
 	add_child(plugin_config_dialog);
+
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		HBoxContainer *c = memnew(HBoxContainer);
+		add_child(c);
+
+		recovery_mode_icon = memnew(TextureRect);
+		recovery_mode_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+		c->add_child(recovery_mode_icon);
+
+		Label *recovery_mode_label = memnew(Label(TTR("Recovery mode is enabled. Enabled plugins will not run while this mode is active.")));
+		recovery_mode_label->set_theme_type_variation("HeaderSmall");
+		recovery_mode_label->set_h_size_flags(SIZE_EXPAND_FILL);
+		c->add_child(recovery_mode_label);
+
+		HSeparator *sep = memnew(HSeparator);
+		add_child(sep);
+	}
 
 	HBoxContainer *title_hb = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Installed Plugins:")));

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -33,6 +33,7 @@
 
 #include "editor/plugins/plugin_config_dialog.h"
 
+class TextureRect;
 class Tree;
 
 class EditorPluginSettings : public VBoxContainer {
@@ -54,6 +55,7 @@ class EditorPluginSettings : public VBoxContainer {
 	};
 
 	PluginConfigDialog *plugin_config_dialog = nullptr;
+	TextureRect *recovery_mode_icon = nullptr;
 	Tree *plugin_list = nullptr;
 	bool updating = false;
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -44,6 +44,7 @@ class LineEdit;
 class MarginContainer;
 class OptionButton;
 class PanelContainer;
+class PopupMenu;
 class ProjectDialog;
 class ProjectList;
 class QuickSettingsDialog;
@@ -145,11 +146,15 @@ class ProjectManager : public Control {
 	Button *import_btn = nullptr;
 	Button *scan_btn = nullptr;
 	Button *open_btn = nullptr;
+	Button *open_options_btn = nullptr;
 	Button *run_btn = nullptr;
 	Button *rename_btn = nullptr;
 	Button *manage_tags_btn = nullptr;
 	Button *erase_btn = nullptr;
 	Button *erase_missing_btn = nullptr;
+
+	HBoxContainer *open_btn_container = nullptr;
+	PopupMenu *open_options_popup = nullptr;
 
 	EditorFileDialog *scan_dir = nullptr;
 
@@ -161,6 +166,7 @@ class ProjectManager : public Control {
 	ConfirmationDialog *erase_missing_ask = nullptr;
 	ConfirmationDialog *multi_open_ask = nullptr;
 	ConfirmationDialog *multi_run_ask = nullptr;
+	ConfirmationDialog *open_recovery_mode_ask = nullptr;
 
 	ProjectDialog *project_dialog = nullptr;
 
@@ -168,8 +174,9 @@ class ProjectManager : public Control {
 	void _run_project();
 	void _run_project_confirm();
 	void _open_selected_projects();
-	void _open_selected_projects_ask();
 	void _open_selected_projects_with_migration();
+	void _open_selected_projects_check_warnings();
+	void _open_selected_projects_check_recovery_mode();
 
 	void _install_project(const String &p_zip_path, const String &p_title);
 	void _import_project();
@@ -180,9 +187,14 @@ class ProjectManager : public Control {
 	void _erase_project_confirm();
 	void _erase_missing_projects_confirm();
 	void _update_project_buttons();
+	void _open_options_popup();
+	void _open_recovery_mode_ask(bool manual = false);
 
 	void _on_project_created(const String &dir, bool edit);
 	void _on_projects_updated();
+	void _on_open_options_selected(int p_option);
+	void _on_recovery_mode_popup_open_normal();
+	void _on_recovery_mode_popup_open_recovery();
 
 	void _on_order_option_changed(int p_idx);
 	void _on_search_term_changed(const String &p_term);
@@ -218,6 +230,7 @@ class ProjectManager : public Control {
 	Button *full_convert_button = nullptr;
 
 	String version_convert_feature;
+	bool open_in_recovery_mode = false;
 
 #ifndef DISABLE_DEPRECATED
 	void _minor_project_migrate();

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -116,6 +116,7 @@ public:
 		bool favorite = false;
 		bool grayed = false;
 		bool missing = false;
+		bool recovery_mode = false;
 		int version = 0;
 
 		ProjectListItemControl *control = nullptr;
@@ -134,6 +135,7 @@ public:
 				bool p_favorite,
 				bool p_grayed,
 				bool p_missing,
+				bool p_recovery_mode,
 				int p_version) {
 			project_name = p_name;
 			description = p_description;
@@ -147,6 +149,7 @@ public:
 			favorite = p_favorite;
 			grayed = p_grayed;
 			missing = p_missing;
+			recovery_mode = p_recovery_mode;
 			version = p_version;
 
 			control = nullptr;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -214,7 +214,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ControlEditorPlugin>();
 	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<CurveEditorPlugin>();
-	EditorPlugins::add_by_type<DebugAdapterServer>();
+	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
+		EditorPlugins::add_by_type<DebugAdapterServer>();
+	}
 	EditorPlugins::add_by_type<FontEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1945,6 +1945,11 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		style_launch_pad_movie->set_border_color(p_config.accent_color);
 		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
 		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
+		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = style_launch_pad->duplicate();
+		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
+		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
+		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
 
 		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
 		Ref<StyleBoxFlat> style_write_movie_button = p_config.button_style_pressed->duplicate();
@@ -1970,6 +1975,17 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox(CoreStringName(normal), "ProfilerAutostartIndicator", style_profiler_autostart);
 		p_theme->set_stylebox(SceneStringName(pressed), "ProfilerAutostartIndicator", style_profiler_autostart);
 		p_theme->set_stylebox("hover", "ProfilerAutostartIndicator", style_profiler_autostart);
+
+		// Recovery mode button style
+		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
+		style_recovery_mode_button->set_bg_color(p_config.warning_color);
+		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_recovery_mode_button->set_content_margin_all(0);
+		// Recovery mode button is implicitly styled from the panel's background.
+		// So, remove any existing borders. (e.g. from draw_extra_borders config)
+		style_recovery_mode_button->set_border_width_all(0);
+		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
 	}
 
 	// Standard GUI variations.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -254,7 +254,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallErr
 
 bool GDScript::can_instantiate() const {
 #ifdef TOOLS_ENABLED
-	return valid && (tool || ScriptServer::is_scripting_enabled());
+	return valid && (tool || ScriptServer::is_scripting_enabled()) && !Engine::get_singleton()->is_recovery_mode_hint();
 #else
 	return valid;
 #endif

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2328,7 +2328,7 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 
 bool CSharpScript::can_instantiate() const {
 #ifdef TOOLS_ENABLED
-	bool extra_cond = type_info.is_tool || ScriptServer::is_scripting_enabled();
+	bool extra_cond = (type_info.is_tool || ScriptServer::is_scripting_enabled()) && !Engine::get_singleton()->is_recovery_mode_hint();
 #else
 	bool extra_cond = true;
 #endif

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -118,7 +118,7 @@ String GodotIOJavaWrapper::get_temp_dir() {
 	}
 }
 
-String GodotIOJavaWrapper::get_user_data_dir() {
+String GodotIOJavaWrapper::get_user_data_dir(const String &p_user_dir) {
 	if (_get_data_dir) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, String());

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -73,7 +73,7 @@ public:
 	Error open_uri(const String &p_uri);
 	String get_cache_dir();
 	String get_temp_dir();
-	String get_user_data_dir();
+	String get_user_data_dir(const String &p_user_dir);
 	String get_locale();
 	String get_model();
 	int get_screen_dpi();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -413,7 +413,7 @@ String OS_Android::get_model_name() const {
 }
 
 String OS_Android::get_data_path() const {
-	return get_user_data_dir();
+	return OS::get_user_data_dir();
 }
 
 void OS_Android::_load_system_font_config() const {
@@ -647,12 +647,12 @@ String OS_Android::get_executable_path() const {
 	return OS::get_executable_path();
 }
 
-String OS_Android::get_user_data_dir() const {
+String OS_Android::get_user_data_dir(const String &p_user_dir) const {
 	if (!data_dir_cache.is_empty()) {
 		return data_dir_cache;
 	}
 
-	String data_dir = godot_io_java->get_user_data_dir();
+	String data_dir = godot_io_java->get_user_data_dir(p_user_dir);
 	if (!data_dir.is_empty()) {
 		data_dir_cache = _remove_symlink(data_dir);
 		return data_dir_cache;
@@ -764,7 +764,7 @@ void OS_Android::vibrate_handheld(int p_duration_ms, float p_amplitude) {
 }
 
 String OS_Android::get_config_path() const {
-	return get_user_data_dir().path_join("config");
+	return OS::get_user_data_dir().path_join("config");
 }
 
 void OS_Android::benchmark_begin_measure(const String &p_context, const String &p_what) {
@@ -897,7 +897,7 @@ String OS_Android::get_system_ca_certificates() {
 }
 
 Error OS_Android::setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path) {
-	r_project_path = get_user_data_dir();
+	r_project_path = OS::get_user_data_dir();
 	Error err = OS_Unix::setup_remote_filesystem(p_server_host, p_port, p_password, r_project_path);
 	if (err == OK) {
 		remote_fs_dir = r_project_path;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -146,7 +146,7 @@ public:
 	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 	virtual String get_executable_path() const override;
-	virtual String get_user_data_dir() const override;
+	virtual String get_user_data_dir(const String &p_user_dir) const override;
 	virtual String get_data_path() const override;
 	virtual String get_cache_path() const override;
 	virtual String get_temp_path() const override;

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -114,7 +114,7 @@ public:
 
 	virtual Error shell_open(const String &p_uri) override;
 
-	virtual String get_user_data_dir() const override;
+	virtual String get_user_data_dir(const String &p_user_dir) const override;
 
 	virtual String get_cache_path() const override;
 	virtual String get_temp_path() const override;

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -314,7 +314,7 @@ Error OS_IOS::shell_open(const String &p_uri) {
 	return OK;
 }
 
-String OS_IOS::get_user_data_dir() const {
+String OS_IOS::get_user_data_dir(const String &p_user_dir) const {
 	static String ret;
 	if (ret.is_empty()) {
 		NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -182,23 +182,9 @@ void OS_Web::vibrate_handheld(int p_duration_ms, float p_amplitude) {
 	godot_js_input_vibrate_handheld(p_duration_ms);
 }
 
-String OS_Web::get_user_data_dir() const {
+String OS_Web::get_user_data_dir(const String &p_user_dir) const {
 	String userfs = "/userfs";
-	String appname = get_safe_dir_name(GLOBAL_GET("application/config/name"));
-	if (!appname.is_empty()) {
-		bool use_custom_dir = GLOBAL_GET("application/config/use_custom_user_dir");
-		if (use_custom_dir) {
-			String custom_dir = get_safe_dir_name(GLOBAL_GET("application/config/custom_user_dir_name"), true);
-			if (custom_dir.is_empty()) {
-				custom_dir = appname;
-			}
-			return userfs.path_join(custom_dir).replace("\\", "/");
-		} else {
-			return userfs.path_join(get_godot_dir_name()).path_join("app_userdata").path_join(appname).replace("\\", "/");
-		}
-	}
-
-	return userfs.path_join(get_godot_dir_name()).path_join("app_userdata").path_join("[unnamed project]");
+	return userfs.path_join(p_user_dir).replace("\\", "/");
 }
 
 String OS_Web::get_cache_path() const {

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -107,7 +107,7 @@ public:
 	String get_cache_path() const override;
 	String get_config_path() const override;
 	String get_data_path() const override;
-	String get_user_data_dir() const override;
+	String get_user_data_dir(const String &p_user_dir) const override;
 
 	bool is_userfs_persistent() const override;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2214,22 +2214,8 @@ String OS_Windows::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 	return path;
 }
 
-String OS_Windows::get_user_data_dir() const {
-	String appname = get_safe_dir_name(GLOBAL_GET("application/config/name"));
-	if (!appname.is_empty()) {
-		bool use_custom_dir = GLOBAL_GET("application/config/use_custom_user_dir");
-		if (use_custom_dir) {
-			String custom_dir = get_safe_dir_name(GLOBAL_GET("application/config/custom_user_dir_name"), true);
-			if (custom_dir.is_empty()) {
-				custom_dir = appname;
-			}
-			return get_data_path().path_join(custom_dir).replace("\\", "/");
-		} else {
-			return get_data_path().path_join(get_godot_dir_name()).path_join("app_userdata").path_join(appname).replace("\\", "/");
-		}
-	}
-
-	return get_data_path().path_join(get_godot_dir_name()).path_join("app_userdata").path_join("[unnamed project]");
+String OS_Windows::get_user_data_dir(const String &p_user_dir) const {
+	return get_data_path().path_join(p_user_dir).replace("\\", "/");
 }
 
 String OS_Windows::get_unique_id() const {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -231,7 +231,7 @@ public:
 	virtual String get_godot_dir_name() const override;
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
-	virtual String get_user_data_dir() const override;
+	virtual String get_user_data_dir(const String &p_user_dir) const override;
 
 	virtual String get_unique_id() const override;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2628

> [!note]
> This description is updated whenever any significant changes are made, and should always reflect the current state of this PR

## Overview

This adds a new special "Recovery Mode" that, as described, disables some engine features that can make a project fail to launch during startup. When this mode is launched, the following features are completely disabled:

- Tool scripts (GDScript and C#)
- Editor plugins
- GDExtension addons
- Scene restoring

This is displayed to the user as soon as the project is opened in this mode, through both a popup, and a notification:

![image](https://github.com/user-attachments/assets/c46c2c99-566e-4f53-89b4-e59724188cc3)
![image](https://github.com/user-attachments/assets/618a2bc6-28d9-4a40-a2b0-51a202582a44)

Because some of these features may be necessary for a project to work properly, this mode may put the project in an unusable/unworkable state. Since this is a temporary mode meant to allow only for some basic troubleshooting, a few other changes were done as well to reflect this:

- All launching functionality is disabled, with the run bar modified to reflect it
![image](https://github.com/user-attachments/assets/1c19d3fb-8de6-4a52-abad-8d25df94637a)
- The Asset Library and Game View plugins are disabled, since they can't really work during this mode
![image](https://github.com/user-attachments/assets/831a9184-5052-4d4b-a4e7-6af708fa2963)
- Tool scripts are displayed differently to clarify that they're not being run during this mode
![image](https://github.com/godotengine/godot/assets/6501975/6e81ba6a-b853-483c-9d38-a854330ef97d)
- The plugin configuration panel has a warning to clarify plugins do not run during this mode
![image](https://github.com/user-attachments/assets/736cea3b-26c3-46a2-95d4-300aa8198628)

## Usage

### Automatic detection

When launching a project, Godot creates a lock file at `user://.recovery_mode_lock`. This file persists during the engine initialization, and is removed when the editor starts scanning the project files, after one second.

If any crash/hang happens during initialization, this file is not removed. So, if this file exists the next time Godot attempts to open the project, then the engine knows the project failed to open last time, thus prompting the user to open it in this mode.

### CLI

This mode can be manually triggered by opening a project with the new `--recovery-mode` flag:

```
$ godot -e -path <...> --recovery-mode
```

```
$ godot --help

Godot Engine v4.4.dev.mono.custom_build.f7a0552d5 (2024-12-06 14:59:43 UTC) - https://godotengine.org
...
Run options:
...
  --recovery-mode                   E  Start the editor in recovery mode, which disables features that can typically cause startup crashes, such as tool scripts, editor plugins, GDExtension addons, and others.
...
```

### UI

When a project is opened, the project manager searches for any existing lock file; if that's the case, it opens a popup to suggest using this mode, explaining what it does and its intended usage.

![image](https://github.com/user-attachments/assets/3c01849e-0fca-4ffb-95bc-84bc9bbdc40b)

It is also possible to use this mode manually from the new options button next to the Edit button:

![image](https://github.com/user-attachments/assets/195c1841-2e15-4636-a6cb-df50b91137aa)

## Test projects

To test this functionality, I've made a test suite of projects that crash the engine on initialization with typical user scenarios:

- **GDScript tool script:** - Project with a bad tool script, which is attached to a node on the main scene.
- **C# tool script:** - Same as above, but with a C# script, which requires rebuilding the project when the script is changed.
- **Editor plugin:** - Project with a bad editor plugin, which internally has bad GDScript code.
- **GDExtension addon:** - Project with an external error in the GDExtension addon.

All of these test cases fail to open on a normal Godot session and require manual intervention to be recovered. But under recovery mode, every test **must** open successfully.

|   | GDScript tool script | C# tool script | Editor plugin | GDExtension addon |
|---|---|---|---|---|
| Crash |[tool_gdscript_crash.zip](https://github.com/godotengine/godot/files/15503597/tool_gdscript_crash.zip) |[tool_csharp_crash.zip](https://github.com/godotengine/godot/files/15503595/tool_csharp_crash.zip) |[plugin_crash.zip](https://github.com/godotengine/godot/files/15503593/plugin_crash.zip) |[gdextension_crash.zip](https://github.com/godotengine/godot/files/15503591/gdextension_crash.zip) |
| Hang  |[tool_gdscript_hang.zip](https://github.com/godotengine/godot/files/15503599/tool_gdscript_hang.zip) |[tool_csharp_hang.zip](https://github.com/godotengine/godot/files/15503596/tool_csharp_hang.zip) |[plugin_hang.zip](https://github.com/godotengine/godot/files/15503594/plugin_hang.zip) |[gdextension_hang.zip](https://github.com/godotengine/godot/files/15503592/gdextension_hang.zip) |

- **Crash:** This project has some bad code that immediately crashes the engine when opened.
- **Hang:** This project has some bad code that loops infinitely, which hangs the engine and leaves it frozen until forcibly closed.

## Future work

This is a basic implementation so far, and the usefulness of this mode should be improved with other additional features:

- ~~An automatic mechanism to detect failing scenarios and automatically prompt users to enable this mode, as described in https://github.com/godotengine/godot-proposals/issues/2628~~ (edit: implemented in this PR too)
- Being able to open/edit scenes when some dependencies are missing, since these can originate from temporarily disabled editor/GDExtension plugins.
- Adding other problematic features for recovery mode that I didn't cover (e.g. importing assets)