### PR TITLE
Add `PlatformText` utility to have specific platform strings

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input_event.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/platform_text.h"
 #include "core/templates/hash_set.h"
 #include "core/variant/variant.h"
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -110,6 +110,7 @@ protected:
 
 	virtual void initialize() = 0;
 	virtual void initialize_joypads() = 0;
+	virtual void initialize_platform_text() = 0;
 
 	void set_current_rendering_driver_name(const String &p_driver_name) { _current_rendering_driver_name = p_driver_name; }
 	void set_current_rendering_method(const String &p_name) { _current_rendering_method = p_name; }

--- a/core/os/platform_text.cpp
+++ b/core/os/platform_text.cpp
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  platform_text.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text.h"
+
+String PlatformTextImplementation::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return "";
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return "";
+}
+
+String PlatformTextImplementation::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return "";
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return "";
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return "";
+#else
+	return "";
+#endif
+}
+
+bool PlatformTextImplementation::_is_editor() const {
+	return Engine::get_singleton()->is_editor_hint();
+}
+
+//////////////////////////
+
+PlatformText *PlatformText::singleton = nullptr;
+
+String PlatformText::get_string(PlatformTextID p_id) const {
+	ERR_FAIL_COND_V(implementation == nullptr, "");
+	return implementation->get_string(p_id);
+}
+
+String PlatformText::get_editor_string(PlatformTextEditorID p_id) const {
+	ERR_FAIL_COND_V(implementation == nullptr, "");
+	return implementation->get_editor_string(p_id);
+}
+
+void PlatformText::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_string", "id"), &PlatformText::get_string);
+	ClassDB::bind_method(D_METHOD("get_editor_string", "id"), &PlatformText::get_editor_string);
+}

--- a/core/os/platform_text.h
+++ b/core/os/platform_text.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  platform_text.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_H
+#define PLATFORM_TEXT_H
+
+#include "core/object/object.h"
+#include "core/os/os.h"
+#include "core/variant/binder_common.h"
+
+enum class PlatformTextID {
+};
+VARIANT_ENUM_CAST(PlatformTextID);
+
+enum class PlatformTextEditorID {
+};
+VARIANT_ENUM_CAST(PlatformTextEditorID);
+
+class PlatformTextImplementation {
+protected:
+	bool _is_editor() const;
+
+public:
+	virtual String get_string(PlatformTextID p_id) const;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const;
+
+	PlatformTextImplementation() {}
+	virtual ~PlatformTextImplementation() {}
+};
+
+//////////////////////////
+
+class PlatformText : public Object {
+	GDCLASS(PlatformText, Object);
+
+	static PlatformText *singleton;
+	PlatformTextImplementation *implementation = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static PlatformText *get_singleton() { return singleton; }
+
+	void set_implementation(PlatformTextImplementation *p_implementation) {
+		implementation = p_implementation;
+	}
+
+	virtual String get_string(PlatformTextID p_id) const;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const;
+
+	PlatformText() {
+		singleton = this;
+	}
+	virtual ~PlatformText() {}
+};
+
+#endif // PLATFORM_TEXT_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -76,6 +76,7 @@
 #include "core/object/undo_redo.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/main_loop.h"
+#include "core/os/platform_text.h"
 #include "core/os/time.h"
 #include "core/string/optimized_translation.h"
 #include "core/string/translation.h"
@@ -102,6 +103,7 @@ static core_bind::EngineDebugger *_engine_debugger = nullptr;
 
 static IP *ip = nullptr;
 static Time *_time = nullptr;
+static PlatformText *_platform_text = nullptr;
 
 static core_bind::Geometry2D *_geometry_2d = nullptr;
 static core_bind::Geometry3D *_geometry_3d = nullptr;
