### PR TITLE
[Wayland] Implement IME support.

### DIFF
--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -152,6 +152,16 @@ env.WAYLAND_API_CODE(
 )
 
 env.WAYLAND_API_HEADER(
+    target="protocol/text_input.gen.h",
+    source="#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
+)
+
+env.WAYLAND_API_CODE(
+    target="protocol/text_input.gen.c",
+    source="#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
+)
+
+env.WAYLAND_API_HEADER(
     target="protocol/xdg_foreign.gen.h",
     source="#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml",
 )
@@ -175,6 +185,7 @@ source_files = [
     "protocol/primary_selection.gen.c",
     "protocol/idle_inhibit.gen.c",
     "protocol/tablet.gen.c",
+    "protocol/text_input.gen.c",
     "display_server_wayland.cpp",
     "wayland_thread.cpp",
     "key_mapping_xkb.cpp",

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -208,6 +208,7 @@ bool DisplayServerWayland::has_feature(Feature p_feature) const {
 		case FEATURE_HIDPI:
 		case FEATURE_SWAP_BUFFERS:
 		case FEATURE_KEEP_SCREEN_ON:
+		case FEATURE_IME:
 		case FEATURE_CLIPBOARD_PRIMARY: {
 			return true;
 		} break;
@@ -903,13 +904,23 @@ bool DisplayServerWayland::can_any_window_draw() const {
 }
 
 void DisplayServerWayland::window_set_ime_active(const bool p_active, DisplayServer::WindowID p_window_id) {
-	// TODO
-	DEBUG_LOG_WAYLAND(vformat("wayland stub window_set_ime_active active %s", p_active ? "true" : "false"));
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	wayland_thread.window_set_ime_active(p_active, MAIN_WINDOW_ID);
 }
 
 void DisplayServerWayland::window_set_ime_position(const Point2i &p_pos, DisplayServer::WindowID p_window_id) {
-	// TODO
-	DEBUG_LOG_WAYLAND(vformat("wayland stub window_set_ime_position pos %s window %d", p_pos, p_window_id));
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	wayland_thread.window_set_ime_position(p_pos, MAIN_WINDOW_ID);
+}
+
+Point2i DisplayServerWayland::ime_get_selection() const {
+	return ime_selection;
+}
+
+String DisplayServerWayland::ime_get_text() const {
+	return ime_text;
 }
 
 // NOTE: While Wayland is supposed to be tear-free, wayland-protocols version
@@ -1145,6 +1156,37 @@ void DisplayServerWayland::process_events() {
 					ERR_PRINT(vformat("Failed to execute drop files callback: %s.", Variant::get_callable_error_text(wd.drop_files_callback, v_args, 1, ce)));
 				}
 			}
+		}
+
+		Ref<WaylandThread::IMECommitEventMessage> ime_commit_msg = msg;
+		if (ime_commit_msg.is_valid()) {
+			for (int i = 0; i < ime_commit_msg->text.length(); i++) {
+				const char32_t codepoint = ime_commit_msg->text[i];
+
+				Ref<InputEventKey> ke;
+				ke.instantiate();
+				ke->set_window_id(MAIN_WINDOW_ID);
+				ke->set_pressed(true);
+				ke->set_echo(false);
+				ke->set_keycode(Key::NONE);
+				ke->set_physical_keycode(Key::NONE);
+				ke->set_key_label(Key::NONE);
+				ke->set_unicode(codepoint);
+
+				Input::get_singleton()->parse_input_event(ke);
+			}
+			ime_text = String();
+			ime_selection = Vector2i();
+
+			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+		}
+
+		Ref<WaylandThread::IMEUpdateEventMessage> ime_update_msg = msg;
+		if (ime_update_msg.is_valid()) {
+			ime_text = ime_update_msg->text;
+			ime_selection = ime_update_msg->selection;
+
+			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 		}
 	}
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -115,6 +115,9 @@ class DisplayServerWayland : public DisplayServer {
 
 	Context context;
 
+	String ime_text;
+	Vector2i ime_selection;
+
 	bool suspended = false;
 	bool emulate_vsync = false;
 
@@ -258,6 +261,9 @@ public:
 
 	virtual void window_set_ime_active(const bool p_active, WindowID p_window_id = MAIN_WINDOW_ID) override;
 	virtual void window_set_ime_position(const Point2i &p_pos, WindowID p_window_id = MAIN_WINDOW_ID) override;
+
+	virtual Point2i ime_get_selection() const override;
+	virtual String ime_get_text() const override;
 
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window_id = MAIN_WINDOW_ID) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_window_id) const override;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -448,6 +448,12 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 			zwp_tablet_seat_v2_add_listener(ss->wp_tablet_seat, &wp_tablet_seat_listener, ss);
 		}
 
