### PR TITLE
State Machine Editor - Animation Node Groups

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1030,10 +1030,6 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		Vector2 ofs_to = (dragging_selected && selected_nodes.has(tl.to_node)) ? drag_ofs : Vector2();
 		tl.to = (state_machine->get_node_position(tl.to_node) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
 
-		if (!state_machine->_get_node_visibility(tl.from_node) || !state_machine->_get_node_visibility(tl.to_node)) {
-			continue;
-		}
-
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
 		tl.disabled = bool(tr->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED);
 		tl.auto_advance = bool(tr->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO);
@@ -1045,6 +1041,10 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		tl.fade_ratio = 0.0;
 		tl.hidden = false;
 		tl.is_across_group = state_machine->is_transition_across_group(i);
+
+		if (!state_machine->_get_node_visibility(tl.from_node) || !state_machine->_get_node_visibility(tl.to_node)) {
+			tl.hidden = true;
+		}
 
 		if (state_machine->has_transition(tl.to_node, tl.from_node)) { //offset if same exists
 			Vector2 offset = -(tl.from - tl.to).normalized().orthogonal() * tr_bidi_offset;

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -42,11 +42,14 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/separator.h"
+#include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
@@ -210,6 +213,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				selected_node = node_rects[i].node_name;
 
 				if (!selected_nodes.has(selected_node)) {
+					_node_group_edit_redraw(selected_node);
 					selected_nodes.clear();
 				}
 
@@ -226,6 +230,8 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				_update_mode();
 				return;
 			}
+
+			_node_group_edit_redraw(StringName());
 		}
 
 		//test the lines now
