### PR TITLE
Add editor check for compatible visibility layers for `CanvasItem`

### DIFF
--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -141,6 +141,9 @@ private:
 	virtual void _top_level_changed();
 	virtual void _top_level_changed_on_parent();
 
+	void _visibility_layer_changed();
+	void _visibility_layer_changed_on_parent();
+
 	void _redraw_callback();
 
 	void _enter_canvas();


### PR DESCRIPTION
The wording might need some improvement, and need confirmation that this catches the full behavior of this feature. It doesn't check the cull layers of any viewport, can add if desired but keeping it simple for just the hierarchy (and an error for the viewport might be annoying if you *want* them to be invisible at the start just by the layers, but the hierarchy itself would *usually* be an accident I'd say)

In short: This checks that the condition for visibility is met, i.e. that a `CanvasItem` has at least one layer shared with *all* parents until either the root or one parent that is top-level. To avoid annoying potential false positives it also doesn't check if the layers for the node itself is empty, that feels like something intentional and shouldn't throw a warning

Correctly updates when layers of parents update, as well as when top-level changes for parents and self

* Closes: https://github.com/godotengine/godot/issues/93316

See (I'd say regardless of that one being merged this one is useful, but not vice versa):
* https://github.com/godotengine/godot/pull/93335
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
