### PR TITLE
Add input event callback to `DisplayServerHeadless`

### DIFF
--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -36,7 +36,7 @@
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 // Specialized DisplayServer for unittests based on DisplayServerHeadless, that
-// additionally supports rudimentary InputEvent handling and mouse position.
+// additionally supports things like mouse enter/exit events and clipboard.
 class DisplayServerMock : public DisplayServerHeadless {
 private:
 	friend class DisplayServer;
@@ -45,7 +45,6 @@ private:
 	CursorShape cursor_shape = CursorShape::CURSOR_ARROW;
 	bool window_over = false;
 	Callable event_callback;
-	Callable input_event_callback;
 
 	String clipboard_text;
 	String primary_clipboard_text;
@@ -60,16 +59,6 @@ private:
 		r_error = OK;
 		RasterizerDummy::make_current();
 		return memnew(DisplayServerMock());
-	}
-
-	static void _dispatch_input_events(const Ref<InputEvent> &p_event) {
-		static_cast<DisplayServerMock *>(get_singleton())->_dispatch_input_event(p_event);
-	}
-
-	void _dispatch_input_event(const Ref<InputEvent> &p_event) {
-		if (input_event_callback.is_valid()) {
-			input_event_callback.call(p_event);
-		}
 	}
 
 	void _set_mouse_position(const Point2i &p_position) {
@@ -153,18 +142,9 @@ public:
 		event_callback = p_callable;
 	}
 
-	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override {
-		input_event_callback = p_callable;
-	}
-
 	static void register_mock_driver() {
 		register_create_function("mock", create_func, get_rendering_drivers_func);
 	}
-
-	DisplayServerMock() {
-		Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
-	}
-	~DisplayServerMock() {}
 };
 
 #endif // DISPLAY_SERVER_MOCK_H


### PR DESCRIPTION
This adds input capabilities to `DisplayServerHeadless`. by simply adding an input event callback to it, in pretty much the exact same way as how `DisplayServerMock` does it, while also removing the now redundant one from `DisplayServerMock`.

This could perhaps be considered a mildly controversial change, seeing as how input handling is tied to windows in the eyes of the display server API, but in the interest of sparking a discussion about it, here it is.

The motivation for this isn't too complicated: When dealing with things like unit tests that run on a headless CI, it can be desirable to manually inject input events (with something like [`Input.parse_input_event`](https://docs.godotengine.org/en/stable/classes/class_input.html#class-input-method-parse-input-event)) in order to test the input code paths, or perhaps simulate an actual user more accurately.

This is technically possible already by relying on [`Viewport.push_input`](https://docs.godotengine.org/en/stable/classes/class_viewport.html#class-viewport-method-push-input) instead, but there you run into the problem that's mentioned in its documentation, namely that input emulation (like `input_devices/pointing/emulate_touch_from_mouse`) doesn't exist in that context, leaving you to having to recreate/copy this emulation into your own code instead, which is somewhat unfortunate and potentially brittle. This emulation also can't be added to `Viewport.push_input` since that's in turn used by `Input.parse_input_event`, so you'd end up not only with double emulation, but emulated events themselves triggering further emulation.

The much simpler solution to this seems to be to just add an input event callback to `DisplayServerHeadless`, allowing you to use `Input.parse_input_event` and its emulation just fine.