### PR TITLE
Implement multiple occlusion polygons within each TileSet occlusion layer

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -16,6 +16,13 @@
 				Adds a collision polygon to the tile on the given TileSet physics layer.
 			</description>
 		</method>
+		<method name="add_occluder_polygon">
+			<return type="void" />
+			<param index="0" name="layer_id" type="int" />
+			<description>
+				Adds an occlusion polygon to the tile on the TileSet occlusion layer with index [param layer_id].
+			</description>
+		</method>
 		<method name="get_collision_polygon_one_way_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="layer_id" type="int" />
@@ -78,7 +85,7 @@
 				[param flip_h], [param flip_v], and [param transpose] allow transforming the returned polygon.
 			</description>
 		</method>
-		<method name="get_occluder" qualifiers="const">
+		<method name="get_occluder" qualifiers="const" deprecated="Use [method get_occluder_polygon] instead.">
 			<return type="OccluderPolygon2D" />
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="flip_h" type="bool" default="false" />
@@ -87,6 +94,25 @@
 			<description>
 				Returns the occluder polygon of the tile for the TileSet occlusion layer with index [param layer_id].
 				[param flip_h], [param flip_v], and [param transpose] allow transforming the returned polygon.
+			</description>
+		</method>
+		<method name="get_occluder_polygon" qualifiers="const">
+			<return type="OccluderPolygon2D" />
+			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="polygon_index" type="int" />
+			<param index="2" name="flip_h" type="bool" default="false" />
+			<param index="3" name="flip_v" type="bool" default="false" />
+			<param index="4" name="transpose" type="bool" default="false" />
+			<description>
+				Returns the occluder polygon at index [param polygon_index] from the TileSet occlusion layer with index [param layer_id].
+				The [param flip_h], [param flip_v], and [param transpose] parameters can be [code]true[/code] to transform the returned polygon.
+			</description>
+		</method>
+		<method name="get_occluder_polygons_count" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="layer_id" type="int" />
+			<description>
+				Returns the number of occluder polygons of the tile in the TileSet occlusion layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_terrain_peering_bit" qualifiers="const">
@@ -117,6 +143,14 @@
 			<param index="1" name="polygon_index" type="int" />
 			<description>
 				Removes the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
+			</description>
+		</method>
+		<method name="remove_occluder_polygon">
+			<return type="void" />
+			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="polygon_index" type="int" />
+			<description>
+				Removes the polygon at index [param polygon_index] for TileSet occlusion layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_collision_polygon_one_way">
@@ -194,12 +228,29 @@
 				Sets the navigation polygon for the TileSet navigation layer with index [param layer_id].
 			</description>
 		</method>
-		<method name="set_occluder">
+		<method name="set_occluder" deprecated="Use [method set_occluder_polygon] instead.">
 			<return type="void" />
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="occluder_polygon" type="OccluderPolygon2D" />
 			<description>
 				Sets the occluder for the TileSet occlusion layer with index [param layer_id].
