### PR TITLE
Fix not being able to reopen signals panel immediately after connecting a signal

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -981,7 +981,6 @@ void ConnectionsDock::_make_or_edit_connection() {
 		}
 
 		EditorNode::get_singleton()->emit_signal(SNAME("script_add_function_request"), target, cd.method, script_function_args);
-		hide();
 	}
 
 	update_tree();
@@ -1607,7 +1606,6 @@ ConnectionsDock::ConnectionsDock() {
 	connect_button->connect(SceneStringName(pressed), callable_mp(this, &ConnectionsDock::_connect_pressed));
 
 	connect_dialog = memnew(ConnectDialog);
-	connect_dialog->connect("connected", callable_mp(NodeDock::get_singleton(), &NodeDock::restore_last_valid_node), CONNECT_DEFERRED);
 	connect_dialog->set_process_shortcut_input(true);
 	add_child(connect_dialog);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2304,6 +2304,12 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 	_edit_current();
 }
 
+void EditorNode::edit_previous_item() {
+	if (editor_history.previous()) {
+		_edit_current();
+	}
+}
+
 void EditorNode::push_item_no_inspector(Object *p_object) {
 	_add_to_history(p_object, "", false);
 	_edit_current(false, true);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -764,6 +764,7 @@ public:
 
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void push_item_no_inspector(Object *p_object);
+	void edit_previous_item();
 	void edit_item(Object *p_object, Object *p_editing_owner);
 	void push_node_item(Node *p_node);
 	void hide_unused_editors(const Object *p_editing_owner = nullptr);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -67,23 +67,11 @@ void NodeDock::update_lists() {
 	connections->update_tree();
 }
 
-void NodeDock::_on_node_tree_exited() {
-	set_node(nullptr);
-}
-
 void NodeDock::set_node(Node *p_node) {
-	if (last_valid_node) {
-		last_valid_node->disconnect(SceneStringName(tree_exited), callable_mp(this, &NodeDock::_on_node_tree_exited));
-		last_valid_node = nullptr;
-	}
-
 	connections->set_node(p_node);
 	groups->set_current(p_node);
 
 	if (p_node) {
-		last_valid_node = p_node;
-		last_valid_node->connect(SceneStringName(tree_exited), callable_mp(this, &NodeDock::_on_node_tree_exited));
-
 		if (connections_button->is_pressed()) {
 			connections->show();
 		} else {
@@ -98,10 +86,6 @@ void NodeDock::set_node(Node *p_node) {
 		mode_hb->hide();
 		select_a_node->show();
 	}
-}
-
-void NodeDock::restore_last_valid_node() {
-	set_node(last_valid_node);
 }
 
 NodeDock::NodeDock() {

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -47,7 +47,6 @@ class NodeDock : public VBoxContainer {
 	HBoxContainer *mode_hb = nullptr;
 
 	Label *select_a_node = nullptr;
-	Node *last_valid_node = nullptr;
 
 private:
 	static NodeDock *singleton;
@@ -58,11 +57,9 @@ public:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	void _on_node_tree_exited();
 
 public:
 	void set_node(Node *p_node);
-	void restore_last_valid_node();
 
 	void show_groups();
 	void show_connections();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2856,6 +2856,10 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 
 		break;
 	}
+
+	// Move back to the previously edited node to reselect it in the Inspector and the NodeDock.
+	// We assume that the previous item is the node on which the callbacks were added.
+	EditorNode::get_singleton()->edit_previous_item();
 }
 
 void ScriptEditor::_save_editor_state(ScriptEditorBase *p_editor) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2696,6 +2696,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	editor_history->cleanup_history();
 	InspectorDock::get_singleton()->call("_prepare_history");
 	InspectorDock::get_singleton()->update(nullptr);
+	NodeDock::get_singleton()->set_node(nullptr);
 }
 
 void SceneTreeDock::_update_script_button() {


### PR DESCRIPTION
Fixes #92996 

The issue was that `last_valid_node` was being set to null when `p_node` was null, causing the loss of the last valid node. After a signal connection, `restore_last_valid_node` is called, but `last_valid_node` no longer contained the node being edited.