### PR TITLE
[Web] Fix dlopen threading issues by pre-opening all GDExtensions

### DIFF
--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -47,12 +47,14 @@ extern void godot_js_config_canvas_id_get(char *p_ptr, int p_ptr_max);
 // OS
 extern void godot_js_os_finish_async(void (*p_callback)());
 extern void godot_js_os_request_quit_cb(void (*p_callback)());
+extern void godot_js_os_real_main_cb(int (*p_callback)(int argc, char **argv));
 extern int godot_js_os_fs_is_persistent();
 extern void godot_js_os_fs_sync(void (*p_callback)());
 extern int godot_js_os_execute(const char *p_json);
 extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
 extern int godot_js_os_has_feature(const char *p_ftr);
+extern int godot_js_os_preload_libraries(void (*p_callback)(char *p_lib));
 extern int godot_js_pwa_cb(void (*p_callback)());
 extern int godot_js_pwa_update();
 

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -177,9 +177,13 @@ const Engine = (function () {
 								me.rtenv['copyToFS'](file.path, file.buffer);
 							});
 							preloader.preloadedFiles.length = 0; // Clear memory
+							me.config.gdextensionLibs.forEach(function (lib) {
+								me.rtenv['godot_dlopen'](lib);
+							});
 							me.rtenv['callMain'](me.config.args);
 							initPromise = null;
 							me.installServiceWorker();
+							me.rtenv['call_real_main'](me.config.args);
 							resolve();
 						});
 					});

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -358,11 +358,11 @@ const GodotOS = {
 	godot_js_os_preload_libraries__sig: 'vi',
 	godot_js_os_preload_libraries: function (p_func) {
 		const cb = GodotRuntime.get_func(p_func);
-		GodotOS._libs.forEach(function (lib) {
+		for (const lib of GodotOS._libs) {
 			const c_str = GodotRuntime.allocString(lib);
 			cb(c_str);
 			GodotRuntime.free(c_str);
-		});
+		};
 	},
 
 	godot_js_os_real_main_cb__proxy: 'sync',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -249,8 +249,13 @@ bool OS_Web::is_userfs_persistent() const {
 
 Error OS_Web::open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data) {
 	String path = p_path.get_file();
-	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
-	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));
+	if (libraries.has(path)) {
+		p_library_handle = libraries[path];
+	} else {
+		p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
+		ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));
+		libraries[path] = p_library_handle;
+	}
 
 	if (p_data != nullptr && p_data->r_resolved_path != nullptr) {
 		*p_data->r_resolved_path = path;

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -44,6 +44,7 @@
 class OS_Web : public OS_Unix {
 	MainLoop *main_loop = nullptr;
 	List<AudioDriverWeb *> audio_drivers;
+	HashMap<String, void *> libraries;
 
 	bool idb_is_syncing = false;
 	bool idb_available = false;

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -5,7 +5,9 @@
 #define THORVG_SVG_LOADER_SUPPORT
 #define THORVG_PNG_LOADER_SUPPORT
 #define THORVG_JPG_LOADER_SUPPORT
+#ifndef WEB_ENABLED
 #define THORVG_THREAD_SUPPORT
+#endif
 
 // Added conditionally if webp module is enabled.
 //#define THORVG_WEBP_LOADER_SUPPORT

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -38,7 +38,9 @@ cat << EOF > ../inc/config.h
 #define THORVG_SVG_LOADER_SUPPORT
 #define THORVG_PNG_LOADER_SUPPORT
 #define THORVG_JPG_LOADER_SUPPORT
+#ifndef WEB_ENABLED
 #define THORVG_THREAD_SUPPORT
+#endif
 
 // Added conditionally if webp module is enabled.
 //#define THORVG_WEBP_LOADER_SUPPORT


### PR DESCRIPTION
Calling dlopen from a thread cause stalling on some browsers (notably firefox: https://github.com/godotengine/godot/issues/86382), the only valid workaround seems to be to dlopen all GDExtensions from the main thread as soon as possible.
We then keep track of the pre-opened libraries, and return the correct stored when a thread try to dlopen.

This means still no editor+thread+dlink support yet (since we don't know which libraries to open at startup in that case).

Draft status:
- Requires way more hacks than I'd like (having 3 main functions, 4 callbacks, and a fake loop is not great :/ )
- Only tested in 4.2 yet (via https://github.com/Faless/godot/tree/web/4.2_fix_dlopen_by_preloading)