### PR TITLE
Fix glsl shader for Android Mali-GXXx GPUs and Vulkan API 1.3.xxx

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
@@ -11,9 +11,22 @@ layout(location = 0) out vec2 uv_interp;
 /* clang-format on */
 
 void main() {
-	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
-	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
-	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
+	// https://github.com/godotengine/godot/pull/92817#issuecomment-2168625982
+	//vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+	//gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
+	//uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+
+	vec2 vertex_base;
+	if (gl_VertexIndex == 0) {
+		vertex_base = vec2(-1.0, -1.0);
+	} else if (gl_VertexIndex == 1) {
+		vertex_base = vec2(-1.0, 3.0);
+	} else {
+		vertex_base = vec2(3.0, -1.0);
+	}
+	gl_Position = vec4(vertex_base, 0.0, 1.0);
+	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
 /* clang-format off */

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -13,9 +13,22 @@
 layout(location = 0) out vec2 uv_interp;
 
 void main() {
-	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
-	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
-	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
+	// https://github.com/godotengine/godot/pull/92817#issuecomment-2168625982
+	//vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+	//gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
+	//uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+
+	vec2 vertex_base;
+	if (gl_VertexIndex == 0) {
+		vertex_base = vec2(-1.0, -1.0);
+	} else if (gl_VertexIndex == 1) {
+		vertex_base = vec2(-1.0, 3.0);
+	} else {
+		vertex_base = vec2(3.0, -1.0);
+	}
+	gl_Position = vec4(vertex_base, 0.0, 1.0);
+	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
 #[fragment]


### PR DESCRIPTION
Fixes #86621

Issue #73384  maybe only partially, **not 3D** on `PowerVR Rogue` GPUs [comment](https://github.com/godotengine/godot/issues/73384#issuecomment-2155312745)

---------------------

<details><summary>Test on Firebase</summary>

--------------------

**Test Project:** [GlowTest.zip](https://github.com/user-attachments/files/15645386/GlowTest.zip)

- Glow on/off
- DOF Blur on/off
- `rendering/scaling_3d/scale` = 0.5



https://github.com/godotengine/godot/assets/41921395/ba2cbb1e-a5aa-43fb-9f16-002f90db2a53





</details>


- [x] Glow
- [x] DOF Blur
- [x] Rendering Scale 3D


