### PR TITLE
Add Bake Mask to GPUParticlesCollisionHeightField3D, Collision Mask to GPUParticles3D and Collision Layer to GPUParticlesCollision3D & GPUParticlesAttractor3D.

### DIFF
--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -74,6 +74,11 @@
 			The base diameter for particle collision in meters. If particles appear to sink into the ground when colliding, increase this value. If particles appear to float when colliding, decrease this value. Only effective if [member ParticleProcessMaterial.collision_mode] is [constant ParticleProcessMaterial.COLLISION_RIGID] or [constant ParticleProcessMaterial.COLLISION_HIDE_ON_CONTACT].
 			[b]Note:[/b] Particles always have a spherical collision shape.
 		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="4294967295">
+			The particle collision layers that will affect the particles in this node. By default, all collision shapes and attractors affect this node.
+			After configuring the [member GPUParticlesCollision3D.collision_layer] in particle collision nodes and the [member GPUParticlesAttractor3D.collision_layer] in attractor nodes accordingly, specific layers can be unchecked in this mask to prevent the particles from being affected by the collision shapes and attractors in these layers. For example, this can be used if you're using an attractor as part of a spell effect but don't want the attractor to affect unrelated weather particles at the same position.
+			Particle attraction can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
+		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="GPUParticles3D.DrawOrder" default="0">
 			Particle draw order. Uses [enum DrawOrder] values.
 			[b]Note:[/b] [constant DRAW_ORDER_INDEX] is the only option that supports motion vectors for effects like TAA. It is suggested to use this draw order if the particles are opaque to fix ghosting artifacts.

--- a/doc/classes/GPUParticlesAttractor3D.xml
+++ b/doc/classes/GPUParticlesAttractor3D.xml
@@ -15,10 +15,15 @@
 		<member name="attenuation" type="float" setter="set_attenuation" getter="get_attenuation" default="1.0">
 			The particle attractor's attenuation. Higher values result in more gradual pushing of particles as they come closer to the attractor's origin. Zero or negative values will cause particles to be pushed very fast as soon as the touch the attractor's edges.
 		</member>
-		<member name="cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" default="4294967295">
-			The particle rendering layers ([member VisualInstance3D.layers]) that will be affected by the attractor. By default, all particles are affected by an attractor.
-			After configuring particle nodes accordingly, specific layers can be unchecked to prevent certain particles from being affected by attractors. For example, this can be used if you're using an attractor as part of a spell effect but don't want the attractor to affect unrelated weather particles at the same position.
+		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
+			The particle collision layers that this attractor belongs to. In the [GPUParticles3D] node, set ([member GPUParticles3D.collision_mask]) to determine which collision layers should affect it.
+			After configuring collision layers the attractors, specific layers can be unchecked in the collision mask of certain particles to prevent them from being affected by the attractors in these layers. For example, this can be used if you're using an attractor as part of a spell effect but don't want the attractor to affect unrelated weather particles at the same position.
 			Particle attraction can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
+		</member>
+		<member name="cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" deprecated="Use [member GPUParticlesAttractor3D.collision_layer] instead.">
+			The particle collision layers that this collision shape belongs to. In the [GPUParticles3D] node, set ([member GPUParticles3D.collision_mask]) to determine which collision layers should affect it.
+			After configuring collision layers the collision shapes, specific layers can be unchecked in the collision mask of certain particles to prevent them from being affected by the collision shapes in these layers. For example, this can be used if you're using a collision shape to block certain spell effects but don't want the collision to affect unrelated weather particles at the same position.
+			Particle collision can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
 		</member>
 		<member name="directionality" type="float" setter="set_directionality" getter="get_directionality" default="0.0">
 			Adjusts how directional the attractor is. At [code]0.0[/code], the attractor is not directional at all: it will attract particles towards its center. At [code]1.0[/code], the attractor is fully directional: particles will always be pushed towards local -Z (or +Z if [member strength] is negative).

--- a/doc/classes/GPUParticlesCollision3D.xml
+++ b/doc/classes/GPUParticlesCollision3D.xml
@@ -14,10 +14,15 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" default="4294967295">
-			The particle rendering layers ([member VisualInstance3D.layers]) that will be affected by the collision shape. By default, all particles that have [member ParticleProcessMaterial.collision_mode] set to [constant ParticleProcessMaterial.COLLISION_RIGID] or [constant ParticleProcessMaterial.COLLISION_HIDE_ON_CONTACT] will be affected by a collision shape.
-			After configuring particle nodes accordingly, specific layers can be unchecked to prevent certain particles from being affected by attractors. For example, this can be used if you're using an attractor as part of a spell effect but don't want the attractor to affect unrelated weather particles at the same position.
-			Particle attraction can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
+		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
+			The particle collision layers that this collision shape belongs to. In the [GPUParticles3D] node, set ([member GPUParticles3D.collision_mask]) to determine which collision layers should affect it.
+			After configuring collision layers the collision shapes, specific layers can be unchecked in the collision mask of certain particles to prevent them from being affected by the collision shapes in these layers. For example, this can be used if you're using a collision shape to block certain spell effects but don't want the collision to affect unrelated weather particles at the same position.
+			Particle collision can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
+		</member>
+		<member name="cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" deprecated="Use [member GPUParticlesCollision3D.collision_layer] instead.">
+			The particle collision layers that this collision shape belongs to. In the [GPUParticles3D] node, set ([member GPUParticles3D.collision_mask]) to determine which collision layers should affect it.
+			After configuring collision layers the collision shapes, specific layers can be unchecked in the collision mask of certain particles to prevent them from being affected by the collision shapes in these layers. For example, this can be used if you're using a collision shape to block certain spell effects but don't want the collision to affect unrelated weather particles at the same position.
+			Particle collision can also be disabled on a per-process material basis by setting [member ParticleProcessMaterial.attractor_interaction_enabled] on the [GPUParticles3D] node.
 		</member>
 	</members>
 </class>

