### PR TITLE
[3.x] Physics Interpolation - refactor `Camera` and fix `get_camera_transform()`

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -34,6 +34,10 @@
 #include "core/ustring.h"
 #include "os/os.h"
 
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+#include "scene/main/node.h"
+#endif
+
 static ErrorHandlerList *error_handler_list = nullptr;
 
 void add_error_handler(ErrorHandlerList *p_handler) {
@@ -116,4 +120,51 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 
 void _err_flush_stdout() {
 	fflush(stdout);
+}
+
+// Prevent error spam by limiting the warnings to a certain frequency.
+void _physics_interpolation_warning(const char *p_function, const char *p_file, int p_line, ObjectID p_id, const char *p_warn_string) {
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+	const uint32_t warn_max = 2048;
+	const uint32_t warn_timeout_seconds = 15;
+
+	static uint32_t warn_count = warn_max;
+	static uint32_t warn_timeout = warn_timeout_seconds;
+
+	uint32_t time_now = UINT32_MAX;
+
+	if (warn_count) {
+		warn_count--;
+	}
+
+	if (!warn_count) {
+		time_now = OS::get_singleton()->get_ticks_msec() / 1000;
+	}
+
+	if ((warn_count == 0) && (time_now >= warn_timeout)) {
+		warn_count = warn_max;
+		warn_timeout = time_now + warn_timeout_seconds;
+
+		if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+			// UINT64_MAX means unused.
+			if (p_id == UINT64_MAX) {
+				_err_print_error(p_function, p_file, p_line, "[Physics interpolation] " + String(p_warn_string) + " (possibly benign).", ERR_HANDLER_WARNING);
+			} else {
+				String node_name;
+				if (p_id != 0) {
+					if (ObjectDB::get_instance(p_id)) {
+						Node *node = Object::cast_to<Node>(ObjectDB::get_instance(p_id));
+						if (node && node->is_inside_tree()) {
+							node_name = "\"" + String(node->get_path()) + "\"";
+						} else {
+							node_name = "\"unknown\"";
+						}
+					}
+				}
+
+				_err_print_error(p_function, p_file, p_line, "[Physics interpolation] " + String(p_warn_string) + ": " + node_name + " (possibly benign).", ERR_HANDLER_WARNING);
+			}
+		}
+	}
+#endif
 }

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -31,6 +31,7 @@
 #ifndef ERROR_MACROS_H
 #define ERROR_MACROS_H
 
+#include "core/object_id.h"
 #include "core/safe_refcount.h"
 #include "core/typedefs.h"
 
@@ -85,6 +86,8 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
 void _err_flush_stdout();
+
+void _physics_interpolation_warning(const char *p_function, const char *p_file, int p_line, ObjectID p_id, const char *p_warn_string);
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -557,5 +560,15 @@ void _err_flush_stdout();
 #else
 #define DEV_CHECK_ONCE(m_cond)
 #endif
+
+/**
+ * Physics Interpolation warnings.
+ * These are spam protection warnings.
+ */
+#define PHYSICS_INTERPOLATION_NODE_WARNING(m_object_id, m_string) \
+	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, m_object_id, m_string)
+
+#define PHYSICS_INTERPOLATION_WARNING(m_string) \
+	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, UINT64_MAX, m_string)
 
 #endif // ERROR_MACROS_H

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -45,14 +45,6 @@
 				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
 			</description>
 		</method>
-		<method name="camera_reset_physics_interpolation">
-			<return type="void" />
-			<argument index="0" name="camera" type="RID" />
-			<description>
-				Prevents physics interpolation for the current physics tick.
-				This is useful when moving a [Camera] to a new location, to give an instantaneous change rather than interpolation from the previous location.
-			</description>
-		</method>
 		<method name="camera_set_cull_mask">
 			<return type="void" />
 			<argument index="0" name="camera" type="RID" />
@@ -78,14 +70,6 @@
 			<argument index="4" name="z_far" type="float" />
 			<description>
 				Sets camera to use frustum projection. This mode allows adjusting the [code]offset[/code] argument to create "tilted frustum" effects.
-			</description>
-		</method>
-		<method name="camera_set_interpolated">
-			<return type="void" />
-			<argument index="0" name="camera" type="RID" />
-			<argument index="1" name="interpolated" type="bool" />
-			<description>
-				Turns on and off physics interpolation for the [Camera].
 			</description>
 		</method>
 		<method name="camera_set_orthogonal">

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1267,7 +1267,7 @@ void CPUParticles2D::_notification(int p_what) {
 			}
 		}
 	}
