### PR TITLE
Fix mismatched external parser with binary exports

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -771,8 +771,16 @@ Error GDScript::reload(bool p_keep_state) {
 			if (GDScriptCache::has_parser(source_path)) {
 				Error err = OK;
 				Ref<GDScriptParserRef> parser_ref = GDScriptCache::get_parser(source_path, GDScriptParserRef::EMPTY, err);
-				if (parser_ref.is_valid() && parser_ref->get_source_hash() != source.hash()) {
-					GDScriptCache::remove_parser(source_path);
+				if (parser_ref.is_valid()) {
+					uint32_t source_hash;
+					if (!binary_tokens.is_empty()) {
+						source_hash = hash_djb2_buffer(binary_tokens.ptr(), binary_tokens.size());
+					} else {
+						source_hash = source.hash();
+					}
+					if (parser_ref->get_source_hash() != source_hash) {
+						GDScriptCache::remove_parser(source_path);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* Fixes #92021
* Fixes #93102
* Fixes #92233
* Fixes #92337

The problem was caused by the `reload` method that was recreating a new parser for a base class even if the source was the same. The hash used was not based on the binary tokens but always on the text source. That’s why the problem was only on binary exports.

I adjusted to calculate the hash on binary tokens when present. I was wondering if we should skip this hash calculation and this check for binary exports since it’s probably not possible to change the binary at runtime?

Having 2 instances of the same parser/class was causing problem in `has_class` because the comparison is done on pointers only.

Example of the problem:
![image](https://github.com/godotengine/godot/assets/81109165/a42f9a3a-01b0-4dab-8ead-6ee390dd553a)

To reproduce the problem, I used the MRP from #92021 (https://github.com/godotengine/godot/files/15337905/reprobug.zip)
I exported the pck.
And I ran godot in debug with --main-pack test.pck

There is the test.pck I used if you want to test it without having to reexport the project:
[test.pck.zip](https://github.com/user-attachments/files/15840288/test.pck.zip)
