### PR TITLE
Optimize Editor `_init_grid()`

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7258,9 +7258,15 @@ void Node3DEditor::_init_grid() {
 
 	bool orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
 
-	Vector<Color> grid_colors[3];
-	Vector<Vector3> grid_points[3];
-	Vector<Vector3> grid_normals[3];
+	static LocalVector<Color> grid_colors[3];
+	static LocalVector<Vector3> grid_points[3];
+	static LocalVector<Vector3> grid_normals[3];
+
+	for (uint32_t n = 0; n < 3; n++) {
+		grid_colors[n].clear();
+		grid_points[n].clear();
+		grid_normals[n].clear();
+	}
 
 	Color primary_grid_color = EDITOR_GET("editors/3d/primary_grid_color");
 	Color secondary_grid_color = EDITOR_GET("editors/3d/secondary_grid_color");
@@ -7336,10 +7342,9 @@ void Node3DEditor::_init_grid() {
 		grid_mat[c]->set_shader_parameter("grid_size", grid_fade_size);
 		grid_mat[c]->set_shader_parameter("orthogonal", orthogonal);
 
-		// Cache these so we don't have to re-access memory.
-		Vector<Vector3> &ref_grid = grid_points[c];
-		Vector<Vector3> &ref_grid_normals = grid_normals[c];
-		Vector<Color> &ref_grid_colors = grid_colors[c];
+		LocalVector<Vector3> &ref_grid = grid_points[c];
+		LocalVector<Vector3> &ref_grid_normals = grid_normals[c];
+		LocalVector<Color> &ref_grid_colors = grid_colors[c];
 
 		// Count our elements same as code below it.
 		int expected_size = 0;
@@ -7384,12 +7389,12 @@ void Node3DEditor::_init_grid() {
 				line_end[a] = position_a;
 				line_bgn[b] = bgn_b;
 				line_end[b] = end_b;
-				ref_grid.set(idx, line_bgn);
-				ref_grid.set(idx + 1, line_end);
-				ref_grid_colors.set(idx, line_color);
-				ref_grid_colors.set(idx + 1, line_color);
-				ref_grid_normals.set(idx, normal);
-				ref_grid_normals.set(idx + 1, normal);
+				ref_grid[idx] = line_bgn;
+				ref_grid[idx + 1] = line_end;
+				ref_grid_colors[idx] = line_color;
+				ref_grid_colors[idx + 1] = line_color;
+				ref_grid_normals[idx] = normal;
+				ref_grid_normals[idx + 1] = normal;
 				idx += 2;
 			}
 
@@ -7400,12 +7405,12 @@ void Node3DEditor::_init_grid() {
 				line_end[b] = position_b;
 				line_bgn[a] = bgn_a;
 				line_end[a] = end_a;
-				ref_grid.set(idx, line_bgn);
-				ref_grid.set(idx + 1, line_end);
-				ref_grid_colors.set(idx, line_color);
-				ref_grid_colors.set(idx + 1, line_color);
-				ref_grid_normals.set(idx, normal);
-				ref_grid_normals.set(idx + 1, normal);
+				ref_grid[idx] = line_bgn;
+				ref_grid[idx + 1] = line_end;
+				ref_grid_colors[idx] = line_color;
+				ref_grid_colors[idx + 1] = line_color;
+				ref_grid_normals[idx] = normal;
+				ref_grid_normals[idx + 1] = normal;
 				idx += 2;
 			}
 		}
@@ -7414,9 +7419,9 @@ void Node3DEditor::_init_grid() {
 		grid[c] = RenderingServer::get_singleton()->mesh_create();
 		Array d;
 		d.resize(RS::ARRAY_MAX);
-		d[RenderingServer::ARRAY_VERTEX] = grid_points[c];
-		d[RenderingServer::ARRAY_COLOR] = grid_colors[c];
-		d[RenderingServer::ARRAY_NORMAL] = grid_normals[c];
+		d[RenderingServer::ARRAY_VERTEX] = (Vector<Vector3>)grid_points[c];
+		d[RenderingServer::ARRAY_COLOR] = (Vector<Color>)grid_colors[c];
+		d[RenderingServer::ARRAY_NORMAL] = (Vector<Vector3>)grid_normals[c];
 		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(grid[c], RenderingServer::PRIMITIVE_LINES, d);
 		RenderingServer::get_singleton()->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
 		grid_instance[c] = RenderingServer::get_singleton()->instance_create2(grid[c], get_tree()->get_root()->get_world_3d()->get_scenario());


### PR DESCRIPTION
Use static `LocalVectors` instead of `Vectors` for temporaries.

Forward port of #92725

## Notes
* Not profiled this but it should be significantly faster like #92725 because it avoids COW machinery (moo :cow: ) and excessive allocations (the temporary vectors are static and will re-use memory, and only the final conversion to `Vectors` should cause allocations).
* The IDX indexing and bounds checking could also be avoided by using pointers, but I've left that alone for now as it slightly less safe to future bugs (anyone else feel free to change).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
