### PR TITLE
NavigationPolygon: Implement `get`/`set_polygon` fast paths.

### DIFF
--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -39,10 +39,7 @@ class NavigationPolygon : public Resource {
 	RWLock rwlock;
 
 	Vector<Vector2> vertices;
-	struct Polygon {
-		Vector<int> indices;
-	};
-	Vector<Polygon> polygons;
+	Vector<Vector<int>> polygons;
 	Vector<Vector<Vector2>> outlines;
 	Vector<Vector<Vector2>> baked_outlines;
 
@@ -109,6 +106,8 @@ public:
 	Vector<Vector2> get_outline(int p_idx) const;
 	void remove_outline(int p_idx);
 	int get_outline_count() const;
+	void set_outlines(const Vector<Vector<Vector2>> &p_outlines);
+	Vector<Vector<Vector2>> get_outlines() const;
 
 	void clear_outlines();
 #ifndef DISABLE_DEPRECATED
@@ -116,7 +115,7 @@ public:
 #endif // DISABLE_DEPRECATED
 
 	void set_polygons(const Vector<Vector<int>> &p_polygons);
-	const Vector<Vector<int>> &get_polygons() const;
+	Vector<Vector<int>> get_polygons() const;
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
 
@@ -155,7 +154,9 @@ public:
 	void clear();
 
 	void set_data(const Vector<Vector2> &p_vertices, const Vector<Vector<int>> &p_polygons);
+	void set_data(const Vector<Vector2> &p_vertices, const Vector<Vector<int>> &p_polygons, const Vector<Vector<Vector2>> &p_outlines);
 	void get_data(Vector<Vector2> &r_vertices, Vector<Vector<int>> &r_polygons);
+	void get_data(Vector<Vector2> &r_vertices, Vector<Vector<int>> &r_polygons, Vector<Vector<Vector2>> &r_outlines);
 
 	NavigationPolygon() {}
 	~NavigationPolygon() {}

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6502,17 +6502,18 @@ Ref<NavigationPolygon> TileData::get_navigation_polygon(int p_layer_id, bool p_f
 		transformed_polygon.instantiate();
 
 		PackedVector2Array new_points = get_transformed_vertices(layer_tile_data.navigation_polygon->get_vertices(), p_flip_h, p_flip_v, p_transpose);
-		transformed_polygon->set_vertices(new_points);
 
-		int num_polygons = layer_tile_data.navigation_polygon->get_polygon_count();
-		for (int i = 0; i < num_polygons; ++i) {
-			transformed_polygon->add_polygon(layer_tile_data.navigation_polygon->get_polygon(i));
+		const Vector<Vector<Vector2>> outlines = layer_tile_data.navigation_polygon->get_outlines();
+		int outline_count = outlines.size();
+
+		Vector<Vector<Vector2>> new_outlines;
+		new_outlines.resize(outline_count);
+
+		for (int i = 0; i < outline_count; i++) {
+			new_outlines.write[i] = get_transformed_vertices(outlines[i], p_flip_h, p_flip_v, p_transpose);
 		}
 
-		for (int i = 0; i < layer_tile_data.navigation_polygon->get_outline_count(); i++) {
-			PackedVector2Array new_outline = get_transformed_vertices(layer_tile_data.navigation_polygon->get_outline(i), p_flip_h, p_flip_v, p_transpose);
-			transformed_polygon->add_outline(new_outline);
-		}
+		transformed_polygon->set_data(new_points, layer_tile_data.navigation_polygon->get_polygons(), new_outlines);
 
 		layer_tile_data.transformed_navigation_polygon[key] = transformed_polygon;
 		return transformed_polygon;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1108,9 +1108,12 @@ Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 	}
 
 	HashMap<Vector3, int> unique_vertices;
-	LocalVector<int> face_indices;
+	Vector<Vector<int>> face_polygons;
+	face_polygons.resize(faces.size());
 
 	for (int i = 0; i < faces.size(); i++) {
+		Vector<int> face_indices;
+		face_indices.resize(3);
 		for (int j = 0; j < 3; j++) {
 			Vector3 v = faces[i].vertex[j];
 			int idx;
@@ -1120,8 +1123,9 @@ Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 				idx = unique_vertices.size();
 				unique_vertices[v] = idx;
 			}
-			face_indices.push_back(idx);
+			face_indices.write[j] = idx;
 		}
+		face_polygons.write[i] = face_indices;
 	}
 
 	Vector<Vector3> vertices;
@@ -1132,16 +1136,7 @@ Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 
 	Ref<NavigationMesh> nm;
 	nm.instantiate();
-	nm->set_vertices(vertices);
-
-	Vector<int> v3;
-	v3.resize(3);
-	for (uint32_t i = 0; i < face_indices.size(); i += 3) {
-		v3.write[0] = face_indices[i + 0];
-		v3.write[1] = face_indices[i + 1];
-		v3.write[2] = face_indices[i + 2];
-		nm->add_polygon(v3);
-	}
+	nm->set_data(vertices, face_polygons);
 
 	return nm;
 }

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -61,12 +61,12 @@ void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 		int rlen = iarr.size();
 		const int *r = iarr.ptr();
 
