### PR TITLE
Fix inability to use ResourceLoader in C# after threaded load in GDScript

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -57,8 +57,11 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
 	float progress = 0;
 	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, &progress);
-	r_progress.resize(1);
-	r_progress[0] = progress;
+	// Default array should never be modified, it causes the hash of the method to change.
+	if (!ClassDB::is_default_array_arg(r_progress)) {
+		r_progress.resize(1);
+		r_progress[0] = progress;
+	}
 	return (ThreadLoadStatus)tls;
 }
 
@@ -131,7 +134,7 @@ ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
 
 void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
-	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL(Array()));
+	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL_ARRAY);
 	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &ResourceLoader::load_threaded_get);
 
 	ClassDB::bind_method(D_METHOD("load", "path", "type_hint", "cache_mode"), &ResourceLoader::load, DEFVAL(""), DEFVAL(CACHE_MODE_REUSE));
@@ -307,7 +310,10 @@ int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r
 	String pipe;
 	int exitcode = 0;
 	Error err = ::OS::get_singleton()->execute(p_path, args, &pipe, &exitcode, p_read_stderr, nullptr, p_open_console);
-	r_output.push_back(pipe);
+	// Default array should never be modified, it causes the hash of the method to change.
+	if (!ClassDB::is_default_array_arg(r_output)) {
+		r_output.push_back(pipe);
+	}
 	if (err != OK) {
 		return -1;
 	}
@@ -618,7 +624,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_system_font_path_for_text", "font_name", "text", "locale", "script", "weight", "stretch", "italic"), &OS::get_system_font_path_for_text, DEFVAL(String()), DEFVAL(String()), DEFVAL(400), DEFVAL(100), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &OS::get_executable_path);
 	ClassDB::bind_method(D_METHOD("read_string_from_stdin"), &OS::read_string_from_stdin);
-	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr", "open_console"), &OS::execute, DEFVAL(Array()), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr", "open_console"), &OS::execute, DEFVAL_ARRAY, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("execute_with_pipe", "path", "arguments", "blocking"), &OS::execute_with_pipe, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("create_process", "path", "arguments", "open_console"), &OS::create_process, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -73,7 +73,7 @@ public:
 	static ResourceLoader *get_singleton() { return singleton; }
 
 	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
-	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = Array());
+	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = ClassDB::default_array_arg);
 	Ref<Resource> load_threaded_get(const String &p_path);
 
 	Ref<Resource> load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
@@ -166,7 +166,7 @@ public:
 	Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const;
 	String get_executable_path() const;
 	String read_string_from_stdin();
-	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false, bool p_open_console = false);
+	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = ClassDB::default_array_arg, bool p_read_stderr = false, bool p_open_console = false);
 	Dictionary execute_with_pipe(const String &p_path, const Vector<String> &p_arguments, bool p_blocking = true);
 	int create_process(const String &p_path, const Vector<String> &p_arguments, bool p_open_console = false);
 	int create_instance(const Vector<String> &p_arguments);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2310,4 +2310,11 @@ void ClassDB::cleanup() {
 	native_structs.clear();
 }
 
+// Array to use in optional parameters on methods and the DEFVAL_ARRAY macro.
+Array ClassDB::default_array_arg = Array::create_read_only();
+
+bool ClassDB::is_default_array_arg(const Array &p_array) {
+	return p_array.is_same_instance(default_array_arg);
+}
+
 //

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -43,6 +43,7 @@
 #include <type_traits>
 
 #define DEFVAL(m_defval) (m_defval)
+#define DEFVAL_ARRAY DEFVAL(ClassDB::default_array_arg)
 
 #ifdef DEBUG_METHODS_ENABLED
 
@@ -180,6 +181,9 @@ public:
 		uint64_t struct_size; // local size of struct, for comparison
 	};
 	static HashMap<StringName, NativeStruct> native_structs;
+
+	static Array default_array_arg;
+	static bool is_default_array_arg(const Array &p_array);
 
 private:
 	// Non-locking variants of get_parent_class and is_parent_class.

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -803,6 +803,10 @@ bool Array::is_same_typed(const Array &p_other) const {
 	return _p->typed == p_other._p->typed;
 }
 
+bool Array::is_same_instance(const Array &p_other) const {
+	return _p == p_other._p;
+}
+
 uint32_t Array::get_typed_builtin() const {
 	return _p->typed.type;
 }
@@ -813,6 +817,12 @@ StringName Array::get_typed_class_name() const {
 
 Variant Array::get_typed_script() const {
 	return _p->typed.script;
+}
+
+Array Array::create_read_only() {
+	Array array;
+	array.make_read_only();
+	return array;
 }
 
 void Array::make_read_only() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -186,12 +186,14 @@ public:
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	bool is_typed() const;
 	bool is_same_typed(const Array &p_other) const;
+	bool is_same_instance(const Array &p_other) const;
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;
 
 	void make_read_only();
 	bool is_read_only() const;
+	static Array create_read_only();
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);


### PR DESCRIPTION
Fixes #92798 

As @raulsntos pointed out, the problem was from the modification of the default array. The hash of the method changed after the first call in GDScript.

I modified the method `ResourceLoader::load_threaded_get_status` to never modify the default array.

I search for `DEFVAL(Array())` through all the code base and only found one another place where the default array was modified: `OS::execute`. I modified this method as well.

I was able to reproduce the problem and tested the correction with with the MRP project.