### PR TITLE
Center the label in EditorObjectSelector

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -239,6 +239,7 @@ EditorObjectSelector::EditorObjectSelector(EditorSelectionHistory *p_history) {
 	current_object_label = memnew(Label);
 	current_object_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	current_object_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	current_object_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	current_object_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	main_hb->add_child(current_object_label);
 


### PR DESCRIPTION
The label of `EditorObjectSelector` wasn't vertically aligned, may be more noticeable depending on the editor theme

| Before | After |
|--------|--------|
| ![1](https://github.com/godotengine/godot/assets/60579014/7610ef62-77cc-4a84-bad3-37d90b9b6ff5) | ![2](https://github.com/godotengine/godot/assets/60579014/b580b083-3142-4183-ac16-89c5427f843c) |