### PR TITLE
Remove NavigationRegion `get_region_rid()` from builds with `DISABLE_DEPRECATED`

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -38,6 +38,12 @@ RID NavigationRegion2D::get_rid() const {
 	return region;
 }
 
+#ifndef DISABLE_DEPRECATED
+RID NavigationRegion2D::get_region_rid() const {
+	return get_rid();
+}
+#endif // DISABLE_DEPRECATED
+
 void NavigationRegion2D::set_enabled(bool p_enabled) {
 	if (enabled == p_enabled) {
 		return;
@@ -136,10 +142,6 @@ void NavigationRegion2D::set_travel_cost(real_t p_travel_cost) {
 
 real_t NavigationRegion2D::get_travel_cost() const {
 	return travel_cost;
-}
-
-RID NavigationRegion2D::get_region_rid() const {
-	return get_rid();
 }
 
 #ifdef TOOLS_ENABLED
@@ -305,6 +307,9 @@ PackedStringArray NavigationRegion2D::get_configuration_warnings() const {
 
 void NavigationRegion2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationRegion2D::get_rid);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion2D::get_region_rid);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_navigation_polygon", "navigation_polygon"), &NavigationRegion2D::set_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("get_navigation_polygon"), &NavigationRegion2D::get_navigation_polygon);
@@ -323,8 +328,6 @@ void NavigationRegion2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_navigation_layer_value", "layer_number", "value"), &NavigationRegion2D::set_navigation_layer_value);
 	ClassDB::bind_method(D_METHOD("get_navigation_layer_value", "layer_number"), &NavigationRegion2D::get_navigation_layer_value);
-
-	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion2D::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("set_enter_cost", "enter_cost"), &NavigationRegion2D::set_enter_cost);
 	ClassDB::bind_method(D_METHOD("get_enter_cost"), &NavigationRegion2D::get_enter_cost);

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -80,6 +80,9 @@ public:
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 #endif
 	RID get_rid() const;
+#ifndef DISABLE_DEPRECATED
+	RID get_region_rid() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
@@ -95,8 +98,6 @@ public:
 
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
-
-	RID get_region_rid() const;
 
 	void set_enter_cost(real_t p_enter_cost);
 	real_t get_enter_cost() const;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -37,6 +37,12 @@ RID NavigationRegion3D::get_rid() const {
 	return region;
 }
 
+#ifndef DISABLE_DEPRECATED
+RID NavigationRegion3D::get_region_rid() const {
+	return get_rid();
+}
+#endif // DISABLE_DEPRECATED
+
 void NavigationRegion3D::set_enabled(bool p_enabled) {
 	if (enabled == p_enabled) {
 		return;
@@ -155,10 +161,6 @@ void NavigationRegion3D::set_travel_cost(real_t p_travel_cost) {
 
 real_t NavigationRegion3D::get_travel_cost() const {
 	return travel_cost;
-}
-
-RID NavigationRegion3D::get_region_rid() const {
-	return get_rid();
 }
 
 void NavigationRegion3D::_notification(int p_what) {
@@ -284,6 +286,9 @@ PackedStringArray NavigationRegion3D::get_configuration_warnings() const {
 
 void NavigationRegion3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationRegion3D::get_rid);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion3D::get_region_rid);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_navigation_mesh", "navigation_mesh"), &NavigationRegion3D::set_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_navigation_mesh"), &NavigationRegion3D::get_navigation_mesh);
@@ -302,8 +307,6 @@ void NavigationRegion3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_navigation_layer_value", "layer_number", "value"), &NavigationRegion3D::set_navigation_layer_value);
 	ClassDB::bind_method(D_METHOD("get_navigation_layer_value", "layer_number"), &NavigationRegion3D::get_navigation_layer_value);
-
-	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion3D::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("set_enter_cost", "enter_cost"), &NavigationRegion3D::set_enter_cost);
 	ClassDB::bind_method(D_METHOD("get_enter_cost"), &NavigationRegion3D::get_enter_cost);

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -75,6 +75,9 @@ protected:
 
 public:
 	RID get_rid() const;
+#ifndef DISABLE_DEPRECATED
+	RID get_region_rid() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
@@ -90,8 +93,6 @@ public:
 
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
-
-	RID get_region_rid() const;
 
 	void set_enter_cost(real_t p_enter_cost);
 	real_t get_enter_cost() const;


### PR DESCRIPTION
Remove NavigationRegion `get_region_rid()` from builds with `DISABLE_DEPRECATED`.

The function has been marked as deprecated for half a year by now in the documentation.
Groups the depr function next to the replacement `get_rid()` function in the files.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
