### PR TITLE
[Doc] Clarify the session-specific nature of `RID` and `ObjectID`

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -693,6 +693,7 @@
 			<return type="int" />
 			<description>
 				Returns the object's unique instance ID. This ID can be saved in [EncodedObjectAsID], and can be used to retrieve this object instance with [method @GlobalScope.instance_from_id].
+				[b]Note:[/b] This ID is only useful during the current session. It won't correspond to a similar object if the ID is sent over a network, or loaded from a file at a later time.
 			</description>
 		</method>
 		<method name="get_meta" qualifiers="const">

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -6,6 +6,7 @@
 	<description>
 		The RID [Variant] type is used to access a low-level resource by its unique ID. RIDs are opaque, which means they do not grant access to the resource by themselves. They are used by the low-level server classes, such as [DisplayServer], [RenderingServer], [TextServer], etc.
 		A low-level resource may correspond to a high-level [Resource], such as [Texture] or [Mesh].
+		[b]Note:[/b] RIDs are only useful during the current session. It won't correspond to a similar resource if sent over a network, or loaded from a file at a later time.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Unsure if it should be a `Note` or a `Warning`, and if it should suggest other means to do things instead of using these types, but this helps clarifying the nature (and why they can't generally be serialized in the case of `RID`)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
