### PR TITLE
[Crypto] Expose `get_system_ca_certificates`.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -194,6 +194,10 @@ void ResourceSaver::_bind_methods() {
 
 ////// OS //////
 
+String OS::get_system_ca_certificates() {
+	return ::OS::get_singleton()->get_system_ca_certificates();
+}
+
 PackedStringArray OS::get_connected_midi_inputs() {
 	return ::OS::get_singleton()->get_connected_midi_inputs();
 }
@@ -573,6 +577,7 @@ String OS::get_unique_id() const {
 OS *OS::singleton = nullptr;
 
 void OS::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_system_ca_certificates"), &OS::get_system_ca_certificates);
 	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &OS::get_connected_midi_inputs);
 	ClassDB::bind_method(D_METHOD("open_midi_inputs"), &OS::open_midi_inputs);
 	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &OS::close_midi_inputs);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -134,6 +134,8 @@ public:
 		RENDERING_DRIVER_D3D12,
 	};
 
+	String get_system_ca_certificates();
+
 	virtual PackedStringArray get_connected_midi_inputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -455,6 +455,12 @@
 				Returns the amount of static memory being used by the program in bytes. Only works in debug builds.
 			</description>
 		</method>
+		<method name="get_system_ca_certificates">
+			<return type="String" />
+			<description>
+				Returns the list of certification authorities trusted by the operating system as a string of concatenated certificates in PEM format.
+			</description>
+		</method>
 		<method name="get_system_dir" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="dir" type="int" enum="OS.SystemDir" />


### PR DESCRIPTION
So that custom TLS and HTTP clients can use the Godot OS API to read the system certificates.