### PR TITLE
Fix `Container::pending_sort` tracking

### DIFF
--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -80,6 +80,7 @@ void Container::remove_child_notify(Node *p_child) {
 
 void Container::_sort_children() {
 	if (!is_inside_tree()) {
+		pending_sort = false;
 		return;
 	}
 


### PR DESCRIPTION
When `Container::queue_sort()` is called, `pending_sort` is set to true to indicate when a call to `_sort_children()` is queued, to avoid queueing multiple calls. `Container::_sort_children()` sets `pending_sort` back to false when finished, but did not do this when the container was not inside the tree.  This would allow cases where `queue_sort()` could be called just before removing from the tree, causing `_sort_children()` to never reset `pending_sort`, preventing any future `queue_sort()` calls from queueing again.

One case where this happened was with the "Saving Scene" progress bar in the editor - when saving for the first time (or the first time the progress bar popup otherwise appeared in the editor), `_sort_children()` would be called successfully.  After the progress bar popup was hidden, then shown again on future saves, `_sort_children()` would not be called again, resulting in the progress bar not taking up as much space as it should.

This issue used to be avoided by setting `pending_sort` to false immediately on NOTIFICATION_ENTER_TREE - however, this would allow multiple calls to be queued at the same time when entering the tree (#92644).  The multiple calls was fixed recently by removing this assignment, but this also made possible the case where `pending_sort` is never reset.

This change sets `pending_sort` back to false in `_sort_children()` whether or not it's in the tree.  Since this is done in a deferred call, it should still avoid the previous issue of multiple calls being queued at once on entering the tree.

Fixes #92971

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
