### PR TITLE
GDExtension: Mark virtual function as `is_required` in `extension_api.json`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1017,6 +1017,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						d2["name"] = String(method_name);
 						d2["is_const"] = (F.flags & METHOD_FLAG_CONST) ? true : false;
 						d2["is_static"] = (F.flags & METHOD_FLAG_STATIC) ? true : false;
+						d2["is_required"] = (F.flags & METHOD_FLAG_VIRTUAL_REQUIRED) ? true : false;
 						d2["is_vararg"] = false;
 						d2["is_virtual"] = true;
 						// virtual functions have no hash since no MethodBind is involved

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -55,10 +55,10 @@ def generate_mod_version(argcount, const=False, returns=False):
 
 proto_ex = """
 #define EXBIND$VER($RETTYPE m_name$ARG) \\
-GDVIRTUAL$VER($RETTYPE_##m_name$ARG)\\
+GDVIRTUAL$VER_REQUIRED($RETTYPE_##m_name$ARG)\\
 virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
     $RETPRE\\
-    GDVIRTUAL_REQUIRED_CALL(_##m_name$CALLARGS$RETREF);\\
+    GDVIRTUAL_CALL(_##m_name$CALLARGS$RETREF);\\
     $RETPOST\\
 }
 """

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -215,6 +215,7 @@ enum MethodFlags {
 	METHOD_FLAG_VARARG = 16,
 	METHOD_FLAG_STATIC = 32,
 	METHOD_FLAG_OBJECT_CORE = 64,
+	METHOD_FLAG_VIRTUAL_REQUIRED = 128,
 	METHOD_FLAGS_DEFAULT = METHOD_FLAG_NORMAL,
 };
 
@@ -368,11 +369,8 @@ struct ObjectGDExtension {
 #endif
 };
 
-#define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call<false>(__VA_ARGS__)
-#define GDVIRTUAL_CALL_PTR(m_obj, m_name, ...) m_obj->_gdvirtual_##m_name##_call<false>(__VA_ARGS__)
-
-#define GDVIRTUAL_REQUIRED_CALL(m_name, ...) _gdvirtual_##m_name##_call<true>(__VA_ARGS__)
-#define GDVIRTUAL_REQUIRED_CALL_PTR(m_obj, m_name, ...) m_obj->_gdvirtual_##m_name##_call<true>(__VA_ARGS__)
+#define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)
+#define GDVIRTUAL_CALL_PTR(m_obj, m_name, ...) m_obj->_gdvirtual_##m_name##_call(__VA_ARGS__)
 
 #ifdef DEBUG_METHODS_ENABLED
 #define GDVIRTUAL_BIND(m_name, ...) ::ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info(), true, sarray(__VA_ARGS__));

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -57,16 +57,16 @@ public:
 	EXBIND1RC(bool, inherits_script, const Ref<Script> &)
 	EXBIND0RC(StringName, get_instance_base_type)
 
-	GDVIRTUAL1RC(GDExtensionPtr<void>, _instance_create, Object *)
+	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<void>, _instance_create, Object *)
 	virtual ScriptInstance *instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
-		GDVIRTUAL_REQUIRED_CALL(_instance_create, p_this, ret);
+		GDVIRTUAL_CALL(_instance_create, p_this, ret);
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
-	GDVIRTUAL1RC(GDExtensionPtr<void>, _placeholder_instance_create, Object *)
+	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<void>, _placeholder_instance_create, Object *)
 	PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
-		GDVIRTUAL_REQUIRED_CALL(_placeholder_instance_create, p_this, ret);
+		GDVIRTUAL_CALL(_placeholder_instance_create, p_this, ret);
 		return reinterpret_cast<PlaceHolderScriptInstance *>(ret.operator void *());
 	}
 
@@ -76,12 +76,12 @@ public:
 	EXBIND1(set_source_code, const String &)
 	EXBIND1R(Error, reload, bool)
 
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_documentation)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_documentation)
 	GDVIRTUAL0RC(String, _get_class_icon_path)
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const override {
 		TypedArray<Dictionary> doc;
-		GDVIRTUAL_REQUIRED_CALL(_get_documentation, doc);
+		GDVIRTUAL_CALL(_get_documentation, doc);
 
 		Vector<DocData::ClassDoc> class_doc;
 		for (int i = 0; i < doc.size(); i++) {
@@ -114,10 +114,10 @@ public:
 		return Script::get_script_method_argument_count(p_method, r_is_valid);
 	}
 
-	GDVIRTUAL1RC(Dictionary, _get_method_info, const StringName &)
+	GDVIRTUAL1RC_REQUIRED(Dictionary, _get_method_info, const StringName &)
 	virtual MethodInfo get_method_info(const StringName &p_method) const override {
 		Dictionary mi;
-		GDVIRTUAL_REQUIRED_CALL(_get_method_info, p_method, mi);
+		GDVIRTUAL_CALL(_get_method_info, p_method, mi);
 		return MethodInfo::from_dict(mi);
 	}
 
@@ -133,47 +133,47 @@ public:
 	EXBIND0RC(ScriptLanguage *, get_language)
 	EXBIND1RC(bool, has_script_signal, const StringName &)
 
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_script_signal_list)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list)
 
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_REQUIRED_CALL(_get_script_signal_list, sl);
+		GDVIRTUAL_CALL(_get_script_signal_list, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_signals->push_back(MethodInfo::from_dict(sl[i]));
 		}
 	}
 
-	GDVIRTUAL1RC(bool, _has_property_default_value, const StringName &)
-	GDVIRTUAL1RC(Variant, _get_property_default_value, const StringName &)
+	GDVIRTUAL1RC_REQUIRED(bool, _has_property_default_value, const StringName &)
+	GDVIRTUAL1RC_REQUIRED(Variant, _get_property_default_value, const StringName &)
 
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const override {
 		bool has_dv = false;
-		if (!GDVIRTUAL_REQUIRED_CALL(_has_property_default_value, p_property, has_dv) || !has_dv) {
+		if (!GDVIRTUAL_CALL(_has_property_default_value, p_property, has_dv) || !has_dv) {
 			return false;
 		}
 		Variant ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_property_default_value, p_property, ret);
+		GDVIRTUAL_CALL(_get_property_default_value, p_property, ret);
 		r_value = ret;
 		return true;
 	}
 
 	EXBIND0(update_exports)
 
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_script_method_list)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list)
 
 	virtual void get_script_method_list(List<MethodInfo> *r_methods) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_REQUIRED_CALL(_get_script_method_list, sl);
+		GDVIRTUAL_CALL(_get_script_method_list, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_methods->push_back(MethodInfo::from_dict(sl[i]));
 		}
 	}
 
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_script_property_list)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list)
 
 	virtual void get_script_property_list(List<PropertyInfo> *r_propertys) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_REQUIRED_CALL(_get_script_property_list, sl);
+		GDVIRTUAL_CALL(_get_script_property_list, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_propertys->push_back(PropertyInfo::from_dict(sl[i]));
 		}
@@ -181,21 +181,21 @@ public:
 
 	EXBIND1RC(int, get_member_line, const StringName &)
 
-	GDVIRTUAL0RC(Dictionary, _get_constants)
+	GDVIRTUAL0RC_REQUIRED(Dictionary, _get_constants)
 
 	virtual void get_constants(HashMap<StringName, Variant> *p_constants) override {
 		Dictionary constants;
-		GDVIRTUAL_REQUIRED_CALL(_get_constants, constants);
+		GDVIRTUAL_CALL(_get_constants, constants);
 		List<Variant> keys;
 		constants.get_key_list(&keys);
 		for (const Variant &K : keys) {
 			p_constants->insert(K, constants[K]);
 		}
 	}
-	GDVIRTUAL0RC(TypedArray<StringName>, _get_members)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<StringName>, _get_members)
 	virtual void get_members(HashSet<StringName> *p_members) override {
 		TypedArray<StringName> members;
-		GDVIRTUAL_REQUIRED_CALL(_get_members, members);
+		GDVIRTUAL_CALL(_get_members, members);
 		for (int i = 0; i < members.size(); i++) {
 			p_members->insert(members[i]);
 		}
@@ -203,11 +203,11 @@ public:
 
 	EXBIND0RC(bool, is_placeholder_fallback_enabled)
 
-	GDVIRTUAL0RC(Variant, _get_rpc_config)
+	GDVIRTUAL0RC_REQUIRED(Variant, _get_rpc_config)
 
 	virtual const Variant get_rpc_config() const override {
 		Variant ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_rpc_config, ret);
+		GDVIRTUAL_CALL(_get_rpc_config, ret);
 		return ret;
 	}
 
@@ -233,22 +233,22 @@ public:
 
 	/* EDITOR FUNCTIONS */
 
-	GDVIRTUAL0RC(Vector<String>, _get_reserved_words)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_reserved_words)
 
 	virtual void get_reserved_words(List<String> *p_words) const override {
 		Vector<String> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_reserved_words, ret);
+		GDVIRTUAL_CALL(_get_reserved_words, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_words->push_back(ret[i]);
 		}
 	}
 	EXBIND1RC(bool, is_control_flow_keyword, const String &)
 
-	GDVIRTUAL0RC(Vector<String>, _get_comment_delimiters)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_comment_delimiters)
 
 	virtual void get_comment_delimiters(List<String> *p_words) const override {
 		Vector<String> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_comment_delimiters, ret);
+		GDVIRTUAL_CALL(_get_comment_delimiters, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_words->push_back(ret[i]);
 		}
@@ -264,11 +264,11 @@ public:
 		}
 	}
 
-	GDVIRTUAL0RC(Vector<String>, _get_string_delimiters)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_string_delimiters)
 
 	virtual void get_string_delimiters(List<String> *p_words) const override {
 		Vector<String> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_string_delimiters, ret);
+		GDVIRTUAL_CALL(_get_string_delimiters, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_words->push_back(ret[i]);
 		}
@@ -276,11 +276,11 @@ public:
 
 	EXBIND3RC(Ref<Script>, make_template, const String &, const String &, const String &)
 
-	GDVIRTUAL1RC(TypedArray<Dictionary>, _get_built_in_templates, StringName)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_built_in_templates, StringName)
 
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) override {
 		TypedArray<Dictionary> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_built_in_templates, p_object, ret);
+		GDVIRTUAL_CALL(_get_built_in_templates, p_object, ret);
 		Vector<ScriptTemplate> stret;
 		for (int i = 0; i < ret.size(); i++) {
 			Dictionary d = ret[i];
@@ -304,10 +304,10 @@ public:
 
 	EXBIND0R(bool, is_using_templates)
 
-	GDVIRTUAL6RC(Dictionary, _validate, const String &, const String &, bool, bool, bool, bool)
+	GDVIRTUAL6RC_REQUIRED(Dictionary, _validate, const String &, const String &, bool, bool, bool, bool)
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_validate, p_script, p_path, r_functions != nullptr, r_errors != nullptr, r_warnings != nullptr, r_safe_lines != nullptr, ret);
+		GDVIRTUAL_CALL(_validate, p_script, p_path, r_functions != nullptr, r_errors != nullptr, r_warnings != nullptr, r_safe_lines != nullptr, ret);
 		if (!ret.has("valid")) {
 			return false;
 		}
@@ -371,10 +371,10 @@ public:
 	}
 
 	EXBIND1RC(String, validate_path, const String &)
-	GDVIRTUAL0RC(Object *, _create_script)
+	GDVIRTUAL0RC_REQUIRED(Object *, _create_script)
 	Script *create_script() const override {
 		Object *ret = nullptr;
-		GDVIRTUAL_REQUIRED_CALL(_create_script, ret);
+		GDVIRTUAL_CALL(_create_script, ret);
 		return Object::cast_to<Script>(ret);
 	}
 #ifndef DISABLE_DEPRECATED
@@ -400,11 +400,11 @@ public:
 		return ScriptNameCasing::SCRIPT_NAME_CASING_SNAKE_CASE;
 	}
 
-	GDVIRTUAL3RC(Dictionary, _complete_code, const String &, const String &, Object *)
+	GDVIRTUAL3RC_REQUIRED(Dictionary, _complete_code, const String &, const String &, Object *)
 
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_complete_code, p_code, p_path, p_owner, ret);
+		GDVIRTUAL_CALL(_complete_code, p_code, p_path, p_owner, ret);
 		if (!ret.has("result")) {
 			return ERR_UNAVAILABLE;
 		}
@@ -449,11 +449,11 @@ public:
 		return result;
 	}
 
-	GDVIRTUAL4RC(Dictionary, _lookup_code, const String &, const String &, const String &, Object *)
+	GDVIRTUAL4RC_REQUIRED(Dictionary, _lookup_code, const String &, const String &, const String &, Object *)
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_lookup_code, p_code, p_symbol, p_path, p_owner, ret);
+		GDVIRTUAL_CALL(_lookup_code, p_code, p_symbol, p_path, p_owner, ret);
 		if (!ret.has("result")) {
 			return ERR_UNAVAILABLE;
 		}
@@ -474,10 +474,10 @@ public:
 		return result;
 	}
 
-	GDVIRTUAL3RC(String, _auto_indent_code, const String &, int, int)
+	GDVIRTUAL3RC_REQUIRED(String, _auto_indent_code, const String &, int, int)
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {
 		String ret;
-		GDVIRTUAL_REQUIRED_CALL(_auto_indent_code, p_code, p_from_line, p_to_line, ret);
+		GDVIRTUAL_CALL(_auto_indent_code, p_code, p_from_line, p_to_line, ret);
 		p_code = ret;
 	}
 	EXBIND2(add_global_constant, const StringName &, const Variant &)