-	if (p_what == NOTIFICATION_RESET_PHYSICS_INTERPOLATION) {
+	if (p_what == NOTIFICATION_RESET_PHYSICS_INTERPOLATION && is_inside_tree()) {
 		// Make sure current is up to date with any pending global transform changes.
 		_interpolation_data.global_xform_curr = get_global_transform_const();
 		_interpolation_data.global_xform_prev = _interpolation_data.global_xform_curr;

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -61,6 +61,7 @@ public:
 private:
 	bool force_change;
 	bool current;
+
 	Viewport *viewport;
 
 	Projection mode;
@@ -90,12 +91,43 @@ private:
 	Ref<SpatialVelocityTracker> velocity_tracker;
 	bool affect_lod = true;
 
+	///////////////////////////////////////////////////////
+	// INTERPOLATION FUNCTIONS
+	void _physics_interpolation_ensure_transform_calculated(bool p_force = false) const;
+	void _physics_interpolation_ensure_data_flipped();
+
+	// These can be set by derived Cameras,
+	// if they wish to do processing (while still
+	// allowing physics interpolation to function).
+	bool _desired_process_internal = false;
+	bool _desired_physics_process_internal = false;
+
+	mutable struct InterpolationData {
+		Transform xform_curr;
+		Transform xform_prev;
+		Transform xform_interpolated;
+		Transform camera_xform_interpolated; // After modification according to camera type.
+		uint32_t last_update_physics_tick = 0;
+		uint32_t last_update_frame = UINT32_MAX;
+	} _interpolation_data;
+
+	void _update_process_mode();
+
 protected:
+	// Use from derived classes to set process modes instead of setting directly.
+	// This is because physics interpolation may need to request process modes additionally.
+	void set_desired_process_modes(bool p_process_internal, bool p_physics_process_internal);
+
+	// Opportunity for derived classes to interpolate extra attributes.
+	virtual void physics_interpolation_flip_data() {}
+
+	virtual void _physics_interpolated_changed();
+	virtual Transform _get_adjusted_camera_transform(const Transform &p_xform) const;
+	///////////////////////////////////////////////////////
+
 	void _update_camera();
 	virtual void _request_camera_update();
 	void _update_camera_mode();
-
-	virtual void _physics_interpolated_changed();
 
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
@@ -135,7 +167,7 @@ public:
 	void set_znear(float p_znear);
 	void set_frustum_offset(Vector2 p_offset);
 
-	virtual Transform get_camera_transform() const;
+	Transform get_camera_transform() const;
 
 	virtual Vector3 project_ray_normal(const Point2 &p_pos) const;
 	virtual Vector3 project_ray_origin(const Point2 &p_pos) const;
@@ -195,7 +227,9 @@ private:
 	ProcessMode process_mode;
 	RID pyramid_shape;
 	float margin;
-	float clip_offset;
+
+	float clip_offset = 0;
+
 	uint32_t collision_mask;
 	bool clip_to_areas;
 	bool clip_to_bodies;
@@ -204,10 +238,21 @@ private:
 
 	Vector<Vector3> points;
 
+	///////////////////////////////////////////////////////
+	// INTERPOLATION FUNCTIONS
+	struct InterpolatedData {
+		float clip_offset_curr = 0;
+		float clip_offset_prev = 0;
+	} _interpolation_data;
+
 protected:
+	virtual Transform _get_adjusted_camera_transform(const Transform &p_xform) const;
+	virtual void physics_interpolation_flip_data();
+	virtual void _physics_interpolated_changed();
+	///////////////////////////////////////////////////////
+
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual Transform get_camera_transform() const;
 
 public:
 	void set_clip_to_areas(bool p_clip);

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -900,14 +900,6 @@ void CPUParticles::_particles_process(float p_delta) {
 				p.velocity.z = 0.0;
 				p.transform.origin.z = 0.0;
 			}
-
-			// Teleport if starting a new particle, so
-			// we don't get a streak from the old position
-			// to this new start.
-			if (_interpolated) {
-				p.copy_to(particles_prev[i]);
-			}
-
 		} else if (!p.active) {
 			continue;
 		} else if (p.time > p.lifetime) {
@@ -1012,6 +1004,13 @@ void CPUParticles::_particles_process(float p_delta) {
 		}
 
 		p.transform.origin += p.velocity * local_delta;
+
+		// Teleport if starting a new particle, so
+		// we don't get a streak from the old position
+		// to this new start.
+		if (restart && _interpolated) {
+			p.copy_to(particles_prev[i]);
+		}
 	}
 }
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -359,7 +359,7 @@ void Spatial::_disable_client_physics_interpolation() {
 }
 
 Transform Spatial::_get_global_transform_interpolated(real_t p_interpolation_fraction) {
-	ERR_FAIL_NULL_V(is_inside_tree(), Transform());
+	ERR_FAIL_COND_V(!is_inside_tree(), Transform());
 
 	// set in motion the mechanisms for client side interpolation if not already active
 	if (!_is_physics_interpolated_client_side()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -101,6 +101,12 @@ void Node::_notification(int p_notification) {
 			get_tree()->node_count++;
 			orphan_node_count--;
 
+			// Allow physics interpolated nodes to automatically reset when added to the tree
+			// (this is to save the user doing this manually each time).
+			if (get_tree()->is_physics_interpolation_enabled()) {
+				_set_physics_interpolation_reset_requested(true);
+			}
+
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			ERR_FAIL_COND(!get_viewport());
@@ -221,14 +227,14 @@ void Node::_propagate_physics_interpolated(bool p_interpolated) {
 	data.blocked--;
 }
 
-void Node::_propagate_physics_interpolation_reset_requested() {
+void Node::_propagate_physics_interpolation_reset_requested(bool p_requested) {
 	if (is_physics_interpolated()) {
-		data.physics_interpolation_reset_requested = true;
+		data.physics_interpolation_reset_requested = p_requested;
 	}
 
 	data.blocked++;
 	for (int i = 0; i < data.children.size(); i++) {
-		data.children[i]->_propagate_physics_interpolation_reset_requested();
+		data.children[i]->_propagate_physics_interpolation_reset_requested(p_requested);
 	}
 	data.blocked--;
 }
@@ -885,15 +891,23 @@ void Node::set_physics_interpolation_mode(PhysicsInterpolationMode p_mode) {
 
 	// if swapping from interpolated to non-interpolated, use this as
 	// an extra means to cause a reset
-	if (is_physics_interpolated() && !interpolate) {
-		reset_physics_interpolation();
+	if (is_physics_interpolated() && !interpolate && is_inside_tree()) {
+		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 	}
 
 	_propagate_physics_interpolated(interpolate);
 }
 
 void Node::reset_physics_interpolation() {
-	propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+	if (is_inside_tree()) {
+		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+
+		// If `reset_physics_interpolation()` is called explicitly by the user
+		// (e.g. from scripts) then we prevent deferred auto-resets taking place.
+		// The user is trusted to call reset in the right order, and auto-reset
+		// will interfere with their control of prev / curr, so should be turned off.
+		_propagate_physics_interpolation_reset_requested(false);
+	}
 }
 
 float Node::get_physics_process_delta_time() const {
@@ -1297,12 +1311,6 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	//recognize children created in this node constructor
 	p_child->data.parent_owned = data.in_constructor;
 	add_child_notify(p_child);
-
-	// Allow physics interpolated nodes to automatically reset when added to the tree
-	// (this is to save the user doing this manually each time)
-	if (is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) {
-		p_child->_propagate_physics_interpolation_reset_requested();
-	}
 }
 
 void Node::add_child(Node *p_child, bool p_force_readable_name) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -209,7 +209,7 @@ private:
 	void _propagate_exit_tree();
 	void _propagate_after_exit_branch(bool p_exiting_tree);
 	void _propagate_physics_interpolated(bool p_interpolated);
-	void _propagate_physics_interpolation_reset_requested();
+	void _propagate_physics_interpolation_reset_requested(bool p_requested);
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);
 	void _propagate_groups_dirty();

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -555,6 +555,9 @@ void SceneTree::client_physics_interpolation_remove_spatial(SelfList<Spatial> *p
 
 void SceneTree::iteration_prepare() {
 	if (_physics_interpolation_enabled) {
+		// Make sure any pending transforms from the last tick / frame
+		// are flushed before pumping the interpolation prev and currents.
+		flush_transform_notifications();
 		VisualServer::get_singleton()->tick();
 	}
 }

--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -361,11 +361,7 @@ void RasterizerStorage::multimesh_instance_set_transform(RID p_multimesh, int p_
 
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 			if (!Engine::get_singleton()->is_in_physics_frame()) {
-				static int32_t warn_count = 0;
-				warn_count++;
-				if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
-					WARN_PRINT("[Physics interpolation] MultiMesh interpolation is being triggered from outside physics process, this might lead to issues (possibly benign).");
-				}
+				PHYSICS_INTERPOLATION_WARNING("Interpolated MultiMesh triggered from outside physics process");
 			}
 #endif
 			return;
@@ -521,11 +517,7 @@ void RasterizerStorage::multimesh_set_as_bulk_array_interpolated(RID p_multimesh
 		_multimesh_add_to_interpolation_lists(p_multimesh, *mmi);
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 		if (!Engine::get_singleton()->is_in_physics_frame()) {
-			static int32_t warn_count = 0;
-			warn_count++;
-			if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
-				WARN_PRINT("[Physics interpolation] MultiMesh interpolation is being triggered from outside physics process, this might lead to issues (possibly benign).");
-			}
+			PHYSICS_INTERPOLATION_WARNING("Interpolated MultiMesh triggered from outside physics process");
 		}
 #endif
 	}
@@ -541,11 +533,7 @@ void RasterizerStorage::multimesh_set_as_bulk_array(RID p_multimesh, const PoolV
 			_multimesh_add_to_interpolation_lists(p_multimesh, *mmi);
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 			if (!Engine::get_singleton()->is_in_physics_frame()) {
-				static int32_t warn_count = 0;
-				warn_count++;
-				if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
-					WARN_PRINT("[Physics interpolation] MultiMesh interpolation is being triggered from outside physics process, this might lead to issues (possibly benign).");
-				}
+				PHYSICS_INTERPOLATION_WARNING("Interpolated MultiMesh triggered from outside physics process");
 			}
 #endif
 			return;

--- a/servers/visual/visual_server_constants.h
+++ b/servers/visual/visual_server_constants.h
@@ -53,6 +53,9 @@
 // This is expensive.
 // #define VISUAL_SERVER_CANVAS_CHECK_BOUNDS
 
+// Uncomment this define to produce debugging output for physics interpolation.
+// #define VISUAL_SERVER_DEBUG_PHYSICS_INTERPOLATION
+
 #endif // DEV_ENABLED
 
 #endif // VISUAL_SERVER_CONSTANTS_H

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -461,8 +461,6 @@ public:
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND5(camera_set_frustum, RID, float, Vector2, float, float)
 	BIND2(camera_set_transform, RID, const Transform &)
-	BIND2(camera_set_interpolated, RID, bool)
-	BIND1(camera_reset_physics_interpolation, RID)
 	BIND2(camera_set_cull_mask, RID, uint32_t)
 	BIND2(camera_set_environment, RID, RID)
 	BIND2(camera_set_use_vertical_aspect, RID, bool)

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -81,19 +81,11 @@ public:
 		uint32_t visible_layers;
 		RID env;
 
-		// transform_prev is only used when using fixed timestep interpolation
 		Transform transform;
-		Transform transform_prev;
-
-		bool interpolated : 1;
-		bool on_interpolate_transform_list : 1;
 
 		bool vaspect : 1;
-		TransformInterpolator::Method interpolation_method : 3;
 
 		int32_t previous_room_id_hint;
-
-		Transform get_transform_interpolated() const;
 
 		Camera() {
 			visible_layers = 0xFFFFFFFF;
@@ -105,9 +97,6 @@ public:
 			offset = Vector2();
 			vaspect = false;
 			previous_room_id_hint = -1;
-			interpolated = true;
-			on_interpolate_transform_list = false;
-			interpolation_method = TransformInterpolator::INTERP_LERP;
 		}
 	};
 
@@ -118,8 +107,6 @@ public:
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform);
-	virtual void camera_set_interpolated(RID p_camera, bool p_interpolated);
-	virtual void camera_reset_physics_interpolation(RID p_camera);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable);
@@ -410,18 +397,11 @@ public:
 	virtual void set_physics_interpolation_enabled(bool p_enabled);
 
 	struct InterpolationData {
-		void notify_free_camera(RID p_rid, Camera &r_camera);
 		void notify_free_instance(RID p_rid, Instance &r_instance);
 		LocalVector<RID> instance_interpolate_update_list;
 		LocalVector<RID> instance_transform_update_lists[2];
 		LocalVector<RID> *instance_transform_update_list_curr = &instance_transform_update_lists[0];
 		LocalVector<RID> *instance_transform_update_list_prev = &instance_transform_update_lists[1];
-		LocalVector<RID> instance_teleport_list;
-
-		LocalVector<RID> camera_transform_update_lists[2];
-		LocalVector<RID> *camera_transform_update_list_curr = &camera_transform_update_lists[0];
-		LocalVector<RID> *camera_transform_update_list_prev = &camera_transform_update_lists[1];
-		LocalVector<RID> camera_teleport_list;
 
 		bool interpolation_enabled = false;
 	} _interpolation_data;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -375,8 +375,6 @@ public:
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
 	FUNC2(camera_set_transform, RID, const Transform &)
-	FUNC2(camera_set_interpolated, RID, bool)
-	FUNC1(camera_reset_physics_interpolation, RID)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)
 	FUNC2(camera_set_use_vertical_aspect, RID, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2095,8 +2095,6 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &VisualServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &VisualServer::camera_set_frustum);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &VisualServer::camera_set_transform);
