### PR TITLE
Add GetNode Attribute for CSharp

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -3,3 +3,10 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 GD0003  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0003.html)
+GD0501  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0501.html)
+GD0502  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0502.html)
+GD0503  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0503.html)
+GD0504  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0504.html)
+GD0505  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0505.html)
+GD0506  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0506.html)
+GD0507  |  Usage   |  Error   | ScriptMethodsGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0507.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -186,5 +186,75 @@ namespace Godot.SourceGenerators
                 isEnabledByDefault: true,
                 "The class must not be generic. Make the class non-generic, or remove the '[GlobalClass]' attribute.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0402"));
+
+        public static readonly DiagnosticDescriptor GetNodeMemberIsStaticRule =
+            new DiagnosticDescriptor(id: "GD0501",
+                title: "The GetNode member is static",
+                messageFormat: "The GetNode member '{0}' is static",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode member is static. Only instance fields and properties can be GetNode. Remove the 'static' modifier, or the '[GetNode]' attribute.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0501"));
+
+        public static readonly DiagnosticDescriptor GetNodeMemberIsReadOnlyRule =
+            new DiagnosticDescriptor(id: "GD0502",
+                title: "The GetNode member is read-only",
+                messageFormat: "The GetNode member '{0}' is read-only",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode member is read-only. GetNode member must be writable.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0501"));
+
+        public static readonly DiagnosticDescriptor GetNodeMemberIsIndexerRule =
+            new DiagnosticDescriptor(id: "GD0503",
+                title: "The GetNode property is an indexer",
+                messageFormat: "The GetNode property '{0}' is an indexer",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode property is an indexer. Remove the '[GetNode]' attribute.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0503"));
+
+        public static readonly DiagnosticDescriptor GetNodeMemberIsExplicitInterfaceImplementationRule =
+            new DiagnosticDescriptor(id: "GD0504",
+                title: "The GetNode property is an explicit interface implementation",
+                messageFormat: "The GetNode property '{0}' is an explicit interface implementation",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode property is an explicit interface implementation. Remove the '[GetNode]' attribute.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0504"));
+
+        public static readonly DiagnosticDescriptor GetNodeAttributePathIsEmpty =
+            new DiagnosticDescriptor(id: "GD0505",
+                title: "The GetNode attribute path is empty",
+                messageFormat: "The GetNode attribute path for member '{0}' is empty",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode attribute path is empty. Set the 'Path' parameter in the '[GetNode]' attribute.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0505"));
+
+        public static readonly DiagnosticDescriptor OnlyNodesShouldHaveGetNodeRule =
+            new DiagnosticDescriptor(id: "GD0506",
+                title: "Types not derived from Node should not have GetNode members",
+                messageFormat: "Types not derived from Node should not have GetNode members",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "Types not derived from Node should not have GetNode members. GetNode is only supported in Node-derived classes.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0506"));
+
+        public static readonly DiagnosticDescriptor GetNodeMemberShouldBeNodes =
+            new DiagnosticDescriptor(id: "GD0507",
+                title: "The GetNode member type should derived from Node",
+                messageFormat: "The GetNode member type for member '{0}' should derived from Node",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The GetNode member type should derived from Node. Remove the '[GetNode]' attribute or use a member type deriving from Node.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0507"));
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -264,6 +264,9 @@ namespace Godot.SourceGenerators
         public static bool IsSystemFlagsAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SystemFlagsAttr;
 
+        public static bool IsGodotGetNodeAttribute(this INamedTypeSymbol symbol)
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.GetNodeAttr;
+
         public static GodotMethodData? HasGodotCompatibleSignature(
             this IMethodSymbol method,
             MarshalUtils.TypeCache typeCache

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -14,5 +14,6 @@ namespace Godot.SourceGenerators
         public const string GodotClassNameAttr = "Godot.GodotClassNameAttribute";
         public const string GlobalClassAttr = "Godot.GlobalClassAttribute";
         public const string SystemFlagsAttr = "System.FlagsAttribute";
+        public const string GetNodeAttr = "Godot.GetNodeAttribute";
     }
 }

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -87,6 +87,7 @@ StringBuilder &operator<<(StringBuilder &r_sb, const char *p_cstring) {
 #define CS_METHOD_INVOKE_GODOT_CLASS_METHOD "InvokeGodotClassMethod"
 #define CS_METHOD_HAS_GODOT_CLASS_METHOD "HasGodotClassMethod"
 #define CS_METHOD_HAS_GODOT_CLASS_SIGNAL "HasGodotClassSignal"
+#define CS_METHOD_INIT_GODOT_GET_NODE_MEMBERS "_InitGodotGetNodeMembers"
 
 #define CS_STATIC_FIELD_NATIVE_CTOR "NativeCtor"
 #define CS_STATIC_FIELD_METHOD_BIND_PREFIX "MethodBind"
@@ -2431,6 +2432,21 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		}
 
 		output << INDENT1 "}\n";
+
+		if (itype.proxy_name == "Node") {
+			// Generate _InitGodotGetNodeMembers only for Node has the base method.
+			// If the [GetNode] attribute is used, the ScriptMethodsGenerator will generate an override for this method
+			// and put the assignations for GetNode property and fields into it.
+			output << MEMBER_BEGIN "/// <summary>\n"
+				   << INDENT1 "/// Initialize the properties and fields based on [GetNode] attribute.\n"
+				   << INDENT1 "/// This method is used internally by Godot.\n"
+				   << INDENT1 "/// Do not call or override this method.\n"
+				   << INDENT1 "/// </summary>\n";
+
+			output << INDENT1 "protected internal virtual void " CS_METHOD_INIT_GODOT_GET_NODE_MEMBERS "()\n"
+				   << INDENT1 "{\n";
+			output << INDENT1 "}\n";
+		}
 	}
 
 	//Generate StringName for all class members

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GetNodeAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GetNodeAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Define a resource to populate with a GetNode before _Ready.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class GetNodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Path of the resource in the scene.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Constructs a new GetNodeAttribute Instance.
+        /// </summary>
+        /// <param name="path">Path of the resource in the scene.</param>
+        public GetNodeAttribute(string path)
+        {
+            Path = path;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -48,6 +48,7 @@
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="Core\Aabb.cs" />
+    <Compile Include="Core\Attributes\GetNodeAttribute.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
     <Compile Include="Core\Callable.generics.cs" />


### PR DESCRIPTION
This should implement the proposal https://github.com/godotengine/godot-proposals/issues/2425

This PR adds an new `GetNodeAttribute` for C# which can be used on properties or fields and has one parameter: the path to a Node which will be assigned to the property or field just before the _Ready.

### Exemple
```cs
[GetNode("TestSprite2D")]
public Sprite2D TestSprite { get; set; }

[GetNode("SubPath/FieldSprite")]
public Node2D TestFieldSprite;
```

Should do the same has:
```cs
public Sprite2D TestSprite { get; set; }
public Node2D TestFieldSprite;

public override void _Ready()
{
    this.TestSprite = GetNode<Sprite2D>("TestSprite2D");
    this.TestFieldSprite = GetNode<Node2D>("SubPath/FieldSprite");
}
```


### How does it work
- The `Node` class in C# has a new virtual internal method `_InitGodotGetNodeMembers` generated by `bindings_generator.cpp` on ` --generate-mono-glue`.
- When Nodes receives a call for `_ready` from the engine, it always calls `_InitGodotGetNodeMembers` which is empty by default.
- The `ScriptMethodsGenerator` generates an override for the `_InitGodotGetNodeMembers` when the class has fields or properties with the `GetNode` attributes. The method simply assigns the GetNode<...> to the property/field and manages errors.
- The generated `_InitGodotGetNodeMembers` method also always begins by a call to `base._InitGodotGetNodeMembers()` to assign the GetNode members for the inherited classes before the current class.

### Example of generated code
```cs
[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
{
    if(method == global::Godot.Node.MethodName._Ready && args.Count == 0) {
        _InitGodotGetNodeMembers();
    }
    if (method == MethodName._Ready && args.Count == 0) {
        _Ready();
        ret = default;
        return true;
    }
    if (method == MethodName._Process && args.Count == 1) {
        _Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
        ret = default;
        return true;
    }
    return base.InvokeGodotClassMethod(method, args, out ret);
}

[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
protected override void _InitGodotGetNodeMembers() {
    base._InitGodotGetNodeMembers();
    try
    {
        TestSprite = GetNode<Sprite2D>("TestSprite2D");
    }
    catch (global::System.Exception e)
    {
        global::Godot.GD.PushError($"Error GetNode for '{this.Name}.TestSprite': {e.Message}");
    }
}
```
** Note the usage of `global::Godot.Node.MethodName._Ready` and not the `MethodName._Ready`, that's because `MethodName._Ready` correspond to `_Ready` and `global::Godot.Node.MethodName._Ready` correspond to `_ready`. We when to trap the call from the engine, which is in lowercase.


### Example project
There a example project with a couple of example to test with properties, fields, inheritance, etc...
You will probably need to change the path for generated script in the csproj for something that works on your computer:
`<CompilerGeneratedFilesOutputPath>C:\Projects\Temp\GodotGeneratedFiles</CompilerGeneratedFilesOutputPath>`

[Test Godot GetNode Attribute.zip](https://github.com/user-attachments/files/15845436/Test.Godot.GetNode.Attribute.zip)


### What's missing
- I did not test with addons or autoload script or hot reload
- If this PR is approved there's some documentation missing:
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0501.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0502.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0503.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0504.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0505.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0506.html
  - https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0507.html