@@ -496,10 +496,10 @@ public:
 	EXBIND1RC(String, debug_get_stack_level_function, int)
 	EXBIND1RC(String, debug_get_stack_level_source, int)
 
-	GDVIRTUAL3R(Dictionary, _debug_get_stack_level_locals, int, int, int)
+	GDVIRTUAL3R_REQUIRED(Dictionary, _debug_get_stack_level_locals, int, int, int)
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_debug_get_stack_level_locals, p_level, p_max_subitems, p_max_depth, ret);
+		GDVIRTUAL_CALL(_debug_get_stack_level_locals, p_level, p_max_subitems, p_max_depth, ret);
 		if (ret.size() == 0) {
 			return;
 		}
@@ -516,10 +516,10 @@ public:
 			}
 		}
 	}
-	GDVIRTUAL3R(Dictionary, _debug_get_stack_level_members, int, int, int)
+	GDVIRTUAL3R_REQUIRED(Dictionary, _debug_get_stack_level_members, int, int, int)
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_debug_get_stack_level_members, p_level, p_max_subitems, p_max_depth, ret);
+		GDVIRTUAL_CALL(_debug_get_stack_level_members, p_level, p_max_subitems, p_max_depth, ret);
 		if (ret.size() == 0) {
 			return;
 		}
@@ -536,17 +536,17 @@ public:
 			}
 		}
 	}
-	GDVIRTUAL1R(GDExtensionPtr<void>, _debug_get_stack_level_instance, int)
+	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<void>, _debug_get_stack_level_instance, int)
 
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) override {
 		GDExtensionPtr<void> ret = nullptr;
-		GDVIRTUAL_REQUIRED_CALL(_debug_get_stack_level_instance, p_level, ret);
+		GDVIRTUAL_CALL(_debug_get_stack_level_instance, p_level, ret);
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
-	GDVIRTUAL2R(Dictionary, _debug_get_globals, int, int)
+	GDVIRTUAL2R_REQUIRED(Dictionary, _debug_get_globals, int, int)
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_debug_get_globals, p_max_subitems, p_max_depth, ret);
+		GDVIRTUAL_CALL(_debug_get_globals, p_max_subitems, p_max_depth, ret);
 		if (ret.size() == 0) {
 			return;
 		}
@@ -566,10 +566,10 @@ public:
 
 	EXBIND4R(String, debug_parse_stack_level_expression, int, const String &, int, int)
 
-	GDVIRTUAL0R(TypedArray<Dictionary>, _debug_get_current_stack_info)
+	GDVIRTUAL0R_REQUIRED(TypedArray<Dictionary>, _debug_get_current_stack_info)
 	virtual Vector<StackInfo> debug_get_current_stack_info() override {
 		TypedArray<Dictionary> ret;
-		GDVIRTUAL_REQUIRED_CALL(_debug_get_current_stack_info, ret);
+		GDVIRTUAL_CALL(_debug_get_current_stack_info, ret);
 		Vector<StackInfo> sret;
 		for (const Variant &var : ret) {
 			StackInfo si;
@@ -590,29 +590,29 @@ public:
 	EXBIND2(reload_tool_script, const Ref<Script> &, bool)
 	/* LOADER FUNCTIONS */
 
-	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions)
+	GDVIRTUAL0RC_REQUIRED(PackedStringArray, _get_recognized_extensions)
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override {
 		PackedStringArray ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_recognized_extensions, ret);
+		GDVIRTUAL_CALL(_get_recognized_extensions, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_extensions->push_back(ret[i]);
 		}
 	}
 
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_public_functions)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_public_functions)
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const override {
 		TypedArray<Dictionary> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_public_functions, ret);
+		GDVIRTUAL_CALL(_get_public_functions, ret);
 		for (const Variant &var : ret) {
 			MethodInfo mi = MethodInfo::from_dict(var);
 			p_functions->push_back(mi);
 		}
 	}
-	GDVIRTUAL0RC(Dictionary, _get_public_constants)
+	GDVIRTUAL0RC_REQUIRED(Dictionary, _get_public_constants)
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_public_constants, ret);
+		GDVIRTUAL_CALL(_get_public_constants, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			Dictionary d = ret[i];
 			ERR_CONTINUE(!d.has("name"));
@@ -620,10 +620,10 @@ public:
 			p_constants->push_back(Pair<String, Variant>(d["name"], d["value"]));
 		}
 	}
-	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_public_annotations)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_public_annotations)
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const override {
 		TypedArray<Dictionary> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_public_annotations, ret);
