### PR TITLE
Option to disable the checkerboard background of the Tiles Editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -773,6 +773,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/tiles_editor/display_grid", true);
 	_initial_set("editors/tiles_editor/highlight_selected_layer", true);
 	_initial_set("editors/tiles_editor/grid_color", Color(1.0, 0.5, 0.2, 0.5));
+	_initial_set("editors/tiles_editor/draw_checkerboard", true);
 
 	// Polygon editor
 	_initial_set("editors/polygon_editor/point_grab_radius", has_touchscreen_ui ? 32 : 8);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -774,6 +774,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/tiles_editor/highlight_selected_layer", true);
 	_initial_set("editors/tiles_editor/grid_color", Color(1.0, 0.5, 0.2, 0.5));
 	_initial_set("editors/tiles_editor/draw_checkerboard", true);
+	_initial_set("editors/tiles_editor/background_color", Color(1.0, 1.0, 1.0, 1.0));
 
 	// Polygon editor
 	_initial_set("editors/polygon_editor/point_grab_radius", has_touchscreen_ui ? 32 : 8);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -448,11 +448,17 @@ void TileAtlasView::_draw_alternatives() {
 }
 
 void TileAtlasView::_draw_background_left() {
-	background_left->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_left->get_size()), true);
+	bool draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
+	if (draw_checkerboard) {
+		background_left->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_left->get_size()), true);
+	}
 }
 
 void TileAtlasView::_draw_background_right() {
-	background_right->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_right->get_size()), true);
+	bool draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
+	if (draw_checkerboard) {
+		background_right->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_right->get_size()), true);
+	}
 }
 
 void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id) {

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -39,6 +39,8 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
+#include <scene/resources/style_box_flat.h>
+#include <scene/theme/default_theme.cpp>
 
 void TileAtlasView::gui_input(const Ref<InputEvent> &p_event) {
 	if (panner->gui_input(p_event)) {
@@ -459,8 +461,10 @@ void TileAtlasView::_draw_background_right() {
 	}
 }
 
-void TileAtlasView::_update_checkerboard_setting() {
+void TileAtlasView::_update_background_settings() {
 	draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
+	background_color = EDITOR_GET("editors/tiles_editor/background_color");
+	panel->set_self_modulate(background_color);
 	queue_redraw();
 }
 
@@ -618,7 +622,7 @@ void TileAtlasView::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
 				if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/tiles_editor")) {
-					_update_checkerboard_setting();
+					_update_background_settings();
 				}
 				break;
 			}
@@ -641,7 +645,9 @@ void TileAtlasView::_bind_methods() {
 TileAtlasView::TileAtlasView() {
 	set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 
-	Panel *panel = memnew(Panel);
+	panel = memnew(Panel);
+	background_color = EDITOR_GET("editors/tiles_editor/background_color");
+	panel->set_self_modulate(background_color);
 	panel->set_clip_contents(true);
 	panel->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 	panel->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -448,17 +448,20 @@ void TileAtlasView::_draw_alternatives() {
 }
 
 void TileAtlasView::_draw_background_left() {
-	bool draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
 	if (draw_checkerboard) {
 		background_left->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_left->get_size()), true);
 	}
 }
 
 void TileAtlasView::_draw_background_right() {
-	bool draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
 	if (draw_checkerboard) {
 		background_right->draw_texture_rect(theme_cache.checkerboard, Rect2(Vector2(), background_right->get_size()), true);
 	}
+}
+
+void TileAtlasView::_update_checkerboard_setting() {
+	draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
+	queue_redraw();
 }
 
 void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id) {
@@ -614,6 +617,9 @@ void TileAtlasView::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
+				if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/tiles_editor")) {
+					_update_checkerboard_setting();
+				}
 				break;
 			}
 			[[fallthrough]];
@@ -705,6 +711,7 @@ TileAtlasView::TileAtlasView() {
 	base_tiles_root_control->connect(SceneStringName(gui_input), callable_mp(this, &TileAtlasView::_base_tiles_root_control_gui_input));
 	left_vbox->add_child(base_tiles_root_control);
 
+	draw_checkerboard = EDITOR_GET("editors/tiles_editor/draw_checkerboard");
 	background_left = memnew(Control);
 	background_left->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 	background_left->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -39,8 +39,7 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
-#include <scene/resources/style_box_flat.h>
-#include <scene/theme/default_theme.cpp>
+#include "scene/resources/style_box_flat.h"
 
 void TileAtlasView::gui_input(const Ref<InputEvent> &p_event) {
 	if (panner->gui_input(p_event)) {

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -81,6 +81,8 @@ private:
 	void _draw_background_left();
 	Control *background_right = nullptr;
 	void _draw_background_right();
+	bool draw_checkerboard = true;
+	void _update_checkerboard_setting();
 
 	// Left side.
 	Control *base_tiles_root_control = nullptr;

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -82,7 +82,9 @@ private:
 	Control *background_right = nullptr;
 	void _draw_background_right();
 	bool draw_checkerboard = true;
-	void _update_checkerboard_setting();
+	void _update_background_settings();
+	Color background_color = Color(1.0, 1.0, 1.0, 1.0);
+	Panel *panel = nullptr;
 
 	// Left side.
 	Control *base_tiles_root_control = nullptr;


### PR DESCRIPTION
Some pixel art is hard to see with a transparent background in the tiles editor for tilesets and the tilemap tile selector. I have added a basic bool option to disable the checkboard background from these panels to make it easier to see.

Checkboard Enabled (default):
![checkboard_on](https://github.com/godotengine/godot/assets/6030030/c1dc4b32-8dfd-48e8-89ad-8102f7b14d1f)

Checkboard disabled:
![checkboard_off](https://github.com/godotengine/godot/assets/6030030/c2b3e1aa-5bf8-4a3e-9c3d-bfd0538fe100)

Settings:
![settings](https://github.com/godotengine/godot/assets/6030030/681a5ea1-fe44-497c-944f-db6eea268f5d)

Works for the tile selector as well.
![tilse_selector_on](https://github.com/godotengine/godot/assets/6030030/b5923a6d-3fcf-452d-9b42-b43f00e7011b)
![tile_selector_off](https://github.com/godotengine/godot/assets/6030030/83197573-78bf-4608-9ae5-e628a67e6472)
