### PR TITLE
Add blend point check to `AnimationNodeBlendSpace2D::_process()`

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -278,7 +278,7 @@ void AnimationNodeBlendSpace1D::_add_blend_point(int p_index, const Ref<Animatio
 }
 
 AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	if (blend_points_used == 0) {
+	if (!blend_points_used) {
 		return NodeTimeInfo();
 	}
 

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -448,6 +448,10 @@ void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vect
 AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
 	_update_triangles();
 
+	if (!blend_points_used) {
+		return NodeTimeInfo();
+	}
+
 	Vector2 blend_pos = get_parameter(blend_position);
 	int cur_closest = get_parameter(closest);
 	NodeTimeInfo mind; //time of min distance point
@@ -455,7 +459,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {
-		if (triangles.size() == 0) {
+		if (triangles.is_empty()) {
 			return NodeTimeInfo();
 		}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92528. Check is needed same with `AnimationNodeBlendSpace1D`.