### PR TITLE
[Window] Ignore duplicate mouse enter events.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -738,6 +738,9 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 				return;
 			}
 			Window *root = get_tree()->get_root();
+			if (mouse_in_window && root->gui.windowmanager_window_over == this) {
+				return;
+			}
 			if (root->gui.windowmanager_window_over) {
 #ifdef DEV_ENABLED
 				WARN_PRINT_ONCE("Entering a window while a window is hovered should never happen in DisplayServer.");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93085

Alternatively, https://github.com/godotengine/godot/pull/92908 code can be moved to the macOS `DisplayServer`, but this will require more complicated checks (actually tracking is event was received by Widows), and might require the same changes on other platforms (I can't reproduce it on Windows or Linux, but system events timing can be inconsistent).

Receiving a duplicate enter event for the same window and ignoring it should not have any negative effects, not receiving it at all will break UI, so it is a safer option. The original check which was showing a warning is preserved (it is supposed to warn if different window get enter event without previously hovered window getting exit event first and still serve this purpose).