### PR TITLE
Improve tileset editor view performance

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -354,7 +354,10 @@ void TileAtlasView::_draw_base_tiles_texture_grid() {
 					}
 				} else {
 					// Draw the grid.
-					base_tiles_texture_grid->draw_rect(Rect2i(origin, texture_region_size), Color(0.7, 0.7, 0.7, 0.1), false);
+					Transform2D tile_xform;
+					tile_xform.set_origin(Rect2(origin, texture_region_size).get_center());
+					tile_xform.set_scale(texture_region_size);
+					tile_set->draw_tile_shape(base_tiles_texture_grid, tile_xform, Color(0.7, 0.7, 0.7, 0.1));
 				}
 			}
 		}


### PR DESCRIPTION
As reported in #72405 and #84963 the tileset editor becomes unusable when editing large tileset atlases due to repeated calls to `CanvasItem::draw_rect` to draw the tile grid:


https://github.com/godotengine/godot/assets/57678460/73659b04-0bdf-48e1-8670-25c147450282


This pull request is a workaround which replaces `CanvasItem::draw_rect` with `TileSet::draw_tile_shape` which does not seem to display the same performance issues.

Unlike #84963 this workaround works with tileset setups with non-zero tile separation and non-square texture regions.

Tested both on forward+ and compatibility on Mesa 23.2.1 on AMD Radeon RX 6700 XT (navi22, LLVM 15.0.7, DRM 3.54, 6.5.0-35-generic) (0x73df) under Ubuntu 23.10:

https://github.com/godotengine/godot/assets/57678460/40a72045-b4a9-4d59-b738-f6cc4b6db5d7

Example project: [example.zip](https://github.com/user-attachments/files/15546341/example.zip)

