### PR TITLE
Fix building with `use_volk=yes` on MacOS

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -16,14 +16,14 @@ if env["use_volk"]:
 if env["platform"] == "android":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])
 elif env["platform"] == "ios":
-    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_IOS_MVK"])
+    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_IOS_MVK", "VK_USE_PLATFORM_METAL_EXT"])
 elif env["platform"] == "linuxbsd":
     if env["x11"]:
         env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_XLIB_KHR"])
     if env["wayland"]:
         env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_WAYLAND_KHR"])
 elif env["platform"] == "macos":
-    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_MACOS_MVK"])
+    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_MACOS_MVK", "VK_USE_PLATFORM_METAL_EXT"])
 elif env["platform"] == "windows":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_WIN32_KHR"])
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -102,6 +102,10 @@ Error RenderingContextDriverVulkan::_initialize_instance_extensions() {
 	// This extension allows us to use the properties2 features to query additional device capabilities.
 	_register_requested_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
 
+#if defined(USE_VOLK) && (defined(MACOS_ENABLED) || defined(IOS_ENABLED))
+	_register_requested_instance_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, true);
+#endif
+
 	// Only enable debug utils in verbose mode or DEV_ENABLED.
 	// End users would get spammed with messages of varying verbosity due to the
 	// mess that thirdparty layers/extensions and drivers seem to leave in their
@@ -360,6 +364,11 @@ Error RenderingContextDriverVulkan::_initialize_instance() {
 
 	VkInstanceCreateInfo instance_info = {};
 	instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+
+#if defined(USE_VOLK) && (defined(MACOS_ENABLED) || defined(IOS_ENABLED))
+	instance_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
+
 	instance_info.pApplicationInfo = &app_info;
 	instance_info.enabledExtensionCount = enabled_extension_names.size();
 	instance_info.ppEnabledExtensionNames = enabled_extension_names.ptr();


### PR DESCRIPTION
Without the change in this PR, running `scons platform=macos arch=arm64 dev_build=yes use_volk=yes` I get these errors:

```
platform/macos/rendering_context_driver_vulkan_macos.mm:42:9: error: use of undeclared identifier 'VK_EXT_METAL_SURFACE_EXTENSION_NAME'
        return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
               ^
platform/macos/rendering_context_driver_vulkan_macos.mm:48:2: error: unknown type name 'VkMetalSurfaceCreateInfoEXT'; did you mean 'VkHeadlessSurfaceCreateInfoEXT'?
        VkMetalSurfaceCreateInfoEXT create_info = {};
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        VkHeadlessSurfaceCreateInfoEXT
thirdparty/vulkan/include/vulkan/vulkan_core.h:14897:3: note: 'VkHeadlessSurfaceCreateInfoEXT' declared here
} VkHeadlessSurfaceCreateInfoEXT;
  ^
platform/macos/rendering_context_driver_vulkan_macos.mm:50:14: error: no member named 'pLayer' in 'VkHeadlessSurfaceCreateInfoEXT'
        create_info.pLayer = *wpd->layer_ptr;
        ~~~~~~~~~~~ ^
platform/macos/rendering_context_driver_vulkan_macos.mm:53:17: error: use of undeclared identifier 'vkCreateMetalSurfaceEXT'; did you mean 'vkCreateHeadlessSurfaceEXT'?
        VkResult err = vkCreateMetalSurfaceEXT(instance_get(), &create_info, nullptr, &vk_surface);
                       ^~~~~~~~~~~~~~~~~~~~~~~
                       vkCreateHeadlessSurfaceEXT
thirdparty/volk/volk.h:1350:39: note: 'vkCreateHeadlessSurfaceEXT' declared here
extern PFN_vkCreateHeadlessSurfaceEXT vkCreateHeadlessSurfaceEXT;
```

With the changes in this PR, compilation succeeds, and loading MoltenVK via Volk seems to work in my testing!

However, I'm not terribly knowledgeable of either MacOS or Vulkan, so I'm not sure if this is the correct fix, or I've got some issue on my system.