### PR TITLE
Allow changing project theme without restart

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -365,6 +365,8 @@ private:
 	AcceptDialog *execute_output_dialog = nullptr;
 
 	Ref<Theme> theme;
+	Ref<Theme> project_theme;
+	Ref<Font> project_font;
 
 	Timer *system_theme_timer = nullptr;
 	bool follow_system_theme = false;
@@ -523,6 +525,7 @@ private:
 	static void _resource_loaded(Ref<Resource> p_resource, const String &p_path);
 
 	void _update_theme(bool p_skip_creation = false);
+	void _update_project_theme(bool p_also_update_previews);
 	void _build_icon_type_cache();
 	void _enable_pending_addons();
 

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -49,8 +49,8 @@ void ThemeDB::initialize_theme() {
 	// Allow creating the default theme at a different scale to suit higher/lower base resolutions.
 	float default_theme_scale = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/theme/default_theme_scale", PROPERTY_HINT_RANGE, "0.5,8,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 1.0);
 
-	String project_theme_path = GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
-	String project_font_path = GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.otf,*.ttf,*.woff,*.woff2,*.fnt,*.font,*.pfb,*.pfm", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
+	String project_theme_path = GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
+	String project_font_path = GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.otf,*.ttf,*.woff,*.woff2,*.fnt,*.font,*.pfb,*.pfm", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
 
 	TextServer::FontAntialiasing font_antialiasing = (TextServer::FontAntialiasing)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_antialiasing", PROPERTY_HINT_ENUM, "None,Grayscale,LCD Subpixel", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 1);
 	TextServer::Hinting font_hinting = (TextServer::Hinting)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), TextServer::HINTING_LIGHT);
@@ -412,6 +412,23 @@ void ThemeDB::_sort_theme_items() {
 	}
 }
 
+void ThemeDB::_update_project_settings() {
+	String project_theme_path = GLOBAL_GET("gui/theme/custom");
+	String project_font_path = GLOBAL_GET("gui/theme/custom_font");
+
+	Ref<Theme> new_theme;
+	if (!project_theme_path.is_empty()) {
+		new_theme = ResourceLoader::load(project_theme_path);
+	}
+	set_project_theme(new_theme);
+
+	Ref<Font> new_font;
+	if (!project_font_path.is_empty()) {
+		new_font = ResourceLoader::load(project_font_path);
+	}
+	set_fallback_font(new_font);
+}
+
 // Object methods.
 
 void ThemeDB::_bind_methods() {
@@ -452,6 +469,7 @@ ThemeDB::ThemeDB() {
 	if (MessageQueue::get_singleton()) { // May not exist in tests etc.
 		callable_mp(this, &ThemeDB::_sort_theme_items).call_deferred();
 	}
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ThemeDB::_update_project_settings));
 }
 
 ThemeDB::~ThemeDB() {

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -120,6 +120,7 @@ private:
 	HashMap<StringName, List<ThemeItemBind>> theme_item_binds_list; // Used for listing purposes.
 
 	void _sort_theme_items();
+	void _update_project_settings();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION

https://github.com/godotengine/godot/assets/2223172/9e93ea44-a842-4881-ac29-4fb83c391644

Only works in editor; not sure how to update it at runtime, and it's probably less useful anyway.