### PR TITLE
Make `AudioDriverOpenSL`'s input callback thread-safe

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -234,6 +234,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 				ad->input_buffer_write(sample);
 			}
 		}
+		ad->input_buffer_end_write();
 	} else {
 		ERR_PRINT("AudioUnitRender failed, code: " + itos(result));
 	}
@@ -633,8 +634,8 @@ void AudioDriverCoreAudio::_set_device(const String &output_device, bool input) 
 
 		if (input) {
 			// Reset audio input to keep synchronization.
-			input_position = 0;
-			input_size = 0;
+			input_read = SizePosition(0, 0);
+			input_write = SizePosition(0, 0);
 		}
 	}
 }

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -269,8 +269,8 @@ Error AudioDriverPulseAudio::init_output_device() {
 	samples_out.resize(pa_buffer_size);
 
 	// Reset audio input to keep synchronization.
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 
 	return OK;
 }
@@ -546,6 +546,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 							ad->input_buffer_write(sample);
 						}
 					}
+					ad->input_buffer_end_write();
 
 					read_bytes += bytes;
 					ret = pa_stream_drop(ad->pa_rec_str);

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -483,8 +483,8 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 	// Sample rate is independent of channels (ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels)
 	samples_in.resize(buffer_frames * channels);
 
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 
 	print_verbose("WASAPI: detected " + itos(audio_output.channels) + " channels");
 	print_verbose("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
@@ -859,6 +859,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 						ad->input_buffer_write(l);
 						ad->input_buffer_write(r);
 					}
+					ad->input_buffer_end_write();
 
 					read_frames += num_frames_available;
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -184,11 +184,13 @@ void AudioDriverOpenSL::start() {
 }
 
 void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf queueItf) {
+	lock();
 	for (int i = 0; i < rec_buffer.size(); i++) {
 		int32_t sample = rec_buffer[i] << 16;
 		input_buffer_write(sample);
 		input_buffer_write(sample); // call twice to convert to Stereo
 	}
+	unlock();
 
 	SLresult res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));
 	ERR_FAIL_COND(res != SL_RESULT_SUCCESS);

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -190,6 +190,7 @@ void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf qu
 		input_buffer_write(sample);
 		input_buffer_write(sample); // call twice to convert to Stereo
 	}
+	input_buffer_end_write();
 	input_unlock();
 
 	SLresult res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -44,7 +44,7 @@ void AudioDriverOpenSL::_buffer_callback(
 	if (pause) {
 		mix = false;
 	} else {
-		mix = mutex.try_lock();
+		mix = output_mutex.try_lock();
 	}
 
 	if (mix) {
@@ -57,7 +57,7 @@ void AudioDriverOpenSL::_buffer_callback(
 	}
 
 	if (mix) {
-		mutex.unlock();
+		output_mutex.unlock();
 	}
 
 	const int32_t *src_buff = mixdown_buffer;
@@ -184,13 +184,13 @@ void AudioDriverOpenSL::start() {
 }
 
 void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf queueItf) {
-	lock();
+	input_lock();
 	for (int i = 0; i < rec_buffer.size(); i++) {
 		int32_t sample = rec_buffer[i] << 16;
 		input_buffer_write(sample);
 		input_buffer_write(sample); // call twice to convert to Stereo
 	}
-	unlock();
+	input_unlock();
 
 	SLresult res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));
 	ERR_FAIL_COND(res != SL_RESULT_SUCCESS);
@@ -294,6 +294,14 @@ Error AudioDriverOpenSL::input_stop() {
 	return OK;
 }
 
+void AudioDriverOpenSL::input_lock() {
+	input_mutex.lock();
+}
+
+void AudioDriverOpenSL::input_unlock() {
+	input_mutex.unlock();
+}
+
 int AudioDriverOpenSL::get_mix_rate() const {
 	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
 }
@@ -303,15 +311,11 @@ AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
 }
 
 void AudioDriverOpenSL::lock() {
-	if (active) {
-		mutex.lock();
-	}
+	output_mutex.lock();
 }
 
 void AudioDriverOpenSL::unlock() {
-	if (active) {
-		mutex.unlock();
-	}
+	output_mutex.unlock();
 }
 
 void AudioDriverOpenSL::finish() {

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -39,7 +39,8 @@
 
 class AudioDriverOpenSL : public AudioDriver {
 	bool active = false;
-	Mutex mutex;
+	Mutex output_mutex;
+	Mutex input_mutex;
 
 	enum {
 		BUFFER_COUNT = 2
@@ -102,6 +103,9 @@ public:
 
 	virtual Error input_start() override;
 	virtual Error input_stop() override;
+
+	virtual void input_lock() override;
+	virtual void input_unlock() override;
 
 	void set_pause(bool p_pause);
 

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -100,6 +100,7 @@ void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
 	for (int i = read_pos; i < read_pos + to_read; i++) {
 		input_buffer_write(int32_t(input_rb[i] * 32768.f) * (1U << 16));
 	}
+	input_buffer_end_write();
 }
 
 Error AudioDriverWeb::init() {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -322,7 +322,7 @@ AudioStreamMicrophone::AudioStreamMicrophone() {
 }
 
 int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_frames) {
-	AudioDriver::get_singleton()->lock();
+	AudioDriver::get_singleton()->input_lock();
 
 	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
@@ -369,8 +369,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 	}
 #endif
 
-	AudioDriver::get_singleton()->unlock();
-
+	AudioDriver::get_singleton()->input_unlock();
 	return mixed_frames;
 }
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -362,7 +362,9 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 	}
 
 #ifdef DEBUG_ENABLED
