### PR TITLE
Fix scroll bar will disapplear in scroll container the second time open it

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -42,8 +42,8 @@ Size2 ScrollContainer::get_minimum_size() const {
 	largest_child_min_size = Size2();
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
-		if (!c) {
+		Control *c = Object::cast_to<Control>(get_child(i));
+		if (!c || !c->is_visible() || c->is_set_as_top_level()) {
 			continue;
 		}
 		if (c == h_scroll || c == v_scroll) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92614, it looks like when `get_minimum_size` we should not check `is_visible_in_tree` ? cc @KoBeWi 

Thanks for @matheusmdx for bisecting ❤️ 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
