### PR TITLE
[Core] Optimize hash map/set by moving checks if there are no collisions

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -105,20 +105,31 @@ private:
 		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
 		uint32_t hash = _hash(p_key);
 		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-		uint32_t distance = 0;
 
+		if (hashes[pos] == hash && Comparator::compare(elements[pos]->data.key, p_key)) {
+			r_pos = pos;
+			return true;
+		}
+
+		if (hashes[pos] == EMPTY_HASH) {
+			return false;
+		}
+
+		// A collision occurred.
+		pos = fastmod(pos + 1, capacity_inv, capacity);
+		uint32_t distance = 1;
 		while (true) {
+			if (hashes[pos] == hash && Comparator::compare(elements[pos]->data.key, p_key)) {
+				r_pos = pos;
+				return true;
+			}
+
 			if (hashes[pos] == EMPTY_HASH) {
 				return false;
 			}
 
 			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
 				return false;
-			}
-
-			if (hashes[pos] == hash && Comparator::compare(elements[pos]->data.key, p_key)) {
-				r_pos = pos;
-				return true;
 			}
 
 			pos = fastmod((pos + 1), capacity_inv, capacity);
@@ -129,18 +140,25 @@ private:
 	void _insert_with_hash(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
 		const uint32_t capacity = hash_table_size_primes[capacity_index];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+		uint32_t pos = fastmod(p_hash, capacity_inv, capacity);
+
+		if (hashes[pos] == EMPTY_HASH) {
+			elements[pos] = p_value;
+			hashes[pos] = p_hash;
+			num_elements++;
+			return;
+		}
+
+		// A collision occurred.
+		pos = fastmod(pos + 1, capacity_inv, capacity);
+		uint32_t distance = 1;
 		uint32_t hash = p_hash;
 		HashMapElement<TKey, TValue> *value = p_value;
-		uint32_t distance = 0;
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-
 		while (true) {
 			if (hashes[pos] == EMPTY_HASH) {
 				elements[pos] = value;
 				hashes[pos] = hash;
-
 				num_elements++;
-
 				return;
 			}
 

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -88,20 +88,31 @@ private:
 		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
 		uint32_t hash = _hash(p_key);
 		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-		uint32_t distance = 0;
 
+		if (hashes[pos] == hash && Comparator::compare(keys[hash_to_key[pos]], p_key)) {
+			r_pos = hash_to_key[pos];
+			return true;
+		}
+
+		if (hashes[pos] == EMPTY_HASH) {
+			return false;
+		}
+
+		// A collision occurred.
+		pos = fastmod(pos + 1, capacity_inv, capacity);
+		uint32_t distance = 1;
 		while (true) {
+			if (hashes[pos] == hash && Comparator::compare(keys[hash_to_key[pos]], p_key)) {
+				r_pos = hash_to_key[pos];
+				return true;
+			}
+
 			if (hashes[pos] == EMPTY_HASH) {
 				return false;
 			}
 
 			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
 				return false;
-			}
-
-			if (hashes[pos] == hash && Comparator::compare(keys[hash_to_key[pos]], p_key)) {
-				r_pos = hash_to_key[pos];
-				return true;
 			}
 
 			pos = fastmod(pos + 1, capacity_inv, capacity);
@@ -112,11 +123,20 @@ private:
 	uint32_t _insert_with_hash(uint32_t p_hash, uint32_t p_index) {
 		const uint32_t capacity = hash_table_size_primes[capacity_index];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+		uint32_t pos = fastmod(p_hash, capacity_inv, capacity);
+
+		if (hashes[pos] == EMPTY_HASH) {
+			hashes[pos] = p_hash;
+			key_to_hash[p_index] = pos;
+			hash_to_key[pos] = p_index;
+			return pos;
+		}
+
+		// A collision occurred.
+		uint32_t distance = 1;
+		pos = fastmod(pos + 1, capacity_inv, capacity);
 		uint32_t hash = p_hash;
 		uint32_t index = p_index;
-		uint32_t distance = 0;
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
-
 		while (true) {
 			if (hashes[pos] == EMPTY_HASH) {
 				hashes[pos] = hash;


### PR DESCRIPTION
Part of #90082 #90126 #90210. 
I'm splitting these PRs into smaller ones according to @Geometror advice. https://github.com/godotengine/godot/pull/90082#issuecomment-2150470263

I think that this is a pretty good optimization because it is not risky and brings a pretty good result to the performance of search and insertion.

In my benchmarks, it makes search/insert an average of 6%-10% better.

For the compiler, this code means that there will probably be 0 or 1 collision, which happens in more than half of the cases.
It also removes the unnecessary copy constructor in the OAHashMap `_insert_with_hash` method.
From an aesthetic point of view, it shows how the map/set works when it doesn't have a collision and how the map/set handles collisions.