--- a/doc/classes/GPUParticlesCollisionHeightField3D.xml
+++ b/doc/classes/GPUParticlesCollisionHeightField3D.xml
@@ -12,7 +12,27 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_bake_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns [code]true[/code] if the specified layer of the [member bake_mask] is enabled, given a [param layer_number] between [code]1[/code] and [code]32[/code].
+			</description>
+		</method>
+		<method name="set_bake_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member bake_mask], given a [param layer_number] between [code]1[/code] and [code]32[/code].
+			</description>
+		</method>
+	</methods>
 	<members>
+		<member name="bake_mask" type="int" setter="set_bake_mask" getter="get_bake_mask" default="4294967295">
+			The visual layers to account for when updating the heightmap. Only [MeshInstance3D]s whose [member VisualInstance3D.layers] match with this [member bake_mask] will be included in the heightmap collision update. By default, all objects are taken into account for updating the heightmap collision.
+		</member>
 		<member name="follow_camera_enabled" type="bool" setter="set_follow_camera_enabled" getter="is_follow_camera_enabled" default="false">
 			If [code]true[/code], the [GPUParticlesCollisionHeightField3D] will follow the current camera in global space. The [GPUParticlesCollisionHeightField3D] does not need to be a child of the [Camera3D] node for this to work.
 			Following the camera has a performance cost, as it will force the heightmap to update whenever the camera moves. Consider lowering [member resolution] to improve performance if [member follow_camera_enabled] is [code]true[/code].

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2695,6 +2695,14 @@
 				Sets the [param extents] for the 3D GPU particles collision by the [param particles_collision] RID. Equivalent to [member GPUParticlesCollisionBox3D.size], [member GPUParticlesCollisionSDF3D.size], [member GPUParticlesCollisionHeightField3D.size], [member GPUParticlesAttractorBox3D.size] or [member GPUParticlesAttractorVectorField3D.size] depending on the [param particles_collision] type.
 			</description>
 		</method>
+		<method name="particles_collision_set_collision_layer">
+			<return type="void" />
+			<param index="0" name="particles_collision" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<description>
+				Sets the collision [param layer] for the 3D GPU particles collision or attractor specified by the [param particles_collision] RID. Equivalent to [member GPUParticlesCollision3D.collision_layer] or [member GPUParticlesAttractor3D.collision_layer] depending on the [param particles_collision] type.
+			</description>
+		</method>
 		<method name="particles_collision_set_collision_type">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
@@ -2703,12 +2711,12 @@
 				Sets the collision or attractor shape [param type] for the 3D GPU particles collision or attractor specified by the [param particles_collision] RID.
 			</description>
 		</method>
-		<method name="particles_collision_set_cull_mask">
+		<method name="particles_collision_set_cull_mask" deprecated="Use [method RenderingServer.particles_collision_set_collision_layer] instead.">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
-				Sets the cull [param mask] for the 3D GPU particles collision or attractor specified by the [param particles_collision] RID. Equivalent to [member GPUParticlesCollision3D.cull_mask] or [member GPUParticlesAttractor3D.cull_mask] depending on the [param particles_collision] type.
+				Sets the collision layer to be equal [param mask] for the 3D GPU particles collision or attractor specified by the [param particles_collision] RID. Equivalent to [member GPUParticlesCollision3D.collision_layer] or [member GPUParticlesAttractor3D.collision_layer] depending on the [param particles_collision] type.
 			</description>
 		</method>
 		<method name="particles_collision_set_field_texture">

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -304,6 +304,13 @@ void ParticlesStorage::particles_set_collision_base_size(RID p_particles, real_t
 	particles->collision_base_size = p_size;
 }
 
+void ParticlesStorage::particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->collision_mask = p_collision_mask;
+}
+
 void ParticlesStorage::particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
@@ -607,6 +614,9 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 			}
 			ParticlesCollision *pc = particles_collision_owner.get_or_null(pci->collision);
 			ERR_CONTINUE(!pc);
+			if (!(p_particles->collision_mask & pc->collision_layer)) {
+				continue;
+			}
 
 			Transform3D to_collider = pci->transform;
 			if (p_particles->use_local_coords) {
@@ -1297,10 +1307,10 @@ void ParticlesStorage::particles_collision_set_collision_type(RID p_particles_co
 	particles_collision->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 }
 
-void ParticlesStorage::particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) {
+void ParticlesStorage::particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) {
 	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL(particles_collision);
-	particles_collision->cull_mask = p_cull_mask;
+	particles_collision->collision_layer = p_collision_layer;
 }
 
 void ParticlesStorage::particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) {
@@ -1369,6 +1379,13 @@ void ParticlesStorage::particles_collision_set_height_field_resolution(RID p_par
 	}
 }
 
