### PR TITLE
Fix popup windows content margins

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -393,7 +393,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.base_margin = config.base_spacing;
 	config.increased_margin = config.base_spacing + config.extra_spacing;
 	config.separation_margin = (config.base_spacing + config.extra_spacing / 2) * EDSCALE;
-	config.popup_margin = config.base_margin * 3 * EDSCALE;
+	config.popup_margin = config.base_margin * 2.4 * EDSCALE;
 	// Make sure content doesn't stick to window decorations; this can be fixed in future with layout changes.
 	config.window_border_margin = MAX(1, config.base_margin * 2);
 	config.top_bar_separation = config.base_margin * 2 * EDSCALE;
@@ -633,6 +633,7 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 			p_config.dialog_style = p_config.base_style->duplicate();
 			p_config.dialog_style->set_corner_radius(CORNER_TOP_LEFT, 0);
 			p_config.dialog_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
 			// Prevent visible line between window title and body.
 			p_config.dialog_style->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
 		}


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/89718

This does 2 things:

- Makes `AcceptDialog` use margins that scale with the editor scale to support HiDPI displays

- Unifies all of the popup margins in the editor by decreasing the margins of the Project/Editor Settings popups and increasing them for `AcceptDialog`s, making them meet halfway at the same value

Visual comparison (default theme, 1.5 editor scale):

**Before:**

![before](https://github.com/godotengine/godot/assets/60579014/06b7d9fd-926d-430e-a5ff-beb7212d03c0)

**After:**

![after](https://github.com/godotengine/godot/assets/60579014/4964fef5-4a7e-4baa-9191-4d436d82180a)
