### PR TITLE
[Image Font Importer] Fix reading advance after hex/dec range.

### DIFF
--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -229,6 +229,7 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 							} else {
 								end = token.hex_to_int();
 								step = STEP_ADVANCE_BEGIN;
+								c--;
 							}
 						}
 					} break;
@@ -244,6 +245,7 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 							} else {
 								end = token.to_int();
 								step = STEP_ADVANCE_BEGIN;
+								c--;
 							}
 						}
 					} break;


### PR DESCRIPTION
Fixes `advance` value skipped after hex/dec range.