### PR TITLE
Ensure Motion Vectors are enabled by particles and skeletons when using the Motion Vector debug draw option

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -971,7 +971,7 @@ void RendererViewport::_viewport_set_size(Viewport *p_viewport, int p_width, int
 }
 
 bool RendererViewport::_viewport_requires_motion_vectors(Viewport *p_viewport) {
-	return p_viewport->use_taa || p_viewport->scaling_3d_mode == RenderingServer::VIEWPORT_SCALING_3D_MODE_FSR2;
+	return p_viewport->use_taa || p_viewport->scaling_3d_mode == RenderingServer::VIEWPORT_SCALING_3D_MODE_FSR2 || p_viewport->debug_draw == RenderingServer::VIEWPORT_DEBUG_DRAW_MOTION_VECTORS;
 }
 
 void RendererViewport::viewport_set_active(RID p_viewport, bool p_active) {
@@ -1370,7 +1370,13 @@ void RendererViewport::viewport_set_debug_draw(RID p_viewport, RS::ViewportDebug
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_NULL(viewport);
 
+	bool motion_vectors_before = _viewport_requires_motion_vectors(viewport);
 	viewport->debug_draw = p_draw;
+
+	bool motion_vectors_after = _viewport_requires_motion_vectors(viewport);
+	if (motion_vectors_before != motion_vectors_after) {
+		num_viewports_with_motion_vectors += motion_vectors_after ? 1 : -1;
+	}
 }
 
 void RendererViewport::viewport_set_measure_render_time(RID p_viewport, bool p_enable) {


### PR DESCRIPTION
Fixes issue reported in https://github.com/godotengine/godot/pull/92711#issuecomment-2157313608

Particles, MultiMesh, and Skeletons need to know in advance if they should save enough information for Motion Vectors. 

### Further work

Motion Vectors will still be missing when using a compositor effect since the check currently only happens at draw time here:
https://github.com/godotengine/godot/blob/292e50e17e3f6e2509d3178a00204f964a907460/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L1645-L1656

We will need to add some sort of registration so if a Compositor effect requests motion vectors all systems are aware that motion vectors are needed

CC @BastiaanOlij 