### PR TITLE
CI: Migrate codespell logic to `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,37 +35,10 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
-        types_or: [text]
-        exclude: |
-          (?x)^(
-            .*\.desktop$|
-            .*\.gitignore$|
-            .*\.po$|
-            .*\.pot$|
-            .*\.rc$|
-            \.mailmap$|
-            AUTHORS.md$|
-            COPYRIGHT.txt$|
-            DONORS.md$|
-            core/input/gamecontrollerdb.txt$|
-            core/string/locales.h$|
-            editor/project_converter_3_to_4.cpp$|
-            platform/android/java/lib/src/com/.*|
-            platform/web/package-lock.json$
-          )
-        args:
-          - --enable-colors
-          - --write-changes
-          - --check-hidden
-          - --quiet-level
-          - '3'
-          - --ignore-words-list
-          - aesthetic,aesthetics,breaked,cancelled,colour,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,thirdparty,vai
-          - --builtin
-          - clear,rare,en-GB_to_en-US
+        additional_dependencies: [tomli]
 
   ### Requires Docker; look into alternative implementation.
   # - repo: https://github.com/comkieffer/pre-commit-xmllint.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,51 @@ extend-select = [
 	"E402", # Module level import not at top of file
 	"F821", # Undefined name
 ]
+
+[tool.codespell]
+enable-colors = ""
+write-changes = ""
+check-hidden = ""
+quiet-level = 3
+builtin = "clear,rare,en-GB_to_en-US"
+skip = """\
+	.mailmap,
+	*.desktop,
+	*.gitignore,
+	*.po,
+	*.pot,
+	*.rc,
+	AUTHORS.md,
+	COPYRIGHT.txt,
+	core/input/gamecontrollerdb.txt,
+	core/string/locales.h,
+	DONORS.md,
+	editor/project_converter_3_to_4.cpp,
+	platform/android/java/lib/src/com/*,
+	platform/web/package-lock.json
+"""
+ignore-words-list = """\
+	breaked,
+	cancelled,
+	checkin,
+	colour,
+	curvelinear,
+	doubleclick,
+	expct,
+	findn,
+	gird,
+	hel,
+	inout,
+	labelin,
+	lod,
+	mis,
+	nd,
+	numer,
+	ot,
+	outin,
+	requestor,
+	te,
+	textin,
+	thirdparty,
+	vai
+"""


### PR DESCRIPTION
Being a python module, codespell's logic is better suited for `pyproject.toml`. As such, this PR takes the arguments passed in `.pre-commit-config.yaml` and migrated them as needed. Toml also supports multi-line strings, so the long arguments for skips/ignores are now split by line for better version control parsing. In the process of doing all this, I've also bumped the codespell version up from `2.2.6` to `2.3.0`, which caused the following changes:
- Removed legacy skips: `aesthetic`/`aesthetics`
- Added new skips: `checkin`/`labelin`/`outin`/`textin`
- Output is now colored, neat!