### PR TITLE
Unset the owner of `ImporterMeshInstance3D` before adding it to skeleton's child

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6328,6 +6328,7 @@ void GLTFDocument::_process_mesh_instances(Ref<GLTFState> p_state, Node *p_scene
 			ERR_CONTINUE_MSG(skeleton == nullptr, vformat("Unable to find Skeleton for node %d skin %d", node_i, skin_i));
 
 			mi->get_parent()->remove_child(mi);
+			mi->set_owner(nullptr);
 			skeleton->add_child(mi, true);
 			mi->set_owner(p_scene_root);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93092

Tested locally it doesn't seem to break the import functionality.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