+		GDVIRTUAL_CALL(_get_public_annotations, ret);
 		for (const Variant &var : ret) {
 			MethodInfo mi = MethodInfo::from_dict(var);
 			p_annotations->push_back(mi);
@@ -634,19 +634,19 @@ public:
 	EXBIND0(profiling_stop)
 	EXBIND1(profiling_set_save_native_calls, bool)
 
-	GDVIRTUAL2R(int, _profiling_get_accumulated_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
+	GDVIRTUAL2R_REQUIRED(int, _profiling_get_accumulated_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
 
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override {
 		int ret = 0;
-		GDVIRTUAL_REQUIRED_CALL(_profiling_get_accumulated_data, p_info_arr, p_info_max, ret);
+		GDVIRTUAL_CALL(_profiling_get_accumulated_data, p_info_arr, p_info_max, ret);
 		return ret;
 	}
 
-	GDVIRTUAL2R(int, _profiling_get_frame_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
+	GDVIRTUAL2R_REQUIRED(int, _profiling_get_frame_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
 
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override {
 		int ret = 0;
-		GDVIRTUAL_REQUIRED_CALL(_profiling_get_frame_data, p_info_arr, p_info_max, ret);
+		GDVIRTUAL_CALL(_profiling_get_frame_data, p_info_arr, p_info_max, ret);
 		return ret;
 	}
 
@@ -654,11 +654,11 @@ public:
 
 	EXBIND1RC(bool, handles_global_class_type, const String &)
 
-	GDVIRTUAL1RC(Dictionary, _get_global_class_name, const String &)
+	GDVIRTUAL1RC_REQUIRED(Dictionary, _get_global_class_name, const String &)
 
 	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const override {
 		Dictionary ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_global_class_name, p_path, ret);
+		GDVIRTUAL_CALL(_get_global_class_name, p_path, ret);
 		if (!ret.has("name")) {
 			return String();
 		}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -112,9 +112,9 @@ class EditorFileSystemImportFormatSupportQuery : public RefCounted {
 	GDCLASS(EditorFileSystemImportFormatSupportQuery, RefCounted);
 
 protected:
-	GDVIRTUAL0RC(bool, _is_active)
-	GDVIRTUAL0RC(Vector<String>, _get_file_extensions)
-	GDVIRTUAL0RC(bool, _query)
+	GDVIRTUAL0RC_REQUIRED(bool, _is_active)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_file_extensions)
+	GDVIRTUAL0RC_REQUIRED(bool, _query)
 	static void _bind_methods() {
 		GDVIRTUAL_BIND(_is_active);
 		GDVIRTUAL_BIND(_get_file_extensions);
@@ -124,17 +124,17 @@ protected:
 public:
 	virtual bool is_active() const {
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_is_active, ret);
+		GDVIRTUAL_CALL(_is_active, ret);
 		return ret;
 	}
 	virtual Vector<String> get_file_extensions() const {
 		Vector<String> ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_file_extensions, ret);
+		GDVIRTUAL_CALL(_get_file_extensions, ret);
 		return ret;
 	}
 	virtual bool query() {
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_query, ret);
+		GDVIRTUAL_CALL(_query, ret);
 		return ret;
 	}
 };

--- a/editor/editor_script.cpp
+++ b/editor/editor_script.cpp
@@ -78,7 +78,7 @@ EditorInterface *EditorScript::get_editor_interface() const {
 }
 
 void EditorScript::run() {
-	GDVIRTUAL_REQUIRED_CALL(_run);
+	GDVIRTUAL_CALL(_run);
 }
 
 void EditorScript::_bind_methods() {

--- a/editor/editor_script.h
+++ b/editor/editor_script.h
@@ -44,7 +44,7 @@ class EditorScript : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0(_run)
+	GDVIRTUAL0_REQUIRED(_run)
 
 public:
 	void add_root_node(Node *p_node);

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -41,17 +41,17 @@ void EditorVCSInterface::popup_error(const String &p_msg) {
 
 bool EditorVCSInterface::initialize(const String &p_project_path) {
 	bool result = false;
-	GDVIRTUAL_REQUIRED_CALL(_initialize, p_project_path, result);
+	GDVIRTUAL_CALL(_initialize, p_project_path, result);
 	return result;
 }
 
 void EditorVCSInterface::set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key, const String &p_ssh_private_key, const String &p_ssh_passphrase) {
-	GDVIRTUAL_REQUIRED_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase);
+	GDVIRTUAL_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase);
 }
 
 List<String> EditorVCSInterface::get_remotes() {
 	TypedArray<String> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_remotes, result)) {
+	if (!GDVIRTUAL_CALL(_get_remotes, result)) {
 		return {};
 	}
 
@@ -64,7 +64,7 @@ List<String> EditorVCSInterface::get_remotes() {
 
 List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data() {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_modified_files_data, result)) {
+	if (!GDVIRTUAL_CALL(_get_modified_files_data, result)) {
 		return {};
 	}
 
@@ -76,24 +76,24 @@ List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data
 }
 
 void EditorVCSInterface::stage_file(const String &p_file_path) {
-	GDVIRTUAL_REQUIRED_CALL(_stage_file, p_file_path);
+	GDVIRTUAL_CALL(_stage_file, p_file_path);
 }
 
 void EditorVCSInterface::unstage_file(const String &p_file_path) {
-	GDVIRTUAL_REQUIRED_CALL(_unstage_file, p_file_path);
+	GDVIRTUAL_CALL(_unstage_file, p_file_path);
 }
 
 void EditorVCSInterface::discard_file(const String &p_file_path) {
-	GDVIRTUAL_REQUIRED_CALL(_discard_file, p_file_path);
+	GDVIRTUAL_CALL(_discard_file, p_file_path);
 }
 
 void EditorVCSInterface::commit(const String &p_msg) {
-	GDVIRTUAL_REQUIRED_CALL(_commit, p_msg);
+	GDVIRTUAL_CALL(_commit, p_msg);
 }
 
 List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(const String &p_identifier, TreeArea p_area) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_diff, p_identifier, int(p_area), result)) {
+	if (!GDVIRTUAL_CALL(_get_diff, p_identifier, int(p_area), result)) {
 		return {};
 	}
 
@@ -106,7 +106,7 @@ List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(const String &p_
 
 List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_max_commits) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_previous_commits, p_max_commits, result)) {
+	if (!GDVIRTUAL_CALL(_get_previous_commits, p_max_commits, result)) {
 		return {};
 	}
 
@@ -119,7 +119,7 @@ List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_
 
 List<String> EditorVCSInterface::get_branch_list() {
 	TypedArray<String> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_branch_list, result)) {
+	if (!GDVIRTUAL_CALL(_get_branch_list, result)) {
 		return {};
 	}
 
@@ -131,48 +131,48 @@ List<String> EditorVCSInterface::get_branch_list() {
 }
 
 void EditorVCSInterface::create_branch(const String &p_branch_name) {
-	GDVIRTUAL_REQUIRED_CALL(_create_branch, p_branch_name);
+	GDVIRTUAL_CALL(_create_branch, p_branch_name);
 }
 
 void EditorVCSInterface::create_remote(const String &p_remote_name, const String &p_remote_url) {
-	GDVIRTUAL_REQUIRED_CALL(_create_remote, p_remote_name, p_remote_url);
+	GDVIRTUAL_CALL(_create_remote, p_remote_name, p_remote_url);
 }
 
 void EditorVCSInterface::remove_branch(const String &p_branch_name) {
-	GDVIRTUAL_REQUIRED_CALL(_remove_branch, p_branch_name);
+	GDVIRTUAL_CALL(_remove_branch, p_branch_name);
 }
 
 void EditorVCSInterface::remove_remote(const String &p_remote_name) {
-	GDVIRTUAL_REQUIRED_CALL(_remove_remote, p_remote_name);
+	GDVIRTUAL_CALL(_remove_remote, p_remote_name);
 }
 
 String EditorVCSInterface::get_current_branch_name() {
 	String result;
-	GDVIRTUAL_REQUIRED_CALL(_get_current_branch_name, result);
+	GDVIRTUAL_CALL(_get_current_branch_name, result);
 	return result;
 }
 
 bool EditorVCSInterface::checkout_branch(const String &p_branch_name) {
 	bool result = false;
-	GDVIRTUAL_REQUIRED_CALL(_checkout_branch, p_branch_name, result);
+	GDVIRTUAL_CALL(_checkout_branch, p_branch_name, result);
 	return result;
 }
 
 void EditorVCSInterface::pull(const String &p_remote) {
-	GDVIRTUAL_REQUIRED_CALL(_pull, p_remote);
+	GDVIRTUAL_CALL(_pull, p_remote);
 }
 
 void EditorVCSInterface::push(const String &p_remote, bool p_force) {
-	GDVIRTUAL_REQUIRED_CALL(_push, p_remote, p_force);
+	GDVIRTUAL_CALL(_push, p_remote, p_force);
 }
 
 void EditorVCSInterface::fetch(const String &p_remote) {
-	GDVIRTUAL_REQUIRED_CALL(_fetch, p_remote);
+	GDVIRTUAL_CALL(_fetch, p_remote);
 }
 
 List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(const String &p_file_path, const String &p_text) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_REQUIRED_CALL(_get_line_diff, p_file_path, p_text, result)) {
+	if (!GDVIRTUAL_CALL(_get_line_diff, p_file_path, p_text, result)) {
 		return {};
 	}
 
@@ -185,13 +185,13 @@ List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(const Strin
 
 bool EditorVCSInterface::shut_down() {
 	bool result = false;
-	GDVIRTUAL_REQUIRED_CALL(_shut_down, result);
+	GDVIRTUAL_CALL(_shut_down, result);
 	return result;
 }
 
 String EditorVCSInterface::get_vcs_name() {
 	String result;
-	GDVIRTUAL_REQUIRED_CALL(_get_vcs_name, result);
+	GDVIRTUAL_CALL(_get_vcs_name, result);
 	return result;
 }
 

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -106,29 +106,29 @@ protected:
 	StatusFile _convert_status_file(const Dictionary &p_status_file);
 
 	// Proxy endpoints for extensions to implement
-	GDVIRTUAL1R(bool, _initialize, String);
-	GDVIRTUAL5(_set_credentials, String, String, String, String, String);
-	GDVIRTUAL0R(TypedArray<Dictionary>, _get_modified_files_data);
-	GDVIRTUAL1(_stage_file, String);
-	GDVIRTUAL1(_unstage_file, String);
-	GDVIRTUAL1(_discard_file, String);
-	GDVIRTUAL1(_commit, String);
-	GDVIRTUAL2R(TypedArray<Dictionary>, _get_diff, String, int);
-	GDVIRTUAL0R(bool, _shut_down);
-	GDVIRTUAL0R(String, _get_vcs_name);
-	GDVIRTUAL1R(TypedArray<Dictionary>, _get_previous_commits, int);
-	GDVIRTUAL0R(TypedArray<String>, _get_branch_list);
-	GDVIRTUAL0R(TypedArray<String>, _get_remotes);
-	GDVIRTUAL1(_create_branch, String);
-	GDVIRTUAL1(_remove_branch, String);
-	GDVIRTUAL2(_create_remote, String, String);
-	GDVIRTUAL1(_remove_remote, String);
-	GDVIRTUAL0R(String, _get_current_branch_name);
-	GDVIRTUAL1R(bool, _checkout_branch, String);
-	GDVIRTUAL1(_pull, String);
-	GDVIRTUAL2(_push, String, bool);
-	GDVIRTUAL1(_fetch, String);
-	GDVIRTUAL2R(TypedArray<Dictionary>, _get_line_diff, String, String);
+	GDVIRTUAL1R_REQUIRED(bool, _initialize, String);
+	GDVIRTUAL5_REQUIRED(_set_credentials, String, String, String, String, String);
+	GDVIRTUAL0R_REQUIRED(TypedArray<Dictionary>, _get_modified_files_data);
+	GDVIRTUAL1_REQUIRED(_stage_file, String);
+	GDVIRTUAL1_REQUIRED(_unstage_file, String);
+	GDVIRTUAL1_REQUIRED(_discard_file, String);
+	GDVIRTUAL1_REQUIRED(_commit, String);
+	GDVIRTUAL2R_REQUIRED(TypedArray<Dictionary>, _get_diff, String, int);
+	GDVIRTUAL0R_REQUIRED(bool, _shut_down);
+	GDVIRTUAL0R_REQUIRED(String, _get_vcs_name);
+	GDVIRTUAL1R_REQUIRED(TypedArray<Dictionary>, _get_previous_commits, int);
+	GDVIRTUAL0R_REQUIRED(TypedArray<String>, _get_branch_list);
+	GDVIRTUAL0R_REQUIRED(TypedArray<String>, _get_remotes);
+	GDVIRTUAL1_REQUIRED(_create_branch, String);
+	GDVIRTUAL1_REQUIRED(_remove_branch, String);
+	GDVIRTUAL2_REQUIRED(_create_remote, String, String);
+	GDVIRTUAL1_REQUIRED(_remove_remote, String);
+	GDVIRTUAL0R_REQUIRED(String, _get_current_branch_name);
+	GDVIRTUAL1R_REQUIRED(bool, _checkout_branch, String);
+	GDVIRTUAL1_REQUIRED(_pull, String);
+	GDVIRTUAL2_REQUIRED(_push, String, bool);
+	GDVIRTUAL1_REQUIRED(_fetch, String);
+	GDVIRTUAL2R_REQUIRED(TypedArray<Dictionary>, _get_line_diff, String, String);
 
 public:
 	static EditorVCSInterface *get_singleton();

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -79,7 +79,7 @@ void EditorExportPlatformExtension::_bind_methods() {
 
 void EditorExportPlatformExtension::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	Vector<String> ret;
-	if (GDVIRTUAL_REQUIRED_CALL(_get_preset_features, p_preset, ret) && r_features) {
+	if (GDVIRTUAL_CALL(_get_preset_features, p_preset, ret) && r_features) {
 		for (const String &E : ret) {
 			r_features->push_back(E);
 		}
@@ -142,19 +142,19 @@ String EditorExportPlatformExtension::get_export_option_warning(const EditorExpo
 
 String EditorExportPlatformExtension::get_os_name() const {
 	String ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_os_name, ret);
+	GDVIRTUAL_CALL(_get_os_name, ret);
 	return ret;
 }
 
 String EditorExportPlatformExtension::get_name() const {
 	String ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+	GDVIRTUAL_CALL(_get_name, ret);
 	return ret;
 }
 
 Ref<Texture2D> EditorExportPlatformExtension::get_logo() const {
 	Ref<Texture2D> ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_logo, ret);
+	GDVIRTUAL_CALL(_get_logo, ret);
 	return ret;
 }
 
@@ -236,7 +236,7 @@ bool EditorExportPlatformExtension::has_valid_export_configuration(const Ref<Edi
 	bool ret = false;
 	config_error = r_error;
 	config_missing_templates = r_missing_templates;
-	if (GDVIRTUAL_REQUIRED_CALL(_has_valid_export_configuration, p_preset, p_debug, ret)) {
+	if (GDVIRTUAL_CALL(_has_valid_export_configuration, p_preset, p_debug, ret)) {
 		r_error = config_error;
 		r_missing_templates = config_missing_templates;
 	}
@@ -246,7 +246,7 @@ bool EditorExportPlatformExtension::has_valid_export_configuration(const Ref<Edi
 bool EditorExportPlatformExtension::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
 	bool ret = false;
 	config_error = r_error;
-	if (GDVIRTUAL_REQUIRED_CALL(_has_valid_project_configuration, p_preset, ret)) {
+	if (GDVIRTUAL_CALL(_has_valid_project_configuration, p_preset, ret)) {
 		r_error = config_error;
 	}
 	return ret;
@@ -255,7 +255,7 @@ bool EditorExportPlatformExtension::has_valid_project_configuration(const Ref<Ed
 List<String> EditorExportPlatformExtension::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
 	List<String> ret_list;
 	Vector<String> ret;
-	if (GDVIRTUAL_REQUIRED_CALL(_get_binary_extensions, p_preset, ret)) {
+	if (GDVIRTUAL_CALL(_get_binary_extensions, p_preset, ret)) {
 		for (const String &E : ret) {
 			ret_list.push_back(E);
 		}
@@ -267,7 +267,7 @@ Error EditorExportPlatformExtension::export_project(const Ref<EditorExportPreset
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
 	Error ret = FAILED;
-	GDVIRTUAL_REQUIRED_CALL(_export_project, p_preset, p_debug, p_path, p_flags, ret);
+	GDVIRTUAL_CALL(_export_project, p_preset, p_debug, p_path, p_flags, ret);
 	return ret;
 }
 
@@ -293,7 +293,7 @@ Error EditorExportPlatformExtension::export_zip(const Ref<EditorExportPreset> &p
 
 void EditorExportPlatformExtension::get_platform_features(List<String> *r_features) const {
 	Vector<String> ret;
-	if (GDVIRTUAL_REQUIRED_CALL(_get_platform_features, ret) && r_features) {
+	if (GDVIRTUAL_CALL(_get_platform_features, ret) && r_features) {
 		for (const String &E : ret) {
 			r_features->push_back(E);
 		}

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -45,7 +45,7 @@ protected:
 
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
-	GDVIRTUAL1RC(Vector<String>, _get_preset_features, Ref<EditorExportPreset>);
+	GDVIRTUAL1RC_REQUIRED(Vector<String>, _get_preset_features, Ref<EditorExportPreset>);
 
 	virtual bool is_executable(const String &p_path) const override;
 	GDVIRTUAL1RC(bool, _is_executable, const String &);
@@ -63,13 +63,13 @@ public:
 	GDVIRTUAL2RC(String, _get_export_option_warning, Ref<EditorExportPreset>, const StringName &);
 
 	virtual String get_os_name() const override;
-	GDVIRTUAL0RC(String, _get_os_name);
+	GDVIRTUAL0RC_REQUIRED(String, _get_os_name);
 
 	virtual String get_name() const override;
-	GDVIRTUAL0RC(String, _get_name);
+	GDVIRTUAL0RC_REQUIRED(String, _get_name);
 
 	virtual Ref<Texture2D> get_logo() const override;
-	GDVIRTUAL0RC(Ref<Texture2D>, _get_logo);
+	GDVIRTUAL0RC_REQUIRED(Ref<Texture2D>, _get_logo);
 
 	virtual bool poll_export() override;
 	GDVIRTUAL0R(bool, _poll_export);
@@ -119,16 +119,16 @@ public:
 	GDVIRTUAL2RC(bool, _can_export, Ref<EditorExportPreset>, bool);
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
-	GDVIRTUAL2RC(bool, _has_valid_export_configuration, Ref<EditorExportPreset>, bool);
+	GDVIRTUAL2RC_REQUIRED(bool, _has_valid_export_configuration, Ref<EditorExportPreset>, bool);
 
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
-	GDVIRTUAL1RC(bool, _has_valid_project_configuration, Ref<EditorExportPreset>);
+	GDVIRTUAL1RC_REQUIRED(bool, _has_valid_project_configuration, Ref<EditorExportPreset>);
 
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
-	GDVIRTUAL1RC(Vector<String>, _get_binary_extensions, Ref<EditorExportPreset>);
+	GDVIRTUAL1RC_REQUIRED(Vector<String>, _get_binary_extensions, Ref<EditorExportPreset>);
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
-	GDVIRTUAL4R(Error, _export_project, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
+	GDVIRTUAL4R_REQUIRED(Error, _export_project, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
 
 	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 	GDVIRTUAL4R(Error, _export_pack, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
@@ -137,7 +137,7 @@ public:
 	GDVIRTUAL4R(Error, _export_zip, Ref<EditorExportPreset>, bool, const String &, BitField<EditorExportPlatform::DebugFlags>);
 
 	virtual void get_platform_features(List<String> *r_features) const override;
-	GDVIRTUAL0RC(Vector<String>, _get_platform_features);
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_platform_features);
 
 	virtual String get_debug_protocol() const override;
 	GDVIRTUAL0RC(String, _get_debug_protocol);

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -187,7 +187,7 @@ bool EditorExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatfo
 
 Ref<Resource> EditorExportPlugin::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
 	Ref<Resource> ret;
-	GDVIRTUAL_REQUIRED_CALL(_customize_resource, p_resource, p_path, ret);
+	GDVIRTUAL_CALL(_customize_resource, p_resource, p_path, ret);
 	return ret;
 }
 
@@ -199,13 +199,13 @@ bool EditorExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform>
 
 Node *EditorExportPlugin::_customize_scene(Node *p_root, const String &p_path) {
 	Node *ret = nullptr;
-	GDVIRTUAL_REQUIRED_CALL(_customize_scene, p_root, p_path, ret);
+	GDVIRTUAL_CALL(_customize_scene, p_root, p_path, ret);
 	return ret;
 }
 
 uint64_t EditorExportPlugin::_get_customization_configuration_hash() const {
 	uint64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_customization_configuration_hash, ret);
+	GDVIRTUAL_CALL(_get_customization_configuration_hash, ret);
 	return ret;
 }
 
@@ -219,7 +219,7 @@ void EditorExportPlugin::_end_customize_resources() {
 
 String EditorExportPlugin::get_name() const {
 	String ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+	GDVIRTUAL_CALL(_get_name, ret);
 	return ret;
 }
 

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -119,11 +119,11 @@ protected:
 	GDVIRTUAL0(_export_end)
 
 	GDVIRTUAL2RC(bool, _begin_customize_resources, const Ref<EditorExportPlatform> &, const Vector<String> &)
-	GDVIRTUAL2R(Ref<Resource>, _customize_resource, const Ref<Resource> &, String)
+	GDVIRTUAL2R_REQUIRED(Ref<Resource>, _customize_resource, const Ref<Resource> &, String)
 
 	GDVIRTUAL2RC(bool, _begin_customize_scenes, const Ref<EditorExportPlatform> &, const Vector<String> &)
-	GDVIRTUAL2R(Node *, _customize_scene, Node *, String)
-	GDVIRTUAL0RC(uint64_t, _get_customization_configuration_hash)
+	GDVIRTUAL2R_REQUIRED(Node *, _customize_scene, Node *, String)
+	GDVIRTUAL0RC_REQUIRED(uint64_t, _get_customization_configuration_hash)
 
 	GDVIRTUAL0(_end_customize_scenes)
 	GDVIRTUAL0(_end_customize_resources)
@@ -134,7 +134,7 @@ protected:
 	GDVIRTUAL1RC(bool, _should_update_export_options, const Ref<EditorExportPlatform> &);
 	GDVIRTUAL2RC(String, _get_export_option_warning, const Ref<EditorExportPlatform> &, String);
 
-	GDVIRTUAL0RC(String, _get_name)
+	GDVIRTUAL0RC_REQUIRED(String, _get_name)
 
 	GDVIRTUAL1RC(bool, _supports_platform, const Ref<EditorExportPlatform> &);
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -113,12 +113,12 @@ void Material::inspect_native_shader_code() {
 
 RID Material::get_shader_rid() const {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_shader_rid, ret);
+	GDVIRTUAL_CALL(_get_shader_rid, ret);
 	return ret;
 }
 Shader::Mode Material::get_shader_mode() const {
 	Shader::Mode ret = Shader::MODE_MAX;
-	GDVIRTUAL_REQUIRED_CALL(_get_shader_mode, ret);
+	GDVIRTUAL_CALL(_get_shader_mode, ret);
 	return ret;
 }
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -66,8 +66,8 @@ protected:
 	void _mark_initialized(const Callable &p_add_to_dirty_list, const Callable &p_update_shader);
 	bool _is_initialized() { return init_state == INIT_STATE_READY; }
 
-	GDVIRTUAL0RC(RID, _get_shader_rid)
-	GDVIRTUAL0RC(Shader::Mode, _get_shader_mode)
+	GDVIRTUAL0RC_REQUIRED(RID, _get_shader_rid)
+	GDVIRTUAL0RC_REQUIRED(Shader::Mode, _get_shader_mode)
 	GDVIRTUAL0RC(bool, _can_do_next_pass)
 	GDVIRTUAL0RC(bool, _can_use_render_priority)
 public:

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -205,81 +205,81 @@ Mesh::ConvexDecompositionFunc Mesh::convex_decomposition_function = nullptr;
 
 int Mesh::get_surface_count() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_surface_count, ret);
+	GDVIRTUAL_CALL(_get_surface_count, ret);
 	return ret;
 }
 
 int Mesh::surface_get_array_len(int p_idx) const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_array_len, p_idx, ret);
+	GDVIRTUAL_CALL(_surface_get_array_len, p_idx, ret);
 	return ret;
 }
 
 int Mesh::surface_get_array_index_len(int p_idx) const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_array_index_len, p_idx, ret);
+	GDVIRTUAL_CALL(_surface_get_array_index_len, p_idx, ret);
 	return ret;
 }
 
 Array Mesh::surface_get_arrays(int p_surface) const {
 	Array ret;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_arrays, p_surface, ret);
+	GDVIRTUAL_CALL(_surface_get_arrays, p_surface, ret);
 	return ret;
 }
 
 TypedArray<Array> Mesh::surface_get_blend_shape_arrays(int p_surface) const {
 	TypedArray<Array> ret;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_blend_shape_arrays, p_surface, ret);
+	GDVIRTUAL_CALL(_surface_get_blend_shape_arrays, p_surface, ret);
 	return ret;
 }
 
 Dictionary Mesh::surface_get_lods(int p_surface) const {
 	Dictionary ret;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_lods, p_surface, ret);
+	GDVIRTUAL_CALL(_surface_get_lods, p_surface, ret);
 	return ret;
 }
 
 BitField<Mesh::ArrayFormat> Mesh::surface_get_format(int p_idx) const {
 	uint32_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_format, p_idx, ret);
+	GDVIRTUAL_CALL(_surface_get_format, p_idx, ret);
 	return ret;
 }
 
 Mesh::PrimitiveType Mesh::surface_get_primitive_type(int p_idx) const {
 	uint32_t ret = PRIMITIVE_MAX;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_primitive_type, p_idx, ret);
+	GDVIRTUAL_CALL(_surface_get_primitive_type, p_idx, ret);
 	return (Mesh::PrimitiveType)ret;
 }
 
 void Mesh::surface_set_material(int p_idx, const Ref<Material> &p_material) {
-	GDVIRTUAL_REQUIRED_CALL(_surface_set_material, p_idx, p_material);
+	GDVIRTUAL_CALL(_surface_set_material, p_idx, p_material);
 }
 
 Ref<Material> Mesh::surface_get_material(int p_idx) const {
 	Ref<Material> ret;
-	GDVIRTUAL_REQUIRED_CALL(_surface_get_material, p_idx, ret);
+	GDVIRTUAL_CALL(_surface_get_material, p_idx, ret);
 	return ret;
 }
 
 int Mesh::get_blend_shape_count() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_blend_shape_count, ret);
+	GDVIRTUAL_CALL(_get_blend_shape_count, ret);
 	return ret;
 }
 
 StringName Mesh::get_blend_shape_name(int p_index) const {
 	StringName ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_blend_shape_name, p_index, ret);
+	GDVIRTUAL_CALL(_get_blend_shape_name, p_index, ret);
 	return ret;
 }
 
 void Mesh::set_blend_shape_name(int p_index, const StringName &p_name) {
-	GDVIRTUAL_REQUIRED_CALL(_set_blend_shape_name, p_index, p_name);
+	GDVIRTUAL_CALL(_set_blend_shape_name, p_index, p_name);
 }
 
 AABB Mesh::get_aabb() const {
 	AABB ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_aabb, ret);
+	GDVIRTUAL_CALL(_get_aabb, ret);
 	return ret;
 }
 

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -68,20 +68,20 @@ public:
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0RC(int, _get_surface_count)
-	GDVIRTUAL1RC(int, _surface_get_array_len, int)
-	GDVIRTUAL1RC(int, _surface_get_array_index_len, int)
-	GDVIRTUAL1RC(Array, _surface_get_arrays, int)
-	GDVIRTUAL1RC(TypedArray<Array>, _surface_get_blend_shape_arrays, int)
-	GDVIRTUAL1RC(Dictionary, _surface_get_lods, int)
-	GDVIRTUAL1RC(uint32_t, _surface_get_format, int)
-	GDVIRTUAL1RC(uint32_t, _surface_get_primitive_type, int)
-	GDVIRTUAL2(_surface_set_material, int, Ref<Material>)
-	GDVIRTUAL1RC(Ref<Material>, _surface_get_material, int)
-	GDVIRTUAL0RC(int, _get_blend_shape_count)
-	GDVIRTUAL1RC(StringName, _get_blend_shape_name, int)
-	GDVIRTUAL2(_set_blend_shape_name, int, StringName)
-	GDVIRTUAL0RC(AABB, _get_aabb)
+	GDVIRTUAL0RC_REQUIRED(int, _get_surface_count)
+	GDVIRTUAL1RC_REQUIRED(int, _surface_get_array_len, int)
+	GDVIRTUAL1RC_REQUIRED(int, _surface_get_array_index_len, int)
+	GDVIRTUAL1RC_REQUIRED(Array, _surface_get_arrays, int)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Array>, _surface_get_blend_shape_arrays, int)
+	GDVIRTUAL1RC_REQUIRED(Dictionary, _surface_get_lods, int)
+	GDVIRTUAL1RC_REQUIRED(uint32_t, _surface_get_format, int)
+	GDVIRTUAL1RC_REQUIRED(uint32_t, _surface_get_primitive_type, int)
+	GDVIRTUAL2_REQUIRED(_surface_set_material, int, Ref<Material>)
+	GDVIRTUAL1RC_REQUIRED(Ref<Material>, _surface_get_material, int)
+	GDVIRTUAL0RC_REQUIRED(int, _get_blend_shape_count)
+	GDVIRTUAL1RC_REQUIRED(StringName, _get_blend_shape_name, int)
+	GDVIRTUAL2_REQUIRED(_set_blend_shape_name, int, StringName)
+	GDVIRTUAL0RC_REQUIRED(AABB, _get_aabb)
 
 public:
 	enum {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -90,7 +90,7 @@ Point2 StyleBox::get_offset() const {
 }
 
 void StyleBox::draw(RID p_canvas_item, const Rect2 &p_rect) const {
-	GDVIRTUAL_REQUIRED_CALL(_draw, p_canvas_item, p_rect);
+	GDVIRTUAL_CALL(_draw, p_canvas_item, p_rect);
 }
 
 Rect2 StyleBox::get_draw_rect(const Rect2 &p_rect) const {

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -48,7 +48,7 @@ protected:
 	static void _bind_methods();
 	virtual float get_style_margin(Side p_side) const { return 0; }
 
-	GDVIRTUAL2C(_draw, RID, Rect2)
+	GDVIRTUAL2C_REQUIRED(_draw, RID, Rect2)
 	GDVIRTUAL1RC(Rect2, _get_draw_rect, Rect2)
 	GDVIRTUAL0RC(Size2, _get_minimum_size)
 	GDVIRTUAL2RC(bool, _test_mask, Point2, Rect2)

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -34,13 +34,13 @@
 
 int Texture2D::get_width() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_width, ret);
+	GDVIRTUAL_CALL(_get_width, ret);
 	return ret;
 }
 
 int Texture2D::get_height() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_height, ret);