+		if (!ss->wp_text_input && registry->wp_text_input_manager) {
+			// IME.
+			ss->wp_text_input = zwp_text_input_manager_v3_get_text_input(registry->wp_text_input_manager, wl_seat);
+			zwp_text_input_v3_add_listener(ss->wp_text_input, &wp_text_input_listener, ss);
+		}
+
 		registry->wl_seats.push_back(wl_seat);
 
 		wl_seat_add_listener(wl_seat, &wl_seat_listener, ss);
@@ -543,6 +549,22 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 
 			ss->wp_tablet_seat = zwp_tablet_manager_v2_get_tablet_seat(registry->wp_tablet_manager, wl_seat);
 			zwp_tablet_seat_v2_add_listener(ss->wp_tablet_seat, &wp_tablet_seat_listener, ss);
+		}
+
+		return;
+	}
+
+	if (strcmp(interface, zwp_text_input_manager_v3_interface.name) == 0) {
+		registry->wp_text_input_manager = (struct zwp_text_input_manager_v3 *)wl_registry_bind(wl_registry, name, &zwp_text_input_manager_v3_interface, 1);
+		registry->wp_text_input_manager_name = name;
+
+		// This global creates some seat data. Let's do that for the ones already available.
+		for (struct wl_seat *wl_seat : registry->wl_seats) {
+			SeatState *ss = wl_seat_get_seat_state(wl_seat);
+			ERR_FAIL_NULL(ss);
+
+			ss->wp_text_input = zwp_text_input_manager_v3_get_text_input(registry->wp_text_input_manager, wl_seat);
+			zwp_text_input_v3_add_listener(ss->wp_text_input, &wp_text_input_listener, ss);
 		}
 
 		return;
@@ -820,6 +842,25 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 			}
 
 			ss->tablet_tools.clear();
+		}
+
+		return;
+	}
+
+	if (name == registry->wp_text_input_manager_name) {
+		if (registry->wp_text_input_manager) {
+			zwp_text_input_manager_v3_destroy(registry->wp_text_input_manager);
+			registry->wp_text_input_manager = nullptr;
+		}
+
+		registry->wp_text_input_manager_name = 0;
+
+		for (struct wl_seat *wl_seat : registry->wl_seats) {
+			SeatState *ss = wl_seat_get_seat_state(wl_seat);
+			ERR_FAIL_NULL(ss);
+
+			zwp_text_input_v3_destroy(ss->wp_text_input);
+			ss->wp_text_input = nullptr;
 		}
 
 		return;
@@ -2535,6 +2576,118 @@ void WaylandThread::_wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_
 	old_td = td;
 }
 
