### PR TITLE
Add CSG options to bake to static mesh and collision shape

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -460,32 +460,56 @@ void CSGShape3D::_update_shape() {
 	_update_collision_faces();
 }
 
-void CSGShape3D::_update_collision_faces() {
-	if (use_collision && is_root_shape() && root_collision_shape.is_valid()) {
-		CSGBrush *n = _get_brush();
-		ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
-		Vector<Vector3> physics_faces;
-		physics_faces.resize(n->faces.size() * 3);
-		Vector3 *physicsw = physics_faces.ptrw();
+Vector<Vector3> CSGShape3D::_get_brush_collision_faces() {
+	Vector<Vector3> collision_faces;
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_V_MSG(n, collision_faces, "Cannot get CSGBrush.");
+	collision_faces.resize(n->faces.size() * 3);
+	Vector3 *collision_faces_ptrw = collision_faces.ptrw();
 
-		for (int i = 0; i < n->faces.size(); i++) {
-			int order[3] = { 0, 1, 2 };
+	for (int i = 0; i < n->faces.size(); i++) {
+		int order[3] = { 0, 1, 2 };
 
-			if (n->faces[i].invert) {
-				SWAP(order[1], order[2]);
-			}
-
-			physicsw[i * 3 + 0] = n->faces[i].vertices[order[0]];
-			physicsw[i * 3 + 1] = n->faces[i].vertices[order[1]];
-			physicsw[i * 3 + 2] = n->faces[i].vertices[order[2]];
+		if (n->faces[i].invert) {
+			SWAP(order[1], order[2]);
 		}
 
-		root_collision_shape->set_faces(physics_faces);
+		collision_faces_ptrw[i * 3 + 0] = n->faces[i].vertices[order[0]];
+		collision_faces_ptrw[i * 3 + 1] = n->faces[i].vertices[order[1]];
+		collision_faces_ptrw[i * 3 + 2] = n->faces[i].vertices[order[2]];
+	}
+
+	return collision_faces;
+}
+
+void CSGShape3D::_update_collision_faces() {
+	if (use_collision && is_root_shape() && root_collision_shape.is_valid()) {
+		root_collision_shape->set_faces(_get_brush_collision_faces());
 
 		if (_is_debug_collision_shape_visible()) {
 			_update_debug_collision_shape();
 		}
 	}
+}
+
+Ref<ArrayMesh> CSGShape3D::bake_static_mesh() {
+	Ref<ArrayMesh> baked_mesh;
+	if (is_root_shape() && root_mesh.is_valid()) {
+		baked_mesh = root_mesh;
+	}
+	return baked_mesh;
+}
+
+Ref<ConcavePolygonShape3D> CSGShape3D::bake_collision_shape() {
+	Ref<ConcavePolygonShape3D> baked_collision_shape;
+	if (is_root_shape() && root_collision_shape.is_valid()) {
+		baked_collision_shape.instantiate();
+		baked_collision_shape->set_faces(root_collision_shape->get_faces());
+	} else if (is_root_shape()) {
+		baked_collision_shape.instantiate();
+		baked_collision_shape->set_faces(_get_brush_collision_faces());
+	}
+	return baked_collision_shape;
 }
 
 bool CSGShape3D::_is_debug_collision_shape_visible() {
@@ -703,6 +727,9 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
+
+	ClassDB::bind_method(D_METHOD("bake_static_mesh"), &CSGShape3D::bake_static_mesh);
+	ClassDB::bind_method(D_METHOD("bake_collision_shape"), &CSGShape3D::bake_collision_shape);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "operation", PROPERTY_HINT_ENUM, "Union,Intersection,Subtraction"), "set_operation", "get_operation");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "snap", PROPERTY_HINT_RANGE, "0.000001,1,0.000001,suffix:m"), "set_snap", "get_snap");

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -113,6 +113,7 @@ private:
 	void _update_debug_collision_shape();
 	void _clear_debug_collision_shape();
 	void _on_transform_changed();
+	Vector<Vector3> _get_brush_collision_faces();
 
 protected:
 	void _notification(int p_what);
@@ -161,6 +162,10 @@ public:
 	bool is_calculating_tangents() const;
 
 	bool is_root_shape() const;
+
+	Ref<ArrayMesh> bake_static_mesh();
+	Ref<ConcavePolygonShape3D> bake_collision_shape();
+
 	CSGShape3D();
 	~CSGShape3D();
 };

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -5,12 +5,29 @@
 	</brief_description>
 	<description>
 		This is the CSG base class that provides CSG operation support to the various CSG nodes in Godot.
