### PR TITLE
[3.x] GDNative: Fix Linux riscv warning about ignored `sysv_abi`

### DIFF
--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 
 #else // Linux/BSD/Web
-#if defined(__aarch64__) || defined(__arm__)
+#if defined(__aarch64__) || defined(__arm__) || defined(__riscv)
 #define GDCALLINGCONV
 #else
 #define GDCALLINGCONV __attribute__((sysv_abi))


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/41160 but for RISC-V. This is the same as PR https://github.com/godotengine/godot/pull/85916 but for RISC-V.

The `__riscv` define is set on all RISC-V targets, including rv32 and rv64. It's the same define we use in the OS class.