### PR TITLE
Fix "BUG: Unreferenced static string to 0"- errors when generating script tests

### DIFF
--- a/core/debugger/engine_profiler.cpp
+++ b/core/debugger/engine_profiler.cpp
@@ -71,6 +71,8 @@ Error EngineProfiler::bind(const String &p_name) {
 Error EngineProfiler::unbind() {
 	ERR_FAIL_COND_V(!is_bound(), ERR_UNCONFIGURED);
 	EngineDebugger::unregister_profiler(registration);
+
+	// Mark this instance unbound by clearing the registration name.
 	registration.clear();
 	return OK;
 }

--- a/core/debugger/engine_profiler.h
+++ b/core/debugger/engine_profiler.h
@@ -38,7 +38,7 @@ class EngineProfiler : public RefCounted {
 	GDCLASS(EngineProfiler, RefCounted);
 
 private:
-	String registration;
+	StringName registration;
 
 protected:
 	static void _bind_methods();
@@ -50,7 +50,7 @@ public:
 
 	Error bind(const String &p_name);
 	Error unbind();
-	bool is_bound() const { return registration.length() > 0; }
+	bool is_bound() const { return registration.data_unique_pointer() != nullptr; }
 
 	GDVIRTUAL2(_toggle, bool, Array);
 	GDVIRTUAL1(_add_frame, Array);

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -189,6 +189,14 @@ public:
 		}
 	}
 
+	// Explicitly reset a StringName instance to be null.
+	_FORCE_INLINE_ void clear() {
+		if (likely(configured) && _data) { //only free if configured
+			unref();
+		}
+		_data = nullptr;
+	}
+
 #ifdef DEBUG_ENABLED
 	static void set_debug_stringnames(bool p_enable) { debug_stringname = p_enable; }
 #endif

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -42,6 +42,7 @@
 #include "core/io/file_access_pack.h"
 #include "core/os/os.h"
 #include "core/string/string_builder.h"
+#include "main/main.h"
 #include "scene/resources/packed_scene.h"
 
 #include "tests/test_macros.h"
@@ -421,6 +422,13 @@ void GDScriptTestRunner::handle_cmdline() {
 
 			bool completed = runner.generate_outputs();
 			int failed = completed ? 0 : -1;
+
+			// When script test generation is invoked, we don't want to run the rest of the program,
+			// but command line parameter handlers are not expected to decide that running the rest of the program
+			// is unwanted, so we have no way to signal the caller that the process should exit.
+			// We have to exit by force. Run some de-initializations before that, to
+			// avoid assertions about uncleaned resources.
+			Main::cleanup(true);
 			exit(failed);
 		}
 	}


### PR DESCRIPTION
### The context

When the command line parameter `--gdscript-generate-tests` is provided, the logic in `GDScriptTestRunner::handle_cmdline` generates the script tests. When godot is run for the purpose of this generation, the process should not do anything else, so it needs to exit at this point. But the logic hasn't been set up for a command line handler to make such a decision. So the handler has to run the exit by force. 

### The problem

Running a raw `exit` bypasses the cleanups performed by the normal execution of main, causing a number of `BUG` messages, such as `ERROR: BUG: Unreferenced static string to 0` as noted in issue #92676.

### The solution

The "correct" solution would probably be to make command line parameter handlers able to tell the process to exit, but that would require refactoring that exceeds my boldness. Instead I just added a direct invocation of the cleanup logic before the call to `exit`. This and avoiding one `StringName` construction in the destructor of a static variable (by making it live its entire life as a StringName) got rid of all error messages when executing `--gdscript-generate-tests` from a dev build.

This is valuable, because if people accidentally genuinely break invariants guarded by BUG messages, they are more likely to notice the error messages when the normal output from master contains none of them.

* _Bugsquad edit:_ Fixes #92676.