### PR TITLE
[3.x] Physics Interpolation - refactor client interpolation pump

### DIFF
--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -24,6 +24,7 @@
 			<description>
 				When using physics interpolation, there will be circumstances in which you want to know the interpolated (displayed) transform of a node rather than the standard transform (which may only be accurate to the most recent physics tick).
 				This is particularly important for frame-based operations that take place in [method Node._process], rather than [method Node._physics_process]. Examples include [Camera]s focusing on a node, or finding where to fire lasers from on a frame rather than physics tick.
+				[b]Note:[/b] This function creates an interpolation pump on the [Spatial] the first time it is called, which can respond to physics interpolation resets. If you get problems with "streaking" when initially following a [Spatial], be sure to call [method get_global_transform_interpolated] at least once [i]before[/i] resetting the [Spatial] physics interpolation.
 			</description>
 		</method>
 		<method name="get_parent_spatial" qualifiers="const">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2367,13 +2367,13 @@ bool Main::iteration() {
 
 		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
-		PhysicsServer::get_singleton()->flush_queries();
-
 		// Prepare the fixed timestep interpolated nodes
-		// BEFORE they are updated by the physics 2D,
+		// BEFORE they are updated by the physics,
 		// otherwise the current and previous transforms
 		// may be the same, and no interpolation takes place.
 		OS::get_singleton()->get_main_loop()->iteration_prepare();
+
+		PhysicsServer::get_singleton()->flush_queries();
 
 		Physics2DServer::get_singleton()->sync();
 		Physics2DServer::get_singleton()->flush_queries();

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -407,7 +407,14 @@ Transform Spatial::get_global_transform_interpolated() {
 	// Pass through if physics interpolation is switched off.
 	// This is a convenience, as it allows you to easy turn off interpolation
 	// without changing any code.
-	if (Engine::get_singleton()->is_in_physics_frame() || !is_physics_interpolated_and_enabled()) {
+	if (!is_physics_interpolated_and_enabled()) {
+		return get_global_transform();
+	}
+
+	// If we are in the physics frame, the interpolated global transform is meaningless.
+	// However, there is an exception, we may want to use this as a means of starting off the client
+	// interpolation pump if not already started (when _is_physics_interpolated_client_side() is false).
+	if (Engine::get_singleton()->is_in_physics_frame() && _is_physics_interpolated_client_side()) {
 		return get_global_transform();
 	}
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -559,6 +559,11 @@ void SceneTree::iteration_prepare() {
 		// are flushed before pumping the interpolation prev and currents.
 		flush_transform_notifications();
 		VisualServer::get_singleton()->tick();
+
+		// Any objects performing client physics interpolation
+		// should be given an opportunity to keep their previous transforms
+		// up to date before each new physics tick.
+		_client_physics_interpolation.physics_process();
 	}
 }
 
@@ -574,11 +579,6 @@ bool SceneTree::iteration(float p_time) {
 	root_lock++;
 
 	current_frame++;
-
-	// Any objects performing client physics interpolation
-	// should be given an opportunity to keep their previous transforms
-	// up to take before each new physics tick.
-	_client_physics_interpolation.physics_process();
 
 	flush_transform_notifications();
 


### PR DESCRIPTION
* Move client interpolation pump to earlier in the iteration before 3D physics synced
* Allow `get_global_transform_interpolated()` to prime the client interpolation inside a physics tick

Fixes https://github.com/godotengine/godot/pull/92391#issuecomment-2177431834

## Notes
* Client interpolation is now pumped at the same place as in master, this keeps 3.x and 4.x in sync.
* There wasn't an obvious bug in 3.x from the old location, but on balance the new position makes more sense.
* Allowing `get_global_transform_interpolated()` to prime the client pump is _non-obvious_, so a note is added to classref, and should probably be added to docs later.
* It allows both starting the pump from a physics tick, and allows for moving starts with client interpolation, which previously were not supported.

## Discussion
We could alternatively have a specific function to prime the client interpolation, but it isn't necessary from an engine perspective. But could be considered if it would make the user experience more straight forward.

Prior to this, the user didn't need to be aware of implementation details (they would assume `get_global_transform_interpolated()` could be called anytime and would always work as usual), but the need for priming is important for initial placement and resets where a moving start is required.

It doesn't seem easy to remove the need for priming, because client interpolation is _expensive_ (both in terms of extra data and processing), and we only want it to operate on those few nodes that are actively queried.

## MRP

This project is derived from the MRP in the linked issue, but has one important difference, it calls `get_global_transform_interpolated()` _prior_ to resetting the ball, in order to prime the client interpolation for the moving start.

[matmas_get_interpolated_streak.zip](https://github.com/user-attachments/files/15897303/matmas_get_interpolated_streak.zip)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
