### PR TITLE
Fix iOS exports never embedding framework bundles

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1357,12 +1357,7 @@ void EditorExportPlatformIOS::_add_assets_to_project(const String &p_out_dir, co
 
 		String type;
 		if (asset.exported_path.ends_with(".framework")) {
-			int total_libs = 0;
-			int static_libs = 0;
-			int dylibs = 0;
-			int frameworks = 0;
-			_check_xcframework_content(p_out_dir.path_join(asset.exported_path), total_libs, static_libs, dylibs, frameworks);
-			if (asset.should_embed && (static_libs != total_libs)) {
+			if (asset.should_embed) {
 				additional_asset_info_format += "$framework_id = {isa = PBXBuildFile; fileRef = $ref_id; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };\n";
 				framework_id = (++current_id).str();
 				pbx_embeded_frameworks += framework_id + ",\n";


### PR DESCRIPTION
This partially reverts #86288.

Currently when exporting projects for iOS that (for example) rely on a GDExtension which is built as a `.framework` bundle, you will find that while said `.framework` bundle is exported along with the Xcode project, it doesn't actually get embedded into the app bundle when building/archiving, which breaks the application.

This seems to be because the iOS export plugin currently treats `.framework` the same as `.xcframework`, where it expects there to be an `AvailableLibraries` key in the bundle `Info.plist`, which doesn't seem to be a thing for regular `.framework` bundles.

This PR fixes this issue by going back to the behavior prior to #86288 for `.framework` bundles specifically, where `IOSExportAsset::should_embed` is always respected.