### PR TITLE
Fix Windows Activate Process leading to stuck input

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4727,6 +4727,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_EXITSIZEMOVE: {
 			KillTimer(windows[window_id].hWnd, windows[window_id].move_timer_id);
+			windows[window_id].move_timer_id = 0;
 		} break;
 		case WM_TIMER: {
 			if (wParam == windows[window_id].move_timer_id) {


### PR DESCRIPTION
- Fixes #92305
- Fixes #92304
*Bugsquad edit:*
- Fixes #92307
- Fixes #92759

I was able to reproduce the problem of key being stuck after Alt-Tab everything time after the editor windows moved.
The problem was caused by the `move_timer_id` that was not resetted and was stucked with same value of the `activate_timer_id` preventing the `_process_activate_event` from executing.

Godot 4.3 beta 1:

https://github.com/godotengine/godot/assets/81109165/f7f13f1f-7fda-4d31-880c-2b9a37e68d79

After the fix:

https://github.com/godotengine/godot/assets/81109165/84514045-bfca-4048-86a8-d6a8e6386fdf