-	ClassDB::bind_method(D_METHOD("camera_set_interpolated", "camera", "interpolated"), &VisualServer::camera_set_interpolated);
-	ClassDB::bind_method(D_METHOD("camera_reset_physics_interpolation", "camera"), &VisualServer::camera_reset_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &VisualServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &VisualServer::camera_set_environment);
 	ClassDB::bind_method(D_METHOD("camera_set_use_vertical_aspect", "camera", "enable"), &VisualServer::camera_set_use_vertical_aspect);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -634,8 +634,6 @@ public:
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;
-	virtual void camera_set_interpolated(RID p_camera, bool p_interpolated) = 0;
-	virtual void camera_reset_physics_interpolation(RID p_camera) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;


### PR DESCRIPTION
* Adds auto-resets for 3D.
* Moves 3D Camera interpolation scene side.
* Automatically switches `get_camera_transform()` to report interpolated transform during `_process()`.
* Fixes `ClippedCamera` to work with physics interpolation.
* Fixes `VisualInstance` `reset_physics_interpolation` transforms being out of date.
* Refactors resets, particularly for 3D.

Fixes issue mentioned in https://github.com/godotengine/godot/pull/92391#issuecomment-2147675432
Fixes issue mentioned in https://github.com/godotengine/godot/pull/92391#issuecomment-2150787753

