### PR TITLE
Expose `get_skeleton()` from `SkeletonModifier3D`

### DIFF
--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -18,6 +18,12 @@
 				[method _process_modification] must not apply [member influence] to bone poses because the [Skeleton3D] automatically applies influence to all bone poses set by the modifier.
 			</description>
 		</method>
+		<method name="get_skeleton" qualifiers="const">
+			<return type="Skeleton3D" />
+			<description>
+				Get parent [Skeleton3D] node if found.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="is_active" default="true">

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -123,6 +123,8 @@ void SkeletonModifier3D::_notification(int p_what) {
 }
 
 void SkeletonModifier3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_skeleton"), &SkeletonModifier3D::get_skeleton);
+
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &SkeletonModifier3D::set_active);
 	ClassDB::bind_method(D_METHOD("is_active"), &SkeletonModifier3D::is_active);
 


### PR DESCRIPTION
Follow up https://github.com/godotengine/godot/pull/91507.

To create a custom SkeletonModifier, a method to safely retrieve the Skeleton was lacked for gdscript and extention.