@@ -943,43 +949,45 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	//pre pass nodes so we know the rectangles
 	for (const StringName &E : nodes) {
 		String name = E;
-		int name_string_size = theme_cache.node_title_font->get_string_size(name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size).width;
+		if (state_machine->_get_node_visibility(name)) {
+			int name_string_size = theme_cache.node_title_font->get_string_size(name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size).width;
 
-		Ref<AnimationNode> anode = state_machine->get_node(name);
-		bool needs_editor = AnimationTreeEditor::get_singleton()->can_edit(anode);
-		bool is_selected = selected_nodes.has(name);
+			Ref<AnimationNode> anode = state_machine->get_node(name);
+			bool needs_editor = AnimationTreeEditor::get_singleton()->can_edit(anode);
+			bool is_selected = selected_nodes.has(name);
 
-		Size2 s = (is_selected ? theme_cache.node_frame_selected : theme_cache.node_frame)->get_minimum_size();
-		s.width += name_string_size;
-		s.height += MAX(theme_cache.node_title_font->get_height(theme_cache.node_title_font_size), theme_cache.play_node->get_height());
-		s.width += sep + theme_cache.play_node->get_width();
+			Size2 s = (is_selected ? theme_cache.node_frame_selected : theme_cache.node_frame)->get_minimum_size();
+			s.width += name_string_size;
+			s.height += MAX(theme_cache.node_title_font->get_height(theme_cache.node_title_font_size), theme_cache.play_node->get_height());
+			s.width += sep + theme_cache.play_node->get_width();
 
-		if (needs_editor) {
-			s.width += sep + theme_cache.edit_node->get_width();
+			if (needs_editor) {
+				s.width += sep + theme_cache.edit_node->get_width();
+			}
+
+			Vector2 offset;
+			offset += state_machine->get_node_position(E) * EDSCALE;
+
+			if (selected_nodes.has(E) && dragging_selected) {
+				offset += drag_ofs;
+			}
+
+			offset -= s / 2;
+			offset = offset.floor();
+
+			//prepre rect
+
+			NodeRect nr;
+			nr.node = Rect2(offset, s);
+			nr.node_name = E;
+
+			scroll_range = scroll_range.merge(nr.node); //merge with range
+
+			//now scroll it to draw
+			nr.node.position -= state_machine->get_graph_offset() * EDSCALE;
+
+			node_rects.push_back(nr);
 		}
-
-		Vector2 offset;
-		offset += state_machine->get_node_position(E) * EDSCALE;
-
-		if (selected_nodes.has(E) && dragging_selected) {
-			offset += drag_ofs;
-		}
-
-		offset -= s / 2;
-		offset = offset.floor();
-
-		//prepre rect
-
-		NodeRect nr;
-		nr.node = Rect2(offset, s);
-		nr.node_name = E;
-
-		scroll_range = scroll_range.merge(nr.node); //merge with range
-
-		//now scroll it to draw
-		nr.node.position -= state_machine->get_graph_offset() * EDSCALE;
-
-		node_rects.push_back(nr);
 	}
 
 	transition_lines.clear();
@@ -1021,6 +1029,10 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		tl.to_node = state_machine->get_transition_to(i);
 		Vector2 ofs_to = (dragging_selected && selected_nodes.has(tl.to_node)) ? drag_ofs : Vector2();
 		tl.to = (state_machine->get_node_position(tl.to_node) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
+
+		if (!state_machine->_get_node_visibility(tl.from_node) || !state_machine->_get_node_visibility(tl.to_node)) {
+			continue;
+		}
 
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
 		tl.disabled = bool(tr->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED);
@@ -1095,60 +1107,62 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	//draw actual nodes
 	for (int i = 0; i < node_rects.size(); i++) {
 		String name = node_rects[i].node_name;
-		int name_string_size = theme_cache.node_title_font->get_string_size(name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size).width;
+		if (state_machine->_get_node_visibility(name)) {
+			int name_string_size = theme_cache.node_title_font->get_string_size(name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size).width;
 
-		Ref<AnimationNode> anode = state_machine->get_node(name);
-		bool needs_editor = AnimationTreeEditor::get_singleton()->can_edit(anode);
-		bool is_selected = selected_nodes.has(name);
+			Ref<AnimationNode> anode = state_machine->get_node(name);
+			bool needs_editor = AnimationTreeEditor::get_singleton()->can_edit(anode);
+			bool is_selected = selected_nodes.has(name);
 
-		NodeRect &nr = node_rects.write[i];
-		Vector2 offset = nr.node.position;
-		int h = nr.node.size.height;
+			NodeRect &nr = node_rects.write[i];
+			Vector2 offset = nr.node.position;
+			int h = nr.node.size.height;
 
-		//prepre rect
+			//prepre rect
 
-		//now scroll it to draw
-		Ref<StyleBox> node_frame_style = is_selected ? theme_cache.node_frame_selected : theme_cache.node_frame;
-		state_machine_draw->draw_style_box(node_frame_style, nr.node);
+			//now scroll it to draw
+			Ref<StyleBox> node_frame_style = is_selected ? theme_cache.node_frame_selected : theme_cache.node_frame;
+			state_machine_draw->draw_style_box(node_frame_style, nr.node);
 
-		if (!is_selected && state_machine->start_node == name) {
-			state_machine_draw->draw_style_box(theme_cache.node_frame_start, nr.node);
-		}
-		if (!is_selected && state_machine->end_node == name) {
-			state_machine_draw->draw_style_box(theme_cache.node_frame_end, nr.node);
-		}
-		if (playing && (blend_from == name || current == name || travel_path.has(name))) {
-			state_machine_draw->draw_style_box(theme_cache.node_frame_playing, nr.node);
-		}
+			if (!is_selected && state_machine->start_node == name) {
+				state_machine_draw->draw_style_box(theme_cache.node_frame_start, nr.node);
+			}
+			if (!is_selected && state_machine->end_node == name) {
+				state_machine_draw->draw_style_box(theme_cache.node_frame_end, nr.node);
+			}
+			if (playing && (blend_from == name || current == name || travel_path.has(name))) {
+				state_machine_draw->draw_style_box(theme_cache.node_frame_playing, nr.node);
+			}
 
-		offset.x += node_frame_style->get_offset().x;
+			offset.x += node_frame_style->get_offset().x;
 
-		nr.play.position = offset + Vector2(0, (h - theme_cache.play_node->get_height()) / 2).floor();
-		nr.play.size = theme_cache.play_node->get_size();
+			nr.play.position = offset + Vector2(0, (h - theme_cache.play_node->get_height()) / 2).floor();
+			nr.play.size = theme_cache.play_node->get_size();
 
-		if (hovered_node_name == name && hovered_node_area == HOVER_NODE_PLAY) {
-			state_machine_draw->draw_texture(theme_cache.play_node, nr.play.position, theme_cache.highlight_color);
-		} else {
-			state_machine_draw->draw_texture(theme_cache.play_node, nr.play.position);
-		}
-
-		offset.x += sep + theme_cache.play_node->get_width();
-
-		nr.name.position = offset + Vector2(0, (h - theme_cache.node_title_font->get_height(theme_cache.node_title_font_size)) / 2).floor();
-		nr.name.size = Vector2(name_string_size, theme_cache.node_title_font->get_height(theme_cache.node_title_font_size));
-
-		state_machine_draw->draw_string(theme_cache.node_title_font, nr.name.position + Vector2(0, theme_cache.node_title_font->get_ascent(theme_cache.node_title_font_size)), name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size, theme_cache.node_title_font_color);
-		offset.x += name_string_size + sep;
-
-		nr.can_edit = needs_editor;
-		if (needs_editor) {
-			nr.edit.position = offset + Vector2(0, (h - theme_cache.edit_node->get_height()) / 2).floor();
-			nr.edit.size = theme_cache.edit_node->get_size();
-
-			if (hovered_node_name == name && hovered_node_area == HOVER_NODE_EDIT) {
-				state_machine_draw->draw_texture(theme_cache.edit_node, nr.edit.position, theme_cache.highlight_color);
+			if (hovered_node_name == name && hovered_node_area == HOVER_NODE_PLAY) {
+				state_machine_draw->draw_texture(theme_cache.play_node, nr.play.position, theme_cache.highlight_color);
 			} else {
-				state_machine_draw->draw_texture(theme_cache.edit_node, nr.edit.position);
+				state_machine_draw->draw_texture(theme_cache.play_node, nr.play.position);
+			}
+
+			offset.x += sep + theme_cache.play_node->get_width();
+
+			nr.name.position = offset + Vector2(0, (h - theme_cache.node_title_font->get_height(theme_cache.node_title_font_size)) / 2).floor();
+			nr.name.size = Vector2(name_string_size, theme_cache.node_title_font->get_height(theme_cache.node_title_font_size));
+
+			state_machine_draw->draw_string(theme_cache.node_title_font, nr.name.position + Vector2(0, theme_cache.node_title_font->get_ascent(theme_cache.node_title_font_size)), name, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.node_title_font_size, theme_cache.node_title_font_color);
+			offset.x += name_string_size + sep;
+
+			nr.can_edit = needs_editor;
+			if (needs_editor) {
+				nr.edit.position = offset + Vector2(0, (h - theme_cache.edit_node->get_height()) / 2).floor();
+				nr.edit.size = theme_cache.edit_node->get_size();
+
+				if (hovered_node_name == name && hovered_node_area == HOVER_NODE_EDIT) {
+					state_machine_draw->draw_texture(theme_cache.edit_node, nr.edit.position, theme_cache.highlight_color);
+				} else {
+					state_machine_draw->draw_texture(theme_cache.edit_node, nr.edit.position);
+				}
 			}
 		}
 	}
@@ -1260,6 +1274,7 @@ void AnimationNodeStateMachineEditor::_update_graph() {
 	updating = true;
 
 	state_machine_draw->queue_redraw();
+	_draw_sidepanel_node_group();
 
 	updating = false;
 }
@@ -1274,6 +1289,13 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			tool_select->set_icon(theme_cache.tool_icon_select);
 			tool_create->set_icon(theme_cache.tool_icon_create);
 			tool_connect->set_icon(theme_cache.tool_icon_connect);
+
+			for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+				show_node_group_buttons[i]->set_icon(theme_cache.toggle_icon_visible);
+				hide_node_group_buttons[i]->set_icon(theme_cache.toggle_icon_hidden);
+			}
+			show_all_node_group_button->set_icon(theme_cache.toggle_icon_visible);
+			hide_all_node_group_button->set_icon(theme_cache.toggle_icon_hidden);
 
 			switch_mode->clear();
 			switch_mode->add_icon_item(theme_cache.transition_icon_immediate, TTR("Immediate"));
@@ -1601,6 +1623,205 @@ void AnimationNodeStateMachineEditor::_update_mode() {
 	}
 }
 
+void AnimationNodeStateMachineEditor::_node_group_edit_redraw(const StringName &p_node_name) {
+	if (side_panel_mode == NODE_GROUP_EDIT) {
+		if (p_node_name) {
+			sidepanel_title_2->set_text(String(p_node_name));
+			sidepanel_title_2->add_theme_color_override(SceneStringName(font_color), Color(.55, .93, .59));
+			for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+				node_group_select_checkboxes[i]->set_visible(true);
+				node_group_select_checkboxes[i]->set_pressed(bool(state_machine->_get_node_group_selections(p_node_name)[i]));
+			}
+		} else {
+			sidepanel_title_2->set_text(TTR("Select An Animation Node"));
+			sidepanel_title_2->add_theme_color_override(SceneStringName(font_color), Color(1, .5, .5));
+			for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+				node_group_select_checkboxes[i]->set_visible(false);
+			}
+		}
+	}
+}
+
+void AnimationNodeStateMachineEditor::_draw_sidepanel_edit_node_group() {
+	side_panel_mode = NODE_GROUP_EDIT;
+
+	sidepanel_title->set_text(TTR("Animation Node:"));
+	return_to_node_group_selection_menu_button->set_text(TTR("Return"));
+	return_to_node_group_selection_menu_button->set_visible(true);
+	sidepanel_title_2->set_visible(true);
+	show_all_node_group_button->set_visible(false);
+	hide_all_node_group_button->set_visible(false);
+	node_group_selection_menu_button->set_visible(false);
+	node_group_select_menu_button->set_visible(false);
+	node_group_name_edit_menu_button->set_visible(false);
+	node_group_selection_menu_button->set_visible(false);
+
+	if (selected_node) {
+		sidepanel_title_2->set_text(String(selected_node));
+		sidepanel_title_2->add_theme_color_override(SceneStringName(font_color), Color(.55, .93, .59));
+		for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+			node_group_select_checkboxes[i]->set_visible(true);
+			node_group_select_checkboxes[i]->set_pressed(bool(state_machine->_get_node_group_selections(selected_node)[i]));
+		}
+
+	} else {
+		sidepanel_title_2->set_text(TTR("Select An Animation Node"));
+		sidepanel_title_2->add_theme_color_override(SceneStringName(font_color), Color(1, .5, .5));
+	}
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		show_node_group_buttons[i]->set_visible(false);
+		hide_node_group_buttons[i]->set_visible(false);
+		node_group_labels[i]->set_visible(true);
+		node_group_labels[i]->set_text(state_machine->_get_node_group_names()[i]);
+		node_group_name_line[i]->set_visible(false);
+	}
+}
+
+void AnimationNodeStateMachineEditor::_draw_sidepanel_node_group() {
+	PackedStringArray node_group_names = state_machine->_get_node_group_names();
+
+	// !updating is for keeping the name consistent when changing between animation trees while entering a new node group name
+	if ((side_panel_mode == NODE_GROUP_NAME_EDIT) && !updating) {
+		for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+			if (node_group_name_line[i]->get_text() != "") {
+				node_group_names.set(i, node_group_name_line[i]->get_text());
+			}
+		}
+		state_machine->_set_node_group_names(node_group_names);
+	}
+
+	side_panel_mode = NODE_GROUP_SELECTION;
+
+	node_group_names = state_machine->_get_node_group_names();
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		node_group_name_line[i]->set_placeholder(node_group_names[i]);
+		node_group_labels[i]->set_text(node_group_names[i]);
+	}
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		show_node_group_buttons[i]->set_visible(true);
+		hide_node_group_buttons[i]->set_visible(true);
+		node_group_name_line[i]->set_visible(false);
+		node_group_select_checkboxes[i]->set_visible(false);
+		node_group_labels[i]->set_visible(true);
+	}
+
+	show_all_node_group_button->set_visible(true);
+	hide_all_node_group_button->set_visible(true);
+	sidepanel_title_2->set_visible(false);
+	node_group_select_menu_button->set_visible(true);
+	node_group_name_edit_menu_button->set_visible(true);
+	node_group_selection_menu_button->set_visible(false);
+	return_to_node_group_selection_menu_button->set_visible(false);
+	sidepanel_title->set_text(TTR("Node Groups"));
+}
+
+void AnimationNodeStateMachineEditor::_draw_sidepanel_node_group_name_edit() {
+	sidepanel_title->set_text(TTR("Node Group Rename"));
+	return_to_node_group_selection_menu_button->set_text(TTR("Save"));
+	side_panel_mode = NODE_GROUP_NAME_EDIT;
+	PackedStringArray node_group_names = state_machine->_get_node_group_names();
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		show_node_group_buttons[i]->set_visible(false);
+		hide_node_group_buttons[i]->set_visible(false);
+		node_group_labels[i]->set_visible(false);
+		node_group_name_line[i]->set_visible(true);
+		node_group_name_line[i]->set_text("");
+		node_group_name_line[i]->set_placeholder(node_group_names[i]);
+	}
+
+	show_all_node_group_button->set_visible(false);
+	hide_all_node_group_button->set_visible(false);
+	node_group_select_menu_button->set_visible(false);
+	node_group_name_edit_menu_button->set_visible(false);
+	node_group_selection_menu_button->set_visible(false);
+	return_to_node_group_selection_menu_button->set_visible(true);
+}
+
+void AnimationNodeStateMachineEditor::_checkbox_pressed() {
+	if (selected_node) {
+		for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+			if (node_group_select_checkboxes[i]->is_pressing()) {
+				if (node_group_select_checkboxes[i]->is_pressed()) {
+					state_machine->_set_node_group_selections(selected_node, i, 1);
+					break;
+				} else {
+					state_machine->_set_node_group_selections(selected_node, i, 0);
+					break;
+				}
+			}
+		}
+	}
+}
+
+void AnimationNodeStateMachineEditor::_show_all_node_group() {
+	List<StringName> nodes;
+	state_machine->get_node_list(&nodes);
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		show_node_group_buttons[i]->set_pressed(false);
+		hide_node_group_buttons[i]->set_pressed(false);
+	}
+
+	for (const StringName &E : nodes) {
+		state_machine->_set_node_visibility(E, true);
+		for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		}
+	}
+	state_machine_draw->queue_redraw();
+}
+
+void AnimationNodeStateMachineEditor::_hide_all_node_group() {
+	List<StringName> nodes;
+	state_machine->get_node_list(&nodes);
+
+	for (const StringName &E : nodes) {
+		state_machine->_set_node_visibility(E, false);
+		for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		}
+	}
+	state_machine_draw->queue_redraw();
+}
+
+void AnimationNodeStateMachineEditor::_show_node_group_pressed() {
+	PackedInt32Array node_group_selections;
+	List<StringName> nodes;
+	state_machine->get_node_list(&nodes);
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		if (show_node_group_buttons[i]->is_pressing()) {
+			for (const StringName &E : nodes) {
+				node_group_selections = state_machine->_get_node_group_selections(E);
+				if (node_group_selections[i] == 1) {
+					state_machine->_set_node_visibility(E, true);
+				}
+			}
+		}
+	}
+	state_machine_draw->queue_redraw();
+}
+
+void AnimationNodeStateMachineEditor::_hide_node_group_pressed() {
+	PackedInt32Array node_group_selections;
+	List<StringName> nodes;
+	state_machine->get_node_list(&nodes);
+
+	for (int i = 0; i < AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT; i++) {
+		if (hide_node_group_buttons[i]->is_pressing()) {
+			for (const StringName &E : nodes) {
+				node_group_selections = state_machine->_get_node_group_selections(E);
+				if (node_group_selections[i] == 1) {
+					state_machine->_set_node_visibility(E, false);
+				}
+			}
+		}
+	}
+	state_machine_draw->queue_redraw();
+}
+
 void AnimationNodeStateMachineEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph", &AnimationNodeStateMachineEditor::_update_graph);
 
