### PR TITLE
Add OptionButton type property to implement carousel buttons.

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OptionButton" inherits="Button" keywords="select" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A button that brings up a dropdown with selectable options when pressed.
+		A button that allows the user to select from a list of options.
 	</brief_description>
 	<description>
-		[OptionButton] is a type of button that brings up a dropdown with selectable items when pressed. The item selected becomes the "current" item and is displayed as the button text.
+		[OptionButton] is a type of button that allows the user to select from a list of options. The item selected becomes the "current" item and is displayed as the button text.
 		See also [BaseButton] which contains common properties and methods associated with this node.
+		The [OptionButton]'s type determines how the options are presented to the user.
+		If the [OptionButton]'s [code]type[/code] is [constant DROPDOWN], it brings up a dropdown with selectable items when pressed.
+		If the [OptionButton]'s [code]type[/code] is [constant CAROUSEL], it shows arrows that allow the user to select the next or previous option.
+		If the [OptionButton]'s [code]type[/code] is [constant HYBRID], it shows arrows that allow the user to select the next or previous option and also brings up a dropdown when pressed.
 		[b]Note:[/b] The ID values used for items are limited to 32 bits, not full 64 bits of [int]. This has a range of [code]-2^32[/code] to [code]2^32 - 1[/code], i.e. [code]-2147483648[/code] to [code]2147483647[/code].
 		[b]Note:[/b] The [member Button.text] and [member Button.icon] properties are set automatically based on the selected item. They shouldn't be changed manually.
 	</description>
@@ -226,6 +230,9 @@
 			The index of the currently selected item, or [code]-1[/code] if no item is selected.
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
+		<member name="carousel_wraparound" type="bool" setter="set_carousel_wraparound" getter="is_carousel_wraparound" default="true">
+			If [code]false[/code], the [OptionButton] will stop at the first and last option when [code]type[/code] is [constant CAROUSEL] or [constant HYBRID].
+		</member>
 	</members>
 	<signals>
 		<signal name="item_focused">
@@ -242,6 +249,20 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="DROPDOWN" value="0" enum="Type">
+			When pressed, the [OptionButton] displays a dropdown menu with selectable items.
+		</constant>
+		<constant name="HYBRID" value="1" enum="Type">
+			When pressed, the [OptionButton] displays a dropdown menu with selectable items.
+			It also displays arrows on the left and right side that can be clicked to select the previous or next item.
+			Pressing [code]ui_left[/code] or [code]ui_right[/code] while the [OptionButton] is focused will select the previous or next item.
+		</constant>
+		<constant name="CAROUSEL" value="2" enum="Type">
+			The [OptionButton] displays arrows on the left and right side that can be clicked to select the previous or next item.
+			Pressing [code]ui_left[/code] or [code]ui_right[/code] while the [OptionButton] is focused will select the previous or next item.
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="arrow_margin" data_type="constant" type="int" default="4">
 			The horizontal space between the arrow icon and the right edge of the button.
@@ -250,7 +271,37 @@
 			If different than [code]0[/code], the arrow icon will be modulated to the font color.
 		</theme_item>
 		<theme_item name="arrow" data_type="icon" type="Texture2D">