-		[b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance3D] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
+		[b]Performance:[/b] CSG nodes are only intended for prototyping as they have a significant CPU performance cost.
+		Consider baking final CSG operation results into static geometry that replaces the CSG nodes.
+		Individual CSG root node results can be baked to nodes with static resources with the editor menu that appears when a CSG root node is selected.
+		Individual CSG root nodes can also be baked to static resources with scripts by calling [method bake_static_mesh] for the visual mesh or [method bake_collision_shape] for the physics collision.
+		Entire scenes of CSG nodes can be baked to static geometry and exported with the editor gltf scene exporter.
 	</description>
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<methods>
+		<method name="bake_collision_shape">
+			<return type="ConcavePolygonShape3D" />
+			<description>
+				Returns a baked physics [ConcavePolygonShape3D] of this node's CSG operation result. Returns an empty shape if the node is not a CSG root node or has no valid geometry.
+				[b]Performance:[/b] If the CSG operation results in a very detailed geometry with many faces physics performance will be very slow. Concave shapes should in general only be used for static level geometry and not with dynamic objects that are moving.
+			</description>
+		</method>
+		<method name="bake_static_mesh">
+			<return type="ArrayMesh" />
+			<description>
+				Returns a baked static [ArrayMesh] of this node's CSG operation result. Materials from involved CSG nodes are added as extra mesh surfaces. Returns an empty mesh if the node is not a CSG root node or has no valid geometry.
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -37,8 +37,11 @@
 
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/node_3d_editor_gizmos.h"
+#include "scene/gui/control.h"
 
+class AcceptDialog;
 class Gizmo3DHelper;
+class MenuButton;
 
 class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(CSGShape3DGizmoPlugin, EditorNode3DGizmoPlugin);
@@ -62,10 +65,43 @@ public:
 	~CSGShape3DGizmoPlugin();
 };
 
+class CSGShapeEditor : public Control {
+	GDCLASS(CSGShapeEditor, Control);
+
+	enum Menu {
+		MENU_OPTION_BAKE_MESH_INSTANCE,
+		MENU_OPTION_BAKE_COLLISION_SHAPE,
+	};
+
+	CSGShape3D *node = nullptr;
+	MenuButton *options = nullptr;
+	AcceptDialog *err_dialog = nullptr;
+
+	void _menu_option(int p_option);
+
+	void _create_baked_mesh_instance();
+	void _create_baked_collision_shape();
+
+protected:
+	void _node_removed(Node *p_node);
+
+	void _notification(int p_what);
+
+public:
+	void edit(CSGShape3D *p_csg_shape);
+	CSGShapeEditor();
+};
+
 class EditorPluginCSG : public EditorPlugin {
 	GDCLASS(EditorPluginCSG, EditorPlugin);
 
+	CSGShapeEditor *csg_shape_editor = nullptr;
+
 public:
+	virtual String get_name() const override { return "CSGShape3D"; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+
 	EditorPluginCSG();
 };
 


### PR DESCRIPTION
Adds API to bake a CSG root node operation to either a static `ArrayMesh` or a `ConcavePolygonShape3D` physics collision shape. 

resolves https://github.com/godotengine/godot-proposals/issues/1920 providing access to a static copy of the CSG mesh or shape.

Adds menu options to the CSG editor plugin when selecting a CSG root node to add baked sibling nodes.

![csg_bake](https://github.com/godotengine/godot/assets/52464204/25d2cb99-f1cd-40aa-a1c2-b3fe3480cf1c)

A CSG root node is a CSG node that has no CSG parent, e.g. a `CSGCombiner3D` usually but also works with standalone CSG nodes.

For scripting the following functions are added to just bake the CSG operation results as new resources without adding nodes.

```gdscript
var baked_mesh: ArrayMesh = CSGShape3D.bake_static_mesh()
var baked_shape: ConcavePolygonShape3D = CSGShape3D.bake_collision_shape()
```

CSG nodes are only intended for prototyping as they have a significant CPU performance cost when changed or moved at runtime.
The baking can be used to greatly improve level performance by converting the final result of CSG operations into static geometry.

Note that while the updated documentation mentiones the gltf scene exporter as a valid option to bake CSG nodes it has  limitations atm. E.g. the exported scenes are full of clutter nodes that require manual cleanup and the physics collision bake also does not really work correct with the shapes being empty or just normal Node3D. Not sure if those gltf export issues are tracked somewhere.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