@@ -1612,6 +1833,9 @@ void AnimationNodeStateMachineEditor::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_create, "ToolAddNode", "EditorIcons");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_connect, "ToolConnect", "EditorIcons");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_erase, "Remove", "EditorIcons");
+
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, toggle_icon_visible, "GuiVisibilityVisible", "EditorIcons");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, toggle_icon_hidden, "GuiVisibilityHidden", "EditorIcons");
 
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_immediate, "TransitionImmediate", "EditorIcons");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_sync, "TransitionSync", "EditorIcons");
@@ -1726,11 +1950,16 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	play_mode = memnew(OptionButton);
 	top_hb->add_child(play_mode);
 
+	hsplit = memnew(HSplitContainer);
+	add_child(hsplit);
+	hsplit->set_v_size_flags(SIZE_EXPAND_FILL);
+
 	panel = memnew(PanelContainer);
 	panel->set_clip_contents(true);
 	panel->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	add_child(panel);
-	panel->set_v_size_flags(SIZE_EXPAND_FILL);
+	hsplit->add_child(panel);
+	panel->set_h_size_flags(SIZE_EXPAND_FILL);
+	panel->set_v_size_flags(SIZE_FILL);
 
 	state_machine_draw = memnew(Control);
 	panel->add_child(state_machine_draw);
