### PR TITLE
Fix playing backwards discrete animation will begin with the first keyframe

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -236,7 +236,12 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	}
 	// AnimationPlayer doesn't have internal seeking.
 	// However, immediately after playback, discrete keys should be retrieved with EXACT mode since behind keys must be ignored at that time.
-	pi.is_external_seeking = !p_started;
+	if (backwards) {
+		pi.is_external_seeking = true;
+	} else {
+		pi.is_external_seeking = !p_started;
+	}
+
 	pi.looped_flag = looped_flag;
 	pi.weight = p_blend;
 	make_animation_instance(cd.from->name, pi);


### PR DESCRIPTION
This seems to fix #92840