### PR TITLE
[Windows] Add Windows version and Wine checks for Windows 10+ dark mode API.

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -162,6 +162,7 @@ enum PreferredAppMode {
 	APPMODE_MAX = 4
 };
 
+typedef const char *(CDECL *WineGetVersionPtr)(void);
 typedef bool(WINAPI *ShouldAppsUseDarkModePtr)();
 typedef DWORD(WINAPI *GetImmersiveColorFromColorSetExPtr)(UINT dwImmersiveColorSet, UINT dwImmersiveColorType, bool bIgnoreHighContrast, UINT dwHighContrastCacheMode);
 typedef int(WINAPI *GetImmersiveColorTypeFromNamePtr)(const WCHAR *name);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93123