### PR TITLE
Fix `Container` pending_sort and "Saving Scene" `ProgressDialog` size.

### DIFF
--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -143,10 +143,7 @@ void ProgressDialog::_popup() {
 	Ref<StyleBox> style = main->get_theme_stylebox(SceneStringName(panel), SNAME("PopupMenu"));
 	ms += style->get_minimum_size();
 
-	main->set_offset(SIDE_LEFT, style->get_margin(SIDE_LEFT));
-	main->set_offset(SIDE_RIGHT, -style->get_margin(SIDE_RIGHT));
-	main->set_offset(SIDE_TOP, style->get_margin(SIDE_TOP));
-	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
+	main->call_deferred("notification", Container::NOTIFICATION_SORT_CHILDREN);
 
 	if (is_inside_tree()) {
 		Rect2i adjust = _popup_adjust_rect();

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -80,7 +80,6 @@ void Container::remove_child_notify(Node *p_child) {
 
 void Container::_sort_children() {
 	if (!is_inside_tree()) {
-		pending_sort = false;
 		return;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/92971

<s>Since both issues are closed, and each one produces the other, it's better to fix both at the same time.</s>

If this ever leads to any other issues that can't be fixed by deferring a sort children notification call, please tag me. 