### PR TITLE
Fix Left Joystick motion not registering on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -228,16 +228,6 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 	public boolean onGenericMotionEvent(MotionEvent event) {
 		lastSeenToolType = getEventToolType(event);
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && gestureDetector.onGenericMotionEvent(event)) {
-			// The gesture detector has handled the event.
-			return true;
-		}
-
-		if (godotGestureHandler.onMotionEvent(event)) {
-			// The gesture handler has handled the event.
-			return true;
-		}
-
 		if (event.isFromSource(InputDevice.SOURCE_JOYSTICK) && event.getActionMasked() == MotionEvent.ACTION_MOVE) {
 			// Check if the device exists
 			final int deviceId = event.getDeviceId();
@@ -273,11 +263,20 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 				}
 				return true;
 			}
-		} else {
-			return handleMouseEvent(event);
+			return false;
 		}
 
-		return false;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && gestureDetector.onGenericMotionEvent(event)) {
+			// The gesture detector has handled the event.
+			return true;
+		}
+
+		if (godotGestureHandler.onMotionEvent(event)) {
+			// The gesture handler has handled the event.
+			return true;
+		}
+
+		return handleMouseEvent(event);
 	}
 
 	public void initInputDevices() {


### PR DESCRIPTION
Due to a change made in commit ab9e377fe68b1735f1d30a8cdd83f518c7091925, left joystick motion inputs don't get properly registered. I reordered the guards in the `onGenericMotionEvent()` function so that joystick inputs don't get sent to the `GodotGestureHandler` in the first place.

I believe the `GodotGestureHandler` should not have to make an exception for that one function and do an event source check. Every other function in it is able to assume only the events with the proper sources are sent to it. However, a maintainer with a better overview of the systems should give their opinion.

Fixes #92939
