### PR TITLE
Add confirm dialog for render mesh to navigation mesh conversion

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -214,28 +214,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 		} break;
 
 		case MENU_OPTION_CREATE_NAVMESH: {
-			Ref<NavigationMesh> nmesh = memnew(NavigationMesh);
-
-			if (nmesh.is_null()) {
-				return;
-			}
-
-			nmesh->create_from_mesh(mesh);
-			NavigationRegion3D *nmi = memnew(NavigationRegion3D);
-			nmi->set_navigation_mesh(nmesh);
-
-			Node *owner = get_tree()->get_edited_scene_root();
-
-			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(TTR("Create Navigation Mesh"));
-
-			ur->add_do_method(node, "add_child", nmi, true);
-			ur->add_do_method(nmi, "set_owner", owner);
-			ur->add_do_method(Node3DEditor::get_singleton(), SceneStringName(_request_gizmo), nmi);
-
-			ur->add_do_reference(nmi);
-			ur->add_undo_method(node, "remove_child", nmi);
-			ur->commit_action();
+			navigation_mesh_dialog->popup_centered(Vector2(200, 90));
 		} break;
 
 		case MENU_OPTION_CREATE_OUTLINE_MESH: {
@@ -472,6 +451,36 @@ void MeshInstance3DEditor::_debug_uv_draw() {
 	debug_uv->draw_multiline(uv_lines, get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.5));
 }
 
+void MeshInstance3DEditor::_create_navigation_mesh() {
+	Ref<Mesh> mesh = node->get_mesh();
+	if (mesh.is_null()) {
+		return;
+	}
+
+	Ref<NavigationMesh> nmesh = memnew(NavigationMesh);
+
+	if (nmesh.is_null()) {
+		return;
+	}
+
+	nmesh->create_from_mesh(mesh);
+	NavigationRegion3D *nmi = memnew(NavigationRegion3D);
+	nmi->set_navigation_mesh(nmesh);
+
+	Node *owner = get_tree()->get_edited_scene_root();
+
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Create Navigation Mesh"));
+
+	ur->add_do_method(node, "add_child", nmi, true);
+	ur->add_do_method(nmi, "set_owner", owner);
+	ur->add_do_method(Node3DEditor::get_singleton(), SceneStringName(_request_gizmo), nmi);
+
+	ur->add_do_reference(nmi);
+	ur->add_undo_method(node, "remove_child", nmi);
+	ur->commit_action();
+}
+
 void MeshInstance3DEditor::_create_outline_mesh() {
 	Ref<Mesh> mesh = node->get_mesh();
 	if (mesh.is_null()) {
@@ -608,6 +617,20 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
 	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_dialog->add_child(debug_uv);
+
+	navigation_mesh_dialog = memnew(ConfirmationDialog);
+	navigation_mesh_dialog->set_title(TTR("Create NavigationMesh"));
+	navigation_mesh_dialog->set_ok_button_text(TTR("Create"));
+
+	VBoxContainer *navigation_mesh_dialog_vbc = memnew(VBoxContainer);
+	navigation_mesh_dialog->add_child(navigation_mesh_dialog_vbc);
+
+	Label *navigation_mesh_l = memnew(Label);
+	navigation_mesh_l->set_text(TTR("Before converting a rendering mesh to a navigation mesh, please verify:\n\n- The mesh is two-dimensional.\n- The mesh has no surface overlap.\n- The mesh has no self-intersection.\n- The mesh surfaces have indices.\n\nIf the mesh does not fulfill these requirements, the pathfinding will be broken."));
+	navigation_mesh_dialog_vbc->add_child(navigation_mesh_l);
+
+	add_child(navigation_mesh_dialog);
+	navigation_mesh_dialog->connect("confirmed", callable_mp(this, &MeshInstance3DEditor::_create_navigation_mesh));
 }
 
 void MeshInstance3DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -82,10 +82,13 @@ class MeshInstance3DEditor : public Control {
 	Control *debug_uv = nullptr;
 	Vector<Vector2> uv_lines;
 
+	ConfirmationDialog *navigation_mesh_dialog = nullptr;
+
 	void _create_collision_shape();
 	Vector<Ref<Shape3D>> create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose);
 	void _menu_option(int p_option);
 	void _create_outline_mesh();
+	void _create_navigation_mesh();
 
 	void _create_uv_lines(int p_layer);
 	friend class MeshInstance3DEditorPlugin;


### PR DESCRIPTION
Adds confirm dialog for render mesh to navigation mesh conversion that lists all the requirement for the pathfinding.

![navmesh_warning](https://github.com/godotengine/godot/assets/52464204/c40592ee-6efb-4af9-9775-f9deb1c5d724)

Adding this confirm dialog has basically the same reasoning why I wanted that option to be gone in the past as the situation has not changed and users create regular issues and complains. See https://github.com/godotengine/godot/pull/77702.

Most  rendering meshes are invalid to be used 1:1 as a navigation mesh and there is no sensible way to verify this upfront.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
