### PR TITLE
[TextServer, GDExtension] Fix building text servers as GDExtension, expose new/changed low-level methods to GDExtension API.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -805,10 +805,22 @@ static void gdextension_string_new_with_utf8_chars_and_len(GDExtensionUninitiali
 	dest->parse_utf8(p_contents, p_size);
 }
 
+static GDExtensionInt gdextension_string_new_with_utf8_chars_and_len2(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
+	memnew_placement(r_dest, String);
+	String *dest = reinterpret_cast<String *>(r_dest);
+	return (GDExtensionInt)dest->parse_utf8(p_contents, p_size);
+}
+
 static void gdextension_string_new_with_utf16_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count) {
 	memnew_placement(r_dest, String);
 	String *dest = reinterpret_cast<String *>(r_dest);
 	dest->parse_utf16(p_contents, p_char_count);
+}
+
+static GDExtensionInt gdextension_string_new_with_utf16_chars_and_len2(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count, GDExtensionBool p_default_little_endian) {
+	memnew_placement(r_dest, String);
+	String *dest = reinterpret_cast<String *>(r_dest);
+	return (GDExtensionInt)dest->parse_utf16(p_contents, p_char_count, p_default_little_endian);
 }
 
 static void gdextension_string_new_with_utf32_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_char_count) {
@@ -960,6 +972,16 @@ static void gdextension_file_access_store_buffer(GDExtensionObjectPtr p_instance
 static uint64_t gdextension_file_access_get_buffer(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length) {
 	const FileAccess *fa = (FileAccess *)p_instance;
 	return fa->get_buffer(p_dst, p_length);
+}
+
+static uint8_t *gdextension_image_ptrw(GDExtensionObjectPtr p_instance) {
+	Image *img = (Image *)p_instance;
+	return img->ptrw();
+}
+
+static const uint8_t *gdextension_image_ptr(GDExtensionObjectPtr p_instance) {
+	Image *img = (Image *)p_instance;
+	return img->ptr();
 }
 
 static int64_t gdextension_worker_thread_pool_add_native_group_task(GDExtensionObjectPtr p_instance, void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description) {
@@ -1598,7 +1620,9 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(string_new_with_wide_chars);
 	REGISTER_INTERFACE_FUNC(string_new_with_latin1_chars_and_len);
 	REGISTER_INTERFACE_FUNC(string_new_with_utf8_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf8_chars_and_len2);
 	REGISTER_INTERFACE_FUNC(string_new_with_utf16_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf16_chars_and_len2);
 	REGISTER_INTERFACE_FUNC(string_new_with_utf32_chars_and_len);
 	REGISTER_INTERFACE_FUNC(string_new_with_wide_chars_and_len);
 	REGISTER_INTERFACE_FUNC(string_to_latin1_chars);
@@ -1684,6 +1708,8 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(editor_remove_plugin);
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars);
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars_and_len);
+	REGISTER_INTERFACE_FUNC(image_ptrw);
+	REGISTER_INTERFACE_FUNC(image_ptr);
 }
 
 #undef REGISTER_INTERFACE_FUNCTION

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -1582,6 +1582,7 @@ typedef void (*GDExtensionInterfaceStringNewWithLatin1CharsAndLen)(GDExtensionUn
 /**
  * @name string_new_with_utf8_chars_and_len
  * @since 4.1
+ * @deprecated in Godot 4.3. Use `string_new_with_utf8_chars_and_len2` instead.
  *
  * Creates a String from a UTF-8 encoded C string with the given length.
  *
@@ -1592,8 +1593,23 @@ typedef void (*GDExtensionInterfaceStringNewWithLatin1CharsAndLen)(GDExtensionUn
 typedef void (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
 
 /**
+ * @name string_new_with_utf8_chars_and_len2
+ * @since 4.3
+ *
+ * Creates a String from a UTF-8 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of bytes (not code units).
+ *
+ * @return Error code signifying if the operation successful.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen2)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
  * @name string_new_with_utf16_chars_and_len
  * @since 4.1
+ * @deprecated in Godot 4.3. Use `string_new_with_utf16_chars_and_len2` instead.
  *
  * Creates a String from a UTF-16 encoded C string with the given length.
  *
@@ -1602,6 +1618,21 @@ typedef void (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen)(GDExtensionUnin
  * @param p_size The number of characters (not bytes).
  */
 typedef void (*GDExtensionInterfaceStringNewWithUtf16CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count);
+
+/**
+ * @name string_new_with_utf16_chars_and_len2
+ * @since 4.3
+ *
+ * Creates a String from a UTF-16 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string.
+ * @param p_size The number of characters (not bytes).
+ * @param p_default_little_endian If true, UTF-16 use little endian.
+ *
+ * @return Error code signifying if the operation successful.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringNewWithUtf16CharsAndLen2)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count, GDExtensionBool p_default_little_endian);
 
 /**
  * @name string_new_with_utf32_chars_and_len
@@ -1898,6 +1929,36 @@ typedef void (*GDExtensionInterfaceFileAccessStoreBuffer)(GDExtensionObjectPtr p
  * @return The actual number of bytes read (may be less than requested).
  */
 typedef uint64_t (*GDExtensionInterfaceFileAccessGetBuffer)(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length);
+
+/* INTERFACE: Image Utilities */
+
+/**
+ * @name image_ptrw
+ * @since 4.3
+ *
+ * Returns writable pointer to internal Image buffer.
+ *
+ * @param p_instance A pointer to a Image object.
+ *
+ * @return Pointer to internal Image buffer.
+ *
+ * @see Image::ptrw()
+ */
+typedef uint8_t *(*GDExtensionInterfaceImagePtrw)(GDExtensionObjectPtr p_instance);
+
+/**
+ * @name image_ptr
+ * @since 4.3
+ *
+ * Returns read only pointer to internal Image buffer.
+ *
+ * @param p_instance A pointer to a Image object.
+ *
+ * @return Pointer to internal Image buffer.
+ *
+ * @see Image::ptr()
+ */
+typedef const uint8_t *(*GDExtensionInterfaceImagePtr)(GDExtensionObjectPtr p_instance);
 
 /* INTERFACE: WorkerThreadPool Utilities */
 

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3312,7 +3312,7 @@ uint8_t *Image::ptrw() {
 	return data.ptrw();
 }
 
-int64_t Image::data_size() const {
+int64_t Image::get_data_size() const {
 	return data.size();
 }
 
@@ -3427,6 +3427,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Image::has_mipmaps);
 	ClassDB::bind_method(D_METHOD("get_format"), &Image::get_format);
 	ClassDB::bind_method(D_METHOD("get_data"), &Image::get_data);
+	ClassDB::bind_method(D_METHOD("get_data_size"), &Image::get_data_size);
 
 	ClassDB::bind_method(D_METHOD("convert", "format"), &Image::convert);
 
@@ -3443,7 +3444,10 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::generate_mipmaps, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_static_method("Image", D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::create_empty);
+#endif
+	ClassDB::bind_static_method("Image", D_METHOD("create_empty", "width", "height", "use_mipmaps", "format"), &Image::create_empty);
 	ClassDB::bind_static_method("Image", D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::create_from_data);
 	ClassDB::bind_method(D_METHOD("set_data", "width", "height", "use_mipmaps", "format", "data"), &Image::set_data);
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -429,7 +429,7 @@ public:
 
 	const uint8_t *ptr() const;
 	uint8_t *ptrw();
-	int64_t data_size() const;
+	int64_t get_data_size() const;
 
 	void adjust_bcs(float p_brightness, float p_contrast, float p_saturation);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2265,6 +2265,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Dictionary, get_or_add, sarray("key", "default"), varray(Variant()));
 	bind_method(Dictionary, make_read_only, sarray(), varray());
 	bind_method(Dictionary, is_read_only, sarray(), varray());
