### PR TITLE
Editor: Fix `EditorHelpBit` title height is wrong on initialization

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3735,6 +3735,7 @@ EditorHelpBit::EditorHelpBit(const String &p_symbol) {
 
 	title = memnew(RichTextLabel);
 	title->set_theme_type_variation("EditorHelpBitTitle");
+	title->set_custom_minimum_size(Size2(512 * EDSCALE, 0)); // GH-93031. Set the minimum width even if `fit_content` is true.
 	title->set_fit_content(true);
 	title->set_selection_enabled(true);
 	//title->set_context_menu_enabled(true); // TODO: Fix opening context menu hides tooltip.


### PR DESCRIPTION
* Fixes #93031.

The bug is caused by the fact that the `title` label uses `fit_content = true`, unlike the `content` label. At initialization, the width is still 0, which is why the calculated `title` height is too large.

![](https://github.com/godotengine/godot/assets/47700418/908b6fca-577e-4af5-b65a-026b18ef986c)

Although this is not entirely true for non-tooltip `EditorHelpBit`s, `512 * EDSCALE` is already used below, so I think it's ok.

https://github.com/godotengine/godot/blob/292e50e17e3f6e2509d3178a00204f964a907460/editor/editor_help.cpp#L3736-L3738

https://github.com/godotengine/godot/blob/292e50e17e3f6e2509d3178a00204f964a907460/editor/editor_help.cpp#L3748-L3750