### PR TITLE
Update Camera2D gizmos when screen size changes

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -74,6 +74,14 @@ void Camera2D::_update_scroll() {
 	}
 }
 
+#ifdef TOOLS_ENABLED
+void Camera2D::_project_settings_changed() {
+	if (screen_drawing_enabled) {
+		queue_redraw();
+	}
+}
+#endif
+
 void Camera2D::_update_process_callback() {
 	if (is_physics_interpolated_and_enabled()) {
 		set_process_internal(is_current());
@@ -267,6 +275,14 @@ void Camera2D::_ensure_update_interpolation_data() {
 
 void Camera2D::_notification(int p_what) {
 	switch (p_what) {
+#ifdef TOOLS_ENABLED
+		case NOTIFICATION_READY: {
+			if (Engine::get_singleton()->is_editor_hint() && is_part_of_edited_scene()) {
+				ProjectSettings::get_singleton()->connect(SNAME("settings_changed"), callable_mp(this, &Camera2D::_project_settings_changed));
+			}
+		} break;
+#endif
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			_update_scroll();
 		} break;

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -88,6 +88,9 @@ protected:
 	bool _is_editing_in_editor() const;
 	void _update_process_callback();
 	void _update_scroll();
+#ifdef TOOLS_ENABLED
+	void _project_settings_changed();
+#endif
 
 	void _make_current(Object *p_which);
 	void _reset_just_exited() { just_exited_tree = false; }


### PR DESCRIPTION
Fixes #92976

*Technically* it causes unnecessary redraws when other settings change, but it's not really a problem.