+void ParticlesStorage::particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) {
+	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
+	ERR_FAIL_NULL(particles_collision);
+
+	particles_collision->bake_mask = p_bake_mask;
+}
+
 AABB ParticlesStorage::particles_collision_get_aabb(RID p_particles_collision) const {
 	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL_V(particles_collision, AABB());
@@ -1400,6 +1417,12 @@ bool ParticlesStorage::particles_collision_is_heightfield(RID p_particles_collis
 	const ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL_V(particles_collision, false);
 	return particles_collision->type == RS::PARTICLES_COLLISION_TYPE_HEIGHTFIELD_COLLIDE;
+}
+
+uint32_t ParticlesStorage::particles_collision_get_bake_mask(RID p_particles_collision) const {
+	const ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
+	ERR_FAIL_NULL_V(particles_collision, 0);
+	return particles_collision->bake_mask;
 }
 
 Dependency *ParticlesStorage::particles_collision_get_dependency(RID p_particles_collision) const {

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -164,6 +164,7 @@ private:
 		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
 		bool use_local_coords = false;
 		bool has_collision_cache = false;
+		uint32_t collision_mask = 0xFFFFFFFF;
 
 		bool has_sdf_collision = false;
 		Transform2D sdf_collision_transform;
@@ -276,7 +277,8 @@ private:
 
 	struct ParticlesCollision {
 		RS::ParticlesCollisionType type = RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT;
-		uint32_t cull_mask = 0xFFFFFFFF;
+		uint32_t collision_layer = 1;
+		uint32_t bake_mask = 0xFFFFFFFF;
 		float radius = 1.0;
 		Vector3 extents = Vector3(1, 1, 1);
 		float attractor_strength = 1.0;
@@ -339,6 +341,7 @@ public:
 	virtual void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) override;
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override;
 	virtual void particles_set_collision_base_size(RID p_particles, real_t p_size) override;
+	virtual void particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) override;
 
 	virtual void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) override;
 
@@ -418,7 +421,7 @@ public:
 	virtual void particles_collision_free(RID p_rid) override;
 
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type) override;
-	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) override;
+	virtual void particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) override;
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) override;
 	virtual void particles_collision_set_box_extents(RID p_particles_collision, const Vector3 &p_extents) override;
 	virtual void particles_collision_set_attractor_strength(RID p_particles_collision, real_t p_strength) override;
@@ -427,9 +430,11 @@ public:
 	virtual void particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) override;
 	virtual void particles_collision_height_field_update(RID p_particles_collision) override;
 	virtual void particles_collision_set_height_field_resolution(RID p_particles_collision, RS::ParticlesCollisionHeightfieldResolution p_resolution) override;
+	virtual void particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) override; //for SDF and vector field
 	virtual AABB particles_collision_get_aabb(RID p_particles_collision) const override;
 	Vector3 particles_collision_get_extents(RID p_particles_collision) const;
 	virtual bool particles_collision_is_heightfield(RID p_particles_collision) const override;
+	virtual uint32_t particles_collision_get_bake_mask(RID p_particles_collision) const override;
 	GLuint particles_collision_get_heightfield_framebuffer(RID p_particles_collision) const;
 
 	_FORCE_INLINE_ Size2i particles_collision_get_heightfield_size(RID p_particles_collision) const {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -143,6 +143,11 @@ void GPUParticles3D::set_collision_base_size(real_t p_size) {
 	RS::get_singleton()->particles_set_collision_base_size(particles, p_size);
 }
 
+void GPUParticles3D::set_collision_mask(uint32_t p_collision_mask) {
+	collision_mask = p_collision_mask;
+	RS::get_singleton()->particles_set_collision_mask(particles, p_collision_mask);
+}
+
 bool GPUParticles3D::is_emitting() const {
 	return emitting;
 }
@@ -193,6 +198,10 @@ double GPUParticles3D::get_speed_scale() const {
 
 real_t GPUParticles3D::get_collision_base_size() const {
 	return collision_base_size;
+}
+
+uint32_t GPUParticles3D::get_collision_mask() const {
+	return collision_mask;
 }
 
 void GPUParticles3D::set_draw_order(DrawOrder p_order) {
@@ -680,6 +689,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_material", "material"), &GPUParticles3D::set_process_material);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &GPUParticles3D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("set_collision_base_size", "size"), &GPUParticles3D::set_collision_base_size);
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &GPUParticles3D::set_collision_mask);
 	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles3D::set_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles3D::is_emitting);
@@ -697,6 +707,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_process_material"), &GPUParticles3D::get_process_material);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &GPUParticles3D::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_collision_base_size"), &GPUParticles3D::get_collision_base_size);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &GPUParticles3D::get_collision_mask);
 	ClassDB::bind_method(D_METHOD("get_interp_to_end"), &GPUParticles3D::get_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("set_draw_order", "order"), &GPUParticles3D::set_draw_order);
@@ -754,6 +765,7 @@ void GPUParticles3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_base_size", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater,suffix:m"), "set_collision_base_size", "get_collision_base_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_GROUP("Drawing", "");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "visibility_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_visibility_aabb", "get_visibility_aabb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_coords"), "set_use_local_coordinates", "get_use_local_coordinates");

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -78,6 +78,7 @@ private:
 	bool interpolate = true;
 	NodePath sub_emitter;
 	real_t collision_base_size = 0.01;
