### PR TITLE
Implement a LayoutContainer

### DIFF
--- a/doc/classes/LayoutContainer.xml
+++ b/doc/classes/LayoutContainer.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LayoutContainer" inherits="Container" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+		A container meant to position and resize a single [Control] child dynamically within its boundaries. It features a set of common presets (see [member preset]), providing similar capabilities to the [Control] anchor and offset system.
+		The child [Control] is positioned so that it takes all space available in this container, and is then constrained by the provided margins.
+		The base margins, and the theme constant margins, are both in pixels, and are accounted in the computed minimum size of this container. When there's enough space for them, the custom relative margins define how much space the child control will fill.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_custom_relative_margin" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<description>
+				Returns the custom relative margin for the provided [param side].
+			</description>
+		</method>
+		<method name="get_margin" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<description>
+				Returns the margin (in pixel) for the provided [param side].
+			</description>
+		</method>
+		<method name="set_custom_relative_margin">
+			<return type="void" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<param index="1" name="relative_margin" type="float" />
+			<param index="2" name="push_opposite_margin" type="bool" default="true" />
+			<description>
+				Sets the custom relative margin for the provided [param side].
+				As opposite margins should not overlap, by default, the opposite margin will be reduced if needed. If [param push_opposite_margin] is instead set to [code]false[/code], the margin will be clamped instead.
+			</description>
+		</method>
+		<method name="set_margin">
+			<return type="void" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<param index="1" name="offset" type="float" />
+			<description>
+				Sets the margin (in pixel) for the provided [param side].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="custom_relative_margin_bottom" type="float" setter="_set_custom_relative_margin" getter="get_custom_relative_margin" default="0.0">
+			Margin to keep at the bottom of the node, relative to this [LayoutContainer]'s height.
+		</member>
+		<member name="custom_relative_margin_left" type="float" setter="_set_custom_relative_margin" getter="get_custom_relative_margin" default="0.0">
+			Margin to keep at the left of the node, relative to this [LayoutContainer]'s width.
+		</member>
+		<member name="custom_relative_margin_right" type="float" setter="_set_custom_relative_margin" getter="get_custom_relative_margin" default="0.0">
+			Margin to keep at the right of the node, relative to this [LayoutContainer]'s width.
+		</member>
+		<member name="custom_relative_margin_top" type="float" setter="_set_custom_relative_margin" getter="get_custom_relative_margin" default="0.0">
+			Margin to keep at the top of the node, relative to this [LayoutContainer]'s height.
+		</member>
+		<member name="margin_bottom" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			Margin to keep at the bottom of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</member>
+		<member name="margin_left" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			Margin to keep at the left of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</member>
+		<member name="margin_right" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			Margin to keep at the right of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</member>
+		<member name="margin_top" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			Margin to keep at the top of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</member>
+		<member name="preset" type="int" setter="set_margin_layout_preset" getter="get_margin_layout_preset" enum="LayoutContainer.LayoutContainerPreset" default="0">
+			A preset for the relative margins. If set to any value except [constant PRESET_CUSTOM], the custom relative margins are not taken into account.
+		</member>
+	</members>
+	<constants>
+		<constant name="PRESET_TOP_LEFT" value="0" enum="LayoutContainerPreset">
+			Position the child control at the top-left of this container.
+		</constant>
+		<constant name="PRESET_TOP_RIGHT" value="1" enum="LayoutContainerPreset">
+			Position the child control at the top-right of this container.
+		</constant>
+		<constant name="PRESET_BOTTOM_LEFT" value="2" enum="LayoutContainerPreset">
+			Position the child control at the bottom-left of this container.
+		</constant>
+		<constant name="PRESET_BOTTOM_RIGHT" value="3" enum="LayoutContainerPreset">
+			Position the child control at the bottom-left of this container.
+		</constant>
+		<constant name="PRESET_CENTER_LEFT" value="4" enum="LayoutContainerPreset">
+			Position the child control at the center-left of this container.
+		</constant>
+		<constant name="PRESET_CENTER_TOP" value="5" enum="LayoutContainerPreset">
+			Position the child control at the center-top of this container.
+		</constant>
+		<constant name="PRESET_CENTER_RIGHT" value="6" enum="LayoutContainerPreset">
+			Position the child control at the center-right of this container.
+		</constant>
+		<constant name="PRESET_CENTER_BOTTOM" value="7" enum="LayoutContainerPreset">
+			Position the child control at the center-bottom of this container.
+		</constant>
+		<constant name="PRESET_CENTER" value="8" enum="LayoutContainerPreset">
+			Position the child control at the center of this container.
+		</constant>
+		<constant name="PRESET_LEFT_WIDE" value="9" enum="LayoutContainerPreset">
+			Position the child control at the left of this container, taking all vertical space available.
+		</constant>
+		<constant name="PRESET_TOP_WIDE" value="10" enum="LayoutContainerPreset">
+			Position the child control at the top of this container, taking all horizontal space available.
+		</constant>
+		<constant name="PRESET_RIGHT_WIDE" value="11" enum="LayoutContainerPreset">
+			Position the child control at the right of this container, taking all vertical space available.
+		</constant>
+		<constant name="PRESET_BOTTOM_WIDE" value="12" enum="LayoutContainerPreset">
+			Position the child control at the bottom of this container, taking all horizontal space available.
+		</constant>
+		<constant name="PRESET_VCENTER_WIDE" value="13" enum="LayoutContainerPreset">
+			Position the child control at the horizontal center of this container, taking all vertical space available.
+		</constant>
+		<constant name="PRESET_HCENTER_WIDE" value="14" enum="LayoutContainerPreset">
+			Position the child control at the vertical center of this container, taking all horizontal space available.
+		</constant>
+		<constant name="PRESET_FULL_RECT" value="15" enum="LayoutContainerPreset">
+			Position the child control so that it takes all space available.
+		</constant>
+		<constant name="PRESET_CUSTOM" value="16" enum="LayoutContainerPreset">
+			Position the child control according to the custom relative margins.
+		</constant>
+	</constants>
+	<theme_items>
+		<theme_item name="margin_bottom" data_type="constant" type="int" default="0">
+			Margin added to [member margin_bottom] to keep at the bottom of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</theme_item>
+		<theme_item name="margin_left" data_type="constant" type="int" default="0">
+			Margin added to [member margin_left] to keep at the left of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</theme_item>
+		<theme_item name="margin_right" data_type="constant" type="int" default="0">
+			Margin added to [member margin_right] to keep at the right of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</theme_item>
+		<theme_item name="margin_top" data_type="constant" type="int" default="0">
+			Margin added to [member margin_top] to keep at the top of the child control, in pixels. This is included in the minimum size of this [LayoutContainer].
+		</theme_item>
+	</theme_items>
+</class>

