### PR TITLE
Fix tile atlas view performance issue with a lot of tiles

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -338,6 +338,24 @@ void TileAtlasView::_draw_base_tiles_texture_grid() {
 		Vector2i separation = tile_set_atlas_source->get_separation();
 		Vector2i texture_region_size = tile_set_atlas_source->get_texture_region_size();
 
+		if (grid_line_mesh_size != texture_region_size) {
+			// Using a mesh is more performant than draw_rect (for whatever reason), so we use that for the grid.
+			Vector<Vector2> shape = { Vector2(0, 0), Vector2(texture_region_size.x, 0), texture_region_size, Vector2(0, texture_region_size.y), Vector2(0, 0) };
+			Vector<Color> colors;
+			colors.resize(shape.size());
+			colors.fill(Color(1.0, 1.0, 1.0, 1.0));
+
+			grid_line_mesh->clear_surfaces();
+
+			Array a;
+			a.resize(Mesh::ARRAY_MAX);
+			a[Mesh::ARRAY_VERTEX] = shape;
+			a[Mesh::ARRAY_COLOR] = colors;
+			grid_line_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINE_STRIP, a, Array(), Dictionary(), Mesh::ARRAY_FLAG_USE_2D_VERTICES);
+
+			grid_line_mesh_size = texture_region_size;
+		}
+
 		Size2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 
 		// Draw each tile texture region.
@@ -354,7 +372,7 @@ void TileAtlasView::_draw_base_tiles_texture_grid() {
 					}
 				} else {
 					// Draw the grid.
-					base_tiles_texture_grid->draw_rect(Rect2i(origin, texture_region_size), Color(0.7, 0.7, 0.7, 0.1), false);
+					base_tiles_texture_grid->draw_mesh(grid_line_mesh, Ref<Texture2D>(), Transform2D(0.0, origin), Color(0.7, 0.7, 0.7, 0.1));
 				}
 			}
 		}
@@ -759,6 +777,8 @@ TileAtlasView::TileAtlasView() {
 	alternatives_draw->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	alternatives_draw->connect(SceneStringName(draw), callable_mp(this, &TileAtlasView::_draw_alternatives));
 	alternative_tiles_drawing_root->add_child(alternatives_draw);
+
+	grid_line_mesh.instantiate();
 }
 
 TileAtlasView::~TileAtlasView() {

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -97,6 +97,8 @@ private:
 
 	Control *base_tiles_texture_grid = nullptr;
 	void _draw_base_tiles_texture_grid();
+	Ref<ArrayMesh> grid_line_mesh; // A rectangular mesh of the size of texture_region, to avoid the performance issue with draw_rect.
+	Vector2 grid_line_mesh_size;
 
 	Control *base_tiles_shape_grid = nullptr;
 	void _draw_base_tiles_shape_grid();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72405
Supersedes https://github.com/godotengine/godot/pull/84963

This is a bit of a workaround, as it seems that using a mesh makes things significantly faster than `draw_rect` (not sure why). But well, it works.

Added to 4.3 milestone, but can be moved to later releases if we think it's too risky.