### PR TITLE
Fix same importer will be added multiple times in `get_importers_for_extension`

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -410,6 +410,7 @@ void ResourceFormatImporter::get_importers_for_extension(const String &p_extensi
 		for (const String &F : local_exts) {
 			if (p_extension.to_lower() == F) {
 				r_importers->push_back(importers[i]);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92710

The problem lies in the fact that both `EditorSceneFormatImporterUFBX` and `EditorSceneFormatImporterFBX2GLTF` can import `.fbx`, so `local_exts` for scene importer will contain duplicate `fbx` entry. 

I suppose we can also make `local_exts` a unique set instead of list? But put a `break` here seems reasonable.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
