### PR TITLE
[Button] Adds theme option to align button text and icon to either largest or current stylebox.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -118,6 +118,9 @@
 		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
+		<theme_item name="align_to_largest_stylebox" data_type="constant" type="int" default="0">
+			This constant acts as a boolean. If [code]true[/code], text and icon are always aligned to the largest stylebox margins, otherwise it's aligned to the current button state stylebox margins.
+		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -728,6 +728,8 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
 		p_theme->set_constant("outline_size", "Button", 0);
 
+		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
+
 		// MenuButton.
 
 		p_theme->set_stylebox(CoreStringName(normal), "MenuButton", p_config.panel_container_style);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -121,6 +121,7 @@ void Button::_update_theme_item_cache() {
 		theme_cache.style_margin_top = MAX(theme_cache.style_margin_top, theme_cache.disabled->get_margin(SIDE_TOP));
 		theme_cache.style_margin_bottom = MAX(theme_cache.style_margin_bottom, theme_cache.disabled->get_margin(SIDE_BOTTOM));
 	}
+	theme_cache.max_style_size = theme_cache.max_style_size.max(Vector2(theme_cache.style_margin_left + theme_cache.style_margin_right, theme_cache.style_margin_top + theme_cache.style_margin_bottom));
 }
 
 Size2 Button::_get_largest_stylebox_size() const {
@@ -214,9 +215,10 @@ void Button::_notification(int p_what) {
 			const RID ci = get_canvas_item();
 			const Size2 size = get_size();
 
+			Ref<StyleBox> style = _get_current_stylebox();
 			// Draws the stylebox in the current state.
 			if (!flat) {
-				_get_current_stylebox()->draw(ci, Rect2(Point2(), size));
+				style->draw(ci, Rect2(Point2(), size));
 			}
 
 			if (has_focus()) {
@@ -232,18 +234,23 @@ void Button::_notification(int p_what) {
 				break;
 			}
 
+			const float style_margin_left = (theme_cache.align_to_largest_stylebox) ? theme_cache.style_margin_left : style->get_margin(SIDE_LEFT);
+			const float style_margin_right = (theme_cache.align_to_largest_stylebox) ? theme_cache.style_margin_right : style->get_margin(SIDE_RIGHT);
+			const float style_margin_top = (theme_cache.align_to_largest_stylebox) ? theme_cache.style_margin_top : style->get_margin(SIDE_TOP);
+			const float style_margin_bottom = (theme_cache.align_to_largest_stylebox) ? theme_cache.style_margin_bottom : style->get_margin(SIDE_BOTTOM);
+
 			Size2 drawable_size_remained = size;
 
 			{ // The size after the stelybox is stripped.
-				drawable_size_remained.width -= theme_cache.style_margin_left + theme_cache.style_margin_right;
-				drawable_size_remained.height -= theme_cache.style_margin_top + theme_cache.style_margin_bottom;
+				drawable_size_remained.width -= style_margin_left + style_margin_right;
+				drawable_size_remained.height -= style_margin_top + style_margin_bottom;
 			}
 
 			const int h_separation = MAX(0, theme_cache.h_separation);
 
 			float left_internal_margin_with_h_separation = _internal_margin[SIDE_LEFT];
 			float right_internal_margin_with_h_separation = _internal_margin[SIDE_RIGHT];
-			{ // The width reserved for internal element in derived classes (and h_separation if need).
+			{ // The width reserved for internal element in derived classes (and h_separation if needed).
 
 				if (_internal_margin[SIDE_LEFT] > 0.0f) {
 					left_internal_margin_with_h_separation += h_separation;
@@ -381,12 +388,12 @@ void Button::_notification(int p_what) {
 							[[fallthrough]];
 						case HORIZONTAL_ALIGNMENT_FILL:
 						case HORIZONTAL_ALIGNMENT_LEFT: {
-							icon_ofs.x += theme_cache.style_margin_left;
+							icon_ofs.x += style_margin_left;
 							icon_ofs.x += left_internal_margin_with_h_separation;
 						} break;
 
 						case HORIZONTAL_ALIGNMENT_RIGHT: {
-							icon_ofs.x = size.x - theme_cache.style_margin_right;
+							icon_ofs.x = size.x - style_margin_right;
 							icon_ofs.x -= right_internal_margin_with_h_separation;
 							icon_ofs.x -= icon_size.width;
 						} break;
@@ -399,11 +406,11 @@ void Button::_notification(int p_what) {
 							[[fallthrough]];
 						case VERTICAL_ALIGNMENT_FILL:
 						case VERTICAL_ALIGNMENT_TOP: {
-							icon_ofs.y += theme_cache.style_margin_top;
+							icon_ofs.y += style_margin_top;
 						} break;
 
 						case VERTICAL_ALIGNMENT_BOTTOM: {
-							icon_ofs.y = size.y - theme_cache.style_margin_bottom - icon_size.height;
+							icon_ofs.y = size.y - style_margin_bottom - icon_size.height;
 						} break;
 					}
 					icon_ofs = icon_ofs.floor();
@@ -442,7 +449,7 @@ void Button::_notification(int p_what) {
 					case HORIZONTAL_ALIGNMENT_FILL:
 					case HORIZONTAL_ALIGNMENT_LEFT:
 					case HORIZONTAL_ALIGNMENT_RIGHT: {
-						text_ofs.x += theme_cache.style_margin_left;
+						text_ofs.x += style_margin_left;
 						text_ofs.x += left_internal_margin_with_h_separation;
 						if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 							// Offset by the space's width that occupied by icon and h_separation together.
@@ -451,7 +458,7 @@ void Button::_notification(int p_what) {
 					} break;
 				}
 
-				text_ofs.y = (drawable_size_remained.height - text_buf->get_size().height) / 2.0f + theme_cache.style_margin_top;
+				text_ofs.y = (drawable_size_remained.height - text_buf->get_size().height) / 2.0f + style_margin_top;
 				if (vertical_icon_alignment == VERTICAL_ALIGNMENT_TOP) {
 					text_ofs.y += custom_element_size.height - drawable_size_remained.height; // Offset by the icon's height.
 				}
@@ -491,6 +498,21 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 	Size2 minsize = paragraph->get_size();
 	if (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF) {
 		minsize.width = 0;
+	}
+
+	float left_internal_margin_with_h_separation = _internal_margin[SIDE_LEFT];
+	float right_internal_margin_with_h_separation = _internal_margin[SIDE_RIGHT];
+	{ // The width reserved for internal element in derived classes (and h_separation if needed).
+
+		if (_internal_margin[SIDE_LEFT] > 0.0f) {
+			left_internal_margin_with_h_separation += theme_cache.h_separation;
+		}
+
+		if (_internal_margin[SIDE_RIGHT] > 0.0f) {
+			right_internal_margin_with_h_separation += theme_cache.h_separation;
+		}
+
+		minsize.width += left_internal_margin_with_h_separation + right_internal_margin_with_h_separation; // The size after the internal element is stripped.
 	}
 
 	if (!expand_icon && p_icon.is_valid()) {
@@ -828,6 +850,8 @@ void Button::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Button, h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Button, icon_max_width);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Button, align_to_largest_stylebox);
 }
 
 Button::Button(const String &p_text) {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -75,6 +75,8 @@ private:
 		float style_margin_top = 0;
 		float style_margin_bottom = 0;
 
+		bool align_to_largest_stylebox = false;
+
 		Color font_color;
 		Color font_focus_color;
 		Color font_pressed_color;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -187,6 +187,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("h_separation", "Button", Math::round(4 * scale));
 	theme->set_constant("icon_max_width", "Button", 0);
 
+	theme->set_constant("align_to_largest_stylebox", "Button", 0); // Disabled.
+
 	// MenuBar
 	theme->set_stylebox(CoreStringName(normal), "MenuBar", button_normal);
 	theme->set_stylebox("hover", "MenuBar", button_hover);


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/92625

Adds new theme option (disabled for default theme and enabled for the editor theme) to control whether button elements are aligned to largest or current stylebox.

Fixes button issues cause by https://github.com/godotengine/godot/pull/92009 without reintroducing https://github.com/godotengine/godot/pull/92009#issuecomment-2114744369

Fixes https://github.com/godotengine/godot/issues/92602
Fixes https://github.com/godotengine/godot/issues/92466
