### PR TITLE
Replace deprecated `USE_WEBGL2` linker flag

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -204,7 +204,7 @@ def configure(env: "SConsEnvironment"):
     if env["opengl3"]:
         env.AppendUnique(CPPDEFINES=["GLES3_ENABLED"])
         # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
-        env.Append(LINKFLAGS=["-s", "USE_WEBGL2=1"])
+        env.Append(LINKFLAGS=["-s", "MAX_WEBGL_VERSION=2"])
         # Allow use to take control of swapping WebGL buffers.
         env.Append(LINKFLAGS=["-s", "OFFSCREEN_FRAMEBUFFER=1"])
         # Breaking change since emscripten 3.1.51


### PR DESCRIPTION
[As mentioned in the developers chat](https://chat.godotengine.org/channel/web?msg=d2AHNNMrAAhguPJsc) by @patwork, we use [a deprecated linker flag](https://emscripten.org/docs/tools_reference/settings_reference.html?highlight=use_webgl2#use-webgl2): `-sUSE_WEBGL2`.

It has been replaced with `-sMAX_WEBGL_VERSION=2`. This is what this PR does.

It seems to be compatible with previous emscripten versions, at least since 3.1.0, so I think it's alright in terms of building the project with an older compiler.