### PR TITLE
GDScript: Set current line when continuing typed `for` loop

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -537,7 +537,7 @@ public:
 	virtual void write_end_jump_if_shared() override;
 	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) override;
 	virtual void write_for_assignment(const Address &p_list) override;
-	virtual void write_for(const Address &p_variable, bool p_use_conversion) override;
+	virtual void write_for(const Address &p_variable, bool p_use_conversion, int p_variable_line) override;
 	virtual void write_endfor() override;
 	virtual void start_while_condition() override;
 	virtual void write_while(const Address &p_condition) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -150,7 +150,7 @@ public:
 	virtual void write_end_jump_if_shared() = 0;
 	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) = 0;
 	virtual void write_for_assignment(const Address &p_list) = 0;
-	virtual void write_for(const Address &p_variable, bool p_use_conversion) = 0;
+	virtual void write_for(const Address &p_variable, bool p_use_conversion, int p_variable_line) = 0;
 	virtual void write_endfor() = 0;
 	virtual void start_while_condition() = 0; // Used to allow a jump to the expression evaluation.
 	virtual void write_while(const Address &p_condition) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2024,10 +2024,11 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_for_assignment(list);
 
 				if (list.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					gen->pop_temporary();
+					gen->clear_temporaries(); // Statement ended. Clear the temporary outside the loop body.
 				}
 
-				gen->write_for(iterator, for_n->use_conversion_assign);
+				gen->write_for(iterator, for_n->use_conversion_assign, for_n->variable->start_line);
 
 				// Loop variables must be cleared even when `break`/`continue` is used.
 				List<GDScriptCodeGenerator::Address> loop_locals = _add_block_locals(codegen, for_n->loop);

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_assign_line.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_assign_line.gd
@@ -1,0 +1,6 @@
+# GH-92681
+
+func test():
+	var a = [1, 2, "3"]
+	for x: int in a: # The error should be here.
+		print(x) # Not here.

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_assign_line.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_assign_line.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/for_loop_typed_iterator_assign_line.gd
+>> 5
+>> Trying to assign value of type 'String' to a variable of type 'int'.


### PR DESCRIPTION
* Fixes #92681.
* Also clear the iterator assignment temporary outside the loop body.