### PR TITLE
Fix menu bar popup placement ignoring parent window content scale factor when not embedded

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -120,9 +120,11 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 		return;
 	}
 
+	float content_scale_factor = pm->is_embedded() ? 1.0f : get_window()->get_content_scale_factor();
+	Size2 scale = get_viewport()->get_canvas_transform().get_scale() * content_scale_factor;
 	Rect2 item_rect = _get_menu_item_rect(p_index);
-	Point2 screen_pos = get_screen_position() + item_rect.position * get_viewport()->get_canvas_transform().get_scale();
-	Size2 screen_size = item_rect.size * get_viewport()->get_canvas_transform().get_scale();
+	Point2 screen_pos = get_screen_position() + item_rect.position * scale;
+	Size2 screen_size = item_rect.size * scale;
 
 	active_menu = p_index;
 


### PR DESCRIPTION

## Problem
When using non-embedded windows and a content scaling factor != 1, `menu_bar` would not place its popups properly. In the below image I set the scaling factor to 2, so you can see it's placed halfway.
![image](https://github.com/godotengine/godot/assets/31664665/51717df1-9ad5-4c8a-9ad7-a01ec5b471f5)

Embedded window popups didn't have this issue

This is building on #86553


## Solution
My fix is to multiply the position scale by the content scaling factor of the parent window. Not applied when using embedded windows

![image](https://github.com/godotengine/godot/assets/31664665/af5e5079-04e0-4de2-b6d8-5d5f219ae809)

Example project:
https://github.com/StefanH-AT/godot-example-popupmenuscaling


## Note

Non-embedded window popups still behave weirdly when using strange combinations of aspect ratio settings as they did before. I just wanted to get this working for scaling factors