### PR TITLE
Fix huge .tscn icon and icon in background of File System panel

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -962,6 +962,9 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_max_text_lines(2);
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
+		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+		files->set_fixed_tag_icon_size(Size2(icon_size, icon_size));
+
 		if (thumbnail_size < 64) {
 			folder_thumbnail = get_editor_theme_icon(SNAME("FolderMediumThumb"));
 			file_thumbnail = get_editor_theme_icon(SNAME("FileMediumThumb"));

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -638,6 +638,16 @@ Size2 ItemList::Item::get_icon_size() const {
 	return size_result;
 }
 
+void ItemList::set_fixed_tag_icon_size(const Size2i &p_size) {
+	if (fixed_tag_icon_size == p_size) {
+		return;
+	}
+
+	fixed_tag_icon_size = p_size;
+	queue_redraw();
+	shape_changed = true;
+}
+
 void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -1225,13 +1235,21 @@ void ItemList::_notification(int p_what) {
 				}
 
 				if (items[i].tag_icon.is_valid()) {
+					Size2 tag_icon_size;
+					if (fixed_tag_icon_size.x > 0 && fixed_tag_icon_size.y > 0) {
+						tag_icon_size = fixed_tag_icon_size;
+					} else {
+						tag_icon_size = items[i].tag_icon->get_size();
+					}
+
 					Point2 draw_pos = items[i].rect_cache.position;
 					draw_pos.x += theme_cache.h_separation / 2;
 					draw_pos.y += theme_cache.v_separation / 2;
 					if (rtl) {
-						draw_pos.x = size.width - draw_pos.x - items[i].tag_icon->get_width();
+						draw_pos.x = size.width - draw_pos.x - tag_icon_size.x;
 					}
-					draw_texture(items[i].tag_icon, draw_pos + base_ofs);
+
+					draw_texture_rect(items[i].tag_icon, Rect2(draw_pos + base_ofs, tag_icon_size));
 				}
 
 				if (!items[i].text.is_empty()) {

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -120,6 +120,7 @@ private:
 
 	Size2 fixed_icon_size;
 	Size2 max_item_size_cache;
+	Size2 fixed_tag_icon_size;
 
 	int defer_select_single = -1;
 	bool allow_rmb_select = false;
@@ -260,6 +261,8 @@ public:
 
 	void set_fixed_icon_size(const Size2i &p_size);
 	Size2i get_fixed_icon_size() const;
+
+	void set_fixed_tag_icon_size(const Size2i &p_size);
 
 	void set_allow_rmb_select(bool p_allow);
 	bool get_allow_rmb_select() const;


### PR DESCRIPTION
Fixes #92646 

The problem was caused by a custom tag icon of the scene in the FileSystemDock `ItemList`. It was not possible to set a size for tag icons in `ItemList`, so I added the method `set_fixed_tag_icon_size` and called it in FileSystemDock.

Was able to reproduce and test with this project:
[test-godot-cloud-icon.zip](https://github.com/user-attachments/files/15523810/test-godot-cloud-icon.zip)

I guess the black square comes from the blank scene:
![image](https://github.com/godotengine/godot/assets/81109165/ed697e50-7a77-4691-94a6-9b9a70ecd204)
