### PR TITLE
[Window] Fix mouse hover state of the main window when mouse enter event was sent before setting callbacks.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1354,6 +1354,10 @@ void Window::_notification(int p_what) {
 					_update_window_size(); // Inform DisplayServer of minimum and maximum size.
 					_update_viewport_size(); // Then feed back to the viewport.
 					_update_window_callbacks();
+					// Simulate mouse-enter event when mouse is over the window, since OS event might arrive before setting callbacks.
+					if (!mouse_in_window && Rect2(position, size).has_point(DisplayServer::get_singleton()->mouse_get_position())) {
+						_event_callback(DisplayServer::WINDOW_EVENT_MOUSE_ENTER);
+					}
 					RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_VISIBLE);
 					if (DisplayServer::get_singleton()->window_get_flag(DisplayServer::WindowFlags(FLAG_TRANSPARENT), window_id)) {
 						set_transparent_background(true);


### PR DESCRIPTION
Main window is shown before event callbacks for `Window` are set, and OS mouse-enter event might arrive before it and get lost.

Fixes https://github.com/godotengine/godot/issues/91589