@@ -1743,7 +1972,126 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	state_machine_draw->add_child(state_machine_play_pos);
 	state_machine_play_pos->set_mouse_filter(MOUSE_FILTER_PASS); //pass all to parent
 	state_machine_play_pos->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
-	state_machine_play_pos->connect(SceneStringName(draw), callable_mp(this, &AnimationNodeStateMachineEditor::_state_machine_pos_draw_all));
+
+	sidepanel = memnew(PanelContainer);
+	hsplit->add_child(sidepanel);
+	sidepanel->set_clip_contents(true);
+	sidepanel->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+
+	sidepanel_rect = memnew(MarginContainer);
+	sidepanel->add_child(sidepanel_rect);
+	sidepanel_rect->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+
+	sp_vertical_partition = memnew(VBoxContainer);
+	sidepanel_rect->add_child(sp_vertical_partition);
+	sp_vertical_partition->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+
+	sp_title_container = memnew(HBoxContainer);
+	sp_vertical_partition->add_child(sp_title_container);
+	sp_title_container->set_anchors_and_offsets_preset(PRESET_TOP_WIDE);
+
+	sidepanel_title = memnew(Label(TTR("Node Groups")));
+	sp_title_container->add_child(sidepanel_title);
+	sidepanel_title->set_h_size_flags(SIZE_EXPAND_FILL);
+	sidepanel_title->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	sidepanel_title_2 = memnew(Label);
+	sp_title_container->add_child(sidepanel_title_2);
+	sidepanel_title_2->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	sidepanel_title_2->set_visible(false);
+
+	h_sep = memnew(HSeparator);
+	sp_vertical_partition->add_child(h_sep);
+	h_sep->set_anchors_and_offsets_preset(PRESET_TOP_WIDE);
+	h_sep->set_custom_minimum_size(Size2(0, 12));
+
+	visibility_reset_container = memnew(HBoxContainer);
+	sp_vertical_partition->add_child(visibility_reset_container);
+	visibility_reset_container->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	show_all_node_group_button = memnew(Button);
+	visibility_reset_container->add_child(show_all_node_group_button);
+	show_all_node_group_button->set_custom_minimum_size(Size2(50, 35));
+	show_all_node_group_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_show_all_node_group));
+	show_all_node_group_button->set_expand_icon(true);
+	show_all_node_group_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	show_all_node_group_button->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	hide_all_node_group_button = memnew(Button);
+	visibility_reset_container->add_child(hide_all_node_group_button);
+	hide_all_node_group_button->set_custom_minimum_size(Size2(50, 35));
+	hide_all_node_group_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_hide_all_node_group));
+	hide_all_node_group_button->set_expand_icon(true);
+	hide_all_node_group_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	hide_all_node_group_button->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	for (int i = 0; AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT > i; i++) {
+		node_group_hor_containers[i] = memnew(HBoxContainer);
+		sp_vertical_partition->add_child(node_group_hor_containers[i]);
+		node_group_containers[i] = memnew(HBoxContainer);
+		node_group_hor_containers[i]->add_child(node_group_containers[i]);
+		node_group_containers[i]->set_h_size_flags(SIZE_EXPAND);
+		node_group_name_line[i] = memnew(LineEdit);
+		node_group_containers[i]->add_child(node_group_name_line[i]);
+		node_group_name_line[i]->set_custom_minimum_size(Size2(140, 30));
+		node_group_name_line[i]->set_expand_to_text_length_enabled(true);
+		node_group_name_line[i]->set_h_size_flags(SIZE_SHRINK_CENTER);
+		node_group_name_line[i]->set_visible(false);
+
+		show_node_group_buttons[i] = memnew(Button);
+		show_node_group_buttons[i]->set_custom_minimum_size(Size2(25, 25));
+		show_node_group_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_show_node_group_pressed));
+
+		hide_node_group_buttons[i] = memnew(Button);
+		hide_node_group_buttons[i]->set_custom_minimum_size(Size2(25, 25));
+		hide_node_group_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_hide_node_group_pressed));
+
+		node_group_containers[i]->add_child(show_node_group_buttons[i]);
+		node_group_containers[i]->add_child(hide_node_group_buttons[i]);
+
+		node_group_select_checkboxes[i] = memnew(CheckBox);
+		node_group_labels[i] = memnew(Label);
+
+		node_group_containers[i]->add_child(node_group_select_checkboxes[i]);
+		node_group_containers[i]->add_child(node_group_labels[i]);
+		node_group_select_checkboxes[i]->set_visible(false);
+		node_group_labels[i]->set_visible(false);
+		node_group_select_checkboxes[i]->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_checkbox_pressed));
+	}
+
+	spacer = memnew(HBoxContainer);
+	spacer->set_v_size_flags(SIZE_EXPAND);
+	sp_vertical_partition->add_child(spacer);
+
+	node_group_selection_menu_button = memnew(Button);
+	node_group_selection_menu_button->set_text(TTR("Select Node Groups"));
+	node_group_selection_menu_button->set_custom_minimum_size(Size2(0, 25));
+	node_group_selection_menu_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	node_group_selection_menu_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_draw_sidepanel_node_group), CONNECT_DEFERRED);
+	sp_vertical_partition->add_child(node_group_selection_menu_button);
+
+	node_group_select_menu_button = memnew(Button);
+	node_group_select_menu_button->set_text(TTR("Edit Node Groups"));
+	node_group_select_menu_button->set_custom_minimum_size(Size2(0, 25));
+	node_group_select_menu_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	node_group_select_menu_button->set_visible(false);
+	node_group_select_menu_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_draw_sidepanel_edit_node_group), CONNECT_DEFERRED);
+	sp_vertical_partition->add_child(node_group_select_menu_button);
+
+	node_group_name_edit_menu_button = memnew(Button);
+	node_group_name_edit_menu_button->set_text(TTR("Edit Node Group Names"));
+	node_group_name_edit_menu_button->set_custom_minimum_size(Size2(0, 25));
+	node_group_name_edit_menu_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	node_group_name_edit_menu_button->set_visible(false);
+	node_group_name_edit_menu_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_draw_sidepanel_node_group_name_edit), CONNECT_DEFERRED);
+	sp_vertical_partition->add_child(node_group_name_edit_menu_button);
+
+	return_to_node_group_selection_menu_button = memnew(Button);
+	return_to_node_group_selection_menu_button->set_text(TTR("Save"));
+	return_to_node_group_selection_menu_button->set_custom_minimum_size(Size2(0, 25));
+	return_to_node_group_selection_menu_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	return_to_node_group_selection_menu_button->set_visible(false);
+	return_to_node_group_selection_menu_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_draw_sidepanel_node_group), CONNECT_DEFERRED);
+	sp_vertical_partition->add_child(return_to_node_group_selection_menu_button);
 
 	v_scroll = memnew(VScrollBar);
 	state_machine_draw->add_child(v_scroll);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -41,6 +41,11 @@ class ConfirmationDialog;
 class EditorFileDialog;
 class OptionButton;
 class PanelContainer;
