### PR TITLE
Fix tile polygon editor grid and missing update

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -142,13 +142,9 @@ private:
 	Vector2 panning;
 	bool initializing = true;
 
-	Ref<Texture2D> background_texture;
-	Rect2 background_region;
-	Vector2 background_offset;
-	bool background_h_flip = false;
-	bool background_v_flip = false;
-	bool background_transpose = false;
-	Color background_modulate;
+	Ref<TileSetAtlasSource> background_atlas_source;
+	Vector2i background_atlas_coords;
+	int background_alternative_id;
 
 	Color polygon_color = Color(1.0, 0.0, 0.0);
 
@@ -183,7 +179,7 @@ public:
 	void set_use_undo_redo(bool p_use_undo_redo);
 
 	void set_tile_set(Ref<TileSet> p_tile_set);
-	void set_background(Ref<Texture2D> p_texture, Rect2 p_region = Rect2(), Vector2 p_offset = Vector2(), bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, Color p_modulate = Color(1.0, 1.0, 1.0, 0.0));
+	void set_background_tile(const TileSetAtlasSource *p_atlas_source, const Vector2 &p_atlas_coords, int p_alternative_id);
 
 	int get_polygon_count();
 	int add_polygon(const Vector<Point2> &p_polygon, int p_index = -1);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2820,13 +2820,15 @@ void EditorPropertyTilePolygon::update_property() {
 	ERR_FAIL_COND(atlas_tile_proxy_object->get_edited_tiles().is_empty());
 
 	Ref<TileSetAtlasSource> tile_set_atlas_source = atlas_tile_proxy_object->get_edited_tile_set_atlas_source();
-	generic_tile_polygon_editor->set_tile_set(Ref<TileSet>(tile_set_atlas_source->get_tile_set()));
+	Ref<TileSet> tile_set(tile_set_atlas_source->get_tile_set());
+
+	// Update the polyugon editor tile_set.
+	generic_tile_polygon_editor->set_tile_set(tile_set);
 
 	// Set the background
 	Vector2i coords = atlas_tile_proxy_object->get_edited_tiles().front()->get().tile;
 	int alternative = atlas_tile_proxy_object->get_edited_tiles().front()->get().alternative;
-	TileData *tile_data = tile_set_atlas_source->get_tile_data(coords, alternative);
-	generic_tile_polygon_editor->set_background(tile_set_atlas_source->get_texture(), tile_set_atlas_source->get_tile_texture_region(coords), tile_data->get_texture_origin(), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
+	generic_tile_polygon_editor->set_background_tile(*tile_set_atlas_source, coords, alternative);
 
 	// Reset the polygons.
 	generic_tile_polygon_editor->clear_polygons();


### PR DESCRIPTION
Fixes this comment: https://github.com/godotengine/godot/pull/92171#issuecomment-2144036148

I also needed to add more changes to register to the TileSet's update, to redraw the editors. This helps as it allows updating the background flips, modulation, texture offset or anything else while editing the polygon.