### PR TITLE
Add SVG pre-commit check to avoid broken colors when using style tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,6 +174,13 @@ repos:
         entry: python misc/scripts/dotnet_format.py
         types_or: [c#]
 
+      - id: svg-check
+        name: svg-check
+        args: [--multiline]
+        entry: (?si)style=(\"|\')(.+)?(fill|stop-color|stroke)( +)?:(.+)?(\1)
+        language: pygrep
+        types: [svg]
+
 # End of upstream Godot pre-commit hooks.
 #
 # Keep this separation to let downstream forks add their own hooks to this file,


### PR DESCRIPTION
Added a pygrep-based check to pre-commit that checks if any  `fill`, `stroke` and `stop-color` properties are being set inside style tags in SVG, this prevents introducing icons that will have broken colors in light modes.

I've ran into this issue twice before in #92504 and #91821, because `ImageLoaderSVG` does a search & replace on the attribute values but not the style tags, and rather than complicate that code it's probably simpler to just avoid committing SVG it doesn't like in the first place.