### PR TITLE
[3.x] Fix double `TOOLS_ENABLED` checks from `NO_EDITOR_SPLASH`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -82,7 +82,7 @@
 #include "editor/progress_dialog.h"
 #include "editor/project_manager.h"
 #include "editor/script_editor_debugger.h"
-#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+#ifndef NO_EDITOR_SPLASH
 #include "main/splash_editor.gen.h"
 #endif
 #endif


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I accidentally not noticed it while i was working on my modified version so i fixed it.