+	uint32_t collision_mask = 0xFFFFFFFF;
 
 	bool trail_enabled = false;
 	double trail_lifetime = 0.3;
@@ -122,6 +123,7 @@ public:
 	void set_process_material(const Ref<Material> &p_material);
 	void set_speed_scale(double p_scale);
 	void set_collision_base_size(real_t p_ratio);
+	void set_collision_mask(uint32_t p_collision_mask);
 	void set_trail_enabled(bool p_enabled);
 	void set_trail_lifetime(double p_seconds);
 	void set_interp_to_end(float p_interp);
@@ -139,6 +141,7 @@ public:
 	Ref<Material> get_process_material() const;
 	double get_speed_scale() const;
 	real_t get_collision_base_size() const;
+	uint32_t get_collision_mask() const;
 	bool is_trail_enabled() const;
 	double get_trail_lifetime() const;
 	float get_interp_to_end() const;

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -35,20 +35,40 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/main/viewport.h"
 
+void GPUParticlesCollision3D::set_collision_layer(uint32_t p_collision_layer) {
+	collision_layer = p_collision_layer;
+	RS::get_singleton()->particles_collision_set_collision_layer(collision, p_collision_layer);
+}
+
+uint32_t GPUParticlesCollision3D::get_collision_layer() const {
+	return collision_layer;
+}
+
+#ifndef DISABLE_DEPRECATED
 void GPUParticlesCollision3D::set_cull_mask(uint32_t p_cull_mask) {
-	cull_mask = p_cull_mask;
-	RS::get_singleton()->particles_collision_set_cull_mask(collision, p_cull_mask);
+	WARN_DEPRECATED_MSG(R"(The "cull_mask" property is deprecated, use "collision_layer" instead.)");
+	set_collision_layer(p_cull_mask);
 }
 
 uint32_t GPUParticlesCollision3D::get_cull_mask() const {
-	return cull_mask;
+	return collision_layer;
 }
+#endif // DISABLE_DEPRECATED
 
 void GPUParticlesCollision3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &GPUParticlesCollision3D::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &GPUParticlesCollision3D::get_collision_layer);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_cull_mask", "mask"), &GPUParticlesCollision3D::set_cull_mask);
 	ClassDB::bind_method(D_METHOD("get_cull_mask"), &GPUParticlesCollision3D::get_cull_mask);
+#endif // DISABLE_DEPRECATED
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
+
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS, "", PROPERTY_USAGE_NONE), "set_cull_mask", "get_cull_mask");
+#endif // DISABLE_DEPRECATED
 }
 
 GPUParticlesCollision3D::GPUParticlesCollision3D(RS::ParticlesCollisionType p_type) {
@@ -613,6 +633,7 @@ GPUParticlesCollisionSDF3D::Resolution GPUParticlesCollisionSDF3D::get_resolutio
 
 void GPUParticlesCollisionSDF3D::set_bake_mask(uint32_t p_mask) {
 	bake_mask = p_mask;
+	RS::get_singleton()->particles_collision_set_bake_mask(_get_collision(), p_mask);
 	update_configuration_warnings();
 }
 
@@ -724,10 +745,16 @@ void GPUParticlesCollisionHeightField3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_follow_camera_enabled", "enabled"), &GPUParticlesCollisionHeightField3D::set_follow_camera_enabled);
 	ClassDB::bind_method(D_METHOD("is_follow_camera_enabled"), &GPUParticlesCollisionHeightField3D::is_follow_camera_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_bake_mask", "mask"), &GPUParticlesCollisionHeightField3D::set_bake_mask);
+	ClassDB::bind_method(D_METHOD("get_bake_mask"), &GPUParticlesCollisionHeightField3D::get_bake_mask);
+	ClassDB::bind_method(D_METHOD("set_bake_mask_value", "layer_number", "value"), &GPUParticlesCollisionHeightField3D::set_bake_mask_value);
+	ClassDB::bind_method(D_METHOD("get_bake_mask_value", "layer_number"), &GPUParticlesCollisionHeightField3D::get_bake_mask_value);
+
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_RANGE, "0.01,1024,0.01,or_greater,suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "resolution", PROPERTY_HINT_ENUM, "256 (Fastest),512 (Fast),1024 (Average),2048 (Slow),4096 (Slower),8192 (Slowest)"), "set_resolution", "get_resolution");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "When Moved (Fast),Always (Slow)"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "follow_camera_enabled"), "set_follow_camera_enabled", "is_follow_camera_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bake_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_bake_mask", "get_bake_mask");
 
 	BIND_ENUM_CONSTANT(RESOLUTION_256);
 	BIND_ENUM_CONSTANT(RESOLUTION_512);
@@ -799,6 +826,32 @@ bool GPUParticlesCollisionHeightField3D::is_follow_camera_enabled() const {
 	return follow_camera_mode;
 }
 
+void GPUParticlesCollisionHeightField3D::set_bake_mask(uint32_t p_mask) {
+	bake_mask = p_mask;
+	RS::get_singleton()->particles_collision_set_bake_mask(_get_collision(), p_mask);
+	update_configuration_warnings();
+}
+
+uint32_t GPUParticlesCollisionHeightField3D::get_bake_mask() const {
+	return bake_mask;
+}
+
+void GPUParticlesCollisionHeightField3D::set_bake_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1 || p_layer_number > 20, vformat("The render layer number (%d) must be between 1 and 20 (inclusive).", p_layer_number));
+	uint32_t mask = get_bake_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_bake_mask(mask);
+}
+
+bool GPUParticlesCollisionHeightField3D::get_bake_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1 || p_layer_number > 20, false, vformat("The render layer number (%d) must be between 1 and 20 (inclusive).", p_layer_number));
+	return bake_mask & (1 << (p_layer_number - 1));
+}
+
 AABB GPUParticlesCollisionHeightField3D::get_aabb() const {
 	return AABB(-size / 2, size);
 }
