### PR TITLE
Fix incorrect camera transform of animation view in the import window

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -609,7 +609,7 @@ void SceneImportSettingsDialog::_update_camera() {
 	float rot_y = cam_rot_y;
 	float zoom = cam_zoom;
 
-	if (selected_type == "Node" || selected_type.is_empty()) {
+	if (selected_type == "Node" || selected_type == "Animation" || selected_type.is_empty()) {
 		camera_aabb = contents_aabb;
 	} else {
 		if (mesh_preview->get_mesh().is_valid()) {


### PR DESCRIPTION
Fixes incorrect AABB transformation of the camera of the models in animation view of the advanced import settings, which leads to clipping issues:

![import_settings_bug](https://github.com/godotengine/godot/assets/3036176/a79daa1b-f27a-4bad-95f2-c4712bf0c634)

After the fix:

![import_settings_bug_fix](https://github.com/godotengine/godot/assets/3036176/4af9177b-74db-4c90-b316-e06d5f3627db)

