### PR TITLE
Correcting Vector3 operator *

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -445,11 +445,11 @@
 				[codeblocks]
 				[gdscript]
 				var my_basis = Basis(Vector3(1, 1, 1), Vector3(1, 1, 1), Vector3(0, 2, 5))
-				print(my_basis * Vector3(1, 2, 3)) # Prints (7, 3, 16)
+				print(my_basis * Vector3(1, 2, 3)) # Prints (3, 9, 18)
 				[/gdscript]
 				[csharp]
 				var myBasis = new Basis(new Vector3(1, 1, 1), new Vector3(1, 1, 1), new Vector3(0, 2, 5));
-				GD.Print(my_basis * new Vector3(1, 2, 3)); // Prints (7, 3, 16)
+				GD.Print(my_basis * new Vector3(1, 2, 3)); // Prints (3, 9, 18)
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
Corrected the code comment from stating the result is (7, 3, 16) to (3, 9, 18). These numbers can be verified by running the displayed code in Godot. Screenshot of correct result being given in-engine:

![image](https://github.com/godotengine/godot/assets/14372844/79c8503d-7b71-45fd-be65-be0a699bac81)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
