### PR TITLE
TileSet: Transform rotated navigation (sub)-polygons individually.

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6489,18 +6489,16 @@ Ref<NavigationPolygon> TileData::get_navigation_polygon(int p_layer_id, bool p_f
 		PackedVector2Array new_points = get_transformed_vertices(layer_tile_data.navigation_polygon->get_vertices(), p_flip_h, p_flip_v, p_transpose);
 		transformed_polygon->set_vertices(new_points);
 
+		int num_polygons = layer_tile_data.navigation_polygon->get_polygon_count();
+		for (int i = 0; i < num_polygons; ++i) {
+			transformed_polygon->add_polygon(layer_tile_data.navigation_polygon->get_polygon(i));
+		}
+
 		for (int i = 0; i < layer_tile_data.navigation_polygon->get_outline_count(); i++) {
 			PackedVector2Array new_outline = get_transformed_vertices(layer_tile_data.navigation_polygon->get_outline(i), p_flip_h, p_flip_v, p_transpose);
 			transformed_polygon->add_outline(new_outline);
 		}
 
-		PackedInt32Array indices;
-		indices.resize(new_points.size());
-		int *w = indices.ptrw();
-		for (int i = 0; i < new_points.size(); i++) {
-			w[i] = i;
-		}
-		transformed_polygon->add_polygon(indices);
 		layer_tile_data.transformed_navigation_polygon[key] = transformed_polygon;
 		return transformed_polygon;
 	} else {


### PR DESCRIPTION
Fixes #92125.

This PR fixes the get_navigation_polygon function to ensure that individual sub-polygons of a NavigationPolygon2D are preserved when generating alternate (i.e., rotated, flipped, or transposed) tiles in TileSet. 

This ensures that triangulation works properly, as unifying sub-polygons to a single polygon can create non-simple polygons.

Rotated tiles without the fix:

![bugged](https://github.com/godotengine/godot/assets/42714034/d86fde15-a3dd-48e4-a9b1-df5f83475f5f)

With the fix:

![fixed](https://github.com/godotengine/godot/assets/42714034/3f263439-5e10-4143-a606-508f94462a44)
