### PR TITLE
CI: Hotfix for build error with newer clang++

### DIFF
--- a/thirdparty/embree/kernels/geometry/pointi.h
+++ b/thirdparty/embree/kernels/geometry/pointi.h
@@ -210,9 +210,9 @@ namespace embree
     };
 
     /*! output operator */
-    friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& line)
+    friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& point)
     {
-      return cout << "Line" << M << "i {" << line.v0 << ", " << line.geomID() << ", " << line.primID() << "}";
+      return cout << "Point" << M << "i {" << point.geomID() << ", " << point.primID() << "}";
     }
 
    public:

--- a/thirdparty/embree/kernels/subdiv/bezier_curve.h
+++ b/thirdparty/embree/kernels/subdiv/bezier_curve.h
@@ -135,7 +135,7 @@ namespace embree
       }
       
       friend embree_ostream operator<<(embree_ostream cout, const QuadraticBezierCurve& a) {
-        return cout << "QuadraticBezierCurve ( (" << a.u.lower << ", " << a.u.upper << "), " << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
+        return cout << "QuadraticBezierCurve (" << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
       }
     };
   


### PR DESCRIPTION
It will be included in the next release at some point.
- https://github.com/RenderKit/embree/issues 486 "fix output operator"

[ 30%] Compiling thirdparty/embree/kernels/common/accelset.cpp ... In file included from thirdparty/embree/kernels/common/device.cpp:12: In file included from thirdparty/embree/kernels/common/scene_curves.h:10: thirdparty/embree/kernels/common/../subdiv/bezier_curve.h:138:56: **error:** no member named 'u' in 'QuadraticBezierCurve<V>'
  138 |         return cout << "QuadraticBezierCurve ( (" << a.u.lower << ", "
  << a.u.upper << "), " << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
 ...

