### PR TITLE
Customize the file manager label for each platform

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -68,6 +68,11 @@ public:
 		RENDERING_SOURCE_FALLBACK
 	};
 
+	enum PlatformString {
+		PLATFORM_STRING_FILE_MANAGER_OPEN,
+		PLATFORM_STRING_FILE_MANAGER_SHOW,
+	};
+
 private:
 	static OS *singleton;
 	static uint64_t target_ticks;
@@ -391,6 +396,17 @@ public:
 	// Load GDExtensions specific to this platform.
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
+
+	virtual String get_platform_string(PlatformString p_platform_string) const {
+		switch (p_platform_string) {
+			case PlatformString::PLATFORM_STRING_FILE_MANAGER_OPEN:
+				return ETR("Open in File Manager");
+			case PlatformString::PLATFORM_STRING_FILE_MANAGER_SHOW:
+				return ETR("Show in File Manager");
+			default:
+				ERR_FAIL_V_MSG("", vformat("Couldn't find a string for platform string: %d.", p_platform_string));
+		}
+	}
 
 #ifdef TOOLS_ENABLED
 	// Tests OpenGL context and Rendering Device simultaneous creation. This function is expected to crash on some NVIDIA drivers.

--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -144,6 +144,17 @@ public:
 
 	virtual bool request_permission(const String &p_name) override;
 	virtual Vector<String> get_granted_permissions() const override;
+
+	virtual String get_platform_string(PlatformString p_platform_string) const override {
+		switch (p_platform_string) {
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_OPEN:
+				return ETR("Open in Files");
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_SHOW:
+				return ETR("Show in Files");
+			default:
+				return OS::get_platform_string(p_platform_string);
+		}
+	}
 };
 
 #endif // APPLE_EMBEDDED_ENABLED

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2438,7 +2438,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_item_menu = memnew(PopupMenu);
 		vmem_item_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditorDebugger::_vmem_item_menu_id_pressed));
 		vmem_item_menu->add_item(TTRC("Show in FileSystem"), VMEM_MENU_SHOW_IN_FILESYSTEM);
-		vmem_item_menu->add_item(TTRC("Show in File Manager"), VMEM_MENU_SHOW_IN_EXPLORER);
+		vmem_item_menu->add_item(OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_SHOW), VMEM_MENU_SHOW_IN_EXPLORER);
 		vmem_item_menu->add_item(TTRC("View Owners..."), VMEM_MENU_OWNERS);
 		add_child(vmem_item_menu);
 	}

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -3651,7 +3651,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		}
 
 		p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Filesystem")), ED_GET_SHORTCUT("filesystem_dock/show_in_explorer"), FILE_MENU_SHOW_IN_EXPLORER);
-		p_popup->set_item_text(p_popup->get_item_index(FILE_MENU_SHOW_IN_EXPLORER), is_directory ? TTRC("Open in File Manager") : TTRC("Show in File Manager"));
+		p_popup->set_item_text(p_popup->get_item_index(FILE_MENU_SHOW_IN_EXPLORER), is_directory ? OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN) : OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_SHOW));
 #endif
 
 		current_path = fpath;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9191,7 +9191,7 @@ EditorNode::EditorNode() {
 	}
 
 	remove_android_build_template = memnew(ConfirmationDialog);
-	remove_android_build_template->set_ok_button_text(TTR("Show in File Manager"));
+	remove_android_build_template->set_ok_button_text(OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN));
 	remove_android_build_template->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_android_explore_build_templates));
 	gui_base->add_child(remove_android_build_template);
 

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -361,7 +361,7 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 
 			file_context_menu = memnew(PopupMenu);
 			file_context_menu->add_item(TTR("Show in FileSystem"), FILE_SHOW_IN_FILESYSTEM);
-			file_context_menu->add_item(TTR("Show in File Manager"), FILE_SHOW_IN_FILE_MANAGER);
+			file_context_menu->add_item(OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_SHOW), FILE_SHOW_IN_FILE_MANAGER);
 			file_context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &QuickOpenResultContainer::_menu_option));
 			file_context_menu->hide();
 			scroll_container->add_child(file_context_menu);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -328,13 +328,13 @@ void ProjectListItemControl::set_is_missing(bool p_missing) {
 		explore_button->set_button_icon(get_editor_theme_icon(SNAME("FileBroken")));
 		explore_button->set_tooltip_text(TTRC("Error: Project is missing on the filesystem."));
 	} else {
-#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
-		explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
-		explore_button->set_tooltip_text(TTRC("Show in File Manager"));
-#else
+#if defined(ANDROID_ENABLED) || defined(WEB_ENABLED)
 		// Opening the system file manager is not supported on the Android and web editors.
 		explore_button->hide();
-#endif
+#else // !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
+		explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
+		explore_button->set_tooltip_text(OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN));
+#endif // defined(ANDROID_ENABLED) || defined(WEB_ENABLED)
 	}
 }
 
