### PR TITLE
Make query for `GL_MAX_VIEWPORT_DIMS` compatible with web exports 

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2742,8 +2742,7 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	}
 
-	int uniform_max_size = config->max_uniform_buffer_size;
-	if (uniform_max_size < 65536) {
+	if (config->max_uniform_buffer_size < 65536) {
 		data.max_lights_per_render = 64;
 	} else {
 		data.max_lights_per_render = 256;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -398,8 +398,7 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 			// Viewport doesn't cover entire window so clear window to black before blitting.
 			// Querying the actual window size from the DisplayServer would deadlock in separate render thread mode,
 			// so let's set the biggest viewport the implementation supports, to be sure the window is fully covered.
-			GLsizei max_vp[2] = {};
-			glGetIntegerv(GL_MAX_VIEWPORT_DIMS, max_vp);
+			Size2i max_vp = GLES3::Utilities::get_singleton()->get_maximum_viewport_size();
 			glViewport(0, 0, max_vp[0], max_vp[1]);
 			glClearColor(0.0, 0.0, 0.0, 1.0);
 			glClear(GL_COLOR_BUFFER_BIT);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -37,6 +37,7 @@
 #include "core/io/file_access.h"
 
 #include "drivers/gles3/rasterizer_gles3.h"
+#include "drivers/gles3/storage/config.h"
 
 static String _mkid(const String &p_id) {
 	String id = "m_" + p_id.replace("__", "_dus_");
@@ -801,7 +802,9 @@ void ShaderGLES3::initialize(const String &p_general_defines, int p_base_texture
 		print_verbose("Shader '" + name + "' SHA256: " + base_sha256);
 	}
 
-	glGetInteger64v(GL_MAX_TEXTURE_IMAGE_UNITS, &max_image_units);
+	GLES3::Config *config = GLES3::Config::get_singleton();
+	ERR_FAIL_NULL(config);
+	max_image_units = config->max_texture_image_units;
 }
 
 void ShaderGLES3::set_shader_cache_dir(const String &p_dir) {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -148,7 +148,7 @@ private:
 	static bool shader_cache_save_debug;
 	bool shader_cache_dir_valid = false;
 
-	int64_t max_image_units = 0;
+	GLint max_image_units = 0;
 
 	enum StageType {
 		STAGE_TYPE_VERTEX,

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -45,9 +45,9 @@ Config::Config() {
 	singleton = this;
 
 	{
-		int64_t max_extensions = 0;
-		glGetInteger64v(GL_NUM_EXTENSIONS, &max_extensions);
-		for (int64_t i = 0; i < max_extensions; i++) {
+		GLint max_extensions = 0;
+		glGetIntegerv(GL_NUM_EXTENSIONS, &max_extensions);
+		for (int i = 0; i < max_extensions; i++) {
 			const GLubyte *s = glGetStringi(GL_EXTENSIONS, i);
 			if (!s) {
 				break;
@@ -80,11 +80,14 @@ Config::Config() {
 		rgtc_supported = extensions.has("GL_EXT_texture_compression_rgtc") || extensions.has("GL_ARB_texture_compression_rgtc") || extensions.has("EXT_texture_compression_rgtc");
 	}
 
-	glGetInteger64v(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &max_vertex_texture_image_units);
-	glGetInteger64v(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_image_units);
-	glGetInteger64v(GL_MAX_TEXTURE_SIZE, &max_texture_size);
+	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &max_vertex_texture_image_units);
+	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_image_units);
+	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
+	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, max_viewport_size);
 	glGetInteger64v(GL_MAX_UNIFORM_BLOCK_SIZE, &max_uniform_buffer_size);
-	glGetInteger64v(GL_MAX_VIEWPORT_DIMS, max_viewport_size);
+
+	// sanity clamp buffer size to 16K..1MB
+	max_uniform_buffer_size = CLAMP(max_uniform_buffer_size, 16384, 1048576);
 
 	support_anisotropic_filter = extensions.has("GL_EXT_texture_filter_anisotropic");
 	if (support_anisotropic_filter) {

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -57,11 +57,12 @@ public:
 	bool use_nearest_mip_filter = false;
 	bool use_depth_prepass = true;
 
-	int64_t max_vertex_texture_image_units = 0;
-	int64_t max_texture_image_units = 0;
-	int64_t max_texture_size = 0;
-	int64_t max_viewport_size[2] = { 0, 0 };
-	int64_t max_uniform_buffer_size = 0;
+	GLint max_vertex_texture_image_units = 0;
+	GLint max_texture_image_units = 0;
+	GLint max_texture_size = 0;
+	GLint max_viewport_size[2] = { 0, 0 };
+	GLint64 max_uniform_buffer_size = 0;
+
 	int64_t max_renderable_elements = 0;
 	int64_t max_renderable_lights = 0;
 	int64_t max_lights_per_object = 0;

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -463,10 +463,7 @@ String Utilities::get_video_adapter_api_version() const {
 
 Size2i Utilities::get_maximum_viewport_size() const {
 	Config *config = Config::get_singleton();
-	if (!config) {
-		return Size2i();
-	}
-
+	ERR_FAIL_NULL_V(config, Size2i());
 	return Size2i(config->max_viewport_size[0], config->max_viewport_size[1]);
 }
 


### PR DESCRIPTION
# Info

This is an attempt to fix https://github.com/godotengine/godot/issues/92601 which turned out to be more puzzling than I originally thought.

## Investigation

As described in the original bug, tooltips in web exports were not moving correctly to avoid being cut off by the edge of the screen. At the same time, Windows and Linux exports were working correctly.

The problem was that in `godot/scene/main/viewport.cpp` the function `panel->get_max_size()` was returning values of 0/0 making the function `min()` to set the tooltip size to zero. In fact, it happened only in web exports.

https://github.com/godotengine/godot/blob/e96ad5af98547df71b50c4c4695ac348638113e0/scene/main/viewport.cpp#L1505

Going a step further, `get_max_size()` returned the value of the `max_viewport_size` variable from the Config class of `drivers/gles3/storage/config.cpp`. This value should be set by querying the GL driver for the `GL_MAX_VIEWPORT_DIMS` variable.

https://github.com/godotengine/godot/blob/e96ad5af98547df71b50c4c4695ac348638113e0/drivers/gles3/storage/config.h#L63

https://github.com/godotengine/godot/blob/e96ad5af98547df71b50c4c4695ac348638113e0/drivers/gles3/storage/config.cpp#L83-L87

Here is the source of the problem, because it turns out that in the case of web export, query for GL_MAX_VIEWPORT_DIMS does not save anything. Of these above 5 queries, the first 4 work correctly and the last 4 do not. The variable is not changed at all, if we write some values to it beforehand it remains the same.

However, it turns out that in the `drivers/gles3/rasterizer_gles3.cpp` file, a different `glGetIntegerv` function is used for the same query. It works in both Windows / Linux and web exports.

https://github.com/godotengine/godot/blob/e96ad5af98547df71b50c4c4695ac348638113e0/drivers/gles3/rasterizer_gles3.cpp#L401-L402

# Fix

My suggested fix is to replace `glGetInteger64v` with `glGetIntegerv`. Unfortunately `max_viewport_size` in Config class is of type `int64_t [2]` and `glGetIntegerv` operates on `GLint * data` (32 bit).

Please review if it is possible to somehow rewrite the values of these variables more elegantly?

```cpp
max_viewport_size[0] = max_vp[0];
max_viewport_size[1] = max_vp[1];
```

https://www.khronos.org/opengl/wiki/OpenGL_Type

# Notes

The `glGetInteger64v` function is used in Godot only in the `drivers/gles3/storage/config.cpp` and `drivers/gles3/shader_gles3.cpp` files. It seems that except for one case it doesn't cause any other problems, but the mystery for me remains why it doesn't work for `GL_MAX_VIEWPORT_DIMS` (this is the only case where it sets an array and not a single variable).

Perhaps the problem is that the web export is in WASM32? I have not tested 32-bit Windows / Linux exports.

In addition, according to the Khronos table, `glGetInteger64v` officialy appeared in OpenGL 3.2 / OpenGL ES 3.0 and `glGetIntegerv` had been around since OpenGL 2.0 / OpenGL ES 2.0.

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGet.xhtml

https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml
