### PR TITLE
[3.x] Physics Interpolation - Fix 3D CPUParticle restart bug

### DIFF
--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -901,13 +901,6 @@ void CPUParticles::_particles_process(float p_delta) {
 				p.transform.origin.z = 0.0;
 			}
 
-			// Teleport if starting a new particle, so
-			// we don't get a streak from the old position
-			// to this new start.
-			if (_interpolated) {
-				p.copy_to(particles_prev[i]);
-			}
-
 		} else if (!p.active) {
 			continue;
 		} else if (p.time > p.lifetime) {
@@ -1012,6 +1005,13 @@ void CPUParticles::_particles_process(float p_delta) {
 		}
 
 		p.transform.origin += p.velocity * local_delta;
+
+		// Teleport if starting a new particle, so
+		// we don't get a streak from the old position
+		// to this new start.
+		if (restart && _interpolated) {
+			p.copy_to(particles_prev[i]);
+		}
 	}
 }
 


### PR DESCRIPTION
Particles that were being emitted were having their data copied to previous particle data too early, missing some transform changes that could result in graphical anomalies in some situations.

### Before

https://github.com/godotengine/godot/assets/21999379/ad43b181-c42c-48cb-89bf-dc849d2263cf

### After

https://github.com/godotengine/godot/assets/21999379/38f8f174-c36d-43cc-aa7a-e22cd4ff0b9f

## Notes
* Fixes emitted particles being overly large for a frame in 3D platformer demo.
* In retrospect this bug is obvious, was a no brainer to fix.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
