### PR TITLE
Clarify the results of `VectorN.normalized()` in the docs

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -324,7 +324,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
 				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
 			</description>
 		</method>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -293,7 +293,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
 				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
 			</description>
 		</method>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -227,7 +227,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector4" />
 			<description>
-				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0, 0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
 				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
 			</description>
 		</method>


### PR DESCRIPTION
The current documentation for `VectorN.normalized()` does not explicitly state what happens if you normalize a zero-length vector. As there are at least two logical outcomes (a divide by zero error or `VectorN.Zero`), it is worth it to specify how godot handles this case; something which is potentially further confused by the note RE potential odd behavior when the vector length is very small.

This change simply adds the clarifying note that normalizing a zero-length vector will return `(0,0)`, `(0,0,0)`, or `(0,0,0,0)`, depending on the vector size normalized. 