### PR TITLE
SCons: Add unobtrusive type hints in SCons files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 EnsureSConsVersion(3, 1, 2)
 EnsurePythonVersion(3, 6)

--- a/core/SCsub
+++ b/core/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/config/SCsub
+++ b/core/config/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/debugger/SCsub
+++ b/core/debugger/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/error/SCsub
+++ b/core/error/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/string/SCsub
+++ b/core/string/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/templates/SCsub
+++ b/core/templates/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/core/variant/SCsub
+++ b/core/variant/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/alsamidi/SCsub
+++ b/drivers/alsamidi/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/backtrace/SCsub
+++ b/drivers/backtrace/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 import os
 from pathlib import Path

--- a/drivers/egl/SCsub
+++ b/drivers/egl/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/SCsub
+++ b/drivers/gles3/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/effects/SCsub
+++ b/drivers/gles3/effects/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/environment/SCsub
+++ b/drivers/gles3/environment/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/shaders/effects/SCsub
+++ b/drivers/gles3/shaders/effects/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/gles3/storage/SCsub
+++ b/drivers/gles3/storage/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/wasapi/SCsub
+++ b/drivers/wasapi/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/winmidi/SCsub
+++ b/drivers/winmidi/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/debugger/SCsub
+++ b/editor/debugger/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/debugger/debug_adapter/SCsub
+++ b/editor/debugger/debug_adapter/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/export/SCsub
+++ b/editor/export/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/gui/SCsub
+++ b/editor/gui/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/plugins/gizmos/SCsub
+++ b/editor/plugins/gizmos/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/plugins/tiles/SCsub
+++ b/editor/plugins/tiles/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/project_manager/SCsub
+++ b/editor/project_manager/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/misc/utility/scons_hints.py
+++ b/misc/utility/scons_hints.py
@@ -1,0 +1,98 @@
+"""
+Adds type hints to SCons scripts. Implemented via
+`from misc.utility.scons_hints import *`.
+
+This is NOT a 1-1 representation of what the defines will represent in an
+SCons build, as proxies are almost always utilized instead. Rather, this is
+a means of tracing back what those proxies are calling to in the first place.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # ruff: noqa: F401
+    from SCons.Action import Action
+    from SCons.Builder import Builder
+    from SCons.Defaults import Chmod, Copy, CScan, DefaultEnvironment, Delete, DirScanner, Mkdir, Move, Touch
+    from SCons.Environment import Base
+    from SCons.Platform import Platform
+    from SCons.Platform.virtualenv import Virtualenv
+    from SCons.Scanner import FindPathDirs, ScannerBase
+    from SCons.Script import ARGLIST, ARGUMENTS, BUILD_TARGETS, COMMAND_LINE_TARGETS, DEFAULT_TARGETS
+    from SCons.Script.Main import (
+        AddOption,
+        BuildTask,
+        CleanTask,
+        DebugOptions,
+        GetBuildFailures,
+        GetOption,
+        PrintHelp,
+        Progress,
+        QuestionTask,
+        SetOption,
+        ValidateOptions,
+    )
+    from SCons.Script.SConscript import Configure, Return, SConsEnvironment, call_stack
+    from SCons.Script.SConscript import SConsEnvironment as Environment
+    from SCons.Subst import SetAllowableExceptions as AllowSubstExceptions
+    from SCons.Tool import CScanner, DScanner, ProgramScanner, SourceFileScanner, Tool
+    from SCons.Util import AddMethod, WhereIs
+    from SCons.Variables import BoolVariable, EnumVariable, ListVariable, PackageVariable, PathVariable, Variables
+
+    # Global functions
+    GetSConsVersion = SConsEnvironment.GetSConsVersion
+    EnsurePythonVersion = SConsEnvironment.EnsurePythonVersion
+    EnsureSConsVersion = SConsEnvironment.EnsureSConsVersion
+    Exit = SConsEnvironment.Exit
+    GetLaunchDir = SConsEnvironment.GetLaunchDir
+    SConscriptChdir = SConsEnvironment.SConscriptChdir
+
+    # SConsEnvironment functions
+    Default = SConsEnvironment(DefaultEnvironment()).Default
+    Export = SConsEnvironment(DefaultEnvironment()).Export
+    Help = SConsEnvironment(DefaultEnvironment()).Help
+    Import = SConsEnvironment(DefaultEnvironment()).Import
+    SConscript = SConsEnvironment(DefaultEnvironment()).SConscript
+
+    # Environment functions
+    AddPostAction = DefaultEnvironment().AddPostAction
+    AddPreAction = DefaultEnvironment().AddPreAction
+    Alias = DefaultEnvironment().Alias
+    AlwaysBuild = DefaultEnvironment().AlwaysBuild
+    CacheDir = DefaultEnvironment().CacheDir
+    Clean = DefaultEnvironment().Clean
+    Command = DefaultEnvironment().Command
+    Decider = DefaultEnvironment().Decider
+    Depends = DefaultEnvironment().Depends
+    Dir = DefaultEnvironment().Dir
+    Entry = DefaultEnvironment().Entry
+    Execute = DefaultEnvironment().Execute
+    File = DefaultEnvironment().File
+    FindFile = DefaultEnvironment().FindFile
+    FindInstalledFiles = DefaultEnvironment().FindInstalledFiles
+    FindSourceFiles = DefaultEnvironment().FindSourceFiles
+    Flatten = DefaultEnvironment().Flatten
+    GetBuildPath = DefaultEnvironment().GetBuildPath
+    Glob = DefaultEnvironment().Glob
+    Ignore = DefaultEnvironment().Ignore
+    Install = DefaultEnvironment().Install
+    InstallAs = DefaultEnvironment().InstallAs
+    InstallVersionedLib = DefaultEnvironment().InstallVersionedLib
+    Literal = DefaultEnvironment().Literal
+    Local = DefaultEnvironment().Local
+    NoCache = DefaultEnvironment().NoCache
+    NoClean = DefaultEnvironment().NoClean
+    ParseDepends = DefaultEnvironment().ParseDepends
+    Precious = DefaultEnvironment().Precious
+    PyPackageDir = DefaultEnvironment().PyPackageDir
+    Repository = DefaultEnvironment().Repository
+    Requires = DefaultEnvironment().Requires
+    SConsignFile = DefaultEnvironment().SConsignFile
+    SideEffect = DefaultEnvironment().SideEffect
+    Split = DefaultEnvironment().Split
+    Tag = DefaultEnvironment().Tag
+    Value = DefaultEnvironment().Value
+    VariantDir = DefaultEnvironment().VariantDir
+
+    env: SConsEnvironment
+    env_modules: SConsEnvironment

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 import os
 

--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -1,4 +1,6 @@
-# !/ usr / bin / env python
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/bmp/SCsub
+++ b/modules/bmp/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/dds/SCsub
+++ b/modules/dds/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/gltf/extensions/SCsub
+++ b/modules/gltf/extensions/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/godot_physics_2d/SCsub
+++ b/modules/godot_physics_2d/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
-Import('env')
+Import("env")
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/godot_physics_3d/SCsub
+++ b/modules/godot_physics_3d/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
-Import('env')
+Import("env")
 
 env.add_source_files(env.modules_sources, "*.cpp")
 

--- a/modules/godot_physics_3d/joints/SCsub
+++ b/modules/godot_physics_3d/joints/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
-Import('env')
+Import("env")
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/hdr/SCsub
+++ b/modules/hdr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/interactive_music/SCsub
+++ b/modules/interactive_music/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/meshoptimizer/SCsub
+++ b/modules/meshoptimizer/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 import build_scripts.mono_configure as mono_configure
 

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/multiplayer/SCsub
+++ b/modules/multiplayer/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/openxr/action_map/SCsub
+++ b/modules/openxr/action_map/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_openxr")

--- a/modules/openxr/editor/SCsub
+++ b/modules/openxr/editor/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/modules/openxr/extensions/SCsub
+++ b/modules/openxr/extensions/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_openxr")

--- a/modules/openxr/scene/SCsub
+++ b/modules/openxr/scene/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_openxr")

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
+
 import atexit
 import sys
 import time

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
+
 import atexit
 import sys
 import time

--- a/modules/tga/SCsub
+++ b/modules/tga/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/webxr/SCsub
+++ b/modules/webxr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/modules/zip/SCsub
+++ b/modules/zip/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 Import("env_modules")

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 from glob import glob
 from pathlib import Path

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 import subprocess
 import sys

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/platform/linuxbsd/x11/SCsub
+++ b/platform/linuxbsd/x11/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 from methods import print_error
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,19 @@ extend-select = [
 [tool.ruff.lint.per-file-ignores]
 "{SConstruct,SCsub}" = [
 	"E402", # Module level import not at top of file
-	"F821", # Undefined name
+	"F403", # Undefined local with import star
+	"F405", # Undefined local with import star usage
+]
+
+[tool.ruff.lint.isort]
+sections = { metadata = ["misc.utility.scons_hints"] }
+section-order = [
+	"future",
+	"metadata",
+	"standard-library",
+	"third-party",
+	"first-party",
+	"local-folder",
 ]
 
 [tool.codespell]

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/2d/physics/SCsub
+++ b/scene/2d/physics/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/2d/physics/joints/SCsub
+++ b/scene/2d/physics/joints/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/3d/physics/SCsub
+++ b/scene/3d/physics/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/3d/physics/joints/SCsub
+++ b/scene/3d/physics/joints/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/debugger/SCsub
+++ b/scene/debugger/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/resources/2d/SCsub
+++ b/scene/resources/2d/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/resources/3d/SCsub
+++ b/scene/resources/3d/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/camera/SCsub
+++ b/servers/camera/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/debugger/SCsub
+++ b/servers/debugger/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/display/SCsub
+++ b/servers/display/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/extensions/SCsub
+++ b/servers/extensions/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/movie_writer/SCsub
+++ b/servers/movie_writer/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/navigation/SCsub
+++ b/servers/navigation/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/SCsub
+++ b/servers/rendering/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/dummy/SCsub
+++ b/servers/rendering/dummy/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/dummy/storage/SCsub
+++ b/servers/rendering/dummy/storage/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/SCsub
+++ b/servers/rendering/renderer_rd/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/environment/SCsub
+++ b/servers/rendering/renderer_rd/environment/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/forward_clustered/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/forward_mobile/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/spirv-reflect/SCsub
+++ b/servers/rendering/renderer_rd/spirv-reflect/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/renderer_rd/storage_rd/SCsub
+++ b/servers/rendering/renderer_rd/storage_rd/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/rendering/storage/SCsub
+++ b/servers/rendering/storage/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/text/SCsub
+++ b/servers/text/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/servers/xr/SCsub
+++ b/servers/xr/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
 
 Import("env")
 


### PR DESCRIPTION
- Supersedes #86213
- Supersedes #92264

This PR adds `scons_hints.py` to the repo, which grants intellisense logic to **all** SCons files. Like #86213, this doesn't change any of the script files themselves outside of the include statement; however, the actual line is even more compact & setup to play nice with our new `ruff` formatter. Now all SCons files will have this header:
```python
#!/usr/bin/env python
from misc.utility.scons_hints import *
```
No space after the shebang is deliberate, as this new line is effectively metadata. ~~The comments at the end are to disable a warning for a star import (not added to `pyproject.toml`, as this *should* be warned about for all other cases) & to not account for this line when performing `isort`~~ (**EDIT:** Removed comments; logic handled entirely by `pyproject.toml`). Opted to put the hint file in `misc/utility` to avoid cluttering the root, and the added verbosity helps the line feel more "no-touchy".

The only other changes were making `isort` automatically put the metadata import on top & adjusting the `per-file-ignores` for SCons files:
- `F821` (Undefined name) was removed, as now all the names are properly defined.
- `F403` (Import star) was added, as this setup relies on the import star syntax.
- `F405` (Import star variable) was added, same as above.