+	bind_method(Dictionary, recursive_equal, sarray("dictionary", "recursion_count"), varray());
 }
 
 static void _register_variant_builtin_methods_array() {

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -358,6 +358,14 @@
 				See also [method merge].
 			</description>
 		</method>
+		<method name="recursive_equal" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="dictionary" type="Dictionary" />
+			<param index="1" name="recursion_count" type="int" />
+			<description>
+				Returns [code]true[/code] if the two dictionaries contain the same keys and values, inner [Dictionary] and [Array] keys and values are compared recursively.
+			</description>
+		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -118,7 +118,17 @@
 				Copies [param src] image to this image.
 			</description>
 		</method>
-		<method name="create" qualifiers="static">
+		<method name="create" qualifiers="static" deprecated="Use [method create_empty].">
+			<return type="Image" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="use_mipmaps" type="bool" />
+			<param index="3" name="format" type="int" enum="Image.Format" />
+			<description>
+				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+			</description>
+		</method>
+		<method name="create_empty" qualifiers="static">
 			<return type="Image" />
 			<param index="0" name="width" type="int" />
 			<param index="1" name="height" type="int" />
@@ -212,6 +222,12 @@
 			<return type="PackedByteArray" />
 			<description>
 				Returns a copy of the image's raw data.
+			</description>
+		</method>
+		<method name="get_data_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns size (in bytes) of the image's raw data.
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -61,8 +61,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     thirdparty_tvg_dir = "../../../thirdparty/thorvg/"
     thirdparty_tvg_sources = [
         # common
-        "src/common/tvgBezier.cpp",
         "src/common/tvgCompressor.cpp",
+        "src/common/tvgLines.cpp",
         "src/common/tvgMath.cpp",
         "src/common/tvgStr.cpp",
         # SVG parser
@@ -73,6 +73,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/loaders/svg/tvgSvgUtil.cpp",
         "src/loaders/svg/tvgXmlParser.cpp",
         "src/loaders/raw/tvgRawLoader.cpp",
+        # image loaders
         "src/loaders/external_png/tvgPngLoader.cpp",
         "src/loaders/jpg/tvgJpgd.cpp",
         "src/loaders/jpg/tvgJpgLoader.cpp",
@@ -117,6 +118,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
             "../../../thirdparty/thorvg/src/loaders/raw",
             "../../../thirdparty/thorvg/src/loaders/external_png",
             "../../../thirdparty/thorvg/src/loaders/jpg",
+            "../../../thirdparty/libpng",
         ]
     )
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -851,7 +851,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 		{
 			// Zero texture.
 			uint8_t *w = tex.image->ptrw();
-			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.image->data_size(), ret);
+			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.image->get_data_size(), ret);
 			// Initialize the texture to all-white pixels to prevent artifacts when the
 			// font is displayed at a non-default scale with filtering enabled.
 			if (p_color_size == 2) {
@@ -1040,7 +1040,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 			for (int i = 0; i < h; i++) {
 				for (int j = 0; j < w; j++) {
 					int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * 4;
-					ERR_FAIL_COND_V(ofs >= tex.image->data_size(), FontGlyph());
+					ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
 					wr[ofs + 0] = (uint8_t)(CLAMP(image(j, i)[0] * 256.f, 0.f, 255.f));
 					wr[ofs + 1] = (uint8_t)(CLAMP(image(j, i)[1] * 256.f, 0.f, 255.f));
 					wr[ofs + 2] = (uint8_t)(CLAMP(image(j, i)[2] * 256.f, 0.f, 255.f));
@@ -1118,7 +1118,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 		for (int i = 0; i < h; i++) {
 			for (int j = 0; j < w; j++) {
 				int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * color_size;
-				ERR_FAIL_COND_V(ofs >= tex.image->data_size(), FontGlyph());
+				ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
 				switch (p_bitmap.pixel_mode) {
 					case FT_PIXEL_MODE_MONO: {
 						int byte = i * p_bitmap.pitch + (j >> 3);
@@ -2468,7 +2468,7 @@ int64_t TextServerAdvanced::_font_get_spacing(const RID &p_font_rid, SpacingType
 	}
 }
 
-void TextServerAdvanced::_font_set_baseline_offset(const RID &p_font_rid, float p_baseline_offset) {
+void TextServerAdvanced::_font_set_baseline_offset(const RID &p_font_rid, double p_baseline_offset) {
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		if (fdv->baseline_offset != p_baseline_offset) {
@@ -2486,7 +2486,7 @@ void TextServerAdvanced::_font_set_baseline_offset(const RID &p_font_rid, float 
 	}
 }
 
-float TextServerAdvanced::_font_get_baseline_offset(const RID &p_font_rid) const {
+double TextServerAdvanced::_font_get_baseline_offset(const RID &p_font_rid) const {
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		return fdv->baseline_offset;
@@ -7142,9 +7142,7 @@ PackedInt32Array TextServerAdvanced::_string_get_character_breaks(const String &
 		}
 		ubrk_close(bi);
 	} else {
-		for (int i = 0; i <= p_string.size(); i++) {
-			ret.push_back(i);
-		}
+		return TextServer::string_get_character_breaks(p_string, p_language);
 	}
 
 	return ret;
@@ -7342,7 +7340,7 @@ bool TextServerAdvanced::_is_valid_identifier(const String &p_string) const {
 	return true;
 }
 
-bool TextServerAdvanced::_is_valid_letter(char32_t p_unicode) const {
+bool TextServerAdvanced::_is_valid_letter(uint64_t p_unicode) const {
 #ifndef ICU_STATIC_DATA
 	if (!icu_data_loaded) {
 		return TextServer::is_valid_letter(p_unicode);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -296,7 +296,7 @@ class TextServerAdvanced : public TextServerExtension {
 	struct FontAdvancedLinkedVariation {
 		RID base_font;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 	};
 
 	struct FontAdvanced {
@@ -325,7 +325,7 @@ class TextServerAdvanced : public TextServerExtension {
 		int weight = 400;
 		int stretch = 100;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 
 		HashMap<Vector2i, FontForSizeAdvanced *, VariantHasher, VariantComparator> cache;
 
@@ -578,7 +578,7 @@ class TextServerAdvanced : public TextServerExtension {
 		double embolden = 0.0;
 		Transform2D transform;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 
 		bool operator==(const SystemFontKey &p_b) const {
 			return (font_name == p_b.font_name) && (antialiasing == p_b.antialiasing) && (italic == p_b.italic) && (disable_embedded_bitmaps == p_b.disable_embedded_bitmaps) && (mipmaps == p_b.mipmaps) && (msdf == p_b.msdf) && (force_autohinter == p_b.force_autohinter) && (weight == p_b.weight) && (stretch == p_b.stretch) && (msdf_range == p_b.msdf_range) && (msdf_source_size == p_b.msdf_source_size) && (fixed_size == p_b.fixed_size) && (hinting == p_b.hinting) && (subpixel_positioning == p_b.subpixel_positioning) && (variation_coordinates == p_b.variation_coordinates) && (oversampling == p_b.oversampling) && (embolden == p_b.embolden) && (transform == p_b.transform) && (extra_spacing[SPACING_TOP] == p_b.extra_spacing[SPACING_TOP]) && (extra_spacing[SPACING_BOTTOM] == p_b.extra_spacing[SPACING_BOTTOM]) && (extra_spacing[SPACING_SPACE] == p_b.extra_spacing[SPACING_SPACE]) && (extra_spacing[SPACING_GLYPH] == p_b.extra_spacing[SPACING_GLYPH]) && (baseline_offset == p_b.baseline_offset);
@@ -791,8 +791,8 @@ public:
 	MODBIND3(font_set_spacing, const RID &, SpacingType, int64_t);
 	MODBIND2RC(int64_t, font_get_spacing, const RID &, SpacingType);
 
-	MODBIND2(font_set_baseline_offset, const RID &, float);
-	MODBIND1RC(float, font_get_baseline_offset, const RID &);
+	MODBIND2(font_set_baseline_offset, const RID &, double);
+	MODBIND1RC(double, font_get_baseline_offset, const RID &);
 
 	MODBIND2(font_set_transform, const RID &, const Transform2D &);
 	MODBIND1RC(Transform2D, font_get_transform, const RID &);
@@ -988,7 +988,7 @@ public:
 
 	MODBIND1RC(String, strip_diacritics, const String &);
 	MODBIND1RC(bool, is_valid_identifier, const String &);
-	MODBIND1RC(bool, is_valid_letter, char32_t);
+	MODBIND1RC(bool, is_valid_letter, uint64_t);
 
 	MODBIND2RC(String, string_to_upper, const String &, const String &);
 	MODBIND2RC(String, string_to_lower, const String &, const String &);

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -56,8 +56,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     thirdparty_tvg_dir = "../../../thirdparty/thorvg/"
     thirdparty_tvg_sources = [
         # common
-        "src/common/tvgBezier.cpp",
         "src/common/tvgCompressor.cpp",
+        "src/common/tvgLines.cpp",
         "src/common/tvgMath.cpp",
         "src/common/tvgStr.cpp",
         # SVG parser
@@ -68,6 +68,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/loaders/svg/tvgSvgUtil.cpp",
         "src/loaders/svg/tvgXmlParser.cpp",
         "src/loaders/raw/tvgRawLoader.cpp",
+        # image loaders
         "src/loaders/external_png/tvgPngLoader.cpp",
         "src/loaders/jpg/tvgJpgd.cpp",
         "src/loaders/jpg/tvgJpgLoader.cpp",
@@ -112,6 +113,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
             "../../../thirdparty/thorvg/src/loaders/raw",
             "../../../thirdparty/thorvg/src/loaders/external_png",
             "../../../thirdparty/thorvg/src/loaders/jpg",
+            "../../../thirdparty/libpng",
         ]
     )
 
@@ -146,8 +148,6 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
         "core/Projection.cpp",
         "core/Scanline.cpp",
         "core/Shape.cpp",
-        "core/SignedDistance.cpp",
-        "core/Vector2.cpp",
         "core/contour-combiners.cpp",
         "core/edge-coloring.cpp",
         "core/edge-segments.cpp",

--- a/modules/text_server_fb/register_types.cpp
+++ b/modules/text_server_fb/register_types.cpp
@@ -62,8 +62,8 @@ using namespace godot;
 
 extern "C" {
 
-GDExtensionBool GDE_EXPORT textserver_fallback_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+GDExtensionBool GDE_EXPORT textserver_fallback_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
 	init_obj.register_initializer(&initialize_text_server_fb_module);
 	init_obj.register_terminator(&uninitialize_text_server_fb_module);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -247,7 +247,7 @@ class TextServerFallback : public TextServerExtension {
 	struct FontFallbackLinkedVariation {
 		RID base_font;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 	};
 
 	struct FontFallback {
@@ -276,7 +276,7 @@ class TextServerFallback : public TextServerExtension {
 		int weight = 400;
 		int stretch = 100;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 
 		HashMap<Vector2i, FontForSizeFallback *, VariantHasher, VariantComparator> cache;
 
@@ -494,7 +494,7 @@ class TextServerFallback : public TextServerExtension {
 		double embolden = 0.0;
 		Transform2D transform;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
-		float baseline_offset = 0.0;
+		double baseline_offset = 0.0;
 
 		bool operator==(const SystemFontKey &p_b) const {
 			return (font_name == p_b.font_name) && (antialiasing == p_b.antialiasing) && (italic == p_b.italic) && (disable_embedded_bitmaps == p_b.disable_embedded_bitmaps) && (mipmaps == p_b.mipmaps) && (msdf == p_b.msdf) && (force_autohinter == p_b.force_autohinter) && (weight == p_b.weight) && (stretch == p_b.stretch) && (msdf_range == p_b.msdf_range) && (msdf_source_size == p_b.msdf_source_size) && (fixed_size == p_b.fixed_size) && (hinting == p_b.hinting) && (subpixel_positioning == p_b.subpixel_positioning) && (variation_coordinates == p_b.variation_coordinates) && (oversampling == p_b.oversampling) && (embolden == p_b.embolden) && (transform == p_b.transform) && (extra_spacing[SPACING_TOP] == p_b.extra_spacing[SPACING_TOP]) && (extra_spacing[SPACING_BOTTOM] == p_b.extra_spacing[SPACING_BOTTOM]) && (extra_spacing[SPACING_SPACE] == p_b.extra_spacing[SPACING_SPACE]) && (extra_spacing[SPACING_GLYPH] == p_b.extra_spacing[SPACING_GLYPH]) && (baseline_offset == p_b.baseline_offset);
@@ -659,8 +659,8 @@ public:
 	MODBIND3(font_set_spacing, const RID &, SpacingType, int64_t);
 	MODBIND2RC(int64_t, font_get_spacing, const RID &, SpacingType);
 
-	MODBIND2(font_set_baseline_offset, const RID &, float);
-	MODBIND1RC(float, font_get_baseline_offset, const RID &);
+	MODBIND2(font_set_baseline_offset, const RID &, double);
+	MODBIND1RC(double, font_get_baseline_offset, const RID &);
 
 	MODBIND2(font_set_transform, const RID &, const Transform2D &);
 	MODBIND1RC(Transform2D, font_get_transform, const RID &);

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -659,12 +659,12 @@ int64_t TextServerExtension::font_get_spacing(const RID &p_font_rid, SpacingType
 	return ret;
 }
 
-void TextServerExtension::font_set_baseline_offset(const RID &p_font_rid, float p_baseline_offset) {
+void TextServerExtension::font_set_baseline_offset(const RID &p_font_rid, double p_baseline_offset) {
 	GDVIRTUAL_CALL(_font_set_baseline_offset, p_font_rid, p_baseline_offset);
 }
 
-float TextServerExtension::font_get_baseline_offset(const RID &p_font_rid) const {
-	float ret = 0.0;
+double TextServerExtension::font_get_baseline_offset(const RID &p_font_rid) const {
+	double ret = 0.0;
 	GDVIRTUAL_CALL(_font_get_baseline_offset, p_font_rid, ret);
 	return ret;
 }
@@ -1493,7 +1493,7 @@ bool TextServerExtension::is_valid_identifier(const String &p_string) const {
 	return TextServer::is_valid_identifier(p_string);
 }
 
-bool TextServerExtension::is_valid_letter(char32_t p_unicode) const {
+bool TextServerExtension::is_valid_letter(uint64_t p_unicode) const {
 	bool ret;
 	if (GDVIRTUAL_CALL(_is_valid_letter, p_unicode, ret)) {
 		return ret;

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -178,10 +178,10 @@ public:
 	GDVIRTUAL3(_font_set_spacing, const RID &, SpacingType, int64_t);
 	GDVIRTUAL2RC(int64_t, _font_get_spacing, const RID &, SpacingType);
 
-	virtual void font_set_baseline_offset(const RID &p_font_rid, float p_baseline_offset) override;
-	virtual float font_get_baseline_offset(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_baseline_offset, const RID &, float);
-	GDVIRTUAL1RC(float, _font_get_baseline_offset, const RID &);
+	virtual void font_set_baseline_offset(const RID &p_font_rid, double p_baseline_offset) override;
+	virtual double font_get_baseline_offset(const RID &p_font_rid) const override;
+	GDVIRTUAL2(_font_set_baseline_offset, const RID &, double);
+	GDVIRTUAL1RC(double, _font_get_baseline_offset, const RID &);
 
 	virtual void font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) override;
 	virtual Transform2D font_get_transform(const RID &p_font_rid) const override;
@@ -563,8 +563,8 @@ public:
 
 	virtual bool is_valid_identifier(const String &p_string) const override;
 	GDVIRTUAL1RC(bool, _is_valid_identifier, const String &);
-	virtual bool is_valid_letter(char32_t p_unicode) const override;
-	GDVIRTUAL1RC(bool, _is_valid_letter, char32_t);
+	virtual bool is_valid_letter(uint64_t p_unicode) const override;
+	GDVIRTUAL1RC(bool, _is_valid_letter, uint64_t);
 
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const override;
 	virtual String string_to_lower(const String &p_string, const String &p_language = "") const override;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -2183,7 +2183,7 @@ bool TextServer::is_valid_identifier(const String &p_string) const {
 	return true;
 }
 
-bool TextServer::is_valid_letter(char32_t p_unicode) const {
+bool TextServer::is_valid_letter(uint64_t p_unicode) const {
 	return is_unicode_letter(p_unicode);
 }
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -320,8 +320,8 @@ public:
 	virtual void font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) = 0;
 	virtual int64_t font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const = 0;
 
-	virtual void font_set_baseline_offset(const RID &p_font_rid, float p_baseline_offset) = 0;
-	virtual float font_get_baseline_offset(const RID &p_font_rid) const = 0;
+	virtual void font_set_baseline_offset(const RID &p_font_rid, double p_baseline_offset) = 0;
+	virtual double font_get_baseline_offset(const RID &p_font_rid) const = 0;
 
 	virtual void font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) = 0;
 	virtual Transform2D font_get_transform(const RID &p_font_rid) const = 0;
@@ -547,7 +547,7 @@ public:
 
 	virtual String strip_diacritics(const String &p_string) const;
 	virtual bool is_valid_identifier(const String &p_string) const;
-	virtual bool is_valid_letter(char32_t p_unicode) const;
+	virtual bool is_valid_letter(uint64_t p_unicode) const;
 
 	// Other string operations.
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const = 0;


### PR DESCRIPTION
Restores ability to build text serves as GDExtension:
- Exposes modified String and Image low-level access methods to GDExtension.
- Exposes some previously private methods to the scripting.
- Fixes various inconsistencies in the text server API.
- Fixes outdated GDExtension build configs.

godot-cpp counterpart - https://github.com/godotengine/godot-cpp/pull/1479