### PR TITLE
GDScript: Call static methods in native base class

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -941,9 +941,19 @@ Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int 
 		top = top->base.ptr();
 	}
 
-	//none found, regular
+	{
+		Variant ret = Script::callp(p_method, p_args, p_argcount, r_error);
+		if (r_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD) {
+			return ret;
+		}
+	}
 
-	return Script::callp(p_method, p_args, p_argcount, r_error);
+	if (native.is_valid()) {
+		return native->callp(p_method, p_args, p_argcount, r_error);
+	}
+
+	r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	return Variant();
 }
 
 bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {

--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_base_method_runtime.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_base_method_runtime.gd
@@ -1,0 +1,9 @@
+class_name TestCallNativeStatic
+extends JSON
+
+func test():
+	var s: GDScript = get_script()
+	@warning_ignore("unsafe_method_access")
+	print(s.stringify("test"))
+	print(s.call(&"stringify", "test"))
+	print(TestCallNativeStatic.stringify("test"))

--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_base_method_runtime.out
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_base_method_runtime.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+"test"
+"test"
+"test"


### PR DESCRIPTION
allows calling the static methods of the native base on a gdscript object at runtime

fixes https://github.com/godotengine/godot/issues/111021
