### PR TITLE
Update editor `Window` preview position when resizing window.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -391,6 +391,7 @@ void Window::set_size(const Size2i &p_size) {
 
 	size = p_size;
 	_update_window_size();
+	_settings_changed();
 }
 
 Size2i Window::get_size() const {


### PR DESCRIPTION
A small follow-up to https://github.com/godotengine/godot/pull/92506, updates preview position when window size is changed.