### PR TITLE
Fix crash when trying to undo SpriteFrames animation rename

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1476,8 +1476,8 @@ void SpriteFramesEditor::edit(Ref<SpriteFrames> p_frames) {
 	_fetch_sprite_node(); // Fetch node after set frames.
 }
 
-bool SpriteFramesEditor::is_editing() const {
-	return frames.is_valid();
+Ref<SpriteFrames> SpriteFramesEditor::get_sprite_frames() const {
+	return frames;
 }
 
 Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
@@ -2337,7 +2337,11 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 	if (animated_sprite_3d && *animated_sprite_3d->get_sprite_frames()) {
 		return true;
 	}
-	return !frames_editor->is_editing() && Object::cast_to<SpriteFrames>(p_object);
+	SpriteFrames *frames = Object::cast_to<SpriteFrames>(p_object);
+	if (frames && (frames_editor->get_sprite_frames().is_null() || frames_editor->get_sprite_frames() == frames)) {
+		return true;
+	}
+	return false;
 }
 
 void SpriteFramesEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -269,7 +269,7 @@ protected:
 
 public:
 	void edit(Ref<SpriteFrames> p_frames);
-	bool is_editing() const;
+	Ref<SpriteFrames> get_sprite_frames() const;
 
 	SpriteFramesEditor();
 };


### PR DESCRIPTION
Fixes #93079 
*Bugsquad edit:* Also fixes #92600

The problem was introduced by PR #90815. As suggested by KoBeWi in that PR, I modified the verification to check if the new SpriteFrames is different. I removed the method `is_editing` because I found it redundant with `get_sprite_frames`.

Tested with renaming animations, Ctrl-Z, adding animations, and removing animations.