### PR TITLE
[RTL] Add more list control options.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -451,8 +451,12 @@
 			<param index="1" name="type" type="int" enum="RichTextLabel.ListType" />
 			<param index="2" name="capitalize" type="bool" />
 			<param index="3" name="bullet" type="String" default="&quot;•&quot;" />
+			<param index="4" name="prefix" type="String" default="&quot;&quot;" />
+			<param index="5" name="suffix" type="String" default="&quot;.&quot;" />
+			<param index="6" name="indent_size" type="int" default="-1" />
+			<param index="7" name="break_at_level" type="bool" default="false" />
 			<description>
-				Adds [code skip-lint][ol][/code] or [code skip-lint][ul][/code] tag to the tag stack. Multiplies [param level] by current [member tab_size] to determine new margin length.
+				Adds [code skip-lint][ol][/code] or [code skip-lint][ul][/code] tag to the tag stack. Multiplies [param level] by current [member tab_size] to determine new margin length. If [param break_at_level] is set, list sublevels are reset.
 			</description>
 		</method>
 		<method name="push_meta" keywords="push_url">
@@ -763,6 +767,9 @@
 		</constant>
 		<constant name="LIST_DOTS" value="3" enum="ListType">
 			Each list item has a filled circle marker.
+		</constant>
+		<constant name="LIST_CUSTOM" value="4" enum="ListType">
+			Each list item has a marker from user defined marker list.
 		</constant>
 		<constant name="MENU_COPY" value="0" enum="MenuItems">
 			Copies the selected text.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable.expected
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable.expected
@@ -231,7 +231,7 @@ Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_node/
 GH-75017
 --------
 Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_list', from 8593DF77 to F0951C19. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 3 to 8.
 
 Added an optional parameter with a default value. No adjustments should be necessary.
 

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -334,3 +334,10 @@ Validate extension JSON: Error: Field 'classes/EditorTranslationParserPlugin/met
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/EditorTranslationParserPlugin/methods/_parse_file': return_value
 
 Returning by argument reference is not safe in extensions, changed to returning as an Array and merged with `get_comments`. Compatibility method registered.
+
+
+GH-92749
+--------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 4 to 8.
+
+Optional arguments added. Compatibility methods registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -46,6 +46,10 @@ void RichTextLabel::_push_meta_bind_compat_99481(const Variant &p_meta, MetaUnde
 	push_meta(p_meta, p_underline_mode, String());
 }
 
+void RichTextLabel::_push_list_bind_compat_92749(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet) {
+	push_list(p_level, p_list, p_capitalize, p_bullet, "", ".", -1, false);
+}
+
 void RichTextLabel::_push_meta_bind_compat_89024(const Variant &p_meta) {
 	push_meta(p_meta, RichTextLabel::MetaUnderline::META_UNDERLINE_ALWAYS, String());
 }
@@ -63,6 +67,7 @@ void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("set_table_column_expand", "column", "expand", "ratio"), &RichTextLabel::_set_table_column_expand_bind_compat_79053);
 	ClassDB::bind_compatibility_method(D_METHOD("set_table_column_expand", "column", "expand", "ratio"), &RichTextLabel::_set_table_column_expand_bind_compat_101482, DEFVAL(1));
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data", "underline_mode"), &RichTextLabel::_push_meta_bind_compat_99481, DEFVAL(META_UNDERLINE_ALWAYS));
+	ClassDB::bind_compatibility_method(D_METHOD("push_list", "level", "type", "capitalize", "bullet"), &RichTextLabel::_push_list_bind_compat_92749, DEFVAL(String::utf8("•")));
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89024);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));
 	ClassDB::bind_compatibility_method(D_METHOD("remove_paragraph", "paragraph"), &RichTextLabel::_remove_paragraph_bind_compat_91098);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -57,7 +57,8 @@ public:
 		LIST_NUMBERS,
 		LIST_LETTERS,
 		LIST_ROMAN,
-		LIST_DOTS
+		LIST_DOTS,
+		LIST_CUSTOM,
 	};
 
 	enum MetaUnderline {
@@ -135,6 +136,7 @@ protected:
 	void _push_font_bind_compat_79053(const Ref<Font> &p_font, int p_size);
 	void _set_table_column_expand_bind_compat_79053(int p_column, bool p_expand, int p_ratio);
 	void _push_meta_bind_compat_99481(const Variant &p_meta, MetaUnderline p_underline_mode);
+	void _push_list_bind_compat_92749(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = U"•");
 	void _push_meta_bind_compat_89024(const Variant &p_meta);
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	bool _remove_paragraph_bind_compat_91098(int p_paragraph);
@@ -329,9 +331,13 @@ private:
 	struct ItemList : public Item {
 		ListType list_type = LIST_DOTS;
 		bool capitalize = false;
+		bool break_at_level = false;
 		int level = 0;
+		int indent_size = -1;
 		String bullet = U"•";
 		float max_width = 0;
+		String prefix = U"";
+		String suffix = U". ";
 		ItemList() { type = ITEM_LIST; }
 	};
 
@@ -714,7 +720,7 @@ public:
 	void push_language(const String &p_language);
 	void push_paragraph(HorizontalAlignment p_alignment, Control::TextDirection p_direction = Control::TEXT_DIRECTION_INHERITED, const String &p_language = "", TextServer::StructuredTextParser p_st_parser = TextServer::STRUCTURED_TEXT_DEFAULT, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE, const PackedFloat32Array &p_tab_stops = PackedFloat32Array());
 	void push_indent(int p_level);
-	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = String::utf8("•"));
+	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = U"•", const String &p_prefix = "", const String &p_suffix = ".", int p_indent_size = -1, bool p_break_at_level = false);
 	void push_meta(const Variant &p_meta, MetaUnderline p_underline_mode = META_UNDERLINE_ALWAYS, const String &p_tooltip = String());
 	void push_hint(const String &p_string);
 	void push_table(int p_columns, InlineAlignment p_alignment = INLINE_ALIGNMENT_TOP, int p_align_to_row = -1);


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/92745, add some extra control for list:

- Adds support for custom ordered list elements, and custom prefixes/suffixes:
<img width="500" src="https://github.com/godotengine/godot/assets/7645683/303a4135-428f-43f3-a874-3e5d7efe7c5d">

- Adds option to customize specific sublevel indentation size:
<img width="500" src="https://github.com/godotengine/godot/assets/7645683/330c008b-6469-45ff-ae7e-c827378e4354">

- Adds option to break ordered list sublevels:
<img width="500" src="https://github.com/godotengine/godot/assets/7645683/436329c1-9a95-4313-91ad-a56d4590ec0f">
