### PR TITLE
[Core] Add `non_empty` to complement `is_empty`

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -116,7 +116,7 @@ struct LocalDebugger::ScriptsProfiler {
 void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
 
-	if (!target_function.is_empty()) {
+	if (target_function.non_empty()) {
 		String current_function = script_lang->debug_get_stack_level_function(0);
 		if (current_function != target_function) {
 			script_debugger->set_depth(0);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -118,7 +118,7 @@ void RemoteDebugger::_err_handler(void *p_this, const char *p_func, const char *
 
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		si = ScriptServer::get_language(i)->debug_get_current_stack_info();
-		if (si.size()) {
+		if (si.non_empty()) {
 			break;
 		}
 	}
@@ -201,14 +201,14 @@ void RemoteDebugger::flush_output() {
 		}
 	}
 
-	if (output_strings.size()) {
+	if (output_strings.non_empty()) {
 		// Join output strings so we generate less messages.
 		Vector<String> joined_log_strings;
 		Vector<String> strings;
 		Vector<int> types;
 		for (const OutputString &output_string : output_strings) {
 			if (output_string.type == MESSAGE_TYPE_ERROR) {
-				if (!joined_log_strings.is_empty()) {
+				if (joined_log_strings.non_empty()) {
 					strings.push_back(String("\n").join(joined_log_strings));
 					types.push_back(MESSAGE_TYPE_LOG);
 					joined_log_strings.clear();
@@ -216,7 +216,7 @@ void RemoteDebugger::flush_output() {
 				strings.push_back(output_string.message);
 				types.push_back(MESSAGE_TYPE_ERROR);
 			} else if (output_string.type == MESSAGE_TYPE_LOG_RICH) {
-				if (!joined_log_strings.is_empty()) {
+				if (joined_log_strings.non_empty()) {
 					strings.push_back(String("\n").join(joined_log_strings));
 					types.push_back(MESSAGE_TYPE_LOG_RICH);
 					joined_log_strings.clear();
@@ -228,7 +228,7 @@ void RemoteDebugger::flush_output() {
 			}
 		}
 
-		if (!joined_log_strings.is_empty()) {
+		if (joined_log_strings.non_empty()) {
 			strings.push_back(String("\n").join(joined_log_strings));
 			types.push_back(MESSAGE_TYPE_LOG);
 		}
@@ -240,7 +240,7 @@ void RemoteDebugger::flush_output() {
 		output_strings.clear();
 	}
 
-	while (errors.size()) {
+	while (errors.non_empty()) {
 		ErrorMessage oe = errors.front()->get();
 		_put_msg("error", oe.serialize());
 		errors.pop_front();
@@ -375,7 +375,7 @@ void RemoteDebugger::_poll_messages() {
 
 bool RemoteDebugger::_has_messages() {
 	MutexLock mutex_lock(mutex);
-	return messages.has(Thread::get_caller_id()) && !messages[Thread::get_caller_id()].is_empty();
+	return messages.has(Thread::get_caller_id()) && messages[Thread::get_caller_id()].non_empty();
 }
 
 Array RemoteDebugger::_get_message() {
@@ -596,7 +596,7 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 				ScriptServer::get_language(i)->reload_all_scripts();
 			}
 			reload_all_scripts = false;
-		} else if (!script_paths_to_reload.is_empty()) {
+		} else if (script_paths_to_reload.non_empty()) {
 			Array scripts_to_reload;
 			for (int i = 0; i < script_paths_to_reload.size(); ++i) {
 				String path = script_paths_to_reload[i];

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -39,7 +39,7 @@ bool RemoteDebuggerPeerTCP::is_peer_connected() {
 }
 
 bool RemoteDebuggerPeerTCP::has_message() {
-	return in_queue.size() > 0;
+	return in_queue.non_empty();
 }
 
 Array RemoteDebuggerPeerTCP::get_message() {

--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -130,21 +130,21 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 	}
 
 	if (p_methodinfo.flags & METHOD_FLAG_CONST) {
-		if (!p_method.qualifiers.is_empty()) {
+		if (p_method.qualifiers.non_empty()) {
 			p_method.qualifiers += " ";
 		}
 		p_method.qualifiers += "const";
 	}
 
 	if (p_methodinfo.flags & METHOD_FLAG_VARARG) {
-		if (!p_method.qualifiers.is_empty()) {
+		if (p_method.qualifiers.non_empty()) {
 			p_method.qualifiers += " ";
 		}
 		p_method.qualifiers += "vararg";
 	}
 
 	if (p_methodinfo.flags & METHOD_FLAG_STATIC) {
-		if (!p_method.qualifiers.is_empty()) {
+		if (p_method.qualifiers.non_empty()) {
 			p_method.qualifiers += " ";
 		}
 		p_method.qualifiers += "static";

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -85,20 +85,20 @@ public:
 		static Dictionary to_dict(const ArgumentDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.type.is_empty()) {
+			if (p_doc.type.non_empty()) {
 				dict["type"] = p_doc.type;
 			}
 
-			if (!p_doc.enumeration.is_empty()) {
+			if (p_doc.enumeration.non_empty()) {
 				dict["enumeration"] = p_doc.enumeration;
 				dict["is_bitfield"] = p_doc.is_bitfield;
 			}
 
-			if (!p_doc.default_value.is_empty()) {
+			if (p_doc.default_value.non_empty()) {
 				dict["default_value"] = p_doc.default_value;
 			}
 
@@ -219,24 +219,24 @@ public:
 		static Dictionary to_dict(const MethodDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.return_type.is_empty()) {
+			if (p_doc.return_type.non_empty()) {
 				dict["return_type"] = p_doc.return_type;
 			}
 
-			if (!p_doc.return_enum.is_empty()) {
+			if (p_doc.return_enum.non_empty()) {
 				dict["return_enum"] = p_doc.return_enum;
 				dict["return_is_bitfield"] = p_doc.return_is_bitfield;
 			}
 
-			if (!p_doc.qualifiers.is_empty()) {
+			if (p_doc.qualifiers.non_empty()) {
 				dict["qualifiers"] = p_doc.qualifiers;
 			}
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
@@ -248,11 +248,11 @@ public:
 				dict["experimental"] = p_doc.experimental_message;
 			}
 
-			if (!p_doc.keywords.is_empty()) {
+			if (p_doc.keywords.non_empty()) {
 				dict["keywords"] = p_doc.keywords;
 			}
 
-			if (!p_doc.arguments.is_empty()) {
+			if (p_doc.arguments.non_empty()) {
 				Array arguments;
 				for (int i = 0; i < p_doc.arguments.size(); i++) {
 					arguments.push_back(ArgumentDoc::to_dict(p_doc.arguments[i]));
@@ -260,7 +260,7 @@ public:
 				dict["arguments"] = arguments;
 			}
 
-			if (!p_doc.errors_returned.is_empty()) {
+			if (p_doc.errors_returned.non_empty()) {
 				Array errors_returned;
 				for (int i = 0; i < p_doc.errors_returned.size(); i++) {
 					errors_returned.push_back(p_doc.errors_returned[i]);
@@ -342,22 +342,22 @@ public:
 		static Dictionary to_dict(const ConstantDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.value.is_empty()) {
+			if (p_doc.value.non_empty()) {
 				dict["value"] = p_doc.value;
 			}
 
 			dict["is_value_valid"] = p_doc.is_value_valid;
 
-			if (!p_doc.enumeration.is_empty()) {
+			if (p_doc.enumeration.non_empty()) {
 				dict["enumeration"] = p_doc.enumeration;
 				dict["is_bitfield"] = p_doc.is_bitfield;
 			}
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
@@ -369,7 +369,7 @@ public:
 				dict["experimental"] = p_doc.experimental_message;
 			}
 
-			if (!p_doc.keywords.is_empty()) {
+			if (p_doc.keywords.non_empty()) {
 				dict["keywords"] = p_doc.keywords;
 			}
 
@@ -466,38 +466,38 @@ public:
 		static Dictionary to_dict(const PropertyDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.type.is_empty()) {
+			if (p_doc.type.non_empty()) {
 				dict["type"] = p_doc.type;
 			}
 
-			if (!p_doc.enumeration.is_empty()) {
+			if (p_doc.enumeration.non_empty()) {
 				dict["enumeration"] = p_doc.enumeration;
 				dict["is_bitfield"] = p_doc.is_bitfield;
 			}
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
-			if (!p_doc.setter.is_empty()) {
+			if (p_doc.setter.non_empty()) {
 				dict["setter"] = p_doc.setter;
 			}
 
-			if (!p_doc.getter.is_empty()) {
+			if (p_doc.getter.non_empty()) {
 				dict["getter"] = p_doc.getter;
 			}
 
-			if (!p_doc.default_value.is_empty()) {
+			if (p_doc.default_value.non_empty()) {
 				dict["default_value"] = p_doc.default_value;
 			}
 
 			dict["overridden"] = p_doc.overridden;
 
-			if (!p_doc.overrides.is_empty()) {
+			if (p_doc.overrides.non_empty()) {
 				dict["overrides"] = p_doc.overrides;
 			}
 
@@ -509,7 +509,7 @@ public:
 				dict["experimental"] = p_doc.experimental_message;
 			}
 
-			if (!p_doc.keywords.is_empty()) {
+			if (p_doc.keywords.non_empty()) {
 				dict["keywords"] = p_doc.keywords;
 			}
 
@@ -563,27 +563,27 @@ public:
 		static Dictionary to_dict(const ThemeItemDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.type.is_empty()) {
+			if (p_doc.type.non_empty()) {
 				dict["type"] = p_doc.type;
 			}
 
-			if (!p_doc.data_type.is_empty()) {
+			if (p_doc.data_type.non_empty()) {
 				dict["data_type"] = p_doc.data_type;
 			}
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
-			if (!p_doc.default_value.is_empty()) {
+			if (p_doc.default_value.non_empty()) {
 				dict["default_value"] = p_doc.default_value;
 			}
 
-			if (!p_doc.keywords.is_empty()) {
+			if (p_doc.keywords.non_empty()) {
 				dict["keywords"] = p_doc.keywords;
 			}
 
@@ -610,11 +610,11 @@ public:
 		static Dictionary to_dict(const TutorialDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.link.is_empty()) {
+			if (p_doc.link.non_empty()) {
 				dict["link"] = p_doc.link;
 			}
 
-			if (!p_doc.title.is_empty()) {
+			if (p_doc.title.non_empty()) {
 				dict["title"] = p_doc.title;
 			}
 
@@ -660,7 +660,7 @@ public:
 		static Dictionary to_dict(const EnumDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
@@ -837,23 +837,23 @@ public:
 		static Dictionary to_dict(const ClassDoc &p_doc) {
 			Dictionary dict;
 
-			if (!p_doc.name.is_empty()) {
+			if (p_doc.name.non_empty()) {
 				dict["name"] = p_doc.name;
 			}
 
-			if (!p_doc.inherits.is_empty()) {
+			if (p_doc.inherits.non_empty()) {
 				dict["inherits"] = p_doc.inherits;
 			}
 
-			if (!p_doc.brief_description.is_empty()) {
+			if (p_doc.brief_description.non_empty()) {
 				dict["brief_description"] = p_doc.brief_description;
 			}
 
-			if (!p_doc.description.is_empty()) {
+			if (p_doc.description.non_empty()) {
 				dict["description"] = p_doc.description;
 			}
 
-			if (!p_doc.tutorials.is_empty()) {
+			if (p_doc.tutorials.non_empty()) {
 				Array tutorials;
 				for (int i = 0; i < p_doc.tutorials.size(); i++) {
 					tutorials.push_back(TutorialDoc::to_dict(p_doc.tutorials[i]));
@@ -861,7 +861,7 @@ public:
 				dict["tutorials"] = tutorials;
 			}
 
-			if (!p_doc.constructors.is_empty()) {
+			if (p_doc.constructors.non_empty()) {
 				Array constructors;
 				for (int i = 0; i < p_doc.constructors.size(); i++) {
 					constructors.push_back(MethodDoc::to_dict(p_doc.constructors[i]));
@@ -869,7 +869,7 @@ public:
 				dict["constructors"] = constructors;
 			}
 
-			if (!p_doc.methods.is_empty()) {
+			if (p_doc.methods.non_empty()) {
 				Array methods;
 				for (int i = 0; i < p_doc.methods.size(); i++) {
 					methods.push_back(MethodDoc::to_dict(p_doc.methods[i]));
@@ -877,7 +877,7 @@ public:
 				dict["methods"] = methods;
 			}
 
-			if (!p_doc.operators.is_empty()) {
+			if (p_doc.operators.non_empty()) {
 				Array operators;
 				for (int i = 0; i < p_doc.operators.size(); i++) {
 					operators.push_back(MethodDoc::to_dict(p_doc.operators[i]));
@@ -885,7 +885,7 @@ public:
 				dict["operators"] = operators;
 			}
 
-			if (!p_doc.signals.is_empty()) {
+			if (p_doc.signals.non_empty()) {
 				Array signals;
 				for (int i = 0; i < p_doc.signals.size(); i++) {
 					signals.push_back(MethodDoc::to_dict(p_doc.signals[i]));
@@ -893,7 +893,7 @@ public:
 				dict["signals"] = signals;
 			}
 
-			if (!p_doc.constants.is_empty()) {
+			if (p_doc.constants.non_empty()) {
 				Array constants;
 				for (int i = 0; i < p_doc.constants.size(); i++) {
 					constants.push_back(ConstantDoc::to_dict(p_doc.constants[i]));
@@ -901,7 +901,7 @@ public:
 				dict["constants"] = constants;
 			}
 
-			if (!p_doc.enums.is_empty()) {
+			if (p_doc.enums.non_empty()) {
 				Dictionary enums;
 				for (const KeyValue<String, EnumDoc> &E : p_doc.enums) {
 					enums[E.key] = EnumDoc::to_dict(E.value);
@@ -909,7 +909,7 @@ public:
 				dict["enums"] = enums;
 			}
 
-			if (!p_doc.properties.is_empty()) {
+			if (p_doc.properties.non_empty()) {
 				Array properties;
 				for (int i = 0; i < p_doc.properties.size(); i++) {
 					properties.push_back(PropertyDoc::to_dict(p_doc.properties[i]));
@@ -917,7 +917,7 @@ public:
 				dict["properties"] = properties;
 			}
 
-			if (!p_doc.annotations.is_empty()) {
+			if (p_doc.annotations.non_empty()) {
 				Array annotations;
 				for (int i = 0; i < p_doc.annotations.size(); i++) {
 					annotations.push_back(MethodDoc::to_dict(p_doc.annotations[i]));
@@ -925,7 +925,7 @@ public:
 				dict["annotations"] = annotations;
 			}
 
-			if (!p_doc.theme_properties.is_empty()) {
+			if (p_doc.theme_properties.non_empty()) {
 				Array theme_properties;
 				for (int i = 0; i < p_doc.theme_properties.size(); i++) {
 					theme_properties.push_back(ThemeItemDoc::to_dict(p_doc.theme_properties[i]));
@@ -943,11 +943,11 @@ public:
 
 			dict["is_script_doc"] = p_doc.is_script_doc;
 
-			if (!p_doc.script_path.is_empty()) {
+			if (p_doc.script_path.non_empty()) {
 				dict["script_path"] = p_doc.script_path;
 			}
 
-			if (!p_doc.keywords.is_empty()) {
+			if (p_doc.keywords.non_empty()) {
 				dict["keywords"] = p_doc.keywords;
 			}
 

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -493,7 +493,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			String enum_name = CoreConstants::get_global_constant_enum(i);
 			String name = CoreConstants::get_global_constant_name(i);
 			bool bitfield = CoreConstants::is_global_constant_bitfield(i);
-			if (!enum_name.is_empty()) {
+			if (enum_name.non_empty()) {
 				enum_list[enum_name].push_back(Pair<String, int64_t>(name, value));
 				enum_is_bitfield[enum_name] = bitfield;
 			} else {
@@ -591,7 +591,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 				arguments.push_back(arg);
 			}
 
-			if (arguments.size()) {
+			if (arguments.non_empty()) {
 				func["arguments"] = arguments;
 			}
 
@@ -656,7 +656,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					}
 					members.push_back(d2);
 				}
-				if (members.size()) {
+				if (members.non_empty()) {
 					d["members"] = members;
 				}
 			}
@@ -682,7 +682,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					}
 					constants.push_back(d2);
 				}
-				if (constants.size()) {
+				if (constants.non_empty()) {
 					d["constants"] = constants;
 				}
 			}
@@ -723,13 +723,13 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						}
 					}
 
-					if (values.size()) {
+					if (values.non_empty()) {
 						enum_dict["values"] = values;
 					}
 					enums.push_back(enum_dict);
 				}
 
-				if (enums.size()) {
+				if (enums.non_empty()) {
 					d["enums"] = enums;
 				}
 			}
@@ -767,7 +767,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						}
 					}
 				}
-				if (operators.size()) {
+				if (operators.non_empty()) {
 					d["operators"] = operators;
 				}
 			}
@@ -805,7 +805,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						arguments.push_back(d3);
 					}
 
-					if (arguments.size()) {
+					if (arguments.non_empty()) {
 						d2["arguments"] = arguments;
 					}
 
@@ -820,7 +820,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 					methods.push_back(d2);
 				}
-				if (methods.size()) {
+				if (methods.non_empty()) {
 					d["methods"] = methods;
 				}
 			}
@@ -840,7 +840,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						d3["type"] = get_builtin_or_variant_type_name(Variant::get_constructor_argument_type(type, j, k));
 						arguments.push_back(d3);
 					}
-					if (arguments.size()) {
+					if (arguments.non_empty()) {
 						d2["arguments"] = arguments;
 					}
 
@@ -868,7 +868,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					constructors.push_back(d2);
 				}
 
-				if (constructors.size()) {
+				if (constructors.non_empty()) {
 					d["constructors"] = constructors;
 				}
 			}
@@ -950,7 +950,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					constants.push_back(d2);
 				}
 
-				if (constants.size()) {
+				if (constants.non_empty()) {
 					d["constants"] = constants;
 				}
 			}
@@ -996,7 +996,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					enums.push_back(d2);
 				}
 
-				if (enums.size()) {
+				if (enums.non_empty()) {
 					d["enums"] = enums;
 				}
 			}
@@ -1048,7 +1048,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 							arguments.push_back(d3);
 						}
 
-						if (arguments.size()) {
+						if (arguments.non_empty()) {
 							d2["arguments"] = arguments;
 						}
 
@@ -1083,7 +1083,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 						Vector<uint32_t> compat_hashes = ClassDB::get_method_compatibility_hashes(class_name, method_name);
 						Array compatibility;
-						if (compat_hashes.size()) {
+						if (compat_hashes.non_empty()) {
 							for (int i = 0; i < compat_hashes.size(); i++) {
 								compatibility.push_back(compat_hashes[i]);
 							}
@@ -1093,7 +1093,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						GDExtensionCompatHashes::get_legacy_hashes(class_name, method_name, compatibility);
 #endif
 
-						if (compatibility.size() > 0) {
+						if (compatibility.non_empty()) {
 							d2["hash_compatibility"] = compatibility;
 						}
 
@@ -1125,7 +1125,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 							}
 						}
 
-						if (arguments.size()) {
+						if (arguments.non_empty()) {
 							d2["arguments"] = arguments;
 						}
 
@@ -1142,7 +1142,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					}
 				}
 
-				if (methods.size()) {
+				if (methods.non_empty()) {
 					d["methods"] = methods;
 				}
 			}
@@ -1169,7 +1169,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						}
 						arguments.push_back(d3);
 					}
-					if (arguments.size()) {
+					if (arguments.non_empty()) {
 						d2["arguments"] = arguments;
 					}
 
@@ -1185,7 +1185,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					signals.push_back(d2);
 				}
 
-				if (signals.size()) {
+				if (signals.non_empty()) {
 					d["signals"] = signals;
 				}
 			}
@@ -1234,7 +1234,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					properties.push_back(d2);
 				}
 
-				if (properties.size()) {
+				if (properties.non_empty()) {
 					d["properties"] = properties;
 				}
 			}
@@ -1268,7 +1268,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			singletons.push_back(d);
 		}
 
-		if (singletons.size()) {
+		if (singletons.non_empty()) {
 			api_dump["singletons"] = singletons;
 		}
 	}

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -109,7 +109,7 @@ String GDExtension::find_extension_library(const String &p_path, Ref<ConfigFile>
 			}
 		}
 
-		if (!best_library_path.is_empty()) {
+		if (best_library_path.non_empty()) {
 			if (best_library_path.is_relative_path()) {
 				best_library_path = p_path.get_base_dir().path_join(best_library_path);
 			}
@@ -125,7 +125,7 @@ String GDExtension::find_extension_library(const String &p_path, Ref<ConfigFile>
 	if (p_config->has_section_key("configuration", "autodetect_library_prefix")) {
 		autodetect_library_prefix = p_config->get_value("configuration", "autodetect_library_prefix");
 	}
-	if (!autodetect_library_prefix.is_empty()) {
+	if (autodetect_library_prefix.non_empty()) {
 		String autodetect_path = autodetect_library_prefix;
 		if (autodetect_path.is_relative_path()) {
 			autodetect_path = p_path.get_base_dir().path_join(autodetect_path);
@@ -177,7 +177,7 @@ String GDExtension::find_extension_library(const String &p_path, Ref<ConfigFile>
 			file_name = dir->_get_next();
 		}
 
-		if (!best_file.is_empty()) {
+		if (best_file.non_empty()) {
 			String library_path = folder.path_join(best_file);
 			if (r_tags != nullptr) {
 				r_tags->append_array(best_file_tags);
@@ -775,7 +775,7 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 	String abs_path = ProjectSettings::get_singleton()->globalize_path(p_path);
 
 	Vector<String> abs_dependencies_paths;
-	if (p_dependencies != nullptr && !p_dependencies->is_empty()) {
+	if (p_dependencies != nullptr && p_dependencies->non_empty()) {
 		for (const SharedObject &dependency : *p_dependencies) {
 			abs_dependencies_paths.push_back(ProjectSettings::get_singleton()->globalize_path(dependency.path));
 		}

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -229,7 +229,7 @@ void GDExtensionManager::load_extensions() {
 	Ref<FileAccess> f = FileAccess::open(GDExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f.is_valid() && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
-		if (!s.is_empty()) {
+		if (s.non_empty()) {
 			LoadStatus err = load_extension(s);
 			ERR_CONTINUE_MSG(err == LOAD_STATUS_FAILED, "Error loading extension: " + s);
 		}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -252,7 +252,7 @@ Input::VelocityTrack::VelocityTrack() {
 bool Input::is_anything_pressed() const {
 	_THREAD_SAFE_METHOD_
 
-	if (!keys_pressed.is_empty() || !joy_buttons_pressed.is_empty() || !mouse_button_mask.is_empty()) {
+	if (keys_pressed.non_empty() || joy_buttons_pressed.non_empty() || mouse_button_mask.non_empty()) {
 		return true;
 	}
 
@@ -1644,7 +1644,7 @@ Input::Input() {
 
 	// If defined, parse SDL_GAMECONTROLLERCONFIG for possible new mappings/overrides.
 	String env_mapping = OS::get_singleton()->get_environment("SDL_GAMECONTROLLERCONFIG");
-	if (!env_mapping.is_empty()) {
+	if (env_mapping.non_empty()) {
 		Vector<String> entries = env_mapping.split("\n");
 		for (int i = 0; i < entries.size(); i++) {
 			if (entries[i].is_empty()) {
@@ -1655,7 +1655,7 @@ Input::Input() {
 	}
 
 	String env_ignore_devices = OS::get_singleton()->get_environment("SDL_GAMECONTROLLER_IGNORE_DEVICES");
-	if (!env_ignore_devices.is_empty()) {
+	if (env_ignore_devices.non_empty()) {
 		Vector<String> entries = env_ignore_devices.split(",");
 		for (int i = 0; i < entries.size(); i++) {
 			Vector<String> vid_pid = entries[i].split("/");

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -269,7 +269,7 @@ String InputEventWithModifiers::as_text() const {
 		mod_names.push_back(find_keycode_name(Key::META));
 	}
 
-	if (!mod_names.is_empty()) {
+	if (mod_names.non_empty()) {
 		return String("+").join(mod_names);
 	} else {
 		return "";

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -418,7 +418,7 @@ String InputMap::get_builtin_display_name(const String &p_name) const {
 
 const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	// Return cache if it has already been built.
-	if (default_builtin_cache.size()) {
+	if (default_builtin_cache.non_empty()) {
 		return default_builtin_cache;
 	}
 
@@ -781,7 +781,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 }
 
 const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_feature_overrides_applied() {
-	if (default_builtin_with_overrides_cache.size() > 0) {
+	if (default_builtin_with_overrides_cache.non_empty()) {
 		return default_builtin_with_overrides_cache;
 	}
 
@@ -798,7 +798,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 		const String &name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
-		if (!override_for.is_empty() && OS::get_singleton()->has_feature(override_for)) {
+		if (override_for.non_empty() && OS::get_singleton()->has_feature(override_for)) {
 			builtins_with_overrides[name].push_back(override_for);
 		}
 	}
@@ -815,7 +815,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 			continue;
 		}
 
-		if (!override_for.is_empty() && !OS::get_singleton()->has_feature(override_for)) {
+		if (override_for.non_empty() && !OS::get_singleton()->has_feature(override_for)) {
 			// OS does not support this override - skip.
 			continue;
 		}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -140,7 +140,7 @@ String ConfigFile::encode_to_text() const {
 		} else {
 			sb.append("\n");
 		}
-		if (!E.key.is_empty()) {
+		if (E.key.non_empty()) {
 			sb.append("[" + E.key + "]\n\n");
 		}
 
@@ -207,7 +207,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 		} else {
 			file->store_string("\n");
 		}
-		if (!E.key.is_empty()) {
+		if (E.key.non_empty()) {
 			file->store_string("[" + E.key.replace("]", "\\]") + "]\n\n");
 		}
 
@@ -305,9 +305,9 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 			return err;
 		}
 
-		if (!assign.is_empty()) {
+		if (assign.non_empty()) {
 			set_value(section, assign, value);
-		} else if (!next_tag.name.is_empty()) {
+		} else if (next_tag.name.non_empty()) {
 			section = next_tag.name.replace("\\]", "]");
 		}
 	}

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -82,7 +82,7 @@ static Error _erase_recursive(DirAccess *da) {
 
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (!n.is_empty()) {
+	while (n.non_empty()) {
 		if (n != "." && n != "..") {
 			if (da->current_is_dir() && !da->is_link(n)) {
 				dirs.push_back(n);
@@ -194,7 +194,7 @@ String DirAccess::fix_path(const String &p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (p_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (!resource_path.is_empty()) {
+					if (resource_path.non_empty()) {
 						return p_path.replace_first("res:/", resource_path);
 					}
 					return p_path.replace_first("res://", "");
@@ -205,7 +205,7 @@ String DirAccess::fix_path(const String &p_path) const {
 		case ACCESS_USERDATA: {
 			if (p_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (!data_dir.is_empty()) {
+				if (data_dir.non_empty()) {
 					return p_path.replace_first("user:/", data_dir);
 				}
 				return p_path.replace_first("user://", "");
@@ -413,7 +413,7 @@ Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int 
 	String curdir = get_current_dir();
 	list_dir_begin();
 	String n = get_next();
-	while (!n.is_empty()) {
+	while (n.non_empty()) {
 		if (n != "." && n != "..") {
 			if (p_copy_links && is_link(get_current_dir().path_join(n))) {
 				create_link(read_link(get_current_dir().path_join(n)), p_to + n);
@@ -511,7 +511,7 @@ PackedStringArray DirAccess::_get_contents(bool p_directories) {
 
 	list_dir_begin();
 	String s = _get_next();
-	while (!s.is_empty()) {
+	while (s.non_empty()) {
 		if (current_is_dir() == p_directories) {
 			ret.append(s);
 		}
@@ -524,7 +524,7 @@ PackedStringArray DirAccess::_get_contents(bool p_directories) {
 
 String DirAccess::_get_next() {
 	String next = get_next();
-	while (!next.is_empty() && ((!include_navigational && (next == "." || next == "..")) || (!include_hidden && current_is_hidden()))) {
+	while (next.non_empty() && ((!include_navigational && (next == "." || next == "..")) || (!include_hidden && current_is_hidden()))) {
 		next = get_next();
 	}
 	return next;

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -193,7 +193,7 @@ String FileAccess::fix_path(const String &p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (r_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (!resource_path.is_empty()) {
+					if (resource_path.non_empty()) {
 						return r_path.replace("res:/", resource_path);
 					}
 					return r_path.replace("res://", "");
@@ -204,7 +204,7 @@ String FileAccess::fix_path(const String &p_path) const {
 		case ACCESS_USERDATA: {
 			if (r_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (!data_dir.is_empty()) {
+				if (data_dir.non_empty()) {
 					return r_path.replace("user:/", data_dir);
 				}
 				return r_path.replace("user://", "");

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -90,7 +90,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 		}
 		String filename = simplified_path.get_file();
 		// Don't add as a file if the path points to a directory
-		if (!filename.is_empty()) {
+		if (filename.non_empty()) {
 			cd->files.insert(filename);
 		}
 	}
@@ -426,12 +426,12 @@ Error DirAccessPack::list_dir_begin() {
 }
 
 String DirAccessPack::get_next() {
-	if (list_dirs.size()) {
+	if (list_dirs.non_empty()) {
 		cdir = true;
 		String d = list_dirs.front()->get();
 		list_dirs.pop_front();
 		return d;
-	} else if (list_files.size()) {
+	} else if (list_files.non_empty()) {
 		cdir = false;
 		String f = list_files.front()->get();
 		list_files.pop_front();

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -289,7 +289,7 @@ Error HTTPClientTCP::poll() {
 					resolving = IP::RESOLVER_INVALID_ID;
 
 					Error err = ERR_BUG; // Should be at least one entry.
-					while (ip_candidates.size() > 0) {
+					while (ip_candidates.non_empty()) {
 						err = tcp_connection->connect_to_host(ip_candidates.pop_front(), server_port);
 						if (err == OK) {
 							break;
@@ -407,7 +407,7 @@ Error HTTPClientTCP::poll() {
 				case StreamPeerTCP::STATUS_ERROR:
 				case StreamPeerTCP::STATUS_NONE: {
 					Error err = ERR_CANT_CONNECT;
-					while (ip_candidates.size() > 0) {
+					while (ip_candidates.non_empty()) {
 						tcp_connection->disconnect_from_host();
 						err = tcp_connection->connect_to_host(ip_candidates.pop_front(), server_port);
 						if (err == OK) {

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -136,7 +136,7 @@ void ImageLoader::remove_image_format_loader(Ref<ImageFormatLoader> p_loader) {
 }
 
 void ImageLoader::cleanup() {
-	while (loader.size()) {
+	while (loader.non_empty()) {
 		remove_image_format_loader(loader[0]);
 	}
 }

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -97,7 +97,7 @@ struct _IP_ResolverPrivate {
 				continue;
 			}
 			// We might be overriding another result, but we don't care as long as the result is valid.
-			if (response.size()) {
+			if (response.non_empty()) {
 				String key = get_cache_key(hostname, type);
 				cache[key] = response;
 			}
@@ -124,7 +124,7 @@ struct _IP_ResolverPrivate {
 
 IPAddress IP::resolve_hostname(const String &p_hostname, IP::Type p_type) {
 	const PackedStringArray addresses = resolve_hostname_addresses(p_hostname, p_type);
-	return addresses.size() ? (IPAddress)addresses[0] : IPAddress();
+	return addresses.non_empty() ? (IPAddress)addresses[0] : IPAddress();
 }
 
 PackedStringArray IP::resolve_hostname_addresses(const String &p_hostname, Type p_type) {
@@ -141,7 +141,7 @@ PackedStringArray IP::resolve_hostname_addresses(const String &p_hostname, Type 
 		_resolve_hostname(res, p_hostname, p_type);
 		resolver->mutex.lock();
 		// We might be overriding another result, but we don't care as long as the result is valid.
-		if (res.size()) {
+		if (res.non_empty()) {
 			resolver->cache[key] = res;
 		}
 	}

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -56,7 +56,7 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 	String colon = ":";
 	String end_statement = "";
 
-	if (!p_indent.is_empty()) {
+	if (p_indent.non_empty()) {
 		colon += " ";
 		end_statement += "\n";
 	}

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -132,7 +132,7 @@ void RotatedFileLogger::clear_old_backups() {
 	da->list_dir_begin();
 	String f = da->get_next();
 	HashSet<String> backups;
-	while (!f.is_empty()) {
+	while (f.non_empty()) {
 		if (!da->current_is_dir() && f.begins_with(basename) && f.get_extension() == extension && f != base_path.get_file()) {
 			backups.insert(f);
 		}
@@ -157,7 +157,7 @@ void RotatedFileLogger::rotate_file() {
 		if (max_files > 1) {
 			String timestamp = Time::get_singleton()->get_datetime_string_from_system().replace(":", ".");
 			String backup_name = base_path.get_basename() + timestamp;
-			if (!base_path.get_extension().is_empty()) {
+			if (base_path.get_extension().non_empty()) {
 				backup_name += "." + base_path.get_extension();
 			}
 

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -697,7 +697,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 		}
 
 		if (token == "dict") {
-			if (!stack.is_empty()) {
+			if (stack.non_empty()) {
 				// Add subnode end enter it.
 				Ref<PListNode> dict = PListNode::new_dict();
 				dict->data_type = PList::PLNodeType::PL_NODE_TYPE_DICT;
@@ -730,7 +730,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 		}
 
 		if (token == "array") {
-			if (!stack.is_empty()) {
+			if (stack.non_empty()) {
 				// Add subnode end enter it.
 				Ref<PListNode> arr = PListNode::new_array();
 				if (!stack.back()->get()->push_subnode(arr, key)) {
@@ -806,7 +806,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 			}
 		}
 	}
-	if (!stack.is_empty() || !done_plist) {
+	if (stack.non_empty() || !done_plist) {
 		r_err_out = "Unexpected end of data. Root node is not closed.";
 		return false;
 	}

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -213,7 +213,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 
 	// Encode file cache to send it via network.
 	Vector<uint8_t> file_cache_buffer;
-	if (file_cache.size()) {
+	if (file_cache.non_empty()) {
 		StringBuilder sbuild;
 		for (int i = 0; i < file_cache.size(); i++) {
 			sbuild.append(file_cache[i].path);

--- a/core/io/remote_filesystem_client.h
+++ b/core/io/remote_filesystem_client.h
@@ -47,7 +47,7 @@ protected:
 		uint64_t server_modified_time = 0; // MD5 checksum.
 		uint64_t modified_time = 0;
 	};
-	virtual bool _is_configured() { return !cache_path.is_empty(); }
+	virtual bool _is_configured() { return cache_path.non_empty(); }
 	// Can be re-implemented per platform. If so, feel free to ignore get_cache_path()
 	virtual Vector<FileCache> _load_cache_file();
 	virtual Error _store_file(const String &p_path, const LocalVector<uint8_t> &p_file, uint64_t &modified_time);

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -57,7 +57,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 
 	ResourceCache::lock.lock();
 
-	if (!path_cache.is_empty()) {
+	if (path_cache.non_empty()) {
 		ResourceCache::resources.erase(path_cache);
 	}
 
@@ -77,7 +77,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 
 	path_cache = p_path;
 
-	if (!path_cache.is_empty()) {
+	if (path_cache.non_empty()) {
 		ResourceCache::resources[path_cache] = this;
 	}
 	ResourceCache::lock.unlock();
@@ -579,7 +579,7 @@ RWLock ResourceCache::path_cache_lock;
 #endif
 
 void ResourceCache::clear() {
-	if (!resources.is_empty()) {
+	if (resources.non_empty()) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			ERR_PRINT(vformat("%d resources still in use at exit.", resources.size()));
 			for (const KeyValue<String, Resource *> &E : resources) {

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -787,7 +787,7 @@ Error ResourceLoaderBinary::load() {
 			}
 
 			res = Ref<Resource>(r);
-			if (!path.is_empty()) {
+			if (path.non_empty()) {
 				if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 					r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); // If got here because the resource with same path has different type, replace it.
 				} else {
@@ -856,7 +856,7 @@ Error ResourceLoaderBinary::load() {
 			missing_resource->set_recording_properties(false);
 		}
 
-		if (!missing_resource_properties.is_empty()) {
+		if (missing_resource_properties.non_empty()) {
 			res->set_meta(META_MISSING_RESOURCES, missing_resource_properties);
 		}
 
@@ -949,10 +949,10 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 			dep = external_resources[i].path;
 		}
 
-		if (p_add_types && !external_resources[i].type.is_empty()) {
+		if (p_add_types && external_resources[i].type.non_empty()) {
 			dep += "::" + external_resources[i].type;
 		}
-		if (!fallback_path.is_empty()) {
+		if (fallback_path.non_empty()) {
 			if (!p_add_types) {
 				dep += "::"; // Ensure that path comes third, even if there is no type.
 			}
@@ -1222,7 +1222,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 	}
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.progress = r_progress;
-	String path = !p_original_path.is_empty() ? p_original_path : p_path;
+	String path = p_original_path.non_empty() ? p_original_path : p_path;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
 	loader.res_path = loader.local_path;
 	loader.open(f);
@@ -2173,7 +2173,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 			Ref<Script> s = p_resource->get_script();
 			if (s.is_valid()) {
 				script_class = s->get_global_name();
-				if (!script_class.is_empty()) {
+				if (script_class.non_empty()) {
 					format_flags |= ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS;
 				}
 			}
@@ -2183,7 +2183,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	}
 	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
 	f->store_64(uid);
-	if (!script_class.is_empty()) {
+	if (script_class.non_empty()) {
 		save_unicode_string(f, script_class);
 	}
 
@@ -2277,7 +2277,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 	for (Ref<Resource> &r : saved_resources) {
 		if (r->is_built_in()) {
-			if (!r->get_scene_unique_id().is_empty()) {
+			if (r->get_scene_unique_id().non_empty()) {
 				if (used_unique_ids.has(r->get_scene_unique_id())) {
 					r->set_scene_unique_id("");
 				} else {

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -77,7 +77,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 			return err;
 		}
 
-		if (!assign.is_empty()) {
+		if (assign.non_empty()) {
 			if (!path_found && assign.begins_with("path.") && r_path_and_type.path.is_empty()) {
 				String feature = assign.get_slicec('.', 1);
 				if (OS::get_singleton()->has_feature(feature)) {
@@ -110,7 +110,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 	}
 
 #ifdef TOOLS_ENABLED
-	if (r_path_and_type.metadata && !r_path_and_type.path.is_empty()) {
+	if (r_path_and_type.metadata && r_path_and_type.path.non_empty()) {
 		Dictionary meta = r_path_and_type.metadata;
 		if (meta.has("has_editor_variant")) {
 			r_path_and_type.path = r_path_and_type.path.get_basename() + ".editor." + r_path_and_type.path.get_extension();
@@ -304,7 +304,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 			return;
 		}
 
-		if (!assign.is_empty()) {
+		if (assign.non_empty()) {
 			if (assign.begins_with("path.")) {
 				r_paths->push_back(value);
 			} else if (assign == "path") {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -91,7 +91,7 @@ void ResourceFormatLoader::get_classes_used(const String &p_path, HashSet<String
 	}
 
 	String res = get_resource_type(p_path);
-	if (!res.is_empty()) {
+	if (res.non_empty()) {
 		r_classes->insert(res);
 	}
 }
@@ -212,7 +212,7 @@ void ResourceLoader::LoadToken::clear() {
 
 	WorkerThreadPool::TaskID task_to_await = 0;
 
-	if (!local_path.is_empty()) { // Empty is used for the special case where the load task is not registered.
+	if (local_path.non_empty()) { // Empty is used for the special case where the load task is not registered.
 		DEV_ASSERT(thread_load_tasks.has(local_path));
 		ThreadLoadTask &load_task = thread_load_tasks[local_path];
 		if (!load_task.awaited) {
@@ -223,7 +223,7 @@ void ResourceLoader::LoadToken::clear() {
 		local_path.clear();
 	}
 
-	if (!user_path.is_empty()) {
+	if (user_path.non_empty()) {
 		DEV_ASSERT(user_load_tokens.has(user_path));
 		user_load_tokens.erase(user_path);
 		user_path.clear();
@@ -244,7 +244,7 @@ ResourceLoader::LoadToken::~LoadToken() {
 Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_original_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error, bool p_use_sub_threads, float *r_progress) {
 	const String &original_path = p_original_path.is_empty() ? p_path : p_original_path;
 	load_nesting++;
-	if (load_paths_stack->size()) {
+	if (load_paths_stack->non_empty()) {
 		thread_load_mutex.lock();
 		const String &parent_task_path = load_paths_stack->get(load_paths_stack->size() - 1);
 		HashMap<String, ThreadLoadTask>::Iterator E = thread_load_tasks.find(parent_task_path);
@@ -307,7 +307,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	if (load_nesting == 0) {
 		load_paths_stack = memnew(Vector<String>);
 
-		if (!load_task.dependent_path.is_empty()) {
+		if (load_task.dependent_path.non_empty()) {
 			load_paths_stack->push_back(load_task.dependent_path);
 		}
 		if (!Thread::is_main_thread()) {
@@ -635,7 +635,7 @@ Ref<Resource> ResourceLoader::_load_complete_inner(LoadToken &p_load_token, Erro
 		*r_error = OK;
 	}
 
-	if (!p_load_token.local_path.is_empty()) {
+	if (p_load_token.local_path.non_empty()) {
 		if (!thread_load_tasks.has(p_load_token.local_path)) {
 #ifdef DEV_ENABLED
 			CRASH_NOW();
@@ -891,7 +891,7 @@ String ResourceLoader::get_resource_type(const String &p_path) {
 
 	for (int i = 0; i < loader_count; i++) {
 		String result = loader[i]->get_resource_type(local_path);
-		if (!result.is_empty()) {
+		if (result.non_empty()) {
 			return result;
 		}
 	}
@@ -904,7 +904,7 @@ String ResourceLoader::get_resource_script_class(const String &p_path) {
 
 	for (int i = 0; i < loader_count; i++) {
 		String result = loader[i]->get_resource_script_class(local_path);
-		if (!result.is_empty()) {
+		if (result.non_empty()) {
 			return result;
 		}
 	}
@@ -1080,7 +1080,7 @@ void ResourceLoader::clear_thread_load_tasks() {
 
 	while (true) {
 		bool none_running = true;
-		if (thread_load_tasks.size()) {
+		if (thread_load_tasks.non_empty()) {
 			for (KeyValue<String, ResourceLoader::ThreadLoadTask> &E : thread_load_tasks) {
 				if (E.value.status == THREAD_LOAD_IN_PROGRESS) {
 					if (E.value.cond_var) {

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -125,7 +125,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 							str_start = j + 1;
 						}
 					}
-					if (!plural_msg.is_empty()) {
+					if (plural_msg.non_empty()) {
 						translation->add_plural_message(msg_id, plural_msg, msg_context);
 					}
 				}
@@ -181,7 +181,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 
 				// In PO file, "msgctxt" appears before "msgid". If we encounter a "msgctxt", we add what we have read
 				// and set "entered_context" to true to prevent adding twice.
-				if (!skip_this && !msg_id.is_empty()) {
+				if (!skip_this && msg_id.non_empty()) {
 					if (status == STATUS_READING_STRING) {
 						translation->add_message(msg_id, msg_str, msg_context);
 					} else if (status == STATUS_READING_PLURAL) {
@@ -211,7 +211,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 			} else if (l.begins_with("msgid")) {
 				ERR_FAIL_COND_V_MSG(status == STATUS_READING_ID, Ref<Resource>(), "Unexpected 'msgid', was expecting 'msgstr' while parsing: " + path + ":" + itos(line));
 
-				if (!msg_id.is_empty()) {
+				if (msg_id.non_empty()) {
 					if (!skip_this && !entered_context) {
 						if (status == STATUS_READING_STRING) {
 							translation->add_message(msg_id, msg_str, msg_context);
@@ -305,7 +305,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 
 		// Add the last set of data from last iteration.
 		if (status == STATUS_READING_STRING) {
-			if (!msg_id.is_empty()) {
+			if (msg_id.non_empty()) {
 				if (!skip_this) {
 					translation->add_message(msg_id, msg_str, msg_context);
 				}
@@ -313,7 +313,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 				config = msg_str;
 			}
 		} else if (status == STATUS_READING_PLURAL) {
-			if (!skip_this && !msg_id.is_empty()) {
+			if (!skip_this && msg_id.non_empty()) {
 				ERR_FAIL_COND_V_MSG(plural_index != plural_forms - 1, Ref<Resource>(), "Number of 'msgstr[]' doesn't match with number of plural forms: " + path + ":" + itos(line));
 				translation->add_plural_message(msg_id, msgs_plural, msg_context);
 			}

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -135,7 +135,7 @@ bool UDPServer::is_connection_available() const {
 		return false;
 	}
 
-	return pending.size() > 0;
+	return pending.non_empty();
 }
 
 void UDPServer::set_max_pending_connections(int p_max) {

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -338,7 +338,7 @@ bool AStar3D::_solve(Point *begin_point, Point *end_point) {
 	begin_point->abs_f_score = _estimate_cost(begin_point->id, end_point->id);
 	open_list.push_back(begin_point);
 
-	while (!open_list.is_empty()) {
+	while (open_list.non_empty()) {
 		Point *p = open_list[0]; // The currently processed point.
 
 		// Find point closer to end_point, or same distance to end_point but closer to begin_point.
@@ -835,7 +835,7 @@ bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point) {
 	begin_point->abs_f_score = _estimate_cost(begin_point->id, end_point->id);
 	open_list.push_back(begin_point);
 
-	while (!open_list.is_empty()) {
+	while (open_list.non_empty()) {
 		AStar3D::Point *p = open_list[0]; // The currently processed point.
 
 		// Find point closer to end_point, or same distance to end_point but closer to begin_point.

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -466,7 +466,7 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point) {
 	open_list.push_back(p_begin_point);
 	end = p_end_point;
 
-	while (!open_list.is_empty()) {
+	while (open_list.non_empty()) {
 		Point *p = open_list[0]; // The currently processed point.
 
 		// Find point closer to end_point, or same distance to end_point but closer to begin_point.

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -647,7 +647,7 @@ private:
 
 		// remove from pairing list for every partner.
 		// can't easily use a for loop here, because removing changes the size of the list
-		while (p_from.extended_pairs.size()) {
+		while (p_from.extended_pairs.non_empty()) {
 			BVHHandle h_to = p_from.extended_pairs[0].handle;
 			_unpair(p_handle, h_to);
 		}

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -1689,7 +1689,7 @@ real_t ConvexHullInternal::shrink(real_t p_amount, real_t p_clamp_amount) {
 	Int128 hull_center_z(0, 0);
 	Int128 volume(0, 0);
 
-	while (stack.size() > 0) {
+	while (stack.non_empty()) {
 		Vertex *v = stack[stack.size() - 1];
 		stack.remove_at(stack.size() - 1);
 		Edge *e = v->edges;
@@ -2090,7 +2090,7 @@ bool ConvexHullInternal::shift_face(Face *p_face, real_t p_amount, LocalVector<V
 		p_stack.push_back(nullptr);
 	}
 
-	CHULL_ASSERT(p_stack.size() > 0);
+	CHULL_ASSERT(p_stack.non_empty());
 	vertex_list = p_stack[0];
 
 #ifdef DEBUG_CONVEX_HULL

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -213,7 +213,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 	uint32_t debug_stop = debug_stop_after;
 
-	while (debug_stop > 0 && faces.back()->get().points_over.size()) {
+	while (debug_stop > 0 && faces.back()->get().points_over.non_empty()) {
 		debug_stop--;
 		Face &f = faces.back()->get();
 
@@ -313,7 +313,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 		//erase lit faces
 
-		while (lit_faces.size()) {
+		while (lit_faces.non_empty()) {
 			faces.erase(lit_faces.front()->get());
 			lit_faces.pop_front();
 		}

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -107,7 +107,7 @@ void TriangleMesh::get_indices(Vector<int> *r_triangles_indices) const {
 void TriangleMesh::create(const Vector<Vector3> &p_faces, const Vector<int32_t> &p_surface_indices) {
 	valid = false;
 
-	ERR_FAIL_COND(p_surface_indices.size() && p_surface_indices.size() != p_faces.size());
+	ERR_FAIL_COND(p_surface_indices.non_empty() && p_surface_indices.size() != p_faces.size());
 
 	int fc = p_faces.size();
 	ERR_FAIL_COND(!fc || ((fc % 3) != 0));

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -973,7 +973,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 	type->constant_map[p_name] = p_constant;
 
 	String enum_name = p_enum;
-	if (!enum_name.is_empty()) {
+	if (enum_name.non_empty()) {
 		if (enum_name.contains(".")) {
 			enum_name = enum_name.get_slicec('.', 1);
 		}

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -188,7 +188,7 @@ public:
 		set_argument_count(method_info.arguments.size());
 		Variant::Type *at = memnew_arr(Variant::Type, method_info.arguments.size() + 1);
 		at[0] = _gen_return_type_info().type;
-		if (method_info.arguments.size()) {
+		if (method_info.arguments.non_empty()) {
 #ifdef DEBUG_METHODS_ENABLED
 			Vector<StringName> names;
 			names.resize(method_info.arguments.size());

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -452,7 +452,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	set(p_names[0], value_stack.back()->get(), r_valid);
 	value_stack.pop_back();
 
-	ERR_FAIL_COND(!value_stack.is_empty());
+	ERR_FAIL_COND(value_stack.non_empty());
 }
 
 Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) const {
@@ -768,7 +768,7 @@ void Object::setvar(const Variant &p_key, const Variant &p_value, bool *r_valid)
 Variant Object::callv(const StringName &p_method, const Array &p_args) {
 	const Variant **argptrs = nullptr;
 
-	if (p_args.size() > 0) {
+	if (p_args.non_empty()) {
 		argptrs = (const Variant **)alloca(sizeof(Variant *) * p_args.size());
 		for (int i = 0; i < p_args.size(); i++) {
 			argptrs[i] = &p_args[i];
@@ -1340,7 +1340,7 @@ void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 	//find maybe usersignals?
 
 	for (const KeyValue<StringName, SignalData> &E : signal_map) {
-		if (!E.value.user.name.is_empty()) {
+		if (E.value.user.name.non_empty()) {
 			//user signal
 			p_signals->push_back(E.value.user);
 		}
@@ -1554,7 +1554,7 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 
 	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
 		String tr_msg = TranslationServer::get_singleton()->extractable_translate(p_message, p_context);
-		if (!tr_msg.is_empty() && tr_msg != p_message) {
+		if (tr_msg.non_empty() && tr_msg != p_message) {
 			return tr_msg;
 		}
 
@@ -1575,7 +1575,7 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 
 	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
 		String tr_msg = TranslationServer::get_singleton()->extractable_translate_plural(p_message, p_message_plural, p_n, p_context);
-		if (!tr_msg.is_empty() && tr_msg != p_message && tr_msg != p_message_plural) {
+		if (tr_msg.non_empty() && tr_msg != p_message && tr_msg != p_message_plural) {
 			return tr_msg;
 		}
 
@@ -2112,7 +2112,7 @@ Object::~Object() {
 	}
 
 	// Drop all connections to the signals of this object.
-	while (signal_map.size()) {
+	while (signal_map.non_empty()) {
 		// Avoid regular iteration so erasing is safe.
 		KeyValue<StringName, SignalData> &E = *signal_map.begin();
 		SignalData *s = &E.value;
@@ -2128,7 +2128,7 @@ Object::~Object() {
 	}
 
 	// Disconnect signals that connect to this object.
-	while (connections.size()) {
+	while (connections.non_empty()) {
 		Connection c = connections.front()->get();
 		bool disconnected = c.signal.get_object()->_disconnect(c.signal.get_name(), c.callable, true);
 		if (unlikely(!disconnected)) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -736,7 +736,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 		}
 	}
 
-	while (to_remove.size()) {
+	while (to_remove.non_empty()) {
 		values.erase(to_remove.front()->get());
 		to_remove.pop_front();
 	}

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -92,7 +92,7 @@ void UndoRedo::create_action(const String &p_name, MergeMode p_mode, bool p_back
 		_discard_redo();
 
 		// Check if the merge operation is valid
-		if (p_mode != MERGE_DISABLE && actions.size() && actions[actions.size() - 1].name == p_name && actions[actions.size() - 1].backward_undo_ops == p_backward_undo_ops && actions[actions.size() - 1].last_tick + 800 > ticks) {
+		if (p_mode != MERGE_DISABLE && actions.non_empty() && actions[actions.size() - 1].name == p_name && actions[actions.size() - 1].backward_undo_ops == p_backward_undo_ops && actions[actions.size() - 1].last_tick + 800 > ticks) {
 			current_action = actions.size() - 2;
 
 			if (p_mode == MERGE_ENDS) {
@@ -338,7 +338,7 @@ void UndoRedo::commit_action(bool p_execute) {
 		}
 	}
 
-	if (add_message && callback && actions.size() > 0) {
+	if (add_message && callback && actions.non_empty()) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
 }
@@ -457,7 +457,7 @@ void UndoRedo::clear_history(bool p_increase_version) {
 	ERR_FAIL_COND(action_level > 0);
 	_discard_redo();
 
-	while (actions.size()) {
+	while (actions.non_empty()) {
 		_pop_history_tail();
 	}
 

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -644,7 +644,7 @@ void WorkerThreadPool::thread_exit_command_queue_mt_flush() {
 }
 
 void WorkerThreadPool::init(int p_thread_count, float p_low_priority_task_ratio) {
-	ERR_FAIL_COND(threads.size() > 0);
+	ERR_FAIL_COND(threads.non_empty());
 	if (p_thread_count < 0) {
 		p_thread_count = OS::get_singleton()->get_default_thread_pool_size();
 	}

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -662,7 +662,7 @@ void OS::benchmark_dump() {
 		return;
 	}
 
-	if (!benchmark_file.is_empty()) {
+	if (benchmark_file.non_empty()) {
 		Ref<FileAccess> f = FileAccess::open(benchmark_file, FileAccess::WRITE);
 		if (f.is_valid()) {
 			Dictionary benchmark_marks;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -50,7 +50,7 @@ void NodePath::_update_hash_cache() const {
 }
 
 void NodePath::prepend_period() {
-	if (data->path.size() && data->path[0].operator String() != ".") {
+	if (data->path.non_empty() && data->path[0].operator String() != ".") {
 		data->path.insert(0, ".");
 		data->hash_cache_valid = false;
 	}

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -81,6 +81,7 @@ public:
 
 	operator String() const;
 	bool is_empty() const;
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 
 	bool operator==(const NodePath &p_path) const;
 	bool operator!=(const NodePath &p_path) const;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -92,7 +92,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
+	operator const void *() const { return (_data && (_data->cname || _data->name.non_empty())) ? (void *)1 : nullptr; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -290,7 +290,7 @@ void TranslationServer::init_locale_info() {
 	locale_rename_map.clear();
 	idx = 0;
 	while (locale_renames[idx][0] != nullptr) {
-		if (!String(locale_renames[idx][1]).is_empty()) {
+		if (String(locale_renames[idx][1]).non_empty()) {
 			locale_rename_map[locale_renames[idx][0]] = locale_renames[idx][1];
 		}
 		idx++;
@@ -308,7 +308,7 @@ void TranslationServer::init_locale_info() {
 	country_rename_map.clear();
 	idx = 0;
 	while (country_renames[idx][0] != nullptr) {
-		if (!String(country_renames[idx][1]).is_empty()) {
+		if (String(country_renames[idx][1]).non_empty()) {
 			country_rename_map[country_renames[idx][0]] = country_renames[idx][1];
 		}
 		idx++;
@@ -393,7 +393,7 @@ String TranslationServer::_standardize_locale(const String &p_locale, bool p_add
 				}
 			}
 		}
-		if (!script_name.is_empty() && country_name.is_empty()) {
+		if (script_name.non_empty() && country_name.is_empty()) {
 			// Add conntry code based on script for some ambiguous cases.
 			for (int i = 0; i < locale_script_info.size(); i++) {
 				const LocaleScriptInfo &info = locale_script_info[i];
@@ -407,13 +407,13 @@ String TranslationServer::_standardize_locale(const String &p_locale, bool p_add
 
 	// Combine results.
 	String out = lang_name;
-	if (!script_name.is_empty()) {
+	if (script_name.non_empty()) {
 		out = out + "_" + script_name;
 	}
-	if (!country_name.is_empty()) {
+	if (country_name.non_empty()) {
 		out = out + "_" + country_name;
 	}
-	if (!variant_name.is_empty()) {
+	if (variant_name.non_empty()) {
 		out = out + "_" + variant_name;
 	}
 	return out;
@@ -467,10 +467,10 @@ String TranslationServer::get_locale_name(const String &p_locale) const {
 	}
 
 	String name = language_map[lang_name];
-	if (!script_name.is_empty()) {
+	if (script_name.non_empty()) {
 		name = name + " (" + script_map[script_name] + ")";
 	}
-	if (!country_name.is_empty()) {
+	if (country_name.non_empty()) {
 		name = name + ", " + country_name_map[country_name];
 	}
 	return name;
@@ -684,7 +684,7 @@ bool TranslationServer::_load_translations(const String &p_from) {
 void TranslationServer::setup() {
 	String test = GLOBAL_DEF("internationalization/locale/test", "");
 	test = test.strip_edges();
-	if (!test.is_empty()) {
+	if (test.non_empty()) {
 		set_locale(test);
 	} else {
 		set_locale(OS::get_singleton()->get_locale());

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1139,7 +1139,7 @@ String String::capitalize() const {
 
 String String::to_camel_case() const {
 	String s = to_pascal_case();
-	if (!s.is_empty()) {
+	if (s.non_empty()) {
 		s[0] = _find_lower(s[0]);
 	}
 	return s;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -427,6 +427,7 @@ public:
 	Vector<uint8_t> sha256_buffer() const;
 
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool containsn(const char *p_str) const { return findn(p_str) != -1; }

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -422,7 +422,7 @@ public:
 	SPACE_SEP_LIST(DECL_PUSH_AND_SYNC, 15)
 
 	_FORCE_INLINE_ void flush_if_pending() {
-		if (unlikely(command_mem.size() > 0)) {
+		if (unlikely(command_mem.non_empty())) {
 			_flush();
 		}
 	}

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -188,6 +188,7 @@ public:
 
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) {
 		ERR_FAIL_INDEX(p_index, size());

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -250,6 +250,9 @@ public:
 	bool is_empty() const {
 		return num_elements == 0;
 	}
+	_FORCE_INLINE_ bool non_empty() const {
+		return !is_empty();
+	}
 
 	void clear() {
 		if (elements == nullptr || num_elements == 0) {

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -235,6 +235,9 @@ public:
 	bool is_empty() const {
 		return num_elements == 0;
 	}
+	_FORCE_INLINE_ bool non_empty() const {
+		return !is_empty();
+	}
 
 	void clear() {
 		if (keys == nullptr || num_elements == 0) {

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -459,6 +459,9 @@ public:
 	_FORCE_INLINE_ bool is_empty() const {
 		return (!_data || !_data->size_cache);
 	}
+	_FORCE_INLINE_ bool non_empty() const {
+		return !is_empty();
+	}
 
 	/**
 	 * clear the list

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -136,6 +136,7 @@ public:
 		}
 	}
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	_FORCE_INLINE_ void reserve(U p_size) {
 		p_size = tight ? p_size : nearest_power_of_2_templated(p_size);

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -192,6 +192,9 @@ public:
 	bool is_empty() const {
 		return num_elements == 0;
 	}
+	_FORCE_INLINE_ bool non_empty() const {
+		return !is_empty();
+	}
 
 	void clear() {
 		for (uint32_t i = 0; i < capacity; i++) {

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -99,7 +99,7 @@ public:
 	T *request(U &r_id) {
 		_used_size++;
 
-		if (freelist.size()) {
+		if (freelist.non_empty()) {
 			// pop from freelist
 			int new_size = freelist.size() - 1;
 			r_id = freelist[new_size];

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -729,6 +729,9 @@ public:
 	inline bool is_empty() const {
 		return _data.size_cache == 0;
 	}
+	inline bool non_empty() const {
+		return !is_empty();
+	}
 	inline int size() const {
 		return _data.size_cache;
 	}

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -667,6 +667,9 @@ public:
 	inline bool is_empty() const {
 		return _data.size_cache == 0;
 	}
+	inline bool non_empty() const {
+		return !is_empty();
+	}
 	inline int size() const {
 		return _data.size_cache;
 	}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -87,6 +87,7 @@ public:
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
+	_FORCE_INLINE_ bool non_empty() const { return _cowdata.non_empty(); }
 
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }

--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -151,6 +151,7 @@ public:
 
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
+	_FORCE_INLINE_ bool non_empty() const { return _cowdata.non_empty(); }
 
 	const Pair *get_array() const {
 		return _cowdata.ptr();

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -127,6 +127,7 @@ public:
 	}
 
 	_FORCE_INLINE_ bool is_empty() const { return _data.is_empty(); }
+	_FORCE_INLINE_ bool non_empty() const { return _data.non_empty(); }
 
 	_FORCE_INLINE_ int size() const { return _data.size(); }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -549,7 +549,7 @@ Array Array::map(const Callable &p_callable) const {
 Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const {
 	int start = 0;
 	Variant ret = p_accum;
-	if (ret == Variant() && size() > 0) {
+	if (ret == Variant() && non_empty()) {
 		ret = front();
 		start = 1;
 	}
@@ -680,7 +680,7 @@ void Array::push_front(const Variant &p_value) {
 
 Variant Array::pop_back() {
 	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
-	if (!_p->array.is_empty()) {
+	if (_p->array.non_empty()) {
 		const int n = _p->array.size() - 1;
 		const Variant ret = _p->array.get(n);
 		_p->array.resize(n);
@@ -691,7 +691,7 @@ Variant Array::pop_back() {
 
 Variant Array::pop_front() {
 	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
-	if (!_p->array.is_empty()) {
+	if (_p->array.non_empty()) {
 		const Variant ret = _p->array.get(0);
 		_p->array.remove_at(0);
 		return ret;
@@ -782,7 +782,7 @@ Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_nam
 
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
+	ERR_FAIL_COND_MSG(_p->array.non_empty(), "Type can only be set when array is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
 	ERR_FAIL_COND_MSG(_p->typed.type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -120,6 +120,7 @@ public:
 
 	int size() const;
 	bool is_empty() const;
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 	void clear();
 
 	bool operator==(const Array &p_array) const;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -62,6 +62,7 @@ public:
 
 	int size() const;
 	bool is_empty() const;
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 	void clear();
 	void merge(const Dictionary &p_dictionary, bool p_overwrite = false);
 	Dictionary merged(const Dictionary &p_dictionary, bool p_overwrite = false) const;

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -257,6 +257,7 @@ public:
 	}
 	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & (int64_t)p_flag; }
 	_FORCE_INLINE_ bool is_empty() const { return value == 0; }
+	_FORCE_INLINE_ bool non_empty() const { return !is_empty(); }
 	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~(int64_t)p_flag; }
 	_FORCE_INLINE_ void clear() { value = 0; }
 	_FORCE_INLINE_ constexpr BitField() = default;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -660,7 +660,7 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 struct _VariantCall {
 	static String func_PackedByteArray_get_string_from_ascii(PackedByteArray *p_instance) {
 		String s;
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			const uint8_t *r = p_instance->ptr();
 			CharString cs;
 			cs.resize(p_instance->size() + 1);
@@ -674,7 +674,7 @@ struct _VariantCall {
 
 	static String func_PackedByteArray_get_string_from_utf8(PackedByteArray *p_instance) {
 		String s;
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			const uint8_t *r = p_instance->ptr();
 			s.parse_utf8((const char *)r, p_instance->size());
 		}
@@ -683,7 +683,7 @@ struct _VariantCall {
 
 	static String func_PackedByteArray_get_string_from_utf16(PackedByteArray *p_instance) {
 		String s;
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			const uint8_t *r = p_instance->ptr();
 			s.parse_utf16((const char16_t *)r, floor((double)p_instance->size() / (double)sizeof(char16_t)));
 		}
@@ -692,7 +692,7 @@ struct _VariantCall {
 
 	static String func_PackedByteArray_get_string_from_utf32(PackedByteArray *p_instance) {
 		String s;
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			const uint8_t *r = p_instance->ptr();
 			s = String((const char32_t *)r, floor((double)p_instance->size() / (double)sizeof(char32_t)));
 		}
@@ -701,7 +701,7 @@ struct _VariantCall {
 
 	static String func_PackedByteArray_get_string_from_wchar(PackedByteArray *p_instance) {
 		String s;
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			const uint8_t *r = p_instance->ptr();
 #ifdef WINDOWS_ENABLED
 			s.parse_utf16((const char16_t *)r, floor((double)p_instance->size() / (double)sizeof(char16_t)));
@@ -715,7 +715,7 @@ struct _VariantCall {
 	static PackedByteArray func_PackedByteArray_compress(PackedByteArray *p_instance, int p_mode) {
 		PackedByteArray compressed;
 
-		if (p_instance->size() > 0) {
+		if (p_instance->non_empty()) {
 			Compression::Mode mode = (Compression::Mode)(p_mode);
 			compressed.resize(Compression::get_max_compressed_buffer_size(p_instance->size(), mode));
 			int result = Compression::compress(compressed.ptrw(), p_instance->ptr(), p_instance->size(), mode);

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -2003,7 +2003,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 
 				//could come up with some sort of text
-				if (!res_text.is_empty()) {
+				if (res_text.non_empty()) {
 					p_store_string_func(p_store_string_ud, res_text);
 					break;
 				}
@@ -2085,7 +2085,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 						resource_text = "Resource(\"" + script->get_path() + "\")";
 					}
 
-					if (!resource_text.is_empty()) {
+					if (resource_text.non_empty()) {
 						p_store_string_func(p_store_string_ud, resource_text);
 					} else {
 						ERR_PRINT("Failed to encode a path to a custom script for an array type.");
@@ -2137,7 +2137,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 					}
 					p_store_string_func(p_store_string_ud, itos(ptr[i]));
 				}
-			} else if (data.size() > 0) {
+			} else if (data.non_empty()) {
 				p_store_string_func(p_store_string_ud, "\"");
 				p_store_string_func(p_store_string_ud, CryptoCore::b64_encode_str(data.ptr(), data.size()));
 				p_store_string_func(p_store_string_ud, "\"");


### PR DESCRIPTION
This helps with readability as negation easily gets lost especially in long expressions like:
```cpp
if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
```

It's easy to miss a tiny `!` in the middle of a long expression, this aims to reduce that by removing a common case (I've done some scanning for candidates and I've not fixed all and am already over 1300 cases) also replaced a few cases with `size` checks that are equivalent 

Included a limited subset of uses here to display and confirm, and will follow up if merged with further cases

This can also be exposed if desired, I think it'd be useful in scripting as well
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
