### PR TITLE
Improve type info in debug prints

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -962,6 +962,25 @@ String Object::to_string() {
 	return _to_string();
 }
 
+String Object::debug_get_type_name() {
+	Ref<Script> scr = get_script();
+	if (scr.is_null()) {
+		return get_class_name();
+	}
+
+	String script_name = scr->get_global_name();
+	if (!script_name.is_empty()) {
+		return script_name;
+	}
+
+	script_name = scr->debug_get_script_name();
+	if (script_name.is_empty()) {
+		script_name = "?";
+	}
+
+	return vformat("%s(%s)", get_class_name(), script_name);
+}
+
 void Object::set_script(const Variant &p_script) {
 	if (get_script() == p_script) {
 		return;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -686,6 +686,7 @@ public:
 	bool derives_from() const;
 
 	const StringName &get_class_name() const;
+	virtual String debug_get_type_name();
 
 	StringName get_class_name_for_extension(const GDExtension *p_library) const;
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -171,6 +171,7 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_instance_base_type"), &Script::get_instance_base_type);
 
 	ClassDB::bind_method(D_METHOD("get_global_name"), &Script::get_global_name);
+	ClassDB::bind_method(D_METHOD("debug_get_script_name"), &Script::debug_get_script_name);
 
 	ClassDB::bind_method(D_METHOD("has_script_method", "method_name"), &Script::has_method);
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
@@ -208,6 +209,19 @@ void Script::reload_from_file() {
 #else
 	Resource::reload_from_file();
 #endif
+}
+
+String Script::debug_get_script_name() const {
+	String ret = get_global_name();
+	if (!ret.is_empty()) {
+		return ret;
+	}
+
+	return get_path().get_file();
+}
+
+String Script::debug_get_type_name() {
+	return vformat("%s[%s]", get_class_name(), debug_get_script_name());
 }
 
 void ScriptServer::set_scripting_enabled(bool p_enabled) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -150,6 +150,8 @@ public:
 
 	virtual Ref<Script> get_base_script() const = 0; //for script inheritance
 	virtual StringName get_global_name() const = 0;
+	virtual String debug_get_script_name() const;
+	String debug_get_type_name() override;
 	virtual bool inherits_script(const Ref<Script> &p_script) const = 0;
 
 	virtual StringName get_instance_base_type() const = 0; // this may not work in all scripts, will return empty if so

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -233,14 +233,14 @@ void Array::assign(const Array &p_array) {
 		for (int i = 0; i < size; i++) {
 			const Variant &element = source[i];
 			if (element.get_type() != Variant::NIL && (element.get_type() != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, element.debug_get_type_name(), typed.debug_get_type_name()));
 			}
 		}
 		_p->array = p_array._p->array;
 		return;
 	}
 	if (typed.type == Variant::OBJECT || source_typed.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", source_typed.debug_get_type_name(), typed.debug_get_type_name()));
 	}
 
 	Vector<Variant> array;
@@ -256,11 +256,11 @@ void Array::assign(const Array &p_array) {
 				continue;
 			}
 			if (!Variant::can_convert_strict(value->get_type(), typed.type)) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, value->debug_get_type_name(), typed.debug_get_type_name()));
 			}
 			Callable::CallError ce;
 			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, value->debug_get_type_name(), typed.debug_get_type_name()));
 		}
 	} else if (Variant::can_convert_strict(source_typed.type, typed.type)) {
 		// from primitives to different convertible primitives
@@ -268,10 +268,10 @@ void Array::assign(const Array &p_array) {
 			const Variant *value = source + i;
 			Callable::CallError ce;
 			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, value->debug_get_type_name(), typed.debug_get_type_name()));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", source_typed.debug_get_type_name(), typed.debug_get_type_name()));
 	}
 
 	_p->array = array;
@@ -925,6 +925,10 @@ StringName Array::get_typed_class_name() const {
 
 Variant Array::get_typed_script() const {
 	return _p->typed.script;
+}
+
+String Array::debug_get_value_type_name() const {
+	return _p->typed.debug_get_type_name();
 }
 
 Array Array::create_read_only() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -39,6 +39,7 @@
 
 class Callable;
 class StringName;
+class String;
 class Variant;
 
 struct ArrayPrivate;
@@ -191,6 +192,7 @@ public:
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;
+	String debug_get_value_type_name() const;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -70,7 +70,7 @@ private:
 			}
 
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(r_inout_variant.get_type()), where, Variant::get_type_name(type)));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), r_inout_variant.debug_get_type_name(), where, debug_get_type_name()));
 			} else {
 				return false;
 			}
@@ -194,5 +194,30 @@ public:
 	}
 	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
 		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
+	}
+
+	String debug_get_type_name() const {
+		if (type == Variant::NIL) {
+			return "Variant";
+		}
+
+		if (type != Variant::OBJECT) {
+			return Variant::get_type_name(type);
+		}
+
+		String name = class_name;
+		if (name.is_empty()) {
+			name = "Object";
+		}
+
+		if (script.is_null()) {
+			return name;
+		}
+
+		String global_name = script->get_global_name();
+		if (!global_name.is_empty()) {
+			return global_name;
+		}
+		return vformat("%s(%s)", name, script->debug_get_script_name());
 	}
 };

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -462,13 +462,14 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
 			if (key->get_type() != Variant::NIL && (key->get_type() != Variant::OBJECT || !typed_key.validate_object(*key, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", key->debug_get_type_name(), typed_key.debug_get_type_name()));
 			}
 			key_data[i++] = *key;
 		}
 	} else if (typed_key.type == Variant::OBJECT || typed_key_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)",
