### PR TITLE
Make shader language editors inherit the same base class

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3799,7 +3799,10 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_editor_data().get_editor_by_name("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);
-			shader_editor->get_shader_editor(res)->goto_line_selection(line_number - 1, begin, end);
+			TextShaderEditor *text_shader_editor = Object::cast_to<TextShaderEditor>(shader_editor->get_shader_editor(res));
+			if (text_shader_editor) {
+				text_shader_editor->goto_line_selection(line_number - 1, begin, end);
+			}
 			return;
 		} else if (fpath.get_extension() == "tscn") {
 			Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);

--- a/editor/plugins/shader/shader_editor.h
+++ b/editor/plugins/shader/shader_editor.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  shader_editor.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SHADER_EDITOR_H
+#define SHADER_EDITOR_H
+
+#include "scene/gui/control.h"
+#include "scene/resources/shader.h"
+
+class ShaderEditor : public Control {
+	GDCLASS(ShaderEditor, Control);
+
+public:
+	virtual void edit_shader(const Ref<Shader> &p_shader) = 0;
+	virtual void edit_shader_include(const Ref<ShaderInclude> &p_shader_inc) {}
+
+	virtual void apply_shaders() = 0;
+	virtual bool is_unsaved() const = 0;
+	virtual void save_external_data(const String &p_str = "") = 0;
+	virtual void validate_script() = 0;
+};
+
+#endif // SHADER_EDITOR_H

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -37,6 +37,7 @@ class HSplitContainer;
 class ItemList;
 class MenuButton;
 class ShaderCreateDialog;
+class ShaderEditor;
 class TabContainer;
 class TextShaderEditor;
 class VisualShaderEditor;
@@ -52,8 +53,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	struct EditedShader {
 		Ref<Shader> shader;
 		Ref<ShaderInclude> shader_inc;
-		TextShaderEditor *shader_editor = nullptr;
-		VisualShaderEditor *visual_shader_editor = nullptr;
+		ShaderEditor *shader_editor = nullptr;
 		String path;
 		String name;
 	};
@@ -121,8 +121,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 	virtual void selected_notify() override;
 
-	TextShaderEditor *get_shader_editor(const Ref<Shader> &p_for_shader);
-	VisualShaderEditor *get_visual_shader_editor(const Ref<Shader> &p_for_shader);
+	ShaderEditor *get_shader_editor(const Ref<Shader> &p_for_shader);
 
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -895,7 +895,7 @@ void TextShaderEditor::_reload() {
 	}
 }
 