+	GDVIRTUAL_CALL(_get_height, ret);
 	return ret;
 }
 
@@ -133,37 +133,37 @@ TypedArray<Image> Texture3D::_get_datai() const {
 
 Image::Format Texture3D::get_format() const {
 	Image::Format ret = Image::FORMAT_MAX;
-	GDVIRTUAL_REQUIRED_CALL(_get_format, ret);
+	GDVIRTUAL_CALL(_get_format, ret);
 	return ret;
 }
 
 int Texture3D::get_width() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_width, ret);
+	GDVIRTUAL_CALL(_get_width, ret);
 	return ret;
 }
 
 int Texture3D::get_height() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_height, ret);
+	GDVIRTUAL_CALL(_get_height, ret);
 	return ret;
 }
 
 int Texture3D::get_depth() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_depth, ret);
+	GDVIRTUAL_CALL(_get_depth, ret);
 	return ret;
 }
 
 bool Texture3D::has_mipmaps() const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_has_mipmaps, ret);
+	GDVIRTUAL_CALL(_has_mipmaps, ret);
 	return ret;
 }
 
 Vector<Ref<Image>> Texture3D::get_data() const {
 	TypedArray<Image> ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_data, ret);
+	GDVIRTUAL_CALL(_get_data, ret);
 	Vector<Ref<Image>> data;
 	data.resize(ret.size());
 	for (int i = 0; i < data.size(); i++) {
@@ -198,43 +198,43 @@ Ref<Resource> Texture3D::create_placeholder() const {
 
 Image::Format TextureLayered::get_format() const {
 	Image::Format ret = Image::FORMAT_MAX;
-	GDVIRTUAL_REQUIRED_CALL(_get_format, ret);
+	GDVIRTUAL_CALL(_get_format, ret);
 	return ret;
 }
 
 TextureLayered::LayeredType TextureLayered::get_layered_type() const {
 	uint32_t ret = LAYERED_TYPE_2D_ARRAY;
-	GDVIRTUAL_REQUIRED_CALL(_get_layered_type, ret);
+	GDVIRTUAL_CALL(_get_layered_type, ret);
 	return (LayeredType)ret;
 }
 
 int TextureLayered::get_width() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_width, ret);
+	GDVIRTUAL_CALL(_get_width, ret);
 	return ret;
 }
 
 int TextureLayered::get_height() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_height, ret);
+	GDVIRTUAL_CALL(_get_height, ret);
 	return ret;
 }
 
 int TextureLayered::get_layers() const {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_layers, ret);
+	GDVIRTUAL_CALL(_get_layers, ret);
 	return ret;
 }
 
 bool TextureLayered::has_mipmaps() const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_has_mipmaps, ret);
