### PR TITLE
Fix callable not clearing freed pointer

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -324,6 +324,7 @@ void Callable::operator=(const Callable &p_callable) {
 
 		if (custom->ref_count.unref()) {
 			memdelete(custom);
+			custom = nullptr;
 		}
 	}
 
@@ -428,6 +429,7 @@ Callable::~Callable() {
 	if (is_custom()) {
 		if (custom->ref_count.unref()) {
 			memdelete(custom);
+			custom = nullptr;
 		}
 	}
 }


### PR DESCRIPTION
fixes a crash i had on shutdown,, 
but it happens anytime a callable with a custom pointer is copy-assigned a regular callable, then destructed
manual reference counting and memory managment should rlly be abstracted or avoided to prevent silly crashes like this