### PR TITLE
Remove no longer needed thread safety measures

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -40,12 +40,7 @@
 #include <stdio.h>
 
 void Resource::emit_changed() {
-	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
-		// Let the connection happen on the main thread, later, since signals are not thread-safe.
-		call_deferred("emit_signal", CoreStringName(changed));
-	} else {
-		emit_signal(CoreStringName(changed));
-	}
+	emit_signal(CoreStringName(changed));
 }
 
 void Resource::_resource_path_changed() {
@@ -166,22 +161,12 @@ bool Resource::editor_can_reload_from_file() {
 }
 
 void Resource::connect_changed(const Callable &p_callable, uint32_t p_flags) {
-	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
-		// Let the check and connection happen on the main thread, later, since signals are not thread-safe.
-		callable_mp(this, &Resource::connect_changed).call_deferred(p_callable, p_flags);
-		return;
-	}
 	if (!is_connected(CoreStringName(changed), p_callable) || p_flags & CONNECT_REFERENCE_COUNTED) {
 		connect(CoreStringName(changed), p_callable, p_flags);
 	}
 }
 
 void Resource::disconnect_changed(const Callable &p_callable) {
-	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
-		// Let the check and disconnection happen on the main thread, later, since signals are not thread-safe.
-		callable_mp(this, &Resource::disconnect_changed).call_deferred(p_callable);
-		return;
-	}
 	if (is_connected(CoreStringName(changed), p_callable)) {
 		disconnect(CoreStringName(changed), p_callable);
 	}


### PR DESCRIPTION
This is basically a revertion of commit 84b85d894c47cf5d680992fcae1d9af48eee0d3f.

Those changes happened in #88561 and became superfluous in #91630.

There's risk of regressions, though, as this is slippery ground. I'm testing this change in big projects, but you power maintainers may want to reschedule to 4.4.