### PR TITLE
Avoid crashing when scene import settings are empty

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2780,6 +2780,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	}
 
 	ERR_FAIL_COND_V(!importer.is_valid(), nullptr);
+	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
 
 	Error err = OK;
 
@@ -2838,6 +2839,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	}
 
 	ERR_FAIL_COND_V(!importer.is_valid(), ERR_FILE_UNRECOGNIZED);
+	ERR_FAIL_COND_V(p_options.is_empty(), ERR_BUG);
 
 	int import_flags = 0;
 


### PR DESCRIPTION
follow up to https://github.com/godotengine/godot/pull/90097 as its been inactive for months

fixes a crash from the scene import settings being empty when importers assume they exist in a `HashMap` causing a crash
more details in https://github.com/godotengine/godot/pull/90097

fixes https://github.com/godotengine/godot/issues/90014
fixes https://github.com/godotengine/godot/issues/92940
fixes https://github.com/godotengine/godot/issues/84371

i think all these issues also have another underlying issue to them, this just turns the crashes into error prints