### PR TITLE
Expose run() method of EditorScript

### DIFF
--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -60,5 +60,16 @@
 				Returns the Editor's currently active scene.
 			</description>
 		</method>
+		<method name="run">
+			<return type="void" />
+			<description>
+				Runs this [EditorScript], by calling its [method _run] method. Fails if called inside [method _run].
+				This method is intended to run the script without having to open it in script editor. You can call it from a plugin or a tool script.
+				[codeblock]
+				var editor_script = load("res://editor_script.gd").new()
+				editor_script.run()
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 </class>

--- a/editor/editor_script.cpp
+++ b/editor/editor_script.cpp
@@ -62,10 +62,16 @@ EditorInterface *EditorScript::get_editor_interface() const {
 }
 
 void EditorScript::run() {
+	ERR_FAIL_COND_MSG(is_running, "The EditorScript is already running.");
+
+	is_running = true;
 	GDVIRTUAL_REQUIRED_CALL(_run);
+	is_running = false;
 }
 
 void EditorScript::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("run"), &EditorScript::run);
+
 	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
 	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);

--- a/editor/editor_script.h
+++ b/editor/editor_script.h
@@ -41,6 +41,8 @@ class Node;
 class EditorScript : public RefCounted {
 	GDCLASS(EditorScript, RefCounted);
 
+	bool is_running = false;
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
[Some context:](https://x.com/passivestar_/status/1801637472075481163)
![image](https://github.com/godotengine/godot/assets/2223172/f1dd0c07-4548-405d-b3b8-3c95a4f31a73)

Currently there is no way to run EditorScript other than opening it in Script Editor and selecting the File -> Run menu option (you can do it with a script, but it's ungodly hack). While EditorScript UX could be improved, I think it would be nice to at expose for now some reliable option to allow making plugins that run the scripts.

At first I wanted to create some EditorInterface method to do that, but then I realized that running an EditorScript simply involves calling its `run()` method, which just calls the `_run()` virtual method. So basically you are executing some random script method in an instance, and the script does not even need to be tool for that. Given that, I just exposed the `run()` method and added a safe-guard to prevent stack overflow.