### PR TITLE
AnimatedTexture: Fix crash when loaded from a thread

### DIFF
--- a/scene/resources/animated_texture.cpp
+++ b/scene/resources/animated_texture.cpp
@@ -270,13 +270,18 @@ void AnimatedTexture::_bind_methods() {
 	BIND_CONSTANT(MAX_FRAMES);
 }
 
+void AnimatedTexture::_finish_non_thread_safe_setup() {
+	RenderingServer::get_singleton()->connect("frame_pre_draw", callable_mp(this, &AnimatedTexture::_update_proxy));
+}
+
 AnimatedTexture::AnimatedTexture() {
 	//proxy = RS::get_singleton()->texture_create();
 	proxy_ph = RS::get_singleton()->texture_2d_placeholder_create();
 	proxy = RS::get_singleton()->texture_proxy_create(proxy_ph);
 
 	RenderingServer::get_singleton()->texture_set_force_redraw_if_visible(proxy, true);
-	RenderingServer::get_singleton()->connect("frame_pre_draw", callable_mp(this, &AnimatedTexture::_update_proxy));
+
+	MessageQueue::get_main_singleton()->push_callable(callable_mp(this, &AnimatedTexture::_finish_non_thread_safe_setup));
 }
 
 AnimatedTexture::~AnimatedTexture() {

--- a/scene/resources/animated_texture.h
+++ b/scene/resources/animated_texture.h
@@ -65,6 +65,7 @@ private:
 	uint64_t prev_ticks = 0;
 
 	void _update_proxy();
+	void _finish_non_thread_safe_setup();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Signals (like most, or all?, of the `Object` API) is not thread-safe. `AnimatedTexture` tries to connect to `RenderingServer`'s singal `frame_pre_draw` in the constructor. The issue is that such constructor may be running on any thread.

An alternative solution would be to make all the signal API in `Object` virtual so that `RenderingServer` can wrap all the functions with the `server_wrap_mt_common.h` utilities. However, that would harm performance in every other case.

In conclusion, it's OK to consider the specification for writing resource classes to include it should only deal with thread-safe APIs.