### PR TITLE
[3.x] Fix physics tick counter

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -506,13 +506,14 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 
 			// If not echo and action pressed state has changed
 			if (!p_event->is_echo() && is_action_pressed(E->key(), false) != p_event->is_action_pressed(E->key())) {
+				// As input may come in part way through a physics tick, the earliest we can react to it is the next physics tick.
 				if (p_event->is_action_pressed(E->key())) {
 					action.pressed = true;
-					action.pressed_physics_frame = Engine::get_singleton()->get_physics_frames();
+					action.pressed_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 					action.pressed_idle_frame = Engine::get_singleton()->get_idle_frames();
 				} else {
 					action.pressed = false;
-					action.released_physics_frame = Engine::get_singleton()->get_physics_frames();
+					action.released_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 					action.released_idle_frame = Engine::get_singleton()->get_idle_frames();
 				}
 				action.strength = 0.0f;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2364,6 +2364,7 @@ bool Main::iteration() {
 		}
 
 		Engine::get_singleton()->_in_physics = true;
+		Engine::get_singleton()->_physics_frames++;
 
 		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
@@ -2398,7 +2399,6 @@ bool Main::iteration() {
 
 		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
 		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-		Engine::get_singleton()->_physics_frames++;
 
 		Engine::get_singleton()->_in_physics = false;
 	}

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -98,7 +98,7 @@ protected:
 	struct InterpolationData {
 		Transform2D xform_curr;
 		Transform2D xform_prev;
-		uint32_t last_update_physics_tick = 0;
+		uint32_t last_update_physics_tick = UINT32_MAX;
 	} _interpolation_data;
 
 protected:

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -70,7 +70,7 @@ class NavigationAgent2D : public Node {
 	bool target_reached = false;
 	bool navigation_finished = true;
 	// No initialized on purpose
-	uint32_t update_frame_id = 0;
+	uint32_t update_frame_id = UINT32_MAX;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
The counter is now incremented at the start of a physics tick rather than the end.

Fixes #92903

## Notes
* Full details on the problem in the issue.
* This also fixes a knock-on potential regression in the `Input.is_action_just_pressed()` that occurs when the counter is changed.
* Some uint counters are initialized to -1 to ensure they register tick 0 as a change.
* It turns out there's actually very little in core that depends on the tick count, so it may be less prone to regressions than I initially thought.

## Discussion
There are some input considerations for changing the tick increment timing: the `pressed_physics_frame` of the action is used to determine whether input has _just_ been pressed (i.e. `is_action_just_pressed()`).

This was previously set to the current physics tick, which was fine providing this was not incremented until _after_ the tick. However, now the tick is incremented at the start of the tick, we have to account for two situations:

1) Agile input being flushed at the start of the tick
2) Input coming in _during_ the current physics tick

The key problem with (2), which was already present (but may not have occurred in the wild) is that multithread input coming in part way through a physics tick could have been missed if the `_physics_process()` to detect it had already run.

This PR sets the action physics tick to the **current + 1**. This ensures that input coming in within the physics tick will never be missed. As a result of this, the regular agile flushing with `flush_buffered_events()` is (as before) set to take place _before_ the physics tick begins (especially the tick increment). This ensures that input from `flush_buffered_events()` is processed as quickly as possibly, on the tick that begins straight after the flush.

### Future considerations
I am not absolutely sure that agile flushing should logically best take place _outside_ the physics tick, however that is the position that @RandomShaper added it originally, so to keep this PR as simple as possible and reduce risk of regressions I'm keeping that order for now.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
