### PR TITLE
Consistently display script icons for nodes in connect dialog's scene tree editor

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -232,22 +232,26 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	item->set_icon(0, icon);
 	item->set_metadata(0, p_node->get_path());
 
+	if (connecting_signal) {
+		// Add script icons for all scripted nodes.
+		Ref<Script> scr = p_node->get_script();
+		if (scr.is_valid()) {
+			item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT);
+			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr) {
+				// Disable button on custom scripts (pure visual cue).
+				item->set_button_disabled(0, item->get_button_count(0) - 1, true);
+			}
+		}
+	}
+
 	if (connect_to_script_mode) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
 		Ref<Script> scr = p_node->get_script();
-		if (!scr.is_null() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) != scr) {
-			//has script
-			item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT);
-		} else {
-			//has no script (or script is a custom type)
+		bool has_custom_script = scr.is_valid() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr;
+		if (scr.is_null() || has_custom_script) {
 			_set_item_custom_color(item, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
 			item->set_selectable(0, false);
-
-			if (!scr.is_null()) { // make sure to mark the script if a custom type
-				item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT);
-				item->set_button_disabled(0, item->get_button_count(0) - 1, true);
-			}
 
 			accent.a *= 0.7;
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
#92513 requested to be able to view script icons with/without the ConnectDialog's advanced tab enabled for better context when selecting signals.

The change made was simple, with the biggest change involving the use of 'connecting_signal' boolean to ensure all script icons are displayed (custom or otherwise) when the connect dialog scene tree is open. 
Before this change, all icon additions were made under the connect_to_script_mode. When Advanced is enabled, the connect_to_script_mode is set to false, which results in never adding the script buttons to the scene tree editor.

The fix should be low-risk because the icons are only added during connect dialog scene tree's. I would have added tests, but I noticed there are currently no test files under editor/ (and this being my first ticket, I wasn't sure how to proceed with the tests).

The 'before change' video (linked in the original ticket) displays the issue, and below I have the 'after change' result of both advanced off/on.

Advanced off:
![GODOT-92513_Advanced_Disabled](https://github.com/godotengine/godot/assets/24625454/45102c64-4df3-4666-9cea-a2b0701a4aeb)

Advanced on:
![GODOT-92513_Advanced_Enabled](https://github.com/godotengine/godot/assets/24625454/25b9c498-50f4-4a4f-9cd1-3b3695eaea3e)
 
*Bugsquad edit:*
- Fixes #92513.