### PR TITLE
Fix building glslang on platforms without `<filesystem>`

### DIFF
--- a/thirdparty/glslang/glslang/Include/InfoSink.h
+++ b/thirdparty/glslang/glslang/Include/InfoSink.h
@@ -36,7 +36,7 @@
 #define _INFOSINK_INCLUDED_
 
 #include "../Include/Common.h"
-#include <filesystem>
+//#include <filesystem>
 #include <cmath>
 
 namespace glslang {

--- a/thirdparty/glslang/patches/disable-absolute-paths-for-apple-compat.patch
+++ b/thirdparty/glslang/patches/disable-absolute-paths-for-apple-compat.patch
@@ -1,7 +1,16 @@
 diff --git a/thirdparty/glslang/glslang/Include/InfoSink.h b/thirdparty/glslang/glslang/Include/InfoSink.h
-index 23f495dcb7..b1b537df54 100644
+index 23f495dc..137ede85 100644
 --- a/thirdparty/glslang/glslang/Include/InfoSink.h
 +++ b/thirdparty/glslang/glslang/Include/InfoSink.h
+@@ -36,7 +36,7 @@
+ #define _INFOSINK_INCLUDED_
+ 
+ #include "../Include/Common.h"
+-#include <filesystem>
++//#include <filesystem>
+ #include <cmath>
+ 
+ namespace glslang {
 @@ -101,14 +101,14 @@ public:
          snprintf(locText, maxSize, ":%d", loc.line);
  


### PR DESCRIPTION
Certain platforms using older libc++ versions have \<filesystem> support disabled, which causes the builds after 7f1d3b1cfad648be5009b67b37ee8f6ea1061d8e  to fail.

[As there's already been a hack added for similar issue on macOS in upstream](https://github.com/godotengine/godot/pull/92010#issuecomment-2114829729), this include is unused and can be removed.