### PR TITLE
Fix typo in preprocessor symbol

### DIFF
--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -31,7 +31,7 @@
 #ifndef SERVER_WRAP_MT_COMMON_H
 #define SERVER_WRAP_MT_COMMON_H
 
-#ifdef DEBIG_ENABLED
+#ifdef DEBUG_ENABLED
 #define MAIN_THREAD_SYNC_CHECK                                                                         \
 	if (unlikely(Thread::is_main_thread() && Engine::get_singleton()->notify_frame_server_synced())) { \
 		MAIN_THREAD_SYNC_WARN                                                                          \


### PR DESCRIPTION
There was a typo in preprocessor symbol. 