+		Vector<int> polygon;
 		for (int j = 0; j < rlen; j += 3) {
-			Polygon polygon;
-			polygon.indices.resize(3);
-			polygon.indices.write[0] = r[j + 0] + from;
-			polygon.indices.write[1] = r[j + 1] + from;
-			polygon.indices.write[2] = r[j + 2] + from;
+			polygon.resize(3);
+			polygon.write[0] = r[j + 0] + from;
+			polygon.write[1] = r[j + 1] + from;
+			polygon.write[2] = r[j + 2] + from;
 			polygons.push_back(polygon);
 		}
 	}
@@ -318,7 +318,7 @@ void NavigationMesh::_set_polygons(const Array &p_array) {
 	RWLockWrite write_lock(rwlock);
 	polygons.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
-		polygons.write[i].indices = p_array[i];
+		polygons.write[i] = p_array[i];
 	}
 	notify_property_list_changed();
 }
@@ -328,17 +328,26 @@ Array NavigationMesh::_get_polygons() const {
 	Array ret;
 	ret.resize(polygons.size());
 	for (int i = 0; i < ret.size(); i++) {
-		ret[i] = polygons[i].indices;
+		ret[i] = polygons[i];
 	}
 
 	return ret;
 }
 
+void NavigationMesh::set_polygons(const Vector<Vector<int>> &p_polygons) {
+	RWLockWrite write_lock(rwlock);
+	polygons = p_polygons;
+	notify_property_list_changed();
+}
+
+Vector<Vector<int>> NavigationMesh::get_polygons() const {
+	RWLockRead read_lock(rwlock);
+	return polygons;
+}
+
 void NavigationMesh::add_polygon(const Vector<int> &p_polygon) {
 	RWLockWrite write_lock(rwlock);
-	Polygon polygon;
-	polygon.indices = p_polygon;
-	polygons.push_back(polygon);
+	polygons.push_back(p_polygon);
 	notify_property_list_changed();
 }
 
@@ -350,7 +359,7 @@ int NavigationMesh::get_polygon_count() const {
 Vector<int> NavigationMesh::get_polygon(int p_idx) {
 	RWLockRead read_lock(rwlock);
 	ERR_FAIL_INDEX_V(p_idx, polygons.size(), Vector<int>());
-	return polygons[p_idx].indices;
+	return polygons[p_idx];
 }
 
 void NavigationMesh::clear_polygons() {
@@ -367,19 +376,13 @@ void NavigationMesh::clear() {
 void NavigationMesh::set_data(const Vector<Vector3> &p_vertices, const Vector<Vector<int>> &p_polygons) {
 	RWLockWrite write_lock(rwlock);
 	vertices = p_vertices;
-	polygons.resize(p_polygons.size());
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.write[i].indices = p_polygons[i];
-	}
+	polygons = p_polygons;
 }
 
 void NavigationMesh::get_data(Vector<Vector3> &r_vertices, Vector<Vector<int>> &r_polygons) {
 	RWLockRead read_lock(rwlock);
 	r_vertices = vertices;
-	r_polygons.resize(polygons.size());
-	for (int i = 0; i < polygons.size(); i++) {
-		r_polygons.write[i] = polygons[i].indices;
-	}
+	r_polygons = polygons;
 }
 
 #ifdef DEBUG_ENABLED

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -39,10 +39,7 @@ class NavigationMesh : public Resource {
 	RWLock rwlock;
 
 	Vector<Vector3> vertices;
-	struct Polygon {
-		Vector<int> indices;
-	};
-	Vector<Polygon> polygons;
+	Vector<Vector<int>> polygons;
 	Ref<ArrayMesh> debug_mesh;
 
 protected:
@@ -194,6 +191,8 @@ public:
 	int get_polygon_count() const;
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
+	void set_polygons(const Vector<Vector<int>> &p_polygons);
+	Vector<Vector<int>> get_polygons() const;
 
 	void clear();
 


### PR DESCRIPTION
Follow up to PR #92955. This PR implements the changes outlined in https://github.com/godotengine/godot/pull/92955#discussion_r1635665360. 

As a first step, it implements fast-path `get/set_polygons` and `get/set_outlines` functions, updating `NavMeshGenerator2D` accordingly. Implemented `get/set_polygons` for `NavigationMesh` as well, replacing `add_polygon` whenever a direct update was preferable.