### PR TITLE
Fix shader for SkeletonGizmo to follow renderer's reversed-z change

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -922,7 +922,7 @@ void vertex() {
 
 	VERTEX = VERTEX;
 	POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0);
-	POSITION.z = mix(POSITION.z, 0.0, 0.999);
+	POSITION.z = mix(POSITION.z, POSITION.w, 0.999);
 	POINT_SIZE = point_size;
 }
 
@@ -1201,7 +1201,7 @@ void vertex() {
 	}
 	VERTEX = VERTEX;
 	POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0);
-	POSITION.z = mix(POSITION.z, 0, 0.998);
+	POSITION.z = mix(POSITION.z, POSITION.w, 0.998);
 }
 void fragment() {
 	ALBEDO = COLOR.rgb;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/92773

Co-authored-by: @lyuma 

Renderer has make coordinate of the z inverted to adopt reversed-z, so the skeleton gizmo shader must follow the change.

![image](https://github.com/godotengine/godot/assets/61938263/ca68c851-768b-4cf1-9bfa-1892b1e4bdcd)
