### PR TITLE
TextServerFallback: 2x performance improvement by removing redundant lookups

### DIFF
--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -624,18 +624,21 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitma
 /* Font Cache                                                            */
 /*************************************************************************/
 
-_FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const {
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size), false);
+_FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph, FontGlyph &r_glyph) const {
+	FontForSizeFallback *fd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size, fd), false);
 
 	int32_t glyph_index = p_glyph & 0xffffff; // Remove subpixel shifts.
 
-	FontForSizeFallback *fd = p_font_data->cache[p_size];
-	if (fd->glyph_map.has(p_glyph)) {
-		return fd->glyph_map[p_glyph].found;
+	HashMap<int32_t, FontGlyph>::Iterator E = fd->glyph_map.find(p_glyph);
+	if (E) {
+		r_glyph = E->value;
+		return E->value.found;
 	}
 
 	if (glyph_index == 0) { // Non graphical or invalid glyph, do not render.
-		fd->glyph_map[p_glyph] = FontGlyph();
+		E = fd->glyph_map.insert(p_glyph, FontGlyph());
+		r_glyph = E->value;
 		return true;
 	}
 
@@ -673,7 +676,8 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data,
 
 		int error = FT_Load_Glyph(fd->face, glyph_index, flags);
 		if (error) {
-			fd->glyph_map[p_glyph] = FontGlyph();
+			E = fd->glyph_map.insert(p_glyph, FontGlyph());
+			r_glyph = E->value;
 			return false;
 		}
 
@@ -777,20 +781,26 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data,
 		cleanup_stroker:
 			FT_Stroker_Done(stroker);
 		}
-		fd->glyph_map[p_glyph] = gl;
+		E = fd->glyph_map.insert(p_glyph, gl);
+		r_glyph = E->value;
 		return gl.found;
 	}
 #endif
-	fd->glyph_map[p_glyph] = FontGlyph();
+	E = fd->glyph_map.insert(p_glyph, FontGlyph());
+	r_glyph = E->value;
 	return false;
 }
 
-_FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size) const {
+_FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size, FontForSizeFallback *&r_cache_for_size) const {
 	ERR_FAIL_COND_V(p_size.x <= 0, false);
-	if (p_font_data->cache.has(p_size)) {
+
+	HashMap<Vector2i, FontForSizeFallback *>::Iterator E = p_font_data->cache.find(p_size);
+	if (E) {
+		r_cache_for_size = E->value;
 		return true;
 	}
 
+	r_cache_for_size = nullptr;
 	FontForSizeFallback *fd = memnew(FontForSizeFallback);
 	fd->size = p_size;
 	if (p_font_data->data_ptr && (p_font_data->data_size > 0)) {
@@ -973,7 +983,9 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_f
 		ERR_FAIL_V_MSG(false, "FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
 #endif
 	}
-	p_font_data->cache[p_size] = fd;
+
+	p_font_data->cache.insert(p_size, fd);
+	r_cache_for_size = fd;
 	return true;
 }
 
@@ -1041,7 +1053,8 @@ void TextServerFallback::_font_set_style(const RID &p_font_rid, BitField<FontSty
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->style_flags = p_style;
 }
 
@@ -1119,7 +1132,8 @@ BitField<TextServer::FontStyle> TextServerFallback::_font_get_style(const RID &p
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0);
 	return fd->style_flags;
 }
 
@@ -1129,7 +1143,8 @@ void TextServerFallback::_font_set_style_name(const RID &p_font_rid, const Strin
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->style_name = p_name;
 }
 
@@ -1139,7 +1154,8 @@ String TextServerFallback::_font_get_style_name(const RID &p_font_rid) const {
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), String());
 	return fd->style_name;
 }
 
@@ -1149,7 +1165,8 @@ void TextServerFallback::_font_set_weight(const RID &p_font_rid, int64_t p_weigh
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->weight = CLAMP(p_weight, 100, 999);
 }
 
@@ -1159,7 +1176,8 @@ int64_t TextServerFallback::_font_get_weight(const RID &p_font_rid) const {
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 400);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 400);
 	return fd->weight;
 }
 
@@ -1169,7 +1187,8 @@ void TextServerFallback::_font_set_stretch(const RID &p_font_rid, int64_t p_stre
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->stretch = CLAMP(p_stretch, 50, 200);
 }
 
@@ -1179,7 +1198,8 @@ int64_t TextServerFallback::_font_get_stretch(const RID &p_font_rid) const {
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 100);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 100);
 	return fd->stretch;
 }
 
@@ -1189,7 +1209,8 @@ void TextServerFallback::_font_set_name(const RID &p_font_rid, const String &p_n
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->font_name = p_name;
 }
 
@@ -1199,7 +1220,8 @@ String TextServerFallback::_font_get_name(const RID &p_font_rid) const {
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), String());
 	return fd->font_name;
 }
 
@@ -1607,8 +1629,9 @@ void TextServerFallback::_font_set_ascent(const RID &p_font_rid, int64_t p_size,
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->ascent = p_ascent;
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->ascent = p_ascent;
 }
 
 double TextServerFallback::_font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
@@ -1618,18 +1641,19 @@ double TextServerFallback::_font_get_ascent(const RID &p_font_rid, int64_t p_siz
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0.0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0.0);
 
 	if (fd->msdf) {
-		return fd->cache[size]->ascent * (double)p_size / (double)fd->msdf_source_size;
+		return ffsd->ascent * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return fd->cache[size]->ascent * (double)p_size / (double)fd->fixed_size;
+			return ffsd->ascent * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return fd->cache[size]->ascent * Math::round((double)p_size / (double)fd->fixed_size);
+			return ffsd->ascent * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->ascent;
+		return ffsd->ascent;
 	}
 }
 
@@ -1639,8 +1663,9 @@ void TextServerFallback::_font_set_descent(const RID &p_font_rid, int64_t p_size
 
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->descent = p_descent;
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->descent = p_descent;
 }
 
 double TextServerFallback::_font_get_descent(const RID &p_font_rid, int64_t p_size) const {
@@ -1650,18 +1675,19 @@ double TextServerFallback::_font_get_descent(const RID &p_font_rid, int64_t p_si
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0.0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0.0);
 
 	if (fd->msdf) {
-		return fd->cache[size]->descent * (double)p_size / (double)fd->msdf_source_size;
+		return ffsd->descent * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return fd->cache[size]->descent * (double)p_size / (double)fd->fixed_size;
+			return ffsd->descent * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return fd->cache[size]->descent * Math::round((double)p_size / (double)fd->fixed_size);
+			return ffsd->descent * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->descent;
+		return ffsd->descent;
 	}
 }
 