+void WaylandThread::_wp_text_input_on_enter(void *data, struct zwp_text_input_v3 *wp_text_input_v3, struct wl_surface *surface) {
+	SeatState *ss = (SeatState *)data;
+	if (!ss) {
+		return;
+	}
+
+	ss->ime_enabled = true;
+}
+
+void WaylandThread::_wp_text_input_on_leave(void *data, struct zwp_text_input_v3 *wp_text_input_v3, struct wl_surface *surface) {
+	SeatState *ss = (SeatState *)data;
+	if (!ss) {
+		return;
+	}
+
+	ss->ime_enabled = false;
+	ss->ime_active = false;
+	ss->ime_text = String();
+	ss->ime_text_commit = String();
+	ss->ime_cursor = Vector2i();
+
+	Ref<IMEUpdateEventMessage> msg;
+	msg.instantiate();
+	msg->text = String();
+	msg->selection = Vector2i();
+	ss->wayland_thread->push_message(msg);
+}
+
+void WaylandThread::_wp_text_input_on_preedit_string(void *data, struct zwp_text_input_v3 *wp_text_input_v3, const char *text, int32_t cursor_begin, int32_t cursor_end) {
+	SeatState *ss = (SeatState *)data;
+	if (!ss) {
+		return;
+	}
+
+	ss->ime_text = String::utf8(text);
+
+	// Convert cursor positions from UTF-8 to UTF-32 offset.
+	int32_t cursor_begin_utf32 = 0;
+	int32_t cursor_end_utf32 = 0;
+	for (int i = 0; i < ss->ime_text.length(); i++) {
+		uint32_t c = ss->ime_text[i];
+		if (c <= 0x7f) { // 7 bits.
+			cursor_begin -= 1;
+			cursor_end -= 1;
+		} else if (c <= 0x7ff) { // 11 bits
+			cursor_begin -= 2;
+			cursor_end -= 2;
+		} else if (c <= 0xffff) { // 16 bits
+			cursor_begin -= 3;
+			cursor_end -= 3;
+		} else if (c <= 0x001fffff) { // 21 bits
+			cursor_begin -= 4;
+			cursor_end -= 4;
+		} else if (c <= 0x03ffffff) { // 26 bits
+			cursor_begin -= 5;
+			cursor_end -= 5;
+		} else if (c <= 0x7fffffff) { // 31 bits
+			cursor_begin -= 6;
+			cursor_end -= 6;
+		} else {
+			cursor_begin -= 1;
+			cursor_end -= 1;
+		}
+		if (cursor_begin == 0) {
+			cursor_begin_utf32 = i + 1;
+		}
+		if (cursor_end == 0) {
+			cursor_end_utf32 = i + 1;
+		}
+		if (cursor_begin <= 0 && cursor_end <= 0) {
+			break;
+		}
+	}
+	ss->ime_cursor = Vector2i(cursor_begin_utf32, cursor_end_utf32 - cursor_begin_utf32);
+}
+
+void WaylandThread::_wp_text_input_on_commit_string(void *data, struct zwp_text_input_v3 *wp_text_input_v3, const char *text) {
+	SeatState *ss = (SeatState *)data;
+	if (!ss) {
+		return;
+	}
+
+	ss->ime_text_commit = String::utf8(text);
+}
+
+void WaylandThread::_wp_text_input_on_delete_surrounding_text(void *data, struct zwp_text_input_v3 *wp_text_input_v3, uint32_t before_length, uint32_t after_length) {
+	// Not implemented.
+}
+
+void WaylandThread::_wp_text_input_on_done(void *data, struct zwp_text_input_v3 *wp_text_input_v3, uint32_t serial) {
+	SeatState *ss = (SeatState *)data;
+	if (!ss) {
+		return;
+	}
+
+	if (!ss->ime_text_commit.is_empty()) {
+		Ref<IMECommitEventMessage> msg;
+		msg.instantiate();
+		msg->text = ss->ime_text_commit;
+		ss->wayland_thread->push_message(msg);
+	} else if (!ss->ime_text.is_empty()) {
+		Ref<IMEUpdateEventMessage> msg;
+		msg.instantiate();
+		msg->text = ss->ime_text;
+		msg->selection = ss->ime_cursor;
+		ss->wayland_thread->push_message(msg);
+	}
+	ss->ime_text = String();
+	ss->ime_text_commit = String();
+	ss->ime_cursor = Vector2i();
+}
+
 void WaylandThread::_xdg_activation_token_on_done(void *data, struct xdg_activation_token_v1 *xdg_activation_token, const char *token) {
 	WindowState *ws = (WindowState *)data;
 	ERR_FAIL_NULL(ws);
@@ -3726,6 +3879,35 @@ void WaylandThread::cursor_shape_clear_custom_image(DisplayServer::CursorShape p
 		if (cursor.buffer_data) {
 			munmap(cursor.buffer_data, cursor.buffer_data_size);
 		}
+	}
+}
+
+void WaylandThread::window_set_ime_active(const bool p_active, DisplayServer::WindowID p_window_id) {
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+
+	if (ss && ss->wp_text_input && ss->ime_enabled) {
+		if (p_active) {
+			ss->ime_active = true;
+			zwp_text_input_v3_enable(ss->wp_text_input);
+			zwp_text_input_v3_set_cursor_rectangle(ss->wp_text_input, ss->ime_rect.position.x, ss->ime_rect.position.y, ss->ime_rect.size.x, ss->ime_rect.size.y);
+		} else {
+			ss->ime_active = false;
+			ss->ime_text = String();
+			ss->ime_text_commit = String();
+			ss->ime_cursor = Vector2i();
+			zwp_text_input_v3_disable(ss->wp_text_input);
+		}
+		zwp_text_input_v3_commit(ss->wp_text_input);
+	}
+}
+
+void WaylandThread::window_set_ime_position(const Point2i &p_pos, DisplayServer::WindowID p_window_id) {
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+
+	if (ss && ss->wp_text_input && ss->ime_enabled) {
+		ss->ime_rect = Rect2i(p_pos, Size2i(1, 10));
+		zwp_text_input_v3_set_cursor_rectangle(ss->wp_text_input, ss->ime_rect.position.x, ss->ime_rect.position.y, ss->ime_rect.size.x, ss->ime_rect.size.y);
+		zwp_text_input_v3_commit(ss->wp_text_input);
 	}
 }
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -62,6 +62,7 @@
 #undef pointer
 #include "wayland/protocol/fractional_scale.gen.h"
 #include "wayland/protocol/tablet.gen.h"
