### PR TITLE
Animation: Document frame duration units in `SpriteFrames`

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -23,7 +23,7 @@
 			<param index="2" name="duration" type="float" default="1.0" />
 			<param index="3" name="at_position" type="int" default="-1" />
 			<description>
-				Adds a frame to the [param anim] animation. If [param at_position] is [code]-1[/code], the frame will be added to the end of the animation.
+				Adds a frame to the [param anim] animation. If [param at_position] is [code]-1[/code], the frame will be added to the end of the animation. [param duration] specifies the relative duration, see [method get_frame_duration] for details.
 			</description>
 		</method>
 		<method name="clear">
@@ -139,7 +139,7 @@
 			<param index="2" name="texture" type="Texture2D" />
 			<param index="3" name="duration" type="float" default="1.0" />
 			<description>
-				Sets the [param texture] and the [param duration] of the frame [param idx] in the [param anim] animation.
+				Sets the [param texture] and the [param duration] of the frame [param idx] in the [param anim] animation. [param duration] specifies the relative duration, see [method get_frame_duration] for details.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
* Addresses https://github.com/godotengine/godot/pull/65609#issuecomment-2170430462.

The units are already documented in detail, I think we can just refer to `get_frame_duration()`, without the reverse formula.

https://github.com/godotengine/godot/blob/71699e08c9df78b7203fa4ef9cede28e995d6ace/doc/classes/SpriteFrames.xml#L69-L80