@@ -1672,8 +1698,9 @@ void TextServerFallback::_font_set_underline_position(const RID &p_font_rid, int
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->underline_position = p_underline_position;
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->underline_position = p_underline_position;
 }
 
 double TextServerFallback::_font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
@@ -1683,18 +1710,19 @@ double TextServerFallback::_font_get_underline_position(const RID &p_font_rid, i
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0.0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0.0);
 
 	if (fd->msdf) {
-		return fd->cache[size]->underline_position * (double)p_size / (double)fd->msdf_source_size;
+		return ffsd->underline_position * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return fd->cache[size]->underline_position * (double)p_size / (double)fd->fixed_size;
+			return ffsd->underline_position * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return fd->cache[size]->underline_position * Math::round((double)p_size / (double)fd->fixed_size);
+			return ffsd->underline_position * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->underline_position;
+		return ffsd->underline_position;
 	}
 }
 
@@ -1705,8 +1733,9 @@ void TextServerFallback::_font_set_underline_thickness(const RID &p_font_rid, in
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->underline_thickness = p_underline_thickness;
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->underline_thickness = p_underline_thickness;
 }
 
 double TextServerFallback::_font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
@@ -1716,18 +1745,19 @@ double TextServerFallback::_font_get_underline_thickness(const RID &p_font_rid, 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0.0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0.0);
 
 	if (fd->msdf) {
-		return fd->cache[size]->underline_thickness * (double)p_size / (double)fd->msdf_source_size;
+		return ffsd->underline_thickness * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return fd->cache[size]->underline_thickness * (double)p_size / (double)fd->fixed_size;
+			return ffsd->underline_thickness * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return fd->cache[size]->underline_thickness * Math::round((double)p_size / (double)fd->fixed_size);
+			return ffsd->underline_thickness * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->underline_thickness;
+		return ffsd->underline_thickness;
 	}
 }
 
@@ -1738,13 +1768,14 @@ void TextServerFallback::_font_set_scale(const RID &p_font_rid, int64_t p_size, 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 #ifdef MODULE_FREETYPE_ENABLED
-	if (fd->cache[size]->face) {
+	if (ffsd->face) {
 		return; // Do not override scale for dynamic fonts, it's calculated automatically.
 	}
 #endif
-	fd->cache[size]->scale = p_scale;
+	ffsd->scale = p_scale;
 }
 
 double TextServerFallback::_font_get_scale(const RID &p_font_rid, int64_t p_size) const {
@@ -1754,18 +1785,19 @@ double TextServerFallback::_font_get_scale(const RID &p_font_rid, int64_t p_size
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0.0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0.0);
 
 	if (fd->msdf) {
-		return fd->cache[size]->scale * (double)p_size / (double)fd->msdf_source_size;
+		return ffsd->scale * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return fd->cache[size]->scale * (double)p_size / (double)fd->fixed_size;
+			return ffsd->scale * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return fd->cache[size]->scale * Math::round((double)p_size / (double)fd->fixed_size);
+			return ffsd->scale * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->scale / fd->cache[size]->oversampling;
+		return ffsd->scale / ffsd->oversampling;
 	}
 }
 
@@ -1776,9 +1808,10 @@ int64_t TextServerFallback::_font_get_texture_count(const RID &p_font_rid, const
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0);
 
-	return fd->cache[size]->textures.size();
+	return ffsd->textures.size();
 }
 
 void TextServerFallback::_font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
@@ -1787,8 +1820,9 @@ void TextServerFallback::_font_clear_textures(const RID &p_font_rid, const Vecto
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->textures.clear();
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->textures.clear();
 }
 
 void TextServerFallback::_font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) {
@@ -1797,10 +1831,11 @@ void TextServerFallback::_font_remove_texture(const RID &p_font_rid, const Vecto
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	ERR_FAIL_INDEX(p_texture_index, fd->cache[size]->textures.size());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ERR_FAIL_INDEX(p_texture_index, ffsd->textures.size());
 
-	fd->cache[size]->textures.remove_at(p_texture_index);
+	ffsd->textures.remove_at(p_texture_index);
 }
 
 void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) {
@@ -1810,13 +1845,14 @@ void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Ve
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	ERR_FAIL_COND(p_texture_index < 0);
-	if (p_texture_index >= fd->cache[size]->textures.size()) {
-		fd->cache[size]->textures.resize(p_texture_index + 1);
+	if (p_texture_index >= ffsd->textures.size()) {
+		ffsd->textures.resize(p_texture_index + 1);
 	}
 
-	ShelfPackTexture &tex = fd->cache[size]->textures.write[p_texture_index];
+	ShelfPackTexture &tex = ffsd->textures.write[p_texture_index];
 
 	tex.image = p_image;
 	tex.texture_w = p_image->get_width();
@@ -1837,10 +1873,11 @@ Ref<Image> TextServerFallback::_font_get_texture_image(const RID &p_font_rid, co
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Ref<Image>());
-	ERR_FAIL_INDEX_V(p_texture_index, fd->cache[size]->textures.size(), Ref<Image>());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Ref<Image>());
+	ERR_FAIL_INDEX_V(p_texture_index, ffsd->textures.size(), Ref<Image>());
 
-	const ShelfPackTexture &tex = fd->cache[size]->textures[p_texture_index];
+	const ShelfPackTexture &tex = ffsd->textures[p_texture_index];
 	return tex.image;
 }
 
@@ -1851,13 +1888,14 @@ void TextServerFallback::_font_set_texture_offsets(const RID &p_font_rid, const 
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	ERR_FAIL_COND(p_texture_index < 0);
-	if (p_texture_index >= fd->cache[size]->textures.size()) {
-		fd->cache[size]->textures.resize(p_texture_index + 1);
+	if (p_texture_index >= ffsd->textures.size()) {
+		ffsd->textures.resize(p_texture_index + 1);
 	}
 
-	ShelfPackTexture &tex = fd->cache[size]->textures.write[p_texture_index];
+	ShelfPackTexture &tex = ffsd->textures.write[p_texture_index];
 	tex.shelves.clear();
 	for (int32_t i = 0; i < p_offsets.size(); i += 4) {
 		tex.shelves.push_back(Shelf(p_offsets[i], p_offsets[i + 1], p_offsets[i + 2], p_offsets[i + 3]));
@@ -1870,10 +1908,11 @@ PackedInt32Array TextServerFallback::_font_get_texture_offsets(const RID &p_font
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), PackedInt32Array());
-	ERR_FAIL_INDEX_V(p_texture_index, fd->cache[size]->textures.size(), PackedInt32Array());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), PackedInt32Array());
+	ERR_FAIL_INDEX_V(p_texture_index, ffsd->textures.size(), PackedInt32Array());
 
