### PR TITLE
Avoid unnecessary copy-on-write Vector/Array

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -315,8 +315,8 @@ public:
 
 template <typename T>
 void Vector<T>::reverse() {
+	T *p = ptrw();
 	for (Size i = 0; i < size() / 2; i++) {
-		T *p = ptrw();
 		SWAP(p[i], p[size() - i - 1]);
 	}
 }
@@ -329,8 +329,9 @@ void Vector<T>::append_array(Vector<T> p_other) {
 	}
 	const Size bs = size();
 	resize(bs + ds);
+	T *p = ptrw();
 	for (Size i = 0; i < ds; ++i) {
-		ptrw()[bs + i] = p_other[i];
+		p[bs + i] = p_other[i];
 	}
 }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -738,7 +738,7 @@ int Array::bsearch(const Variant &p_value, bool p_before) const {
 	Variant value = p_value;
 	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search"), -1);
 	SearchArray<Variant, _ArrayVariantSort> avs;
-	return avs.bisect(_p->array.ptrw(), _p->array.size(), value, p_before);
+	return avs.bisect(_p->array.ptr(), _p->array.size(), value, p_before);
 }
 
 int Array::bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

There are some `ptrw` used in `Array` and `Vector` where read-only access is needed. Using `ptr` to avoid copy-on-write. There were also some loops that called `ptrw` so I made them similar to other loops that create `ptrw` once outside the loop.