### PR TITLE
[3.x] Expose some helper methods on Viewport

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -108,6 +108,19 @@
 				Returns the drag data from the GUI, that was previously returned by [method Control.get_drag_data].
 			</description>
 		</method>
+		<method name="gui_get_focus_owner" qualifiers="const">
+			<return type="Control" />
+			<description>
+				Returns the [Control] having the focus within this viewport. If no [Control] has the focus, returns [code]null[/code].
+			</description>
+		</method>
+		<method name="gui_get_hovered_control" qualifiers="const">
+			<return type="Control" />
+			<description>
+				Returns the [Control] that the mouse is currently hovering over in this viewport. If no [Control] has the cursor, returns [code]null[/code].
+				Typically the leaf [Control] node or deepest level of the subtree which claims hover. This is very useful when used together with [method Node.is_a_parent_of] to find if the mouse is within a control tree.
+			</description>
+		</method>
 		<method name="gui_has_modal_stack" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -125,6 +138,12 @@
 			<description>
 				Returns [code]true[/code] if the viewport is currently performing a drag operation.
 				Alternative to [constant Node.NOTIFICATION_DRAG_BEGIN] and [constant Node.NOTIFICATION_DRAG_END] when you prefer polling the value.
+			</description>
+		</method>
+		<method name="gui_release_focus">
+			<return type="void" />
+			<description>
+				Removes the focus from the currently focused [Control] within this viewport. If no [Control] has the focus, does nothing.
 			</description>
 		</method>
 		<method name="input">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -30,13 +30,8 @@
 
 #include "control.h"
 
+#include "core/engine.h"
 #include "core/message_queue.h"
-#include "core/os/keyboard.h"
-#include "core/os/os.h"
-#include "core/print_string.h"
-#include "core/project_settings.h"
-#include "scene/gui/label.h"
-#include "scene/gui/panel.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
@@ -2045,8 +2040,7 @@ void Control::release_focus() {
 		return;
 	}
 
-	get_viewport()->_gui_remove_focus();
-	update();
+	get_viewport()->gui_release_focus();
 }
 
 bool Control::is_toplevel_control() const {
@@ -2474,7 +2468,7 @@ bool Control::get_pass_on_modal_close_click() const {
 
 Control *Control::get_focus_owner() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), nullptr);
-	return get_viewport()->_gui_get_focus_owner();
+	return get_viewport()->gui_get_focus_owner();
 }
 
 void Control::warp_mouse(const Point2 &p_to_pos) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -44,12 +44,10 @@
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/menu_button.h"
-#include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/viewport_container.h"
 #include "scene/main/canvas_layer.h"
-#include "scene/main/timer.h"
 #include "scene/resources/mesh.h"
 #include "scene/scene_string_names.h"
 #include "servers/physics_2d_server.h"
@@ -2665,7 +2663,7 @@ void Viewport::_gui_hid_control(Control *p_control) {
 	}
 
 	if (gui.key_focus == p_control) {
-		_gui_remove_focus();
+		gui_release_focus();
 	}
 	if (gui.mouse_over == p_control) {
 		gui.mouse_over = nullptr;
@@ -2697,11 +2695,12 @@ void Viewport::_gui_remove_control(Control *p_control) {
 	}
 }
 
-void Viewport::_gui_remove_focus() {
+void Viewport::gui_release_focus() {
 	if (gui.key_focus) {
-		Node *f = gui.key_focus;
+		Control *f = gui.key_focus;
 		gui.key_focus = nullptr;
 		f->notification(Control::NOTIFICATION_FOCUS_EXIT, true);
+		f->update();
 	}
 }
 
@@ -2718,7 +2717,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	if (gui.key_focus && gui.key_focus == p_control) {
 		return;
 	}
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus");
+	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "gui_release_focus");
 	gui.key_focus = p_control;
 	emit_signal("gui_focus_changed", p_control);
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
@@ -2816,8 +2815,12 @@ List<Control *>::Element *Viewport::_gui_show_modal(Control *p_control) {
 	return node;
 }
 
-Control *Viewport::_gui_get_focus_owner() {
+Control *Viewport::gui_get_focus_owner() const {
 	return gui.key_focus;
+}
+
+Control *Viewport::gui_get_hovered_control() const {
+	return gui.mouse_over;
 }
 
 void Viewport::_gui_grab_click_focus(Control *p_control) {
@@ -3455,6 +3458,10 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gui_is_dragging"), &Viewport::gui_is_dragging);
 	ClassDB::bind_method(D_METHOD("gui_is_drag_successful"), &Viewport::gui_is_drag_successful);
 
+	ClassDB::bind_method(D_METHOD("gui_release_focus"), &Viewport::gui_release_focus);
+	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
+	ClassDB::bind_method(D_METHOD("gui_get_hovered_control"), &Viewport::gui_get_hovered_control);
+
 	ClassDB::bind_method(D_METHOD("get_modal_stack_top"), &Viewport::get_modal_stack_top);
 
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
@@ -3467,7 +3474,6 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_keep_3d_linear"), &Viewport::get_keep_3d_linear);
 
 	ClassDB::bind_method(D_METHOD("_gui_show_tooltip"), &Viewport::_gui_show_tooltip);
-	ClassDB::bind_method(D_METHOD("_gui_remove_focus"), &Viewport::_gui_remove_focus);
 	ClassDB::bind_method(D_METHOD("_post_gui_grab_click_focus"), &Viewport::_post_gui_grab_click_focus);
 
 	ClassDB::bind_method(D_METHOD("set_shadow_atlas_size", "size"), &Viewport::set_shadow_atlas_size);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -35,7 +35,6 @@
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 #include "scene/resources/world_2d.h"
-#include "servers/visual_server.h"
 
 class Camera;
 class Camera2D;
@@ -388,15 +387,12 @@ private:
 	bool _gui_is_modal_on_top(const Control *p_control);
 	List<Control *>::Element *_gui_show_modal(Control *p_control);
 
-	void _gui_remove_focus();
 	void _gui_unfocus_control(Control *p_control);
 	bool _gui_control_has_focus(const Control *p_control);
 	void _gui_control_grab_focus(Control *p_control);
 	void _gui_grab_click_focus(Control *p_control);
 	void _post_gui_grab_click_focus();
 	void _gui_accept_event();
-
-	Control *_gui_get_focus_owner();
 
 	Vector2 _get_window_offset() const;
 
@@ -571,6 +567,10 @@ public:
 
 	void gui_reset_canvas_sort_index();
 	int gui_get_canvas_sort_index();
+
+	void gui_release_focus();
+	Control *gui_get_focus_owner() const;
+	Control *gui_get_hovered_control() const;
 
 	virtual String get_configuration_warning() const;
 


### PR DESCRIPTION
Backports https://github.com/godotengine/godot/pull/57517 & https://github.com/godotengine/godot/pull/85966

Adds these three methods to Viewport:

- `gui_release_focus()`
- `gui_get_focus_owner()`
- `gui_get_hovered_control()`