-	if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
+	if (mixed_frames != p_frames) {
+		ERR_PRINT(vformat("Buffer underrun: input_size = %d, input_ofs = %d, buf.size() = %d.", input_size, input_ofs, buf.size()));
+	} else if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
 		print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
 	}
 #endif

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -98,22 +98,26 @@ double AudioDriver::get_time_to_next_mix() {
 void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 	const int input_buffer_channels = 2;
 	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4);
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 }
 
 void AudioDriver::input_buffer_write(int32_t sample) {
-	if ((int)input_position < input_buffer.size()) {
-		input_buffer.write[input_position++] = sample;
-		if ((int)input_position >= input_buffer.size()) {
-			input_position = 0;
+	if (input_write.position < input_buffer.size()) {
+		input_buffer[input_write.position++] = sample;
+		if (input_write.position >= input_buffer.size()) {
+			input_write.position = 0;
 		}
-		if ((int)input_size < input_buffer.size()) {
-			input_size++;
+		if (input_write.size < input_buffer.size()) {
+			input_write.size++;
 		}
 	} else {
-		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
+		WARN_PRINT("input_buffer_write: Invalid input_write.position=" + itos(input_write.position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
+}
+
+void AudioDriver::input_buffer_end_write() {
+	input_read = input_write;
 }
 
 int AudioDriver::_get_configured_mix_rate() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -56,15 +56,26 @@ class AudioDriver {
 	SafeNumeric<uint64_t> prof_time;
 #endif
 
+public:
+	struct SizePosition {
+		unsigned int size;
+		unsigned int position;
+
+		SizePosition(unsigned int p_size = 0, unsigned int p_position = 0) noexcept :
+				size(p_size), position(p_position) {}
+	};
+
 protected:
-	Vector<int32_t> input_buffer;
-	unsigned int input_position = 0;
-	unsigned int input_size = 0;
+	LocalVector<int32_t> input_buffer;
+	std::atomic<SizePosition> input_read;
+	SizePosition input_write;
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
+
 	void input_buffer_init(int driver_buffer_frames);
 	void input_buffer_write(int32_t sample);
+	void input_buffer_end_write();
 
 	int _get_configured_mix_rate();
 
@@ -123,9 +134,8 @@ public:
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
 
-	Vector<int32_t> get_input_buffer() { return input_buffer; }
-	unsigned int get_input_position() { return input_position; }
-	unsigned int get_input_size() { return input_size; }
+	const LocalVector<int32_t> &get_input_buffer() { return input_buffer; }
+	SizePosition get_input_size_position() { return input_read; }
 
 #ifdef DEBUG_ENABLED
 	uint64_t get_profiling_time() const { return prof_time.get(); }

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -111,6 +111,9 @@ public:
 	virtual Error input_start() { return FAILED; }
 	virtual Error input_stop() { return FAILED; }
 
+	virtual void input_lock() { lock(); }
+	virtual void input_unlock() { unlock(); }
+
 	virtual PackedStringArray get_input_device_list();
 	virtual String get_input_device() { return "Default"; }
 	virtual void set_input_device(const String &p_name) {}


### PR DESCRIPTION
* Fixes: #86428 (Should probably mention that this problem is as old as support for the microphone on Android, there could be other similar issues this PR closes. See https://github.com/godotengine/godot/pull/92969#discussion_r1634441217).
* Superseded by #93154. Still decided to keep it just in case

Tested using this project: [AudioTest.zip](https://github.com/user-attachments/files/15766103/AudioTest.zip).

Turns out that not making the input callback thread-safe caused weird issues and `input_buffer` was not getting referenced (see https://github.com/godotengine/godot/pull/92969#discussion_r1634441217), so now it's thread-safe. However, the copied implementation from `AudioDriverCoreAudio` causes audio issues (you can hear them if you compile only the first commit), as it seems that input and output callbacks run at the same time on Android. That was a problem because there was only one mutex that these two threads needed to share, but the output callback never waits for this mutex to unlock (to make it as fast as possible, this also matches the `AudioDriverCoreAudio` implementation).

However, there needed to be at least something to account for them running at the same time, so I decided to add another mutex that output and input callback both wait for. But why doesn't adding another mutex slow down output callback a lot? First of all, it's because this mutex is only used by the input callback, so it doesn't impact speed that much, the other mutex is pretty much used all over Godot and can be used by `GDScript`. Second of all, output callback only waits for the new mutex mid-executing, if it waited for the other mutex, it would have been waiting for it before starting execution. You can look at the implementation in the second commit, that's why there are two commits. This solution also doesn't impact any other audio driver.

To minimize locking even more, pushed the third commit. It's also a little bit of a different solution to the issue, ~but to function properly it needs the first two commits, that's why I decided to keep it in this PR, can create the new one, if required~. Now it locks on the output callback only when there's an underrun in the input buffer. See https://github.com/godotengine/godot/pull/92969#discussion_r1634507493 and #93154.

The same input mutex can be created for `AudioDriverCoreAudio` as well, but I decided to leave it for the other PR.
I could only come up with this solution, so if anyone has other ideas, I would love to hear them ^^

P.S.: There are also other solutions for locks, but I don't know much about threads, is `Mutex` the best lock here or should I use something else? (I'll also ask in Rocket.Chat)

**EDIT**: ~~This might be a bug that wasn't present since the begging and something in the `Vector` implementation just broke.~~ See https://github.com/godotengine/godot/pull/92969#discussion_r1634441217.