### PR TITLE
Add functionality to optionally enable animation method calls in the editor.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -197,6 +197,8 @@ bool AnimationTrackKeyEdit::_set(const StringName &p_name, const Variant &p_valu
 
 			if (name == "name") {
 				d_new["method"] = p_value;
+			} else if (name == "call_in_editor") {
+				d_new["call_in_editor"] = p_value;
 			} else if (name == "arg_count") {
 				Vector<Variant> args = d_old["args"];
 				args.resize(p_value);
@@ -431,6 +433,12 @@ bool AnimationTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) const
 				return true;
 			}
 
+			ERR_FAIL_COND_V(!d.has("call_in_editor"), false);
+			if (name == "call_in_editor") {
+				r_ret = d["call_in_editor"];
+				return true;
+			}
+
 			ERR_FAIL_COND_V(!d.has("args"), false);
 
 			Vector<Variant> args = d["args"];
@@ -558,6 +566,7 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 		} break;
 		case Animation::TYPE_METHOD: {
 			p_list->push_back(PropertyInfo(Variant::STRING_NAME, PNAME("name")));
+			p_list->push_back(PropertyInfo(Variant::BOOL, PNAME("call_in_editor")));
 			p_list->push_back(PropertyInfo(Variant::INT, PNAME("arg_count"), PROPERTY_HINT_RANGE, "0,32,1,or_greater"));
 
 			Dictionary d = animation->track_get_key_value(track, key);
@@ -1008,6 +1017,12 @@ bool AnimationMultiTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) 
 						return true;
 					}
 
+					ERR_FAIL_COND_V(!d.has("call_in_editor"), false);
+					if (name == "call_in_editor") {
+						r_ret = d["call_in_editor"];
+						return true;
+					}
+
 					ERR_FAIL_COND_V(!d.has("args"), false);
 
 					Vector<Variant> args = d["args"];
@@ -1170,7 +1185,7 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 			} break;
 			case Animation::TYPE_METHOD: {
 				p_list->push_back(PropertyInfo(Variant::STRING_NAME, "name"));
-
+				p_list->push_back(PropertyInfo(Variant::BOOL, "call_in_editor"));
 				p_list->push_back(PropertyInfo(Variant::INT, "arg_count", PROPERTY_HINT_RANGE, "0,32,1,or_greater"));
 
 				Dictionary d = animation->track_get_key_value(first_track, first_key);
@@ -5323,6 +5338,7 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 		if (E.name == p_method) {
 			Dictionary d;
 			d["method"] = p_method;
+			d["call_in_editor"] = false;
 			Array params;
 			int first_defarg = E.arguments.size() - E.default_arguments.size();
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -181,6 +181,7 @@ private:
 
 	struct MethodKey : public Key {
 		StringName method;
+		bool call_in_editor = false;
 		Vector<Variant> params;
 	};
 
@@ -491,6 +492,7 @@ public:
 	UpdateMode value_track_get_update_mode(int p_track) const;
 
 	Vector<Variant> method_track_get_params(int p_track, int p_key_idx) const;
+	bool method_track_get_call_in_editor(int p_track, int p_key_idx) const;
 	StringName method_track_get_name(int p_track, int p_key_idx) const;
 
 	void copy_track(int p_track, Ref<Animation> p_to_animation);


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/9939

Related: https://github.com/godotengine/godot/issues/21388, https://github.com/godotengine/godot/issues/75479, https://github.com/godotengine/godot/issues/73043