### PR TITLE
Fix audio input gets muted after a while on android

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -353,9 +353,6 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 
 				p_buffer[i] = AudioFrame(l, r);
 			} else {
-				if (mixed_frames == p_frames) {
-					mixed_frames = i;
-				}
 				p_buffer[i] = AudioFrame(0.0f, 0.0f);
 			}
 		}


### PR DESCRIPTION
Fix the buffer underrun situation, which leads to unexpected mute of mic input in android application.

Original bug report: (https://github.com/godotengine/godot/issues/86428)

I personally encountered the same problem on my own project.

My solution is to delete mixed_frames correction in AudioStreamMicrophone. In other places of code this correction is used as sign of end of sound source (melody or recordings). But it's mic, folks. Mic stream must work until I stop it by myself, recording ambient sound. So no need to check the end of sound source. Mic source have no end.

Big thanks to @leoyanis, who ponts to problem, and great thanks to @kus04e4ek, who points to roots of the problem.

* *Bugsquad edit, fixed: https://github.com/godotengine/godot/issues/86428*