-			The arrow icon to be drawn on the right end of the button.
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant DROPDOWN].
+		</theme_item>
+		<theme_item name="right_arrow_normal" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID].
+		</theme_item>
+		<theme_item name="right_arrow_hover" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being hovered.
+		</theme_item>
+		<theme_item name="right_arrow_hover_pressed" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being hovered and pressed.
+		</theme_item>
+		<theme_item name="right_arrow_pressed" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being pressed.
+		</theme_item>
+		<theme_item name="right_arrow_disabled" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is disabled.
+		</theme_item>
+		<theme_item name="left_arrow_normal" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the left end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID].
+		</theme_item>
+		<theme_item name="left_arrow_hover" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the left end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being hovered.
+		</theme_item>
+		<theme_item name="left_arrow_hover_pressed" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the left end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being hovered and pressed.
+		</theme_item>
+		<theme_item name="left_arrow_pressed" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the left end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is being pressed.
+		</theme_item>
+		<theme_item name="left_arrow_disabled" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the left end of the button if [code]type[/code] is [constant CAROUSEL] or [constant HYBRID] and it is disabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -36,6 +36,14 @@
 #include "scene/property_list_helper.h"
 
 class OptionButton : public Button {
+public:
+	enum Type {
+		DROPDOWN,
+		HYBRID,
+		CAROUSEL,
+	};
+
+private:
 	GDCLASS(OptionButton, Button);
 
 	bool disable_shortcuts = false;
@@ -47,6 +55,11 @@ class OptionButton : public Button {
 	bool allow_reselect = false;
 	bool initialized = false;
 	int queued_current = -1;
+	MouseButton current_mouse_button = MouseButton::NONE;
+	bool carousel_wraparound = true;
+	Type type = DROPDOWN;
+	DrawMode left_arrow_mode = DRAW_NORMAL;
+	DrawMode right_arrow_mode = DRAW_NORMAL;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal;
@@ -61,6 +74,16 @@ class OptionButton : public Button {
 		int h_separation = 0;
 
 		Ref<Texture2D> arrow_icon;
+		Ref<Texture2D> left_arrow_normal_icon;
+		Ref<Texture2D> left_arrow_hover_icon;
+		Ref<Texture2D> left_arrow_hover_pressed_icon;
+		Ref<Texture2D> left_arrow_pressed_icon;
+		Ref<Texture2D> left_arrow_disabled_icon;
+		Ref<Texture2D> right_arrow_normal_icon;
+		Ref<Texture2D> right_arrow_hover_icon;
+		Ref<Texture2D> right_arrow_hover_pressed_icon;
+		Ref<Texture2D> right_arrow_pressed_icon;
+		Ref<Texture2D> right_arrow_disabled_icon;
 		int arrow_margin = 0;
 		int modulate_arrow = 0;
 	} theme_cache;
@@ -74,6 +97,25 @@ class OptionButton : public Button {
 	void _select_int(int p_which);
 	void _refresh_size_cache();
 	void _dummy_setter() {} // Stub for PropertyListHelper (_set() doesn't use it).
+
+	bool _is_over_arrow(bool p_arrow, Vector2 p_pos);
+	void _set_arrow_mode(bool p_arrow, DrawMode p_mode);
+
+	bool _is_arrow_hovered(bool p_arrow);
+	bool _is_arrow_pressed(bool p_arrow);
+	bool _is_arrow_disabled(bool p_arrow);
+	void _set_arrow_pressed(bool p_arrow, bool p_pressed);
+	void _set_arrow_hovered(bool p_arrow, bool p_hovered);
+	void _set_arrow_disabled(bool p_arrow, bool p_disabled);
+
+	Ref<Texture2D> _get_arrow_icon(bool p_arrow);
+
+	void _on_left_pressed();
+	void _on_right_pressed();
+	void _select_previous(bool p_emit);
+	void _select_next(bool p_emit);
+	bool _has_next_selectable_item();
+	bool _has_previous_selectable_item();
 
 	virtual void pressed() override;
 
@@ -91,6 +133,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	// ATTENTION: This is used by the POT generator's scene parser. If the number of properties returned by `_get_items()` ever changes,
@@ -143,8 +186,16 @@ public:
 
 	void set_disable_shortcuts(bool p_disabled);
 
+	void set_carousel_wraparound(bool p_carousel_wraparound);
+	bool is_carousel_wraparound();
+
+	void set_type(Type p_type);
+	Type get_type();
+
 	OptionButton(const String &p_text = String());
 	~OptionButton();
 };
+
+VARIANT_ENUM_CAST(OptionButton::Type);
 
 #endif // OPTION_BUTTON_H

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -247,6 +247,16 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("disabled_mirrored", "OptionButton", sb_optbutton_disabled_mirrored);
 
 	theme->set_icon("arrow", "OptionButton", icons["option_button_arrow"]);
+	theme->set_icon("left_arrow_normal", "OptionButton", icons["arrow_left"]);
+	theme->set_icon("left_arrow_hover", "OptionButton", icons["arrow_left"]);
+	theme->set_icon("left_arrow_hover_pressed", "OptionButton", icons["arrow_left"]);
+	theme->set_icon("left_arrow_pressed", "OptionButton", icons["arrow_left"]);
+	theme->set_icon("left_arrow_disabled", "OptionButton", icons["arrow_left"]);
+	theme->set_icon("right_arrow_normal", "OptionButton", icons["arrow_right"]);
+	theme->set_icon("right_arrow_hover", "OptionButton", icons["arrow_right"]);
+	theme->set_icon("right_arrow_hover_pressed", "OptionButton", icons["arrow_right"]);
+	theme->set_icon("right_arrow_pressed", "OptionButton", icons["arrow_right"]);
+	theme->set_icon("right_arrow_disabled", "OptionButton", icons["arrow_right"]);
 
 	theme->set_font("font", "OptionButton", Ref<Font>());
 	theme->set_font_size("font_size", "OptionButton", -1);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5139

I implemented the suggestion that @Calinou mentioned in #64535. The carousel button is no longer a separate node, but it is integrated into OptionButton. I also included a hybrid option because @Calinou also mentioned that it would be nice to not sacrifice mouse usability. Also, the hybrid option only adds a few lines of code so I think its worth it.

The hybrid option is the same as the carousel button, but pressing the button shows the dropdown menu instead of advancing to the next option. I think that splitting this into a separate mode is necessary because the dropdown should never be shown in controller only menus (for example on consoles).

I also consulted with my UX/UI designer friend, @elihn5 and she came up with these mockups for the hybrid button:
![image](https://github.com/godotengine/godot/assets/59781761/ded29af7-2d30-45aa-acbf-606ec329637a)
We ultimately decided that leaving it visually the same as the carousel button made the most sense (but we would be happy to be proven wrong on this).

https://github.com/godotengine/godot/assets/59781761/e9451e6b-f52c-401a-85fd-435099abadf0

Also sorry this took me two years, finding a weekend to work on this was difficult.