### PR TITLE
Ignore all material that use transparency in OccluderInstance3D baking.

### DIFF
--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -66,6 +66,7 @@ struct ShaderData {
 	virtual void set_code(const String &p_Code) = 0;
 	virtual bool is_animated() const = 0;
 	virtual bool casts_shadows() const = 0;
+	virtual bool needs_alpha_pass() const = 0;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const { return RS::ShaderNativeSourceCode(); }
 
 	virtual ~ShaderData() {}
@@ -172,10 +173,11 @@ struct CanvasShaderData : public ShaderData {
 
 	uint64_t vertex_input_mask;
 
-	virtual void set_code(const String &p_Code);
-	virtual bool is_animated() const;
-	virtual bool casts_shadows() const;
-	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+	virtual void set_code(const String &p_Code) override;
+	virtual bool is_animated() const override;
+	virtual bool casts_shadows() const override;
+	virtual bool needs_alpha_pass() const override;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 	CanvasShaderData();
 	virtual ~CanvasShaderData();
@@ -217,10 +219,11 @@ struct SkyShaderData : public ShaderData {
 	bool uses_quarter_res;
 	bool uses_light;
 
-	virtual void set_code(const String &p_Code);
-	virtual bool is_animated() const;
-	virtual bool casts_shadows() const;
-	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+	virtual void set_code(const String &p_Code) override;
+	virtual bool is_animated() const override;
+	virtual bool casts_shadows() const override;
+	virtual bool needs_alpha_pass() const override;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 	SkyShaderData();
 	virtual ~SkyShaderData();
 };
@@ -332,10 +335,11 @@ struct SceneShaderData : public ShaderData {
 
 	uint64_t vertex_input_mask;
 
-	virtual void set_code(const String &p_Code);
-	virtual bool is_animated() const;
-	virtual bool casts_shadows() const;
-	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+	virtual void set_code(const String &p_Code) override;
+	virtual bool is_animated() const override;
+	virtual bool casts_shadows() const override;
+	virtual bool needs_alpha_pass() const override;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 	SceneShaderData();
 	virtual ~SceneShaderData();
@@ -384,10 +388,11 @@ struct ParticlesShaderData : public ShaderData {
 	bool userdatas_used[PARTICLES_MAX_USERDATAS] = {};
 	uint32_t userdata_count;
 
-	virtual void set_code(const String &p_Code);
-	virtual bool is_animated() const;
-	virtual bool casts_shadows() const;
-	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+	virtual void set_code(const String &p_Code) override;
+	virtual bool is_animated() const override;
+	virtual bool casts_shadows() const override;
+	virtual bool needs_alpha_pass() const override;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 	ParticlesShaderData() {}
 	virtual ~ParticlesShaderData();
@@ -615,6 +620,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
 	virtual void material_set_render_priority(RID p_material, int priority) override;
+
+	virtual bool material_needs_alpha_pass(RID p_material) const override;
 
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -508,9 +508,8 @@ bool OccluderInstance3D::get_bake_mask_value(int p_layer_number) const {
 }
 
 bool OccluderInstance3D::_bake_material_check(Ref<Material> p_material) {
-	StandardMaterial3D *standard_mat = Object::cast_to<StandardMaterial3D>(p_material.ptr());
-	if (standard_mat && standard_mat->get_transparency() != StandardMaterial3D::TRANSPARENCY_DISABLED) {
-		return false;
+	if (p_material.is_valid()) {
+		return !RS::get_singleton()->material_needs_alpha_pass(p_material->get_rid());
 	}
 	return true;
 }

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -107,6 +107,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override {}
 
+	virtual bool material_needs_alpha_pass(RID p_material) const override { return false; }
+
 	virtual bool material_is_animated(RID p_material) override { return false; }
 	virtual bool material_casts_shadows(RID p_material) override { return false; }
 	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -362,6 +362,10 @@ bool Fog::FogShaderData::casts_shadows() const {
 	return false;
 }
 
+bool Fog::FogShaderData::needs_alpha_pass() const {
+	return false;
+}
+
 RS::ShaderNativeSourceCode Fog::FogShaderData::get_native_source_code() const {
 	Fog *fog_singleton = Fog::get_singleton();
 

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -199,10 +199,11 @@ private:
 
 		bool uses_time = false;
 
-		virtual void set_code(const String &p_Code);
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual void set_code(const String &p_Code) override;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		FogShaderData() {}
 		virtual ~FogShaderData();

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -162,6 +162,10 @@ bool SkyRD::SkyShaderData::casts_shadows() const {
 	return false;
 }
 
+bool SkyRD::SkyShaderData::needs_alpha_pass() const {
+	return false;
+}
+
 RS::ShaderNativeSourceCode SkyRD::SkyShaderData::get_native_source_code() const {
 	RendererSceneRenderRD *scene_singleton = static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton);
 

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -123,10 +123,11 @@ private:
 		bool uses_quarter_res = false;
 		bool uses_light = false;
 
-		virtual void set_code(const String &p_Code);
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual void set_code(const String &p_Code) override;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		SkyShaderData() {}
 		virtual ~SkyShaderData();

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -421,6 +421,14 @@ bool SceneShaderForwardClustered::ShaderData::casts_shadows() const {
 	return !has_alpha || (uses_depth_prepass_alpha && !(depth_draw == DEPTH_DRAW_DISABLED || depth_test == DEPTH_TEST_DISABLED));
 }
 
+bool SceneShaderForwardClustered::ShaderData::needs_alpha_pass() const {
+	bool has_read_screen_alpha = uses_screen_texture || uses_depth_texture || uses_normal_texture;
+	bool has_base_alpha = (uses_alpha && (!uses_alpha_clip || uses_alpha_antialiasing)) || has_read_screen_alpha;
+	bool has_alpha = has_base_alpha || uses_blend_alpha;
+
+	return has_alpha || depth_draw == DEPTH_DRAW_DISABLED || depth_test == DEPTH_TEST_DISABLED;
+}
+
 RS::ShaderNativeSourceCode SceneShaderForwardClustered::ShaderData::get_native_source_code() const {
 	SceneShaderForwardClustered *shader_singleton = (SceneShaderForwardClustered *)SceneShaderForwardClustered::singleton;
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -188,11 +188,12 @@ public:
 		uint64_t last_pass = 0;
 		uint32_t index = 0;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code) override;
 
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		SelfList<ShaderData> shader_list_element;
 		ShaderData();

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -373,6 +373,14 @@ bool SceneShaderForwardMobile::ShaderData::casts_shadows() const {
 	return !has_alpha || (uses_depth_prepass_alpha && !(depth_draw == DEPTH_DRAW_DISABLED || depth_test == DEPTH_TEST_DISABLED));
 }
 
+bool SceneShaderForwardMobile::ShaderData::needs_alpha_pass() const {
+	bool has_read_screen_alpha = uses_screen_texture || uses_depth_texture || uses_normal_texture;
+	bool has_base_alpha = (uses_alpha && (!uses_alpha_clip || uses_alpha_antialiasing)) || has_read_screen_alpha;
+	bool has_alpha = has_base_alpha || uses_blend_alpha;
+
+	return has_alpha || depth_draw == DEPTH_DRAW_DISABLED || depth_test == DEPTH_TEST_DISABLED;
+}
+
 RS::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderData::get_native_source_code() const {
 	SceneShaderForwardMobile *shader_singleton = (SceneShaderForwardMobile *)SceneShaderForwardMobile::singleton;
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -140,10 +140,11 @@ public:
 		uint64_t last_pass = 0;
 		uint32_t index = 0;
 
-		virtual void set_code(const String &p_Code);
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual void set_code(const String &p_Code) override;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		SelfList<ShaderData> shader_list_element;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2379,6 +2379,10 @@ bool RendererCanvasRenderRD::CanvasShaderData::casts_shadows() const {
 	return false;
 }
 
+bool RendererCanvasRenderRD::CanvasShaderData::needs_alpha_pass() const {
+	return false;
+}
+
 RS::ShaderNativeSourceCode RendererCanvasRenderRD::CanvasShaderData::get_native_source_code() const {
 	RendererCanvasRenderRD *canvas_singleton = static_cast<RendererCanvasRenderRD *>(RendererCanvasRender::singleton);
 	return canvas_singleton->shader.canvas_shader.version_get_native_source_code(version);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -179,10 +179,11 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		bool uses_sdf = false;
 		bool uses_time = false;
 
-		virtual void set_code(const String &p_Code);
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual void set_code(const String &p_Code) override;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		CanvasShaderData() {}
 		virtual ~CanvasShaderData();

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2188,6 +2188,14 @@ void MaterialStorage::material_set_render_priority(RID p_material, int priority)
 	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
 }
 
+bool MaterialStorage::material_needs_alpha_pass(RID p_material) const {
+	const Material *material = material_owner.get_or_null(p_material);
+	ERR_FAIL_NULL_V(material, false);
+	ERR_FAIL_NULL_V(material->shader, false);
+	ERR_FAIL_NULL_V(material->shader->data, false);
+	return material->shader->data->needs_alpha_pass();
+}
+
 bool MaterialStorage::material_is_animated(RID p_material) {
 	Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_NULL_V(material, false);

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -70,6 +70,7 @@ public:
 		virtual void set_code(const String &p_Code) = 0;
 		virtual bool is_animated() const = 0;
 		virtual bool casts_shadows() const = 0;
+		virtual bool needs_alpha_pass() const = 0;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const { return RS::ShaderNativeSourceCode(); }
 
 		virtual ~ShaderData() {}
@@ -426,6 +427,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
 	virtual void material_set_render_priority(RID p_material, int priority) override;
+
+	virtual bool material_needs_alpha_pass(RID p_material) const override;
 
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1717,6 +1717,10 @@ bool ParticlesStorage::ParticlesShaderData::casts_shadows() const {
 	return false;
 }
 
+bool ParticlesStorage::ParticlesShaderData::needs_alpha_pass() const {
+	return false;
+}
+
 RS::ShaderNativeSourceCode ParticlesStorage::ParticlesShaderData::get_native_source_code() const {
 	return ParticlesStorage::get_singleton()->particles_shader.shader.version_get_native_source_code(version);
 }

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -357,10 +357,11 @@ private:
 		bool userdatas_used[ParticlesShader::MAX_USERDATAS] = {};
 		uint32_t userdata_count = 0;
 
-		virtual void set_code(const String &p_Code);
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		virtual void set_code(const String &p_Code) override;
+		virtual bool is_animated() const override;
+		virtual bool casts_shadows() const override;
+		virtual bool needs_alpha_pass() const override;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const override;
 
 		ParticlesShaderData() {}
 		virtual ~ParticlesShaderData();

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -251,6 +251,8 @@ public:
 	FUNC2(material_set_render_priority, RID, int)
 	FUNC2(material_set_next_pass, RID, RID)
 
+	FUNC1RC(bool, material_needs_alpha_pass, RID)
+
 	/* MESH API */
 
 //from now on, calls forwarded to this singleton

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -85,6 +85,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
 
+	virtual bool material_needs_alpha_pass(RID p_material) const = 0;
+
 	virtual bool material_is_animated(RID p_material) = 0;
 	virtual bool material_casts_shadows(RID p_material) = 0;
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -242,6 +242,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
 
+	virtual bool material_needs_alpha_pass(RID p_material) const = 0;
+
 	/* MESH API */
 
 	enum ArrayType {


### PR DESCRIPTION
Add material_needs_alpha_pass on MaterialStorage to identify shader that activate transparency and ignore them while baking occluder 3d mesh

Should resolve : https://github.com/godotengine/godot/issues/91030