### PR TITLE
Fix `getSolveSwingLimit` returning wrong member variable

### DIFF
--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -123,15 +123,15 @@ public:
 		m_relaxationFactor = _relaxationFactor;
 	}
 
-	inline int getSolveTwistLimit() {
+	inline int getSolveTwistLimit() const {
 		return m_solveTwistLimit;
 	}
 
-	inline int getSolveSwingLimit() {
-		return m_solveTwistLimit;
+	inline int getSolveSwingLimit() const {
+		return m_solveSwingLimit;
 	}
 
-	inline real_t getTwistLimitSign() {
+	inline real_t getTwistLimitSign() const {
 		return m_twistLimitSign;
 	}
 


### PR DESCRIPTION
There do not seem to be any in-engine uses of this function.

Fixes #92947 