-	const ShelfPackTexture &tex = fd->cache[size]->textures[p_texture_index];
+	const ShelfPackTexture &tex = ffsd->textures[p_texture_index];
 	PackedInt32Array ret;
 	ret.resize(tex.shelves.size() * 4);
 
@@ -1895,10 +1934,11 @@ PackedInt32Array TextServerFallback::_font_get_glyph_list(const RID &p_font_rid,
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), PackedInt32Array());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), PackedInt32Array());
 
 	PackedInt32Array ret;
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	const HashMap<int32_t, FontGlyph> &gl = ffsd->glyph_map;
 	for (const KeyValue<int32_t, FontGlyph> &E : gl) {
 		ret.push_back(E.key);
 	}
@@ -1911,9 +1951,10 @@ void TextServerFallback::_font_clear_glyphs(const RID &p_font_rid, const Vector2
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	fd->cache[size]->glyph_map.clear();
+	ffsd->glyph_map.clear();
 }
 
 void TextServerFallback::_font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) {
@@ -1922,9 +1963,10 @@ void TextServerFallback::_font_remove_glyph(const RID &p_font_rid, const Vector2
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	fd->cache[size]->glyph_map.erase(p_glyph);
+	ffsd->glyph_map.erase(p_glyph);
 }
 
 Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
@@ -1934,21 +1976,21 @@ Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Vector2());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return Vector2(); // Invalid or non graphicl glyph, do not display errors.
 	}
-
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
 
 	Vector2 ea;
 	if (fd->embolden != 0.0) {
@@ -1957,17 +1999,17 @@ Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64
 
 	double scale = _font_get_scale(p_font_rid, p_size);
 	if (fd->msdf) {
-		return (gl[p_glyph | mod].advance + ea) * (double)p_size / (double)fd->msdf_source_size;
+		return (fgl.advance + ea) * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return (gl[p_glyph | mod].advance + ea) * (double)p_size / (double)fd->fixed_size;
+			return (fgl.advance + ea) * (double)p_size / (double)fd->fixed_size;
 		} else {
-			return (gl[p_glyph | mod].advance + ea) * Math::round((double)p_size / (double)fd->fixed_size);
+			return (fgl.advance + ea) * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else if ((scale == 1.0) && ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_DISABLED) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x > SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE))) {
-		return (gl[p_glyph | mod].advance + ea).round();
+		return (fgl.advance + ea).round();
 	} else {
-		return gl[p_glyph | mod].advance + ea;
+		return fgl.advance + ea;
 	}
 }
 
@@ -1978,12 +2020,13 @@ void TextServerFallback::_font_set_glyph_advance(const RID &p_font_rid, int64_t 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	FontGlyph &fgl = ffsd->glyph_map[p_glyph];
 
-	gl[p_glyph].advance = p_advance;
-	gl[p_glyph].found = true;
+	fgl.advance = p_advance;
+	fgl.found = true;
 }
 
 Vector2 TextServerFallback::_font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
@@ -1993,32 +2036,32 @@ Vector2 TextServerFallback::_font_get_glyph_offset(const RID &p_font_rid, const 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Vector2());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return Vector2(); // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-
 	if (fd->msdf) {
-		return gl[p_glyph | mod].rect.position * (double)p_size.x / (double)fd->msdf_source_size;
+		return fgl.rect.position * (double)p_size.x / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size.x) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return gl[p_glyph | mod].rect.position * (double)p_size.x / (double)fd->fixed_size;
+			return fgl.rect.position * (double)p_size.x / (double)fd->fixed_size;
 		} else {
-			return gl[p_glyph | mod].rect.position * Math::round((double)p_size.x / (double)fd->fixed_size);
+			return fgl.rect.position * Math::round((double)p_size.x / (double)fd->fixed_size);
 		}
 	} else {
-		return gl[p_glyph | mod].rect.position;
+		return fgl.rect.position;
 	}
 }
 
@@ -2029,12 +2072,13 @@ void TextServerFallback::_font_set_glyph_offset(const RID &p_font_rid, const Vec
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	FontGlyph &fgl = ffsd->glyph_map[p_glyph];
 
-	gl[p_glyph].rect.position = p_offset;
-	gl[p_glyph].found = true;
+	fgl.rect.position = p_offset;
+	fgl.found = true;
 }
 
 Vector2 TextServerFallback::_font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
@@ -2044,32 +2088,32 @@ Vector2 TextServerFallback::_font_get_glyph_size(const RID &p_font_rid, const Ve
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Vector2());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return Vector2(); // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-
 	if (fd->msdf) {
-		return gl[p_glyph | mod].rect.size * (double)p_size.x / (double)fd->msdf_source_size;
+		return fgl.rect.size * (double)p_size.x / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size.x) {
 		if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
-			return gl[p_glyph | mod].rect.size * (double)p_size.x / (double)fd->fixed_size;
+			return fgl.rect.size * (double)p_size.x / (double)fd->fixed_size;
 		} else {
-			return gl[p_glyph | mod].rect.size * Math::round((double)p_size.x / (double)fd->fixed_size);
+			return fgl.rect.size * Math::round((double)p_size.x / (double)fd->fixed_size);
 		}
 	} else {
-		return gl[p_glyph | mod].rect.size;
+		return fgl.rect.size;
 	}
 }
 
@@ -2080,12 +2124,13 @@ void TextServerFallback::_font_set_glyph_size(const RID &p_font_rid, const Vecto
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	FontGlyph &fgl = ffsd->glyph_map[p_glyph];
 
-	gl[p_glyph].rect.size = p_gl_size;
-	gl[p_glyph].found = true;
+	fgl.rect.size = p_gl_size;
+	fgl.found = true;
 }
 
 Rect2 TextServerFallback::_font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
@@ -2095,22 +2140,23 @@ Rect2 TextServerFallback::_font_get_glyph_uv_rect(const RID &p_font_rid, const V
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Rect2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Rect2());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return Rect2(); // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-	return gl[p_glyph | mod].uv_rect;
+	return fgl.uv_rect;
 }
 
 void TextServerFallback::_font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
@@ -2120,12 +2166,13 @@ void TextServerFallback::_font_set_glyph_uv_rect(const RID &p_font_rid, const Ve
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	FontGlyph &fgl = ffsd->glyph_map[p_glyph];
 
-	gl[p_glyph].uv_rect = p_uv_rect;
-	gl[p_glyph].found = true;
+	fgl.uv_rect = p_uv_rect;
+	fgl.found = true;
 }
 
 int64_t TextServerFallback::_font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