@@ -813,14 +866,25 @@ GPUParticlesCollisionHeightField3D::~GPUParticlesCollisionHeightField3D() {
 ////////////////////////////
 ////////////////////////////
 
+void GPUParticlesAttractor3D::set_collision_layer(uint32_t p_collision_layer) {
+	collision_layer = p_collision_layer;
+	RS::get_singleton()->particles_collision_set_collision_layer(collision, p_collision_layer);
+}
+
+uint32_t GPUParticlesAttractor3D::get_collision_layer() const {
+	return collision_layer;
+}
+
+#ifndef DISABLE_DEPRECATED
 void GPUParticlesAttractor3D::set_cull_mask(uint32_t p_cull_mask) {
-	cull_mask = p_cull_mask;
-	RS::get_singleton()->particles_collision_set_cull_mask(collision, p_cull_mask);
+	WARN_DEPRECATED_MSG(R"(The "cull_mask" property is deprecated, use "collision_layer" instead.)");
+	set_collision_layer(p_cull_mask);
 }
 
 uint32_t GPUParticlesAttractor3D::get_cull_mask() const {
-	return cull_mask;
+	return collision_layer;
 }
+#endif // DISABLE_DEPRECATED
 
 void GPUParticlesAttractor3D::set_strength(real_t p_strength) {
 	strength = p_strength;
@@ -851,8 +915,13 @@ real_t GPUParticlesAttractor3D::get_directionality() const {
 }
 
 void GPUParticlesAttractor3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &GPUParticlesAttractor3D::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &GPUParticlesAttractor3D::get_collision_layer);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_cull_mask", "mask"), &GPUParticlesAttractor3D::set_cull_mask);
 	ClassDB::bind_method(D_METHOD("get_cull_mask"), &GPUParticlesAttractor3D::get_cull_mask);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_strength", "strength"), &GPUParticlesAttractor3D::set_strength);
 	ClassDB::bind_method(D_METHOD("get_strength"), &GPUParticlesAttractor3D::get_strength);
@@ -866,7 +935,11 @@ void GPUParticlesAttractor3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "strength", PROPERTY_HINT_RANGE, "-128,128,0.01,or_greater,or_less"), "set_strength", "get_strength");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "attenuation", PROPERTY_HINT_EXP_EASING, "0,8,0.01"), "set_attenuation", "get_attenuation");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "directionality", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_directionality", "get_directionality");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
+
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS, "", PROPERTY_USAGE_NONE), "set_cull_mask", "get_cull_mask");
+#endif // DISABLE_DEPRECATED
 }
 
 GPUParticlesAttractor3D::GPUParticlesAttractor3D(RS::ParticlesCollisionType p_type) {

--- a/scene/3d/gpu_particles_collision_3d.h
+++ b/scene/3d/gpu_particles_collision_3d.h
@@ -37,7 +37,7 @@
 class GPUParticlesCollision3D : public VisualInstance3D {
 	GDCLASS(GPUParticlesCollision3D, VisualInstance3D);
 
-	uint32_t cull_mask = 0xFFFFFFFF;
+	uint32_t collision_layer = 1;
 	RID collision;
 
 protected:
@@ -47,8 +47,13 @@ protected:
 	GPUParticlesCollision3D(RS::ParticlesCollisionType p_type);
 
 public:
+	void set_collision_layer(uint32_t p_collision_layer);
+	uint32_t get_collision_layer() const;
+
+#ifndef DISABLE_DEPRECATED
 	void set_cull_mask(uint32_t p_cull_mask);
 	uint32_t get_cull_mask() const;
+#endif // DISABLE_DEPRECATED
 
 	~GPUParticlesCollision3D();
 };
@@ -230,6 +235,7 @@ private:
 	bool follow_camera_mode = false;
 
 	UpdateMode update_mode = UPDATE_MODE_WHEN_MOVED;
+	uint32_t bake_mask = 0xFFFFFFFF;
 
 protected:
 	void _notification(int p_what);
@@ -252,6 +258,12 @@ public:
 	void set_follow_camera_enabled(bool p_enabled);
 	bool is_follow_camera_enabled() const;
 
+	void set_bake_mask(uint32_t p_mask);
+	uint32_t get_bake_mask() const;
+
+	void set_bake_mask_value(int p_layer_number, bool p_enable);
+	bool get_bake_mask_value(int p_layer_number) const;
+
 	virtual AABB get_aabb() const override;
 
 	GPUParticlesCollisionHeightField3D();
@@ -264,7 +276,7 @@ VARIANT_ENUM_CAST(GPUParticlesCollisionHeightField3D::UpdateMode)
 class GPUParticlesAttractor3D : public VisualInstance3D {
 	GDCLASS(GPUParticlesAttractor3D, VisualInstance3D);
 
-	uint32_t cull_mask = 0xFFFFFFFF;
+	uint32_t collision_layer = 1;
 	RID collision;
 	real_t strength = 1.0;
 	real_t attenuation = 1.0;
@@ -277,8 +289,13 @@ protected:
 	GPUParticlesAttractor3D(RS::ParticlesCollisionType p_type);
 
 public:
+	void set_collision_layer(uint32_t p_collision_layer);
+	uint32_t get_collision_layer() const;
+
+#ifndef DISABLE_DEPRECATED
 	void set_cull_mask(uint32_t p_cull_mask);
 	uint32_t get_cull_mask() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_strength(real_t p_strength);
 	real_t get_strength() const;

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -64,6 +64,7 @@ public:
 	virtual void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) override {}
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override {}
 	virtual void particles_set_collision_base_size(RID p_particles, real_t p_size) override {}
+	virtual void particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) override {}
 
 	virtual void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) override {}
 
