### PR TITLE
Expose `update_docs_from_script` method

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -94,6 +94,14 @@
 				[b]Note:[/b] The [EditorSyntaxHighlighter] will still be applied to scripts that are already opened.
 			</description>
 		</method>
+		<method name="update_docs_from_script">
+			<return type="void" />
+			<param index="0" name="script" type="Script" />
+			<description>
+				Updates the documentation for the given [param script] if the script's documentation is currently open.
+				[b]Note:[/b] This should be called whenever the script is changed to keep the open documentation state up to date.
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="editor_script_changed">

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3980,6 +3980,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
 
 	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
+	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));


### PR DESCRIPTION
Currently, `ScriptEditor` is not exposed to GDExtension.

So for any implementation of `ScriptExtension` and `ScriptLanguageExtension` that supports documentation, if the user has opened the documentation for a specific script and the user later modifies the script, there is no way to synchronize the changes with the documentation view that's embedded within the `ScriptEditor` framework.

Exposing `update_docs_from_script(Script&)` allows such integrators to trigger a sync of the script's documentation should it already be opened in the `ScriptEditor` interface so that the documentation view works the same as the script editor integration does for C# and GDScript.