### PR TITLE
Update signal connections in `CanvasLayer::set_custom_viewport`

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -225,6 +225,7 @@ RID CanvasLayer::get_viewport() const {
 void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 	ERR_FAIL_NULL_MSG(p_viewport, "Cannot set viewport to nullptr.");
 	if (is_inside_tree()) {
+		get_parent()->disconnect(SNAME("child_order_changed"), callable_mp(vp, &Viewport::canvas_parent_mark_dirty).bind(get_parent()));
 		vp->_canvas_layer_remove(this);
 		RenderingServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
 		viewport = RID();
@@ -251,6 +252,8 @@ void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 		RenderingServer::get_singleton()->viewport_attach_canvas(viewport, canvas);
 		RenderingServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_index());
 		RenderingServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas, transform);
+
+		get_parent()->connect(SNAME("child_order_changed"), callable_mp(vp, &Viewport::canvas_parent_mark_dirty).bind(get_parent()), CONNECT_REFERENCE_COUNTED);
 	}
 }
 


### PR DESCRIPTION
`CanvasLayer` connects/disconnects the "child_order_changed" signal from its parent to its viewport when entering/exiting the tree.  This signal wasn't being updated when changing the viewport in `set_custom_viewport`, causing errors when trying to disconnect a different viewport.  This change updates the signal connections when changing the viewport.

Fixes the disconnect error in #90141

Note: the linked issue also mentions some Vulkan errors, which only appear in the larger project but not the MRP.  This seems separate from the signal disconnect error.  It looks like the Vulkan code has changed a lot since then (I don't see those error messages in the code, or even the .cpp file that had them), so that part might already be fixed, maybe related to https://github.com/godotengine/godot/issues/71929.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
