### PR TITLE
Remove `monospace/fixed-width` from the `ResourceImporterImageFont` name and description.

### DIFF
--- a/doc/classes/ResourceImporterImageFont.xml
+++ b/doc/classes/ResourceImporterImageFont.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterImageFont" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Imports a fixed-width bitmap font where all glyphs have the same width and height.
+		Imports a bitmap font where all glyphs have the same width and height.
 	</brief_description>
 	<description>
-		This image-based workflow can be easier to use than [ResourceImporterBMFont], but it requires all glyphs to have the same width and height. This makes [ResourceImporterImageFont] most suited to fixed-width fonts.
+		This image-based workflow can be easier to use than [ResourceImporterBMFont], but it requires all glyphs to have the same width and height, glyph advances and drawing offsets can be customized. This makes [ResourceImporterImageFont] most suited to fixed-width fonts.
 		See also [ResourceImporterDynamicFont].
 	</description>
 	<tutorials>

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -38,7 +38,7 @@ String ResourceImporterImageFont::get_importer_name() const {
 }
 
 String ResourceImporterImageFont::get_visible_name() const {
-	return "Font Data (Monospace Image Font)";
+	return "Font Data (Image Font)";
 }
 
 void ResourceImporterImageFont::get_recognized_extensions(List<String> *p_extensions) const {


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/93199

The source image for the `ResourceImporterImageFont` is expected to be a uniform grid of characters, but since advances and kerning can be customized, the resulting font is not necessarily monospaced.