### PR TITLE
Fix bug when downloading export templates and re-opening the template manager

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -639,7 +639,7 @@ void ExportTemplateManager::_open_template_folder(const String &p_version) {
 
 void ExportTemplateManager::popup_manager() {
 	_update_template_status();
-	if (downloads_available) {
+	if (downloads_available && !is_downloading_templates) {
 		_refresh_mirrors();
 	}
 	popup_centered(Size2(720, 280) * EDSCALE);


### PR DESCRIPTION
Fixes #93121

The problem was caused by a call to `_download_template` when `is_downloading_templates` is true in `_refresh_mirrors_completed` which was triggered by `_refresh_mirrors` in `popup_manager`.

So preventing a refresh of mirrors at the opening of the Export templates manager fixed the problem.
