### PR TITLE
[Tests] Fix some invalid error messages

### DIFF
--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -93,9 +93,9 @@ void test_rotation(Vector3 deg_original_euler, EulerOrder rot_order) {
 
 	Basis res = to_rotation.inverse() * rotation_from_computed_euler;
 
-	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Fail due to X %s\n", String(res.get_column(0))).utf8().ptr());
-	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Fail due to Y %s\n", String(res.get_column(1))).utf8().ptr());
-	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Fail due to Z %s\n", String(res.get_column(2))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Fail due to X %s\n", String(res.get_column(0))));
+	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Fail due to Y %s\n", String(res.get_column(1))));
+	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Fail due to Z %s\n", String(res.get_column(2))));
 
 	// Double check `to_rotation` decomposing with XYZ rotation order.
 	const Vector3 euler_xyz_from_rotation = to_rotation.get_euler(EulerOrder::XYZ);
@@ -103,13 +103,13 @@ void test_rotation(Vector3 deg_original_euler, EulerOrder rot_order) {
 
 	res = to_rotation.inverse() * rotation_from_xyz_computed_euler;
 
-	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to X %s\n", String(res.get_column(0))).utf8().ptr());
-	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Y %s\n", String(res.get_column(1))).utf8().ptr());
-	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Z %s\n", String(res.get_column(2))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to X %s\n", String(res.get_column(0))));
+	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Y %s\n", String(res.get_column(1))));
+	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Z %s\n", String(res.get_column(2))));
 
-	INFO(vformat("Rotation order: %s\n.", get_rot_order_name(rot_order)).utf8().ptr());
-	INFO(vformat("Original Rotation: %s\n", String(deg_original_euler)).utf8().ptr());
-	INFO(vformat("Quaternion to rotation order: %s\n", String(rad2deg(euler_from_rotation))).utf8().ptr());
+	INFO(vformat("Rotation order: %s\n.", get_rot_order_name(rot_order)));
+	INFO(vformat("Original Rotation: %s\n", String(deg_original_euler)));
+	INFO(vformat("Quaternion to rotation order: %s\n", String(rad2deg(euler_from_rotation))));
 }
 
 TEST_CASE("[Basis] Euler conversions") {

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -405,7 +405,7 @@ void validate_argument(const Context &p_context, const ExposedClass &p_class, co
 			err_msg += " " + type_error_msg;
 		}
 
-		TEST_COND(!arg_defval_assignable_to_type, err_msg.utf8().get_data());
+		TEST_COND(!arg_defval_assignable_to_type, err_msg);
 	}
 }
 
@@ -590,7 +590,7 @@ void add_exposed_classes(Context &r_context) {
 						exposed_class.name, method.name);
 				TEST_FAIL_COND_WARN(
 						(exposed_class.name != r_context.names_cache.object_class || String(method.name) != "free"),
-						warn_msg.utf8().get_data());
+						warn_msg);
 
 			} else if (return_info.type == Variant::INT && return_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) {
 				method.return_type.name = return_info.class_name;
@@ -720,7 +720,7 @@ void add_exposed_classes(Context &r_context) {
 					"Signal name conflicts with %s: '%s.%s.",
 					method_conflict ? "method" : "property", class_name, signal.name);
 			TEST_FAIL_COND((method_conflict || exposed_class.find_method_by_name(signal.name)),
-					warn_msg.utf8().get_data());
+					warn_msg);
 
 			exposed_class.signals_.push_back(signal);
 		}


### PR DESCRIPTION
These used `utf8().get_data()` when they should be passed as `String`

Otherwise the specific warning won't be printed

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
