### PR TITLE
Fix NavigationRegion2D editor plugin clear button not updating debug visuals

### DIFF
--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -217,6 +217,8 @@ void NavigationPolygonEditor::_clear_pressed() {
 	if (node) {
 		if (node->get_navigation_polygon().is_valid()) {
 			node->get_navigation_polygon()->clear();
+			// Needed to update all the region internals.
+			node->set_navigation_polygon(node->get_navigation_polygon());
 		}
 	}
 


### PR DESCRIPTION
Fixes that NavigationRegion2D editor plugin clear button did not update the debug visuals.

Second issues mentioned in https://github.com/godotengine/godot/issues/92987.

This fix is currently not needed in 3D because in 3D the editor gizmo does the debug drawing instead of the node.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
