### PR TITLE
Editor: Warn on UID duplicates

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -961,6 +961,14 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 
 		if (fi->uid != ResourceUID::INVALID_ID) {
 			if (ResourceUID::get_singleton()->has_id(fi->uid)) {
+				// Restrict UID dupe warning to first-scan since we know there are no file moves going on yet.
+				if (first_scan) {
+					// Warn if we detect files with duplicate UIDs.
+					const String other_path = ResourceUID::get_singleton()->get_id_path(fi->uid);
+					if (other_path != path) {
+						WARN_PRINT(vformat("UID duplicate detected between %s and %s.", path, other_path));
+					}
+				}
 				ResourceUID::get_singleton()->set_id(fi->uid, path);
 			} else {
 				ResourceUID::get_singleton()->add_id(fi->uid, path);


### PR DESCRIPTION
This commonly occurs when files are copied outside of the editor and don't get new UIDs.

Restricting this warning to first_scan since we want to exclude the case of files being moved after initial load which is harder to handle.

Closes https://github.com/godotengine/godot-proposals/discussions/8949

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- *Production edit: See https://github.com/godotengine/godot/issues/96313.*