### PR TITLE
Rename FBX2glTF binary path setting back to 4.2 name

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -577,7 +577,7 @@
 			The maximum idle uptime (in seconds) of the Blender process.
 			This prevents Godot from having to create a new process for each import within the given seconds.
 		</member>
-		<member name="filesystem/import/fbx2gltf/fbx2gltf_path" type="String" setter="" getter="">
+		<member name="filesystem/import/fbx/fbx2gltf_path" type="String" setter="" getter="">
 			The path to the FBX2glTF executable used for converting Autodesk FBX 3D scene files [code].fbx[/code] to glTF 2.0 format during import.
 			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/fbx2gltf/enabled].
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1003,7 +1003,7 @@
 		</member>
 		<member name="filesystem/import/fbx2gltf/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Autodesk FBX 3D scene files with the [code].fbx[/code] extension will be imported by converting them to glTF 2.0.
-			This requires configuring a path to an FBX2glTF executable in the editor settings at [member EditorSettings.filesystem/import/fbx2gltf/fbx2gltf_path].
+			This requires configuring a path to an FBX2glTF executable in the editor settings at [member EditorSettings.filesystem/import/fbx/fbx2gltf_path].
 		</member>
 		<member name="filesystem/import/fbx2gltf/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx2gltf/enabled] on Android where FBX2glTF can't easily be accessed from Godot.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -571,7 +571,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/blender/blender_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_port", 6011, "0,65535,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_server_uptime", 5, "0,300,1,or_greater,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx2gltf/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Tools (denoise)
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/tools/oidn/oidn_denoise_path", "", "", PROPERTY_USAGE_DEFAULT)

--- a/editor/fbx_importer_manager.cpp
+++ b/editor/fbx_importer_manager.cpp
@@ -50,7 +50,7 @@ void FBXImporterManager::_notification(int p_what) {
 }
 
 void FBXImporterManager::show_dialog(bool p_exclusive) {
-	String fbx2gltf_path = EDITOR_GET("filesystem/import/fbx2gltf/fbx2gltf_path");
+	String fbx2gltf_path = EDITOR_GET("filesystem/import/fbx/fbx2gltf_path");
 	fbx_path->set_text(fbx2gltf_path);
 	_validate_path(fbx2gltf_path);
 
@@ -109,7 +109,7 @@ void FBXImporterManager::_select_file(const String &p_path) {
 
 void FBXImporterManager::_path_confirmed() {
 	String path = fbx_path->get_text();
-	EditorSettings::get_singleton()->set("filesystem/import/fbx2gltf/fbx2gltf_path", path);
+	EditorSettings::get_singleton()->set("filesystem/import/fbx/fbx2gltf_path", path);
 	EditorSettings::get_singleton()->save();
 }
 

--- a/modules/fbx/doc_classes/EditorSceneFormatImporterFBX2GLTF.xml
+++ b/modules/fbx/doc_classes/EditorSceneFormatImporterFBX2GLTF.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Imports Autodesk FBX 3D scenes by way of converting them to glTF 2.0 using the FBX2glTF command line tool.
-		The location of the FBX2glTF binary is set via the [member EditorSettings.filesystem/import/fbx2gltf/fbx2gltf_path] editor setting.
+		The location of the FBX2glTF binary is set via the [member EditorSettings.filesystem/import/fbx/fbx2gltf_path] editor setting.
 		This importer is only used if [member ProjectSettings.filesystem/import/fbx2gltf/enabled] is set to [code]true[/code].
 	</description>
 	<tutorials>

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -73,7 +73,7 @@ Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint
 
 	// Run fbx2gltf.
 
-	String fbx2gltf_path = EDITOR_GET("filesystem/import/fbx2gltf/fbx2gltf_path");
+	String fbx2gltf_path = EDITOR_GET("filesystem/import/fbx/fbx2gltf_path");
 
 	List<String> args;
 	args.push_back("--pbr-metallic-roughness");


### PR DESCRIPTION
This preserves compatibility when upgrading Godot 4.2 projects which relied on that path being configured in the editor settings.

The old name also makes sense for this one, it's fine for fbx2gltf_path to be under a generic fbx category which could have more settings also impacting ufbx. I was the one doing this rename as part of cleaning up #81746, my bad.

I didn't change the project setting `filesystem/import/fbx2gltf/enabled` back to `fbx/enabled` because this one would really be confusing. But it's also enabled by default in 4.2, so this won't change anything for users who do use fbx2gltf. For those who turned it off, they'll experience either way that their fbx files are now imported by ufbx in 4.3.