### PR TITLE
Use subfolder for temporary test files

### DIFF
--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -78,8 +78,8 @@ TEST_CASE("[Image] Instantiation") {
 
 TEST_CASE("[Image] Saving and loading") {
 	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
-	const String save_path_png = OS::get_singleton()->get_cache_path().path_join("image.png");
-	const String save_path_exr = OS::get_singleton()->get_cache_path().path_join("image.exr");
+	const String save_path_png = TestUtils::get_temp_path("image.png");
+	const String save_path_exr = TestUtils::get_temp_path("image.exr");
 
 	// Save PNG
 	Error err;

--- a/tests/core/io/test_pck_packer.h
+++ b/tests/core/io/test_pck_packer.h
@@ -42,7 +42,7 @@ namespace TestPCKPacker {
 
 TEST_CASE("[PCKPacker] Pack an empty PCK file") {
 	PCKPacker pck_packer;
-	const String output_pck_path = OS::get_singleton()->get_cache_path().path_join("output_empty.pck");
+	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	CHECK_MESSAGE(
 			pck_packer.pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");
@@ -66,7 +66,7 @@ TEST_CASE("[PCKPacker] Pack an empty PCK file") {
 
 TEST_CASE("[PCKPacker] Pack empty with zero alignment invalid") {
 	PCKPacker pck_packer;
-	const String output_pck_path = OS::get_singleton()->get_cache_path().path_join("output_empty.pck");
+	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 0) != OK, "PCK with zero alignment should fail.");
 	ERR_PRINT_ON;
@@ -74,7 +74,7 @@ TEST_CASE("[PCKPacker] Pack empty with zero alignment invalid") {
 
 TEST_CASE("[PCKPacker] Pack empty with invalid key") {
 	PCKPacker pck_packer;
-	const String output_pck_path = OS::get_singleton()->get_cache_path().path_join("output_empty.pck");
+	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 32, "") != OK, "PCK with invalid key should fail.");
 	ERR_PRINT_ON;
@@ -82,7 +82,7 @@ TEST_CASE("[PCKPacker] Pack empty with invalid key") {
 
 TEST_CASE("[PCKPacker] Pack a PCK file with some files and directories") {
 	PCKPacker pck_packer;
-	const String output_pck_path = OS::get_singleton()->get_cache_path().path_join("output_with_files.pck");
+	const String output_pck_path = TestUtils::get_temp_path("output_with_files.pck");
 	CHECK_MESSAGE(
 			pck_packer.pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -76,8 +76,8 @@ TEST_CASE("[Resource] Saving and loading") {
 	Ref<Resource> child_resource = memnew(Resource);
 	child_resource->set_name("I'm a child resource");
 	resource->set_meta("other_resource", child_resource);
-	const String save_path_binary = OS::get_singleton()->get_cache_path().path_join("resource.res");
-	const String save_path_text = OS::get_singleton()->get_cache_path().path_join("resource.tres");
+	const String save_path_binary = TestUtils::get_temp_path("resource.res");
+	const String save_path_text = TestUtils::get_temp_path("resource.tres");
 	ResourceSaver::save(resource, save_path_binary);
 	ResourceSaver::save(resource, save_path_text);
 
@@ -123,8 +123,8 @@ TEST_CASE("[Resource] Breaking circular references on save") {
 	resource_b->set_meta("next", resource_c);
 	resource_c->set_meta("next", resource_b);
 
-	const String save_path_binary = OS::get_singleton()->get_cache_path().path_join("resource.res");
-	const String save_path_text = OS::get_singleton()->get_cache_path().path_join("resource.tres");
+	const String save_path_binary = TestUtils::get_temp_path("resource.res");
+	const String save_path_text = TestUtils::get_temp_path("resource.tres");
 	ResourceSaver::save(resource_a, save_path_binary);
 	// Suppress expected errors caused by the resources above being uncached.
 	ERR_PRINT_OFF;

--- a/tests/scene/test_audio_stream_wav.h
+++ b/tests/scene/test_audio_stream_wav.h
@@ -115,7 +115,7 @@ Vector<uint8_t> gen_pcm16_test(float wav_rate, int wav_count, bool stereo) {
 }
 
 void run_test(String file_name, AudioStreamWAV::Format data_format, bool stereo, float wav_rate, float wav_count) {
-	String save_path = OS::get_singleton()->get_cache_path().path_join(file_name);
+	String save_path = TestUtils::get_temp_path(file_name);
 
 	Vector<uint8_t> test_data;
 	if (data_format == AudioStreamWAV::FORMAT_8_BITS) {
@@ -200,7 +200,7 @@ TEST_CASE("[AudioStreamWAV] Alternate mix rate") {
 }
 
 TEST_CASE("[AudioStreamWAV] save_to_wav() adds '.wav' file extension automatically") {
-	String save_path = OS::get_singleton()->get_cache_path().path_join("test_wav_extension");
+	String save_path = TestUtils::get_temp_path("test_wav_extension");
 	Vector<uint8_t> test_data = gen_pcm8_test(WAV_RATE, WAV_COUNT, false);
 	Ref<AudioStreamWAV> stream = memnew(AudioStreamWAV);
 	stream->set_data(test_data);
@@ -230,7 +230,7 @@ TEST_CASE("[AudioStreamWAV] Save empty file") {
 }
 
 TEST_CASE("[AudioStreamWAV] Saving IMA ADPCM is not supported") {
-	String save_path = OS::get_singleton()->get_cache_path().path_join("test_adpcm.wav");
+	String save_path = TestUtils::get_temp_path("test_adpcm.wav");
 	Ref<AudioStreamWAV> stream = memnew(AudioStreamWAV);
 	stream->set_format(AudioStreamWAV::FORMAT_IMA_ADPCM);
 	ERR_PRINT_OFF;

--- a/tests/scene/test_instance_placeholder.h
+++ b/tests/scene/test_instance_placeholder.h
@@ -350,7 +350,7 @@ TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an
 	Error err = internal_scene->pack(internal);
 	REQUIRE(err == OK);
 
-	const String internal_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_internal.tscn");
+	const String internal_path = TestUtils::get_temp_path("instance_placeholder_test_internal.tscn");
 	err = ResourceSaver::save(internal_scene, internal_path);
 	REQUIRE(err == OK);
 
@@ -379,7 +379,7 @@ TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an
 	err = main_scene->pack(root);
 	REQUIRE(err == OK);
 
-	const String main_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_main.tscn");
+	const String main_path = TestUtils::get_temp_path("instance_placeholder_test_main.tscn");
 	err = ResourceSaver::save(main_scene, main_path);
 	REQUIRE(err == OK);
 
@@ -439,7 +439,7 @@ TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an
 	Error err = internal_scene->pack(internal);
 	REQUIRE(err == OK);
 
-	const String internal_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_internal_override.tscn");
+	const String internal_path = TestUtils::get_temp_path("instance_placeholder_test_internal_override.tscn");
 	err = ResourceSaver::save(internal_scene, internal_path);
 	REQUIRE(err == OK);
 
@@ -480,7 +480,7 @@ TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an
 	err = main_scene->pack(root);
 	REQUIRE(err == OK);
 
-	const String main_path = OS::get_singleton()->get_cache_path().path_join("instance_placeholder_test_main_override.tscn");
+	const String main_path = TestUtils::get_temp_path("instance_placeholder_test_main_override.tscn");
 	err = ResourceSaver::save(main_scene, main_path);
 	REQUIRE(err == OK);
 

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -518,7 +518,7 @@ TEST_CASE("[SceneTree][Node]Exported node checks") {
 		ps.instantiate();
 		ps->pack(node);
 
-		String scene_path = OS::get_singleton()->get_cache_path().path_join("test_scene.tscn");
+		String scene_path = TestUtils::get_temp_path("test_scene.tscn");
 		ps->set_path(scene_path);
 
 		Node *root = memnew(Node);
@@ -531,7 +531,7 @@ TEST_CASE("[SceneTree][Node]Exported node checks") {
 		ps2.instantiate();
 		ps2->pack(root);
 
-		scene_path = OS::get_singleton()->get_cache_path().path_join("new_test_scene.tscn");
+		scene_path = TestUtils::get_temp_path("new_test_scene.tscn");
 		ResourceSaver::save(ps2, scene_path);
 		memdelete(root);
 

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -30,6 +30,7 @@
 
 #include "tests/test_utils.h"
 
+#include "core/io/dir_access.h"
 #include "core/os/os.h"
 
 String TestUtils::get_data_path(const String &p_file) {
@@ -39,4 +40,10 @@ String TestUtils::get_data_path(const String &p_file) {
 
 String TestUtils::get_executable_dir() {
 	return OS::get_singleton()->get_executable_path().get_base_dir();
+}
+
+String TestUtils::get_temp_path(const String &p_suffix) {
+	const String temp_base = OS::get_singleton()->get_cache_path().path_join("godot_test");
+	DirAccess::make_dir_absolute(temp_base); // Ensure the directory exists.
+	return temp_base.path_join(p_suffix);
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -37,6 +37,7 @@ namespace TestUtils {
 
 String get_data_path(const String &p_file);
 String get_executable_dir();
+String get_temp_path(const String &p_suffix);
 } // namespace TestUtils
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
Adds a new test utils method: `get_temp_path(file)`, which returns an absolute path inside a "temporary" folder. That folder is a sub-folder of the folder used before, so all files are in one place.

Closes #92097

Further improvements like removing files automatically (or the whole folder) can be done later.