### PR TITLE
Don't allow creating invalid RESET keys

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -724,6 +724,7 @@ public:
 	bool is_key_clipboard_active() const;
 	bool is_moving_selection() const;
 	bool is_snap_enabled() const;
+	bool can_add_reset_key() const;
 	float get_moving_selection_offset() const;
 	float snap_time(float p_value, bool p_relative = false);
 	bool is_grouping_tracks();


### PR DESCRIPTION
Prevents creating RESET keys (see #55653) for Animation, Audio and Method tracks. Not sure if there are other track types that should be handled.