### PR TITLE
ResourceLoader: Revert workaround resource loading crashes due to buggy TLS

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -188,7 +188,7 @@ private:
 	static thread_local int load_nesting;
 	static thread_local WorkerThreadPool::TaskID caller_task_id;
 	static thread_local HashMap<int, HashMap<String, Ref<Resource>>> res_ref_overrides; // Outermost key is nesting level.
-	static thread_local Vector<String> *load_paths_stack; // A pointer to avoid broken TLS implementations from double-running the destructor.
+	static thread_local Vector<String> load_paths_stack;
 	static SafeBinaryMutex<BINARY_MUTEX_TAG> thread_load_mutex;
 	static HashMap<String, ThreadLoadTask> thread_load_tasks;
 	static bool cleaning_tasks;


### PR DESCRIPTION
With #85039, and as stated in the description thereof, #78977 should be safely revertable.