+			</description>
+		</method>
+		<method name="set_occluder_polygon">
+			<return type="void" />
+			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="polygon_index" type="int" />
+			<param index="2" name="polygon" type="OccluderPolygon2D" />
+			<description>
+				Sets the occluder for polygon with index [param polygon_index] in the TileSet occlusion layer with index [param layer_id].
+			</description>
+		</method>
+		<method name="set_occluder_polygons_count">
+			<return type="void" />
+			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="polygons_count" type="int" />
+			<description>
+				Sets the occluder polygon count in the TileSet occlusion layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_terrain_peering_bit">

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -443,13 +443,15 @@ void TileMapLayer::_rendering_notification(int p_what) {
 			Transform2D tilemap_xform = get_global_transform();
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
 				const CellData &cell_data = kv.value;
-				for (const RID &occluder : cell_data.occluders) {
-					if (occluder.is_null()) {
-						continue;
+				for (const LocalVector<RID> &polygons : cell_data.occluders) {
+					for (const RID &rid : polygons) {
+						if (rid.is_null()) {
+							continue;
+						}
+						Transform2D xform(0, tile_set->map_to_local(kv.key));
+						rs->canvas_light_occluder_attach_to_canvas(rid, get_canvas());
+						rs->canvas_light_occluder_set_transform(rid, tilemap_xform * xform);
 					}
-					Transform2D xform(0, tile_set->map_to_local(kv.key));
-					rs->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
-					rs->canvas_light_occluder_set_transform(occluder, tilemap_xform * xform);
 				}
 			}
 		}
@@ -557,8 +559,10 @@ void TileMapLayer::_rendering_occluders_clear_cell(CellData &r_cell_data) {
 	RenderingServer *rs = RenderingServer::get_singleton();
 
 	// Free the occluders.
-	for (const RID &rid : r_cell_data.occluders) {
-		rs->free(rid);
+	for (const LocalVector<RID> &polygons : r_cell_data.occluders) {
+		for (const RID &rid : polygons) {
+			rs->free(rid);
+		}
 	}
 	r_cell_data.occluders.clear();
 }
@@ -566,11 +570,12 @@ void TileMapLayer::_rendering_occluders_clear_cell(CellData &r_cell_data) {
 void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 	RenderingServer *rs = RenderingServer::get_singleton();
 
-	// Free unused occluders then resize the occluders array.
+	// Free unused occluders then resize the occluder array.
 	for (uint32_t i = tile_set->get_occlusion_layers_count(); i < r_cell_data.occluders.size(); i++) {
-		RID occluder_id = r_cell_data.occluders[i];
-		if (occluder_id.is_valid()) {
-			rs->free(occluder_id);
+		for (const RID &occluder_id : r_cell_data.occluders[i]) {
+			if (occluder_id.is_valid()) {
+				rs->free(occluder_id);
+			}
 		}
 	}
 	r_cell_data.occluders.resize(tile_set->get_occlusion_layers_count());
@@ -598,30 +603,42 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 				// Create, update or clear occluders.
 				bool needs_set_not_interpolated = is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && !is_physics_interpolated();
 				for (uint32_t occlusion_layer_index = 0; occlusion_layer_index < r_cell_data.occluders.size(); occlusion_layer_index++) {
-					Ref<OccluderPolygon2D> occluder_polygon = tile_data->get_occluder(occlusion_layer_index);
+					LocalVector<RID> &occluders = r_cell_data.occluders[occlusion_layer_index];
 
-					RID &occluder = r_cell_data.occluders[occlusion_layer_index];
-
-					if (occluder_polygon.is_valid()) {
-						// Create or update occluder.
-						Transform2D xform;
-						xform.set_origin(tile_set->map_to_local(r_cell_data.coords));
-						if (!occluder.is_valid()) {
-							occluder = rs->canvas_light_occluder_create();
-							if (needs_set_not_interpolated) {
-								rs->canvas_light_occluder_set_interpolated(occluder, false);
-							}
+					// Free unused occluders then resize the occluders array.
+					for (uint32_t i = tile_data->get_occluder_polygons_count(occlusion_layer_index); i < r_cell_data.occluders[occlusion_layer_index].size(); i++) {
+						RID occluder_id = occluders[i];
+						if (occluder_id.is_valid()) {
+							rs->free(occluder_id);
 						}
-						rs->canvas_light_occluder_set_transform(occluder, get_global_transform() * xform);
-						rs->canvas_light_occluder_set_polygon(occluder, tile_data->get_occluder(occlusion_layer_index, flip_h, flip_v, transpose)->get_rid());
-						rs->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
-						rs->canvas_light_occluder_set_light_mask(occluder, tile_set->get_occlusion_layer_light_mask(occlusion_layer_index));
-						rs->canvas_light_occluder_set_as_sdf_collision(occluder, tile_set->get_occlusion_layer_sdf_collision(occlusion_layer_index));
-					} else {
-						// Clear occluder.
-						if (occluder.is_valid()) {
-							rs->free(occluder);
-							occluder = RID();
+					}
+					occluders.resize(tile_data->get_occluder_polygons_count(occlusion_layer_index));
+
+					for (uint32_t occlusion_polygon_index = 0; occlusion_polygon_index < occluders.size(); occlusion_polygon_index++) {
+						RID &occluder = occluders[occlusion_polygon_index];
+						Ref<OccluderPolygon2D> occluder_polygon = tile_data->get_occluder_polygon(occlusion_layer_index, occlusion_polygon_index);
+						if (occluder_polygon.is_valid()) {
+							// Create or update occluder.
+
+							Transform2D xform;
+							xform.set_origin(tile_set->map_to_local(r_cell_data.coords));
+							if (!occluder.is_valid()) {
+								occluder = rs->canvas_light_occluder_create();
+								if (needs_set_not_interpolated) {
+									rs->canvas_light_occluder_set_interpolated(occluder, false);
+								}
+							}
+							rs->canvas_light_occluder_set_transform(occluder, get_global_transform() * xform);
+							rs->canvas_light_occluder_set_polygon(occluder, tile_data->get_occluder_polygon(occlusion_layer_index, occlusion_polygon_index, flip_h, flip_v, transpose)->get_rid());
+							rs->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
+							rs->canvas_light_occluder_set_light_mask(occluder, tile_set->get_occlusion_layer_light_mask(occlusion_layer_index));
+							rs->canvas_light_occluder_set_as_sdf_collision(occluder, tile_set->get_occlusion_layer_sdf_collision(occlusion_layer_index));
+						} else {
+							// Clear occluder.
+							if (occluder.is_valid()) {
+								rs->free(occluder);
+								occluder = RID();
+							}
 						}
 					}
 				}
@@ -1709,11 +1726,13 @@ void TileMapLayer::_physics_interpolated_changed() {
 	}
 
 	for (const KeyValue<Vector2i, CellData> &E : tile_map_layer_data) {
-		for (const RID &occluder : E.value.occluders) {
-			if (occluder.is_valid()) {
-				rs->canvas_light_occluder_set_interpolated(occluder, interpolated);
-				if (needs_reset) {
-					rs->canvas_light_occluder_reset_physics_interpolation(occluder);
+		for (const LocalVector<RID> &polygons : E.value.occluders) {
+			for (const RID &occluder_id : polygons) {
+				if (occluder_id.is_valid()) {
+					rs->canvas_light_occluder_set_interpolated(occluder_id, interpolated);
+					if (needs_reset) {
+						rs->canvas_light_occluder_reset_physics_interpolation(occluder_id);
+					}
 				}
 			}
 		}

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -108,7 +108,7 @@ struct CellData {
 	// Rendering.
 	Ref<RenderingQuadrant> rendering_quadrant;
 	SelfList<CellData> rendering_quadrant_list_element;
-	LocalVector<RID> occluders;
+	LocalVector<LocalVector<RID>> occluders;
 
 	// Physics.
 	LocalVector<RID> bodies;

--- a/scene/resources/2d/tile_set.compat.inc
+++ b/scene/resources/2d/tile_set.compat.inc
@@ -37,7 +37,7 @@ Ref<NavigationPolygon> TileData::_get_navigation_polygon_bind_compat_84660(int p
 }
 
 Ref<OccluderPolygon2D> TileData::_get_occluder_bind_compat_84660(int p_layer_id) const {
-	return get_occluder(p_layer_id, false, false, false);
+	return get_occluder_polygon(p_layer_id, 0, false, false, false);
 }
 
 void TileData::_bind_compatibility_methods() {

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -841,8 +841,11 @@ private:
 	int z_index = 0;
 	int y_sort_origin = 0;
 	struct OcclusionLayerTileData {
-		Ref<OccluderPolygon2D> occluder;
-		mutable HashMap<int, Ref<OccluderPolygon2D>> transformed_occluders;
+		struct PolygonOccluderTileData {
+			Ref<OccluderPolygon2D> occluder_polygon;
+			mutable HashMap<int, Ref<OccluderPolygon2D>> transformed_polygon_occluders;
+		};
+		Vector<PolygonOccluderTileData> polygons;
 	};
 	Vector<OcclusionLayerTileData> occluders;
 
@@ -941,8 +944,17 @@ public:
 	void set_y_sort_origin(int p_y_sort_origin);
 	int get_y_sort_origin() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_occluder(int p_layer_id, Ref<OccluderPolygon2D> p_occluder_polygon);
 	Ref<OccluderPolygon2D> get_occluder(int p_layer_id, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false) const;
+#endif // DISABLE_DEPRECATED
+
+	void set_occluder_polygons_count(int p_layer_id, int p_polygons_count);
+	int get_occluder_polygons_count(int p_layer_id) const;
+	void add_occluder_polygon(int p_layer_id);
+	void remove_occluder_polygon(int p_layer_id, int p_polygon_index);
+	void set_occluder_polygon(int p_layer_id, int p_polygon_index, const Ref<OccluderPolygon2D> &p_occluder_polygon);
+	Ref<OccluderPolygon2D> get_occluder_polygon(int p_layer_id, int p_polygon_index, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false) const;
 
 	// Physics
 	void set_constant_linear_velocity(int p_layer_id, const Vector2 &p_velocity);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/66877

This PR keeps backward compatibility, but I had to modify the API to account for more than one polygon.

I think this is mostly an enhancement, but well, the linked issue is marked as a bug, so well, I used both tags.
Not sure we still have the time for such change for 4.3, so I used the 4.x milestone.