@@ -1199,8 +1199,8 @@ void ProjectList::_open_menu(const Vector2 &p_at, Control *p_hb) {
 		project_context_menu->add_item(TTRC("Run Project"), MENU_RUN);
 		project_context_menu->add_separator();
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
-		project_context_menu->add_item(TTRC("Show in File Manager"), MENU_SHOW_IN_FILE_MANAGER);
-#endif
+		project_context_menu->add_item(OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN), MENU_SHOW_IN_FILE_MANAGER);
+#endif // !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 		project_context_menu->add_item(TTRC("Copy Path"), MENU_COPY_PATH);
 		project_context_menu->add_separator();
 		project_context_menu->add_item(TTRC("Rename"), MENU_RENAME);

--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
@@ -270,7 +270,7 @@ void ObjectDBProfilerPanel::_snapshot_rmb(const Vector2 &p_pos, MouseButton p_bu
 	rmb_menu->clear(false);
 
 	rmb_menu->add_icon_item(get_editor_theme_icon(SNAME("Rename")), TTRC("Rename"), OdbProfilerMenuOptions::ODB_MENU_RENAME);
-	rmb_menu->add_icon_item(get_editor_theme_icon(SNAME("Folder")), TTRC("Show in File Manager"), OdbProfilerMenuOptions::ODB_MENU_SHOW_IN_FOLDER);
+	rmb_menu->add_icon_item(get_editor_theme_icon(SNAME("Folder")), OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN), OdbProfilerMenuOptions::ODB_MENU_SHOW_IN_FOLDER);
 	rmb_menu->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTRC("Delete"), OdbProfilerMenuOptions::ODB_MENU_DELETE);
 
 	rmb_menu->set_position(snapshot_list->get_screen_position() + p_pos);

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -167,6 +167,17 @@ public:
 
 	virtual void run() = 0;
 
+	virtual String get_platform_string(PlatformString p_platform_string) const override {
+		switch (p_platform_string) {
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_OPEN:
+				return ETR("Open in Finder");
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_SHOW:
+				return ETR("Show in Finder");
+			default:
+				return OS::get_platform_string(p_platform_string);
+		}
+	}
+
 	OS_MacOS(const char *p_execpath, int p_argc, char **p_argv);
 };
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -264,6 +264,17 @@ public:
 
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
+	virtual String get_platform_string(PlatformString p_platform_string) const override {
+		switch (p_platform_string) {
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_OPEN:
+				return ETR("Open in File Explorer");
+			case OS::PlatformString::PLATFORM_STRING_FILE_MANAGER_SHOW:
+				return ETR("Show in File Explorer");
+			default:
+				return OS::get_platform_string(p_platform_string);
+		}
+	}
+
 #ifdef TOOLS_ENABLED
 	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const override;
 	virtual bool _test_create_rendering_device(const String &p_display_driver) const override;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -800,7 +800,7 @@ void FileDialog::_popup_menu(const Vector2 &p_pos, int p_for_item) {
 		meta = file_list->get_item_metadata(p_for_item);
 	}
 
-	item_menu->add_item((p_for_item == -1 || meta["dir"]) ? ETR("Open in File Manager") : ETR("Show in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
+	item_menu->add_item((p_for_item == -1 || meta["dir"]) ? OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_OPEN) : OS::get_singleton()->get_platform_string(OS::PLATFORM_STRING_FILE_MANAGER_SHOW), ITEM_MENU_SHOW_IN_EXPLORER);
 	item_menu->set_item_icon(-1, theme_cache.menu_show_in_file_manager);
 	if (meta["bundle"]) {
 		item_menu->add_item(ETR("Show Package Contents"), ITEM_MENU_SHOW_BUNDLE_CONTENT);


### PR DESCRIPTION
This PR changes the lines "Open in File Manager" and "Show in File Manager" to the following: 

| Platform | Line |
| :---: | :--- |
| Windows | ~~Reveal~~ Show in File Explorer |
| macOS | ~~Reveal~~ Show in Finder |
| _others_ | ~~Reveal~~ Show in File Manager |

![Capture d’écran, le 2024-06-10 à 11 28 52](https://github.com/godotengine/godot/assets/270928/8671fa15-2bd1-458a-9da2-0a0e7d222950)

As said @kitbdev on https://github.com/godotengine/godot/issues/89533#issuecomment-2002007135 :
> For reference, in [VSCode](https://github.com/microsoft/vscode/blob/b3b3473543f98f70acd9587ea46c17c0e521706c/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts#L27):
> 
>     * On Windows "Reveal in File Explorer"
> 
>     * On Mac "Reveal in Finder"
> 
>     * Otherwise "Open Containing Folder"
> 
> 
> And they are translated separately.

I chose to use "Reveal in File Manager" for the other platforms as it is close to what we already had.

The fact that it uses reveal for each platform will help the documentation team to say "click on the reveal button" instead of enumerating the choices each time.

Fixes #89533