### PR TITLE
[Editor] Unload addons before quitting to allow cleanup.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3322,6 +3322,13 @@ void EditorNode::_exit_editor(int p_exit_code) {
 	// Dim the editor window while it's quitting to make it clearer that it's busy.
 	dim_editor(true);
 
+	// Unload addons before quitting to allow cleanup.
+	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
+		print_verbose(vformat("Unloading addon: %s", E.key));
+		remove_editor_plugin(E.value, false);
+		memdelete(E.value);
+	}
+
 	get_tree()->quit(p_exit_code);
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92727

Adds extra plugin unloading step before deleting scene tree to ensure plugins can use the same code for both unloading and disabling plugin.

[Existing documentation](https://docs.godotengine.org/de/4.x/tutorials/plugins/editor/making_plugins.html) suggest freeing stuff, including removing nodes in the `_exit_tree`, which can't be done if plugin is unloaded during scene tree deletion. While removing nodes manually is not necessary, unloading other resources might be, and it is needed to handle disabling plugins, doing all of it from the `_exit_tree` probably is more convenient than separate `_disable_plugin` and resource cleanup.