### PR TITLE
Fix runtime navigation and physics debug rendering showing in reflections

### DIFF
--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -1148,6 +1148,10 @@ void NavigationAgent3D::_update_debug_path() {
 
 	RS::get_singleton()->instance_set_base(debug_path_instance, debug_path_mesh->get_rid());
 	RS::get_singleton()->instance_set_scenario(debug_path_instance, agent_parent->get_world_3d()->get_scenario());
+	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(debug_path_instance, RS::SHADOW_CASTING_SETTING_OFF);
+	RS::get_singleton()->instance_set_layer_mask(debug_path_instance, 1 << 26); // GIZMO_EDIT_LAYER
+	RS::get_singleton()->instance_geometry_set_flag(debug_path_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	RS::get_singleton()->instance_geometry_set_flag(debug_path_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	RS::get_singleton()->instance_set_visible(debug_path_instance, agent_parent->is_visible_in_tree());
 }
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -54,6 +54,10 @@ void NavigationLink3D::_update_debug_mesh() {
 
 	if (!debug_instance.is_valid()) {
 		debug_instance = RenderingServer::get_singleton()->instance_create();
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(debug_instance, RS::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(debug_instance, 1 << 26); // GIZMO_EDIT_LAYER
+		RS::get_singleton()->instance_geometry_set_flag(debug_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(debug_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 
 	if (!debug_mesh.is_valid()) {

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -380,6 +380,10 @@ void NavigationObstacle3D::_update_fake_agent_radius_debug() {
 
 	if (!fake_agent_radius_debug_instance.is_valid()) {
 		fake_agent_radius_debug_instance = RenderingServer::get_singleton()->instance_create();
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(fake_agent_radius_debug_instance, RS::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(fake_agent_radius_debug_instance, 1 << 26); // GIZMO_EDIT_LAYER
+		RS::get_singleton()->instance_geometry_set_flag(fake_agent_radius_debug_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(fake_agent_radius_debug_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 	if (!fake_agent_radius_debug_mesh.is_valid()) {
 		fake_agent_radius_debug_mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
@@ -478,6 +482,10 @@ void NavigationObstacle3D::_update_static_obstacle_debug() {
 
 	if (!static_obstacle_debug_instance.is_valid()) {
 		static_obstacle_debug_instance = RenderingServer::get_singleton()->instance_create();
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(static_obstacle_debug_instance, RS::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(static_obstacle_debug_instance, 1 << 26); // GIZMO_EDIT_LAYER
+		RS::get_singleton()->instance_geometry_set_flag(static_obstacle_debug_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(static_obstacle_debug_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 	if (!static_obstacle_debug_mesh.is_valid()) {
 		static_obstacle_debug_mesh = Ref<ArrayMesh>(memnew(ArrayMesh));

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -490,6 +490,10 @@ void NavigationRegion3D::_update_debug_mesh() {
 
 	if (!debug_instance.is_valid()) {
 		debug_instance = RenderingServer::get_singleton()->instance_create();
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(debug_edge_connections_instance, RS::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(debug_edge_connections_instance, 1 << 26); // GIZMO_EDIT_LAYER
+		RS::get_singleton()->instance_geometry_set_flag(debug_edge_connections_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(debug_edge_connections_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 
 	if (!debug_mesh.is_valid()) {
@@ -667,6 +671,10 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 
 	if (!debug_edge_connections_instance.is_valid()) {
 		debug_edge_connections_instance = RenderingServer::get_singleton()->instance_create();
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(debug_edge_connections_instance, RS::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(debug_edge_connections_instance, 1 << 26); // GIZMO_EDIT_LAYER
+		RS::get_singleton()->instance_geometry_set_flag(debug_edge_connections_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(debug_edge_connections_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 
 	if (!debug_edge_connections_mesh.is_valid()) {

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -396,6 +396,10 @@ void CollisionObject3D::_update_debug_shapes() {
 				if (s.debug_shape.is_null()) {
 					s.debug_shape = RS::get_singleton()->instance_create();
 					RS::get_singleton()->instance_set_scenario(s.debug_shape, get_world_3d()->get_scenario());
+					RS::get_singleton()->instance_geometry_set_cast_shadows_setting(s.debug_shape, RS::SHADOW_CASTING_SETTING_OFF);
+					RS::get_singleton()->instance_geometry_set_flag(s.debug_shape, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+					RS::get_singleton()->instance_geometry_set_flag(s.debug_shape, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+					RS::get_singleton()->instance_set_layer_mask(s.debug_shape, 1 << 26); // GIZMO_EDIT_LAYER
 					s.shape->connect_changed(callable_mp(this, &CollisionObject3D::_shape_changed).bind(s.shape), CONNECT_DEFERRED);
 					++debug_shapes_count;
 				}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -542,6 +542,10 @@ void Viewport::_notification(int p_what) {
 				RenderingServer::get_singleton()->instance_set_base(contact_3d_debug_instance, contact_3d_debug_multimesh);
 				RenderingServer::get_singleton()->instance_set_scenario(contact_3d_debug_instance, find_world_3d()->get_scenario());
 				RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, true);
+				RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(contact_3d_debug_instance, RS::SHADOW_CASTING_SETTING_OFF);
+				RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+				RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+				RenderingServer::get_singleton()->instance_set_layer_mask(contact_3d_debug_instance, 1 << 26); // GIZMO_EDIT_LAYER
 #endif // _3D_DISABLED
 				set_physics_process_internal(true);
 			}


### PR DESCRIPTION
Fixes runtime navigation debug rendering in reflections due to default instance flags and render layers.

![debug_reflection](https://github.com/godotengine/godot/assets/52464204/3ddab2ad-2b77-4b14-9fdb-5a050d1ec47b)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
