### PR TITLE
Set `XRHandTracker` property `has_tracking_data` to true only when palm joint is tracked

### DIFF
--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -293,7 +293,12 @@ void OpenXRHandTrackingExtension::on_process() {
 						}
 
 						godot_tracker->set_hand_tracking_source(source);
-						godot_tracker->set_pose("default", transform, linear_velocity, angular_velocity);
+						if (location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) {
+							godot_tracker->set_pose("default", transform, linear_velocity, angular_velocity);
+						} else {
+							godot_tracker->set_has_tracking_data(false);
+							godot_tracker->invalidate_pose("default");
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
Currently when calling `get_has_tracking_data()` on an `XRHandTracker`, it will always return true. This update sets that value to false if the palm joint is not being tracked. It also invalidates the pose of the tracker, making it so the `XRNode3D` property `show_when_tracked` works as expected (e.g. hiding hand tracked meshes when hands aren't visible).