### PR TITLE
Autocompletion: Add support for string name option in more places

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2787,9 +2787,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 								if (opt.is_quoted()) {
 									opt = opt.unquote().quote(quote_style);
 									if (use_string_names && info.arguments.get(p_argidx).type == Variant::STRING_NAME) {
-										opt = opt.indent("&");
+										opt = "&" + opt;
 									} else if (use_node_paths && info.arguments.get(p_argidx).type == Variant::NODE_PATH) {
-										opt = opt.indent("^");
+										opt = "^" + opt;
 									}
 								}
 								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
@@ -2824,7 +2824,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 									if (E.usage & (PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_INTERNAL)) {
 										continue;
 									}
-									ScriptLanguage::CodeCompletionOption option(E.name.quote(quote_style), ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, ScriptLanguage::CodeCompletionLocation::LOCATION_LOCAL + n);
+									String name = E.name.quote(quote_style);
+									if (use_node_paths) {
+										name = "^" + name;
+									}
+									ScriptLanguage::CodeCompletionOption option(name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, ScriptLanguage::CodeCompletionLocation::LOCATION_LOCAL + n);
 									r_result.insert(option.display, option);
 								}
 								script = script->get_base_script();
@@ -2838,7 +2842,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 							while (clss) {
 								for (GDScriptParser::ClassNode::Member member : clss->members) {
 									if (member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
-										ScriptLanguage::CodeCompletionOption option(member.get_name().quote(quote_style), ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, ScriptLanguage::CodeCompletionLocation::LOCATION_LOCAL + n);
+										String name = member.get_name().quote(quote_style);
+										if (use_node_paths) {
+											name = "^" + name;
+										}
+										ScriptLanguage::CodeCompletionOption option(name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, ScriptLanguage::CodeCompletionLocation::LOCATION_LOCAL + n);
 										r_result.insert(option.display, option);
 									}
 								}
@@ -2861,7 +2869,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						if (E.usage & (PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_INTERNAL)) {
 							continue;
 						}
-						ScriptLanguage::CodeCompletionOption option(E.name.quote(quote_style), ScriptLanguage::CODE_COMPLETION_KIND_MEMBER);
+						String name = E.name.quote(quote_style);
+						if (use_node_paths) {
+							name = "^" + name;
+						}
+						ScriptLanguage::CodeCompletionOption option(name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER);
 						r_result.insert(option.display, option);
 					}
 				}
@@ -2877,8 +2889,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 							continue;
 						}
 						String name = s.get_slice("/", 1);
-						ScriptLanguage::CodeCompletionOption option("/root/" + name, ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH);
-						option.insert_text = option.display.quote(quote_style);
+						String path = ("/root/" + name).quote(quote_style);
+						if (use_node_paths) {
+							path = "^" + path;
+						}
+						ScriptLanguage::CodeCompletionOption option(path, ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH);
 						r_result.insert(option.display, option);
 					}
 				}
@@ -2892,9 +2907,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						if (!s.begins_with("input/")) {
 							continue;
 						}
-						String name = s.get_slice("/", 1);
+						String name = s.get_slice("/", 1).quote(quote_style);
+						if (use_string_names) {
+							name = "&" + name;
+						}
 						ScriptLanguage::CodeCompletionOption option(name, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
-						option.insert_text = option.display.quote(quote_style);
 						r_result.insert(option.display, option);
 					}
 				}

--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -25,6 +25,8 @@ The config file contains two section:
 
 - `cs: boolean = false`: If `true`, the test will be skipped when running a non C# build.
 - `use_single_quotes: boolean = false`: Configures the corresponding editor setting for the test.
