### PR TITLE
[3.x] `ImageTexture` - document workaround for mipmap generation

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -26,6 +26,7 @@
 		[/codeblock]
 		An [ImageTexture] is not meant to be operated from within the editor interface directly, and is mostly useful for rendering images on screen dynamically via code. If you need to generate images procedurally from within the editor, consider saving and importing images as custom texture resources implementing a new [EditorImportPlugin].
 		[b]Note:[/b] The maximum texture size is 16384×16384 pixels due to graphics hardware limitations.
+		[b]Note:[/b] Mipmap generation can fail with some graphics drivers (especially on Android), resulting in black textures. In these cases, consider either calling [method Image.generate_mipmaps], or creating an [ImageTexture] without [constant Texture.FLAG_MIPMAPS].
 	</description>
 	<tutorials>
 		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>


### PR DESCRIPTION
Helps address #35459.

## Discussion
I've spent some time investigating the cause and it seems most likely that `glGenerateMipmap()` is failing on some Android devices.

This may not be easy to workaround in the code (OpenGL error reporting can be flakey), so for now (at least) the simplest action is to document the problem and suggest a workaround.

## Notes
* If memory serves, in the old days the recommendation was to steer clear of `glGenerateMipmap()` and generate mipmaps manually because of the unreliability on different drivers.
* We can potentially do this however it would take some thought as generating on CPU single threaded in all cases could adversely affect performance.
* GPU drivers are likely free to either generate locally on CPU, or generate on GPU (which would likely be far more efficient).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
