### PR TITLE
Fix trackpads and graphics tablets being recognized as controllers on Linux/*BSD

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -374,6 +374,12 @@ void JoypadLinux::open_joypad(const char *p_path) {
 			name = namebuf;
 		}
 
+		for (const String &word : name.to_lower().split(" ")) {
+			if (banned_words.has(word)) {
+				return;
+			}
+		}
+
 		if (ioctl(fd, EVIOCGID, &inpid) < 0) {
 			close(fd);
 			return;

--- a/platform/linuxbsd/joypad_linux.h
+++ b/platform/linuxbsd/joypad_linux.h
@@ -94,6 +94,21 @@ private:
 
 	Vector<String> attached_devices;
 
+	// List of lowercase words that will prevent the controller from being recognized if its name matches.
+	// This is done to prevent trackpads, graphics tablets and motherboard LED controllers from being
+	// recognized as controllers (and taking up controller ID slots as a result).
+	// Only whole words are matched within the controller name string. The match is case-insensitive.
+	const Vector<String> banned_words = {
+		"touchpad", // Matches e.g. "SynPS/2 Synaptics TouchPad", "Sony Interactive Entertainment DualSense Wireless Controller Touchpad"
+		"trackpad",
+		"clickpad",
+		"keyboard", // Matches e.g. "PG-90215 Keyboard", "Usb Keyboard Usb Keyboard Consumer Control"
+		"mouse", // Matches e.g. "Mouse passthrough"
+		"pen", // Matches e.g. "Wacom One by Wacom S Pen"
+		"finger", // Matches e.g. "Wacom HID 495F Finger"
+		"led", // Matches e.g. "ASRock LED Controller"
+	};
+
 	static void monitor_joypads_thread_func(void *p_user);
 	void monitor_joypads_thread_run();
 


### PR DESCRIPTION
On my setup, my DualSense is finally at controller ID 0 as the *ASRock LED Controller* is no longer registered and takes up ID 0 as a result. The DualSense's trackpad is also no longer seen as a separate (non-functional) controller.

Tested both with `udev=yes` and `udev=no`, including hotplugging. Thanks to @geekley for providing the list of banned words (to which I added `led`) :slightly_smiling_face: 

- This closes https://github.com/godotengine/godot/issues/59250.

**Testing project:** https://github.com/godotengine/godot-demo-projects/tree/master/misc/joypads
