### PR TITLE
Fix native file dialogs being shown on `set_visible(false)`

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -99,7 +99,9 @@ void FileDialog::set_visible(bool p_visible) {
 #endif
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE) && (use_native_dialog || OS::get_singleton()->is_sandboxed())) {
-		_native_popup();
+		if (p_visible) {
+			_native_popup();
+		}
 	} else {
 		ConfirmationDialog::set_visible(p_visible);
 	}


### PR DESCRIPTION
I was pretty confused when `get_tree().root.propagate_notification(Node.NOTIFICATION_WM_CLOSE_REQUEST)` popped up all my file dialogs.

Here's a MRP: [native-file-dialog-wm-close.zip](https://github.com/user-attachments/files/15753021/native-file-dialog-wm-close.zip)

Fixes #92946.
