### PR TITLE
Tweak warning messages related to V-Sync on OpenGL

### DIFF
--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -357,7 +357,7 @@ void GLManager_X11::set_use_vsync(bool p_use) {
 		GLXDrawable drawable = glXGetCurrentDrawable();
 		glXSwapIntervalEXT(disp.x11_display, drawable, val);
 	} else {
-		WARN_PRINT("Could not set V-Sync mode. V-Sync is not supported.");
+		WARN_PRINT_ONCE("Could not set V-Sync mode, as changing V-Sync mode is not supported by the graphics driver.");
 		return;
 	}
 	use_vsync = p_use;

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -510,10 +510,10 @@ void GLManagerNative_Windows::set_use_vsync(DisplayServer::WindowID p_window_id,
 		win.use_vsync = p_use;
 
 		if (!wglSwapIntervalEXT(p_use ? 1 : 0)) {
-			WARN_PRINT("Could not set V-Sync mode.");
+			WARN_PRINT_ONCE("Could not set V-Sync mode, as changing V-Sync mode is not supported by the graphics driver.");
 		}
 	} else {
-		WARN_PRINT("Could not set V-Sync mode. V-Sync is not supported.");
+		WARN_PRINT_ONCE("Could not set V-Sync mode, as changing V-Sync mode is not supported by the graphics driver.");
 	}
 }
 


### PR DESCRIPTION
- Make warnings print only once per session.
- Tweak the message to be less confusing, and mention that the issue most likely stems from a graphics driver limitation.

___

- This closes https://github.com/godotengine/godot/issues/93027.