+class HSplitContainer;
+class MarginContainer;
+class HSeparator;
+class CheckBox;
+class AnimationNodeAnimation;
 
 class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeStateMachineEditor, AnimationTreeNodeEditorPlugin);
@@ -64,7 +69,36 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	OptionButton *play_mode = nullptr;
 
+	HSplitContainer *hsplit = nullptr;
+	MarginContainer *sidepanel_rect = nullptr;
+
 	PanelContainer *panel = nullptr;
+	PanelContainer *sidepanel = nullptr;
+
+	VBoxContainer *sp_vertical_partition = nullptr;
+
+	HBoxContainer *sp_title_container = nullptr;
+	Label *sidepanel_title = nullptr;
+	Label *sidepanel_title_2 = nullptr;
+	HSeparator *h_sep = nullptr;
+	HBoxContainer *visibility_reset_container = nullptr;
+	Button *show_all_node_group_button = nullptr;
+	Button *hide_all_node_group_button = nullptr;
+
+	HBoxContainer *node_group_hor_containers[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	HBoxContainer *node_group_containers[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	Button *show_node_group_buttons[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	Button *hide_node_group_buttons[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	LineEdit *node_group_name_line[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	CheckBox *node_group_select_checkboxes[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+	Label *node_group_labels[AnimationNodeStateMachine::STATE_MACHINE_GROUPS_LIMIT] = { nullptr };
+
+	HBoxContainer *spacer = nullptr;
+
+	Button *node_group_selection_menu_button = nullptr;
+	Button *node_group_select_menu_button = nullptr;
+	Button *node_group_name_edit_menu_button = nullptr;
+	Button *return_to_node_group_selection_menu_button = nullptr;
 
 	StringName selected_node;
 	HashSet<StringName> selected_nodes;
@@ -87,6 +121,9 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		Ref<Texture2D> tool_icon_create;
 		Ref<Texture2D> tool_icon_connect;
 		Ref<Texture2D> tool_icon_erase;
+
+		Ref<Texture2D> toggle_icon_visible;
+		Ref<Texture2D> toggle_icon_hidden;
 
 		Ref<Texture2D> transition_icon_immediate;
 		Ref<Texture2D> transition_icon_sync;
@@ -232,14 +269,32 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		HOVER_NODE_EDIT = 1,
 	};
 
+	enum SidePanelMode {
+		NODE_GROUP_SELECTION = -1,
+		NODE_GROUP_NAME_EDIT = 0,
+		NODE_GROUP_EDIT = 1,
+	};
+
 	StringName hovered_node_name;
 	HoveredNodeArea hovered_node_area = HOVER_NODE_NONE;
+	SidePanelMode side_panel_mode = NODE_GROUP_SELECTION;
 
 	String prev_name;
 	void _name_edited(const String &p_text);
 	void _name_edited_focus_out();
 	void _open_editor(const String &p_name);
 	void _scroll_changed(double);
+
+	void _draw_sidepanel_node_group();
+	void _draw_sidepanel_edit_node_group();
+	void _draw_sidepanel_node_group_name_edit();
+	void _node_group_edit_redraw(const StringName &p_node_name);
+
+	void _checkbox_pressed();
+	void _show_node_group_pressed();
+	void _hide_node_group_pressed();
+	void _show_all_node_group();
+	void _hide_all_node_group();
 
 	String _get_root_playback_path(String &r_node_directory);
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1266,6 +1266,15 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	State state_new;
 	state_new.node = p_node;
 	state_new.position = p_position;
+#ifdef TOOLS_ENABLED
+	PackedInt32Array node_group_selections;
+
+	state_new.node_group_selections = node_group_selections;
+	state_new.node_visibility = true;
+
+	node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
+	node_group_selections.fill(0);
+#endif //TOOLS_ENABLED
 
 	states[p_name] = state_new;
 
@@ -1653,6 +1662,29 @@ bool AnimationNodeStateMachine::_set(const StringName &p_name, const Variant &p_
 			}
 			return true;
 		}
+#ifdef TOOLS_ENABLED
+		if (what == "node_group_selections") {
+			if (states.has(node_name)) {
+				PackedInt32Array initial_array = p_value;
+
+				if (initial_array.size() != STATE_MACHINE_GROUPS_LIMIT) {
+					initial_array.resize(STATE_MACHINE_GROUPS_LIMIT);
+					initial_array.fill(0);
+					states[node_name].node_group_selections = initial_array;
+				} else {
+					states[node_name].node_group_selections = p_value;
+				}
+			}
+			return true;
+		}
+
+		if (what == "node_visibility") {
+			if (states.has(node_name)) {
+				states[node_name].node_visibility = p_value;
+			}
+			return true;
+		}
+#endif //TOOLS_ENABLED
 	} else if (prop_name == "transitions") {
 		Array trans = p_value;
 		ERR_FAIL_COND_V(trans.size() % 3 != 0, false);
@@ -1665,7 +1697,19 @@ bool AnimationNodeStateMachine::_set(const StringName &p_name, const Variant &p_
 		set_graph_offset(p_value);
 		return true;
 	}
-
+#ifdef TOOLS_ENABLED
+	else if (prop_name == "node_group_names") {
+		PackedStringArray initial_array = p_value;
+		if (initial_array.size() != STATE_MACHINE_GROUPS_LIMIT) {
+			initial_array.resize(STATE_MACHINE_GROUPS_LIMIT);
+			for (int i = 0; i < STATE_MACHINE_GROUPS_LIMIT; i++) {
+				node_group_names.set(i, TTR("Node Group - ") + String::num(i + 1));
+			}
+		}
+		_set_node_group_names(initial_array);
+		return true;
+	}
+#endif //TOOLS_ENABLED
 	return false;
 }
 
@@ -1682,6 +1726,21 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 			}
 		}
 
+#ifdef TOOLS_ENABLED
+		if (what == "node_group_selections") {
+			if (states.has(node_name)) {
+				r_ret = states[node_name].node_group_selections;
+				return true;
+			}
+		}
+
+		if (what == "node_visibility") {
+			if (states.has(node_name)) {
+				r_ret = states[node_name].node_visibility;
+				return true;
+			}
+		}
+#endif //TOOLS_ENABLED
 		if (what == "position") {
 			if (states.has(node_name)) {
 				r_ret = states[node_name].position;
@@ -1705,6 +1764,12 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 		r_ret = get_graph_offset();
 		return true;
 	}
+#ifdef TOOLS_ENABLED
+	else if (prop_name == "node_group_names") {
+		r_ret = _get_node_group_names();
+		return true;
+	}
+#endif //TOOLS_ENABLED
 
 	return false;
 }
@@ -1719,8 +1784,15 @@ void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) c
 	for (const StringName &prop_name : names) {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "states/" + prop_name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, "states/" + prop_name + "/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+#ifdef TOOLS_ENABLED
+		p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "states/" + prop_name + "/node_group_selections", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "states/" + prop_name + "/node_visibility", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+#endif //TOOLS_ENABLED
 	}
 
