### PR TITLE
Document ways to bypass certain GDScript warnings in the messages themselves

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5445,7 +5445,7 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 	if (p_source_node) {
 		if (p_target.kind == GDScriptParser::DataType::ENUM) {
 			if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT) {
-				parser->push_warning(p_source_node, GDScriptWarning::INT_AS_ENUM_WITHOUT_CAST);
+				parser->push_warning(p_source_node, GDScriptWarning::INT_AS_ENUM_WITHOUT_CAST, p_target.to_string());
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -120,9 +120,10 @@ String GDScriptWarning::get_message() const {
 		case INTEGER_DIVISION:
 			return "Integer division, decimal part will be discarded.";
 		case NARROWING_CONVERSION:
-			return "Narrowing conversion (float is converted to int and loses precision).";
+			return R"*(Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".)*";
 		case INT_AS_ENUM_WITHOUT_CAST:
-			return "Integer used when an enum value is expected. If this is intended cast the integer to the enum type.";
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(Integer is used when an enum value of type "%s" is expected. If this is intended, cast the integer to the enum type: "x as %s".)*", symbols[0], symbols[0]);
 		case INT_AS_ENUM_WITHOUT_MATCH:
 			CHECK_SYMBOLS(3);
 			return vformat(R"(Cannot %s %s as Enum "%s": no enum member has matching value.)", symbols[0], symbols[1], symbols[2]);

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_targets.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_targets.out
@@ -6,15 +6,15 @@ GDTEST_OK
 >> WARNING
 >> Line: 8
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 >> WARNING
 >> Line: 19
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 >> WARNING
 >> Line: 24
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 >> WARNING
 >> Line: 27
 >> CONFUSABLE_IDENTIFIER
@@ -22,8 +22,8 @@ GDTEST_OK
 >> WARNING
 >> Line: 31
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 >> WARNING
 >> Line: 35
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".

--- a/modules/gdscript/tests/scripts/parser/warnings/narrowing_conversion.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/narrowing_conversion.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 5
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".

--- a/modules/gdscript/tests/scripts/runtime/features/typed_assignment.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_assignment.out
@@ -2,11 +2,11 @@ GDTEST_OK
 >> WARNING
 >> Line: 6
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 >> WARNING
 >> Line: 8
 >> NARROWING_CONVERSION
->> Narrowing conversion (float is converted to int and loses precision).
+>> Narrowing conversion (float is converted to int and loses precision). If this is intended, cast the float to an integer: "int(x)".
 2
 2
 2


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/93328.

This is preferable to `@warning_ignore()` annotations, as this approach avoids taking up vertical space in the script.

## Preview

```gdscript
extends Node2D


func _ready() -> void:
	visibility_layer = 2.5
	process_mode = 0
```

Results in:

![image](https://github.com/godotengine/godot/assets/180032/80f2e2f5-3b86-4e60-becd-431afde21f07)
