### PR TITLE
C#: Allow customizing assembly data directory name

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -913,6 +913,9 @@
 		<member name="dotnet/project/assembly_reload_attempts" type="int" setter="" getter="" default="3">
 			Number of times to attempt assembly reloading after rebuilding .NET assemblies. Effectively also the timeout in seconds to wait for unloading of script assemblies to finish.
 		</member>
+		<member name="dotnet/project/data_directory" type="String" setter="" getter="" default="&quot;data_{app_name}_{platform}_{arch}&quot;">
+			Directory that contains the dotnet-related files (such as [code].dll[/code] assembly files and dotnet runtime) in the exported project. The following substitutions are available: [code]app_name[/code], [code]platform[/code], [code]arch[/code].
+		</member>
 		<member name="dotnet/project/solution_directory" type="String" setter="" getter="" default="&quot;&quot;">
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -116,6 +116,7 @@ void CSharpLanguage::init() {
 #endif
 
 	GLOBAL_DEF("dotnet/project/assembly_name", "");
+	GLOBAL_DEF("dotnet/project/data_directory", "data_{app_name}_{platform}_{arch}");
 #ifdef TOOLS_ENABLED
 	GLOBAL_DEF("dotnet/project/solution_directory", "");
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "dotnet/project/assembly_reload_attempts", PROPERTY_HINT_RANGE, "1,16,1,or_greater"), 3);

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -221,7 +221,11 @@ namespace GodotTools.Export
                 {
                     string ridArch = DetermineRuntimeIdentifierArch(arch);
                     string runtimeIdentifier = $"{ridOS}-{ridArch}";
-                    string projectDataDirName = $"data_{GodotSharpDirs.CSharpProjectName}_{platform}_{arch}";
+                    string projectDataDirName = ((string)ProjectSettings.GetSettingWithOverride("dotnet/project/data_directory"))
+                        .Replace("{app_name}", GodotSharpDirs.CSharpProjectName)
+                        .Replace("{platform}", platform)
+                        .Replace("{arch}", arch);
+
                     if (platform == OS.Platforms.MacOS)
                     {
                         projectDataDirName = Path.Combine("Contents", "Resources", projectDataDirName);

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -169,9 +169,17 @@ private:
 		String arch = Engine::get_singleton()->get_architecture_name();
 		String appname_safe = path::get_csharp_project_name();
 		String packed_path = "res://.godot/mono/publish/" + arch;
+
+		Dictionary dic;
+		dic["app_name"] = appname_safe;
+		dic["platform"] = platform;
+		dic["arch"] = arch;
+
+		String data_dir_name = String(GLOBAL_GET("dotnet/project/data_directory")).format(dic);
+
 		if (DirAccess::exists(packed_path)) {
 			// The dotnet publish data is packed in the pck/zip.
-			String data_dir_root = OS::get_singleton()->get_cache_path().path_join("data_" + appname_safe + "_" + platform + "_" + arch);
+			String data_dir_root = OS::get_singleton()->get_cache_path().path_join(data_dir_name);
 			bool has_data = false;
 			if (!has_data) {
 				// 1. Try to access the data directly.
@@ -200,10 +208,10 @@ private:
 			api_assemblies_dir = data_dir_root;
 		} else {
 			// The dotnet publish data is in a directory next to the executable.
-			String data_dir_root = exe_dir.path_join("data_" + appname_safe + "_" + platform + "_" + arch);
+			String data_dir_root = exe_dir.path_join(data_dir_name);
 #ifdef MACOS_ENABLED
 			if (!DirAccess::exists(data_dir_root)) {
-				data_dir_root = res_dir.path_join("data_" + appname_safe + "_" + platform + "_" + arch);
+				data_dir_root = res_dir.path_join(data_dir_name);
 			}
 #endif
 			api_assemblies_dir = data_dir_root;


### PR DESCRIPTION
Add a project setting that allow users to customize the name of assembly data directory in C# exports.
So that we can have some fresh folder structures like:
```
bin
game.exe
game.pck
```
Old naming is equivalent to `data_{app_name}_{platform}_{arch}` with placeholders.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9909*