### PR TITLE
Autocompletion: Fix type resolution when assigning variant

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1640,6 +1640,8 @@ static GDScriptCompletionIdentifier _type_from_property(const PropertyInfo &p_pr
 
 	if (p_property.type == Variant::NIL) {
 		// Variant
+		ci.type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
+		ci.type.kind = GDScriptParser::DataType::VARIANT;
 		return ci;
 	}
 
@@ -2338,7 +2340,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 		c.current_line = last_assign_line;
 		GDScriptCompletionIdentifier assigned_type;
 		if (_guess_expression_type(c, last_assigned_expression, assigned_type)) {
-			if (id_type.type.is_set() && assigned_type.type.is_set() && !GDScriptAnalyzer::check_type_compatibility(id_type.type, assigned_type.type)) {
+			if (id_type.type.is_set() && (assigned_type.type.kind == GDScriptParser::DataType::VARIANT || (assigned_type.type.is_set() && !GDScriptAnalyzer::check_type_compatibility(id_type.type, assigned_type.type)))) {
 				// The assigned type is incompatible. The annotated type takes priority.
 				r_type = id_type;
 				r_type.assigned_expression = last_assigned_expression;

--- a/modules/gdscript/tests/scripts/completion/common/assign_local_variant.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/assign_local_variant.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    ; PackedScene
+    {"display": "instantiate(…)"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/assign_local_variant.gd
+++ b/modules/gdscript/tests/scripts/completion/common/assign_local_variant.gd
@@ -1,0 +1,5 @@
+var list: Array
+
+func spawn_npc() -> void:
+	var scene: PackedScene = list.pick_random()
+	scene.➡


### PR DESCRIPTION
Fixes #92566

Explanation from over there:
> https://github.com/godotengine/godot/pull/85224 should have fixed that but I made an oversight. We use the analyzer logic to test whether the assigned type is compatible. The analyzer allows assigning variant types to everything, and pick_random returns a variant which for the analyzer is compatible with PackedScene (though unsave). So we end up with the type of the assigned expression but a variant doesn't has much value for autocompletion.