### PR TITLE
[RTL] Fix `align_to_row` for the last table row.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -408,7 +408,7 @@ float RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font
 				_set_table_size(table, available_width);
 
 				int row_idx = (table->align_to_row < 0) ? table->rows_baseline.size() - 1 : table->align_to_row;
-				if (table->rows_baseline.size() != 0 && row_idx < (int)table->rows_baseline.size() - 1) {
+				if (table->rows_baseline.size() != 0 && row_idx < (int)table->rows_baseline.size()) {
 					l.text_buf->resize_object(it->rid, Size2(table->total_width, table->total_height), table->inline_align, Math::round(table->rows_baseline[row_idx]));
 				} else {
 					l.text_buf->resize_object(it->rid, Size2(table->total_width, table->total_height), table->inline_align);
@@ -632,7 +632,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				_set_table_size(table, available_width);
 
 				int row_idx = (table->align_to_row < 0) ? table->rows_baseline.size() - 1 : table->align_to_row;
-				if (table->rows_baseline.size() != 0 && row_idx < (int)table->rows_baseline.size() - 1) {
+				if (table->rows_baseline.size() != 0 && row_idx < (int)table->rows_baseline.size()) {
 					l.text_buf->add_object(it->rid, Size2(table->total_width, table->total_height), table->inline_align, t_char_count, Math::round(table->rows_baseline[row_idx]));
 				} else {
 					l.text_buf->add_object(it->rid, Size2(table->total_width, table->total_height), table->inline_align, t_char_count);


### PR DESCRIPTION
Fixes baseline-to-baseline alignment for last table row:

e.g., `test [table=1,l,l,2][cell]aa[/cell][cell]aa[/cell][cell]aa[/cell][/table]test` - table settings: `1` column, alignment baseline-to-baseline (`l,l`), to the row with index `2`.

| Before | After |
| -- | -- |
| <img width="104" alt="Screenshot 2024-06-13 at 22 03 22" src="https://github.com/godotengine/godot/assets/7645683/6af4685d-2531-4df9-97cf-284e968c67f6"> | <img width="104" alt="Screenshot 2024-06-13 at 22 03 04" src="https://github.com/godotengine/godot/assets/7645683/5250c7c2-5244-408c-91cb-566ea0bd75ee"> |