### PR TITLE
Add `get_editor_tool_mode` 2D and 3D methods to EditorInterface

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -110,10 +110,16 @@
 				Returns the editor's [EditorSettings] instance.
 			</description>
 		</method>
-		<method name="get_editor_current_tool" qualifiers="const">
+		<method name="get_editor_tool_mode_2d" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the currently selected tool in the editor.
+				Returns the currently selected tool in the 2D editor. If the 2D editor is not open, returns the tool that was most recently active in the 2D editor.
+			</description>
+		</method>
+		<method name="get_editor_tool_mode_3d" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the currently selected tool in the 3D editor. If the 3D editor is not open, returns the tool that was most recently active in the 3D editor.
 			</description>
 		</method>
 		<method name="get_editor_theme" qualifiers="const">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -110,6 +110,12 @@
 				Returns the editor's [EditorSettings] instance.
 			</description>
 		</method>
+		<method name="get_editor_current_tool" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the currently selected tool in the editor.
+			</description>
+		</method>
 		<method name="get_editor_theme" qualifiers="const">
 			<return type="Theme" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -41,6 +41,7 @@
 #include "editor/gui/editor_run_bar.h"
 #include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/property_selector.h"
 #include "editor/themes/editor_scale.h"
@@ -243,6 +244,10 @@ bool EditorInterface::is_multi_window_enabled() const {
 
 float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
+}
+
+int EditorInterface::get_editor_current_tool() const {
+	return CanvasItemEditor::get_singleton()->get_current_tool();
 }
 
 void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
@@ -523,6 +528,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
+	ClassDB::bind_method(D_METHOD("get_editor_current_tool"), &EditorInterface::get_editor_current_tool);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -246,8 +246,12 @@ float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
 }
 
-int EditorInterface::get_editor_current_tool() const {
+int EditorInterface::get_editor_tool_mode_2d() const {
 	return CanvasItemEditor::get_singleton()->get_current_tool();
+}
+
+int EditorInterface::get_editor_tool_mode_3d() const {
+	return Node3DEditor::get_singleton()->get_tool_mode();
 }
 
 void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
@@ -528,7 +532,8 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
-	ClassDB::bind_method(D_METHOD("get_editor_current_tool"), &EditorInterface::get_editor_current_tool);
+	ClassDB::bind_method(D_METHOD("get_editor_tool_mode_2d"), &EditorInterface::get_editor_tool_mode_2d);
+	ClassDB::bind_method(D_METHOD("get_editor_tool_mode_3d"), &EditorInterface::get_editor_tool_mode_3d);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -93,7 +93,8 @@ public:
 	EditorResourcePreview *get_resource_previewer() const;
 	EditorSelection *get_selection() const;
 	Ref<EditorSettings> get_editor_settings() const;
-	int get_editor_current_tool() const;
+	int get_editor_tool_mode_2d() const;
+	int get_editor_tool_mode_3d() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -93,6 +93,7 @@ public:
 	EditorResourcePreview *get_resource_previewer() const;
 	EditorSelection *get_selection() const;
 	Ref<EditorSettings> get_editor_settings() const;
+	int get_editor_current_tool() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 


### PR DESCRIPTION
This PR lets you access the currently selected tool (as an int) via `EditorInterface`.

This feature would be useful to me -- I'm writing an editor plugin that uses mouse input, and I want it to be active only when I'm in Select mode.

(haven't contributed before, so LMK if one should *always* create a proposal first -- i wasn't sure. i'd normally create one but thought this change was small enough it wasn't worth it.)