@@ -129,6 +131,7 @@ void register_core_types() {
 
 	StringName::setup();
 	_time = memnew(Time);
+	_platform_text = memnew(PlatformText);
 	ResourceLoader::initialize();
 
 	register_global_constants();
@@ -330,6 +333,7 @@ void register_core_singletons() {
 	GDREGISTER_CLASS(Expression);
 	GDREGISTER_CLASS(core_bind::EngineDebugger);
 	GDREGISTER_CLASS(Time);
+	GDREGISTER_CLASS(PlatformText);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton(), "IP"));
@@ -349,6 +353,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PlatformText", PlatformText::get_singleton()));
 
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Singletons");
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3025,6 +3025,8 @@ Error Main::setup2() {
 
 		ResourceLoader::load_path_remaps();
 
+		OS::get_singleton()->initialize_platform_text();
+
 		OS::get_singleton()->benchmark_end_measure("Startup", "Translations and Remaps");
 	}
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -9,6 +9,7 @@ Import("env")
 
 android_files = [
     "os_android.cpp",
+    "platform_text_android.cpp",
     "android_input_handler.cpp",
     "file_access_android.cpp",
     "file_access_filesystem_jandroid.cpp",

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -124,6 +124,11 @@ void OS_Android::initialize_joypads() {
 	godot_java->init_input_devices();
 }
 
+void OS_Android::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextAndroid);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
+}
+
 void OS_Android::set_main_loop(MainLoop *p_main_loop) {
 	main_loop = p_main_loop;
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -32,6 +32,7 @@
 #define OS_ANDROID_H
 
 #include "audio_driver_opensl.h"
+#include "platform_text_android.h"
 
 #include "core/os/main_loop.h"
 #include "drivers/unix/os_unix.h"
@@ -63,6 +64,7 @@ private:
 	AudioDriverOpenSL audio_driver_android;
 
 	MainLoop *main_loop = nullptr;
+	PlatformTextAndroid *platform_text_implementation = nullptr;
 
 	struct FontInfo {
 		String font_name;
@@ -95,6 +97,7 @@ public:
 	virtual void initialize() override;
 
 	virtual void initialize_joypads() override;
+	virtual void initialize_platform_text() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;

--- a/platform/android/platform_text_android.cpp
+++ b/platform/android/platform_text_android.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_android.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_android.h"
+
+String PlatformTextAndroid::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextAndroid::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextAndroid::PlatformTextAndroid() {}
+PlatformTextAndroid::~PlatformTextAndroid() {}

--- a/platform/android/platform_text_android.h
+++ b/platform/android/platform_text_android.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_android.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_ANDROID_H
+#define PLATFORM_TEXT_ANDROID_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextAndroid : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextAndroid();
+	virtual ~PlatformTextAndroid();
+};
+
+#endif // PLATFORM_TEXT_ANDROID_H

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -61,6 +61,7 @@ def generate_bundle(target, source, env):
 ios_lib = [
     "godot_ios.mm",
     "os_ios.mm",
+    "platform_text_ios.mm",
     "main.m",
     "app_delegate.mm",
     "view_controller.mm",

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -35,6 +35,7 @@
 
 #import "ios.h"
 #import "joypad_ios.h"
+#import "platform_text_ios.h"
 
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "drivers/unix/os_unix.h"
@@ -61,12 +62,14 @@ private:
 	JoypadIOS *joypad_ios = nullptr;
 
 	MainLoop *main_loop = nullptr;
+	PlatformTextIOS *platform_text_implementation = nullptr;
 
 	virtual void initialize_core() override;
 	virtual void initialize() override;
 
 	virtual void initialize_joypads() override {
 	}
+	virtual void initialize_platform_text() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual MainLoop *get_main_loop() const override;

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -130,6 +130,11 @@ void OS_IOS::initialize() {
 	initialize_core();
 }
 
+void OS_IOS::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextIOS);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
+}
+
 void OS_IOS::initialize_modules() {
 	ios = memnew(iOS);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("iOS", ios));

--- a/platform/ios/platform_text_ios.h
+++ b/platform/ios/platform_text_ios.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_ios.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_IOS_H
+#define PLATFORM_TEXT_IOS_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextIOS : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextIOS();
+	virtual ~PlatformTextIOS();
+};
+
+#endif // PLATFORM_TEXT_IOS_H

