### PR TITLE
Update Node docs to change iOS to Android for `NOTIFICATION_WM_GO_BACK_REQUEST`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1187,7 +1187,7 @@
 		</constant>
 		<constant name="NOTIFICATION_WM_GO_BACK_REQUEST" value="1007">
 			Notification received from the OS when a go back request is sent (e.g. pressing the "Back" button on Android).
-			Implemented only on iOS.
+			Implemented only on Android.
 		</constant>
 		<constant name="NOTIFICATION_WM_SIZE_CHANGED" value="1008">
 			Notification received when the window is resized.


### PR DESCRIPTION
In the documentation for NOTIFICATION_WM_GO_BACK_REQUEST, it says 
```(e.g., pressing the 'Back' button on Android).```
However, below it says that it's only implemented on iOS. Since iOS doesn't have a back button like Android, this should say that it's implemented only on Android.