### PR TITLE
Vulkan: Fix `vkCmdDrawIndexed` crash on Adreno 5XX devices

### DIFF
--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -77,6 +77,7 @@ public:
 
 	struct Workarounds {
 		bool avoid_compute_after_draw = false;
+		bool avoid_render_graph_reorder = false;
 	};
 
 	struct Device {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6472,7 +6472,7 @@ void RenderingDevice::_end_frame() {
 	_submit_transfer_workers(command_buffer);
 	_submit_transfer_barriers(command_buffer);
 
-	draw_graph.end(RENDER_GRAPH_REORDER, RENDER_GRAPH_FULL_BARRIERS, command_buffer, frames[frame].command_buffer_pool);
+	draw_graph.end(render_graph_reorder, RENDER_GRAPH_FULL_BARRIERS, command_buffer, frames[frame].command_buffer_pool);
 	driver->command_buffer_end(command_buffer);
 	driver->end_segment();
 }
@@ -6713,6 +6713,12 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	device = context->device_get(device_index);
 	err = driver->initialize(device_index, frame_count);
 	ERR_FAIL_COND_V_MSG(err != OK, FAILED, "Failed to initialize driver for device.");
+
+	// Apply GPU workarounds (available only after driver initialization).
+	render_graph_reorder = RENDER_GRAPH_REORDER;
+	if (get_device_workarounds().avoid_render_graph_reorder) {
+		render_graph_reorder = false;
+	}
 
 	if (is_main_instance) {
 		// Only the singleton instance with a display should print this information.

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -182,6 +182,13 @@ private:
 	Error _buffer_initialize(Buffer *p_buffer, Span<uint8_t> p_data, uint32_t p_required_align = 32);
 
 	void update_perf_report();
+
+	// Flag for render graph reordering.
+	// Final value is set in RenderingDevice::initialize()
+	// based on '#define RENDER_GRAPH_REORDER' and GPU workarounds.
+	// Disabled on Adreno 5xx (crashes in vkCmdDrawIndexed, no perf gain).
+	bool render_graph_reorder = true;
+
 	// Flag for batching descriptor sets.
 	bool descriptor_set_batching = true;
 	// When true, the final draw call that copies our offscreen result into the Swapchain is put into its
@@ -953,6 +960,7 @@ public:
 	RenderingDeviceDriver *get_device_driver() const { return driver; }
 	RenderingContextDriver *get_context_driver() const { return context; }
 
+	const RenderingContextDriver::Workarounds &get_device_workarounds() const { return device.workarounds; }
 	const RDD::Capabilities &get_device_capabilities() const { return driver->get_capabilities(); }
 
 	bool has_feature(const Features p_feature) const;


### PR DESCRIPTION
Fixes #94741 only (Editor)

---------------

<details><summary>Outdated</summary>

for  #79760, #82602, #85097, #86037

<details><summary>previous solution</summary>

#### Workaround for the Adreno 5XX family of devices.

An issue occurs when the `vkCmdDrawIndexed` function is called multiple times between `vkCmdBeginRenderPass` 
and `vkCmdEndRenderPass`, using a shader that includes a `uniform` variable (`#define MATERIAL_UNIFORMS_USED` enabled). The crash is caused if the subsequent render operations (`Nodes`) within the same render pass do not use material shaders with a `uniform` variable.

In other words, if a shader with `uniform` variables is used within a render pass, all following render operations up to the end of the render pass must also use shaders with `uniform` variables. Otherwise, this can lead to a crash. This workaround ensures that this does not happen by making sure that shaders with `uniform` variables are consistently used between `vkCmdBeginRenderPass` and `vkCmdEndRenderPass`.

</details>

--> https://github.com/Alex2782/godot/tree/fix_uniform_crash_adreno_5xx_back

**Test project:** [ShaderTest.zip](https://github.com/user-attachments/files/15519524/ShaderTest.zip)

<details><summary>Tests on Firebase Test Lab</summary>

---------------------

- Mi A2 Lite   - Adreno (TM) 506 _(reproduced)_
- vivo 1906   - Adreno (TM) 505 _(reproduced)_
- F-01L (Fujitsu)  - Adreno (TM) 506 (_not affected)_

------------------------

**crash if:**`r_device.workarounds.force_material_uniform_set = false;`

```
F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 19822 (VkThread), pid 19502 (lex.shader_test)
F DEBUG   : backtrace:
F DEBUG   :       #00 pc 00000000000f5004  /vendor/lib64/hw/vulkan.msm8953.so (BuildId: 4059f276877a7a61cc16b085624608be)
F DEBUG   :       #01 pc 00000000000a0468  /vendor/lib64/hw/vulkan.msm8953.so (qglinternal::vkCmdDrawIndexed(VkCommandBuffer_T*, unsigned int, unsigned int, unsigned int, int, unsigned int)+232) (BuildId: 4059f276877a7a61cc16b085624608be)

```


**no crash if:** `r_device.workarounds.force_material_uniform_set = true;`

https://github.com/godotengine/godot/assets/41921395/5ecc9e47-80e1-448a-80c2-ac03419da460


</details>

</details>