+#include "wayland/protocol/text_input.gen.h"
 #include "wayland/protocol/viewporter.gen.h"
 #include "wayland/protocol/wayland.gen.h"
 #include "wayland/protocol/xdg_activation.gen.h"
@@ -110,6 +111,17 @@ public:
 	class DropFilesEventMessage : public Message {
 	public:
 		Vector<String> files;
+	};
+
+	class IMEUpdateEventMessage : public Message {
+	public:
+		String text;
+		Vector2i selection;
+	};
+
+	class IMECommitEventMessage : public Message {
+	public:
+		String text;
 	};
 
 	struct RegistryState {
@@ -170,6 +182,9 @@ public:
 
 		struct zwp_tablet_manager_v2 *wp_tablet_manager = nullptr;
 		uint32_t wp_tablet_manager_name = 0;
+
+		struct zwp_text_input_manager_v3 *wp_text_input_manager = nullptr;
+		uint32_t wp_text_input_manager_name = 0;
 	};
 
 	// General Wayland-specific states. Shouldn't be accessed directly.
@@ -438,6 +453,15 @@ public:
 		struct zwp_tablet_seat_v2 *wp_tablet_seat = nullptr;
 
 		List<struct zwp_tablet_tool_v2 *> tablet_tools;
+
+		// IME.
+		struct zwp_text_input_v3 *wp_text_input = nullptr;
+		bool ime_enabled = false;
+		bool ime_active = false;
+		String ime_text;
+		String ime_text_commit;
+		Vector2i ime_cursor;
+		Rect2i ime_rect;
 	};
 
 	struct CustomCursor {
@@ -618,6 +642,13 @@ private:
 	static void _wp_tablet_tool_on_button(void *data, struct zwp_tablet_tool_v2 *wp_tablet_tool_v2, uint32_t serial, uint32_t button, uint32_t state);
 	static void _wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_v2 *wp_tablet_tool_v2, uint32_t time);
 
+	static void _wp_text_input_on_enter(void *data, struct zwp_text_input_v3 *wp_text_input_v3, struct wl_surface *surface);
+	static void _wp_text_input_on_leave(void *data, struct zwp_text_input_v3 *wp_text_input_v3, struct wl_surface *surface);
+	static void _wp_text_input_on_preedit_string(void *data, struct zwp_text_input_v3 *wp_text_input_v3, const char *text, int32_t cursor_begin, int32_t cursor_end);
+	static void _wp_text_input_on_commit_string(void *data, struct zwp_text_input_v3 *wp_text_input_v3, const char *text);
+	static void _wp_text_input_on_delete_surrounding_text(void *data, struct zwp_text_input_v3 *wp_text_input_v3, uint32_t before_length, uint32_t after_length);
+	static void _wp_text_input_on_done(void *data, struct zwp_text_input_v3 *wp_text_input_v3, uint32_t serial);
+
 	static void _xdg_toplevel_decoration_on_configure(void *data, struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration, uint32_t mode);
 
 	static void _xdg_exported_on_exported(void *data, zxdg_exported_v1 *exported, const char *handle);
@@ -779,6 +810,15 @@ private:
 		.frame = _wp_tablet_tool_on_frame,
 	};
 
+	static constexpr struct zwp_text_input_v3_listener wp_text_input_listener = {
+		.enter = _wp_text_input_on_enter,
+		.leave = _wp_text_input_on_leave,
+		.preedit_string = _wp_text_input_on_preedit_string,
+		.commit_string = _wp_text_input_on_commit_string,
+		.delete_surrounding_text = _wp_text_input_on_delete_surrounding_text,
+		.done = _wp_text_input_on_done,
+	};
+
 	static constexpr struct zxdg_exported_v1_listener xdg_exported_listener = {
 		.handle = _xdg_exported_on_exported
 	};