+	GDVIRTUAL_CALL(_has_mipmaps, ret);
 	return ret;
 }
 
 Ref<Image> TextureLayered::get_layer_data(int p_layer) const {
 	Ref<Image> ret;
-	GDVIRTUAL_REQUIRED_CALL(_get_layer_data, p_layer, ret);
+	GDVIRTUAL_CALL(_get_layer_data, p_layer, ret);
 	return ret;
 }
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -57,8 +57,8 @@ class Texture2D : public Texture {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0RC(int, _get_width)
-	GDVIRTUAL0RC(int, _get_height)
+	GDVIRTUAL0RC_REQUIRED(int, _get_width)
+	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL2RC(bool, _is_pixel_opaque, int, int)
 	GDVIRTUAL0RC(bool, _has_alpha)
 
@@ -93,13 +93,13 @@ class TextureLayered : public Texture {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0RC(Image::Format, _get_format)
-	GDVIRTUAL0RC(uint32_t, _get_layered_type)
-	GDVIRTUAL0RC(int, _get_width)
-	GDVIRTUAL0RC(int, _get_height)
-	GDVIRTUAL0RC(int, _get_layers)
-	GDVIRTUAL0RC(bool, _has_mipmaps)
-	GDVIRTUAL1RC(Ref<Image>, _get_layer_data, int)
+	GDVIRTUAL0RC_REQUIRED(Image::Format, _get_format)
+	GDVIRTUAL0RC_REQUIRED(uint32_t, _get_layered_type)
+	GDVIRTUAL0RC_REQUIRED(int, _get_width)
+	GDVIRTUAL0RC_REQUIRED(int, _get_height)
+	GDVIRTUAL0RC_REQUIRED(int, _get_layers)
+	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL1RC_REQUIRED(Ref<Image>, _get_layer_data, int)
 public:
 	enum LayeredType {
 		LAYERED_TYPE_2D_ARRAY,
@@ -128,12 +128,12 @@ protected:
 
 	TypedArray<Image> _get_datai() const;
 
-	GDVIRTUAL0RC(Image::Format, _get_format)
-	GDVIRTUAL0RC(int, _get_width)
-	GDVIRTUAL0RC(int, _get_height)
-	GDVIRTUAL0RC(int, _get_depth)
-	GDVIRTUAL0RC(bool, _has_mipmaps)
-	GDVIRTUAL0RC(TypedArray<Image>, _get_data)
+	GDVIRTUAL0RC_REQUIRED(Image::Format, _get_format)
+	GDVIRTUAL0RC_REQUIRED(int, _get_width)
+	GDVIRTUAL0RC_REQUIRED(int, _get_height)
+	GDVIRTUAL0RC_REQUIRED(int, _get_depth)
+	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL0RC_REQUIRED(TypedArray<Image>, _get_data)
 public:
 	virtual Image::Format get_format() const;
 	virtual int get_width() const;

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -119,7 +119,7 @@ Ref<Texture2D> VideoStreamPlayback::get_texture() const {
 }
 
 void VideoStreamPlayback::update(double p_delta) {
-	GDVIRTUAL_REQUIRED_CALL(_update, p_delta);
+	GDVIRTUAL_CALL(_update, p_delta);
 }
 
 void VideoStreamPlayback::set_mix_callback(AudioMixCallback p_callback, void *p_userdata) {

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -56,7 +56,7 @@ protected:
 	GDVIRTUAL1(_seek, double);
 	GDVIRTUAL1(_set_audio_track, int);
 	GDVIRTUAL0RC(Ref<Texture2D>, _get_texture);
-	GDVIRTUAL1(_update, double);
+	GDVIRTUAL1_REQUIRED(_update, double);
 	GDVIRTUAL0RC(int, _get_channels);
 	GDVIRTUAL0RC(int, _get_mix_rate);
 

--- a/servers/audio/audio_effect.cpp
+++ b/servers/audio/audio_effect.cpp
@@ -31,7 +31,7 @@
 #include "audio_effect.h"
 
 void AudioEffectInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	GDVIRTUAL_REQUIRED_CALL(_process, p_src_frames, p_dst_frames, p_frame_count);
+	GDVIRTUAL_CALL(_process, p_src_frames, p_dst_frames, p_frame_count);
 }
 bool AudioEffectInstance::process_silence() const {
 	bool ret = false;
@@ -48,7 +48,7 @@ void AudioEffectInstance::_bind_methods() {
 
 Ref<AudioEffectInstance> AudioEffect::instantiate() {
 	Ref<AudioEffectInstance> ret;
-	GDVIRTUAL_REQUIRED_CALL(_instantiate, ret);
+	GDVIRTUAL_CALL(_instantiate, ret);
 	return ret;
 }
 void AudioEffect::_bind_methods() {

--- a/servers/audio/audio_effect.h
+++ b/servers/audio/audio_effect.h
@@ -40,7 +40,7 @@ class AudioEffectInstance : public RefCounted {
 	GDCLASS(AudioEffectInstance, RefCounted);
 
 protected:
-	GDVIRTUAL3(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
+	GDVIRTUAL3_REQUIRED(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
 	GDVIRTUAL0RC(bool, _process_silence)
 	static void _bind_methods();
 
@@ -53,7 +53,7 @@ class AudioEffect : public Resource {
 	GDCLASS(AudioEffect, Resource);
 
 protected:
-	GDVIRTUAL0R(Ref<AudioEffectInstance>, _instantiate)
+	GDVIRTUAL0R_REQUIRED(Ref<AudioEffectInstance>, _instantiate)
 	static void _bind_methods();
 
 public:

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -72,7 +72,7 @@ void AudioStreamPlayback::seek(double p_time) {
 
 int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_mix, p_buffer, p_rate_scale, p_frames, ret);
+	GDVIRTUAL_CALL(_mix, p_buffer, p_rate_scale, p_frames, ret);
 	return ret;
 }
 
@@ -132,12 +132,12 @@ void AudioStreamPlaybackResampled::begin_resample() {
 
 int AudioStreamPlaybackResampled::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_mix_resampled, p_buffer, p_frames, ret);
+	GDVIRTUAL_CALL(_mix_resampled, p_buffer, p_frames, ret);
 	return ret;
 }
 float AudioStreamPlaybackResampled::get_stream_sampling_rate() {
 	float ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_stream_sampling_rate, ret);
+	GDVIRTUAL_CALL(_get_stream_sampling_rate, ret);
 	return ret;
 }
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -89,7 +89,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_loop_count)
 	GDVIRTUAL0RC(double, _get_playback_position)
 	GDVIRTUAL1(_seek, double)
-	GDVIRTUAL3R(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
+	GDVIRTUAL3R_REQUIRED(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
 	GDVIRTUAL2(_set_parameter, const StringName &, const Variant &)
 	GDVIRTUAL1RC(Variant, _get_parameter, const StringName &)
@@ -141,8 +141,8 @@ protected:
 	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames);
 	virtual float get_stream_sampling_rate();
 
-	GDVIRTUAL2R(int, _mix_resampled, GDExtensionPtr<AudioFrame>, int)
-	GDVIRTUAL0RC(float, _get_stream_sampling_rate)
+	GDVIRTUAL2R_REQUIRED(int, _mix_resampled, GDExtensionPtr<AudioFrame>, int)
+	GDVIRTUAL0RC_REQUIRED(float, _get_stream_sampling_rate)
 
 	static void _bind_methods();
 

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -127,53 +127,53 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
-	GDVIRTUAL7R(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
-	GDVIRTUAL7R(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
-	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
-	GDVIRTUAL9R(bool, _cast_motion, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>)
-	GDVIRTUAL10R(bool, _collide_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
-	GDVIRTUAL8R(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
+	GDVIRTUAL7R_REQUIRED(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
+	GDVIRTUAL7R_REQUIRED(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
+	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
+	GDVIRTUAL9R_REQUIRED(bool, _cast_motion, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>)
+	GDVIRTUAL10R_REQUIRED(bool, _collide_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
+	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
 
 public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, &r_result, ret);
+		GDVIRTUAL_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, &r_result, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_point, p_parameters.position, p_parameters.canvas_instance_id, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		GDVIRTUAL_CALL(_intersect_point, p_parameters.position, p_parameters.canvas_instance_id, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = 0;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		GDVIRTUAL_CALL(_intersect_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_cast_motion, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, &p_closest_safe, &p_closest_unsafe, ret);
+		GDVIRTUAL_CALL(_cast_motion, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, &p_closest_safe, &p_closest_unsafe, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_collide_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, &r_result_count, ret);
+		GDVIRTUAL_CALL(_collide_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, &r_result_count, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
+		GDVIRTUAL_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
 		exclude = nullptr;
 		return ret;
 	}
@@ -191,9 +191,9 @@ class PhysicsServer2DExtension : public PhysicsServer2D {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL9R(bool, _shape_collide, RID, const Transform2D &, const Vector2 &, RID, const Transform2D &, const Vector2 &, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
+	GDVIRTUAL9R_REQUIRED(bool, _shape_collide, RID, const Transform2D &, const Vector2 &, RID, const Transform2D &, const Vector2 &, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
 
-	GDVIRTUAL8R(bool, _body_collide_shape, RID, int, RID, const Transform2D &, const Vector2 &, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
+	GDVIRTUAL8R_REQUIRED(bool, _body_collide_shape, RID, int, RID, const Transform2D &, const Vector2 &, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
 
 public:
 	// The warning is valid, but unavoidable. If the function is not overridden it will error anyway.
@@ -218,7 +218,7 @@ public:
 
 	virtual bool shape_collide(RID p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, RID p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, Vector2 *r_results, int p_result_max, int &r_result_count) override {
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_shape_collide, p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, &r_result_count, ret);
+		GDVIRTUAL_CALL(_shape_collide, p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, &r_result_count, ret);
 		return ret;
 	}
 
@@ -354,11 +354,11 @@ public:
 
 	EXBIND2(body_add_collision_exception, RID, RID)
 	EXBIND2(body_remove_collision_exception, RID, RID)
-	GDVIRTUAL1RC(TypedArray<RID>, _body_get_collision_exceptions, RID)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<RID>, _body_get_collision_exceptions, RID)
 
 	void body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) override {
 		TypedArray<RID> ret;
-		GDVIRTUAL_REQUIRED_CALL(_body_get_collision_exceptions, p_body, ret);
+		GDVIRTUAL_CALL(_body_get_collision_exceptions, p_body, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_exceptions->push_back(ret[i]);
 		}
@@ -378,7 +378,7 @@ public:
 
 	virtual bool body_collide_shape(RID p_body, int p_body_shape, RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, Vector2 *r_results, int p_result_max, int &r_result_count) override {
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_body_collide_shape, p_body, p_body_shape, p_shape, p_shape_xform, p_motion, r_results, p_result_max, &r_result_count, ret);
+		GDVIRTUAL_CALL(_body_collide_shape, p_body, p_body_shape, p_shape, p_shape_xform, p_motion, r_results, p_result_max, &r_result_count, ret);
 		return ret;
 	}
 
@@ -386,7 +386,7 @@ public:
 
 	EXBIND1R(PhysicsDirectBodyState2D *, body_get_direct_state, RID)
 
-	GDVIRTUAL7RC(bool, _body_test_motion, RID, const Transform2D &, const Vector2 &, real_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionMotionResult>)
+	GDVIRTUAL7RC_REQUIRED(bool, _body_test_motion, RID, const Transform2D &, const Vector2 &, real_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionMotionResult>)
 
 	thread_local static const HashSet<RID> *exclude_bodies;
 	thread_local static const HashSet<ObjectID> *exclude_objects;
@@ -398,7 +398,7 @@ public:
 		bool ret = false;
 		exclude_bodies = &p_parameters.exclude_bodies;
 		exclude_objects = &p_parameters.exclude_objects;
-		GDVIRTUAL_REQUIRED_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
+		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
 		exclude_bodies = nullptr;
 		exclude_objects = nullptr;
 		return ret;
@@ -432,9 +432,9 @@ public:
 
 	/* MISC */
 
-	GDVIRTUAL1(_free_rid, RID)
+	GDVIRTUAL1_REQUIRED(_free_rid, RID)
 	virtual void free(RID p_rid) override {
-		GDVIRTUAL_REQUIRED_CALL(_free_rid, p_rid);
+		GDVIRTUAL_CALL(_free_rid, p_rid);
 	}
 
 	EXBIND1(set_active, bool)

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -129,61 +129,61 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
-	GDVIRTUAL9R(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
-	GDVIRTUAL6R(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
-	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
-	GDVIRTUAL10R(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
-	GDVIRTUAL10R(bool, _collide_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector3>, int, GDExtensionPtr<int>)
-	GDVIRTUAL8R(bool, _rest_info, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
-	GDVIRTUAL2RC(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
+	GDVIRTUAL9R_REQUIRED(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
+	GDVIRTUAL6R_REQUIRED(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
+	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
+	GDVIRTUAL10R_REQUIRED(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
+	GDVIRTUAL10R_REQUIRED(bool, _collide_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector3>, int, GDExtensionPtr<int>)
+	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
+	GDVIRTUAL2RC_REQUIRED(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
 
 public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_result, ret);
+		GDVIRTUAL_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_result, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_point, p_parameters.position, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		GDVIRTUAL_CALL(_intersect_point, p_parameters.position, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = 0;
-		GDVIRTUAL_REQUIRED_CALL(_intersect_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		GDVIRTUAL_CALL(_intersect_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_cast_motion, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, &p_closest_safe, &p_closest_unsafe, r_info, ret);
+		GDVIRTUAL_CALL(_cast_motion, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, &p_closest_safe, &p_closest_unsafe, r_info, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_collide_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, &r_result_count, ret);
+		GDVIRTUAL_CALL(_collide_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, &r_result_count, ret);
 		exclude = nullptr;
 		return ret;
 	}
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;
-		GDVIRTUAL_REQUIRED_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
+		GDVIRTUAL_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
 		exclude = nullptr;
 		return ret;
 	}
 
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const override {
 		Vector3 ret;
-		GDVIRTUAL_REQUIRED_CALL(_get_closest_point_to_object_volume, p_object, p_point, ret);
+		GDVIRTUAL_CALL(_get_closest_point_to_object_volume, p_object, p_point, ret);
 		return ret;
 	}
 
@@ -359,11 +359,11 @@ public:
 	EXBIND2(body_add_collision_exception, RID, RID)
 	EXBIND2(body_remove_collision_exception, RID, RID)
 
-	GDVIRTUAL1RC(TypedArray<RID>, _body_get_collision_exceptions, RID)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<RID>, _body_get_collision_exceptions, RID)
 
 	void body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) override {
 		TypedArray<RID> ret;
-		GDVIRTUAL_REQUIRED_CALL(_body_get_collision_exceptions, p_body, ret);
+		GDVIRTUAL_CALL(_body_get_collision_exceptions, p_body, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_exceptions->push_back(ret[i]);
 		}
@@ -383,7 +383,7 @@ public:
 
 	EXBIND2(body_set_ray_pickable, RID, bool)
 
-	GDVIRTUAL8RC(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionMotionResult>)
+	GDVIRTUAL8RC_REQUIRED(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionMotionResult>)
 
 	thread_local static const HashSet<RID> *exclude_bodies;
 	thread_local static const HashSet<ObjectID> *exclude_objects;
@@ -395,7 +395,7 @@ public:
 		bool ret = false;
 		exclude_bodies = &p_parameters.exclude_bodies;
 		exclude_objects = &p_parameters.exclude_objects;
-		GDVIRTUAL_REQUIRED_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
+		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
 		exclude_bodies = nullptr;
 		exclude_objects = nullptr;
 		return ret;
@@ -423,11 +423,11 @@ public:
 	EXBIND2(soft_body_add_collision_exception, RID, RID)
 	EXBIND2(soft_body_remove_collision_exception, RID, RID)
 
-	GDVIRTUAL1RC(TypedArray<RID>, _soft_body_get_collision_exceptions, RID)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<RID>, _soft_body_get_collision_exceptions, RID)
 
 	void soft_body_get_collision_exceptions(RID p_soft_body, List<RID> *p_exceptions) override {
 		TypedArray<RID> ret;
-		GDVIRTUAL_REQUIRED_CALL(_soft_body_get_collision_exceptions, p_soft_body, ret);
+		GDVIRTUAL_CALL(_soft_body_get_collision_exceptions, p_soft_body, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			p_exceptions->push_back(ret[i]);
 		}
@@ -520,9 +520,9 @@ public:
 
 	/* MISC */
 
-	GDVIRTUAL1(_free_rid, RID)
+	GDVIRTUAL1_REQUIRED(_free_rid, RID)
 	virtual void free(RID p_rid) override {
-		GDVIRTUAL_REQUIRED_CALL(_free_rid, p_rid);
+		GDVIRTUAL_CALL(_free_rid, p_rid);
 	}
 
 	EXBIND1(set_active, bool)

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -54,40 +54,40 @@ MovieWriter *MovieWriter::find_writer_for_file(const String &p_file) {
 
 uint32_t MovieWriter::get_audio_mix_rate() const {
 	uint32_t ret = 48000;
-	GDVIRTUAL_REQUIRED_CALL(_get_audio_mix_rate, ret);
+	GDVIRTUAL_CALL(_get_audio_mix_rate, ret);
 	return ret;
 }
 AudioServer::SpeakerMode MovieWriter::get_audio_speaker_mode() const {
 	AudioServer::SpeakerMode ret = AudioServer::SPEAKER_MODE_STEREO;
-	GDVIRTUAL_REQUIRED_CALL(_get_audio_speaker_mode, ret);
+	GDVIRTUAL_CALL(_get_audio_speaker_mode, ret);
 	return ret;
 }
 
 Error MovieWriter::write_begin(const Size2i &p_movie_size, uint32_t p_fps, const String &p_base_path) {
 	Error ret = ERR_UNCONFIGURED;
-	GDVIRTUAL_REQUIRED_CALL(_write_begin, p_movie_size, p_fps, p_base_path, ret);
+	GDVIRTUAL_CALL(_write_begin, p_movie_size, p_fps, p_base_path, ret);
 	return ret;
 }
 
 Error MovieWriter::write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) {
 	Error ret = ERR_UNCONFIGURED;
-	GDVIRTUAL_REQUIRED_CALL(_write_frame, p_image, p_audio_data, ret);
+	GDVIRTUAL_CALL(_write_frame, p_image, p_audio_data, ret);
 	return ret;
 }
 
 void MovieWriter::write_end() {
-	GDVIRTUAL_REQUIRED_CALL(_write_end);
+	GDVIRTUAL_CALL(_write_end);
 }
 
 bool MovieWriter::handles_file(const String &p_path) const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_handles_file, p_path, ret);
+	GDVIRTUAL_CALL(_handles_file, p_path, ret);
 	return ret;
 }
 
 void MovieWriter::get_supported_extensions(List<String> *r_extensions) const {
 	Vector<String> exts;
-	GDVIRTUAL_REQUIRED_CALL(_get_supported_extensions, exts);
+	GDVIRTUAL_CALL(_get_supported_extensions, exts);
 	for (int i = 0; i < exts.size(); i++) {
 		r_extensions->push_back(exts[i]);
 	}

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -63,15 +63,15 @@ protected:
 	virtual Error write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data);
 	virtual void write_end();
 
-	GDVIRTUAL0RC(uint32_t, _get_audio_mix_rate)
-	GDVIRTUAL0RC(AudioServer::SpeakerMode, _get_audio_speaker_mode)
+	GDVIRTUAL0RC_REQUIRED(uint32_t, _get_audio_mix_rate)
+	GDVIRTUAL0RC_REQUIRED(AudioServer::SpeakerMode, _get_audio_speaker_mode)
 
-	GDVIRTUAL1RC(bool, _handles_file, const String &)
-	GDVIRTUAL0RC(Vector<String>, _get_supported_extensions)
+	GDVIRTUAL1RC_REQUIRED(bool, _handles_file, const String &)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_supported_extensions)
 
-	GDVIRTUAL3R(Error, _write_begin, const Size2i &, uint32_t, const String &)
-	GDVIRTUAL2R(Error, _write_frame, const Ref<Image> &, GDExtensionConstPtr<int32_t>)
-	GDVIRTUAL0(_write_end)
+	GDVIRTUAL3R_REQUIRED(Error, _write_begin, const Size2i &, uint32_t, const String &)
+	GDVIRTUAL2R_REQUIRED(Error, _write_frame, const Ref<Image> &, GDExtensionConstPtr<int32_t>)
+	GDVIRTUAL0_REQUIRED(_write_end)
 
 	static void _bind_methods();
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -37,13 +37,13 @@
 #include "core/variant/typed_array.h"
 
 void PhysicsServer3DRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &p_vertex) {
-	GDVIRTUAL_REQUIRED_CALL(_set_vertex, p_vertex_id, p_vertex);
+	GDVIRTUAL_CALL(_set_vertex, p_vertex_id, p_vertex);
 }
 void PhysicsServer3DRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {
-	GDVIRTUAL_REQUIRED_CALL(_set_normal, p_vertex_id, p_normal);
+	GDVIRTUAL_CALL(_set_normal, p_vertex_id, p_normal);
 }
 void PhysicsServer3DRenderingServerHandler::set_aabb(const AABB &p_aabb) {
-	GDVIRTUAL_REQUIRED_CALL(_set_aabb, p_aabb);
+	GDVIRTUAL_CALL(_set_aabb, p_aabb);
 }
 
 void PhysicsServer3DRenderingServerHandler::_bind_methods() {

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -213,9 +213,9 @@ public:
 class PhysicsServer3DRenderingServerHandler : public Object {
 	GDCLASS(PhysicsServer3DRenderingServerHandler, Object)
 protected:
-	GDVIRTUAL2(_set_vertex, int, const Vector3 &)
-	GDVIRTUAL2(_set_normal, int, const Vector3 &)
-	GDVIRTUAL1(_set_aabb, const AABB &)
+	GDVIRTUAL2_REQUIRED(_set_vertex, int, const Vector3 &)
+	GDVIRTUAL2_REQUIRED(_set_normal, int, const Vector3 &)
+	GDVIRTUAL1_REQUIRED(_set_aabb, const AABB &)
 
 	static void _bind_methods();
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -352,29 +352,29 @@ void TextServerExtension::_bind_methods() {
 
 bool TextServerExtension::has_feature(Feature p_feature) const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_has_feature, p_feature, ret);
+	GDVIRTUAL_CALL(_has_feature, p_feature, ret);
 	return ret;
 }
 
 String TextServerExtension::get_name() const {
 	String ret = "Unknown";
-	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+	GDVIRTUAL_CALL(_get_name, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::get_features() const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_features, ret);
+	GDVIRTUAL_CALL(_get_features, ret);
 	return ret;
 }
 
 void TextServerExtension::free_rid(const RID &p_rid) {
-	GDVIRTUAL_REQUIRED_CALL(_free_rid, p_rid);
+	GDVIRTUAL_CALL(_free_rid, p_rid);
 }
 
 bool TextServerExtension::has(const RID &p_rid) {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_has, p_rid, ret);
+	GDVIRTUAL_CALL(_has, p_rid, ret);
 	return ret;
 }
 
@@ -430,7 +430,7 @@ String TextServerExtension::tag_to_name(int64_t p_tag) const {
 
 RID TextServerExtension::create_font() {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_create_font, ret);
+	GDVIRTUAL_CALL(_create_font, ret);
 	return ret;
 }
 
@@ -581,22 +581,22 @@ int64_t TextServerExtension::font_get_msdf_size(const RID &p_font_rid) const {
 }
 
 void TextServerExtension::font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_fixed_size, p_font_rid, p_fixed_size);
+	GDVIRTUAL_CALL(_font_set_fixed_size, p_font_rid, p_fixed_size);
 }
 
 int64_t TextServerExtension::font_get_fixed_size(const RID &p_font_rid) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_fixed_size, p_font_rid, ret);
+	GDVIRTUAL_CALL(_font_get_fixed_size, p_font_rid, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_fixed_size_scale_mode(const RID &p_font_rid, TextServer::FixedSizeScaleMode p_fixed_size_scale_mode) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_fixed_size_scale_mode, p_font_rid, p_fixed_size_scale_mode);
+	GDVIRTUAL_CALL(_font_set_fixed_size_scale_mode, p_font_rid, p_fixed_size_scale_mode);
 }
 
 TextServer::FixedSizeScaleMode TextServerExtension::font_get_fixed_size_scale_mode(const RID &p_font_rid) const {
 	FixedSizeScaleMode ret = FIXED_SIZE_SCALE_DISABLE;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_fixed_size_scale_mode, p_font_rid, ret);
+	GDVIRTUAL_CALL(_font_get_fixed_size_scale_mode, p_font_rid, ret);
 	return ret;
 }
 
@@ -702,89 +702,89 @@ double TextServerExtension::font_get_oversampling(const RID &p_font_rid) const {
 
 TypedArray<Vector2i> TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
 	TypedArray<Vector2i> ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_size_cache_list, p_font_rid, ret);
+	GDVIRTUAL_CALL(_font_get_size_cache_list, p_font_rid, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_size_cache(const RID &p_font_rid) {
-	GDVIRTUAL_REQUIRED_CALL(_font_clear_size_cache, p_font_rid);
+	GDVIRTUAL_CALL(_font_clear_size_cache, p_font_rid);
 }
 
 void TextServerExtension::font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_REQUIRED_CALL(_font_remove_size_cache, p_font_rid, p_size);
+	GDVIRTUAL_CALL(_font_remove_size_cache, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_ascent, p_font_rid, p_size, p_ascent);
+	GDVIRTUAL_CALL(_font_set_ascent, p_font_rid, p_size, p_ascent);
 }
 
 double TextServerExtension::font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_ascent, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_ascent, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_descent, p_font_rid, p_size, p_descent);
+	GDVIRTUAL_CALL(_font_set_descent, p_font_rid, p_size, p_descent);
 }
 
 double TextServerExtension::font_get_descent(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_descent, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_descent, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_underline_position, p_font_rid, p_size, p_underline_position);
+	GDVIRTUAL_CALL(_font_set_underline_position, p_font_rid, p_size, p_underline_position);
 }
 
 double TextServerExtension::font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_underline_position, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_underline_position, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_underline_thickness, p_font_rid, p_size, p_underline_thickness);
+	GDVIRTUAL_CALL(_font_set_underline_thickness, p_font_rid, p_size, p_underline_thickness);
 }
 
 double TextServerExtension::font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_scale, p_font_rid, p_size, p_scale);
+	GDVIRTUAL_CALL(_font_set_scale, p_font_rid, p_size, p_scale);
 }
 
 double TextServerExtension::font_get_scale(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_scale, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_scale, p_font_rid, p_size, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_texture_count, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_texture_count, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_REQUIRED_CALL(_font_clear_textures, p_font_rid, p_size);
+	GDVIRTUAL_CALL(_font_clear_textures, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) {
-	GDVIRTUAL_REQUIRED_CALL(_font_remove_texture, p_font_rid, p_size, p_texture_index);
+	GDVIRTUAL_CALL(_font_remove_texture, p_font_rid, p_size, p_texture_index);
 }
 
 void TextServerExtension::font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_texture_image, p_font_rid, p_size, p_texture_index, p_image);
+	GDVIRTUAL_CALL(_font_set_texture_image, p_font_rid, p_size, p_texture_index, p_image);
 }
 
 Ref<Image> TextServerExtension::font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
 	Ref<Image> ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret);
+	GDVIRTUAL_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret);
 	return ret;
 }
 
@@ -800,77 +800,77 @@ PackedInt32Array TextServerExtension::font_get_texture_offsets(const RID &p_font
 
 PackedInt32Array TextServerExtension::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
 	PackedInt32Array ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_list, p_font_rid, p_size, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_list, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_REQUIRED_CALL(_font_clear_glyphs, p_font_rid, p_size);
+	GDVIRTUAL_CALL(_font_clear_glyphs, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) {
-	GDVIRTUAL_REQUIRED_CALL(_font_remove_glyph, p_font_rid, p_size, p_glyph);
+	GDVIRTUAL_CALL(_font_remove_glyph, p_font_rid, p_size, p_glyph);
 }
 
 Vector2 TextServerExtension::font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_advance, p_font_rid, p_size, p_glyph, p_advance);
+	GDVIRTUAL_CALL(_font_set_glyph_advance, p_font_rid, p_size, p_glyph, p_advance);
 }
 
 Vector2 TextServerExtension::font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_offset, p_font_rid, p_size, p_glyph, p_offset);
+	GDVIRTUAL_CALL(_font_set_glyph_offset, p_font_rid, p_size, p_glyph, p_offset);
 }
 
 Vector2 TextServerExtension::font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_size, p_font_rid, p_size, p_glyph, p_gl_size);
