### PR TITLE
In debug, avoid force casting if an Autoload object is freed.

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -403,6 +403,11 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 
 		const Variant &var = gl_array[E.value];
 		if (Object *obj = var) {
+			bool freed = false;
+			var.get_validated_object_with_check(freed);	
+			if (freed) {
+				continue;
+			}
 			if (Object::cast_to<GDScriptNativeClass>(obj)) {
 				continue;
 			}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -402,9 +402,8 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 		}
 
 		const Variant &var = gl_array[E.value];
-		if (Object *obj = var) {
-			bool freed = false;
-			var.get_validated_object_with_check(freed);	
+		bool freed = false;
+		if (Object *obj = var.get_validated_object_with_check(freed)) {
 			if (freed) {
 				continue;
 			}


### PR DESCRIPTION
When checking an autoload object, they are force casted, which might result a crash if the object is freed.

This PR adds an additional check to prevent the force casting.

Fixes https://github.com/godotengine/godot/issues/92607