@@ -2135,22 +2182,23 @@ int64_t TextServerFallback::_font_get_glyph_texture_idx(const RID &p_font_rid, c
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), -1);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), -1);
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return -1; // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-	return gl[p_glyph | mod].texture_idx;
+	return fgl.texture_idx;
 }
 
 void TextServerFallback::_font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
@@ -2160,12 +2208,13 @@ void TextServerFallback::_font_set_glyph_texture_idx(const RID &p_font_rid, cons
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
-	HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
+	FontGlyph &fgl = ffsd->glyph_map[p_glyph];
 
-	gl[p_glyph].texture_idx = p_texture_idx;
-	gl[p_glyph].found = true;
+	fgl.texture_idx = p_texture_idx;
+	fgl.found = true;
 }
 
 RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
@@ -2175,27 +2224,28 @@ RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), RID());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), RID());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return RID(); // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-	ERR_FAIL_COND_V(gl[p_glyph | mod].texture_idx < -1 || gl[p_glyph | mod].texture_idx >= fd->cache[size]->textures.size(), RID());
+	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), RID());
 
 	if (RenderingServer::get_singleton() != nullptr) {
-		if (gl[p_glyph | mod].texture_idx != -1) {
-			if (fd->cache[size]->textures[gl[p_glyph | mod].texture_idx].dirty) {
-				ShelfPackTexture &tex = fd->cache[size]->textures.write[gl[p_glyph | mod].texture_idx];
+		if (fgl.texture_idx != -1) {
+			if (ffsd->textures[fgl.texture_idx].dirty) {
+				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
 				Ref<Image> img = tex.image;
 				if (fd->mipmaps && !img->has_mipmaps()) {
 					img = tex.image->duplicate();
@@ -2208,7 +2258,7 @@ RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 				}
 				tex.dirty = false;
 			}
-			return fd->cache[size]->textures[gl[p_glyph | mod].texture_idx].texture->get_rid();
+			return ffsd->textures[fgl.texture_idx].texture->get_rid();
 		}
 	}
 
@@ -2222,27 +2272,28 @@ Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, co
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Size2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Size2());
 
 	int mod = 0;
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+		TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 			mod = (layout << 24);
 		}
 	}
 
-	if (!_ensure_glyph(fd, size, p_glyph | mod)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, p_glyph | mod, fgl)) {
 		return Size2(); // Invalid or non graphicl glyph, do not display errors.
 	}
 
-	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
-	ERR_FAIL_COND_V(gl[p_glyph | mod].texture_idx < -1 || gl[p_glyph | mod].texture_idx >= fd->cache[size]->textures.size(), Size2());
+	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), Size2());
 
 	if (RenderingServer::get_singleton() != nullptr) {
-		if (gl[p_glyph | mod].texture_idx != -1) {
-			if (fd->cache[size]->textures[gl[p_glyph | mod].texture_idx].dirty) {
-				ShelfPackTexture &tex = fd->cache[size]->textures.write[gl[p_glyph | mod].texture_idx];
+		if (fgl.texture_idx != -1) {
+			if (ffsd->textures[fgl.texture_idx].dirty) {
+				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
 				Ref<Image> img = tex.image;
 				if (fd->mipmaps && !img->has_mipmaps()) {
 					img = tex.image->duplicate();
@@ -2255,7 +2306,7 @@ Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, co
 				}
 				tex.dirty = false;
 			}
-			return fd->cache[size]->textures[gl[p_glyph | mod].texture_idx].texture->get_size();
+			return ffsd->textures[fgl.texture_idx].texture->get_size();
 		}
 	}
 
@@ -2269,7 +2320,8 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Dictionary());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Dictionary());
 
 #ifdef MODULE_FREETYPE_ENABLED
 	PackedVector3Array points;
