### PR TITLE
Android: Change the way `doNotStrip` is set

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -301,7 +301,7 @@ task generateGodotTemplates {
  */
 task generateDevTemplate {
     // add parameter to set symbols to true
-    gradle.startParameter.projectProperties += [doNotStrip: "true"]
+    project.ext.doNotStrip = "true"
 
     gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
     dependsOn = generateBuildTasks("template")


### PR DESCRIPTION
Update how `doNotStrip` is set by leveraging the project's extra properties.

See https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#properties for reference.

Fixes #92858 