-void TextShaderEditor::edit(const Ref<Shader> &p_shader) {
+void TextShaderEditor::edit_shader(const Ref<Shader> &p_shader) {
 	if (p_shader.is_null() || !p_shader->is_text_shader()) {
 		return;
 	}
@@ -910,7 +910,7 @@ void TextShaderEditor::edit(const Ref<Shader> &p_shader) {
 	code_editor->set_edited_shader(shader);
 }
 
-void TextShaderEditor::edit(const Ref<ShaderInclude> &p_shader_inc) {
+void TextShaderEditor::edit_shader_include(const Ref<ShaderInclude> &p_shader_inc) {
 	if (p_shader_inc.is_null()) {
 		return;
 	}
@@ -1141,6 +1141,7 @@ TextShaderEditor::TextShaderEditor() {
 	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
+	main_container->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	HBoxContainer *hbc = memnew(HBoxContainer);
 
 	edit_menu = memnew(MenuButton);

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -32,6 +32,7 @@
 #define TEXT_SHADER_EDITOR_H
 
 #include "editor/code_editor.h"
+#include "editor/plugins/shader/shader_editor.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
@@ -104,8 +105,8 @@ public:
 	ShaderTextEditor();
 };
 
-class TextShaderEditor : public MarginContainer {
-	GDCLASS(TextShaderEditor, MarginContainer);
+class TextShaderEditor : public ShaderEditor {
+	GDCLASS(TextShaderEditor, ShaderEditor);
 
 	enum {
 		EDIT_UNDO,
@@ -188,19 +189,21 @@ protected:
 	void _bookmark_item_pressed(int p_idx);
 
 public:
+	virtual void edit_shader(const Ref<Shader> &p_shader) override;
+	virtual void edit_shader_include(const Ref<ShaderInclude> &p_shader_inc) override;
+
+	virtual void apply_shaders() override;
+	virtual bool is_unsaved() const override;
+	virtual void save_external_data(const String &p_str = "") override;
+	virtual void validate_script() override;
+
 	bool was_compilation_successful() const { return compilation_success; }
 	bool get_trim_trailing_whitespace_on_save() const { return trim_trailing_whitespace_on_save; }
 	bool get_trim_final_newlines_on_save() const { return trim_final_newlines_on_save; }
-	void apply_shaders();
 	void ensure_select_current();
-	void edit(const Ref<Shader> &p_shader);
-	void edit(const Ref<ShaderInclude> &p_shader_inc);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
-	void save_external_data(const String &p_str = "");
 	void trim_trailing_whitespace();
 	void trim_final_newlines();
-	void validate_script();
-	bool is_unsaved() const;
 	void tag_saved_version();
 	ShaderTextEditor *get_code_editor() { return code_editor; }
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1509,17 +1509,18 @@ Vector2 VisualShaderEditor::selection_center;
 List<VisualShaderEditor::CopyItem> VisualShaderEditor::copy_items_buffer;
 List<VisualShader::Connection> VisualShaderEditor::copy_connections_buffer;
 
-void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
+void VisualShaderEditor::edit_shader(const Ref<Shader> &p_shader) {
 	bool changed = false;
-	if (p_visual_shader) {
+	VisualShader *visual_shader_ptr = Object::cast_to<VisualShader>(p_shader.ptr());
+	if (visual_shader_ptr) {
 		if (visual_shader.is_null()) {
 			changed = true;
 		} else {
-			if (visual_shader.ptr() != p_visual_shader) {
+			if (visual_shader.ptr() != visual_shader_ptr) {
 				changed = true;
 			}
 		}
-		visual_shader = Ref<VisualShader>(p_visual_shader);
+		visual_shader = p_shader;
 		graph_plugin->register_shader(visual_shader.ptr());
 
 		visual_shader->connect_changed(callable_mp(this, &VisualShaderEditor::_update_preview));
@@ -1544,6 +1545,19 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 			_update_graph();
 		}
 	}
+}
+
+void VisualShaderEditor::apply_shaders() {
+	// Stub. TODO: Implement apply_shaders in visual shaders for parity with text shaders.
+}
+
+bool VisualShaderEditor::is_unsaved() const {
+	// Stub. TODO: Implement is_unsaved in visual shaders for parity with text shaders.
+	return false;
+}
+
+void VisualShaderEditor::save_external_data(const String &p_str) {
+	ResourceSaver::save(visual_shader, visual_shader->get_path());
 }
 
 void VisualShaderEditor::validate_script() {
@@ -6054,8 +6068,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	graph = memnew(GraphEdit);
 	graph->get_menu_hbox()->set_h_size_flags(SIZE_EXPAND_FILL);
-	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	graph->set_grid_pattern(GraphEdit::GridPattern::GRID_PATTERN_DOTS);
 	int grid_pattern = EDITOR_GET("editors/visual_editors/grid_pattern");
 	graph->set_grid_pattern((GraphEdit::GridPattern)grid_pattern);
@@ -7562,7 +7575,7 @@ void EditorPropertyVisualShaderMode::_option_selected(int p_which) {
 	if (!shader_editor) {
 		return;
 	}
-	VisualShaderEditor *editor = shader_editor->get_visual_shader_editor(visual_shader);
+	VisualShaderEditor *editor = Object::cast_to<VisualShaderEditor>(shader_editor->get_shader_editor(visual_shader));
 	if (!editor) {
 		return;
 	}

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -34,6 +34,7 @@
 #include "editor/editor_properties.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
+#include "editor/plugins/shader/shader_editor.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/visual_shader.h"
@@ -195,8 +196,8 @@ public:
 	VisualShaderEditedProperty() {}
 };
 
-class VisualShaderEditor : public VBoxContainer {
-	GDCLASS(VisualShaderEditor, VBoxContainer);
+class VisualShaderEditor : public ShaderEditor {
+	GDCLASS(VisualShaderEditor, ShaderEditor);
 	friend class VisualShaderGraphPlugin;
 
 	PopupPanel *property_editor_popup = nullptr;
@@ -596,6 +597,12 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void edit_shader(const Ref<Shader> &p_shader) override;
+	virtual void apply_shaders() override;
+	virtual bool is_unsaved() const override;
+	virtual void save_external_data(const String &p_str = "") override;
+	virtual void validate_script() override;
+
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 	void remove_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 
@@ -609,10 +616,7 @@ public:
 
 	virtual Size2 get_minimum_size() const override;
 
-	void edit(VisualShader *p_visual_shader);
 	Ref<VisualShader> get_visual_shader() const { return visual_shader; }
-
-	void validate_script();
 
 	VisualShaderEditor();
 };


### PR DESCRIPTION
This PR is a prerequisite to #64596. Currently in the master branch of Godot, the shader editor is not well-abstracted. The general shader editor code has a lot of checks and duplicate code to handle both text and visual shaders. This PR does not completely remove the duplication or the language dependence, but it is a good first step to doing so. In the future we can follow up this PR with another PR that completely isolates the language-specific code from the general code.

When it made sense as something all shaders could conceivably do, I made a virtual method in the new `ShaderLanguageEditorBase` class. This includes the ability to edit and save shaders and shader includes. The `apply_shaders` and `is_unsaved` methods are left as stubs for visual script for now. Note there was previously a TODO comment about implementing `is_unsaved` for visual shaders, now there is a clear place to do that :) I left anything language-specific only on that class, with casts before calling them (such as the methods to go to a line or trim trailing whitespace, which is not relevant for visual shaders). All of these APIs are internal and not exposed, so we can iterate on them in the future.

`TextShaderEditor` used to extend `MarginContainer`, and `VisualShaderEditor` used to extend `VBoxContainer`. For this PR I made them extend `Control`. Instead of using containers, I just set their Control children to use a full rect layout, which acheives the same effect but more efficiently. There might be subtle theme differences, but it looks identical when I click between a before and after image. This PR should not change behavior, if it does that's a bug.