@@ -101,7 +102,7 @@ public:
 	virtual void particles_collision_free(RID p_rid) override {}
 
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type) override {}
-	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) override {}
+	virtual void particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) override {}
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) override {}
 	virtual void particles_collision_set_box_extents(RID p_particles_collision, const Vector3 &p_extents) override {}
 	virtual void particles_collision_set_attractor_strength(RID p_particles_collision, real_t p_strength) override {}
@@ -110,8 +111,10 @@ public:
 	virtual void particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) override {}
 	virtual void particles_collision_height_field_update(RID p_particles_collision) override {}
 	virtual void particles_collision_set_height_field_resolution(RID p_particles_collision, RS::ParticlesCollisionHeightfieldResolution p_resolution) override {}
+	virtual void particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) override {}
 	virtual AABB particles_collision_get_aabb(RID p_particles_collision) const override { return AABB(); }
 	virtual bool particles_collision_is_heightfield(RID p_particles_collision) const override { return false; }
+	virtual uint32_t particles_collision_get_bake_mask(RID p_particles_collision) const override { return 0; }
 
 	virtual RID particles_collision_instance_create(RID p_collision) override { return RID(); }
 	virtual void particles_collision_instance_free(RID p_rid) override {}

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -467,6 +467,13 @@ void ParticlesStorage::particles_set_collision_base_size(RID p_particles, real_t
 	particles->collision_base_size = p_size;
 }
 
+void ParticlesStorage::particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->collision_mask = p_collision_mask;
+}
+
 void ParticlesStorage::particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
@@ -909,6 +916,9 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 			}
 			ParticlesCollision *pc = particles_collision_owner.get_or_null(pci->collision);
 			ERR_CONTINUE(!pc);
+			if (!(p_particles->collision_mask & pc->collision_layer)) {
+				continue;
+			}
 
 			Transform3D to_collider = pci->transform;
 			if (p_particles->use_local_coords) {
@@ -1819,10 +1829,10 @@ void ParticlesStorage::particles_collision_set_collision_type(RID p_particles_co
 	particles_collision->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 }
 
-void ParticlesStorage::particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) {
+void ParticlesStorage::particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) {
 	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL(particles_collision);
-	particles_collision->cull_mask = p_cull_mask;
+	particles_collision->collision_layer = p_collision_layer;
 }
 
 void ParticlesStorage::particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) {
@@ -1892,6 +1902,13 @@ void ParticlesStorage::particles_collision_set_height_field_resolution(RID p_par
 	}
 }
 
+void ParticlesStorage::particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) {
+	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
+	ERR_FAIL_NULL(particles_collision);
+
+	particles_collision->bake_mask = p_bake_mask;
+}
+
 AABB ParticlesStorage::particles_collision_get_aabb(RID p_particles_collision) const {
 	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL_V(particles_collision, AABB());
@@ -1923,6 +1940,12 @@ bool ParticlesStorage::particles_collision_is_heightfield(RID p_particles_collis
 	const ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
 	ERR_FAIL_NULL_V(particles_collision, false);
 	return particles_collision->type == RS::PARTICLES_COLLISION_TYPE_HEIGHTFIELD_COLLIDE;
+}
+
+uint32_t ParticlesStorage::particles_collision_get_bake_mask(RID p_particles_collision) const {
+	const ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_particles_collision);
+	ERR_FAIL_NULL_V(particles_collision, 0);
+	return particles_collision->bake_mask;
 }
 
 Dependency *ParticlesStorage::particles_collision_get_dependency(RID p_particles_collision) const {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -172,6 +172,7 @@ private:
 		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
 		bool use_local_coords = false;
 		bool has_collision_cache = false;
+		uint32_t collision_mask = 0xFFFFFFFF;
 
 		bool has_sdf_collision = false;
 		Transform2D sdf_collision_transform;
@@ -390,7 +391,8 @@ private:
 
 	struct ParticlesCollision {
 		RS::ParticlesCollisionType type = RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT;
-		uint32_t cull_mask = 0xFFFFFFFF;
+		uint32_t collision_layer = 1;
+		uint32_t bake_mask = 0xFFFFFFFF;
 		float radius = 1.0;
 		Vector3 extents = Vector3(1, 1, 1);
 		float attractor_strength = 1.0;
@@ -451,6 +453,7 @@ public:
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) override;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) override;
 	virtual void particles_set_collision_base_size(RID p_particles, real_t p_size) override;
