### PR TITLE
Fix `CanvasItemEditor` smart snap lines.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -465,6 +465,7 @@ private:
 
 	void _draw_viewport();
 
+	void _is_hovering_guide(Point2 p_pos, bool p_is_pressed = false, bool p_ctrl_pressed = false);
 	bool _gui_input_anchors(const Ref<InputEvent> &p_event);
 	bool _gui_input_move(const Ref<InputEvent> &p_event);
 	bool _gui_input_open_scene_on_double_click(const Ref<InputEvent> &p_event);
@@ -489,7 +490,9 @@ private:
 	void _project_settings_changed();
 
 	SnapTarget snap_target[2];
+	SnapTarget snap_target2[2];
 	Transform2D snap_transform;
+	Transform2D snap_transform2;
 	void _snap_if_closer_float(
 			const real_t p_value,
 			real_t &r_current_snap, SnapTarget &r_current_snap_target,


### PR DESCRIPTION
- Fix smart snap drawing by caching the snapping result when using `snap_point` twice in the same function.
- Made some changes to make `_draw_straight_line` more usable by calling it with the transformed vectors as arguments.
- Using duplicate when initializing a node with the same properties twice.
- Add `viewport->queue_redraw()` as a do method when making changes to the guides. [undo/redo is buggy for guides because it uses a cached array instead of proper undo/redo methods].

I used to check if ctrl is pressed while pressing the guide to easily remove it instead of dragging it to the ruler, but i didn't apply it in this pull request to not make a lot of changes in one pull request `_is_hovering_guide(Point2 p_pos, bool p_is_pressed, bool p_ctrl_pressed)`.