### PR TITLE
Prevent using built-ins for func names in shaders

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -884,7 +884,7 @@ public:
 		bool can_discard = false;
 		bool main_function = false;
 	};
-	static bool has_builtin(const HashMap<StringName, ShaderLanguage::FunctionInfo> &p_functions, const StringName &p_name);
+	static bool has_builtin(const HashMap<StringName, ShaderLanguage::FunctionInfo> &p_functions, const StringName &p_name, bool p_check_global_funcs = false);
 
 	typedef DataType (*GlobalShaderUniformGetTypeFunc)(const StringName &p_name);
 


### PR DESCRIPTION
Using built-in functions for function names are incorrect - the code won't allow calling such function (and it won't in GLSL):

![изображение](https://github.com/godotengine/godot/assets/3036176/83337d2d-240e-4f75-9d7a-d5444ee62049)

but currently it will not emit error if user not calling such function:

![изображение](https://github.com/godotengine/godot/assets/3036176/c9c6ad06-f594-47da-bda3-a734461874c9)

after this fix it will:

![изображение](https://github.com/godotengine/godot/assets/3036176/e916cc0b-5e14-4cdd-a7b2-f6dcd3153603)

Note: other use cases for built-in names such as constants, variables and function arguments are still be valid and untouched.