+	GDVIRTUAL_CALL(_font_set_glyph_size, p_font_rid, p_size, p_glyph, p_gl_size);
 }
 
 Rect2 TextServerExtension::font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Rect2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_uv_rect, p_font_rid, p_size, p_glyph, p_uv_rect);
+	GDVIRTUAL_CALL(_font_set_glyph_uv_rect, p_font_rid, p_size, p_glyph, p_uv_rect);
 }
 
 int64_t TextServerExtension::font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
-	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_texture_idx, p_font_rid, p_size, p_glyph, p_texture_idx);
+	GDVIRTUAL_CALL(_font_set_glyph_texture_idx, p_font_rid, p_size, p_glyph, p_texture_idx);
 }
 
 RID TextServerExtension::font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 Size2 TextServerExtension::font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Size2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
@@ -906,31 +906,31 @@ Vector2 TextServerExtension::font_get_kerning(const RID &p_font_rid, int64_t p_s
 
 int64_t TextServerExtension::font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret);
+	GDVIRTUAL_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_char_from_glyph_index, p_font_rid, p_size, p_glyph_index, ret);
+	GDVIRTUAL_CALL(_font_get_char_from_glyph_index, p_font_rid, p_size, p_glyph_index, ret);
 	return ret;
 }
 
 bool TextServerExtension::font_has_char(const RID &p_font_rid, int64_t p_char) const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_font_has_char, p_font_rid, p_char, ret);
