### PR TITLE
Duplicate properties first before remapping resources

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2771,11 +2771,11 @@ Node *Node::duplicate(int p_flags) const {
 	ERR_THREAD_GUARD_V(nullptr);
 	Node *dupe = _duplicate(p_flags);
 
+	_duplicate_properties(this, this, dupe, p_flags);
+
 	if (dupe && (p_flags & DUPLICATE_SIGNALS)) {
 		_duplicate_signals(this, dupe);
 	}
-
-	_duplicate_properties(this, this, dupe, p_flags);
 
 	return dupe;
 }
@@ -2789,6 +2789,8 @@ Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap, con
 	int flags = DUPLICATE_SIGNALS | DUPLICATE_GROUPS | DUPLICATE_SCRIPTS | DUPLICATE_USE_INSTANTIATION | DUPLICATE_FROM_EDITOR;
 	Node *dupe = _duplicate(flags, &r_duplimap);
 
+	_duplicate_properties(this, this, dupe, flags);
+
 	// This is used by SceneTreeDock's paste functionality. When pasting to foreign scene, resources are duplicated.
 	if (!p_resource_remap.is_empty()) {
 		remap_node_resources(dupe, p_resource_remap);
@@ -2798,8 +2800,6 @@ Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap, con
 	// because re-targeting of connections from some descendant to another is not possible
 	// if the emitter node comes later in tree order than the receiver
 	_duplicate_signals(this, dupe);
-
-	_duplicate_properties(this, this, dupe, flags);
 
 	return dupe;
 }


### PR DESCRIPTION
```_duplicate_properties``` was done as a last operation of ```duplicate_from_editor```/```duplicate``` funtion. This PR moves ```_duplicate_properties``` to be done first after ```_duplicate``` function. This should fix the issue of duplicated resource(s) still sharing a reference with an original scene.

https://github.com/godotengine/godot/assets/33091666/165503ea-a510-434e-9c07-ad15bf251a2d



Fixes: https://github.com/godotengine/godot/issues/92641
