### PR TITLE
Android: Fix invalid return value when multiple permission requests are dispatched

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
@@ -125,7 +125,7 @@ public final class PermissionsUtil {
 		}
 
 		activity.requestPermissions(requestedPermissions.toArray(new String[0]), REQUEST_ALL_PERMISSION_REQ_CODE);
-		return true;
+		return false;
 	}
 
 	/**
@@ -281,8 +281,9 @@ public final class PermissionsUtil {
 	public static boolean hasManifestPermission(Context context, String permission) {
 		try {
 			for (String p : getManifestPermissions(context)) {
-				if (permission.equals(p))
+				if (permission.equals(p)) {
 					return true;
+				}
 			}
 		} catch (PackageManager.NameNotFoundException ignored) {
 		}
@@ -299,8 +300,9 @@ public final class PermissionsUtil {
 	public static ArrayList<String> getManifestPermissions(Context context) throws PackageManager.NameNotFoundException {
 		PackageManager packageManager = context.getPackageManager();
 		PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
-		if (packageInfo.requestedPermissions == null)
-			return new ArrayList<String>();
+		if (packageInfo.requestedPermissions == null) {
+			return new ArrayList<>();
+		}
 		return new ArrayList<>(Arrays.asList(packageInfo.requestedPermissions));
 	}
 


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/89260 refactored the previous logic and in the process accidentally changed the return value when requesting multiple permissions from [`false`](https://github.com/godotengine/godot/blob/df4f9e8e64321cf31a1cffd71fe8fe1879c7cd49/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java#L193) to [`true`](https://github.com/godotengine/godot/blob/900fc2a35aa5eec21a8f2d34739c89a0ce3710e0/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java#L128)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