+	GDVIRTUAL_CALL(_font_has_char, p_font_rid, p_char, ret);
 	return ret;
 }
 
 String TextServerExtension::font_get_supported_chars(const RID &p_font_rid) const {
 	String ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_supported_chars, p_font_rid, ret);
+	GDVIRTUAL_CALL(_font_get_supported_chars, p_font_rid, ret);
 	return ret;
 }
 
 PackedInt32Array TextServerExtension::font_get_supported_glyphs(const RID &p_font_rid) const {
 	PackedInt32Array ret;
-	GDVIRTUAL_REQUIRED_CALL(_font_get_supported_glyphs, p_font_rid, ret);
+	GDVIRTUAL_CALL(_font_get_supported_glyphs, p_font_rid, ret);
 	return ret;
 }
 
@@ -943,11 +943,11 @@ void TextServerExtension::font_render_glyph(const RID &p_font_rid, const Vector2
 }
 
 void TextServerExtension::font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	GDVIRTUAL_REQUIRED_CALL(_font_draw_glyph, p_font_rid, p_canvas, p_size, p_pos, p_index, p_color);
+	GDVIRTUAL_CALL(_font_draw_glyph, p_font_rid, p_canvas, p_size, p_pos, p_index, p_color);
 }
 
 void TextServerExtension::font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	GDVIRTUAL_REQUIRED_CALL(_font_draw_glyph_outline, p_font_rid, p_canvas, p_size, p_outline_size, p_pos, p_index, p_color);
+	GDVIRTUAL_CALL(_font_draw_glyph_outline, p_font_rid, p_canvas, p_size, p_outline_size, p_pos, p_index, p_color);
 }
 
 bool TextServerExtension::font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
@@ -1054,12 +1054,12 @@ void TextServerExtension::draw_hex_code_box(const RID &p_canvas, int64_t p_size,
 
 RID TextServerExtension::create_shaped_text(TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_create_shaped_text, p_direction, p_orientation, ret);
+	GDVIRTUAL_CALL(_create_shaped_text, p_direction, p_orientation, ret);
 	return ret;
 }
 
 void TextServerExtension::shaped_text_clear(const RID &p_shaped) {
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_clear, p_shaped);
+	GDVIRTUAL_CALL(_shaped_text_clear, p_shaped);
 }
 
 void TextServerExtension::shaped_text_set_direction(const RID &p_shaped, TextServer::Direction p_direction) {
@@ -1144,47 +1144,47 @@ int64_t TextServerExtension::shaped_text_get_spacing(const RID &p_shaped, TextSe
 
 bool TextServerExtension::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret);
+	GDVIRTUAL_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret);
 	return ret;
 }
 
 bool TextServerExtension::shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int64_t p_length, double p_baseline) {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, p_baseline, ret);
+	GDVIRTUAL_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, p_baseline, ret);
 	return ret;
 }
 
 bool TextServerExtension::shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, double p_baseline) {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, p_baseline, ret);
+	GDVIRTUAL_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, p_baseline, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_get_span_count(const RID &p_shaped) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_get_span_count, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_get_span_count, p_shaped, ret);
 	return ret;
 }
 
 Variant TextServerExtension::shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const {
 	Variant ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_get_span_meta, p_shaped, p_index, ret);
+	GDVIRTUAL_CALL(_shaped_get_span_meta, p_shaped, p_index, ret);
 	return ret;
 }
 
 void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
-	GDVIRTUAL_REQUIRED_CALL(_shaped_set_span_update_font, p_shaped, p_index, p_fonts, p_size, p_opentype_features);
+	GDVIRTUAL_CALL(_shaped_set_span_update_font, p_shaped, p_index, p_fonts, p_size, p_opentype_features);
 }
 
 RID TextServerExtension::shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret);
+	GDVIRTUAL_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret);
 	return ret;
 }
 
 RID TextServerExtension::shaped_text_get_parent(const RID &p_shaped) const {
 	RID ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_parent, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_parent, p_shaped, ret);
 	return ret;
 }
 
@@ -1202,7 +1202,7 @@ double TextServerExtension::shaped_text_tab_align(const RID &p_shaped, const Pac
 
 bool TextServerExtension::shaped_text_shape(const RID &p_shaped) {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_shape, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_shape, p_shaped, ret);
 	return ret;
 }
 
@@ -1220,31 +1220,31 @@ bool TextServerExtension::shaped_text_update_justification_ops(const RID &p_shap
 
 bool TextServerExtension::shaped_text_is_ready(const RID &p_shaped) const {
 	bool ret = false;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_is_ready, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_is_ready, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_glyphs(const RID &p_shaped) const {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_glyphs, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_sort_logical(const RID &p_shaped) {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_sort_logical, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_glyph_count(const RID &p_shaped) const {
 	int64_t ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_glyph_count, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_glyph_count, p_shaped, ret);
 	return ret;
 }
 
 Vector2i TextServerExtension::shaped_text_get_range(const RID &p_shaped) const {
 	Vector2i ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_range, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_range, p_shaped, ret);
 	return ret;
 }
 
@@ -1274,25 +1274,25 @@ PackedInt32Array TextServerExtension::shaped_text_get_word_breaks(const RID &p_s
 
 int64_t TextServerExtension::shaped_text_get_trim_pos(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret);
 	return ret;
 }
 
@@ -1302,61 +1302,61 @@ void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_
 
 Array TextServerExtension::shaped_text_get_objects(const RID &p_shaped) const {
 	Array ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_objects, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_objects, p_shaped, ret);
 	return ret;
 }
 
 Rect2 TextServerExtension::shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const {
 	Rect2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
 	return ret;
 }
 
 Vector2i TextServerExtension::shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const {
 	Vector2i ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_range, p_shaped, p_key, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_object_range, p_shaped, p_key, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_object_glyph(const RID &p_shaped, const Variant &p_key) const {
 	int64_t ret = -1;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_glyph, p_shaped, p_key, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_object_glyph, p_shaped, p_key, ret);
 	return ret;
 }
 
 Size2 TextServerExtension::shaped_text_get_size(const RID &p_shaped) const {
 	Size2 ret;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_size, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_size, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_ascent(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ascent, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_ascent, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_descent(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_descent, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_descent, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_width(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_width, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_width, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_position(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_underline_position, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_underline_position, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_thickness(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_underline_thickness, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_underline_thickness, p_shaped, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -49,15 +49,15 @@ public:
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;
 	virtual int64_t get_features() const override;
-	GDVIRTUAL1RC(bool, _has_feature, Feature);
-	GDVIRTUAL0RC(String, _get_name);
-	GDVIRTUAL0RC(int64_t, _get_features);
+	GDVIRTUAL1RC_REQUIRED(bool, _has_feature, Feature);
+	GDVIRTUAL0RC_REQUIRED(String, _get_name);
+	GDVIRTUAL0RC_REQUIRED(int64_t, _get_features);
 
 	virtual void free_rid(const RID &p_rid) override;
 	virtual bool has(const RID &p_rid) override;
 	virtual bool load_support_data(const String &p_filename) override;
-	GDVIRTUAL1(_free_rid, RID);
-	GDVIRTUAL1R(bool, _has, RID);
+	GDVIRTUAL1_REQUIRED(_free_rid, RID);
+	GDVIRTUAL1R_REQUIRED(bool, _has, RID);
 	GDVIRTUAL1R(bool, _load_support_data, const String &);
 
 	virtual String get_support_data_filename() const override;
@@ -78,7 +78,7 @@ public:
 	/* Font interface */
 
 	virtual RID create_font() override;
-	GDVIRTUAL0R(RID, _create_font);
+	GDVIRTUAL0R_REQUIRED(RID, _create_font);
 
 	virtual RID create_font_linked_variation(const RID &p_font_rid) override;
 	GDVIRTUAL1R(RID, _create_font_linked_variation, RID);
@@ -155,13 +155,13 @@ public:
 
 	virtual void font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) override;
 	virtual int64_t font_get_fixed_size(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_fixed_size, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_fixed_size, RID);
+	GDVIRTUAL2_REQUIRED(_font_set_fixed_size, RID, int64_t);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _font_get_fixed_size, RID);
 
 	virtual void font_set_fixed_size_scale_mode(const RID &p_font_rid, FixedSizeScaleMode p_fixed_size_scale) override;
 	virtual FixedSizeScaleMode font_get_fixed_size_scale_mode(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_fixed_size_scale_mode, RID, FixedSizeScaleMode);
-	GDVIRTUAL1RC(FixedSizeScaleMode, _font_get_fixed_size_scale_mode, RID);
+	GDVIRTUAL2_REQUIRED(_font_set_fixed_size_scale_mode, RID, FixedSizeScaleMode);
+	GDVIRTUAL1RC_REQUIRED(FixedSizeScaleMode, _font_get_fixed_size_scale_mode, RID);
 
 	virtual void font_set_subpixel_positioning(const RID &p_font_rid, SubpixelPositioning p_subpixel) override;
 	virtual SubpixelPositioning font_get_subpixel_positioning(const RID &p_font_rid) const override;
@@ -216,46 +216,46 @@ public:
 	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override;
-	GDVIRTUAL1RC(TypedArray<Vector2i>, _font_get_size_cache_list, RID);
-	GDVIRTUAL1(_font_clear_size_cache, RID);
-	GDVIRTUAL2(_font_remove_size_cache, RID, const Vector2i &);
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Vector2i>, _font_get_size_cache_list, RID);
+	GDVIRTUAL1_REQUIRED(_font_clear_size_cache, RID);
+	GDVIRTUAL2_REQUIRED(_font_remove_size_cache, RID, const Vector2i &);
 
 	virtual void font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) override;
 	virtual double font_get_ascent(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_ascent, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_ascent, RID, int64_t);
+	GDVIRTUAL3_REQUIRED(_font_set_ascent, RID, int64_t, double);
+	GDVIRTUAL2RC_REQUIRED(double, _font_get_ascent, RID, int64_t);
 
 	virtual void font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) override;
 	virtual double font_get_descent(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_descent, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_descent, RID, int64_t);
+	GDVIRTUAL3_REQUIRED(_font_set_descent, RID, int64_t, double);
+	GDVIRTUAL2RC_REQUIRED(double, _font_get_descent, RID, int64_t);
 
 	virtual void font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) override;
 	virtual double font_get_underline_position(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_underline_position, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_underline_position, RID, int64_t);
+	GDVIRTUAL3_REQUIRED(_font_set_underline_position, RID, int64_t, double);
+	GDVIRTUAL2RC_REQUIRED(double, _font_get_underline_position, RID, int64_t);
 
 	virtual void font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) override;
 	virtual double font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_underline_thickness, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_underline_thickness, RID, int64_t);
+	GDVIRTUAL3_REQUIRED(_font_set_underline_thickness, RID, int64_t, double);
+	GDVIRTUAL2RC_REQUIRED(double, _font_get_underline_thickness, RID, int64_t);
 
 	virtual void font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) override;
 	virtual double font_get_scale(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_scale, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_scale, RID, int64_t);
+	GDVIRTUAL3_REQUIRED(_font_set_scale, RID, int64_t, double);
+	GDVIRTUAL2RC_REQUIRED(double, _font_get_scale, RID, int64_t);
 
 	virtual int64_t font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) override;
-	GDVIRTUAL2RC(int64_t, _font_get_texture_count, RID, const Vector2i &);
-	GDVIRTUAL2(_font_clear_textures, RID, const Vector2i &);
-	GDVIRTUAL3(_font_remove_texture, RID, const Vector2i &, int64_t);
+	GDVIRTUAL2RC_REQUIRED(int64_t, _font_get_texture_count, RID, const Vector2i &);
+	GDVIRTUAL2_REQUIRED(_font_clear_textures, RID, const Vector2i &);
+	GDVIRTUAL3_REQUIRED(_font_remove_texture, RID, const Vector2i &, int64_t);
 
 	virtual void font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) override;
 	virtual Ref<Image> font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
-	GDVIRTUAL4(_font_set_texture_image, RID, const Vector2i &, int64_t, const Ref<Image> &);
-	GDVIRTUAL3RC(Ref<Image>, _font_get_texture_image, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_texture_image, RID, const Vector2i &, int64_t, const Ref<Image> &);
+	GDVIRTUAL3RC_REQUIRED(Ref<Image>, _font_get_texture_image, RID, const Vector2i &, int64_t);
 
 	virtual void font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) override;
 	virtual PackedInt32Array font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
@@ -265,40 +265,40 @@ public:
 	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override;
-	GDVIRTUAL2RC(PackedInt32Array, _font_get_glyph_list, RID, const Vector2i &);
-	GDVIRTUAL2(_font_clear_glyphs, RID, const Vector2i &);
-	GDVIRTUAL3(_font_remove_glyph, RID, const Vector2i &, int64_t);
+	GDVIRTUAL2RC_REQUIRED(PackedInt32Array, _font_get_glyph_list, RID, const Vector2i &);
+	GDVIRTUAL2_REQUIRED(_font_clear_glyphs, RID, const Vector2i &);
+	GDVIRTUAL3_REQUIRED(_font_remove_glyph, RID, const Vector2i &, int64_t);
 
 	virtual Vector2 font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_advance, RID, int64_t, int64_t);
