### PR TITLE
Ensure post processing happens when adjustments are enabled in the Compatibility renderer

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -45,7 +45,6 @@
 		</member>
 		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enabled" getter="is_adjustment_enabled" default="false">
 			If [code]true[/code], enables the [code]adjustment_*[/code] properties provided by this resource. If [code]false[/code], modifications to the [code]adjustment_*[/code] properties will have no effect on the rendered scene.
-			[b]Note:[/b] Adjustments are only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 		</member>
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation" default="1.0">
 			The global color saturation value of the rendered scene (default value is 1). Effective only if [member adjustment_enabled] is [code]true[/code].

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2245,9 +2245,9 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 
 	bool glow_enabled = false;
-	if (p_environment.is_valid() && rb.is_valid()) {
+	if (p_environment.is_valid()) {
 		glow_enabled = environment_get_glow_enabled(p_environment);
-		rb->set_glow_enabled(glow_enabled); // ensure our intermediate buffer is available if glow is enabled
+		rb->ensure_internal_buffers(); // Ensure our intermediate buffer is available if glow is enabled
 		if (glow_enabled) {
 			// If glow is enabled, we apply tonemapping etc. in post, so disable it during rendering
 			apply_color_adjustments_in_post = true;
@@ -2339,6 +2339,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	if (render_data.environment.is_valid()) {
 		bool use_bcs = environment_get_adjustments_enabled(render_data.environment);
 		if (use_bcs) {
+			rb->ensure_internal_buffers();
 			apply_color_adjustments_in_post = true;
 		}
 

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -194,7 +194,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 
 	ERR_FAIL_COND(view_count == 0);
 
-	bool use_internal_buffer = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF || glow.glow_enabled;
+	bool use_internal_buffer = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF || needs_internal_buffers;
 	uint32_t depth_format_size = 3;
 	bool use_multiview = view_count > 1;
 
@@ -203,7 +203,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 		return;
 	}
 
-	if (use_internal_buffer) {
+	if (use_internal_buffer && internal3d.color == 0) {
 		// Setup our internal buffer.
 		GLenum texture_target = use_multiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 
@@ -261,14 +261,14 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 		if (status != GL_FRAMEBUFFER_COMPLETE) {
 			_clear_intermediate_buffers();
-			WARN_PRINT("Could not create 3D buffers, status: " + texture_storage->get_framebuffer_error(status));
+			WARN_PRINT("Could not create 3D internal buffers, status: " + texture_storage->get_framebuffer_error(status));
 		}
 
 		glBindTexture(texture_target, 0);
 		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 	}
 
-	if (msaa3d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+	if (msaa3d.mode != RS::VIEWPORT_MSAA_DISABLED && msaa3d.color == 0) {
 		// Setup MSAA.
 		const GLsizei samples[] = { 1, 2, 4, 8 };
 		msaa3d.samples = samples[msaa3d.mode];
@@ -558,14 +558,8 @@ void RenderSceneBuffersGLES3::_clear_back_buffers() {
 	}
 }
 
-void RenderSceneBuffersGLES3::set_glow_enabled(bool p_glow_enabled) {
-	if (glow.glow_enabled != p_glow_enabled) {
-		glow.glow_enabled = p_glow_enabled;
-
-		// Clear our main buffers, this can impact them.
-		_clear_msaa3d_buffers();
-		_clear_intermediate_buffers();
-	}
+void RenderSceneBuffersGLES3::ensure_internal_buffers() {
+	needs_internal_buffers = true;
 }
 
 void RenderSceneBuffersGLES3::check_glow_buffers() {

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -50,6 +50,7 @@ public:
 	//bool use_taa = false;
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
+	bool needs_internal_buffers = false;
 
 	RID render_target;
 
@@ -83,7 +84,6 @@ public:
 
 	// Buffers for our glow implementation
 	struct GLOW {
-		bool glow_enabled = false;
 		GLES3::Glow::GLOWLEVEL levels[4];
 	} glow;
 
@@ -111,6 +111,7 @@ public:
 
 	void check_backbuffer(bool p_need_color, bool p_need_depth); // Check if we need to initialize our backbuffer.
 	void check_glow_buffers(); // Check if we need to initialize our glow buffers.
+	void ensure_internal_buffers();
 
 	GLuint get_render_fbo();
 	GLuint get_msaa3d_fbo() {
@@ -145,8 +146,6 @@ public:
 	GLuint get_backbuffer() const { return backbuffer3d.color; }
 	GLuint get_backbuffer_depth() const { return backbuffer3d.depth; }
 
-	bool get_glow_enabled() const { return glow.glow_enabled; }
-	void set_glow_enabled(bool p_glow_enabled);
 	const GLES3::Glow::GLOWLEVEL *get_glow_buffers() const { return &glow.levels[0]; }
 
 	// Getters


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/92853

This issue was caused by how we manage our post-processing effects. Right now we only do post processing when the internal buffers are allocated. We check if the internal FBO exists (i.e. fbo != 0) as our condition for doing post effects. 

The internal FBO is only ever allocated when glow or scaling are used. If neither of those are used then no post processing happens. Accordingly, the problem here was that adjustments didn't properly request for the internal FBO to get allocated. 

Previously it was requested by Glow each frame. If Glow was enabled or disabled the existing buffers would get thrown out and re-allocated. I have adjusted this logic to simply request that the internal buffer be created. We don't need to free the buffers at run time. They should be allocated if needed, and then kept around to avoid performance penalties if effects are adjusted at run time. 

I have fixed a few related issues too:
1. The old function could leak memory. If the MSAA setting changed, the internal buffers would get re-allocated without freeing the old versions. This would leak them. To fix that, it now checks that the buffers have been freed before creating them.
2. The documentation said that adjustments aren't supported. I removed that note. 