### PR TITLE
Fix unbound child bones of the PhysicalBone aren't modified

### DIFF
--- a/scene/3d/physical_bone_simulator_3d.cpp
+++ b/scene/3d/physical_bone_simulator_3d.cpp
@@ -367,6 +367,20 @@ void PhysicalBoneSimulator3D::_process_modification() {
 		}
 	} else {
 		ERR_FAIL_COND(skeleton->get_bone_count() != bones.size());
+		for (int i = 0; i < skeleton->get_bone_count(); i++) {
+			if (!bones[i].physical_bone) {
+				continue;
+			}
+			skeleton->set_bone_global_pose(i, bones[i].global_pose);
+		}
+
+		// TODO:
+		// The above method is performance heavy and needs to be improved.
+		// Ideally, the processing of set_bone_global_pose within Skeleton3D should be improved,
+		// but the workaround available now is to convert the global pose to a local pose on the SkeletonModifier side.
+		// However, the follow method needs recursive processing for deformations within PhysicalBoneSimulator3D to account for update order.
+		/*
+		ERR_FAIL_COND(skeleton->get_bone_count() != bones.size());
 		LocalVector<Transform3D> local_poses;
 		for (int i = 0; i < skeleton->get_bone_count(); i++) {
 			Transform3D pt;
@@ -376,10 +390,14 @@ void PhysicalBoneSimulator3D::_process_modification() {
 			local_poses.push_back(pt.affine_inverse() * bones[i].global_pose);
 		}
 		for (int i = 0; i < skeleton->get_bone_count(); i++) {
+			if (!bones[i].physical_bone) {
+				continue;
+			}
 			skeleton->set_bone_pose_position(i, local_poses[i].origin);
 			skeleton->set_bone_pose_rotation(i, local_poses[i].basis.get_rotation_quaternion());
 			skeleton->set_bone_pose_scale(i, local_poses[i].basis.get_scale());
 		}
+		*/
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91606.

PhysicalBoneSimulator caches all bones and modify only bound bones, but it stores only the global pose, so unbound bones will not be modified since it doesn’t process recursively.

There is no need to change the child bones global pose recursively to fix the problem. The issue is that the skeleton reflects bones that are not moving, so ignoring the unbound bones fixes the problem.