-	GDVIRTUAL4(_font_set_glyph_advance, RID, int64_t, int64_t, const Vector2 &);
+	GDVIRTUAL3RC_REQUIRED(Vector2, _font_get_glyph_advance, RID, int64_t, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_glyph_advance, RID, int64_t, int64_t, const Vector2 &);
 
 	virtual Vector2 font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_offset, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_offset, RID, const Vector2i &, int64_t, const Vector2 &);
+	GDVIRTUAL3RC_REQUIRED(Vector2, _font_get_glyph_offset, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_glyph_offset, RID, const Vector2i &, int64_t, const Vector2 &);
 
 	virtual Vector2 font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_size, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_size, RID, const Vector2i &, int64_t, const Vector2 &);
+	GDVIRTUAL3RC_REQUIRED(Vector2, _font_get_glyph_size, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_glyph_size, RID, const Vector2i &, int64_t, const Vector2 &);
 
 	virtual Rect2 font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) override;
-	GDVIRTUAL3RC(Rect2, _font_get_glyph_uv_rect, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_uv_rect, RID, const Vector2i &, int64_t, const Rect2 &);
+	GDVIRTUAL3RC_REQUIRED(Rect2, _font_get_glyph_uv_rect, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_glyph_uv_rect, RID, const Vector2i &, int64_t, const Rect2 &);
 
 	virtual int64_t font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) override;
-	GDVIRTUAL3RC(int64_t, _font_get_glyph_texture_idx, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_texture_idx, RID, const Vector2i &, int64_t, int64_t);
+	GDVIRTUAL3RC_REQUIRED(int64_t, _font_get_glyph_texture_idx, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4_REQUIRED(_font_set_glyph_texture_idx, RID, const Vector2i &, int64_t, int64_t);
 
 	virtual RID font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
-	GDVIRTUAL3RC(RID, _font_get_glyph_texture_rid, RID, const Vector2i &, int64_t);
+	GDVIRTUAL3RC_REQUIRED(RID, _font_get_glyph_texture_rid, RID, const Vector2i &, int64_t);
 
 	virtual Size2 font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
-	GDVIRTUAL3RC(Size2, _font_get_glyph_texture_size, RID, const Vector2i &, int64_t);
+	GDVIRTUAL3RC_REQUIRED(Size2, _font_get_glyph_texture_size, RID, const Vector2i &, int64_t);
 
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const override;
 	GDVIRTUAL3RC(Dictionary, _font_get_glyph_contours, RID, int64_t, int64_t);
@@ -316,17 +316,17 @@ public:
 	GDVIRTUAL3RC(Vector2, _font_get_kerning, RID, int64_t, const Vector2i &);
 
 	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector = 0) const override;
-	GDVIRTUAL4RC(int64_t, _font_get_glyph_index, RID, int64_t, int64_t, int64_t);
+	GDVIRTUAL4RC_REQUIRED(int64_t, _font_get_glyph_index, RID, int64_t, int64_t, int64_t);
 
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override;
-	GDVIRTUAL3RC(int64_t, _font_get_char_from_glyph_index, RID, int64_t, int64_t);
+	GDVIRTUAL3RC_REQUIRED(int64_t, _font_get_char_from_glyph_index, RID, int64_t, int64_t);
 
 	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override;
 	virtual String font_get_supported_chars(const RID &p_font_rid) const override;
 	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override;
-	GDVIRTUAL2RC(bool, _font_has_char, RID, int64_t);
-	GDVIRTUAL1RC(String, _font_get_supported_chars, RID);
-	GDVIRTUAL1RC(PackedInt32Array, _font_get_supported_glyphs, RID);
+	GDVIRTUAL2RC_REQUIRED(bool, _font_has_char, RID, int64_t);
+	GDVIRTUAL1RC_REQUIRED(String, _font_get_supported_chars, RID);
+	GDVIRTUAL1RC_REQUIRED(PackedInt32Array, _font_get_supported_glyphs, RID);
 
 	virtual void font_render_range(const RID &p_font, const Vector2i &p_size, int64_t p_start, int64_t p_end) override;
 	virtual void font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) override;
@@ -335,8 +335,8 @@ public:
 
 	virtual void font_draw_glyph(const RID &p_font, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
 	virtual void font_draw_glyph_outline(const RID &p_font, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
-	GDVIRTUAL6C(_font_draw_glyph, RID, RID, int64_t, const Vector2 &, int64_t, const Color &);
-	GDVIRTUAL7C(_font_draw_glyph_outline, RID, RID, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
+	GDVIRTUAL6C_REQUIRED(_font_draw_glyph, RID, RID, int64_t, const Vector2 &, int64_t, const Color &);
+	GDVIRTUAL7C_REQUIRED(_font_draw_glyph_outline, RID, RID, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
 
 	virtual bool font_is_language_supported(const RID &p_font_rid, const String &p_language) const override;
 	virtual void font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) override;
@@ -383,10 +383,10 @@ public:
 	/* Shaped text buffer interface */
 
 	virtual RID create_shaped_text(Direction p_direction = DIRECTION_AUTO, Orientation p_orientation = ORIENTATION_HORIZONTAL) override;
-	GDVIRTUAL2R(RID, _create_shaped_text, Direction, Orientation);
+	GDVIRTUAL2R_REQUIRED(RID, _create_shaped_text, Direction, Orientation);
 
 	virtual void shaped_text_clear(const RID &p_shaped) override;
-	GDVIRTUAL1(_shaped_text_clear, RID);
+	GDVIRTUAL1_REQUIRED(_shaped_text_clear, RID);
 
 	virtual void shaped_text_set_direction(const RID &p_shaped, Direction p_direction = DIRECTION_AUTO) override;
 	virtual Direction shaped_text_get_direction(const RID &p_shaped) const override;
@@ -431,21 +431,21 @@ public:
 	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1, double p_baseline = 0.0) override;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, double p_baseline = 0.0) override;
-	GDVIRTUAL7R(bool, _shaped_text_add_string, RID, const String &, const TypedArray<RID> &, int64_t, const Dictionary &, const String &, const Variant &);
-	GDVIRTUAL6R(bool, _shaped_text_add_object, RID, const Variant &, const Size2 &, InlineAlignment, int64_t, double);
-	GDVIRTUAL5R(bool, _shaped_text_resize_object, RID, const Variant &, const Size2 &, InlineAlignment, double);
+	GDVIRTUAL7R_REQUIRED(bool, _shaped_text_add_string, RID, const String &, const TypedArray<RID> &, int64_t, const Dictionary &, const String &, const Variant &);
+	GDVIRTUAL6R_REQUIRED(bool, _shaped_text_add_object, RID, const Variant &, const Size2 &, InlineAlignment, int64_t, double);
+	GDVIRTUAL5R_REQUIRED(bool, _shaped_text_resize_object, RID, const Variant &, const Size2 &, InlineAlignment, double);
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override;
 	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
-	GDVIRTUAL1RC(int64_t, _shaped_get_span_count, RID);
-	GDVIRTUAL2RC(Variant, _shaped_get_span_meta, RID, int64_t);
-	GDVIRTUAL5(_shaped_set_span_update_font, RID, int64_t, const TypedArray<RID> &, int64_t, const Dictionary &);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_get_span_count, RID);
+	GDVIRTUAL2RC_REQUIRED(Variant, _shaped_get_span_meta, RID, int64_t);
+	GDVIRTUAL5_REQUIRED(_shaped_set_span_update_font, RID, int64_t, const TypedArray<RID> &, int64_t, const Dictionary &);
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override;
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const override;
-	GDVIRTUAL3RC(RID, _shaped_text_substr, RID, int64_t, int64_t);
-	GDVIRTUAL1RC(RID, _shaped_text_get_parent, RID);
+	GDVIRTUAL3RC_REQUIRED(RID, _shaped_text_substr, RID, int64_t, int64_t);
+	GDVIRTUAL1RC_REQUIRED(RID, _shaped_text_get_parent, RID);
 
 	virtual double shaped_text_fit_to_width(const RID &p_shaped, double p_width, BitField<TextServer::JustificationFlag> p_jst_flags = JUSTIFICATION_WORD_BOUND | JUSTIFICATION_KASHIDA) override;
 	virtual double shaped_text_tab_align(const RID &p_shaped, const PackedFloat32Array &p_tab_stops) override;
@@ -455,22 +455,22 @@ public:
 	virtual bool shaped_text_shape(const RID &p_shaped) override;
 	virtual bool shaped_text_update_breaks(const RID &p_shaped) override;
 	virtual bool shaped_text_update_justification_ops(const RID &p_shaped) override;
-	GDVIRTUAL1R(bool, _shaped_text_shape, RID);
+	GDVIRTUAL1R_REQUIRED(bool, _shaped_text_shape, RID);
 	GDVIRTUAL1R(bool, _shaped_text_update_breaks, RID);
 	GDVIRTUAL1R(bool, _shaped_text_update_justification_ops, RID);
 
 	virtual bool shaped_text_is_ready(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(bool, _shaped_text_is_ready, RID);
+	GDVIRTUAL1RC_REQUIRED(bool, _shaped_text_is_ready, RID);
 
 	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override;
 	virtual int64_t shaped_text_get_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_glyphs, RID);
-	GDVIRTUAL1R(GDExtensionConstPtr<const Glyph>, _shaped_text_sort_logical, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_glyph_count, RID);
+	GDVIRTUAL1RC_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_get_glyphs, RID);
+	GDVIRTUAL1R_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_sort_logical, RID);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_glyph_count, RID);
 
 	virtual Vector2i shaped_text_get_range(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(Vector2i, _shaped_text_get_range, RID);
+	GDVIRTUAL1RC_REQUIRED(Vector2i, _shaped_text_get_range, RID);
 
 	virtual PackedInt32Array shaped_text_get_line_breaks_adv(const RID &p_shaped, const PackedFloat32Array &p_width, int64_t p_start = 0, bool p_once = true, BitField<TextServer::LineBreakFlag> p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
 	virtual PackedInt32Array shaped_text_get_line_breaks(const RID &p_shaped, double p_width, int64_t p_start = 0, BitField<TextServer::LineBreakFlag> p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
@@ -483,10 +483,10 @@ public:
 	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const override;
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_trim_pos, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_pos, RID);
-	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_glyph_count, RID);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_trim_pos, RID);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_pos, RID);
+	GDVIRTUAL1RC_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
+	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_glyph_count, RID);
 
 	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) override;
 	GDVIRTUAL3(_shaped_text_overrun_trim_to_width, RID, double, BitField<TextServer::TextOverrunFlag>);
@@ -495,10 +495,10 @@ public:
 	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const override;
 	virtual Vector2i shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const override;
 	virtual int64_t shaped_text_get_object_glyph(const RID &p_shaped, const Variant &p_key) const override;
-	GDVIRTUAL1RC(Array, _shaped_text_get_objects, RID);
-	GDVIRTUAL2RC(Rect2, _shaped_text_get_object_rect, RID, const Variant &);
-	GDVIRTUAL2RC(Vector2i, _shaped_text_get_object_range, RID, const Variant &);
-	GDVIRTUAL2RC(int64_t, _shaped_text_get_object_glyph, RID, const Variant &);
+	GDVIRTUAL1RC_REQUIRED(Array, _shaped_text_get_objects, RID);
+	GDVIRTUAL2RC_REQUIRED(Rect2, _shaped_text_get_object_rect, RID, const Variant &);
+	GDVIRTUAL2RC_REQUIRED(Vector2i, _shaped_text_get_object_range, RID, const Variant &);
+	GDVIRTUAL2RC_REQUIRED(int64_t, _shaped_text_get_object_glyph, RID, const Variant &);
 
 	virtual Size2 shaped_text_get_size(const RID &p_shaped) const override;
 	virtual double shaped_text_get_ascent(const RID &p_shaped) const override;
@@ -506,12 +506,12 @@ public:
 	virtual double shaped_text_get_width(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_position(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_thickness(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(Size2, _shaped_text_get_size, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_ascent, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_descent, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_width, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_underline_position, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_underline_thickness, RID);
+	GDVIRTUAL1RC_REQUIRED(Size2, _shaped_text_get_size, RID);
+	GDVIRTUAL1RC_REQUIRED(double, _shaped_text_get_ascent, RID);
+	GDVIRTUAL1RC_REQUIRED(double, _shaped_text_get_descent, RID);
+	GDVIRTUAL1RC_REQUIRED(double, _shaped_text_get_width, RID);
+	GDVIRTUAL1RC_REQUIRED(double, _shaped_text_get_underline_position, RID);
+	GDVIRTUAL1RC_REQUIRED(double, _shaped_text_get_underline_thickness, RID);
 
 	virtual Direction shaped_text_get_dominant_direction_in_range(const RID &p_shaped, int64_t p_start, int64_t p_end) const override;
 	GDVIRTUAL3RC(int64_t, _shaped_text_get_dominant_direction_in_range, RID, int64_t, int64_t);


### PR DESCRIPTION
This is a draft exploring how to implement https://github.com/godotengine/godot-proposals/discussions/9982

TODO to finish:

- ~~Find all the required virtual methods and swap in the `GDVIRTUAL*_REQUIRED()` macro~~
- ~~Replace all `GDVIRTUAL_REQUIRED_CALL()` with `GDVIRTUAL_CALL()`~~
