### PR TITLE
Fix cleanup order in `unregister_core_types()`

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -444,8 +444,8 @@ void unregister_core_types() {
 
 	unregister_global_constants();
 
-	ClassDB::cleanup();
 	ResourceCache::clear();
+	ClassDB::cleanup();
 	CoreStringNames::free();
 	StringName::cleanup();
 


### PR DESCRIPTION
`ResourceCache::clear()` can use `Object::get_class()` which is cleaned up by `ClassDB::cleanup()` need to rearrange