### PR TITLE
Mention `fmod()` when relevant in GDScript error message about modulo types

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3116,7 +3116,11 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 				if (p_binary_op->reduced_value.get_type() == Variant::STRING) {
 					push_error(vformat(R"(%s in operator %s.)", p_binary_op->reduced_value, Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);
 				} else {
-					push_error(vformat(R"(Invalid operands to operator %s, %s and %s.)",
+					String message = "Invalid operands to operator %s, %s and %s.";
+					if (p_binary_op->variant_op == Variant::OP_MODULE && (p_binary_op->left_operand->reduced_value.get_type() == Variant::FLOAT || p_binary_op->right_operand->reduced_value.get_type() == Variant::FLOAT)) {
+						message += " Use \"fmod(x, y)\" instead.";
+					}
+					push_error(vformat(message,
 									   Variant::get_operator_name(p_binary_op->variant_op),
 									   Variant::get_type_name(p_binary_op->left_operand->reduced_value.get_type()),
 									   Variant::get_type_name(p_binary_op->right_operand->reduced_value.get_type())),
@@ -3152,7 +3156,11 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 		bool valid = false;
 		result = get_operation_type(p_binary_op->variant_op, left_type, right_type, valid, p_binary_op);
 		if (!valid) {
-			push_error(vformat(R"(Invalid operands "%s" and "%s" for "%s" operator.)", left_type.to_string(), right_type.to_string(), Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);
+			String message = vformat(R"(Invalid operands "%s" and "%s" for "%s" operator.)", left_type.to_string(), right_type.to_string(), Variant::get_operator_name(p_binary_op->variant_op));
+			if (p_binary_op->variant_op == Variant::OP_MODULE && (left_type.builtin_type == Variant::FLOAT || right_type.builtin_type == Variant::FLOAT)) {
+				message += " Use \"fmod(x, y)\" instead.";
+			}
+			push_error(message, p_binary_op);
 		} else if (!result.is_hard_type()) {
 			mark_node_unsafe(p_binary_op);
 		}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -780,6 +780,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (unlikely(!op_func)) {
 #ifdef DEBUG_ENABLED
 						err_text = "Invalid operands '" + Variant::get_type_name(a->get_type()) + "' and '" + Variant::get_type_name(b->get_type()) + "' in operator '" + Variant::get_operator_name(op) + "'.";
+						if (op == Variant::OP_MODULE && (a_type == Variant::FLOAT || b_type == Variant::FLOAT)) {
+							err_text += " Use \"fmod(x, y)\" instead.";
+						}
 #endif
 						initializer_mutex.unlock();
 						OPCODE_BREAK;
@@ -822,6 +825,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							err_text += " in operator '" + Variant::get_operator_name(op) + "'.";
 						} else {
 							err_text = "Invalid operands '" + Variant::get_type_name(a->get_type()) + "' and '" + Variant::get_type_name(b->get_type()) + "' in operator '" + Variant::get_operator_name(op) + "'.";
+							if (op == Variant::OP_MODULE && (a->get_type() == Variant::FLOAT || b->get_type() == Variant::FLOAT)) {
+								err_text += " Use \"fmod(x, y)\" instead.";
+							}
 						}
 						OPCODE_BREAK;
 					}


### PR DESCRIPTION
The hint is added if either operand is a float.

- This closes https://github.com/godotengine/godot-proposals/discussions/9996.

## Preview

```gdscript
extends Node2D


func _ready() -> void:
	print(7 % "test")
	print(7.0 % 4)
	print(7 % 4.0)
	print(7.0 % 4.0)
	
	print(float1 % float1)
	print(float1_typed % float1)
	print(float1 % float1_typed)
	print(float1_typed % float1_typed)
	print(float1 % int1)
	print(int1 % int1)
	print(int1_typed % int1_typed)
	print(2.0 % float1)
	print(2.0 % float1_typed)
	print(float1 % 1.0)
	print(2 % "test")
	print(int1 % "test")
	print(int1_typed % "test")
```

Results in:

<img width="647" height="838" alt="Screenshot 2025-09-04 at 16 09 15" src="https://github.com/user-attachments/assets/bbebe9e0-ee2c-479e-bea0-85ec9e331651" />