--- a/platform/ios/platform_text_ios.mm
+++ b/platform/ios/platform_text_ios.mm
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_ios.mm                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_ios.h"
+
+String PlatformTextIOS::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextIOS::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextIOS::PlatformTextIOS() {}
+PlatformTextIOS::~PlatformTextIOS() {}

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -7,6 +7,7 @@ import platform_linuxbsd_builders
 common_linuxbsd = [
     "crash_handler_linuxbsd.cpp",
     "os_linuxbsd.cpp",
+    "platform_text_linuxbsd.cpp",
     "joypad_linux.cpp",
     "freedesktop_portal_desktop.cpp",
     "freedesktop_screensaver.cpp",

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -33,6 +33,7 @@
 #include "core/io/certs_compressed.gen.h"
 #include "core/io/dir_access.h"
 #include "main/main.h"
+#include "platform/linuxbsd/platform_text_linuxbsd.h"
 #include "servers/display_server.h"
 #include "servers/rendering_server.h"
 
@@ -144,6 +145,11 @@ void OS_LinuxBSD::initialize_joypads() {
 #ifdef JOYDEV_ENABLED
 	joypad = memnew(JoypadLinux(Input::get_singleton()));
 #endif
+}
+
+void OS_LinuxBSD::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextLinuxBSD);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
 }
 
 String OS_LinuxBSD::get_unique_id() const {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -33,6 +33,7 @@
 
 #include "crash_handler_linuxbsd.h"
 #include "joypad_linux.h"
+#include "platform_text_linuxbsd.h"
 
 #include "core/input/input.h"
 #include "drivers/alsa/audio_driver_alsa.h"
@@ -80,6 +81,7 @@ class OS_LinuxBSD : public OS_Unix {
 	CrashHandler crash_handler;
 
 	MainLoop *main_loop = nullptr;
+	PlatformTextLinuxBSD *platform_text_implementation = nullptr;
 
 	String get_systemd_os_release_info_value(const String &key) const;
 
@@ -93,6 +95,7 @@ protected:
 	virtual void finalize() override;
 
 	virtual void initialize_joypads() override;
+	virtual void initialize_platform_text() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 

--- a/platform/linuxbsd/platform_text_linuxbsd.cpp
+++ b/platform/linuxbsd/platform_text_linuxbsd.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_linuxbsd.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_linuxbsd.h"
+
+String PlatformTextLinuxBSD::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextLinuxBSD::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextLinuxBSD::PlatformTextLinuxBSD() {}
+PlatformTextLinuxBSD::~PlatformTextLinuxBSD() {}

--- a/platform/linuxbsd/platform_text_linuxbsd.h
+++ b/platform/linuxbsd/platform_text_linuxbsd.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_linuxbsd.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_LINUXBSD_H
+#define PLATFORM_TEXT_LINUXBSD_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextLinuxBSD : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextLinuxBSD();
+	virtual ~PlatformTextLinuxBSD();
+};
+
+#endif // PLATFORM_TEXT_LINUXBSD_H

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -100,6 +100,7 @@ def generate_bundle(target, source, env):
 
 files = [
     "os_macos.mm",
+    "platform_text_macos.mm",
     "godot_application.mm",
     "godot_application_delegate.mm",
     "crash_handler_macos.mm",

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -33,6 +33,7 @@
 
 #include "crash_handler_macos.h"
 #import "joypad_macos.h"
+#include "platform_text_macos.h"
 
 #include "core/input/input.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
@@ -55,6 +56,7 @@ class OS_MacOS : public OS_Unix {
 	CFRunLoopObserverRef pre_wait_observer;
 
 	MainLoop *main_loop = nullptr;
+	PlatformTextMacOS *platform_text_implementation = nullptr;
 
 	List<String> launch_service_args;
 
@@ -71,6 +73,7 @@ protected:
 	virtual void finalize() override;
 
 	virtual void initialize_joypads() override;
+	virtual void initialize_platform_text() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -30,6 +30,8 @@
 
 #include "os_macos.h"
 
+#include "core/object/class_db.h"
+#include "core/os/platform_text.h"
 #include "dir_access_macos.h"
 #include "display_server_macos.h"
 #include "godot_application.h"
@@ -39,6 +41,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/version_generated.gen.h"
 #include "main/main.h"
+#include "platform_text_macos.h"
 
 #include <dlfcn.h>
 #include <libproc.h>
@@ -140,6 +143,11 @@ void OS_MacOS::finalize() {
 
 void OS_MacOS::initialize_joypads() {
 	joypad_macos = memnew(JoypadMacOS());
+}
+
+void OS_MacOS::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextMacOS);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
 }
 
 void OS_MacOS::set_main_loop(MainLoop *p_main_loop) {

--- a/platform/macos/platform_text_macos.h
+++ b/platform/macos/platform_text_macos.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_macos.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_MACOS_H
+#define PLATFORM_TEXT_MACOS_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextMacOS : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextMacOS();
+	virtual ~PlatformTextMacOS();
+};
+
+#endif // PLATFORM_TEXT_MACOS_H

--- a/platform/macos/platform_text_macos.mm
+++ b/platform/macos/platform_text_macos.mm
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_macos.mm                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_macos.h"
+
+String PlatformTextMacOS::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextMacOS::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextMacOS::PlatformTextMacOS() {}
+PlatformTextMacOS::~PlatformTextMacOS() {}

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -26,6 +26,7 @@ web_files = [
     "javascript_bridge_singleton.cpp",
     "web_main.cpp",
     "os_web.cpp",
+    "platform_text_web.cpp",
     "api/web_tools_editor_plugin.cpp",
 ]
 

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -266,6 +266,11 @@ OS_Web *OS_Web::get_singleton() {
 void OS_Web::initialize_joypads() {
 }
 
+void OS_Web::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextWeb);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
+}
+
 OS_Web::OS_Web() {
 	char locale_ptr[16];
 	godot_js_config_locale_get(locale_ptr, 16);

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -34,6 +34,7 @@
 #include "audio_driver_web.h"
 
 #include "godot_js.h"
+#include "platform_text_web.h"
 
 #include "core/input/input.h"
 #include "drivers/unix/os_unix.h"
@@ -43,6 +44,7 @@
 
 class OS_Web : public OS_Unix {
 	MainLoop *main_loop = nullptr;
+	PlatformTextWeb *platform_text_implementation = nullptr;
 	List<AudioDriverWeb *> audio_drivers;
 
 	bool idb_is_syncing = false;
@@ -75,6 +77,7 @@ public:
 	void force_fs_sync();
 
 	void initialize_joypads() override;
+	void initialize_platform_text() override;
 
 	MainLoop *get_main_loop() const override;
 	bool main_loop_iterate();

--- a/platform/web/platform_text_web.cpp
+++ b/platform/web/platform_text_web.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_web.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_web.h"
+
+String PlatformTextWeb::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextWeb::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextWeb::PlatformTextWeb() {}
+PlatformTextWeb::~PlatformTextWeb() {}

--- a/platform/web/platform_text_web.h
+++ b/platform/web/platform_text_web.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_web.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_WEB_H
+#define PLATFORM_TEXT_WEB_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextWeb : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextWeb();
+	virtual ~PlatformTextWeb();
+};
+
+#endif // PLATFORM_TEXT_WEB_H

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -12,6 +12,7 @@ sources = []
 common_win = [
     "godot_windows.cpp",
     "os_windows.cpp",
+    "platform_text_windows.cpp",
     "display_server_windows.cpp",
     "key_mapping_windows.cpp",
     "joypad_windows.cpp",

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -243,6 +243,11 @@ void OS_Windows::initialize() {
 	FileAccessWindows::initialize();
 }
 
+void OS_Windows::initialize_platform_text() {
+	platform_text_implementation = memnew(PlatformTextWindows);
+	PlatformText::get_singleton()->set_implementation(platform_text_implementation);
+}
+
 void OS_Windows::delete_main_loop() {
 	if (main_loop) {
 		memdelete(main_loop);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -33,6 +33,7 @@
 
 #include "crash_handler_windows.h"
 #include "key_mapping_windows.h"
+#include "platform_text_windows.h"
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
@@ -100,6 +101,7 @@ class OS_Windows : public OS {
 
 	HINSTANCE hInstance;
 	MainLoop *main_loop = nullptr;
+	PlatformTextWindows *platform_text_implementation = nullptr;
 
 #ifdef WASAPI_ENABLED
 	AudioDriverWASAPI driver_wasapi;
@@ -137,6 +139,8 @@ class OS_Windows : public OS {
 	// functions used by main to initialize/deinitialize the OS
 protected:
 	virtual void initialize() override;
+
+	virtual void initialize_platform_text() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;

--- a/platform/windows/platform_text_windows.cpp
+++ b/platform/windows/platform_text_windows.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  platform_text_windows.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "platform_text_windows.h"
+
+String PlatformTextWindows::get_string(PlatformTextID p_id) const {
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_string(p_id);
+}
+
+String PlatformTextWindows::get_editor_string(PlatformTextEditorID p_id) const {
+#ifdef TOOLS_ENABLED
+	if (!_is_editor()) {
+		return PlatformTextImplementation::get_editor_string(p_id);
+	}
+
+	// switch (p_id) {
+	// 	default:
+	// 		return PlatformTextImplementation::get_editor_string(p_id);
+	// }
+
+	// TODO: remove me when the previously commented switch will be used.
+	return PlatformTextImplementation::get_editor_string(p_id);
+#else
+	return PlatformTextImplementation::get_editor_string(p_id);
+#endif
+}
+
+PlatformTextWindows::PlatformTextWindows() {}
+PlatformTextWindows::~PlatformTextWindows() {}

--- a/platform/windows/platform_text_windows.h
+++ b/platform/windows/platform_text_windows.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  platform_text_windows.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PLATFORM_TEXT_WINDOWS_H
+#define PLATFORM_TEXT_WINDOWS_H
+
+#include "core/os/platform_text.h"
+
+class PlatformTextWindows : public PlatformTextImplementation {
+public:
+	virtual String get_string(PlatformTextID p_id) const override;
+	virtual String get_editor_string(PlatformTextEditorID p_id) const override;
+
+	PlatformTextWindows();
+	virtual ~PlatformTextWindows();
+};
+
+#endif // PLATFORM_TEXT_WINDOWS_H


### PR DESCRIPTION
This PR adds `PlatformText`. It is a wrapper to access strings localized for the platform.

It permits new and unknown platforms to edit (some specific) text shown by the editor and the game.

![Capture d’écran, le 2024-06-17 à 10 24 19](https://github.com/godotengine/godot/assets/270928/9934f9bc-3685-4567-bcd5-1622fcc02aa0)
**This line isn't hardcoded in the editor, it's based on strings found in platform/macos (not included in this PR)**

For now, this PR doesn't implement any new lines. It just setups the class.

Relates to #92984