@@ -2277,20 +2329,20 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 
-	int error = FT_Load_Glyph(fd->cache[size]->face, FT_Get_Char_Index(fd->cache[size]->face, index), FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
+	int error = FT_Load_Glyph(ffsd->face, FT_Get_Char_Index(ffsd->face, index), FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
 	ERR_FAIL_COND_V(error, Dictionary());
 
 	if (fd->embolden != 0.f) {
 		FT_Pos strength = fd->embolden * p_size * 4; // 26.6 fractional units (1 / 64).
-		FT_Outline_Embolden(&fd->cache[size]->face->glyph->outline, strength);
+		FT_Outline_Embolden(&ffsd->face->glyph->outline, strength);
 	}
 
 	if (fd->transform != Transform2D()) {
 		FT_Matrix mat = { FT_Fixed(fd->transform[0][0] * 65536), FT_Fixed(fd->transform[0][1] * 65536), FT_Fixed(fd->transform[1][0] * 65536), FT_Fixed(fd->transform[1][1] * 65536) }; // 16.16 fractional units (1 / 65536).
-		FT_Outline_Transform(&fd->cache[size]->face->glyph->outline, &mat);
+		FT_Outline_Transform(&ffsd->face->glyph->outline, &mat);
 	}
 
-	double scale = (1.0 / 64.0) / fd->cache[size]->oversampling * fd->cache[size]->scale;
+	double scale = (1.0 / 64.0) / ffsd->oversampling * ffsd->scale;
 	if (fd->msdf) {
 		scale = scale * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
@@ -2300,13 +2352,13 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 			scale = scale * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	}
-	for (short i = 0; i < fd->cache[size]->face->glyph->outline.n_points; i++) {
-		points.push_back(Vector3(fd->cache[size]->face->glyph->outline.points[i].x * scale, -fd->cache[size]->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(fd->cache[size]->face->glyph->outline.tags[i])));
+	for (short i = 0; i < ffsd->face->glyph->outline.n_points; i++) {
+		points.push_back(Vector3(ffsd->face->glyph->outline.points[i].x * scale, -ffsd->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(ffsd->face->glyph->outline.tags[i])));
 	}
-	for (short i = 0; i < fd->cache[size]->face->glyph->outline.n_contours; i++) {
-		contours.push_back(fd->cache[size]->face->glyph->outline.contours[i]);
+	for (short i = 0; i < ffsd->face->glyph->outline.n_contours; i++) {
+		contours.push_back(ffsd->face->glyph->outline.contours[i]);
 	}
-	bool orientation = (FT_Outline_Get_Orientation(&fd->cache[size]->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
+	bool orientation = (FT_Outline_Get_Orientation(&ffsd->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
 
 	Dictionary out;
 	out["points"] = points;
@@ -2325,10 +2377,11 @@ TypedArray<Vector2i> TextServerFallback::_font_get_kerning_list(const RID &p_fon
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), TypedArray<Vector2i>());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), TypedArray<Vector2i>());
 
 	TypedArray<Vector2i> ret;
-	for (const KeyValue<Vector2i, Vector2> &E : fd->cache[size]->kerning_map) {
+	for (const KeyValue<Vector2i, Vector2> &E : ffsd->kerning_map) {
 		ret.push_back(E.key);
 	}
 	return ret;
@@ -2341,8 +2394,9 @@ void TextServerFallback::_font_clear_kerning_map(const RID &p_font_rid, int64_t 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->kerning_map.clear();
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->kerning_map.clear();
 }
 
 void TextServerFallback::_font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) {
@@ -2352,8 +2406,9 @@ void TextServerFallback::_font_remove_kerning(const RID &p_font_rid, int64_t p_s
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->kerning_map.erase(p_glyph_pair);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->kerning_map.erase(p_glyph_pair);
 }
 
 void TextServerFallback::_font_set_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair, const Vector2 &p_kerning) {
@@ -2363,8 +2418,9 @@ void TextServerFallback::_font_set_kerning(const RID &p_font_rid, int64_t p_size
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
-	fd->cache[size]->kerning_map[p_glyph_pair] = p_kerning;
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
+	ffsd->kerning_map[p_glyph_pair] = p_kerning;
 }
 
 Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const {
@@ -2374,9 +2430,10 @@ Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Vector2());
 
-	const HashMap<Vector2i, Vector2> &kern = fd->cache[size]->kerning_map;
+	const HashMap<Vector2i, Vector2> &kern = ffsd->kerning_map;
 
 	if (kern.has(p_glyph_pair)) {
 		if (fd->msdf) {
@@ -2392,11 +2449,11 @@ Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 		}
 	} else {
 #ifdef MODULE_FREETYPE_ENABLED
-		if (fd->cache[size]->face) {
+		if (ffsd->face) {
 			FT_Vector delta;
-			int32_t glyph_a = FT_Get_Char_Index(fd->cache[size]->face, p_glyph_pair.x);
-			int32_t glyph_b = FT_Get_Char_Index(fd->cache[size]->face, p_glyph_pair.y);
-			FT_Get_Kerning(fd->cache[size]->face, glyph_a, glyph_b, FT_KERNING_DEFAULT, &delta);
+			int32_t glyph_a = FT_Get_Char_Index(ffsd->face, p_glyph_pair.x);
+			int32_t glyph_b = FT_Get_Char_Index(ffsd->face, p_glyph_pair.y);
+			FT_Get_Kerning(ffsd->face, glyph_a, glyph_b, FT_KERNING_DEFAULT, &delta);
 			if (fd->msdf) {
 				return Vector2(delta.x, delta.y) * (double)p_size / (double)fd->msdf_source_size;
 			} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
@@ -2431,17 +2488,19 @@ bool TextServerFallback::_font_has_char(const RID &p_font_rid, int64_t p_char) c
 	}
 
 	MutexLock lock(fd->mutex);
+	FontForSizeFallback *ffsd = nullptr;
 	if (fd->cache.is_empty()) {
-		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0)), false);
+		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0), ffsd), false);
+	} else {
+		ffsd = fd->cache.begin()->value;
 	}
-	FontForSizeFallback *at_size = fd->cache.begin()->value;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (at_size && at_size->face) {
-		return FT_Get_Char_Index(at_size->face, p_char) != 0;
+	if (ffsd->face) {
+		return FT_Get_Char_Index(ffsd->face, p_char) != 0;
 	}
 #endif
-	return (at_size) ? at_size->glyph_map.has((int32_t)p_char) : false;
+	return ffsd->glyph_map.has((int32_t)p_char);
 }
 
 String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) const {
@@ -2449,30 +2508,30 @@ String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) cons
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
+	FontForSizeFallback *ffsd = nullptr;
 	if (fd->cache.is_empty()) {
-		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0)), String());
+		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0), ffsd), String());
+	} else {
+		ffsd = fd->cache.begin()->value;
 	}
-	FontForSizeFallback *at_size = fd->cache.begin()->value;
 
 	String chars;
 #ifdef MODULE_FREETYPE_ENABLED
-	if (at_size && at_size->face) {
+	if (ffsd->face) {
 		FT_UInt gindex;
-		FT_ULong charcode = FT_Get_First_Char(at_size->face, &gindex);
+		FT_ULong charcode = FT_Get_First_Char(ffsd->face, &gindex);
 		while (gindex != 0) {
 			if (charcode != 0) {
 				chars = chars + String::chr(charcode);
 			}
-			charcode = FT_Get_Next_Char(at_size->face, charcode, &gindex);
+			charcode = FT_Get_Next_Char(ffsd->face, charcode, &gindex);
 		}
 		return chars;
 	}
 #endif
-	if (at_size) {
-		const HashMap<int32_t, FontGlyph> &gl = at_size->glyph_map;
-		for (const KeyValue<int32_t, FontGlyph> &E : gl) {
-			chars = chars + String::chr(E.key);
-		}
+	const HashMap<int32_t, FontGlyph> &gl = ffsd->glyph_map;
+	for (const KeyValue<int32_t, FontGlyph> &E : gl) {
+		chars = chars + String::chr(E.key);
 	}
 	return chars;
 }
@@ -2482,10 +2541,12 @@ PackedInt32Array TextServerFallback::_font_get_supported_glyphs(const RID &p_fon
 	ERR_FAIL_NULL_V(fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
+	FontForSizeFallback *at_size = nullptr;
 	if (fd->cache.is_empty()) {
-		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0)), PackedInt32Array());
+		ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, fd->msdf ? Vector2i(fd->msdf_source_size, 0) : Vector2i(16, 0), at_size), PackedInt32Array());
+	} else {
+		at_size = fd->cache.begin()->value;
 	}
-	FontForSizeFallback *at_size = fd->cache.begin()->value;
 
 	PackedInt32Array glyphs;
 #ifdef MODULE_FREETYPE_ENABLED
@@ -2516,25 +2577,27 @@ void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	for (int64_t i = p_start; i <= p_end; i++) {
 #ifdef MODULE_FREETYPE_ENABLED
 		int32_t idx = i;
-		if (fd->cache[size]->face) {
+		if (ffsd->face) {
+			FontGlyph fgl;
 			if (fd->msdf) {
-				_ensure_glyph(fd, size, (int32_t)idx);
+				_ensure_glyph(fd, size, (int32_t)idx, fgl);
 			} else {
 				for (int aa = 0; aa < ((fd->antialiasing == FONT_ANTIALIASING_LCD) ? FONT_LCD_SUBPIXEL_LAYOUT_MAX : 1); aa++) {
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24), fgl);
+						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24), fgl);
+						_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24), fgl);
+						_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24), fgl);
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24), fgl);
+						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24), fgl);
 					} else {
-						_ensure_glyph(fd, size, (int32_t)idx | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (aa << 24), fgl);
 					}
 				}
 			}