@@ -928,6 +968,9 @@ public:
 	void cursor_set_custom_shape(DisplayServer::CursorShape p_cursor_shape);
 	void cursor_shape_set_custom_image(DisplayServer::CursorShape p_cursor_shape, Ref<Image> p_image, const Point2i &p_hotspot);
 	void cursor_shape_clear_custom_image(DisplayServer::CursorShape p_cursor_shape);
+
+	void window_set_ime_active(const bool p_active, DisplayServer::WindowID p_window_id);
+	void window_set_ime_position(const Point2i &p_pos, DisplayServer::WindowID p_window_id);
 
 	int keyboard_get_layout_count() const;
 	int keyboard_get_current_layout_index() const;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1004,6 +1004,8 @@ Files extracted from upstream source:
 - `unstable/relative-pointer/relative-pointer-unstable-v1.xml`
 - `unstable/tablet/README`
 - `unstable/tablet/tablet-unstable-v2.xml`
+- `unstable/text-input/README`
+- `unstable/text-input/text-input-unstable-v3.xml`
 - `unstable/xdg-decoration/README`
 - `unstable/xdg-decoration/xdg-decoration-unstable-v1.xml`
 - `unstable/xdg-foreign/README`

--- a/thirdparty/wayland-protocols/unstable/text-input/README
+++ b/thirdparty/wayland-protocols/unstable/text-input/README
@@ -1,0 +1,4 @@
+Text input protocol
+
+Maintainers:
+Jan Arne Petersen <janarne@gmail.com>

