### PR TITLE
Fix NavigationRegion2D debug not clearing canvas item

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -458,6 +458,7 @@ void NavigationRegion2D::_update_debug_mesh() {
 		return;
 	}
 
+	rs->canvas_item_clear(debug_instance_rid);
 	rs->mesh_clear(debug_mesh_rid);
 	debug_mesh_dirty = false;
 


### PR DESCRIPTION
Fixes NavigationRegion2D debug not clearing canvas item on navigation mesh change.

closes https://github.com/godotengine/godot/issues/92987

regression from https://github.com/godotengine/godot/pull/92372

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