+				typed_key_source.debug_get_type_name(), typed_value_source.debug_get_type_name(),
+				typed_key.debug_get_type_name(), typed_value.debug_get_type_name()));
 	} else if (typed_key_source.type == Variant::NIL && typed_key.type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
@@ -479,11 +480,11 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 				continue;
 			}
 			if (!Variant::can_convert_strict(key->get_type(), typed_key.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", key->debug_get_type_name(), typed_key.debug_get_type_name()));
 			}
 			Callable::CallError ce;
 			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", key->debug_get_type_name(), typed_key.debug_get_type_name()));
 		}
 	} else if (Variant::can_convert_strict(typed_key_source.type, typed_key.type)) {
 		// From primitives to different convertible primitives.
@@ -492,11 +493,12 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *key = &E.key;
 			Callable::CallError ce;
 			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", key->debug_get_type_name(), typed_key.debug_get_type_name()));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)",
+				typed_key_source.debug_get_type_name(), typed_value_source.debug_get_type_name(),
+				typed_key.debug_get_type_name(), typed_value.debug_get_type_name()));
 	}
 
 	if (typed_value == typed_value_source || typed_value.type == Variant::NIL || (typed_value_source.type == Variant::OBJECT && typed_value.can_reference(typed_value_source))) {
@@ -515,13 +517,14 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
 			if (value->get_type() != Variant::NIL && (value->get_type() != Variant::OBJECT || !typed_value.validate_object(*value, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], value->debug_get_type_name(), typed_value.debug_get_type_name()));
 			}
 			value_data[i++] = *value;
 		}
 	} else if (typed_value.type == Variant::OBJECT || typed_value_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)",
+				typed_key_source.debug_get_type_name(), typed_value_source.debug_get_type_name(),
+				typed_key.debug_get_type_name(), typed_value.debug_get_type_name()));
 	} else if (typed_value_source.type == Variant::NIL && typed_value.type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
@@ -532,11 +535,11 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 				continue;
 			}
 			if (!Variant::can_convert_strict(value->get_type(), typed_value.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], value->debug_get_type_name(), typed_value.debug_get_type_name()));
 			}
 			Callable::CallError ce;
 			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], value->debug_get_type_name(), typed_value.debug_get_type_name()));
 		}
 	} else if (Variant::can_convert_strict(typed_value_source.type, typed_value.type)) {
 		// From primitives to different convertible primitives.
@@ -545,11 +548,12 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *value = &E.value;
 			Callable::CallError ce;
 			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], value->debug_get_type_name(), typed_value.debug_get_type_name()));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)",
