### PR TITLE
Optimize AnimationMixer blend process

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1085,7 +1085,8 @@ void AnimationMixer::_blend_calc_total_weight() {
 		real_t weight = ai.playback_info.weight;
 		const real_t *track_weights_ptr = ai.playback_info.track_weights.ptr();
 		int track_weights_count = ai.playback_info.track_weights.size();
-		Vector<Animation::TypeHash> processed_hashes;
+		static LocalVector<Animation::TypeHash> processed_hashes;
+		processed_hashes.clear();
 		const Vector<Animation::Track *> tracks = a->get_tracks();
 		for (const Animation::Track *animation_track : tracks) {
 			if (!animation_track->enabled) {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -48,6 +48,7 @@ class AnimationMixer : public Node {
 #endif // TOOLS_ENABLED
 
 	bool reset_on_save = true;
+	bool is_GDVIRTUAL_CALL_post_process_key_value = true;
 
 public:
 	enum AnimationCallbackModeProcess {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -203,10 +203,11 @@ AnimationNode::NodeTimeInfo AnimationNode::_blend_node(Ref<AnimationNode> p_node
 		}
 
 		for (const KeyValue<NodePath, bool> &E : filter) {
-			if (!process_state->track_map.has(E.key)) {
+			const HashMap<NodePath, int> &map = *process_state->track_map;
+			if (!map.has(E.key)) {
 				continue;
 			}
-			int idx = process_state->track_map[E.key];
+			int idx = map[E.key];
 			blendw[idx] = 1.0; // Filtered goes to one.
 		}
 
@@ -618,7 +619,7 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 		process_state.valid = true;
 		process_state.invalid_reasons = "";
 		process_state.last_pass = process_pass;
-		process_state.track_map = p_track_map;
+		process_state.track_map = &p_track_map;
 
 		// Init node state for root AnimationNode.
 		root_animation_node->node_state.track_weights.resize(p_track_count);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -106,7 +106,7 @@ public:
 	// Temporary state for blending process which needs to be started in the AnimationTree, pass through the AnimationNodes, and then return to the AnimationTree.
 	struct ProcessState {
 		AnimationTree *tree = nullptr;
-		HashMap<NodePath, int> track_map; // TODO: Is there a better way to manage filter/tracks?
+		const HashMap<NodePath, int> *track_map; // TODO: Is there a better way to manage filter/tracks?
 		bool is_testing = false;
 		bool valid = false;
 		String invalid_reasons;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -91,13 +91,13 @@ public:
 	};
 
 #ifdef TOOLS_ENABLED
-	enum HandleMode{
+	enum HandleMode {
 		HANDLE_MODE_FREE,
 		HANDLE_MODE_LINEAR,
 		HANDLE_MODE_BALANCED,
 		HANDLE_MODE_MIRRORED,
 	};
-	enum HandleSetMode{
+	enum HandleSetMode {
 		HANDLE_SET_MODE_NONE,
 		HANDLE_SET_MODE_RESET,
 		HANDLE_SET_MODE_AUTO,

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -45,7 +45,7 @@ public:
 
 	static inline String PARAMETERS_BASE_PATH = "parameters/";
 
-	enum TrackType {
+	enum TrackType : uint8_t {
 		TYPE_VALUE, // Set a value in a property, can be interpolated.
 		TYPE_POSITION_3D, // Position 3D track, can be compressed.
 		TYPE_ROTATION_3D, // Rotation 3D track, can be compressed.
@@ -57,7 +57,7 @@ public:
 		TYPE_ANIMATION,
 	};
 
-	enum InterpolationType {
+	enum InterpolationType : uint8_t {
 		INTERPOLATION_NEAREST,
 		INTERPOLATION_LINEAR,
 		INTERPOLATION_CUBIC,
@@ -65,46 +65,45 @@ public:
 		INTERPOLATION_CUBIC_ANGLE,
 	};
 
-	enum UpdateMode {
+	enum UpdateMode : uint8_t {
 		UPDATE_CONTINUOUS,
 		UPDATE_DISCRETE,
 		UPDATE_CAPTURE,
 	};
 
-	enum LoopMode {
+	enum LoopMode : uint8_t {
 		LOOP_NONE,
 		LOOP_LINEAR,
 		LOOP_PINGPONG,
 	};
 
 	// LoopedFlag is used in Animataion to "process the keys at both ends correct".
-	enum LoopedFlag {
+	enum LoopedFlag : uint8_t {
 		LOOPED_FLAG_NONE,
 		LOOPED_FLAG_END,
 		LOOPED_FLAG_START,
 	};
 
-	enum FindMode {
+	enum FindMode : uint8_t {
 		FIND_MODE_NEAREST,
 		FIND_MODE_APPROX,
 		FIND_MODE_EXACT,
 	};
 
 #ifdef TOOLS_ENABLED
-	enum HandleMode {
+	enum HandleMode{
 		HANDLE_MODE_FREE,
 		HANDLE_MODE_LINEAR,
 		HANDLE_MODE_BALANCED,
 		HANDLE_MODE_MIRRORED,
 	};
-	enum HandleSetMode {
+	enum HandleSetMode{
 		HANDLE_SET_MODE_NONE,
 		HANDLE_SET_MODE_RESET,
 		HANDLE_SET_MODE_AUTO,
 	};
 #endif // TOOLS_ENABLED
 
-private:
 	struct Track {
 		TrackType type = TrackType::TYPE_ANIMATION;
 		InterpolationType interpolation = INTERPOLATION_LINEAR;
@@ -117,6 +116,7 @@ private:
 		virtual ~Track() {}
 	};
 
+private:
 	struct Key {
 		real_t transition = 1.0;
 		double time = 0.0; // Time in secs.
@@ -395,6 +395,10 @@ protected:
 public:
 	int add_track(TrackType p_type, int p_at_pos = -1);
 	void remove_track(int p_track);
+
+	_FORCE_INLINE_ const Vector<Track *> get_tracks() {
+		return tracks;
+	}
 
 	bool is_capture_included() const;
 


### PR DESCRIPTION
This PR is created to optimize the AnimaionMixer `_process_animation`. 
```c++
void AnimationMixer::_process_animation(double p_delta, bool p_update_only) {
	_blend_init();
	if (_blend_pre_process(p_delta, track_count, track_map)) {
		_blend_capture(p_delta);
		_blend_calc_total_weight();             
		_blend_process(p_delta, p_update_only);
		_blend_apply();
		_blend_post_process();
		emit_signal(SNAME("mixer_applied"));
	};
	clear_animation_instances();
}
```

# Benchmarking methods:

I made some benchmarks of how long each of these methods takes for one 3D model, using animation_tree.

Some explanations to understand the results.
Units of measurement: usec.
is_process = _blend_pre_process
weight = _blend_calc_total_weight    

Master:
<img src="https://github.com/godotengine/godot/assets/116561933/17284ecb-0cf2-45e0-9bc2-dad888898bb1" width="500" height="300">

You can see here that the `_blend_process`, `_blend_pre_process` and `_blend_calc_total_weight` methods take the most time.

I will show the results that are in this PR.

<img src="https://github.com/godotengine/godot/assets/116561933/5b4b6a77-28bf-4d4d-84ee-496a96cbda7a" width="500" height="300">

You can see that `blend_process` has improved by 30%, blend `calc_total_weight` has improved by 15% and `_blend_pre_process` has improved by 50%.

# Real project benchmarks:

Master:
Project FPS: 56 (17.85 mspf)
Project FPS: 56 (17.85 mspf)
Project FPS: 56 (17.85 mspf)
Project FPS: 56 (17.85 mspf)
Project FPS: 55 (18.18 mspf)
Project FPS: 55 (18.18 mspf)

Current PR:
Project FPS: 68 (14.70 mspf)
Project FPS: 69 (14.49 mspf)
Project FPS: 66 (15.15 mspf)
Project FPS: 66 (15.15 mspf)
Project FPS: 68 (14.70 mspf)

Here you can see a pretty good + 22%. Note that #92554 also improves animation performance, which with this PR adds 40% to performance.

# How to test:
Here #92554 in the benchmark section is Animation_test.zip project. After opening, fps will be output to the console.

# What was done:

**Animation:**

- For enums, the size was reduced from 4 to 1 byte.
- Added the get_tracks method.

**AnimationTree:**

- I made track_map a pointer in order not to copy maps. 

**AnimationMixer:**

- The first is to use getptr instead of has + operator[].
- The second is to use `int count = a->get_track_count();` In order to store in a register the number of iterations.
- Used the method already created in animation.h to take the array. `const Vector<Animation::Track *> tracks = a->get_tracks();`
- In the method `post_process_key_value` I cache whether there is GDVIRTUAL_CALL. That is, there will be only 1 check per _blend_process call.

Probably closes: #92693
