### PR TITLE
Allow theming renderer colors

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -543,6 +543,8 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 				tb->set_icon(theme->get_icon(p_editor->get_name(), EditorStringName(EditorIcons)));
 			}
 		}
+
+		_update_renderer_color();
 	}
 
 	editor_dock_manager->update_tab_styles();
@@ -6177,15 +6179,12 @@ Vector<Ref<EditorResourceConversionPlugin>> EditorNode::find_resource_conversion
 void EditorNode::_update_renderer_color() {
 	String rendering_method = renderer->get_selected_metadata();
 
-	// TODO: Use theme colors instead of hardcoded values.
 	if (rendering_method == "forward_plus") {
-		renderer->add_theme_color_override("font_color", Color::hex(0x5d8c3fff));
-	}
-	if (rendering_method == "mobile") {
-		renderer->add_theme_color_override("font_color", Color::hex(0xa5557dff));
-	}
-	if (rendering_method == "gl_compatibility") {
-		renderer->add_theme_color_override("font_color", Color::hex(0x5586a4ff));
+		renderer->add_theme_color_override("font_color", theme->get_color(SNAME("forward_plus_color"), EditorStringName(Editor)));
+	} else if (rendering_method == "mobile") {
+		renderer->add_theme_color_override("font_color", theme->get_color(SNAME("mobile_color"), EditorStringName(Editor)));
+	} else if (rendering_method == "gl_compatibility") {
+		renderer->add_theme_color_override("font_color", theme->get_color(SNAME("gl_compatibility_color"), EditorStringName(Editor)));
 	}
 }
 


### PR DESCRIPTION
These were already exposed to theming but unused in code

Slightly brighter colors in a theme:

| Before | After |
|--------|--------|
| ![before](https://github.com/godotengine/godot/assets/60579014/6488b2dd-3443-4c3f-89ed-2c7e57e422ab) | ![after](https://github.com/godotengine/godot/assets/60579014/a286eaaa-f326-4715-ad12-e38945493b65) |