--- a/thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml
+++ b/thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<protocol name="text_input_unstable_v3">
+  <copyright>
+    Copyright © 2012, 2013 Intel Corporation
+    Copyright © 2015, 2016 Jan Arne Petersen
+    Copyright © 2017, 2018 Red Hat, Inc.
+    Copyright © 2018       Purism SPC
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for composing text">
+    This protocol allows compositors to act as input methods and to send text
+    to applications. A text input object is used to manage state of what are
+    typically text entry fields in the application.
+
+    This document adheres to the RFC 2119 when using words like "must",
+    "should", "may", etc.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwp_text_input_v3" version="1">
+    <description summary="text input">
+      The zwp_text_input_v3 interface represents text input and input methods
+      associated with a seat. It provides enter/leave events to follow the
+      text input focus for a seat.
+
+      Requests are used to enable/disable the text-input object and set
+      state information like surrounding and selected text or the content type.
+      The information about the entered text is sent to the text-input object
+      via the preedit_string and commit_string events.
+
+      Text is valid UTF-8 encoded, indices and lengths are in bytes. Indices
+      must not point to middle bytes inside a code point: they must either
+      point to the first byte of a code point or to the end of the buffer.
+      Lengths must be measured between two valid indices.
+
+      Focus moving throughout surfaces will result in the emission of
+      zwp_text_input_v3.enter and zwp_text_input_v3.leave events. The focused
+      surface must commit zwp_text_input_v3.enable and
+      zwp_text_input_v3.disable requests as the keyboard focus moves across
+      editable and non-editable elements of the UI. Those two requests are not
+      expected to be paired with each other, the compositor must be able to
+      handle consecutive series of the same request.
+
+      State is sent by the state requests (set_surrounding_text,
+      set_content_type and set_cursor_rectangle) and a commit request. After an
+      enter event or disable request all state information is invalidated and
+      needs to be resent by the client.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the wp_text_input">
+        Destroy the wp_text_input object. Also disables all surfaces enabled
+        through this wp_text_input object.
+      </description>
+    </request>
+
+    <request name="enable">
+      <description summary="Request text input to be enabled">
+        Requests text input on the surface previously obtained from the enter
+        event.
+
+        This request must be issued every time the active text input changes
+        to a new one, including within the current surface. Use
+        zwp_text_input_v3.disable when there is no longer any input focus on
+        the current surface.
+
+        Clients must not enable more than one text input on the single seat
+        and should disable the current text input before enabling the new one.
+        At most one instance of text input may be in enabled state per instance,
+        Requests to enable the another text input when some text input is active
+        must be ignored by compositor.
+
+        This request resets all state associated with previous enable, disable,
+        set_surrounding_text, set_text_change_cause, set_content_type, and
+        set_cursor_rectangle requests, as well as the state associated with
+        preedit_string, commit_string, and delete_surrounding_text events.
+
+        The set_surrounding_text, set_content_type and set_cursor_rectangle
+        requests must follow if the text input supports the necessary
+        functionality.
+
+        State set with this request is double-buffered. It will get applied on
+        the next zwp_text_input_v3.commit request, and stay valid until the
+        next committed enable or disable request.
+
+        The changes must be applied by the compositor after issuing a
+        zwp_text_input_v3.commit request.
+      </description>
+    </request>
+
+    <request name="disable">
+      <description summary="Disable text input on a surface">
+        Explicitly disable text input on the current surface (typically when
+        there is no focus on any text entry inside the surface).
+
+        State set with this request is double-buffered. It will get applied on
+        the next zwp_text_input_v3.commit request.
+      </description>
+    </request>
+
+    <request name="set_surrounding_text">
+      <description summary="sets the surrounding text">
+        Sets the surrounding plain text around the input, excluding the preedit
+        text.
+
+        The client should notify the compositor of any changes in any of the
+        values carried with this request, including changes caused by handling
+        incoming text-input events as well as changes caused by other
+        mechanisms like keyboard typing.
+
+        If the client is unaware of the text around the cursor, it should not
+        issue this request, to signify lack of support to the compositor.
+
+        Text is UTF-8 encoded, and should include the cursor position, the
+        complete selection and additional characters before and after them.
+        There is a maximum length of wayland messages, so text can not be
+        longer than 4000 bytes.
+
+        Cursor is the byte offset of the cursor within text buffer.
+
+        Anchor is the byte offset of the selection anchor within text buffer.
+        If there is no selected text, anchor is the same as cursor.
+
+        If any preedit text is present, it is replaced with a cursor for the
+        purpose of this event.
+
+        Values set with this request are double-buffered. They will get applied
+        on the next zwp_text_input_v3.commit request, and stay valid until the
+        next committed enable or disable request.
+
+        The initial state for affected fields is empty, meaning that the text
+        input does not support sending surrounding text. If the empty values
+        get applied, subsequent attempts to change them may have no effect.
+      </description>
+      <arg name="text" type="string"/>
+      <arg name="cursor" type="int"/>
+      <arg name="anchor" type="int"/>
+    </request>
+
+    <enum name="change_cause">
+      <description summary="text change reason">
+        Reason for the change of surrounding text or cursor posision.
+      </description>
+      <entry name="input_method" value="0" summary="input method caused the change"/>
+      <entry name="other" value="1" summary="something else than the input method caused the change"/>
+    </enum>
+
+    <request name="set_text_change_cause">
+      <description summary="indicates the cause of surrounding text change">
+        Tells the compositor why the text surrounding the cursor changed.
+
+        Whenever the client detects an external change in text, cursor, or
+        anchor posision, it must issue this request to the compositor. This
+        request is intended to give the input method a chance to update the
+        preedit text in an appropriate way, e.g. by removing it when the user
+        starts typing with a keyboard.
+
+        cause describes the source of the change.
+
+        The value set with this request is double-buffered. It must be applied
+        and reset to initial at the next zwp_text_input_v3.commit request.
+
+        The initial value of cause is input_method.
+      </description>
+      <arg name="cause" type="uint" enum="change_cause"/>
+    </request>
+
+    <enum name="content_hint" bitfield="true">
+      <description summary="content hint">
+        Content hint is a bitmask to allow to modify the behavior of the text
+        input.
+      </description>
+      <entry name="none" value="0x0" summary="no special behavior"/>
+      <entry name="completion" value="0x1" summary="suggest word completions"/>
+      <entry name="spellcheck" value="0x2" summary="suggest word corrections"/>
+      <entry name="auto_capitalization" value="0x4" summary="switch to uppercase letters at the start of a sentence"/>
+      <entry name="lowercase" value="0x8" summary="prefer lowercase letters"/>
+      <entry name="uppercase" value="0x10" summary="prefer uppercase letters"/>
+      <entry name="titlecase" value="0x20" summary="prefer casing for titles and headings (can be language dependent)"/>
+      <entry name="hidden_text" value="0x40" summary="characters should be hidden"/>
+      <entry name="sensitive_data" value="0x80" summary="typed text should not be stored"/>
+      <entry name="latin" value="0x100" summary="just Latin characters should be entered"/>
+      <entry name="multiline" value="0x200" summary="the text input is multiline"/>
+    </enum>
+
+    <enum name="content_purpose">
+      <description summary="content purpose">
+        The content purpose allows to specify the primary purpose of a text
+        input.
+
+        This allows an input method to show special purpose input panels with
+        extra characters or to disallow some characters.
+      </description>
+      <entry name="normal" value="0" summary="default input, allowing all characters"/>
+      <entry name="alpha" value="1" summary="allow only alphabetic characters"/>
+      <entry name="digits" value="2" summary="allow only digits"/>
+      <entry name="number" value="3" summary="input a number (including decimal separator and sign)"/>
+      <entry name="phone" value="4" summary="input a phone number"/>
+      <entry name="url" value="5" summary="input an URL"/>
+      <entry name="email" value="6" summary="input an email address"/>
+      <entry name="name" value="7" summary="input a name of a person"/>
+      <entry name="password" value="8" summary="input a password (combine with sensitive_data hint)"/>
+      <entry name="pin" value="9" summary="input is a numeric password (combine with sensitive_data hint)"/>
+      <entry name="date" value="10" summary="input a date"/>
+      <entry name="time" value="11" summary="input a time"/>
+      <entry name="datetime" value="12" summary="input a date and time"/>
+      <entry name="terminal" value="13" summary="input for a terminal"/>
+    </enum>
+
+    <request name="set_content_type">
+      <description summary="set content purpose and hint">
+        Sets the content purpose and content hint. While the purpose is the
+        basic purpose of an input field, the hint flags allow to modify some of
+        the behavior.
+
+        Values set with this request are double-buffered. They will get applied
+        on the next zwp_text_input_v3.commit request.
+        Subsequent attempts to update them may have no effect. The values
+        remain valid until the next committed enable or disable request.
+
+        The initial value for hint is none, and the initial value for purpose
+        is normal.
+      </description>
+      <arg name="hint" type="uint" enum="content_hint"/>
+      <arg name="purpose" type="uint" enum="content_purpose"/>
+    </request>
+
+    <request name="set_cursor_rectangle">
+      <description summary="set cursor position">
+        Marks an area around the cursor as a x, y, width, height rectangle in
+        surface local coordinates.
+
+        Allows the compositor to put a window with word suggestions near the
+        cursor, without obstructing the text being input.
+
+        If the client is unaware of the position of edited text, it should not
+        issue this request, to signify lack of support to the compositor.
+
+        Values set with this request are double-buffered. They will get applied
+        on the next zwp_text_input_v3.commit request, and stay valid until the
+        next committed enable or disable request.
+
+        The initial values describing a cursor rectangle are empty. That means
+        the text input does not support describing the cursor area. If the
+        empty values get applied, subsequent attempts to change them may have
+        no effect.
+      </description>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="commit">
+      <description summary="commit state">
+        Atomically applies state changes recently sent to the compositor.
+
+        The commit request establishes and updates the state of the client, and
+        must be issued after any changes to apply them.
+
+        Text input state (enabled status, content purpose, content hint,
+        surrounding text and change cause, cursor rectangle) is conceptually
+        double-buffered within the context of a text input, i.e. between a
+        committed enable request and the following committed enable or disable
+        request.
+
+        Protocol requests modify the pending state, as opposed to the current
+        state in use by the input method. A commit request atomically applies
+        all pending state, replacing the current state. After commit, the new
+        pending state is as documented for each related request.
+
+        Requests are applied in the order of arrival.
+
+        Neither current nor pending state are modified unless noted otherwise.
+
+        The compositor must count the number of commit requests coming from
+        each zwp_text_input_v3 object and use the count as the serial in done
+        events.
+      </description>
+    </request>
+
+    <event name="enter">
+      <description summary="enter event">
+        Notification that this seat's text-input focus is on a certain surface.
+
+        If client has created multiple text input objects, compositor must send
+        this event to all of them.
+
+        When the seat has the keyboard capability the text-input focus follows
+        the keyboard focus. This event sets the current surface for the
+        text-input object.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </event>
+
+    <event name="leave">
+      <description summary="leave event">
+        Notification that this seat's text-input focus is no longer on a
+        certain surface. The client should reset any preedit string previously
+        set.
+
+        The leave notification clears the current surface. It is sent before
+        the enter notification for the new focus. After leave event, compositor
+        must ignore requests from any text input instances until next enter
+        event.
+
+        When the seat has the keyboard capability the text-input focus follows
+        the keyboard focus.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </event>
+
+    <event name="preedit_string">
+      <description summary="pre-edit">
+        Notify when a new composing text (pre-edit) should be set at the
+        current cursor position. Any previously set composing text must be
+        removed. Any previously existing selected text must be removed.
+
+        The argument text contains the pre-edit string buffer.
+
+        The parameters cursor_begin and cursor_end are counted in bytes
+        relative to the beginning of the submitted text buffer. Cursor should
+        be hidden when both are equal to -1.
+
+        They could be represented by the client as a line if both values are
+        the same, or as a text highlight otherwise.
+
+        Values set with this event are double-buffered. They must be applied
+        and reset to initial on the next zwp_text_input_v3.done event.
+
+        The initial value of text is an empty string, and cursor_begin,
+        cursor_end and cursor_hidden are all 0.
+      </description>
+      <arg name="text" type="string" allow-null="true"/>
+      <arg name="cursor_begin" type="int"/>
+      <arg name="cursor_end" type="int"/>
+    </event>
+
+    <event name="commit_string">
+      <description summary="text commit">
+        Notify when text should be inserted into the editor widget. The text to
+        commit could be either just a single character after a key press or the
+        result of some composing (pre-edit).
+
+        Values set with this event are double-buffered. They must be applied
+        and reset to initial on the next zwp_text_input_v3.done event.
+
+        The initial value of text is an empty string.
+      </description>
+      <arg name="text" type="string" allow-null="true"/>
+    </event>
+
+    <event name="delete_surrounding_text">
+      <description summary="delete surrounding text">
+        Notify when the text around the current cursor position should be
+        deleted.
+
+        Before_length and after_length are the number of bytes before and after
+        the current cursor index (excluding the selection) to delete.
+
+        If a preedit text is present, in effect before_length is counted from
+        the beginning of it, and after_length from its end (see done event
+        sequence).
+
+        Values set with this event are double-buffered. They must be applied
+        and reset to initial on the next zwp_text_input_v3.done event.
+
+        The initial values of both before_length and after_length are 0.
+      </description>
+      <arg name="before_length" type="uint" summary="length of text before current cursor position"/>
+      <arg name="after_length" type="uint" summary="length of text after current cursor position"/>
+    </event>
+
+    <event name="done">
+      <description summary="apply changes">
+        Instruct the application to apply changes to state requested by the
+        preedit_string, commit_string and delete_surrounding_text events. The
+        state relating to these events is double-buffered, and each one
+        modifies the pending state. This event replaces the current state with
+        the pending state.
+
+        The application must proceed by evaluating the changes in the following
+        order:
+
+        1. Replace existing preedit string with the cursor.
+        2. Delete requested surrounding text.
+        3. Insert commit string with the cursor at its end.
+        4. Calculate surrounding text to send.
+        5. Insert new preedit text in cursor position.
+        6. Place cursor inside preedit text.
+
+        The serial number reflects the last state of the zwp_text_input_v3
+        object known to the compositor. The value of the serial argument must
+        be equal to the number of commit requests already issued on that object.
+
+        When the client receives a done event with a serial different than the
+        number of past commit requests, it must proceed with evaluating and
+        applying the changes as normal, except it should not change the current
+        state of the zwp_text_input_v3 object. All pending state requests
+        (set_surrounding_text, set_content_type and set_cursor_rectangle) on
+        the zwp_text_input_v3 object should be sent and committed after
+        receiving a zwp_text_input_v3.done event with a matching serial.
+      </description>
+      <arg name="serial" type="uint"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_text_input_manager_v3" version="1">
+    <description summary="text input manager">
+      A factory for text-input objects. This object is a global singleton.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the wp_text_input_manager">
+        Destroy the wp_text_input_manager object.
+      </description>
+    </request>
+
+    <request name="get_text_input">
+      <description summary="create a new text input object">
+        Creates a new text-input object for a given seat.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_text_input_v3"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
Implements IME support via [zwp_text_input_v3](https://wayland.app/protocols/text-input-unstable-v3#zwp_text_input_v3) protocol.

Fixes https://github.com/godotengine/godot/issues/92643

Not implemented (since it's not supported by other platforms and Godot DisplayServer API):
- Support for `surrounding_text` (it seems to be optional and not doing anything).
- Support for cursor size (currently hardcoded to `1x10`).

I will refactor and unify virtual keyboard and IME `DisplayServer` API for 4.4 and add support for this. For 4.3 it seems to be working fine without any of this (at least to the extent input is working on Wayland in general).