### PR TITLE
Fix incorrect Reinhard tonemap operator

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -414,7 +414,7 @@
 			Linear tonemapper operator. Reads the linear data and passes it on unmodified. This can cause bright lighting to look blown out, with noticeable clipping in the output colors.
 		</constant>
 		<constant name="TONE_MAPPER_REINHARDT" value="1" enum="ToneMapper">
-			Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: [code]color = color / (1 + color)[/code]. This avoids clipping bright highlights, but the resulting image can look a bit dull.
+			Reinhard tonemapper operator. Performs a variation on rendered pixels' colors by this formula: [code]color = color * (1 + color / (white * white)) / (1 + color)[/code]. This avoids clipping bright highlights, but the resulting image can look a bit dull. When [member tonemap_white] is left at the default value of [code]1.0[/code] this is identical to [constant TONE_MAPPER_LINEAR] while also being slightly less performant.
 		</constant>
 		<constant name="TONE_MAPPER_FILMIC" value="2" enum="ToneMapper">
 			Filmic tonemapper operator. This avoids clipping bright highlights, with a resulting image that usually looks more vivid than [constant TONE_MAPPER_REINHARDT].

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -5219,7 +5219,7 @@
 			Output color as they came in. This can cause bright lighting to look blown out, with noticeable clipping in the output colors.
 		</constant>
 		<constant name="ENV_TONE_MAPPER_REINHARD" value="1" enum="EnvironmentToneMapper">
-			Use the Reinhard tonemapper. Performs a variation on rendered pixels' colors by this formula: [code]color = color / (1 + color)[/code]. This avoids clipping bright highlights, but the resulting image can look a bit dull.
+			Use the Reinhard tonemapper. Performs a variation on rendered pixels' colors by this formula: [code]color = color * (1 + color / (white * white)) / (1 + color)[/code]. This avoids clipping bright highlights, but the resulting image can look a bit dull. When [member Environment.tonemap_white] is left at the default value of [code]1.0[/code] this is identical to [constant ENV_TONE_MAPPER_LINEAR] while also being slightly less performant.
 		</constant>
 		<constant name="ENV_TONE_MAPPER_FILMIC" value="2" enum="EnvironmentToneMapper">
 			Use the filmic tonemapper. This avoids clipping bright highlights, with a resulting image that usually looks more vivid than [constant ENV_TONE_MAPPER_REINHARD].

--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -76,8 +76,12 @@ vec3 tonemap_aces(vec3 color, float p_white) {
 	return color_tonemapped / p_white_tonemapped;
 }
 
+// Based on Reinhard's extended formula, see equation 4 in https://doi.org/cjbgrt
 vec3 tonemap_reinhard(vec3 color, float p_white) {
-	return (p_white * color + color) / (color * p_white + p_white);
+	float white_squared = p_white * p_white;
+	vec3 white_squared_color = white_squared * color;
+	// Equivalent to color * (1 + color / white_squared) / (1 + color)
+	return (white_squared_color + color * color) / (white_squared_color + white_squared);
 }
 
 #define TONEMAPPER_LINEAR 0
@@ -85,7 +89,7 @@ vec3 tonemap_reinhard(vec3 color, float p_white) {
 #define TONEMAPPER_FILMIC 2
 #define TONEMAPPER_ACES 3
 
-vec3 apply_tonemapping(vec3 color, float p_white) { // inputs are LINEAR, always outputs clamped [0;1] color
+vec3 apply_tonemapping(vec3 color, float p_white) { // inputs are LINEAR
 	// Ensure color values passed to tonemappers are positive.
 	// They can be negative in the case of negative lights, which leads to undesired behavior.
 	if (tonemapper == TONEMAPPER_LINEAR) {

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -256,8 +256,12 @@ vec3 tonemap_aces(vec3 color, float white) {
 	return color_tonemapped / white_tonemapped;
 }
 
+// Based on Reinhard's extended formula, see equation 4 in https://doi.org/cjbgrt
 vec3 tonemap_reinhard(vec3 color, float white) {
-	return (white * color + color) / (color * white + white);
+	float white_squared = white * white;
+	vec3 white_squared_color = white_squared * color;
+	// Equivalent to color * (1 + color / white_squared) / (1 + color)
+	return (white_squared_color + color * color) / (white_squared_color + white_squared);
 }
 
 vec3 linear_to_srgb(vec3 color) {
@@ -272,7 +276,7 @@ vec3 linear_to_srgb(vec3 color) {
 #define TONEMAPPER_FILMIC 2
 #define TONEMAPPER_ACES 3
 
-vec3 apply_tonemapping(vec3 color, float white) { // inputs are LINEAR, always outputs clamped [0;1] color
+vec3 apply_tonemapping(vec3 color, float white) { // inputs are LINEAR
 	// Ensure color values passed to tonemappers are positive.
 	// They can be negative in the case of negative lights, which leads to undesired behavior.
 	if (params.tonemapper == TONEMAPPER_LINEAR) {


### PR DESCRIPTION
Fixes #93317 

This PR changes the formula for applying the Reinhard tonemap operator to correctly use equation 4 in [Reinhard's orginal 2002 paper](https://www-old.cs.utah.edu/docs/techreports/2002/pdf/UUCS-02-001.pdf) and updates relevant documentation accordingly. For more details see the discussion in #93317.

Here are some screenshots of the TPS demo with and without the fix applied, taken at various whitepoint values:

### With the fix
`white = 6.0`. This is the intended setting for the scene.
![With the fix at white = 6.0](https://github.com/godotengine/godot/assets/155747722/52325b29-9bd0-4457-9db8-895c0a7c80f9)
`white = 1.0`
![With the fix at white = 1.0](https://github.com/godotengine/godot/assets/155747722/5f4c991e-3e25-43c1-afd4-2edcb294c228)
`white = 0.5`
![With the fix at white = 0.5](https://github.com/godotengine/godot/assets/155747722/192d67f7-0504-4d39-ada2-cdef1e4de410)

### Without the fix (current master branch)
`white = 6.0`
![Without the fix at white = 6.0](https://github.com/godotengine/godot/assets/155747722/a43d8f66-3b04-43b8-8f80-726b698aac07)
`white = 1.0`
![Without the fix at white = 1.0](https://github.com/godotengine/godot/assets/155747722/61d118ea-c859-47be-9097-7ec8e11e2030)
`white = 0.5`
![Without the fix at white = 0.5](https://github.com/godotengine/godot/assets/155747722/b6f3b570-440e-4d94-b4be-82ec4dbe43d7)