### PR TITLE
[Image Font Importer] Adds support for `\uXXXX` in the kerning config strings.

### DIFF
--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -291,10 +291,29 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 			WARN_PRINT(vformat("Invalid kerning pairs string: \"%s\"", kp));
 			continue;
 		}
+		String from_tokens;
+		for (int i = 0; i < kp_tokens[0].length(); i++) {
+			if (i <= kp_tokens[0].length() - 6 && kp_tokens[0][i] == '\\' && kp_tokens[0][i + 1] == 'u') {
+				char32_t charcode = kp_tokens[0].substr(i + 2, 4).hex_to_int();
+				from_tokens += charcode;
+			} else {
+				from_tokens += kp_tokens[0][i];
+			}
+		}
+		String to_tokens;
+		for (int i = 0; i < kp_tokens[1].length(); i++) {
+			if (i <= kp_tokens[1].length() - 6 && kp_tokens[1][i] == '\\' && kp_tokens[1][i + 1] == 'u') {
+				char32_t charcode = kp_tokens[1].substr(i + 2, 4).hex_to_int();
+				to_tokens += charcode;
+			} else {
+				to_tokens += kp_tokens[1][i];
+			}
+		}
 		int offset = kp_tokens[2].to_int();
-		for (int a = 0; a < kp_tokens[0].length(); a++) {
-			for (int b = 0; b < kp_tokens[1].length(); b++) {
-				font->set_kerning(0, chr_height, Vector2i(kp_tokens[0].unicode_at(a), kp_tokens[1].unicode_at(b)), Vector2(offset, 0));
+
+		for (int a = 0; a < from_tokens.length(); a++) {
+			for (int b = 0; b < to_tokens.length(); b++) {
+				font->set_kerning(0, chr_height, Vector2i(from_tokens.unicode_at(a), to_tokens.unicode_at(b)), Vector2(offset, 0));
 			}
 		}
 	}


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/93066

Spaces can be now added to kerning pairs with `\u0020`, not the most elegant solution, but not much can be changed without breaking existing imports.

I'll probably make a separate PR adding the advanced import dialog for bitmap fonts, since entering it via standard property editor is not convenient.