@@ -2549,24 +2612,26 @@ void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 #ifdef MODULE_FREETYPE_ENABLED
 	int32_t idx = p_index & 0xffffff; // Remove subpixel shifts.
-	if (fd->cache[size]->face) {
+	if (ffsd->face) {
+		FontGlyph fgl;
 		if (fd->msdf) {
-			_ensure_glyph(fd, size, (int32_t)idx);
+			_ensure_glyph(fd, size, (int32_t)idx, fgl);
 		} else {
 			for (int aa = 0; aa < ((fd->antialiasing == FONT_ANTIALIASING_LCD) ? FONT_LCD_SUBPIXEL_LAYOUT_MAX : 1); aa++) {
 				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24), fgl);
+					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24), fgl);
+					_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24), fgl);
+					_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24), fgl);
 				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24), fgl);
+					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24), fgl);
 				} else {
-					_ensure_glyph(fd, size, (int32_t)idx | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (aa << 24), fgl);
 				}
 			}
 		}
@@ -2583,16 +2648,17 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && fd->cache[size]->face) {
+	if (!fd->msdf && ffsd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-			TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 			if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 				lcd_aa = true;
 				index = index | (layout << 24);
@@ -2609,24 +2675,24 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	}
 #endif
 
-	if (!_ensure_glyph(fd, size, index)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, index, fgl)) {
 		return; // Invalid or non-graphical glyph, do not display errors, nothing to draw.
 	}
 
