### PR TITLE
C#: Skip method name when checking CallError

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -143,7 +143,7 @@ namespace Godot.NativeInterop
             if (error.Error != godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_OK)
             {
                 using godot_variant instanceVariant = VariantUtils.CreateFromGodotObjectPtr(instance);
-                string where = GetCallErrorWhere(method, &instanceVariant, args, argCount);
+                string where = GetCallErrorWhere(ref error, method, &instanceVariant, args, argCount);
                 string errorText = GetCallErrorMessage(error, where, args);
                 GD.PushError(errorText);
             }
@@ -161,7 +161,7 @@ namespace Godot.NativeInterop
             }
         }
 
-        private unsafe static string GetCallErrorWhere(godot_string_name method, godot_variant* instance, godot_variant** args, int argCount)
+        private unsafe static string GetCallErrorWhere(ref godot_variant_call_error error, godot_string_name method, godot_variant* instance, godot_variant** args, int argCount)
         {
             string? methodstr = null;
             string basestr = GetVariantTypeName(instance);
@@ -171,6 +171,10 @@ namespace Godot.NativeInterop
                 if (argCount >= 1)
                 {
                     methodstr = VariantUtils.ConvertToString(*args[0]);
+                    if (error.Error == godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INVALID_ARGUMENT)
+                    {
+                        error.Argument += 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
When invoking `call`, the arguments contain the method name. This argument must be skipped; otherwise, the `error.argument` index will be off.

For example, you can see the bug in the error reported in https://github.com/godotengine/godot/issues/92793:

> ERROR: Invalid type in function 'setup1' in base 'Godot.Node3D'. Cannot convert argument 1 from StringName to Array.

The error says that the first argument `StringName` can't be converted to `Array`. This is wrong because it's checking the method name argument in the `Call` invocation, but it should be checking the first vararg argument instead.

With this PR, the error now looks like this:

> ERROR: Invalid type in function 'setup1' in base 'Godot.Node3D'. The array of argument 2 (Array) does not have the same element type as the expected typed array argument.

This should match what GDScript does:

https://github.com/godotengine/godot/blob/96a386f3c424af96d950ee5098b4b0e4907c9508/modules/gdscript/gdscript_vm.cpp#L1787-L1789