### PR TITLE
[Core] Expose `Packed*Array::erase`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2449,6 +2449,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedByteArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedByteArray, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedByteArray, count, sarray("value"), varray());
+	bind_method(PackedByteArray, erase, sarray("value"), varray());
 
 	bind_function(PackedByteArray, get_string_from_ascii, _VariantCall::func_PackedByteArray_get_string_from_ascii, sarray(), varray());
 	bind_function(PackedByteArray, get_string_from_utf8, _VariantCall::func_PackedByteArray_get_string_from_utf8, sarray(), varray());
@@ -2515,6 +2516,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt32Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedInt32Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedInt32Array, count, sarray("value"), varray());
+	bind_method(PackedInt32Array, erase, sarray("value"), varray());
 
 	/* Int64 Array */
 
@@ -2538,6 +2540,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt64Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedInt64Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedInt64Array, count, sarray("value"), varray());
+	bind_method(PackedInt64Array, erase, sarray("value"), varray());
 
 	/* Float32 Array */
 
@@ -2561,6 +2564,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat32Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedFloat32Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedFloat32Array, count, sarray("value"), varray());
+	bind_method(PackedFloat32Array, erase, sarray("value"), varray());
 
 	/* Float64 Array */
 
@@ -2584,6 +2588,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat64Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedFloat64Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedFloat64Array, count, sarray("value"), varray());
+	bind_method(PackedFloat64Array, erase, sarray("value"), varray());
 
 	/* String Array */
 
@@ -2607,6 +2612,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedStringArray, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedStringArray, count, sarray("value"), varray());
+	bind_method(PackedStringArray, erase, sarray("value"), varray());
 
 	/* Vector2 Array */
 
@@ -2630,6 +2636,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector2Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector2Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedVector2Array, count, sarray("value"), varray());
+	bind_method(PackedVector2Array, erase, sarray("value"), varray());
 
 	/* Vector3 Array */
 
@@ -2653,6 +2660,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector3Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector3Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedVector3Array, count, sarray("value"), varray());
+	bind_method(PackedVector3Array, erase, sarray("value"), varray());
 
 	/* Color Array */
 
@@ -2676,6 +2684,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedColorArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedColorArray, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedColorArray, count, sarray("value"), varray());
+	bind_method(PackedColorArray, erase, sarray("value"), varray());
 
 	/* Vector4 Array */
 
@@ -2699,6 +2708,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector4Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector4Array, rfind, sarray("value", "from"), varray(-1));
 	bind_method(PackedVector4Array, count, sarray("value"), varray());
+	bind_method(PackedVector4Array, erase, sarray("value"), varray());
 }
 
 static void _register_variant_builtin_constants() {

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -292,6 +292,13 @@
 				Encodes a [Variant] at the index of [param byte_offset] bytes. A sufficient space must be allocated, depending on the encoded variant's size. If [param allow_objects] is [code]false[/code], [Object]-derived values are not permitted and will instead be serialized as ID-only.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -79,6 +79,13 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="Color" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="Color" />

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -77,6 +77,14 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+				[b]Note:[/b] [constant @GDScript.NAN] doesn't behave the same as other numbers. Therefore, the results from this method may not be accurate if NaNs are included.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="float" />

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -78,6 +78,14 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+				[b]Note:[/b] [constant @GDScript.NAN] doesn't behave the same as other numbers. Therefore, the results from this method may not be accurate if NaNs are included.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="float" />

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -75,6 +75,13 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -76,6 +76,13 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -82,6 +82,13 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="String" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="String" />

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -82,6 +82,14 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="Vector2" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="Vector2" />

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -81,6 +81,14 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="Vector3" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="Vector3" />

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -81,6 +81,14 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
+		<method name="erase">
+			<return type="bool" />
+			<param index="0" name="value" type="Vector4" />
+			<description>
+				Removes the first occurrence of a value from the array and returns [code]true[/code]. If the value does not exist in the array, nothing happens and [code]false[/code] is returned. To remove an element by index, use [method remove_at] instead.
+				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="Vector4" />


### PR DESCRIPTION
As identified while discussing:
* https://github.com/godotengine/godot-proposals/issues/9856

This bind is trivial and IMO relevant to bind as it's trivial with no glue required, added note about the behavior of `NaN` to the relevant cases

This improves both usability and parity with pure `Vector<T>` for modules and extensions, and when using code that can be both (where you can call `erase` on a `Vector` in modules but not extensions)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
