### PR TITLE
Use `LocalVector` instead of `Vector` in core templates

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -31,11 +31,11 @@
 #ifndef RING_BUFFER_H
 #define RING_BUFFER_H
 
-#include "core/templates/vector.h"
+#include "core/templates/local_vector.h"
 
 template <typename T>
 class RingBuffer {
-	Vector<T> data;
+	LocalVector<T> data;
 	int read_pos = 0;
 	int write_pos = 0;
 	int size_mask;
@@ -50,7 +50,7 @@ class RingBuffer {
 public:
 	T read() {
 		ERR_FAIL_COND_V(space_left() < 1, T());
-		return data.ptr()[inc(read_pos, 1)];
+		return data[inc(read_pos, 1)];
 	}
 
 	int read(T *p_buf, int p_size, bool p_advance = true) {
@@ -143,7 +143,7 @@ public:
 
 	Error write(const T &p_v) {
 		ERR_FAIL_COND_V(space_left() < 1, FAILED);
-		data.write[inc(write_pos, 1)] = p_v;
+		data[inc(write_pos, 1)] = p_v;
 		return OK;
 	}
 
@@ -160,7 +160,7 @@ public:
 			int total = end - pos;
 
 			for (int i = 0; i < total; i++) {
-				data.write[pos + i] = p_buf[src++];
+				data[pos + i] = p_buf[src++];
 			}
 			to_write -= total;
 			pos = 0;
@@ -200,7 +200,7 @@ public:
 		data.resize(int64_t(1) << int64_t(p_power));
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
-				data.write[(old_size + i) & mask] = data[i];
+				data[(old_size + i) & mask] = data[i];
 			}
 			write_pos = (old_size + write_pos) & mask;
 		} else {

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -31,12 +31,11 @@
 #ifndef VSET_H
 #define VSET_H
 
-#include "core/templates/vector.h"
-#include "core/typedefs.h"
+#include "core/templates/local_vector.h"
 
 template <typename T>
 class VSet {
-	Vector<T> _data;
+	LocalVector<T> _data;
 
 	_FORCE_INLINE_ int _find(const T &p_val, bool &r_exact) const {
 		r_exact = false;
@@ -59,16 +58,16 @@ class VSet {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle]) {
-				high = middle - 1; //search low end of array
+				high = middle - 1; // Search the low end of the array.
 			} else if (a[middle] < p_val) {
-				low = middle + 1; //search high end of array
+				low = middle + 1; // Search the high end of the array.
 			} else {
 				r_exact = true;
 				return middle;
 			}
 		}
 
-		//return the position where this would be inserted
+		// Return the position where this would be inserted.
 		if (a[middle] < p_val) {
 			middle++;
 		}
@@ -89,9 +88,9 @@ class VSet {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle]) {
-				high = middle - 1; //search low end of array
+				high = middle - 1; // Search the low end of the array.
 			} else if (a[middle] < p_val) {
-				low = middle + 1; //search high end of array
+				low = middle + 1; // Search the high end of the array.
 			} else {
 				return middle;
 			}
@@ -131,7 +130,7 @@ public:
 	_FORCE_INLINE_ int size() const { return _data.size(); }
 
 	inline T &operator[](int p_index) {
-		return _data.write[p_index];
+		return _data[p_index];
 	}
 
 	inline const T &operator[](int p_index) const {


### PR DESCRIPTION
These fields are private, so there shouldn't be any issues. Also changed comments to match the current style. This change could impact performance slightly, also `LocalVector` allocates less memory, as it doesn't allocate ref counter, but it's mostly to just use `LocalVector` when possible, it wouldn't make anything worse in these cases it looks like ¯\\\_(ツ)\_/¯