### PR TITLE
Change default value for Visible Layer in canvas item

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -653,7 +653,7 @@
 		<member name="use_parent_material" type="bool" setter="set_use_parent_material" getter="get_use_parent_material" default="false">
 			If [code]true[/code], the parent [CanvasItem]'s [member material] is used as this node's material.
 		</member>
-		<member name="visibility_layer" type="int" setter="set_visibility_layer" getter="get_visibility_layer" default="1">
+		<member name="visibility_layer" type="int" setter="set_visibility_layer" getter="get_visibility_layer" default="4294967295">
 			The rendering layer in which this [CanvasItem] is rendered by [Viewport] nodes. A [Viewport] will render a [CanvasItem] if it and all its parents share a layer with the [Viewport]'s canvas cull mask.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -92,7 +92,7 @@ private:
 	} data;
 
 	int light_mask = 1;
-	uint32_t visibility_layer = 1;
+	uint32_t visibility_layer = 0xFFFFFFFF;
 
 	int z_index = 0;
 	bool z_relative = true;


### PR DESCRIPTION
Since tree chain is taken into account for the test of visible layer, changed the value to all layer active by default.
Fixes #93316

* *Bugsquad edit, see also for related PR: https://github.com/godotengine/godot/pull/93512*
