### PR TITLE
Fix Keep/Skip File import selection crash

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -189,13 +189,15 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	params->base_options_path = p_path;
 
 	HashMap<StringName, Variant> import_options;
-	List<String> section_keys;
-	p_config->get_section_keys("params", &section_keys);
-	for (const String &section_key : section_keys) {
-		import_options[section_key] = p_config->get_value("params", section_key);
-	}
-	if (params->importer.is_valid()) {
-		params->importer->handle_compatibility_options(import_options);
+	if (p_config.is_valid() && p_config->has_section("params")) {
+		List<String> section_keys;
+		p_config->get_section_keys("params", &section_keys);
+		for (const String &section_key : section_keys) {
+			import_options[section_key] = p_config->get_value("params", section_key);
+		}
+		if (params->importer.is_valid()) {
+			params->importer->handle_compatibility_options(import_options);
+		}
 	}
 
 	for (const ResourceImporter::ImportOption &E : options) {


### PR DESCRIPTION
Added `is_valid()` and "params" key checks before trying to access `ConfigFile`'s "params" section in `ImportDock::_update_options`, to handle case where selecting "Keep File" or "Skip File" importer passes in a null `ConfigFile`.

- Fixes #92785

*Bugsquad edit:*
- Fixes #92964