### PR TITLE
Fix not using `encoding="utf-8"` when writing to files or reading from them

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -566,7 +566,7 @@ if env["build_profile"] != "":
     import json
 
     try:
-        ft = json.load(open(env["build_profile"]))
+        ft = json.load(open(env["build_profile"], "r", encoding="utf-8"))
         if "disabled_classes" in ft:
             env.disabled_classes = ft["disabled_classes"]
         if "disabled_build_options" in ft:

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -16,7 +16,7 @@ def parse_template(inherits, source, delimiter):
     meta_prefix = delimiter + " meta-"
     meta = ["name", "description", "version", "space-indent"]
 
-    with open(source) as f:
+    with open(source, "r", encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             if line.startswith(meta_prefix):

--- a/methods.py
+++ b/methods.py
@@ -347,7 +347,7 @@ def detect_modules(search_path, recursive=False):
         # Godot sources when using `custom_modules` build option.
         version_path = os.path.join(path, "version.py")
         if os.path.exists(version_path):
-            with open(version_path) as f:
+            with open(version_path, "r", encoding="utf-8") as f:
                 if 'short_name = "godot"' in f.read():
                     return True
         return False
@@ -989,7 +989,7 @@ def show_progress(env):
             pass
 
     try:
-        with open(node_count_fname) as f:
+        with open(node_count_fname, "r", encoding="utf-8") as f:
             node_count_max = int(f.readline())
     except Exception:
         pass

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -37,7 +37,7 @@ def generate_bundle(target, source, env):
             shutil.copy(target_bin, app_dir + "/Contents/MacOS/Godot")
         version = get_build_version(False)
         short_version = get_build_version(True)
-        with open(Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", "rt") as fin:
+        with open(Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", "rt", encoding="utf-8") as fin:
             with open(app_dir + "/Contents/Info.plist", "wt", encoding="utf-8", newline="\n") as fout:
                 for line in fin:
                     line = line.replace("$version", version)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -393,7 +393,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
 
         # Ensure we have a location to write captured output to, in case of false positives.
         capture_path = methods.base_folder_path + "platform/windows/msvc_capture.log"
-        with open(capture_path, "wt"):
+        with open(capture_path, "wt", encoding="utf-8"):
             pass
 
         old_spawn = env["SPAWN"]
@@ -417,7 +417,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
             ret = old_spawn(sh, escape, cmd, args, env)
 
             try:
-                with open(tmp_stdout_name, encoding="oem", errors="replace") as tmp_stdout:
+                with open(tmp_stdout_name, "r", encoding=sys.stdout.encoding, errors="replace") as tmp_stdout:
                     lines = tmp_stdout.read().splitlines()
                 os.remove(tmp_stdout_name)
             except OSError:
@@ -436,7 +436,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
                 if not caught and (is_cl and re_cl_capture.match(line)) or (not is_cl and re_link_capture.match(line)):
                     caught = True
                     try:
-                        with open(capture_path, "a") as log:
+                        with open(capture_path, "a", encoding=sys.stdout.encoding) as log:
                             log.write(line + "\n")
                     except OSError:
                         print_warning(f'Failed to log captured line: "{line}".')


### PR DESCRIPTION
Fixes: #93305 (Didn't test myself though)
Related: #89858

Different encodings may be used by different platfroms, so making all files always use the same encoding feels like a nice change. Also adds missing `"r"`, but it's more of a style change