### PR TITLE
Additional Compiler arguments for dotnet

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -12,6 +12,7 @@ namespace GodotTools.Build
     public static class BuildManager
     {
         private static BuildInfo? _buildInProgress;
+        private static bool _firstBuild = true;
 
         public const string MsBuildIssuesFileName = "msbuild_issues.csv";
         private const string MsBuildLogFileName = "msbuild_log.txt";
@@ -232,7 +233,7 @@ namespace GodotTools.Build
             {
                 ShowBuildErrorDialog("Failed to build project");
             }
-
+            _firstBuild = false;
             return success;
         }
 
@@ -281,7 +282,7 @@ namespace GodotTools.Build
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
-                restore: true, rebuild, onlyClean);
+                restore: _firstBuild, rebuild, onlyClean);
 
             // If a platform was not specified, try determining the current one. If that fails, let MSBuild auto-detect it.
             if (platform != null || Utils.OS.PlatformNameMap.TryGetValue(OS.GetName(), out platform))


### PR DESCRIPTION
For me, on linux, C# builds used to take 2.5 seconds if no change was made. For fast iterations, that's simply unacceptable.
So I investigated and found out that the C# solution is restored every time any godot project builds gets ran.

You can mitigate that somewhat by editing the .csproj file, but it is not possible to completely circumvent all dependency resolution except by passing `--no-restore` to `dotnet build`. To pass that parameter to dotnet from the godot building process, its mono module already has a configuration parameter `Restore` in the `BuildInfo` class, which is supposed to be triggered on rebuilds. 

Since we don't do rebuilds anymore (for reasons I don't understand), it's never used.

So, I made a change that's debatable: 
I added a static flag inside `modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs`: 
`private static bool _firstBuild = true;`, that gets set to false inside `BuildProjectBlocking` the first time a build was successful.
That variable is then used `CreateBuildInfo` to set the `restore` property of the BuildInfo for the build. If we build in the editor for the first time, we restore the solution (update the nuget dependencies). Otherwise, we don't. 
This results in my case (Linux-arch) in a reduction of succedent build times if no change occurred from 2.5 seconds to 0.6 seconds.

The disadvantages to this pull request:
- if external dependencies change, the editor needs to be restarted.

It should not affect exporting since exports don't go through CreateBuildInfo and BuildProjectBlocking but rather the Publish equivalents. In my editor tests, everything works fine.

I'm not an expert in Godot's Mono module, so I'd appreciate feedback from people with more knowledge in this area.