### PR TITLE
Fix `TextureProgressBar` radial mode invalid polygon edge case

### DIFF
--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -537,17 +537,20 @@ void TextureProgressBar::_notification(int p_what) {
 									uvs.push_back(uv);
 								}
 
-								Point2 center_point = get_relative_center();
-								points.push_back(progress_offset + s * center_point);
-								if (valid_atlas_progress) {
-									center_point.x = Math::remap(center_point.x, 0, 1, region_rect.position.x / atlas_size.x, (region_rect.position.x + region_rect.size.x) / atlas_size.x);
-									center_point.y = Math::remap(center_point.y, 0, 1, region_rect.position.y / atlas_size.y, (region_rect.position.y + region_rect.size.y) / atlas_size.y);
-								}
-								uvs.push_back(center_point);
+								// Filter out an edge case where almost equal `from`, `to` were mapped to the same UV.
+								if (points.size() >= 2) {
+									Point2 center_point = get_relative_center();
+									points.push_back(progress_offset + s * center_point);
+									if (valid_atlas_progress) {
+										center_point.x = Math::remap(center_point.x, 0, 1, region_rect.position.x / atlas_size.x, (region_rect.position.x + region_rect.size.x) / atlas_size.x);
+										center_point.y = Math::remap(center_point.y, 0, 1, region_rect.position.y / atlas_size.y, (region_rect.position.y + region_rect.size.y) / atlas_size.y);
+									}
+									uvs.push_back(center_point);
 
-								Vector<Color> colors;
-								colors.push_back(tint_progress);
-								draw_polygon(points, colors, uvs, progress);
+									Vector<Color> colors;
+									colors.push_back(tint_progress);
+									draw_polygon(points, colors, uvs, progress);
+								}
 							}
 
 							// Draw a reference cross.


### PR DESCRIPTION
`TextureProgressBar::unit_val_to_uv(float val)` can produce exactly the same UV for almost equal values. Currently subsequent points on the TextureProgressBar's edge mapped to the same UV would be skipped, which can lead to trying to create a 2-point polygon created from `from` and `center` (in case `to` would be skipped because it is close enough to `from` so `unit_val_to_uv(from) == unit_val_to_uv(to)`).

https://github.com/godotengine/godot/blob/1ce6df7087113a61491567f3ac55561d5688e2a8/scene/gui/texture_progress_bar.cpp#L527-L531

This PR leaves skipping same-UV points as is, and just ensure `points.size() >= 3` before rendering a polygon.

Alternative would be to try improve precision/robustness of `TextureProgressBar::unit_val_to_uv(float val)` but it's probably not needed as the issue happens in an edge case (a super thin triangle which would likely not be rendered anyway).

Fixes #92790.