### PR TITLE
Fix script create dialog will spam invalid classes into templates Dictionary

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -289,7 +289,7 @@ void ScriptCreateDialog::_parent_name_changed(const String &p_parent) {
 void ScriptCreateDialog::_template_changed(int p_template) {
 	const ScriptLanguage::ScriptTemplate &sinfo = _get_current_template();
 	// Update last used dictionaries
-	if (is_using_templates && !parent_name->get_text().begins_with("\"res:")) {
+	if (is_parent_name_valid && is_using_templates && !parent_name->get_text().begins_with("\"res:")) {
 		if (sinfo.origin == ScriptLanguage::TemplateLocation::TEMPLATE_PROJECT) {
 			// Save the last used template for this node into the project dictionary.
 			Dictionary dic_templates_project = EditorSettings::get_singleton()->get_project_metadata("script_setup", "templates_dictionary", Dictionary());


### PR DESCRIPTION
A hacky way of fixing https://github.com/godotengine/godot/issues/92818, IMHO there's no need to remember invalid parent class names.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/92818*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
