### PR TITLE
Add code block example to `AudioStreamPolyphonic `

### DIFF
--- a/doc/classes/AudioStreamPolyphonic.xml
+++ b/doc/classes/AudioStreamPolyphonic.xml
@@ -6,24 +6,22 @@
 	<description>
 		AudioStream that lets the user play custom streams at any time from code, simultaneously using a single player.
 		Playback control is done via the [AudioStreamPlaybackPolyphonic] instance set inside the player, which can be obtained via [method AudioStreamPlayer.get_stream_playback], [method AudioStreamPlayer2D.get_stream_playback] or [method AudioStreamPlayer3D.get_stream_playback] methods. Obtaining the playback instance is only valid after the [code]stream[/code] property is set as an [AudioStreamPolyphonic] in those players.
-		
-		```
+		[codeblock]
 		extends AudioStreamPlayer
 		var polyphonic = AudioStreamPolyphonic.new()
-		var playback : AudioStreamPlaybackPolyphonic
+		var playback
 		
 		var my_sound = preload("res://my_sound.wav")
 		
 		func _ready():
 		    stream = polyphonic
-		    play() # you have to play the stream first
-		    playback = get_stream_playback() # then get playback instance. 
-		    
-		func process():
-		    if Input.is_action_just_pressed("ui_accept"):
-		         playback.play_stream(my_sound, 0, 0, 1) # stream, volume, audio frame, pitch 
-		```
-	
+		    play()  # You have to play the stream first.
+		    playback = get_stream_playback()  # Then get the playback instance.
+		
+		func _input(event):
+		    if event.is_action_pressed("ui_accept"):
+		         playback.play_stream(my_sound, 0, 0, 1)   # stream, volume, audio frame, pitch
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioStreamPolyphonic.xml
+++ b/doc/classes/AudioStreamPolyphonic.xml
@@ -20,7 +20,7 @@
 		
 		func _input(event):
 		    if event.is_action_pressed("ui_accept"):
-		         playback.play_stream(my_sound, 0, 0, 1)   # stream, volume, audio frame, pitch
+		         playback.play_stream(my_sound, 0, 0, 1)  # stream, volume, audio frame, pitch
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/AudioStreamPolyphonic.xml
+++ b/doc/classes/AudioStreamPolyphonic.xml
@@ -6,6 +6,24 @@
 	<description>
 		AudioStream that lets the user play custom streams at any time from code, simultaneously using a single player.
 		Playback control is done via the [AudioStreamPlaybackPolyphonic] instance set inside the player, which can be obtained via [method AudioStreamPlayer.get_stream_playback], [method AudioStreamPlayer2D.get_stream_playback] or [method AudioStreamPlayer3D.get_stream_playback] methods. Obtaining the playback instance is only valid after the [code]stream[/code] property is set as an [AudioStreamPolyphonic] in those players.
+		
+		```
+		extends AudioStreamPlayer
+		var polyphonic = AudioStreamPolyphonic.new()
+		var playback : AudioStreamPlaybackPolyphonic
+		
+		var my_sound = preload("res://my_sound.wav")
+		
+		func _ready():
+		    stream = polyphonic
+		    play() # you have to play the stream first
+		    playback = get_stream_playback() # then get playback instance. 
+		    
+		func process():
+		    if Input.is_action_just_pressed("ui_accept"):
+		         playback.play_stream(my_sound, 0, 0, 1) # stream, volume, audio frame, pitch 
+		```
+	
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioStreamPolyphonic.xml
+++ b/doc/classes/AudioStreamPolyphonic.xml
@@ -10,14 +10,14 @@
 		extends AudioStreamPlayer
 		var polyphonic = AudioStreamPolyphonic.new()
 		var playback
-		
+
 		var my_sound = preload("res://my_sound.wav")
-		
+
 		func _ready():
 		    stream = polyphonic
 		    play()  # You have to play the stream first.
 		    playback = get_stream_playback()  # Then get the playback instance.
-		
+
 		func _input(event):
 		    if event.is_action_pressed("ui_accept"):
 		         playback.play_stream(my_sound, 0, 0, 1)  # stream, volume, audio frame, pitch


### PR DESCRIPTION
do backtick code tags work?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