--- a/editor/icons/LayoutContainer.svg
+++ b/editor/icons/LayoutContainer.svg
@@ -1,0 +1,1 @@
+<svg height="16" width="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M3 1a2 2 0 0 0-2 2h2zm2 0v2h2V1zm4 0v2h2V1zm4 0v2h2a2 2 0 0 0-2-2zM1 5v2h2V5zm12 0v2h2V5zM1 9v2h2V9zm12 0v2h2V9zM1 13a2 2 0 0 0 2 2v-2zm4 0v2h2v-2zm4 0v2h2v-2zm4 0v2a2 2 0 0 0 2-2z" fill="#8eef97"/><path d="M7 7h4v4H7z" fill="#d6d6d6"/></svg>

--- a/scene/gui/layout_container.cpp
+++ b/scene/gui/layout_container.cpp
@@ -1,0 +1,241 @@
+/**************************************************************************/
+/*  layout_container.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "layout_container.h"
+
+#include "scene/theme/theme_db.h"
+
+void LayoutContainer::_resort() {
+	Size2 size = get_size();
+
+	// Get the relative_margin values.
+	const real_t *relative_margins;
+	if (preset == PRESET_CUSTOM) {
+		relative_margins = custom_relative_margins;
+	} else {
+		relative_margins = relative_margins_presets[preset];
+	}
+
+	// The "default" rectangle, independent from the child size.
+	Rect2 rect;
+	rect.set_position(Vector2(size.x * relative_margins[SIDE_LEFT] + margins[SIDE_LEFT] + theme_cache.margin_left, size.y * relative_margins[SIDE_TOP] + margins[SIDE_TOP] + theme_cache.margin_top));
+	rect.set_end(Vector2(size.x * (1.0 - relative_margins[SIDE_RIGHT]) - margins[SIDE_RIGHT] - theme_cache.margin_right, size.y * (1.0 - relative_margins[SIDE_BOTTOM]) - margins[SIDE_BOTTOM] - theme_cache.margin_bottom));
+
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
+		if (!c) {
+			continue;
+		}
+
+		// In case there's not enough room we shift the child according to the relative_margins.
+		Rect2 child_rect(rect);
+		Vector2 child_size = c->get_combined_minimum_size();
+		if (child_rect.size.x < child_size.x) {
+			child_rect.position.x -= (child_size.x - child_rect.size.x) * (relative_margins[SIDE_LEFT] + 1.0 - relative_margins[SIDE_RIGHT]) / 2.0;
+		}
+		if (child_rect.size.y < child_size.y) {
+			child_rect.position.y -= (child_size.y - child_rect.size.y) * (relative_margins[SIDE_TOP] + 1.0 - relative_margins[SIDE_BOTTOM]) / 2.0;
+		}
+		child_rect.size = child_rect.size.max(child_rect.size);
+		fit_child_in_rect(c, child_rect);
+	}
+}
+
+void LayoutContainer::_set_custom_relative_margin(Side p_side, real_t p_relative_margin) {
+	set_custom_relative_margin(p_side, p_relative_margin);
+}
+
+void LayoutContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_margin_layout_preset", "preset"), &LayoutContainer::set_margin_layout_preset);
+	ClassDB::bind_method(D_METHOD("get_margin_layout_preset"), &LayoutContainer::get_margin_layout_preset);
+
+	ClassDB::bind_method(D_METHOD("_set_custom_relative_margin", "side", "relative_margin"), &LayoutContainer::_set_custom_relative_margin);
+	ClassDB::bind_method(D_METHOD("set_custom_relative_margin", "side", "relative_margin", "push_opposite_margin"), &LayoutContainer::set_custom_relative_margin, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_custom_relative_margin", "side"), &LayoutContainer::get_custom_relative_margin);
+
+	ClassDB::bind_method(D_METHOD("set_margin", "side", "offset"), &LayoutContainer::set_margin);
+	ClassDB::bind_method(D_METHOD("get_margin", "side"), &LayoutContainer::get_margin);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "preset",
+						 PROPERTY_HINT_ENUM, "Top Left,Top Right,Bottom left,Bottom Right,Center left,Center Top,Center Right,Center Bottom,Center,Left Wide,Top Wide,Right Wide,Bottom Wide,Vertical Center Wide,Horizontal Center Wide,Full Rect,Custom", PROPERTY_USAGE_DEFAULT),
+			"set_margin_layout_preset", "get_margin_layout_preset");
+
+	ADD_GROUP("Custom relative margins", "custom_relative_margin_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "custom_relative_margin_left", PROPERTY_HINT_RANGE, "0,1,0.001"), "_set_custom_relative_margin", "get_custom_relative_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "custom_relative_margin_top", PROPERTY_HINT_RANGE, "0,1,0.001"), "_set_custom_relative_margin", "get_custom_relative_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "custom_relative_margin_right", PROPERTY_HINT_RANGE, "0,1,0.001"), "_set_custom_relative_margin", "get_custom_relative_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "custom_relative_margin_bottom", PROPERTY_HINT_RANGE, "0,1,0.001"), "_set_custom_relative_margin", "get_custom_relative_margin", SIDE_BOTTOM);
+
+	ADD_GROUP("Margins", "margin_");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_left", PROPERTY_HINT_RANGE, "-4096,4096,suffix:px"), "set_margin", "get_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_top", PROPERTY_HINT_RANGE, "-4096,4096,suffix:px"), "set_margin", "get_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_right", PROPERTY_HINT_RANGE, "-4096,4096,suffix:px"), "set_margin", "get_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_bottom", PROPERTY_HINT_RANGE, "-4096,4096,suffix:px"), "set_margin", "get_margin", SIDE_BOTTOM);
+
+	BIND_ENUM_CONSTANT(PRESET_TOP_LEFT);
+	BIND_ENUM_CONSTANT(PRESET_TOP_RIGHT);
+	BIND_ENUM_CONSTANT(PRESET_BOTTOM_LEFT);
+	BIND_ENUM_CONSTANT(PRESET_BOTTOM_RIGHT);
+	BIND_ENUM_CONSTANT(PRESET_CENTER_LEFT);
+	BIND_ENUM_CONSTANT(PRESET_CENTER_TOP);
+	BIND_ENUM_CONSTANT(PRESET_CENTER_RIGHT);
+	BIND_ENUM_CONSTANT(PRESET_CENTER_BOTTOM);
+	BIND_ENUM_CONSTANT(PRESET_CENTER);
+	BIND_ENUM_CONSTANT(PRESET_LEFT_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_TOP_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_RIGHT_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_BOTTOM_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_VCENTER_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_HCENTER_WIDE);
+	BIND_ENUM_CONSTANT(PRESET_FULL_RECT);
+	BIND_ENUM_CONSTANT(PRESET_CUSTOM);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, LayoutContainer, margin_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, LayoutContainer, margin_top);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, LayoutContainer, margin_right);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, LayoutContainer, margin_bottom);
+}
+
+Size2 LayoutContainer::get_minimum_size() const {
+	Size2 ms;
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *c = as_sortable_control(get_child(i));
+		if (!c) {
+			continue;
+		}
+		Size2 minsize = c->get_combined_minimum_size();
+		ms = ms.max(minsize);
+	}
+	ms += Vector2(margins[SIDE_LEFT] + margins[SIDE_RIGHT], margins[SIDE_TOP] + margins[SIDE_BOTTOM]);
+	ms += Vector2(theme_cache.margin_left + theme_cache.margin_right, theme_cache.margin_top + theme_cache.margin_bottom);
+	ms = ms.maxf(0.0);
+	return ms;
+}
+
+void LayoutContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_SORT_CHILDREN: {
+			_resort();
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			update_minimum_size();
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			queue_sort();
+		} break;
+	}
+}
+
+void LayoutContainer::_validate_property(PropertyInfo &p_property) const {
+	if (preset != LayoutContainerPreset::PRESET_CUSTOM && p_property.name.begins_with("custom_relative_margin_")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
+Vector<int> LayoutContainer::get_allowed_size_flags_horizontal() const {
+	Vector<int> flags;
+	return flags;
+}
+
+Vector<int> LayoutContainer::get_allowed_size_flags_vertical() const {
+	return {};
+}
+
+void LayoutContainer::set_margin_layout_preset(LayoutContainer::LayoutContainerPreset p_preset) {
+	if (p_preset == preset) {
+		return;
+	}
+
+	if (preset == LayoutContainerPreset::PRESET_CUSTOM || p_preset == LayoutContainerPreset::PRESET_CUSTOM) {
+		// We switch to or from custom preset, so we update the property list to hide/show relative margins.
+		preset = p_preset;
+		notify_property_list_changed();
+	} else {
+		preset = p_preset;
+	}
+
+	update_minimum_size();
+	queue_sort();
+}
+
+LayoutContainer::LayoutContainerPreset LayoutContainer::get_margin_layout_preset() const {
+	return preset;
+}
+
+void LayoutContainer::set_custom_relative_margin(Side p_side, real_t p_relative_margin, bool p_push_opposite_margin) {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_INDEX((int)p_side, 4);
+
+	custom_relative_margins[p_side] = p_relative_margin;
+
+	if (custom_relative_margins[p_side] > (1.0 - custom_relative_margins[(p_side + 2) % 4])) {
+		if (p_push_opposite_margin) {
+			custom_relative_margins[(p_side + 2) % 4] = 1.0 - custom_relative_margins[p_side];
+		} else {
+			custom_relative_margins[p_side] = 1.0 - custom_relative_margins[(p_side + 2) % 4];
+		}
+	}
+
+	queue_sort();
+}
+
+real_t LayoutContainer::get_custom_relative_margin(Side p_side) const {
+	ERR_READ_THREAD_GUARD_V(0);
+	ERR_FAIL_INDEX_V(int(p_side), 4, 0.0);
+	return custom_relative_margins[p_side];
+}
+
+void LayoutContainer::set_margin(Side p_side, real_t p_value) {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_INDEX((int)p_side, 4);
+	if (margins[p_side] == p_value) {
+		return;
+	}
+
+	margins[p_side] = p_value;
+	update_minimum_size();
+	queue_sort();
+}
+
+real_t LayoutContainer::get_margin(Side p_side) const {
+	ERR_READ_THREAD_GUARD_V(0);
+	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+
+	return margins[p_side];
+}
+
+void LayoutContainer::set_custom_relative_margin_and_offset(Side p_side, real_t p_relative_margin, real_t p_pos, bool p_push_opposite_margin) {
+	ERR_MAIN_THREAD_GUARD;
+	set_custom_relative_margin(p_side, p_relative_margin, p_push_opposite_margin);
+	set_margin(p_side, p_pos);
+}

--- a/scene/gui/layout_container.h
+++ b/scene/gui/layout_container.h
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  layout_container.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef LAYOUT_CONTAINER_H
+#define LAYOUT_CONTAINER_H
+
+#include "core/math/math_defs.h"
+#include "scene/gui/container.h"
+
+class LayoutContainer : public Container {
+	GDCLASS(LayoutContainer, Container);
+
+public:
+	enum LayoutContainerPreset {
+		PRESET_TOP_LEFT = 0,
+		PRESET_TOP_RIGHT,
+		PRESET_BOTTOM_LEFT,
+		PRESET_BOTTOM_RIGHT,
+		PRESET_CENTER_LEFT,
+		PRESET_CENTER_TOP,
+		PRESET_CENTER_RIGHT,
+		PRESET_CENTER_BOTTOM,
+		PRESET_CENTER,
+		PRESET_LEFT_WIDE,
+		PRESET_TOP_WIDE,
+		PRESET_RIGHT_WIDE,
+		PRESET_BOTTOM_WIDE,
+		PRESET_VCENTER_WIDE,
+		PRESET_HCENTER_WIDE,
+		PRESET_FULL_RECT,
+		PRESET_CUSTOM,
+		PRESET_MAX,
+	};
+
+	inline static const real_t relative_margins_presets[PRESET_CUSTOM][4] = {
+		// LEFT, TOP, RIGHT, BOTTOM.
+		{ 0.0, 0.0, 1.0, 1.0 }, // PRESET_TOP_LEFT
+		{ 1.0, 0.0, 0.0, 1.0 }, // PRESET_TOP_RIGHT
+		{ 0.0, 1.0, 1.0, 0.0 }, // PRESET_BOTTOM_LEFT
+		{ 1.0, 1.0, 0.0, 0.0 }, // PRESET_BOTTOM_RIGHT
+		{ 0.0, 0.5, 1.0, 0.5 }, // PRESET_CENTER_LEFT
+		{ 0.5, 0.0, 0.5, 1.0 }, // PRESET_CENTER_TOP
+		{ 1.0, 0.5, 0.0, 0.5 }, // PRESET_CENTER_RIGHT
+		{ 0.5, 1.0, 0.5, 0.0 }, // PRESET_CENTER_BOTTOM
+		{ 0.5, 0.5, 0.5, 0.5 }, // PRESET_CENTER
+		{ 0.0, 0.0, 1.0, 0.0 }, // PRESET_LEFT_WIDE
+		{ 0.0, 0.0, 0.0, 1.0 }, // PRESET_TOP_WIDE
+		{ 1.0, 0.0, 0.0, 0.0 }, // PRESET_RIGHT_WIDE
+		{ 0.0, 1.0, 0.0, 0.0 }, // PRESET_BOTTOM_WIDE
+		{ 0.5, 0.0, 0.5, 0.0 }, // PRESET_VCENTER_WIDE
+		{ 0.0, 0.5, 0.0, 0.5 }, // PRESET_HCENTER_WIDE
+		{ 0.0, 0.0, 0.0, 0.0 }, // PRESET_FULL_RECT
+	};
+
+private:
+	LayoutContainerPreset preset = PRESET_TOP_LEFT;
+	real_t custom_relative_margins[4] = { 0, 0, 0, 0 };
+	real_t margins[4] = { 0.0, 0.0, 0.0, 0.0 };
+
+	struct ThemeCache {
+		int margin_left = 0;
+		int margin_top = 0;
+		int margin_right = 0;
+		int margin_bottom = 0;
+	} theme_cache;
+
+	void _resort();
+
+	void _set_custom_relative_margin(Side p_side, real_t p_relative_margin);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+	virtual Size2 get_minimum_size() const override;
+	void _validate_property(PropertyInfo &p_property) const;
+
+public:
+	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
+	virtual Vector<int> get_allowed_size_flags_vertical() const override;
+
+	void set_margin_layout_preset(LayoutContainerPreset p_preset);
+	LayoutContainerPreset get_margin_layout_preset() const;
+
+	void set_custom_relative_margin(Side p_side, real_t p_relative_margin, bool p_push_opposite_margin = true);
+	real_t get_custom_relative_margin(Side p_side) const;
+
+	void set_margin(Side p_side, real_t p_value);
+	real_t get_margin(Side p_side) const;
+
+	void set_custom_relative_margin_and_offset(Side p_side, real_t p_relative_margin, real_t p_pos, bool p_push_opposite_margin = true);
+};
+
+VARIANT_ENUM_CAST(LayoutContainer::LayoutContainerPreset);
+
+#endif // LAYOUT_CONTAINER_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -62,6 +62,7 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
+#include "scene/gui/layout_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/margin_container.h"
@@ -416,6 +417,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(ColorRect);
 	GDREGISTER_CLASS(NinePatchRect);
 	GDREGISTER_CLASS(ReferenceRect);
+	GDREGISTER_CLASS(LayoutContainer);
 	GDREGISTER_CLASS(AspectRatioContainer);
 	GDREGISTER_CLASS(TabContainer);
 	GDREGISTER_CLASS(TabBar);


### PR DESCRIPTION
This implements a new `LayoutContainer`. This container aims at placing a single Control child, with a set of presets that are basically the same as the default `Control` anchors presets. This can replace both `CenterContainer`  and `MarginContainer`.

Edit:


https://github.com/godotengine/godot/assets/6093119/5b081f34-efbd-46d0-ad14-1de50d893f4c



In terms of properties, you have:
- A "relative margins" preset (center, top center, top wide, etc.), with an option "custom" option. If set to "custom", the underlying relative margins values can be set manually.
- Margins values: I used `margins` instead of `offsets` as this new container has now a minimum size. And unlike with the usual "anchors and offset" positioning, it makes little sense for a LayoutContainer to have child controls outside of its own area. So I believe using "margins" makes more sense here.
- Theme margins values: additional margins (in pixels) that can use the theme variables. This basically ensure compatibility with the MarginContainer node (which thus could be removed and replaced by a LayoutContainer node)




<details>
<summary>Original post:</summary>

https://github.com/godotengine/godot/assets/6093119/d126a5a9-7ac2-44a3-9ef6-85c51937ca53

In terms of properties, you have:
- An anchors preset (center, top center, top wide, etc.), with an option "custom" option. If set to "custom", the underlying anchors values can be set manually.
- Margins values: I used `margins` instead of `offsets` as this new container has now a minimum size. And unlike with the usual "anchors and offset" positioning, it makes little sense for a LayoutContainer to have child controls outside of its own area. So I believe using "margins" makes more sense here.
- Theme margins values: additional margins that can use the theme variables. This basically ensure compatibility with the MarginContainer node (which thus could be removed and replaced by a LayoutContainer node)

This implements parts of https://github.com/godotengine/godot-proposals/issues/4994

Edit: For the "custom" preset mode, I wonder if we should rename "anchors" to, like, "relative margins" or something, and like, invert the value for right and bottom side. Basically, "relative margins" set as (0,0,0,0) would mean "full rect",  while right now, "full rect" means anchors being (0,0,1,1).

</details>