### PR TITLE
Make `AudioStreamPlaybackMicrophone::_mix_internal` be able to run at the same time as input callback for `AudioDriverOpenSL`

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -234,6 +234,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 				ad->input_buffer_write(sample);
 			}
 		}
+		ad->input_buffer_end_write();
 	} else {
 		ERR_PRINT("AudioUnitRender failed, code: " + itos(result));
 	}
@@ -633,8 +634,8 @@ void AudioDriverCoreAudio::_set_device(const String &output_device, bool input) 
 
 		if (input) {
 			// Reset audio input to keep synchronization.
-			input_position = 0;
-			input_size = 0;
+			input_read = SizePosition(0, 0);
+			input_write = SizePosition(0, 0);
 		}
 	}
 }

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -269,8 +269,8 @@ Error AudioDriverPulseAudio::init_output_device() {
 	samples_out.resize(pa_buffer_size);
 
 	// Reset audio input to keep synchronization.
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 
 	return OK;
 }
@@ -546,6 +546,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 							ad->input_buffer_write(sample);
 						}
 					}
+					ad->input_buffer_end_write();
 
 					read_bytes += bytes;
 					ret = pa_stream_drop(ad->pa_rec_str);

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -483,8 +483,8 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 	// Sample rate is independent of channels (ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels)
 	samples_in.resize(buffer_frames * channels);
 
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 
 	print_verbose("WASAPI: detected " + itos(audio_output.channels) + " channels");
 	print_verbose("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
@@ -868,6 +868,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 					hr = ad->audio_input.capture_client->GetNextPacketSize(&packet_length);
 					ERR_BREAK(hr != S_OK);
 				}
+				ad->input_buffer_end_write();
 			}
 
 			// If we're using the Default output device and it changed finish it so we'll re-init the output device

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -189,6 +189,7 @@ void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf qu
 		input_buffer_write(sample);
 		input_buffer_write(sample); // call twice to convert to Stereo
 	}
+	input_buffer_end_write();
 
 	SLresult res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));
 	ERR_FAIL_COND(res != SL_RESULT_SUCCESS);

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -100,6 +100,7 @@ void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
 	for (int i = read_pos; i < read_pos + to_read; i++) {
 		input_buffer_write(int32_t(input_rb[i] * 32768.f) * (1U << 16));
 	}
