### PR TITLE
Ignore Kate's build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ gmon.out
 
 # Kate
 *.kate-swp
+.kateproject.build
 
 # Kdevelop
 *.kdev4


### PR DESCRIPTION
This file is used to store build instructions for the [Kate](https://kate-editor.org/) editor.