+- `add_node_path_literals: boolean = false`: Configures the corresponding editor setting for the test.
+- `add_string_name_literals: boolean = false`: Configures the corresponding editor setting for the test.
 - `scene: String`: Allows to specify a scene which is opened while autocompletion is performed. If this is not set the test runner will search for a `.tscn` file with the same basename as the GDScript file. If that isn't found either, autocompletion will behave as if no scene was opened.
 - `node_path: String`: The node path of the node which holds the current script inside of the scene. Defaults to the scene root node.
 

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.cfg
@@ -1,0 +1,11 @@
+[input]
+add_node_path_literals=true
+[output]
+include=[
+    {"insert_text": "^\"property_of_a\""},
+    {"insert_text": "^\"name\""},
+]
+exclude=[
+    {"insert_text": "\"property_of_a\""},
+    {"insert_text": "\"name\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.gd
@@ -1,0 +1,8 @@
+extends Node
+
+const A = preload("res://completion/class_a.notest.gd")
+
+func _ready() -> void:
+    var a := A.new()
+    var tween := get_tree().create_tween()
+    tween.tween_property(a, ➡)

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_string_name_input_event.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_string_name_input_event.cfg
@@ -1,0 +1,9 @@
+[input]
+add_string_name_literals=true
+[output]
+include=[
+    {"insert_text": "&\"test_input_action\""},
+]
+exclude=[
+    {"insert_text": "\"test_input_action\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_string_name_input_event.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_string_name_input_event.gd
@@ -1,0 +1,3 @@
+func _input(event: InputEvent) -> void:
+    event.is_action_pressed(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.cfg
@@ -1,0 +1,11 @@
+[input]
+add_node_path_literals=false
+[output]
+include=[
+    {"insert_text": "\"property_of_a\""},
+    {"insert_text": "\"name\""},
+]
+exclude=[
+    {"insert_text": "^\"property_of_a\""},
+    {"insert_text": "^\"name\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.gd
@@ -1,0 +1,8 @@
+extends Node
+
+const A = preload("res://completion/class_a.notest.gd")
+
+func _ready() -> void:
+    var a := A.new()
+    var tween := get_tree().create_tween()
+    tween.tween_property(a, ➡)

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_string_name_input_event.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_string_name_input_event.cfg
@@ -1,0 +1,9 @@
+[input]
+add_string_name_literals=false
+[output]
+include=[
+    {"insert_text": "\"test_input_action\""},
+]
+exclude=[
+    {"insert_text": "&\"test_input_action\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_string_name_input_event.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_string_name_input_event.gd
@@ -1,0 +1,3 @@
+func _input(event: InputEvent) -> void:
+    event.is_action_pressed(➡)
+    pass

--- a/modules/gdscript/tests/scripts/project.godot
+++ b/modules/gdscript/tests/scripts/project.godot
@@ -8,3 +8,10 @@ config_version=5
 [application]
 
 config/name="GDScript Integration Test Suite"
+
+[input]
+
+test_input_action={
+"deadzone": 0.5,
+"events": []
+}

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -130,6 +130,8 @@ static void test_directory(const String &p_dir) {
 #endif
 
 			EditorSettings::get_singleton()->set_setting("text_editor/completion/use_single_quotes", conf.get_value("input", "use_single_quotes", false));
+			EditorSettings::get_singleton()->set_setting("text_editor/completion/add_node_path_literals", conf.get_value("input", "add_node_path_literals", false));
+			EditorSettings::get_singleton()->set_setting("text_editor/completion/add_string_name_literals", conf.get_value("input", "add_string_name_literals", false));
 
 			List<Dictionary> include;
 			to_dict_list(conf.get_value("output", "include", Array()), include);


### PR DESCRIPTION
Fixes #93034

#66481 missed some code paths for special cases of argument options which are handled by the autocompletion.

Those cases now also consistently add the quotes to the preview which is in line with how we handle the default argument options. 'What you see is what you get', makes sense in this place.

Also adds test for most of the special code paths. The autoload code path is hard to test right now, since adding autoloads changes the output of `Node.print_orphan_nodes` which is used by some other unit tests. I will look into that separately.