+				typed_key_source.debug_get_type_name(), typed_value_source.debug_get_type_name(),
+				typed_key.debug_get_type_name(), typed_value.debug_get_type_name()));
 	}
 
 	for (int i = 0; i < size; i++) {
@@ -733,6 +737,14 @@ const ContainerTypeValidate &Dictionary::get_key_validator() const {
 
 const ContainerTypeValidate &Dictionary::get_value_validator() const {
 	return _p->typed_value;
+}
+
+String Dictionary::debug_get_key_type_name() const {
+	return _p->typed_key.debug_get_type_name();
+}
+
+String Dictionary::debug_get_value_type_name() const {
+	return _p->typed_value.debug_get_type_name();
 }
 
 void Dictionary::operator=(const Dictionary &p_dictionary) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -131,6 +131,8 @@ public:
 	Variant get_typed_value_script() const;
 	const ContainerTypeValidate &get_key_validator() const;
 	const ContainerTypeValidate &get_value_validator() const;
+	String debug_get_key_type_name() const;
+	String debug_get_value_type_name() const;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -199,6 +199,43 @@ String Variant::get_type_name(Variant::Type p_type) {
 	return "";
 }
 
+String Variant::debug_get_type_name() const {
+	switch (get_type()) {
+		case OBJECT: {
+			bool was_freed;
+			Object *obj = get_validated_object_with_check(was_freed);
+			if (obj == nullptr) {
+				if (was_freed) {
+					return "Object (previously freed)";
+				} else {
+					return "Object (null instance)";
+				}
+			}
+
+			return obj->debug_get_type_name();
+		}
+		case ARRAY: {
+			const Array &arr = *reinterpret_cast<const Array *>(_data._mem);
+			if (!arr.is_typed()) {
+				return "Array";
+			}
+
+			return vformat("Array[%s]", arr.debug_get_value_type_name());
+		}
+		case DICTIONARY: {
+			const Dictionary &dict = *reinterpret_cast<const Dictionary *>(_data._mem);
+			if (!dict.is_typed()) {
+				return "Dictionary";
+			}
+
+			return vformat("Dictionary[%s, %s]", dict.debug_get_key_type_name(), dict.debug_get_value_type_name());
+		}
+		default: {
+			return get_type_name(get_type());
+		}
+	}
+}
+
 static HashMap<String, Variant::Type> _init_type_name_map() {
 	HashMap<String, Variant::Type> type_names;
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
@@ -3545,7 +3582,7 @@ String Variant::get_call_error_text(Object *p_base, const StringName &p_method, 
 	if (p_ce.error == Callable::CallError::CALL_ERROR_INVALID_ARGUMENT) {
 		int errorarg = p_ce.argument;
 		if (p_argptrs) {
-			err_text = "Cannot convert argument " + itos(errorarg + 1) + " from " + Variant::get_type_name(p_argptrs[errorarg]->get_type()) + " to " + Variant::get_type_name(Variant::Type(p_ce.expected));
+			err_text = "Cannot convert argument " + itos(errorarg + 1) + " from " + p_argptrs[errorarg]->debug_get_type_name() + " to " + Variant::get_type_name(Variant::Type(p_ce.expected));
 		} else {
 			err_text = "Cannot convert argument " + itos(errorarg + 1) + " from [missing argptr, type unknown] to " + Variant::get_type_name(Variant::Type(p_ce.expected));
 		}

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -387,6 +387,7 @@ public:
 		return type;
 	}
 	static String get_type_name(Variant::Type p_type);
+	String debug_get_type_name() const;
 	static Variant::Type get_type_by_name(const String &p_type_name);
 	static bool can_convert(Type p_type_from, Type p_type_to);
 	static bool can_convert_strict(Type p_type_from, Type p_type_to);

--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -45,7 +45,7 @@ uint32_t VariantCallable::hash() const {
 }
 
 String VariantCallable::get_as_text() const {
-	return vformat("%s::%s", Variant::get_type_name(variant.get_type()), method);
+	return vformat("%s::%s", variant.debug_get_type_name(), method);
 }
 
 CallableCustom::CompareEqualFunc VariantCallable::get_compare_equal_func() const {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -957,6 +957,10 @@ String VariantUtilityFunctions::type_string(Variant::Type p_type) {
 	return Variant::get_type_name(p_type);
 }
 
+String VariantUtilityFunctions::debug_get_type_string(const Variant &p_var) {
+	return p_var.debug_get_type_name();
+}
+
 void VariantUtilityFunctions::print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 	print_line(join_string(p_args, p_arg_count));
 	r_error.error = Callable::CallError::CALL_OK;
@@ -1750,6 +1754,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVARARGS(str, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(error_string, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(type_string, sarray("type"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(debug_get_type_string, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print_rich, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printerr, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -130,6 +130,7 @@ struct VariantUtilityFunctions {
 	static String str(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static String error_string(Error p_error);
 	static String type_string(Variant::Type p_type);
+	static String debug_get_type_string(const Variant &p_var);
 	static void print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void print_rich(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void _print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -352,6 +352,13 @@
 				Converts from decibels to linear energy (audio).
 			</description>
 		</method>
+		<method name="debug_get_type_string">
+			<return type="String" />
+			<param index="0" name="variable" type="Variant" />
+			<description>
+				Returns a descriptive name for the type of the passed [param variable]. Suitable for debug print statements.
+			</description>
+		</method>
 		<method name="deg_to_rad">
 			<return type="float" />
 			<param index="0" name="deg" type="float" />

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -18,6 +18,12 @@
 				Returns [code]true[/code] if the script can be instantiated.
 			</description>
 		</method>
+		<method name="debug_get_script_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns a descriptive name for the script. Suitable for debug print statements.
+			</description>
+		</method>
 		<method name="get_base_script" qualifiers="const">
 			<return type="Script" />
 			<description>

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -183,45 +183,7 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 			String result;
 
 			if (dict.is_typed()) {
-				result += "Dictionary[";
-
-				Ref<Script> key_script = dict.get_typed_key_script();
-				if (key_script.is_valid()) {
-					if (key_script->get_global_name() != StringName()) {
-						result += key_script->get_global_name();
-					} else if (!key_script->get_path().get_file().is_empty()) {
-						result += key_script->get_path().get_file();
-					} else {
-						result += dict.get_typed_key_class_name();
-					}
-				} else if (dict.get_typed_key_class_name() != StringName()) {
-					result += dict.get_typed_key_class_name();
-				} else if (dict.is_typed_key()) {
-					result += Variant::get_type_name((Variant::Type)dict.get_typed_key_builtin());
-				} else {
-					result += "Variant";
-				}
-
-				result += ", ";
-
-				Ref<Script> value_script = dict.get_typed_value_script();
-				if (value_script.is_valid()) {
-					if (value_script->get_global_name() != StringName()) {
-						result += value_script->get_global_name();
-					} else if (!value_script->get_path().get_file().is_empty()) {
-						result += value_script->get_path().get_file();
-					} else {
-						result += dict.get_typed_value_class_name();
-					}
-				} else if (dict.get_typed_value_class_name() != StringName()) {
-					result += dict.get_typed_value_class_name();
-				} else if (dict.is_typed_value()) {
-					result += Variant::get_type_name((Variant::Type)dict.get_typed_value_builtin());
-				} else {
-					result += "Variant";
-				}
-
-				result += "](";
+				result += "Dictionary[" + dict.debug_get_key_type_name() + ", " + dict.debug_get_value_type_name() + "](";
 			}
 
 			if (dict.is_empty()) {
@@ -256,24 +218,7 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 			String result;
 
 			if (array.is_typed()) {
-				result += "Array[";
-
-				Ref<Script> script = array.get_typed_script();
-				if (script.is_valid()) {
-					if (script->get_global_name() != StringName()) {
-						result += script->get_global_name();
-					} else if (!script->get_path().get_file().is_empty()) {
-						result += script->get_path().get_file();
-					} else {
-						result += array.get_typed_class_name();
-					}
-				} else if (array.get_typed_class_name() != StringName()) {
-					result += array.get_typed_class_name();
-				} else {
-					result += Variant::get_type_name((Variant::Type)array.get_typed_builtin());
-				}
-
-				result += "](";
+				result += "Array[" + array.debug_get_value_type_name() + "](";
 			}
 
 			if (array.is_empty()) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -92,6 +92,10 @@ void GDScriptNativeClass::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("new"), &GDScriptNativeClass::_new);
 }
 
+String GDScriptNativeClass::debug_get_type_name() {
+	return vformat("GDScriptNativeClass[%s]", get_name());
+}
+
 Variant GDScriptNativeClass::_new() {
 	Object *o = instantiate();
 	ERR_FAIL_NULL_V_MSG(o, Variant(), "Class type: '" + String(name) + "' is not instantiable.");
@@ -1374,29 +1378,22 @@ void GDScript::_save_orphaned_subclasses() {
 	}
 }
 
-#ifdef DEBUG_ENABLED
-String GDScript::debug_get_script_name(const Ref<Script> &p_script) {
-	if (p_script.is_valid()) {
-		Ref<GDScript> gdscript = p_script;
-		if (gdscript.is_valid()) {
-			if (gdscript->get_local_name() != StringName()) {
-				return gdscript->get_local_name();
-			}
-			return gdscript->get_fully_qualified_name().get_file();
-		}
-
-		if (p_script->get_global_name() != StringName()) {
-			return p_script->get_global_name();
-		} else if (!p_script->get_path().is_empty()) {
-			return p_script->get_path().get_file();
-		} else if (!p_script->get_name().is_empty()) {
-			return p_script->get_name(); // Resource name.
-		}
+String GDScript::debug_get_script_name() const {
+	if (!is_script_valid()) {
+		return "<invalid script>";
 	}
 
-	return "<unknown script>";
+	String ret = get_global_name();
+	if (!ret.is_empty()) {
+		return ret;
+	}
+	ret = get_fully_qualified_name().get_file();
+	if (!ret.is_empty()) {
+		return ret;
+	}
+
+	return get_fully_qualified_name();
 }
-#endif
 
 String GDScript::canonicalize_path(const String &p_path) {
 	if (p_path.get_extension() == "gdc") {
@@ -1777,21 +1774,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 						static bool error_shown = false;
 						if (unlikely(!error_shown)) {
 							error_shown = true;
-
-							String elem_type;
-							if (arr.is_typed()) {
-								const Ref<Script> script_type = arr.get_typed_script();
-								if (script_type.is_valid() && script_type->is_script_valid()) {
-									elem_type = GDScript::debug_get_script_name(script_type);
-								} else if (!arr.get_typed_class_name().is_empty()) {
-									elem_type = arr.get_typed_class_name();
-								} else {
-									elem_type = Variant::get_type_name((Variant::Type)arr.get_typed_builtin());
-								}
-								elem_type = vformat("[%s]", elem_type);
-							}
-
-							String msg = vformat(R"*("_get_property_list()" should return "Array[Dictionary]", not "Array%s".)*", elem_type);
+							String msg = vformat(R"*("_get_property_list()" should return "Array[Dictionary]", not "%s".)*", ret.debug_get_type_name());
 							msg += " The old behavior is supported for compatibility and may be removed in the future.";
 							msg += " This message is printed once and will not be repeated for similar errors.";
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -48,6 +48,7 @@ protected:
 
 public:
 	_FORCE_INLINE_ const StringName &get_name() const { return name; }
+	String debug_get_type_name() override;
 	Variant _new();
 	Object *instantiate();
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
@@ -213,9 +214,7 @@ protected:
 	static void _bind_methods();
 
 public:
-#ifdef DEBUG_ENABLED
-	static String debug_get_script_name(const Ref<Script> &p_script);
-#endif
+	String debug_get_script_name() const override;
 
 	static String canonicalize_path(const String &p_path);
 	_FORCE_INLINE_ static bool is_canonically_equal_paths(const String &p_path_a, const String &p_path_b) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1735,7 +1735,7 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 			Variant::construct(argument_info.type, converted_to, &converted_from, 1, call_error);
 
 			if (call_error.error != Callable::CallError::CALL_OK) {
-				push_error(vformat(R"(Cannot convert argument %d of annotation "%s" from "%s" to "%s".)", i + 1, p_annotation->name, Variant::get_type_name(value.get_type()), Variant::get_type_name(argument_info.type)), argument);
+				push_error(vformat(R"(Cannot convert argument %d of annotation "%s" from "%s" to "%s".)", i + 1, p_annotation->name, value.debug_get_type_name(), Variant::get_type_name(argument_info.type)), argument);
 				return;
 			}
 
@@ -3225,8 +3225,8 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 				} else {
 					push_error(vformat(R"(Invalid operands to operator %s, %s and %s.)",
 									   Variant::get_operator_name(p_binary_op->variant_op),
-									   Variant::get_type_name(p_binary_op->left_operand->reduced_value.get_type()),
-									   Variant::get_type_name(p_binary_op->right_operand->reduced_value.get_type())),
+									   p_binary_op->left_operand->reduced_value.debug_get_type_name(),
+									   p_binary_op->right_operand->reduced_value.debug_get_type_name()),
 							p_binary_op);
 				}
 			}

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -55,11 +55,11 @@ static String _get_variant_string(const Variant &p_variant) {
 			} else {
 				Script *script = Object::cast_to<Script>(obj);
 				if (script) {
-					txt = "script(" + GDScript::debug_get_script_name(script) + ")";
+					txt = "script(" + script->debug_get_script_name() + ")";
 				} else {
 					txt = "object(" + obj->get_class();
 					if (obj->get_script_instance()) {
-						txt += ", " + GDScript::debug_get_script_name(obj->get_script_instance()->get_script());
+						txt += ", " + obj->get_script_instance()->get_script()->debug_get_script_name();
 					}
 					txt += ")";
 				}
@@ -165,7 +165,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				if (script_type.is_valid() && script_type->is_script_valid()) {
 					text += "script(";
-					text += GDScript::debug_get_script_name(script_type);
+					text += script_type->debug_get_script_name();
 					text += ")";
 				} else if (native_type != StringName()) {
 					text += native_type;
@@ -190,7 +190,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				if (key_script_type.is_valid() && key_script_type->is_script_valid()) {
 					text += "script(";
-					text += GDScript::debug_get_script_name(key_script_type);
+					text += key_script_type->debug_get_script_name();
 					text += ")";
 				} else if (key_native_type != StringName()) {
 					text += key_native_type;
@@ -206,7 +206,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				if (value_script_type.is_valid() && value_script_type->is_script_valid()) {
 					text += "script(";
-					text += GDScript::debug_get_script_name(value_script_type);
+					text += value_script_type->debug_get_script_name();
 					text += ")";
 				} else if (value_native_type != StringName()) {
 					text += value_native_type;
@@ -371,7 +371,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				}
 
 				text += "set_static_variable script(";
-				text += GDScript::debug_get_script_name(gdscript);
+				text += gdscript->debug_get_script_name();
 				text += ")";
 				if (gdscript.is_valid()) {
 					text += "[\"" + gdscript->debug_get_static_var_by_index(_code_ptr[ip + 3]) + "\"]";
@@ -394,7 +394,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "get_static_variable ";
 				text += DADDR(1);
 				text += " = script(";
-				text += GDScript::debug_get_script_name(gdscript);
+				text += gdscript->debug_get_script_name();
 				text += ")";
 				if (gdscript.is_valid()) {
 					text += "[\"" + gdscript->debug_get_static_var_by_index(_code_ptr[ip + 3]) + "\"]";
@@ -473,7 +473,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Ref<Script> script = get_constant(_code_ptr[ip + 3] & ADDR_MASK);
 
 				text += "assign typed script (";
-				text += GDScript::debug_get_script_name(script);
+				text += script->debug_get_script_name();
 				text += ") ";
 				text += DADDR(1);
 				text += " = ";
@@ -579,7 +579,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				String type_name;
 				if (script_type.is_valid() && script_type->is_script_valid()) {
-					type_name = "script(" + GDScript::debug_get_script_name(script_type) + ")";
+					type_name = "script(" + script_type->debug_get_script_name() + ")";
 				} else if (native_type != StringName()) {
 					type_name = native_type;
 				} else {
@@ -634,7 +634,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				String key_type_name;
 				if (key_script_type.is_valid() && key_script_type->is_script_valid()) {
-					key_type_name = "script(" + GDScript::debug_get_script_name(key_script_type) + ")";
+					key_type_name = "script(" + key_script_type->debug_get_script_name() + ")";
 				} else if (key_native_type != StringName()) {
 					key_type_name = key_native_type;
 				} else {
@@ -647,7 +647,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				String value_type_name;
 				if (value_script_type.is_valid() && value_script_type->is_script_valid()) {
-					value_type_name = "script(" + GDScript::debug_get_script_name(value_script_type) + ")";
+					value_type_name = "script(" + value_script_type->debug_get_script_name() + ")";
 				} else if (value_native_type != StringName()) {
 					value_type_name = value_native_type;
 				} else {
@@ -1110,7 +1110,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Ref<Script> script = get_constant(_code_ptr[ip + 2] & ADDR_MASK);
 
 				text += "return typed script (";
-				text += GDScript::debug_get_script_name(script);
+				text += script->debug_get_script_name();
 				text += ") ";
 				text += DADDR(1);
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1030,7 +1030,7 @@ void GDScriptParser::parse_extends() {
 
 	if (match(GDScriptTokenizer::Token::LITERAL)) {
 		if (previous.literal.get_type() != Variant::STRING) {
-			push_error(vformat(R"(Only strings or identifiers can be used after "extends", found "%s" instead.)", Variant::get_type_name(previous.literal.get_type())));
+			push_error(vformat(R"(Only strings or identifiers can be used after "extends", found "%s" instead.)", previous.literal.debug_get_type_name()));
 		}
 		current_class->extends_path = previous.literal;
 

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -444,7 +444,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 				*r_ret = d.size();
 			} break;
 			default: {
-				*r_ret = vformat(RTR("Value of type '%s' can't provide a length."), Variant::get_type_name(p_args[0]->get_type()));
+				*r_ret = vformat(RTR("Value of type '%s' can't provide a length."), p_args[0]->debug_get_type_name());
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::NIL;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -38,6 +38,8 @@
 
 #ifdef DEBUG_ENABLED
 
+#include "core/variant/container_type_validate.h"
+
 static bool _profile_count_as_native(const Object *p_base_obj, const StringName &p_methodname) {
 	if (!p_base_obj) {
 		return false;
@@ -50,58 +52,15 @@ static bool _profile_count_as_native(const Object *p_base_obj, const StringName 
 }
 
 static String _get_element_type(Variant::Type builtin_type, const StringName &native_type, const Ref<Script> &script_type) {
-	if (script_type.is_valid() && script_type->is_script_valid()) {
-		return GDScript::debug_get_script_name(script_type);
-	} else if (native_type != StringName()) {
-		return native_type.string();
-	} else {
-		return Variant::get_type_name(builtin_type);
-	}
+	ContainerTypeValidate container_type{};
+	container_type.type = builtin_type;
+	container_type.class_name = native_type;
+	container_type.script = script_type;
+	return container_type.debug_get_type_name();
 }
 
 static String _get_var_type(const Variant *p_var) {
-	String basestr;
-
-	if (p_var->get_type() == Variant::OBJECT) {
-		bool was_freed;
-		Object *bobj = p_var->get_validated_object_with_check(was_freed);
-		if (!bobj) {
-			if (was_freed) {
-				basestr = "previously freed";
-			} else {
-				basestr = "null instance";
-			}
-		} else {
-			if (bobj->is_class_ptr(GDScriptNativeClass::get_class_ptr_static())) {
-				basestr = Object::cast_to<GDScriptNativeClass>(bobj)->get_name();
-			} else {
-				basestr = bobj->get_class();
-				if (bobj->get_script_instance()) {
-					basestr += " (" + GDScript::debug_get_script_name(bobj->get_script_instance()->get_script()) + ")";
-				}
-			}
-		}
-
-	} else {
-		if (p_var->get_type() == Variant::ARRAY) {
-			basestr = "Array";
-			const Array *p_array = VariantInternal::get_array(p_var);
-			if (p_array->is_typed()) {
-				basestr += "[" + _get_element_type((Variant::Type)p_array->get_typed_builtin(), p_array->get_typed_class_name(), p_array->get_typed_script()) + "]";
-			}
-		} else if (p_var->get_type() == Variant::DICTIONARY) {
-			basestr = "Dictionary";
-			const Dictionary *p_dictionary = VariantInternal::get_dictionary(p_var);
-			if (p_dictionary->is_typed()) {
-				basestr += "[" + _get_element_type((Variant::Type)p_dictionary->get_typed_key_builtin(), p_dictionary->get_typed_key_class_name(), p_dictionary->get_typed_key_script()) +
-						", " + _get_element_type((Variant::Type)p_dictionary->get_typed_value_builtin(), p_dictionary->get_typed_value_class_name(), p_dictionary->get_typed_value_script()) + "]";
-			}
-		} else {
-			basestr = Variant::get_type_name(p_var->get_type());
-		}
-	}
-
-	return basestr;
+	return p_var->debug_get_type_name();
 }
 
 void GDScriptFunction::_profile_native_call(uint64_t p_t_taken, const String &p_func_name, const String &p_instance_class_name) {
@@ -175,7 +134,7 @@ String GDScriptFunction::_get_call_error(const String &p_where, const Variant **
 			if (p_err.expected == Variant::DICTIONARY && p_argptrs[p_err.argument]->get_type() == p_err.expected) {
 				return "Invalid type in " + p_where + ". The dictionary of argument " + itos(p_err.argument + 1) + " (" + _get_var_type(p_argptrs[p_err.argument]) + ") does not have the same element type as the expected typed dictionary argument.";
 			}
-			return "Invalid type in " + p_where + ". Cannot convert argument " + itos(p_err.argument + 1) + " from " + Variant::get_type_name(p_argptrs[p_err.argument]->get_type()) + " to " + Variant::get_type_name(Variant::Type(p_err.expected)) + ".";
+			return "Invalid type in " + p_where + ". Cannot convert argument " + itos(p_err.argument + 1) + " from " + p_argptrs[p_err.argument]->debug_get_type_name() + " to " + Variant::get_type_name(Variant::Type(p_err.expected)) + ".";
 		case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
 		case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 			return "Invalid call to " + p_where + ". Expected " + itos(p_err.expected) + " argument(s).";
@@ -789,7 +748,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					if (unlikely(!op_func)) {
 #ifdef DEBUG_ENABLED
-						err_text = "Invalid operands '" + Variant::get_type_name(a->get_type()) + "' and '" + Variant::get_type_name(b->get_type()) + "' in operator '" + Variant::get_operator_name(op) + "'.";
+						err_text = "Invalid operands '" + a->debug_get_type_name() + "' and '" + b->debug_get_type_name() + "' in operator '" + Variant::get_operator_name(op) + "'.";
 #endif
 						initializer_mutex.unlock();
 						OPCODE_BREAK;
@@ -831,7 +790,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							err_text = ret;
 							err_text += " in operator '" + Variant::get_operator_name(op) + "'.";
 						} else {
-							err_text = "Invalid operands '" + Variant::get_type_name(a->get_type()) + "' and '" + Variant::get_type_name(b->get_type()) + "' in operator '" + Variant::get_operator_name(op) + "'.";
+							err_text = "Invalid operands '" + a->debug_get_type_name() + "' and '" + b->debug_get_type_name() + "' in operator '" + Variant::get_operator_name(op) + "'.";
 						}
 						OPCODE_BREAK;
 					}
@@ -1319,7 +1278,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					err_text = "Internal error setting property: " + String(*index);
 					OPCODE_BREAK;
 				} else if (!valid) {
-					err_text = "Error setting property '" + String(*index) + "' with value of type " + Variant::get_type_name(src->get_type()) + ".";
+					err_text = "Error setting property '" + String(*index) + "' with value of type " + src->debug_get_type_name() + ".";
 					OPCODE_BREAK;
 				}
 #endif
@@ -1439,7 +1398,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						Variant::construct(var_type, *dst, const_cast<const Variant **>(&src), 1, ce);
 					} else {
 #ifdef DEBUG_ENABLED
-						err_text = "Trying to assign value of type '" + Variant::get_type_name(src->get_type()) +
+						err_text = "Trying to assign value of type '" + src->debug_get_type_name() +
 								"' to a variable of type '" + Variant::get_type_name(var_type) + "'.";
 						OPCODE_BREAK;
 					}
@@ -1541,7 +1500,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GDScriptNativeClass *nc = Object::cast_to<GDScriptNativeClass>(type->operator Object *());
 				GD_ERR_BREAK(!nc);
 				if (src->get_type() != Variant::OBJECT && src->get_type() != Variant::NIL) {
-					err_text = "Trying to assign value of type '" + Variant::get_type_name(src->get_type()) +
+					err_text = "Trying to assign value of type '" + src->debug_get_type_name() +
 							"' to a variable of type '" + nc->get_name() + "'.";
 					OPCODE_BREAK;
 				}
@@ -2988,7 +2947,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (r->get_type() != Variant::OBJECT && r->get_type() != Variant::NIL) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "%s".)",
-							_get_var_type(r), GDScript::debug_get_script_name(Ref<Script>(base_type)));
+							_get_var_type(r), base_type->debug_get_script_name());
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
@@ -3010,7 +2969,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (!ret_inst) {
 #ifdef DEBUG_ENABLED
 						err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "%s".)",
-								_get_var_type(r), GDScript::debug_get_script_name(Ref<GDScript>(base_type)));
+								_get_var_type(r), base_type->debug_get_script_name());
 #endif // DEBUG_ENABLED
 						OPCODE_BREAK;
 					}
@@ -3029,7 +2988,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (!valid) {
 #ifdef DEBUG_ENABLED
 						err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "%s".)",
-								_get_var_type(r), GDScript::debug_get_script_name(Ref<GDScript>(base_type)));
+								_get_var_type(r), base_type->debug_get_script_name());
 #endif // DEBUG_ENABLED
 						OPCODE_BREAK;
 					}
@@ -3054,7 +3013,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (!container->iter_init(*counter, valid)) {
 #ifdef DEBUG_ENABLED
 					if (!valid) {
-						err_text = "Unable to iterate on object of type '" + Variant::get_type_name(container->get_type()) + "'.";
+						err_text = "Unable to iterate on object of type '" + container->debug_get_type_name() + "'.";
 						OPCODE_BREAK;
 					}
 #endif
@@ -3067,7 +3026,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*iterator = container->iter_get(*counter, valid);
 #ifdef DEBUG_ENABLED
 					if (!valid) {
-						err_text = "Unable to obtain iterator object of type '" + Variant::get_type_name(container->get_type()) + "'.";
+						err_text = "Unable to obtain iterator object of type '" + container->debug_get_type_name() + "'.";
 						OPCODE_BREAK;
 					}
 #endif
@@ -3388,7 +3347,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 				if (ref.size() != 1 || ce.error != Callable::CallError::CALL_OK) {
-					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
+					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", obj->debug_get_type_name());
 					OPCODE_BREAK;
 				}
 #endif
@@ -3403,7 +3362,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*iterator = obj->callp(CoreStringName(_iter_get), const_cast<const Variant **>(&state_ptr), 1, ce);
 #ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
-						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
+						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", obj->debug_get_type_name());
 						OPCODE_BREAK;
 					}
 #endif
@@ -3456,7 +3415,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (!container->iter_next(*counter, valid)) {
 #ifdef DEBUG_ENABLED
 					if (!valid) {
-						err_text = "Unable to iterate on object of type '" + Variant::get_type_name(container->get_type()) + "' (type changed since first iteration?).";
+						err_text = "Unable to iterate on object of type '" + container->debug_get_type_name() + "' (type changed since first iteration?).";
 						OPCODE_BREAK;
 					}
 #endif
@@ -3469,7 +3428,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*iterator = container->iter_get(*counter, valid);
 #ifdef DEBUG_ENABLED
 					if (!valid) {
-						err_text = "Unable to obtain iterator object of type '" + Variant::get_type_name(container->get_type()) + "' (but was obtained on first iteration?).";
+						err_text = "Unable to obtain iterator object of type '" + container->debug_get_type_name() + "' (but was obtained on first iteration?).";
 						OPCODE_BREAK;
 					}
 #endif
@@ -3747,7 +3706,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 				if (VariantInternal::get_array(state)->size() != 1 || ce.error != Callable::CallError::CALL_OK) {
-					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
+					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", obj->debug_get_type_name());
 					OPCODE_BREAK;
 				}
 #endif
@@ -3763,7 +3722,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*iterator = obj->callp(CoreStringName(_iter_get), const_cast<const Variant **>(&state_ptr), 1, ce);
 #ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
-						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
+						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", obj->debug_get_type_name());
 						OPCODE_BREAK;
 					}
 #endif

--- a/modules/gdscript/tests/scripts/runtime/errors/construct_abstract_class.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/construct_abstract_class.out
@@ -1,5 +1,5 @@
 GDTEST_RUNTIME_ERROR
 false
->> SCRIPT ERROR at runtime/errors/construct_abstract_class.gd:11 on subtest_gdscript(): Invalid call function 'new' in base 'GDScript': Can't instantiate an abstract class.
+>> SCRIPT ERROR at runtime/errors/construct_abstract_class.gd:11 on subtest_gdscript(): Invalid call function 'new' in base 'GDScript[construct_abstract_class.gd::AbstractClass]': Can't instantiate an abstract class.
 false
->> SCRIPT ERROR at runtime/errors/construct_abstract_class.gd:16 on subtest_variant(): Invalid call function 'new' in base 'GDScript': Can't instantiate an abstract class.
+>> SCRIPT ERROR at runtime/errors/construct_abstract_class.gd:16 on subtest_variant(): Invalid call function 'new' in base 'GDScript[construct_abstract_class.gd::AbstractClass]': Can't instantiate an abstract class.

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
@@ -1,21 +1,21 @@
 GDTEST_RUNTIME_ERROR
 SUBTEST_INIT_ARRAY_LARGE
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:28 on subtest_init_array_large(): There was an error calling "_iter_next" on iterator object of type "BadInit".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:28 on subtest_init_array_large(): There was an error calling "_iter_next" on iterator object of type "RefCounted(for_loop_iterator_array_size.gd::BadInit)".
 SUBTEST_INIT_ARRAY_EMPTY
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:33 on subtest_init_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadInit".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:33 on subtest_init_array_empty(): There was an error calling "_iter_next" on iterator object of type "RefCounted(for_loop_iterator_array_size.gd::BadInit)".
 SUBTEST_NEXT_ARRAY_LARGE
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:67 on subtest_next_array_large(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:67 on subtest_next_array_large(): There was an error calling "_iter_next" on iterator object of type "RefCounted(for_loop_iterator_array_size.gd::BadNext)".
 SUBTEST_NEXT_ARRAY_EMPTY
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:72 on subtest_next_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:72 on subtest_next_array_empty(): There was an error calling "_iter_next" on iterator object of type "RefCounted(for_loop_iterator_array_size.gd::BadNext)".
 SUBTEST_VARIANT_INIT_ARRAY_LARGE
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'RefCounted(for_loop_iterator_array_size.gd::BadInit)'.
 SUBTEST_VARIANT_INIT_ARRAY_EMPTY
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'RefCounted(for_loop_iterator_array_size.gd::BadInit)'.
 SUBTEST_VARIANT_NEXT_ARRAY_LARGE
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'RefCounted(for_loop_iterator_array_size.gd::BadNext)' (type changed since first iteration?).
 SUBTEST_VARIANT_NEXT_ARRAY_EMPTY
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'RefCounted(for_loop_iterator_array_size.gd::BadNext)' (type changed since first iteration?).

--- a/modules/gdscript/tests/scripts/runtime/errors/invalid_property_assignment.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/invalid_property_assignment.out
@@ -1,2 +1,2 @@
 GDTEST_RUNTIME_ERROR
->> SCRIPT ERROR at runtime/errors/invalid_property_assignment.gd:9 on test(): Invalid assignment of property or key 'obj' with value of type 'RefCounted (MyObj)' on a base object of type 'RefCounted (MyObj)'.
+>> SCRIPT ERROR at runtime/errors/invalid_property_assignment.gd:9 on test(): Invalid assignment of property or key 'obj' with value of type 'RefCounted(invalid_property_assignment.gd::MyObj)' on a base object of type 'RefCounted(invalid_property_assignment.gd::MyObj)'.

--- a/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.out
@@ -1,3 +1,3 @@
 GDTEST_RUNTIME_ERROR
 ~~ WARNING at line 4: (UNSAFE_METHOD_ACCESS) The method "has_method()" is not present on the inferred type "Variant" (but may be present on a subtype).
->> SCRIPT ERROR at runtime/errors/non_static_method_call_on_native_class.gd:4 on example(): Invalid call. Nonexistent function 'has_method' in base 'Node2D'.
+>> SCRIPT ERROR at runtime/errors/non_static_method_call_on_native_class.gd:4 on example(): Invalid call. Nonexistent function 'has_method' in base 'GDScriptNativeClass[Node2D]'.

--- a/modules/gdscript/tests/scripts/runtime/errors/outer_class_constants.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/outer_class_constants.out
@@ -1,7 +1,7 @@
 GDTEST_RUNTIME_ERROR
 ~~ WARNING at line 8: (UNSAFE_PROPERTY_ACCESS) The property "OUTER_CONST" is not present on the inferred type "Inner" (but may be present on a subtype).
 ~~ WARNING at line 17: (UNSAFE_PROPERTY_ACCESS) The property "OUTER_CONST" is not present on the inferred type "Inner" (but may be present on a subtype).
->> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:8 on subtest_type_hard(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'GDScript'.
->> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:13 on subtest_type_weak(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'GDScript'.
->> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:17 on subtest_instance_hard(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'RefCounted (Inner)'.
->> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:22 on subtest_instance_weak(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'RefCounted (Inner)'.
+>> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:8 on subtest_type_hard(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'GDScript[outer_class_constants.gd::Outer::Inner]'.
+>> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:13 on subtest_type_weak(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'GDScript[outer_class_constants.gd::Outer::Inner]'.
+>> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:17 on subtest_instance_hard(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'RefCounted(outer_class_constants.gd::Outer::Inner)'.
+>> SCRIPT ERROR at runtime/errors/outer_class_constants.gd:22 on subtest_instance_weak(): Invalid access to property or key 'OUTER_CONST' on a base object of type 'RefCounted(outer_class_constants.gd::Outer::Inner)'.

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array.out
@@ -6,5 +6,5 @@ GDTEST_RUNTIME_ERROR
 >>   Attempted to set an object into a TypedArray of incompatible type 'GDScript'.
 >> ERROR: Condition "!_p->typed.validate(value, "set")" is true.
 end subtest_assign_wrong_to_typed
->> SCRIPT ERROR at runtime/errors/typed_array.gd:24 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_array.gd)'. The array of argument 1 (Array) does not have the same element type as the expected typed array argument.
->> SCRIPT ERROR at runtime/errors/typed_array.gd:29 on subtest_pass_basic_to_differently_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_array.gd)'. The array of argument 1 (Array[float]) does not have the same element type as the expected typed array argument.
+>> SCRIPT ERROR at runtime/errors/typed_array.gd:24 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted(typed_array.gd)'. The array of argument 1 (Array) does not have the same element type as the expected typed array argument.
+>> SCRIPT ERROR at runtime/errors/typed_array.gd:29 on subtest_pass_basic_to_differently_typed(): Invalid type in function 'expect_typed' in base 'RefCounted(typed_array.gd)'. The array of argument 1 (Array[float]) does not have the same element type as the expected typed array argument.

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary.out
@@ -14,5 +14,5 @@ GDTEST_RUNTIME_ERROR
 >>   Attempted to set an object into a TypedDictionary.Key of incompatible type 'GDScript'.
 >> ERROR: Condition "!_p->typed_key.validate(key, "set")" is true. Returning: false
 end subtest_assign_wrong_to_typed
->> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:40 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_dictionary.gd)'. The dictionary of argument 1 (Dictionary) does not have the same element type as the expected typed dictionary argument.
->> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:45 on subtest_pass_basic_to_differently_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_dictionary.gd)'. The dictionary of argument 1 (Dictionary[float, float]) does not have the same element type as the expected typed dictionary argument.
+>> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:40 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted(typed_dictionary.gd)'. The dictionary of argument 1 (Dictionary) does not have the same element type as the expected typed dictionary argument.
+>> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:45 on subtest_pass_basic_to_differently_typed(): Invalid type in function 'expect_typed' in base 'RefCounted(typed_dictionary.gd)'. The dictionary of argument 1 (Dictionary[float, float]) does not have the same element type as the expected typed dictionary argument.


### PR DESCRIPTION
The type info of debug prints in Godot are varied in quality..
Sometimes you'll see `'Character2D(player.gd)'` in an error message, sometimes it's just `'Object'` :/
#### It doesn't feel good to get the error message `Unable to convert key from "Object" to "Object".`<br>And it doesn't have to be like that!!

This PR adds a small number of methods dedicated to creating detailed but (hopefully) not verbose type names specifically for debug prints:
- `Variant::debug_get_type_name()` and `Object::debug_get_type_name()`
  - This is the big one. It takes into account whether it's an array or dictionary, what the contained type is, if its an object with a script attached, a script as a value, or even a GDScriptNativeType as a value.
- `Script::debug_get_script_name()`
  - Same idea but for a script, uses [square brackets] to let you know that a metatype value is being communicated.
  - Taken from the static method on `GDScript` and made into a virtual method for everyones benefit. :)
- `Array::debug_get_value_type_name()`
  - Gets a descriptive name for the contained type.
- `Dictionary::debug_get_key_type_name()`, and `Dictionary::debug_get_value_type_name()`
  - Same but for dictionaries.
- `ContainerTypeValidate::debug_get_type_name()`
  - This is what the previous 2 use internally.
- `VariantUtilityFunctions::debug_get_type_string(var)`
  - A way to call the method that's usable in GDScript.

I've also gone through many calls to `Variant::get_type_name()` in the `core/variant`, `core/object`, and `modules/gdscript` directories and replaced them with calls to `Variant::debug_get_type_name()` when appropriate. There are many more places to add this extra type information, but I've limited it to a small but important area for this forst PR. 

#### The debug type names looks like:
- `Button(CustomButton.gd)`
  - Instance of `Button` with script — script path is just the file name. Not completely unique, but short and almost always good enough
- `PlayerController`
  - Instance of script with a global name.
- `GDScript[GameData.gd::Settings]`
  - Metatype of inner class. Note the square brackets.
- `GDScript[GameData::Settings]`
  - If the last one had a global class name
- `Array[GDScript[GameData.gd::Settings]]`
  - This one is somewhat confusing. If something other than square brackets were used to denote metatype values, it would fix this.

please let me know what you think <3