### PR TITLE
Make unsupported editor/project import settings read-only on web and mobile.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -842,6 +842,7 @@
 			- /usr/local/bin/blender
 			- /opt/blender/bin/blender
 			[/codeblock]
+			[b]Note:[/b] Blender import is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="filesystem/import/blender/rpc_port" type="int" setter="" getter="">
 			The port number used for Remote Procedure Call (RPC) communication with Godot's created process of the blender executable.
@@ -854,6 +855,7 @@
 		<member name="filesystem/import/fbx/fbx2gltf_path" type="String" setter="" getter="">
 			The path to the FBX2glTF executable used for converting Autodesk FBX 3D scene files [code].fbx[/code] to glTF 2.0 format during import.
 			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/fbx2gltf/enabled].
+			[b]Note:[/b] FBX2glTF import is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="filesystem/on_save/compress_binary_resources" type="bool" setter="" getter="">
 			If [code]true[/code], uses lossless compression for binary resources.
@@ -892,6 +894,7 @@
 		<member name="filesystem/tools/oidn/oidn_denoise_path" type="String" setter="" getter="">
 			The path to the directory containing the Open Image Denoise (OIDN) executable, used optionally for denoising lightmaps. It can be downloaded from [url=https://www.openimagedenoise.org/downloads.html]openimagedenoise.org[/url].
 			To enable this feature for your specific project, use [member ProjectSettings.rendering/lightmapping/denoising/denoiser].
+			[b]Note:[/b] OIDN denoising is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="input/buffering/agile_event_flushing" type="bool" setter="" getter="">
 			If [code]true[/code], input events will be flushed just before every idle and physics frame.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1198,6 +1198,7 @@
 		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the [member EditorSettings.filesystem/import/blender/blender_path] setting. Blender 3.0 or later is required.
+			[b]Note:[/b] Blender import is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="filesystem/import/blender/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/blender/enabled] on Android where Blender can't easily be accessed from Godot.
@@ -1208,6 +1209,7 @@
 		<member name="filesystem/import/fbx2gltf/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Autodesk FBX 3D scene files with the [code].fbx[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to an FBX2glTF executable in the editor settings at [member EditorSettings.filesystem/import/fbx/fbx2gltf_path].
+			[b]Note:[/b] FBX2glTF import is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="filesystem/import/fbx2gltf/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx2gltf/enabled] on Android where FBX2glTF can't easily be accessed from Godot.
@@ -3097,6 +3099,7 @@
 			- AMD GPUs: HIP libraries
 			- Intel GPUs: SYCL libraries
 			If no GPU acceleration is configured on the system, multi-threaded CPU-based denoising will be performed instead. This CPU-based denoising is significantly slower than the JNLM denoiser in most cases.
+			[b]Note:[/b] OIDN denoising is supported on Linux, macOS, and Windows.
 		</member>
 		<member name="rendering/lightmapping/lightmap_gi/use_bicubic_filter" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], applies a bicubic filter during lightmap sampling. This makes lightmaps look much smoother, at a moderate performance cost.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -442,6 +442,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Interface */
 
+	PropertyUsageFlags disabled_on_mobile_and_web = PROPERTY_USAGE_NONE;
+#if defined(ANDROID_ENABLED) || defined(APPLE_EMBEDDED_ENABLED) || defined(WEB_ENABLED)
+	disabled_on_mobile_and_web = PROPERTY_USAGE_READ_ONLY;
+#endif
+
 	// Editor
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localize_settings", true, "")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
@@ -673,13 +678,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/quick_open_dialog/default_display_mode", 0, "Adaptive,Last Used")
 
 	// Import (for glft module)
-	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/blender/blender_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/blender/blender_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING | disabled_on_mobile_and_web)
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_port", 6011, "0,65535,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_server_uptime", 5, "0,300,1,or_greater,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | disabled_on_mobile_and_web)
 
 	// Tools (denoise)
-	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/tools/oidn/oidn_denoise_path", "", "", PROPERTY_USAGE_DEFAULT)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/tools/oidn/oidn_denoise_path", "", "", PROPERTY_USAGE_DEFAULT | disabled_on_mobile_and_web)
 
 	/* Docks */
 

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -73,7 +73,12 @@ void initialize_fbx_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		GDREGISTER_CLASS(EditorSceneFormatImporterUFBX);
 
-		GLOBAL_DEF_RST_BASIC("filesystem/import/fbx2gltf/enabled", true);
+		PropertyUsageFlags disabled_on_mobile_and_web = PROPERTY_USAGE_NONE;
+#if defined(ANDROID_ENABLED) || defined(APPLE_EMBEDDED_ENABLED) || defined(WEB_ENABLED)
+		disabled_on_mobile_and_web = PROPERTY_USAGE_READ_ONLY;
+#endif
+
+		GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::BOOL, "filesystem/import/fbx2gltf/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | disabled_on_mobile_and_web), true);
 		GDREGISTER_CLASS(EditorSceneFormatImporterFBX2GLTF);
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.android", false);
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.web", false);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -145,8 +145,13 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(EditorSceneFormatImporterGLTF);
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 
+		PropertyUsageFlags disabled_on_mobile_and_web = PROPERTY_USAGE_NONE;
+#if defined(ANDROID_ENABLED) || defined(APPLE_EMBEDDED_ENABLED) || defined(WEB_ENABLED)
+		disabled_on_mobile_and_web = PROPERTY_USAGE_READ_ONLY;
+#endif
+
 		// Project settings defined here so doctool finds them.
-		GLOBAL_DEF_RST_BASIC("filesystem/import/blender/enabled", true);
+		GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::BOOL, "filesystem/import/blender/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | disabled_on_mobile_and_web), true);
 		GDREGISTER_CLASS(EditorSceneFormatImporterBlend);
 		// Can't (a priori) run external app on these platforms.
 		GLOBAL_DEF_RST("filesystem/import/blender/enabled.android", false);

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -46,6 +46,11 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
+	PropertyUsageFlags disabled_on_mobile_and_web = PROPERTY_USAGE_NONE;
+#if defined(ANDROID_ENABLED) || defined(APPLE_EMBEDDED_ENABLED) || defined(WEB_ENABLED)
+	disabled_on_mobile_and_web = PROPERTY_USAGE_READ_ONLY;
+#endif
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_quality/low_quality_ray_count", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 32);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_quality/medium_quality_ray_count", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 128);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_quality/high_quality_ray_count", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 512);
@@ -60,7 +65,7 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 2048);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_performance/max_rays_per_probe_pass", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
 
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/denoising/denoiser", PROPERTY_HINT_ENUM, "JNLM,OIDN"), 0);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/denoising/denoiser", PROPERTY_HINT_ENUM, "JNLM,OIDN", PROPERTY_USAGE_DEFAULT | disabled_on_mobile_and_web), 0);
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(LightmapperRD);
 	Lightmapper::create_gpu = create_lightmapper_rd;


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/92825

- Makes unsupported importer path and enable settings read only on mobile and web.
- Adds supported platforms notes to the docs (shown in the setting tooltip).

I'm not sure if it is the best way to handle it, read-only settings/properties looks barely different from normal, so some extra indication might be necessary.