### PR TITLE
Fix rename activeglobal group will create a scene group

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -526,7 +526,7 @@ void GroupsEditor::_confirm_rename() {
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Rename Group"));
+	undo_redo->create_action(TTR("Rename Group"), UndoRedo::MergeMode::MERGE_DISABLE, node);
 
 	if (!global_groups.has(old_name)) {
 		undo_redo->add_do_method(this, "_rename_scene_group", old_name, new_name);
@@ -550,6 +550,12 @@ void GroupsEditor::_confirm_rename() {
 
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+
+		if (node->is_in_group(old_name)) {
+			undo_redo->add_do_method(node, "remove_from_group", old_name);
+			undo_redo->add_do_method(node, "add_to_group", new_name, true);
+			undo_redo->add_undo_method(node, "add_to_group", old_name, true);
+		}
 
 		undo_redo->add_do_method(this, "_update_groups");
 		undo_redo->add_undo_method(this, "_update_groups");


### PR DESCRIPTION
Partly fixes https://github.com/godotengine/godot/issues/92732

The problem here is that when renaming the global group, the `global_group` will be updated, but the node's group cache in `data.grouped` is still not updated, and in `_load_scene_groups` it uses the current `global_group` to determine whether the group is scene group or global group, in this case the origin group is renamed and thus outdated, so it thinks it's a scene group.

So the fix is a quick one, it just remove the node from the group to force the node's cache being updated and add it again, not very elegant but works. There still is a problem when renaming the group in the project setting, it's still need to be addressed.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
