### PR TITLE
Fix `RichTextLabel` table overlapping with next line

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -554,6 +554,8 @@ private:
 	float _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, float p_h, int *r_char_offset);
 	float _resize_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, float p_h);
 
+	void _set_table_size(ItemTable *p_table, int p_available_width);
+
 	void _update_line_font(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size);
 	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, int p_shadow_outline_size, const Point2 &p_shadow_ofs, int &r_processed_glyphs);
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool p_table = false, bool p_meta = false);


### PR DESCRIPTION
When calculating table height, `RichTextLabel::_shape_line` would increase the height when it reached the end of a complete row, or the final cell of the table.  `RichTextLabel::_resize_line` would only increase the height at the end of a complete row, causing the height to ignore the final row if not all cells were populated.  This would cause the final row to overlap with the following line in the `RichTextLabel` if it was the last visible line in the `RichTextLabel`, as `_resize_line` is called when updating scrolling properties.

This change moves the common table size calculations to a separate function to reuse the code between `_shape_line` and `_resize_line`, keeping the final cell check that was used in `_shape_line`.

Fixes #92603

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
