### PR TITLE
Mention inverse of hex functions in `Color`

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -203,7 +203,7 @@
 			<return type="Color" />
 			<param index="0" name="hex" type="int" />
 			<description>
-				Returns the [Color] associated with the provided [param hex] integer in 32-bit RGBA format (8 bits per channel).
+				Returns the [Color] associated with the provided [param hex] integer in 32-bit RGBA format (8 bits per channel). This method is the inverse of [method to_rgba32].
 				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix, making it [code]"0xRRGGBBAA"[/code]).
 				[codeblocks]
 				[gdscript]
@@ -223,7 +223,7 @@
 			<return type="Color" />
 			<param index="0" name="hex" type="int" />
 			<description>
-				Returns the [Color] associated with the provided [param hex] integer in 64-bit RGBA format (16 bits per channel).
+				Returns the [Color] associated with the provided [param hex] integer in 64-bit RGBA format (16 bits per channel). This method is the inverse of [method to_rgba64].
 				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix, making it [code]"0xRRRRGGGGBBBBAAAA"[/code]).
 			</description>
 		</method>
@@ -441,7 +441,7 @@
 		<method name="to_rgba32" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the color converted to a 32-bit integer in RGBA format (each component is 8 bits). RGBA is Godot's default format.
+				Returns the color converted to a 32-bit integer in RGBA format (each component is 8 bits). RGBA is Godot's default format. This method is the inverse of [method hex].
 				[codeblocks]
 				[gdscript]
 				var color = Color(1, 0.5, 0.2)
@@ -457,7 +457,7 @@
 		<method name="to_rgba64" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the color converted to a 64-bit integer in RGBA format (each component is 16 bits). RGBA is Godot's default format.
+				Returns the color converted to a 64-bit integer in RGBA format (each component is 16 bits). RGBA is Godot's default format. This method is the inverse of [method hex64].
 				[codeblocks]
 				[gdscript]
 				var color = Color(1, 0.5, 0.2)


### PR DESCRIPTION
the naming of methods converting to hex color and from hex color is different.
since finding the inverse is not obvious, it should be mentioned in the docs.