### PR TITLE
Fix issues related to code-signing for macOS exports

### DIFF
--- a/platform/macos/export/codesign.cpp
+++ b/platform/macos/export/codesign.cpp
@@ -312,6 +312,10 @@ bool CodeSignCodeResources::add_folder_recursive(const String &p_root, const Str
 					info_path = path.path_join(vformat("Versions/%s/Resources/Info.plist", fmw_ver));
 					main_exe = path.path_join(vformat("Versions/%s", fmw_ver));
 					bundle = true;
+				} else if (da->file_exists(path.path_join("Resources/Info.plist"))) {
+					info_path = path.path_join("Resources/Info.plist");
+					main_exe = path;
+					bundle = true;
 				} else if (da->file_exists(path.path_join("Info.plist"))) {
 					info_path = path.path_join("Info.plist");
 					main_exe = path;
@@ -1309,7 +1313,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 			cr.add_rule2("^_CodeSignature", "omit", 2000, false);
 			cr.add_rule2("^CodeResources", "omit", 2000, false);
 		} else {
-			cr.add_rule1("^Resources/");
+			cr.add_rule1("^Resources($|/)");
 			cr.add_rule1("^Resources/.*\\.lproj/", "optional", 1000);
 			cr.add_rule1("^Resources/.*\\.lproj/locversion.plist$", "omit", 1100);
 			cr.add_rule1("^Resources/Base\\.lproj/", "", 1010);
@@ -1321,7 +1325,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 			cr.add_rule2("^.*");
 			cr.add_rule2("^Info\\.plist$", "omit", 20);
 			cr.add_rule2("^PkgInfo$", "omit", 20);
-			cr.add_rule2("^Resources/", "", 20);
+			cr.add_rule2("^Resources($|/)", "", 20);
 			cr.add_rule2("^Resources/.*\\.lproj/", "optional", 1000);
 			cr.add_rule2("^Resources/.*\\.lproj/locversion.plist$", "omit", 1100);
 			cr.add_rule2("^Resources/Base\\.lproj/", "", 1010);
@@ -1539,6 +1543,11 @@ Error CodeSign::codesign(bool p_use_hardened_runtime, bool p_force, const String
 			info_path = p_path.path_join(vformat("Versions/%s/Resources/Info.plist", fmw_ver));
 			main_exe = p_path.path_join(vformat("Versions/%s", fmw_ver));
 			bundle_path = p_path.path_join(vformat("Versions/%s", fmw_ver));
+			bundle = true;
+		} else if (da->file_exists(p_path.path_join("Resources/Info.plist"))) {
+			info_path = p_path.path_join("Resources/Info.plist");
+			main_exe = p_path;
+			bundle_path = p_path;
 			bundle = true;
 		} else if (da->file_exists(p_path.path_join("Info.plist"))) {
 			info_path = p_path.path_join("Info.plist");

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1237,8 +1237,16 @@ Error EditorExportPlatformMacOS::_code_sign_directory(const Ref<EditorExportPres
 		}
 
 		if (extensions_to_sign.has(current_file.get_extension())) {
-			int ftype = MachO::get_filetype(current_file_path);
-			Error code_sign_error{ _code_sign(p_preset, current_file_path, (ftype == 2 || ftype == 5) ? p_helper_ent_path : p_ent_path, false, (ftype == 2 || ftype == 5)) };
+			String ent_path = p_ent_path;
+			bool set_bundle_id = false;
+			if (FileAccess::exists(current_file_path)) {
+				int ftype = MachO::get_filetype(current_file_path);
+				if (ftype == 2 || ftype == 5) {
+					ent_path = p_helper_ent_path;
+					set_bundle_id = true;
+				}
+			}
+			Error code_sign_error{ _code_sign(p_preset, current_file_path, ent_path, false, set_bundle_id) };
 			if (code_sign_error != OK) {
 				return code_sign_error;
 			}
@@ -1358,8 +1366,16 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 			err = _code_sign_directory(p_preset, p_in_app_path, p_ent_path, p_helper_ent_path, p_should_error_on_non_code_sign);
 		} else {
 			if (extensions_to_sign.has(p_in_app_path.get_extension())) {
-				int ftype = MachO::get_filetype(p_in_app_path);
-				err = _code_sign(p_preset, p_in_app_path, (ftype == 2 || ftype == 5) ? p_helper_ent_path : p_ent_path, false, (ftype == 2 || ftype == 5));
+				String ent_path = p_ent_path;
+				bool set_bundle_id = false;
+				if (FileAccess::exists(p_in_app_path)) {
+					int ftype = MachO::get_filetype(p_in_app_path);
+					if (ftype == 2 || ftype == 5) {
+						ent_path = p_helper_ent_path;
+						set_bundle_id = true;
+					}
+				}
+				err = _code_sign(p_preset, p_in_app_path, ent_path, false, set_bundle_id);
 			}
 			if (dir_access->file_exists(p_in_app_path) && is_executable(p_in_app_path)) {
 				// chmod with 0755 if the file is executable.


### PR DESCRIPTION
This PR fixes the following issues related to code-signing macOS exports:

1. When exporting projects that reference a GDExtension bundled as a `*.framework`, you will currently see error messages about `MachO: Can't open file: [...]` due to certain places in `EditorExportPlatformMacOS` assuming that all extensions are files, whereas `*.framework` is a directory.
2. When using Godot's built-in code-signing for macOS (on Windows in my case) for a project that references a GDExtension bundled as a `*.framework`, you will currently end up with a bunch of errors about `LipO: Can't open file: [...]` due to Godot thinking that the `Resources` directory is a bundle directory. This seemed to be the result of the regular expressions in `_codesign_file` not accounting for the slash at the end being optional for the `Resources` directory.
3. Godot's built-in code-signing does not seem to support the `*.framework` bundle layout with which I distribute [Godot Jolt](https://github.com/godot-jolt/godot-jolt) currently, where I don't have a `Versions` directory (since I can't reasonably distribute symlinks) but instead just the binary and a `Resources` directory at the top-level. While this layout probably raises some eyebrows, it works just fine with regular `codesign` as well as `notarytool`, so I don't see why Godot shouldn't support it too.

CC @bruvzg 