+	virtual void particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) override;
 	virtual void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) override;
 
 	virtual void particles_set_trails(RID p_particles, bool p_enable, double p_length) override;
@@ -562,7 +565,7 @@ public:
 	virtual void particles_collision_free(RID p_rid) override;
 
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type) override;
-	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) override;
+	virtual void particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) override;
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) override; //for spheres
 	virtual void particles_collision_set_box_extents(RID p_particles_collision, const Vector3 &p_extents) override; //for non-spheres
 	virtual void particles_collision_set_attractor_strength(RID p_particles_collision, real_t p_strength) override;
@@ -571,9 +574,11 @@ public:
 	virtual void particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) override; //for SDF and vector field, heightfield is dynamic
 	virtual void particles_collision_height_field_update(RID p_particles_collision) override; //for SDF and vector field
 	virtual void particles_collision_set_height_field_resolution(RID p_particles_collision, RS::ParticlesCollisionHeightfieldResolution p_resolution) override; //for SDF and vector field
+	virtual void particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) override; //for SDF and vector field
 	virtual AABB particles_collision_get_aabb(RID p_particles_collision) const override;
 	Vector3 particles_collision_get_extents(RID p_particles_collision) const;
 	virtual bool particles_collision_is_heightfield(RID p_particles_collision) const override;
+	virtual uint32_t particles_collision_get_bake_mask(RID p_particles_collision) const override;
 	RID particles_collision_get_heightfield_framebuffer(RID p_particles_collision) const;
 
 	Dependency *particles_collision_get_dependency(RID p_particles) const;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3829,14 +3829,18 @@ void RendererSceneCull::render_particle_colliders() {
 
 			struct CullAABB {
 				PagedArray<Instance *> *result;
+				uint32_t bake_mask;
 				_FORCE_INLINE_ bool operator()(void *p_data) {
 					Instance *p_instance = (Instance *)p_data;
-					result->push_back(p_instance);
+					if (p_instance->layer_mask & bake_mask) {
+						result->push_back(p_instance);
+					}
 					return false;
 				}
 			};
 
 			CullAABB cull_aabb;
+			cull_aabb.bake_mask = RSG::particles_storage->particles_collision_get_bake_mask(hfpc->base);
 			cull_aabb.result = &instance_cull_result;
 			hfpc->scenario->indexers[Scenario::INDEXER_GEOMETRY].aabb_query(hfpc->transformed_aabb, cull_aabb);
 			hfpc->scenario->indexers[Scenario::INDEXER_VOLUMES].aabb_query(hfpc->transformed_aabb, cull_aabb);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -516,6 +516,7 @@ public:
 	FUNC6(particles_emit, RID, const Transform3D &, const Vector3 &, const Color &, const Color &, uint32_t)
 	FUNC2(particles_set_subemitter, RID, RID)
 	FUNC2(particles_set_collision_base_size, RID, float)
+	FUNC2(particles_set_collision_mask, RID, uint32_t)
 
 	FUNC2(particles_set_transform_align, RID, RS::ParticlesTransformAlign)
 
@@ -534,7 +535,7 @@ public:
 	FUNCRIDSPLIT(particles_collision)
 
 	FUNC2(particles_collision_set_collision_type, RID, ParticlesCollisionType)
-	FUNC2(particles_collision_set_cull_mask, RID, uint32_t)
+	FUNC2(particles_collision_set_collision_layer, RID, uint32_t)
 	FUNC2(particles_collision_set_sphere_radius, RID, real_t)
 	FUNC2(particles_collision_set_box_extents, RID, const Vector3 &)
 	FUNC2(particles_collision_set_attractor_strength, RID, real_t)
@@ -543,6 +544,7 @@ public:
 	FUNC2(particles_collision_set_field_texture, RID, RID)
 	FUNC1(particles_collision_height_field_update, RID)
 	FUNC2(particles_collision_set_height_field_resolution, RID, ParticlesCollisionHeightfieldResolution)
+	FUNC2(particles_collision_set_bake_mask, RID, uint32_t)
 
 	/* FOG VOLUME */
 

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -64,6 +64,7 @@ public:
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_collision_base_size(RID p_particles, real_t p_size) = 0;
+	virtual void particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) = 0;
 
 	virtual void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) = 0;
 
@@ -106,7 +107,7 @@ public:
 	virtual void particles_collision_free(RID p_rid) = 0;
 
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type) = 0;
-	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) = 0;
+	virtual void particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) = 0;
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) = 0; //for spheres
 	virtual void particles_collision_set_box_extents(RID p_particles_collision, const Vector3 &p_extents) = 0; //for non-spheres
 	virtual void particles_collision_set_attractor_strength(RID p_particles_collision, real_t p_strength) = 0;
@@ -115,8 +116,10 @@ public:
 	virtual void particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) = 0; //for SDF and vector field, heightfield is dynamic
 	virtual void particles_collision_height_field_update(RID p_particles_collision) = 0; //for SDF and vector field
 	virtual void particles_collision_set_height_field_resolution(RID p_particles_collision, RS::ParticlesCollisionHeightfieldResolution p_resolution) = 0; //for SDF and vector field
+	virtual void particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) = 0;
 	virtual AABB particles_collision_get_aabb(RID p_particles_collision) const = 0;
 	virtual bool particles_collision_is_heightfield(RID p_particles_collision) const = 0;
