### PR TITLE
Fix ReflectionProbe Cull Mask not working on Mobile rendering method

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1257,6 +1257,11 @@ void main() {
 				break;
 			}
 
+			if (!bool(reflections.data[reflection_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
+				// Not masked; don't render the reflection on this instance.
+				continue;
+			}
+
 			reflection_process(reflection_index, vertex, ref_vec, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
 		}
 


### PR DESCRIPTION
I've also tested [Reflection Mask](https://github.com/godotengine/godot/pull/86073) on all rendering methods and can confirm it still works as intended with this fix.

- This closes https://github.com/godotengine/godot/issues/93173.

**Testing project:** [gd4MRP-MobileReflectionProbeMasks.zip](https://github.com/user-attachments/files/15842498/gd4MRP-MobileReflectionProbeMasks.zip)

## Preview

Before | After
-|-
![image](https://github.com/godotengine/godot/assets/180032/b1c66cd0-7acb-41a7-8c59-6c0e55338017) | ![image](https://github.com/godotengine/godot/assets/180032/530051eb-4181-462e-8d75-021b3dbd4ddf)