### PR TITLE
Add visibility mode to `as_sortable_control()`

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -243,8 +243,8 @@ Size2 BoxContainer::get_minimum_size() const {
 	bool first = true;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
+		if (!c) {
 			continue;
 		}
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -139,9 +139,15 @@ void Container::queue_sort() {
 	pending_sort = true;
 }
 
-Control *Container::as_sortable_control(Node *p_node) const {
+Control *Container::as_sortable_control(Node *p_node, SortableVisbilityMode p_visibility_mode) const {
 	Control *c = Object::cast_to<Control>(p_node);
-	if (!c || !c->is_visible_in_tree() || c->is_set_as_top_level()) {
+	if (!c || c->is_set_as_top_level()) {
+		return nullptr;
+	}
+	if (p_visibility_mode == SortableVisbilityMode::VISIBLE && !c->is_visible()) {
+		return nullptr;
+	}
+	if (p_visibility_mode == SortableVisbilityMode::VISIBLE_IN_TREE && !c->is_visible_in_tree()) {
 		return nullptr;
 	}
 	return c;

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -41,8 +41,14 @@ class Container : public Control {
 	void _child_minsize_changed();
 
 protected:
+	enum class SortableVisbilityMode {
+		VISIBLE,
+		VISIBLE_IN_TREE,
+		IGNORE,
+	};
+
 	void queue_sort();
-	Control *as_sortable_control(Node *p_node) const;
+	Control *as_sortable_control(Node *p_node, SortableVisbilityMode p_visibility_mode = SortableVisbilityMode::VISIBLE_IN_TREE) const;
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -60,8 +60,8 @@ void GraphElement::_resort() {
 Size2 GraphElement::get_minimum_size() const {
 	Size2 minsize;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = Object::cast_to<Control>(get_child(i));
-		if (!child || child->is_set_as_top_level()) {
+		Control *child = as_sortable_control(get_child(i), SortableVisbilityMode::IGNORE);
+		if (!child) {
 			continue;
 		}
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -130,8 +130,8 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 void GraphNode::_get_property_list(List<PropertyInfo> *p_list) const {
 	int idx = 0;
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *child = Object::cast_to<Control>(get_child(i, false));
-		if (!child || child->is_set_as_top_level()) {
+		Control *child = as_sortable_control(get_child(i, false), SortableVisbilityMode::IGNORE);
+		if (!child) {
 			continue;
 		}
 
@@ -658,8 +658,8 @@ void GraphNode::_port_pos_update() {
 	int slot_index = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *child = Object::cast_to<Control>(get_child(i, false));
-		if (!child || child->is_set_as_top_level()) {
+		Control *child = as_sortable_control(get_child(i, false), SortableVisbilityMode::IGNORE);
+		if (!child) {
 			continue;
 		}
 

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -36,8 +36,8 @@ Size2 MarginContainer::get_minimum_size() const {
 	Size2 max;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
+		if (!c) {
 			continue;
 		}
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -35,7 +35,7 @@
 Size2 PanelContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -42,7 +42,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 	largest_child_min_size = Size2();
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -362,8 +362,8 @@ void TabContainer::_on_mouse_exited() {
 Vector<Control *> TabContainer::_get_tab_controls() const {
 	Vector<Control *> controls;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *control = Object::cast_to<Control>(get_child(i));
-		if (!control || control->is_set_as_top_level() || control == tab_bar || children_removing.has(control)) {
+		Control *control = as_sortable_control(get_child(i), SortableVisbilityMode::IGNORE);
+		if (!control || control == tab_bar || children_removing.has(control)) {
 			continue;
 		}
 
@@ -539,8 +539,8 @@ void TabContainer::add_child_notify(Node *p_child) {
 		return;
 	}
 
-	Control *c = Object::cast_to<Control>(p_child);
-	if (!c || c->is_set_as_top_level()) {
+	Control *c = as_sortable_control(p_child, SortableVisbilityMode::IGNORE);
+	if (!c) {
 		return;
 	}
 	c->hide();
@@ -569,8 +569,8 @@ void TabContainer::move_child_notify(Node *p_child) {
 		return;
 	}
 
-	Control *c = Object::cast_to<Control>(p_child);
-	if (c && !c->is_set_as_top_level()) {
+	Control *c = as_sortable_control(p_child, SortableVisbilityMode::IGNORE);
+	if (c) {
 		tab_bar->move_tab(c->get_meta("_tab_index"), get_tab_idx_from_control(c));
 	}
 
@@ -584,8 +584,8 @@ void TabContainer::remove_child_notify(Node *p_child) {
 		return;
 	}
 
-	Control *c = Object::cast_to<Control>(p_child);
-	if (!c || c->is_set_as_top_level()) {
+	Control *c = as_sortable_control(p_child, SortableVisbilityMode::IGNORE);
+	if (!c) {
 		return;
 	}
 


### PR DESCRIPTION
`as_sortable_control()` introduced more problems than it's worth it tbh, most of which come from unifying what's considered a sortable child to always use `is_visible_tree()`. This PR breaks the unification by introducing visibility mode to this method. By default it checks for `is_visible_in_tree()`, but it can be `is_visible()` or no visibility check, depending on needs. This allows to apply it in some classes that couldn't use it before.

Fixes #92618
Fixes https://chat.godotengine.org/channel/gui?msg=dmJWbcbv5amvaLMi9
Fixes #92812 (not tested)
(this time it was PanelContainer)
EDIT:
Also ScrollContainer: Fixes #92614 Supersedes #92714

Alternatives are making sure that containers don't break when using `is_visible_in_tree()` (unlikely, given how Control sizing is unsolved Godot problem since forever), or reverting #91613.