+	virtual uint32_t particles_collision_get_bake_mask(RID p_particles_collision) const = 0;
 
 	//used from 2D and 3D
 	virtual RID particles_collision_instance_create(RID p_collision) = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2698,7 +2698,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("particles_collision_create"), &RenderingServer::particles_collision_create);
 	ClassDB::bind_method(D_METHOD("particles_collision_set_collision_type", "particles_collision", "type"), &RenderingServer::particles_collision_set_collision_type);
-	ClassDB::bind_method(D_METHOD("particles_collision_set_cull_mask", "particles_collision", "mask"), &RenderingServer::particles_collision_set_cull_mask);
+	ClassDB::bind_method(D_METHOD("particles_collision_set_collision_layer", "particles_collision", "layer"), &RenderingServer::particles_collision_set_collision_layer);
 	ClassDB::bind_method(D_METHOD("particles_collision_set_sphere_radius", "particles_collision", "radius"), &RenderingServer::particles_collision_set_sphere_radius);
 	ClassDB::bind_method(D_METHOD("particles_collision_set_box_extents", "particles_collision", "extents"), &RenderingServer::particles_collision_set_box_extents);
 	ClassDB::bind_method(D_METHOD("particles_collision_set_attractor_strength", "particles_collision", "strength"), &RenderingServer::particles_collision_set_attractor_strength);
@@ -2708,6 +2708,10 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("particles_collision_height_field_update", "particles_collision"), &RenderingServer::particles_collision_height_field_update);
 	ClassDB::bind_method(D_METHOD("particles_collision_set_height_field_resolution", "particles_collision", "resolution"), &RenderingServer::particles_collision_set_height_field_resolution);
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("particles_collision_set_cull_mask", "particles_collision", "mask"), &RenderingServer::particles_collision_set_cull_mask);
+#endif // DISABLE_DEPRECATED
 
 	BIND_ENUM_CONSTANT(PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT);
 	BIND_ENUM_CONSTANT(PARTICLES_COLLISION_TYPE_BOX_ATTRACT);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -724,6 +724,7 @@ public:
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_collision_base_size(RID p_particles, float p_size) = 0;
+	virtual void particles_set_collision_mask(RID p_particles, uint32_t p_collision_mask) = 0;
 
 	enum ParticlesTransformAlign {
 		PARTICLES_TRANSFORM_ALIGN_DISABLED,
@@ -786,7 +787,7 @@ public:
 	};
 
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, ParticlesCollisionType p_type) = 0;
-	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) = 0;
+	virtual void particles_collision_set_collision_layer(RID p_particles_collision, uint32_t p_collision_layer) = 0;
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, real_t p_radius) = 0; // For spheres.
 	virtual void particles_collision_set_box_extents(RID p_particles_collision, const Vector3 &p_extents) = 0; // For non-spheres.
 	virtual void particles_collision_set_attractor_strength(RID p_particles_collision, real_t p_strength) = 0;
@@ -795,6 +796,13 @@ public:
 	virtual void particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) = 0; // For SDF and vector field, heightfield is dynamic.
 
 	virtual void particles_collision_height_field_update(RID p_particles_collision) = 0; // For SDF and vector field.
+
+#ifndef DISABLE_DEPRECATED
+	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) {
+		WARN_DEPRECATED_MSG(R"(The "particles_collision_set_cull_mask" function is deprecated, use "particles_collision_set_collision_layer" instead.)");
+		particles_collision_set_collision_layer(p_particles_collision, p_cull_mask);
+	}
+#endif // DISABLE_DEPRECATED
 
 	enum ParticlesCollisionHeightfieldResolution { // Longest axis resolution.
 		PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_256,
@@ -807,6 +815,7 @@ public:
 	};
 
 	virtual void particles_collision_set_height_field_resolution(RID p_particles_collision, ParticlesCollisionHeightfieldResolution p_resolution) = 0; // For SDF and vector field.
+	virtual void particles_collision_set_bake_mask(RID p_particles_collision, uint32_t p_bake_mask) = 0; // For SDF and vector field.
 
 	/* FOG VOLUME API */
 


### PR DESCRIPTION
This supersedes: https://github.com/godotengine/godot/pull/91858

This pull request adds the following:
1. A `bake_mask` property for `GPUParticlesCollisionHeightField3D` that functions similarly to the `bake_mask` in `GPUParticlesCollisionSDF3D`. It is used to filter which meshes are rendered in the height field texture.
2. A `collision_layer` property in both `GPUParticlesCollision3D` & `GPUParticlesAttractor3D` and a corresponding `collision_mask` property in `GPUParticles3D`. These variables replace the `cull_mask` property in `GPUParticlesCollision3D`. The `cull_mask` property was not used in the code, so it did not affect the collisions as noted in this issue: https://github.com/godotengine/godot/issues/61014#issue-1235751692. For backward compatibility, the `cull_mask` property is kept as a deprecated alias to the  `collision_layer` property.

The difference between this pull request and https://github.com/godotengine/godot/pull/91858 is that this pull request uses the 3D physics layers for the `collision_layer` & `collision_mask` properties, while https://github.com/godotengine/godot/pull/91858 adds a new set of layers, which turned out to be unnecessary.

- *This closes https://github.com/godotengine/godot/issues/61014.*