+#ifdef TOOLS_ENABLED
+	p_list->push_back(PropertyInfo(Variant::PACKED_STRING_ARRAY, "node_group_names", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+#endif //TOOLS_ENABLED
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "transitions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 	p_list->push_back(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 
@@ -1750,13 +1822,28 @@ void AnimationNodeStateMachine::reset_state() {
 	State start;
 	start.node = s;
 	start.position = Vector2(200, 100);
-	states[start_node] = start;
 
 	Ref<AnimationNodeEndState> e;
 	e.instantiate();
 	State end;
 	end.node = e;
 	end.position = Vector2(900, 100);
+
+#ifdef TOOLS_ENABLED
+	end.node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
+	end.node_group_selections.fill(0);
+
+	start.node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
+	start.node_group_selections.fill(0);
+
+	node_group_names.resize(STATE_MACHINE_GROUPS_LIMIT);
+
+	for (int i = 0; i < STATE_MACHINE_GROUPS_LIMIT; i++) {
+		node_group_names.set(i, TTR("Node Group - ") + String::num(i + 1));
+	}
+#endif //TOOLS_ENABLED
+
+	states[start_node] = start;
 	states[end_node] = end;
 
 	emit_changed();
@@ -1772,6 +1859,36 @@ Vector2 AnimationNodeStateMachine::get_node_position(const StringName &p_name) c
 	ERR_FAIL_COND_V(!states.has(p_name), Vector2());
 	return states[p_name].position;
 }
+
+#ifdef TOOLS_ENABLED
+void AnimationNodeStateMachine::_set_node_visibility(const StringName &p_name, bool p_node_visibility) {
+	ERR_FAIL_COND(!states.has(p_name));
+	states[p_name].node_visibility = p_node_visibility;
+}
+
+bool AnimationNodeStateMachine::_get_node_visibility(const StringName &p_name) const {
+	ERR_FAIL_COND_V(!states.has(p_name), bool());
+	return states[p_name].node_visibility;
+}
+
+void AnimationNodeStateMachine::_set_node_group_selections(const StringName &p_name, int p_selection_index, int p_selection) {
+	ERR_FAIL_COND(!states.has(p_name));
+	states[p_name].node_group_selections.set(p_selection_index, p_selection);
+}
+
+PackedInt32Array AnimationNodeStateMachine::_get_node_group_selections(const StringName &p_name) const {
+	ERR_FAIL_COND_V(!states.has(p_name), PackedInt32Array());
+	return states[p_name].node_group_selections;
+}
+
+void AnimationNodeStateMachine::_set_node_group_names(const PackedStringArray &p_node_group_names) {
+	node_group_names = p_node_group_names;
+}
+
+PackedStringArray AnimationNodeStateMachine::_get_node_group_names() const {
+	return node_group_names;
+}
+#endif //TOOLS_ENABLED
 
 void AnimationNodeStateMachine::_tree_changed() {
 	emit_changed();
@@ -1791,7 +1908,7 @@ void AnimationNodeStateMachine::get_argument_options(const StringName &p_functio
 	const String pf = p_function;
 	bool add_state_options = false;
 	if (p_idx == 0) {
-		add_state_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "replace_node" || pf == "set_node_position" || pf == "get_node_position");
+		add_state_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "replace_node" || pf == "set_node_position" || pf == "get_node_position" || pf == "_get_node_group_selections" || pf == "_set_node_group_selections" || pf == "_get_node_visibility" || pf == "_set_node_visibility");
 	} else if (p_idx <= 1) {
 		add_state_options = (pf == "has_transition" || pf == "add_transition" || pf == "remove_transition");
 	}
@@ -1802,7 +1919,7 @@ void AnimationNodeStateMachine::get_argument_options(const StringName &p_functio
 	}
 	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);
 }
