### PR TITLE
Add tests for `AnimationPlayer`

### DIFF
--- a/tests/scene/test_animation_player.h
+++ b/tests/scene/test_animation_player.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  test_animation_player.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/animation/animation_player.h"
+#include "scene/resources/animation.h"
+#include "tests/test_macros.h"
+
+namespace TestAnimationPlayer {
+
+TEST_CASE("[AnimationPlayer] get & set default_blend_time") {
+	AnimationPlayer *animation_player = memnew(AnimationPlayer);
+	animation_player->set_default_blend_time(4.0);
+
+	CHECK(animation_player->get_default_blend_time() == doctest::Approx(4.0f));
+	memdelete(animation_player);
+}
+
+TEST_CASE("[AnimationPlayer] get & set blend_time") {
+	String anim1 = "animation1";
+	String anim2 = "animation2";
+	const Ref<Animation> animation1 = memnew(Animation);
+	const Ref<Animation> animation2 = memnew(Animation);
+	const Ref<AnimationLibrary> animation_library = memnew(AnimationLibrary);
+	animation_library->add_animation(anim1, animation1);
+	animation_library->add_animation(anim2, animation2);
+
+	AnimationPlayer *animation_player = memnew(AnimationPlayer);
+	animation_player->add_animation_library("", animation_library);
+
+	animation_player->set_blend_time(anim1, anim2, 4.0);
+	CHECK(animation_player->get_blend_time(anim1, anim2) == doctest::Approx(4.0f));
+	memdelete(animation_player);
+}
+
+} // namespace TestAnimationPlayer

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -122,6 +122,7 @@
 #include "tests/core/variant/test_variant_utility.h"
 #include "tests/scene/test_animation.h"
 #include "tests/scene/test_animation_blend_tree.h"
+#include "tests/scene/test_animation_player.h"
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"
 #include "tests/scene/test_button.h"


### PR DESCRIPTION
Added file test_animation_player.h under tests/scene.

File contains tests cases for methods set_default_blend_time, get_default_blend_time, set_blend_time and get_blend_time.

Modified test_main.cpp to include the new test file.

EDIT: forgot to link to issue #43440 (sorry).