### PR TITLE
[Tests] Ensure all default method arguments can be encoded

### DIFF
--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -289,6 +289,38 @@ bool arg_default_value_is_assignable_to_type(const Context &p_context, const Var
 	return false;
 }
 
+bool arg_default_value_is_valid_data(const Variant &p_val, String *r_err_msg = nullptr) {
+	switch (p_val.get_type()) {
+		case Variant::RID:
+		case Variant::ARRAY:
+		case Variant::DICTIONARY:
+		case Variant::PACKED_BYTE_ARRAY:
+		case Variant::PACKED_INT32_ARRAY:
+		case Variant::PACKED_INT64_ARRAY:
+		case Variant::PACKED_FLOAT32_ARRAY:
+		case Variant::PACKED_FLOAT64_ARRAY:
+		case Variant::PACKED_STRING_ARRAY:
+		case Variant::PACKED_VECTOR2_ARRAY:
+		case Variant::PACKED_VECTOR3_ARRAY:
+		case Variant::PACKED_COLOR_ARRAY:
+		case Variant::PACKED_VECTOR4_ARRAY:
+		case Variant::CALLABLE:
+		case Variant::SIGNAL:
+		case Variant::OBJECT:
+			if (p_val.is_zero()) {
+				return true;
+			}
+			if (r_err_msg) {
+				*r_err_msg = "Must be zero.";
+			}
+			break;
+		default:
+			return true;
+	}
+
+	return false;
+}
+
 void validate_property(const Context &p_context, const ExposedClass &p_class, const PropertyData &p_prop) {
 	const MethodData *setter = p_class.find_method_by_name(p_prop.setter);
 
@@ -411,6 +443,14 @@ void validate_argument(const Context &p_context, const ExposedClass &p_class, co
 		}
 
 		TEST_COND(!arg_defval_assignable_to_type, err_msg);
+
+		bool arg_defval_valid_data = arg_default_value_is_valid_data(p_arg.defval, &type_error_msg);
+
+		if (!type_error_msg.is_empty()) {
+			err_msg += " " + type_error_msg;
+		}
+
+		TEST_COND(!arg_defval_valid_data, err_msg);
 	}
 }
 


### PR DESCRIPTION
Checks that all arguments of bound methods can be encoded in extensions, checking non-empty or non-null cases for containers and objects

Ensures that:
* `RID`s are empty, i.e. encodes as `RID()`
* `Callable`s and `Signal`s are empty as well, as they cannot (currently) be serialized
* All container types are empty

In the future we might add support on for example the godot-cpp side for creating arguments of at least the container types but currently these are not decoded correctly (either there are no checks or they map to an empty array) so this would introduce either failing code or code that won't match up with the default arguments of the engine itself

There are no arguments of these types currently, and at least `RID` wouldn't make sense as it is a dynamic type, and default `Callable`s would only work if they were static as the default value couldn't handle the class in question without some major additions to the code, same goes for `Signal`

The one case that can be improved in the future would be allowing arrays, of course excluding elements that are, themselves invalid, but regardless this would involve quite a bit of work to make it happen so this ensures that we don't accidentally create any broken bindings (many would be caught by the godot-cpp CI step but not all)

Also fixes an error in the test code where the `err_msg` string should be passed directly, this way it won't print anything which I discovered while confirming the new test, this is its own commit as it touches a few other places and could be cherry picked, see:
* https://github.com/godotengine/godot/pull/93135

Edit: note that this is already checked for in the mono bindings generation as well so this just adds some further and easier to utilize checks for non-mono builds (it also doesn't check non-empty status for `Packed*Array`s, might add that in this PR just for completeness, and will take some inspiration from the error messages here for clarity)

Relating to:
* https://github.com/godotengine/godot-cpp/pull/1488

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