-#endif
+#endif //TOOLS_ENABLED
 
 void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeStateMachine::add_node, DEFVAL(Vector2()));
@@ -1815,6 +1932,17 @@ void AnimationNodeStateMachine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_node_position", "name", "position"), &AnimationNodeStateMachine::set_node_position);
 	ClassDB::bind_method(D_METHOD("get_node_position", "name"), &AnimationNodeStateMachine::get_node_position);
+
+#ifdef TOOLS_ENABLED
+	ClassDB::bind_method(D_METHOD("_set_node_visibility", "name", "node_visibility"), &AnimationNodeStateMachine::_set_node_visibility);
+	ClassDB::bind_method(D_METHOD("_get_node_visibility", "name"), &AnimationNodeStateMachine::_get_node_visibility);
+
+	ClassDB::bind_method(D_METHOD("_set_node_group_selections", "name", "selection index", "node_group_selections"), &AnimationNodeStateMachine::_set_node_group_selections);
+	ClassDB::bind_method(D_METHOD("_get_node_group_selections", "name"), &AnimationNodeStateMachine::_get_node_group_selections);
+
+	ClassDB::bind_method(D_METHOD("_set_node_group_names", "node_group_names"), &AnimationNodeStateMachine::_set_node_group_names);
+	ClassDB::bind_method(D_METHOD("_get_node_group_names"), &AnimationNodeStateMachine::_get_node_group_names);
+#endif //TOOLS_ENABLED
 
 	ClassDB::bind_method(D_METHOD("has_transition", "from", "to"), &AnimationNodeStateMachine::has_transition);
 	ClassDB::bind_method(D_METHOD("add_transition", "from", "to", "transition"), &AnimationNodeStateMachine::add_transition);