This should fix the following `Camera` commands to work with physics interpolation:
```
is_position_behind()
project_local_ray_normal()
project_position()
project_ray_normal()
project_ray_origin()
unproject_position()
```
There is quite a bit of reset refactoring here to deal with moving reset bugs revealed in testing for https://github.com/godotengine/godot/pull/92391 .

### Notable Changes
Teleport lists have been removed in favour of instantaneous teleport in `VisualServer`.
This is possible because client code now flushes any dirty transforms prior to the reset.

## Notes
* Refactors the 3D Camera interpolation to more closely match the technique used in 2D. This allows more efficient access to interpolated transforms for the querying functions.
* Moves the physics interpolation warnings to functions within error macros to reduce duplication.
* Adds physics interpolation warning for `Camera` moved in `_process()`.
* Allows instantaneous update of `Camera` parameters within `_process()`.
* `ClippedCamera` is supported, but will force physics process mode when interpolation is active (idle mode makes no sense), and shows a warning when forcing.
* `InterpolatedCamera` is not supported (as deprecated).
* `ARVRCamera` hopefully doesn't need any modifications (but not highly tested).

## Milestones
I originally scheduled this for 3.7 as we are in feature freeze now for 3.6, and although this is not a new feature, moving the `Camera` interpolation scene side is a significant refactor.

However, on reflection, leaving this for 3.7 is going to be a logistical pain, as it fixes a number of significant interpolation bugs in 3.6, and we are finally getting significant testing as a result of this being kept in sync with the version in 4.x. It will also become problematic if we get 3.x and 4.x versions out of sync, as 3.x is the lead for physics interpolation, and @rburing will need this .

So it should be worth it to get in for the first 3.6 RC.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