+	input_buffer_end_write();
 }
 
 Error AudioDriverWeb::init() {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -322,32 +322,27 @@ AudioStreamMicrophone::AudioStreamMicrophone() {
 }
 
 int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_frames) {
-	AudioDriver::get_singleton()->lock();
-
-	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
-	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
-	int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
+	const LocalVector<int32_t> &buf = AudioDriver::get_singleton()->get_input_buffer();
+	AudioDriver::SizePosition size_position = AudioDriver::get_singleton()->get_input_size_position();
+	unsigned int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
 	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
-#ifdef DEBUG_ENABLED
-	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
-#endif
 
 	int mixed_frames = p_frames;
 
-	if (playback_delay > input_size) {
+	if (playback_delay > size_position.size) {
 		for (int i = 0; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0.0f, 0.0f);
 		}
 		input_ofs = 0;
 	} else {
 		for (int i = 0; i < p_frames; i++) {
-			if (input_size > input_ofs && (int)input_ofs < buf.size()) {
+			if (size_position.size > input_ofs && input_ofs < buf.size()) {
 				float l = (buf[input_ofs++] >> 16) / 32768.f;
-				if ((int)input_ofs >= buf.size()) {
+				if (input_ofs >= buf.size()) {
 					input_ofs = 0;
 				}
 				float r = (buf[input_ofs++] >> 16) / 32768.f;
-				if ((int)input_ofs >= buf.size()) {
+				if (input_ofs >= buf.size()) {
 					input_ofs = 0;
 				}
 
@@ -362,12 +357,12 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 	}
 
 #ifdef DEBUG_ENABLED
-	if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
-		print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+	if (mixed_frames != p_frames) {
+		ERR_PRINT(vformat("Buffer underrun: size_position.size = %d, input_ofs = %d, buf.size() = %d.", size_position.size, input_ofs, buf.size()));
+	} else if (input_ofs > size_position.position && (int)(input_ofs - size_position.position) < (p_frames * 2)) {
+		print_verbose(String(get_class_name()) + " buffer underrun: size_position.position=" + itos(size_position.position) + " size_position.size=" + itos(size_position.size) + " input_ofs=" + itos(input_ofs));
 	}
 #endif
-
-	AudioDriver::get_singleton()->unlock();
 
 	return mixed_frames;
 }

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -98,22 +98,26 @@ double AudioDriver::get_time_to_next_mix() {
 void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 	const int input_buffer_channels = 2;
 	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4);
-	input_position = 0;
-	input_size = 0;
+	input_read = SizePosition(0, 0);
+	input_write = SizePosition(0, 0);
 }
 
 void AudioDriver::input_buffer_write(int32_t sample) {
-	if ((int)input_position < input_buffer.size()) {
-		input_buffer.write[input_position++] = sample;
-		if ((int)input_position >= input_buffer.size()) {
-			input_position = 0;
+	if (input_write.position < input_buffer.size()) {
+		input_buffer[input_write.position++] = sample;
+		if (input_write.position >= input_buffer.size()) {
+			input_write.position = 0;
 		}
-		if ((int)input_size < input_buffer.size()) {
-			input_size++;
+		if (input_write.size < input_buffer.size()) {
+			input_write.size++;
 		}
 	} else {
-		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
+		WARN_PRINT("input_buffer_write: Invalid input_write.position=" + itos(input_write.position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
+}
+
+void AudioDriver::input_buffer_end_write() {
+	input_read = input_write;
 }
 
 int AudioDriver::_get_configured_mix_rate() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -56,15 +56,26 @@ class AudioDriver {
 	SafeNumeric<uint64_t> prof_time;
 #endif
 
+public:
+	struct SizePosition {
+		unsigned int size;
+		unsigned int position;
+
+		SizePosition(unsigned int p_size = 0, unsigned int p_position = 0) noexcept :
+				size(p_size), position(p_position) {}
+	};
+
 protected:
-	Vector<int32_t> input_buffer;
-	unsigned int input_position = 0;
-	unsigned int input_size = 0;
+	LocalVector<int32_t> input_buffer;
+	std::atomic<SizePosition> input_read;
+	SizePosition input_write;
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
+
 	void input_buffer_init(int driver_buffer_frames);
 	void input_buffer_write(int32_t sample);
+	void input_buffer_end_write();
 
 	int _get_configured_mix_rate();
 
@@ -120,9 +131,8 @@ public:
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
 
-	Vector<int32_t> get_input_buffer() { return input_buffer; }
-	unsigned int get_input_position() { return input_position; }
-	unsigned int get_input_size() { return input_size; }
+	const LocalVector<int32_t> &get_input_buffer() { return input_buffer; }
+	SizePosition get_input_size_position() { return input_read; }
 
 #ifdef DEBUG_ENABLED
 	uint64_t get_profiling_time() const { return prof_time.get(); }


### PR DESCRIPTION
* Fixes: #86428.
* Supersedes and takes parts from #92969 (IMO using locks was never a good solution).

Tested using this project: [AudioTest.zip](https://github.com/user-attachments/files/15766103/AudioTest.zip).

- Why only `AudioDriverOpenSL`?
  - Changes in the code here don't actually change the logic for `AudioDriverOpenSL` that much, just make it more thread-safe. For other drivers there needs to be much more testing.
- Why should `AudioStreamPlaybackMicrophone::_mix_internal` be able to run at the same time as the input callback?
  - For speed, audio callbacks should run as fast as possible, locking and waiting for the input callback to finish can take some time.
- What if `AudioStreamPlaybackMicrophone::_mix_internal` reads data that is being changed by the input callback?
  - The size of the input buffer or `playback_delay` (here: https://github.com/godotengine/godot/blob/ac95e0f4ff45dcb6f4709edda2c65ff8524c6f7a/servers/audio/audio_stream.cpp#L330) should be increased. Locking wouldn't solve this issue, as currently the position where we read from and the position where we write to are stored separately.