### PR TITLE
`ResourceLoader`: Let the caller thread use its own message queue override

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -395,6 +395,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 
 	if (load_nesting == 0) {
 		if (mq_override) {
+			MessageQueue::set_thread_singleton_override(nullptr);
 			memdelete(mq_override);
 		}
 		memdelete(load_paths_stack);

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -481,10 +481,7 @@ CallQueue::~CallQueue() {
 	if (!allocator_is_custom) {
 		memdelete(allocator);
 	}
-	// This is done here to avoid a circular dependency between the safety checks and the thread singleton pointer.
-	if (this == MessageQueue::thread_singleton) {
-		MessageQueue::thread_singleton = nullptr;
-	}
+	DEV_ASSERT(!is_current_thread_override);
 }
 
 //////////////////////
@@ -493,7 +490,6 @@ CallQueue *MessageQueue::main_singleton = nullptr;
 thread_local CallQueue *MessageQueue::thread_singleton = nullptr;
 
 void MessageQueue::set_thread_singleton_override(CallQueue *p_thread_singleton) {
-	DEV_ASSERT(p_thread_singleton); // To unset the thread singleton, don't call this with nullptr, but just memfree() it.
 #ifdef DEV_ENABLED
 	if (thread_singleton) {
 		thread_singleton->is_current_thread_override = false;

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -53,7 +53,9 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 	int pool_thread_index = thread_ids[Thread::get_caller_id()];
 	ThreadData &curr_thread = threads[pool_thread_index];
 	Task *prev_task = nullptr; // In case this is recursively called.
+
 	bool safe_for_nodes_backup = is_current_thread_safe_for_nodes();
+	CallQueue *call_queue_backup = MessageQueue::get_singleton() != MessageQueue::get_main_singleton() ? MessageQueue::get_singleton() : nullptr;
 
 	{
 		// Tasks must start with this unset. They are free to set-and-forget otherwise.
@@ -169,6 +171,7 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 	}
 
 	set_current_thread_safe_for_nodes(safe_for_nodes_backup);
+	MessageQueue::set_thread_singleton_override(call_queue_backup);
 #endif
 }
 


### PR DESCRIPTION
This allows for extra flexibility in certain (advanced) use cases, where the user may want to exert greater control over the "queued-update-like" actions happening during resource loading. These advanced APIs are not exposed yet, though. Also, this is also a fix as there's no notion of a stack of call queue overrides that can be pushed and popped, and `ResourceLoader` would otherwise be recklessly overriding any currently set, reverting back to the main queue otherwise.

The change has a base commit that fixes the fact that the `WorkerThreadPool` wasn't considering the thread call queue override as part of the thread-wide state to restore in case a task has overridden it. Such commit is a bugfix by itself as well.