### PR TITLE
Simplify the initialization of the static variables holding class names

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -411,10 +411,7 @@ public:                                                                         
 		return String(#m_class);                                                                                                                 \
 	}                                                                                                                                            \
 	virtual const StringName *_get_class_namev() const override {                                                                                \
-		static StringName _class_name_static;                                                                                                    \
-		if (unlikely(!_class_name_static)) {                                                                                                     \
-			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                          \
-		}                                                                                                                                        \
+		static StringName _class_name_static = StringName(#m_class, true);                                                                       \
 		return &_class_name_static;                                                                                                              \
 	}                                                                                                                                            \
 	static _FORCE_INLINE_ void *get_class_ptr_static() {                                                                                         \
@@ -753,10 +750,7 @@ protected:
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	virtual const StringName *_get_class_namev() const {
-		static StringName _class_name_static;
-		if (unlikely(!_class_name_static)) {
-			StringName::assign_static_unique_class_name(&_class_name_static, "Object");
-		}
+		static StringName _class_name_static = StringName("Object", true);
 		return &_class_name_static;
 	}
 

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -199,14 +199,6 @@ StringName::StringName(const StringName &p_name) {
 	}
 }
 
-void StringName::assign_static_unique_class_name(StringName *ptr, const char *p_name) {
-	mutex.lock();
-	if (*ptr == StringName()) {
-		*ptr = StringName(p_name, true);
-	}
-	mutex.unlock();
-}
-
 StringName::StringName(const char *p_name, bool p_static) {
 	_data = nullptr;
 

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -182,7 +182,6 @@ public:
 	StringName(const StaticCString &p_static_string, bool p_static = false);
 	StringName() {}
 
-	static void assign_static_unique_class_name(StringName *ptr, const char *p_name);
 	_FORCE_INLINE_ ~StringName() {
 		if (likely(configured) && _data) { //only free if configured
 			unref();


### PR DESCRIPTION
Before these changes the logic for lazy initialization of StringNames for the names of classes contained a manual check against double initialization as well as invoking a helper from StringName that locked the initialization with StringName's mutex. (The helper was inside StringName, using its mutex, because the thing that makes initializing the names slow enough that it makes sense to cache them is the string interning done by StringName.)

Since C++11 the language standard itself [guarantees](https://stackoverflow.com/questions/8102125/is-local-static-variable-initialization-thread-safe-in-c11) (Section 6.7.4) that block-scope static variables are initialized thread-safely. So we can remove the extra complexity here.