### PR TITLE
Fix Adreno 3xx compatibility for devices with newer driver versions

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -195,9 +195,9 @@ void RasterizerGLES3::initialize() {
 	Engine::get_singleton()->print_header(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
 
 	// FLIP XY Bug: Are more devices affected?
-	// Confirmed so far: all Adreno 3xx
+	// Confirmed so far: all Adreno 3xx with old driver (until 2018)
 	// ok on some tested Adreno devices: 4xx, 5xx and 6xx
-	flip_xy_bugfix = GLES3::Config::get_singleton()->adreno_3xx_compatibility;
+	flip_xy_workaround = GLES3::Config::get_singleton()->flip_xy_workaround;
 }
 
 void RasterizerGLES3::finalize() {
@@ -411,7 +411,7 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	// Adreno (TM) 3xx devices have a bug that create wrong Landscape rotation of 180 degree
 	// Reversing both the X and Y axis is equivalent to rotating 180 degrees
 	bool flip_x = false;
-	if (flip_xy_bugfix && screen_rect_end.x > screen_rect_end.y) {
+	if (flip_xy_workaround && screen_rect_end.x > screen_rect_end.y) {
 		flip_y = !flip_y;
 		flip_x = !flip_x;
 	}

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -56,7 +56,7 @@ private:
 	float delta = 0;
 
 	double time_total = 0.0;
-	bool flip_xy_bugfix = false;
+	bool flip_xy_workaround = false;
 
 	static bool gles_over_gl;
 

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -169,8 +169,31 @@ Config::Config() {
 
 	//Adreno 3xx Compatibility
 	const String rendering_device_name = String::utf8((const char *)glGetString(GL_RENDERER));
-	//TODO: Check the number between 300 and 399(?)
-	adreno_3xx_compatibility = (rendering_device_name.left(13) == "Adreno (TM) 3");
+	if (rendering_device_name.left(13) == "Adreno (TM) 3") {
+		flip_xy_workaround = true;
+		disable_particles_workaround = true;
+
+		// ignore driver version 331+
+		const String gl_version = String::utf8((const char *)glGetString(GL_VERSION));
+		// Adreno 3xx examples (https://opengles.gpuinfo.org/listreports.php):
+		// ===========================================================================
+		// OpenGL ES 3.0 V@84.0 AU@ (CL@)
+		// OpenGL ES 3.0 V@127.0 AU@ (GIT@I96aee987eb)
+		// OpenGL ES 3.0 V@140.0 AU@ (GIT@Ifd751822f5)
+		// OpenGL ES 3.0 V@251.0 AU@08.00.00.312.030 (GIT@Ie4790512f3)
+		// OpenGL ES 3.0 V@269.0 AU@ (GIT@I109c45a694)
+		// OpenGL ES 3.0 V@331.0 (GIT@35e467f, Ice9844a736) (Date:04/15/19)
+		// OpenGL ES 3.0 V@415.0 (GIT@d39f783, I79de86aa2c, 1591296226) (Date:06/04/20)
+		// OpenGL ES 3.0 V@0502.0 (GIT@09fef447e8, I1fe547a144, 1661493934) (Date:08/25/22)
+		String driver_version = gl_version.get_slice("V@", 1).get_slice(" ", 0);
+		if (driver_version.is_valid_float() && driver_version.to_float() >= 331.0) {
+			flip_xy_workaround = false;
+
+			//TODO: also 'GPUParticles'?
+			//https://github.com/godotengine/godot/issues/92662#issuecomment-2161199477
+			//disable_particles_workaround = false;
+		}
+	}
 }
 
 Config::~Config() {

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -91,7 +91,9 @@ public:
 	bool rt_msaa_multiview_supported = false;
 	bool multiview_supported = false;
 
-	bool adreno_3xx_compatibility = false;
+	// Adreno 3XX compatibility
+	bool disable_particles_workaround = false; // set to 'true' to disable 'GPUParticles'
+	bool flip_xy_workaround = false;
 
 #ifdef ANDROID_ENABLED
 	PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC eglFramebufferTextureMultiviewOVR = nullptr;

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -122,7 +122,7 @@ void ParticlesStorage::particles_set_mode(RID p_particles, RS::ParticlesMode p_m
 }
 
 void ParticlesStorage::particles_set_emitting(RID p_particles, bool p_emitting) {
-	ERR_FAIL_COND_MSG(GLES3::Config::get_singleton()->adreno_3xx_compatibility, "Due to driver bugs, GPUParticles are not supported on Adreno 3XX devices. Please use CPUParticles instead.");
+	ERR_FAIL_COND_MSG(GLES3::Config::get_singleton()->disable_particles_workaround, "Due to driver bugs, GPUParticles are not supported on Adreno 3XX devices. Please use CPUParticles instead.");
 
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
@@ -131,7 +131,7 @@ void ParticlesStorage::particles_set_emitting(RID p_particles, bool p_emitting) 
 }
 
 bool ParticlesStorage::particles_get_emitting(RID p_particles) {
-	if (GLES3::Config::get_singleton()->adreno_3xx_compatibility) {
+	if (GLES3::Config::get_singleton()->disable_particles_workaround) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #92662

`Adreno 3xx` devices with newer driver version are not affected.
