### PR TITLE
CI: Refine `mypy` integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,11 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v1.10.0
     hooks:
       - id: mypy
         files: \.py$
-        types_or: [text]
+        additional_dependencies: [tokenize-rt==5.2.0]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -190,7 +190,7 @@ def make_license_header(target, source, env):
 
     from collections import OrderedDict
 
-    projects: dict = OrderedDict()
+    projects = OrderedDict()
     license_list = []
 
     with open(src_copyright, "r", encoding="utf-8") as copyright_file:
@@ -212,7 +212,7 @@ def make_license_header(target, source, env):
                 part = {}
                 reader.next_line()
 
-    data_list: list = []
+    data_list = []
     for project in iter(projects.values()):
         for part in project:
             part["file_index"] = len(data_list)

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -11,7 +11,7 @@ def make_default_controller_mappings(target, source, env):
         g.write('#include "core/input/default_controller_mappings.h"\n')
 
         # ensure mappings have a consistent order
-        platform_mappings: dict = OrderedDict()
+        platform_mappings = OrderedDict()
         for src_path in source:
             with open(str(src_path), "r", encoding="utf-8") as f:
                 # read mapping file and skip header

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,17 @@
 [tool.mypy]
-ignore_missing_imports = true
 disallow_any_generics = true
+explicit_package_bases = true
+ignore_missing_imports = true
+namespace_packages = true
 no_implicit_optional = true
 pretty = true
+scripts_are_modules = true
 show_column_numbers = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
-namespace_packages = true
-explicit_package_bases = true
-exclude = ["thirdparty/"]
+exclude = ["thirdparty"]
+python_version = "3.8"
 
 [tool.ruff]
 extend-exclude = ["thirdparty"]


### PR DESCRIPTION
Depends on: #93058

Updates mypy from `0.971` to `1.10.0`, the latest version at time of writing. With this comes a few changes:
- `pyproject.toml` mypy section is now sorted alphabetically, excluding the last two rules.
- Added `scripts_are_modules`, which is already passed in the pre-commit & properly applies the aforementioned exclusion.
- Added `tokenize-rt` dependency to hook as recommended by the repo's readme.
- Added `python_version`, set to the lowest possible value supported (3.8).
- Fixed three warnings in files caused by making typed declarations in untyped definitions.