### PR TITLE
Use GDExtension `to_string` in Node

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -923,6 +923,7 @@ void Object::notification(int p_notification, bool p_reversed) {
 }
 
 String Object::to_string() {
+	// Keep this method in sync with `Node::to_string`.
 	if (script_instance) {
 		bool valid;
 		String ret = script_instance->to_string(&valid);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2583,6 +2583,7 @@ void Node::get_storable_properties(HashSet<StringName> &r_storable_properties) c
 }
 
 String Node::to_string() {
+	// Keep this method in sync with `Object::to_string`.
 	ERR_THREAD_GUARD_V(String());
 	if (get_script_instance()) {
 		bool valid;
@@ -2591,7 +2592,12 @@ String Node::to_string() {
 			return ret;
 		}
 	}
-
+	if (_get_extension() && _get_extension()->to_string) {
+		String ret;
+		GDExtensionBool is_valid;
+		_get_extension()->to_string(_get_extension_instance(), &is_valid, &ret);
+		return ret;
+	}
 	return (get_name() ? String(get_name()) + ":" : "") + Object::to_string();
 }
 


### PR DESCRIPTION
Before this PR, when a GDExtension class that derives from `Node` implements `_to_string` like this:

```cpp
String _to_string() const {
    return "MyClass";
}
```

Godot will print `@MyNode@2:MyClass` instead of just `MyClass` like it does for other `Object`-derived classes.

Matches the `Object::to_string` implementation:

https://github.com/godotengine/godot/blob/e96ad5af98547df71b50c4c4695ac348638113e0/core/object/object.cpp#L925-L940