### PR TITLE
CI: Pin Python 3.12.3 to workaround GHA issue (reverted)

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -3,7 +3,7 @@ description: Setup Python, install the pip version of SCons.
 inputs:
   python-version:
     description: The Python version to use.
-    default: "3.x"
+    default: "3.12.3"
   python-arch:
     description: The Python architecture.
     default: "x64"


### PR DESCRIPTION
macOS runners can't extract the 3.12.4 tarball properly it seems. https://github.com/actions/setup-python/issues/886