### PR TITLE
Fix `VisualShaderNodeVaryingGetter` expanded ports adding ".x" to shader

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -5162,11 +5162,11 @@ VisualShaderNodeVarying::PortType VisualShaderNodeVarying::get_port_type(VisualS
 		case VisualShader::VARYING_TYPE_UINT:
 			return PORT_TYPE_SCALAR_UINT;
 		case VisualShader::VARYING_TYPE_VECTOR_2D:
-			return PORT_TYPE_VECTOR_2D;
+			return p_port == 0 ? PORT_TYPE_VECTOR_2D : PORT_TYPE_SCALAR;
 		case VisualShader::VARYING_TYPE_VECTOR_3D:
-			return PORT_TYPE_VECTOR_3D;
+			return p_port == 0 ? PORT_TYPE_VECTOR_3D : PORT_TYPE_SCALAR;
 		case VisualShader::VARYING_TYPE_VECTOR_4D:
-			return PORT_TYPE_VECTOR_4D;
+			return p_port == 0 ? PORT_TYPE_VECTOR_4D : PORT_TYPE_SCALAR;
 		case VisualShader::VARYING_TYPE_BOOLEAN:
 			return PORT_TYPE_BOOLEAN;
 		case VisualShader::VARYING_TYPE_TRANSFORM:


### PR DESCRIPTION
When `VisualShaderNodeVaryingGetter` type was Vector2/Vector3/Vector4, expanding the output ports and connecting an individual value to a scalar input would add ".x" to the assignment in the generated shader.  This was due to `VisualShaderNodeVarying::get_port_type` ignoring the port number, and always returning the associated vector type.  Added checks for `p_port == 0` to return either the vector type, or scalar for expanded ports, matching similar logic in other nodes, like `VisualShaderNodeColorConstant::get_output_port_type`.

Fixes #92832

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