-	const FontGlyph &gl = fd->cache[size]->glyph_map[index];
-	if (gl.found) {
-		ERR_FAIL_COND(gl.texture_idx < -1 || gl.texture_idx >= fd->cache[size]->textures.size());
+	if (fgl.found) {
+		ERR_FAIL_COND(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size());
 
-		if (gl.texture_idx != -1) {
+		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (fd->cache[size]->face && fd->cache[size]->textures[gl.texture_idx].image.is_valid() && (fd->cache[size]->textures[gl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (ffsd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
 			if (RenderingServer::get_singleton() != nullptr) {
-				if (fd->cache[size]->textures[gl.texture_idx].dirty) {
-					ShelfPackTexture &tex = fd->cache[size]->textures.write[gl.texture_idx];
+				if (ffsd->textures[fgl.texture_idx].dirty) {
+					ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
 					Ref<Image> img = tex.image;
 					if (fd->mipmaps && !img->has_mipmaps()) {
 						img = tex.image->duplicate();
@@ -2639,12 +2705,12 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					}
 					tex.dirty = false;
 				}
-				RID texture = fd->cache[size]->textures[gl.texture_idx].texture->get_rid();
+				RID texture = ffsd->textures[fgl.texture_idx].texture->get_rid();
 				if (fd->msdf) {
 					Point2 cpos = p_pos;
-					cpos += gl.rect.position * (double)p_size / (double)fd->msdf_source_size;
-					Size2 csize = gl.rect.size * (double)p_size / (double)fd->msdf_source_size;
-					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, 0, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
+					Size2 csize = fgl.rect.size * (double)p_size / (double)fd->msdf_source_size;
+					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, 0, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
 				} else {
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size);
@@ -2657,8 +2723,8 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 						cpos.y = Math::floor(cpos.y);
 						cpos.x = Math::floor(cpos.x);
 					}
-					Vector2 gpos = gl.rect.position;
-					Size2 csize = gl.rect.size;
+					Vector2 gpos = fgl.rect.position;
+					Size2 csize = fgl.rect.size;
 					if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 						if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
 							double gl_scale = (double)p_size / (double)fd->fixed_size;
@@ -2672,9 +2738,9 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					}
 					cpos += gpos;
 					if (lcd_aa) {
-						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate);
+						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate);
 					} else {
-						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, false, false);
+						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, false, false);
 					}
 				}
 			}
@@ -2691,16 +2757,17 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, Vector2i(p_size, p_outline_size));
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && fd->cache[size]->face) {
+	if (!fd->msdf && ffsd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
-			TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
+			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
 			if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 				lcd_aa = true;
 				index = index | (layout << 24);
@@ -2717,24 +2784,24 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	}
 #endif
 
-	if (!_ensure_glyph(fd, size, index)) {
+	FontGlyph fgl;
+	if (!_ensure_glyph(fd, size, index, fgl)) {
 		return; // Invalid or non-graphical glyph, do not display errors, nothing to draw.
 	}
 
-	const FontGlyph &gl = fd->cache[size]->glyph_map[index];
-	if (gl.found) {
-		ERR_FAIL_COND(gl.texture_idx < -1 || gl.texture_idx >= fd->cache[size]->textures.size());
+	if (fgl.found) {
+		ERR_FAIL_COND(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size());
 
-		if (gl.texture_idx != -1) {
+		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (fd->cache[size]->face && fd->cache[size]->textures[gl.texture_idx].image.is_valid() && (fd->cache[size]->textures[gl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (ffsd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
 			if (RenderingServer::get_singleton() != nullptr) {
-				if (fd->cache[size]->textures[gl.texture_idx].dirty) {
-					ShelfPackTexture &tex = fd->cache[size]->textures.write[gl.texture_idx];
+				if (ffsd->textures[fgl.texture_idx].dirty) {
+					ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
 					Ref<Image> img = tex.image;
 					if (fd->mipmaps && !img->has_mipmaps()) {
 						img = tex.image->duplicate();
@@ -2747,12 +2814,12 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 					}
 					tex.dirty = false;
 				}
-				RID texture = fd->cache[size]->textures[gl.texture_idx].texture->get_rid();
+				RID texture = ffsd->textures[fgl.texture_idx].texture->get_rid();
 				if (fd->msdf) {
 					Point2 cpos = p_pos;
-					cpos += gl.rect.position * (double)p_size / (double)fd->msdf_source_size;
-					Size2 csize = gl.rect.size * (double)p_size / (double)fd->msdf_source_size;
-					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, p_outline_size, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
+					Size2 csize = fgl.rect.size * (double)p_size / (double)fd->msdf_source_size;
+					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, p_outline_size, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
 				} else {
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size);
@@ -2765,8 +2832,8 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 						cpos.y = Math::floor(cpos.y);
 						cpos.x = Math::floor(cpos.x);
 					}
-					Vector2 gpos = gl.rect.position;
-					Size2 csize = gl.rect.size;
+					Vector2 gpos = fgl.rect.position;
+					Size2 csize = fgl.rect.size;
 					if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
 						if (fd->fixed_size_scale_mode == FIXED_SIZE_SCALE_ENABLED) {
 							double gl_scale = (double)p_size / (double)fd->fixed_size;
@@ -2780,9 +2847,9 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 					}
 					cpos += gpos;
 					if (lcd_aa) {
-						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate);
+						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate);
 					} else {
-						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, false, false);
+						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, false, false);
 					}
 				}
 			}
@@ -2872,7 +2939,8 @@ void TextServerFallback::_font_remove_script_support_override(const RID &p_font_
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->script_support_overrides.erase(p_script);
 }
 
@@ -2894,7 +2962,8 @@ void TextServerFallback::_font_set_opentype_feature_overrides(const RID &p_font_
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	fd->feature_overrides = p_overrides;
 }
 
@@ -2916,7 +2985,8 @@ Dictionary TextServerFallback::_font_supported_variation_list(const RID &p_font_
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, 16);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Dictionary());
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Dictionary());
 	return fd->supported_varaitions;
 }
 
@@ -2953,7 +3023,7 @@ void TextServerFallback::_font_set_global_oversampling(double p_oversampling) {
 /*************************************************************************/
 
 void TextServerFallback::invalidate(ShapedTextDataFallback *p_shaped) {
-	p_shaped->valid = false;
+	p_shaped->valid.clear();
 	p_shaped->sort_valid = false;
 	p_shaped->line_breaks_valid = false;
 	p_shaped->justification_ops_valid = false;
@@ -3192,7 +3262,7 @@ void TextServerFallback::_shaped_set_span_update_font(const RID &p_shaped, int64
 	span.font_size = p_size;
 	span.features = p_opentype_features;
 
-	sd->valid = false;
+	sd->valid.clear();
 }
 
 bool TextServerFallback::_shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
@@ -3288,7 +3358,7 @@ bool TextServerFallback::_shaped_text_resize_object(const RID &p_shaped, const V
 	sd->objects[p_key].rect.size = p_size;
 	sd->objects[p_key].inline_align = p_inline_align;
 	sd->objects[p_key].baseline = p_baseline;
-	if (sd->valid) {
+	if (sd->valid.is_set()) {
 		// Recalc string metrics.
 		sd->ascent = 0;
 		sd->descent = 0;
@@ -3431,7 +3501,7 @@ RID TextServerFallback::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 	if (sd->parent != RID()) {
 		return _shaped_text_substr(sd->parent, p_start, p_length);
 	}
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	ERR_FAIL_COND_V(p_start < 0 || p_length < 0, RID());
@@ -3514,7 +3584,7 @@ RID TextServerFallback::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 
 		_realign(new_sd);
 	}
-	new_sd->valid = true;
+	new_sd->valid.set();
 
 	return shaped_owner.make_rid(new_sd);
 }
@@ -3532,7 +3602,7 @@ double TextServerFallback::_shaped_text_fit_to_width(const RID &p_shaped, double
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	if (!sd->justification_ops_valid) {
@@ -3641,7 +3711,7 @@ double TextServerFallback::_shaped_text_tab_align(const RID &p_shaped, const Pac
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	if (!sd->line_breaks_valid) {
@@ -3697,7 +3767,7 @@ bool TextServerFallback::_shaped_text_update_breaks(const RID &p_shaped) {
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		_shaped_text_shape(p_shaped);
 	}
 
@@ -3761,7 +3831,7 @@ bool TextServerFallback::_shaped_text_update_justification_ops(const RID &p_shap
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		_shaped_text_shape(p_shaped);
 	}
 	if (!sd->line_breaks_valid) {
@@ -3940,7 +4010,7 @@ void TextServerFallback::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 	ERR_FAIL_NULL_MSG(sd, "ShapedTextDataFallback invalid.");
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		_shaped_text_shape(p_shaped_line);
 	}
 
@@ -3967,7 +4037,7 @@ void TextServerFallback::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 	Vector<ShapedTextDataFallback::Span> &spans = sd->spans;
 	if (sd->parent != RID()) {
 		ShapedTextDataFallback *parent_sd = shaped_owner.get_or_null(sd->parent);
-		ERR_FAIL_COND(!parent_sd->valid);
+		ERR_FAIL_COND(!parent_sd->valid.is_set());
 		spans = parent_sd->spans;
 	}
 
@@ -4161,7 +4231,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
-	if (sd->valid) {
+	if (sd->valid.is_set()) {
 		return true;
 	}
 
@@ -4178,7 +4248,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 	sd->glyphs.clear();
 
 	if (sd->text.length() == 0) {
-		sd->valid = true;
+		sd->valid.set();
 		return true;
 	}
 
@@ -4307,16 +4377,15 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 	// Align embedded objects to baseline.
 	_realign(sd);
 
-	sd->valid = true;
-	return sd->valid;
+	sd->valid.set();
+	return sd->valid.is_set();
 }
 
 bool TextServerFallback::_shaped_text_is_ready(const RID &p_shaped) const {
 	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
-	MutexLock lock(sd->mutex);
-	return sd->valid;
+	return sd->valid.is_set();
 }
 
 const Glyph *TextServerFallback::_shaped_text_get_glyphs(const RID &p_shaped) const {
@@ -4324,7 +4393,7 @@ const Glyph *TextServerFallback::_shaped_text_get_glyphs(const RID &p_shaped) co
 	ERR_FAIL_NULL_V(sd, nullptr);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return sd->glyphs.ptr();
@@ -4335,7 +4404,7 @@ int64_t TextServerFallback::_shaped_text_get_glyph_count(const RID &p_shaped) co
 	ERR_FAIL_NULL_V(sd, 0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return sd->glyphs.size();
@@ -4346,7 +4415,7 @@ const Glyph *TextServerFallback::_shaped_text_sort_logical(const RID &p_shaped) 
 	ERR_FAIL_NULL_V(sd, nullptr);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 
@@ -4380,7 +4449,7 @@ Rect2 TextServerFallback::_shaped_text_get_object_rect(const RID &p_shaped, cons
 
 	MutexLock lock(sd->mutex);
 	ERR_FAIL_COND_V(!sd->objects.has(p_key), Rect2());
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return sd->objects[p_key].rect;
@@ -4417,7 +4486,7 @@ Size2 TextServerFallback::_shaped_text_get_size(const RID &p_shaped) const {
 	ERR_FAIL_NULL_V(sd, Size2());
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	if (sd->orientation == TextServer::ORIENTATION_HORIZONTAL) {
@@ -4432,7 +4501,7 @@ double TextServerFallback::_shaped_text_get_ascent(const RID &p_shaped) const {
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return sd->ascent + sd->extra_spacing[SPACING_TOP];
@@ -4443,7 +4512,7 @@ double TextServerFallback::_shaped_text_get_descent(const RID &p_shaped) const {
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return sd->descent + sd->extra_spacing[SPACING_BOTTOM];
@@ -4454,7 +4523,7 @@ double TextServerFallback::_shaped_text_get_width(const RID &p_shaped) const {
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 	return Math::ceil(sd->width);
@@ -4465,7 +4534,7 @@ double TextServerFallback::_shaped_text_get_underline_position(const RID &p_shap
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 
@@ -4477,7 +4546,7 @@ double TextServerFallback::_shaped_text_get_underline_thickness(const RID &p_sha
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 
@@ -4489,7 +4558,7 @@ PackedInt32Array TextServerFallback::_shaped_text_get_character_breaks(const RID
 	ERR_FAIL_NULL_V(sd, PackedInt32Array());
 
 	MutexLock lock(sd->mutex);
-	if (!sd->valid) {
+	if (!sd->valid.is_set()) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
 
@@ -4626,8 +4695,13 @@ PackedInt32Array TextServerFallback::_string_get_word_breaks(const String &p_str
 	return ret;
 }
 
+void TextServerFallback::_update_settings() {
+	lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+}
+
 TextServerFallback::TextServerFallback() {
 	_insert_feature_sets();
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerFallback::_update_settings));
 };
 
 void TextServerFallback::_cleanup() {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -72,6 +72,7 @@
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/rid_owner.hpp>
+#include <godot_cpp/templates/safe_refcount.hpp>
 #include <godot_cpp/templates/vector.hpp>
 
 using namespace godot;
@@ -83,6 +84,7 @@ using namespace godot;
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid_owner.h"
+#include "core/templates/safe_refcount.h"
 #include "scene/resources/image_texture.h"
 #include "servers/text/text_server_extension.h"
 
@@ -115,6 +117,9 @@ class TextServerFallback : public TextServerExtension {
 
 	HashMap<StringName, int32_t> feature_sets;
 	HashMap<int32_t, StringName> feature_sets_inv;
+
+	SafeNumeric<TextServer::FontLCDSubpixelLayout> lcd_subpixel_layout{ TextServer::FontLCDSubpixelLayout::FONT_LCD_SUBPIXEL_LAYOUT_NONE };
+	void _update_settings();
 
 	void _insert_feature_sets();
 	_FORCE_INLINE_ void _insert_feature(const StringName &p_name, int32_t p_tag);
@@ -278,7 +283,7 @@ class TextServerFallback : public TextServerExtension {
 		int extra_spacing[4] = { 0, 0, 0, 0 };
 		double baseline_offset = 0.0;
 
-		HashMap<Vector2i, FontForSizeFallback *, VariantHasher, VariantComparator> cache;
+		HashMap<Vector2i, FontForSizeFallback *> cache;
 
 		bool face_init = false;
 		Dictionary supported_varaitions;
@@ -308,8 +313,8 @@ class TextServerFallback : public TextServerExtension {
 #ifdef MODULE_FREETYPE_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const;
 #endif
-	_FORCE_INLINE_ bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
-	_FORCE_INLINE_ bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size) const;
+	_FORCE_INLINE_ bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph, FontGlyph &r_glyph) const;
+	_FORCE_INLINE_ bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size, FontForSizeFallback *&r_cache_for_size) const;
 	_FORCE_INLINE_ void _font_clear_cache(FontFallback *p_font_data);
 	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
@@ -432,7 +437,7 @@ class TextServerFallback : public TextServerExtension {
 
 		/* Shaped data */
 		TextServer::Direction para_direction = DIRECTION_LTR; // Detected text direction.
-		bool valid = false; // String is shaped.
+		SafeFlag valid{ false }; // String is shaped.
 		bool line_breaks_valid = false; // Line and word break flags are populated (and virtual zero width spaces inserted).
 		bool justification_ops_valid = false; // Virtual elongation glyphs are added to the string.
 		bool sort_valid = false;


### PR DESCRIPTION
followup to https://github.com/godotengine/godot/pull/92575

- removes redundant FontForSizeFallback cache lookups
- also caches editor setting
- usies a faster hash method on the FontForSizeFallback cache (its the same function its just not converting the key to a variant before hashing)
- ShapedTextDataFallback::valid changed to an atomic bool to avoid locking a mutex, as its read Very often

in total from my benchmark it takes ~38% of the time to render the same text in a Label (~44% in CodeEdit, the main script editor in godot)

benchmark: [TextServerTest.zip](https://github.com/user-attachments/files/15508175/TextServerTest.zip)
benchmark compile flags: `scons target=template_release production=yes optimize=speed lto=full tests=yes deprecated=no scu_build=yes module_text_server_adv_enabled=no module_text_server_fb_enabled=yes`
benchmark run command: `./godot/bin/godot.linuxbsd.template_release.x86_64 --disable-vsync ./TextServerTest/project.godot`

results before:
```
Godot Engine v4.3.beta.custom_build.6b38be699 (2024-05-30 20:38:39 UTC) - https://godotengine.org
Vulkan 1.3.277 - Forward+ - Using Device #0: NVIDIA - NVIDIA GeForce GTX 1080 Ti

18.2138115468651ms avg draw time (99 samples)
18.2687489673345ms avg draw time (198 samples)
18.1693966541226ms avg draw time (297 samples)
18.088425048674ms avg draw time (396 samples)
18.0387193506414ms avg draw time (495 samples)
18.0871025079027ms avg draw time (594 samples)
18.1229936784136ms avg draw time (693 samples)
18.1424099989612ms avg draw time (792 samples)
18.1100280196578ms avg draw time (891 samples)
18.088856369558ms avg draw time (990 samples)
18.1047671206836ms avg draw time (1089 samples)
```
after:
```
Godot Engine v4.3.beta.custom_build.7a4461225 (2024-05-31 05:57:28 UTC) - https://godotengine.org
Vulkan 1.3.277 - Forward+ - Using Device #0: NVIDIA - NVIDIA GeForce GTX 1080 Ti

6.8193662046182ms avg draw time (99 samples)
6.81492054101193ms avg draw time (198 samples)
6.8215898391775ms avg draw time (297 samples)
6.8254777879426ms avg draw time (396 samples)
6.82788376856332ms avg draw time (495 samples)
6.80477530867965ms avg draw time (594 samples)
6.78739540848725ms avg draw time (693 samples)
6.77584548189182ms avg draw time (792 samples)
6.76721113699454ms avg draw time (891 samples)
6.75983934691458ms avg draw time (990 samples)
6.75281939756115ms avg draw time (1089 samples)
```


the last line of each is the most important, its the average of all frame times (minus some longer startup frames)