@@ -1852,12 +1980,26 @@ AnimationNodeStateMachine::AnimationNodeStateMachine() {
 	State start;
 	start.node = s;
 	start.position = Vector2(200, 100);
-	states[start_node] = start;
 
 	Ref<AnimationNodeEndState> e;
 	e.instantiate();
 	State end;
 	end.node = e;
 	end.position = Vector2(900, 100);
+
+#ifdef TOOLS_ENABLED
+	end.node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
+	end.node_group_selections.fill(0);
+	start.node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
+	start.node_group_selections.fill(0);
+
+	node_group_names.resize(STATE_MACHINE_GROUPS_LIMIT);
+
+	for (int i = 0; i < STATE_MACHINE_GROUPS_LIMIT; i++) {
+		node_group_names.set(i, TTR("Node Group - ") + String::num(i + 1));
+	}
+#endif //TOOLS_ENABLED
+
 	states[end_node] = end;
+	states[start_node] = start;
 }

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1268,12 +1268,10 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	state_new.position = p_position;
 #ifdef TOOLS_ENABLED
 	PackedInt32Array node_group_selections;
-
-	state_new.node_group_selections = node_group_selections;
-	state_new.node_visibility = true;
-
 	node_group_selections.resize(STATE_MACHINE_GROUPS_LIMIT);
 	node_group_selections.fill(0);
+	state_new.node_group_selections = node_group_selections;
+	state_new.node_visibility = true;
 #endif //TOOLS_ENABLED
 
 	states[p_name] = state_new;
@@ -1665,15 +1663,7 @@ bool AnimationNodeStateMachine::_set(const StringName &p_name, const Variant &p_
 #ifdef TOOLS_ENABLED
 		if (what == "node_group_selections") {
 			if (states.has(node_name)) {
-				PackedInt32Array initial_array = p_value;
-
-				if (initial_array.size() != STATE_MACHINE_GROUPS_LIMIT) {
-					initial_array.resize(STATE_MACHINE_GROUPS_LIMIT);
-					initial_array.fill(0);
-					states[node_name].node_group_selections = initial_array;
-				} else {
-					states[node_name].node_group_selections = p_value;
-				}
+				states[node_name].node_group_selections = p_value;
 			}
 			return true;
 		}

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -110,6 +110,10 @@ class AnimationNodeStateMachine : public AnimationRootNode {
 	GDCLASS(AnimationNodeStateMachine, AnimationRootNode);
 
 public:
+#ifdef TOOLS_ENABLED
+	static constexpr int STATE_MACHINE_GROUPS_LIMIT = 12;
+#endif //TOOLS_ENABLED
+
 	enum StateMachineType {
 		STATE_MACHINE_TYPE_ROOT,
 		STATE_MACHINE_TYPE_NESTED,
@@ -124,6 +128,10 @@ private:
 	struct State {
 		Ref<AnimationRootNode> node;
 		Vector2 position;
+#ifdef TOOLS_ENABLED
+		PackedInt32Array node_group_selections;
+		bool node_visibility = true;
+#endif //TOOLS_ENABLED
 	};
 
 	HashMap<StringName, State> states;
@@ -142,6 +150,9 @@ private:
 	bool updating_transitions = false;
 
 	Vector2 graph_offset;
+#ifdef TOOLS_ENABLED
+	PackedStringArray node_group_names;
+#endif //TOOLS_ENABLED
 
 	void _remove_transition(const Ref<AnimationNodeStateMachineTransition> p_transition);
 	void _rename_transitions(const StringName &p_name, const StringName &p_new_name);
@@ -183,6 +194,17 @@ public:
 	void set_node_position(const StringName &p_name, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_name) const;
 
+#ifdef TOOLS_ENABLED
+	void _set_node_visibility(const StringName &p_name, bool p_visibility);
+	bool _get_node_visibility(const StringName &p_name) const;
+
+	void _set_node_group_selections(const StringName &p_name, int p_selection_index, int p_selection);
+	PackedInt32Array _get_node_group_selections(const StringName &p_name) const;
+
+	void _set_node_group_names(const PackedStringArray &p_node_group_names);
+	PackedStringArray _get_node_group_names() const;
+#endif //TOOLS_ENABLED
+
 	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
 
 	bool has_transition(const StringName &p_from, const StringName &p_to) const;
@@ -221,7 +243,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
+#endif //TOOLS_ENABLED
 
 	AnimationNodeStateMachine();
 };


### PR DESCRIPTION
A side panel added to state machine editor for hiding and unhiding animation nodes according to <s>selected layers</s> node groups.
Fixes godotengine/godot-proposals#7989
Tried out traditional layers and they weren't really useful for this. Grouping animation nodes for hiding and showing them led to much better results for flexibility and usability. This system is a bit unusual tbh, but still easy to understand.

Added a side panel with 3 different modes; edit node group name menu, edit node group menu, hide-show(select) node group menu; 
![Menus](https://github.com/godotengine/godot/assets/61533529/b81bd474-6b75-4cab-82e6-906937aeab88)

While system is unusual as a tag or layer system, it lets you isolate animation nodes pretty well. like so

![Nodes](https://github.com/godotengine/godot/assets/61533529/7d1d864a-9c7d-4b9e-a578-4f975991b505)

![Nodes-Isolated](https://github.com/godotengine/godot/assets/61533529/18f0096f-09a5-433b-b3a6-87cd1f7a6d88)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
