### PR TITLE
Don't rescan filesystem when adding new directory

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2574,6 +2574,35 @@ void EditorFileSystem::move_group_file(const String &p_path, const String &p_new
 	}
 }
 
+void EditorFileSystem::add_new_directory(const String &p_path) {
+	String path = p_path.get_base_dir();
+	EditorFileSystemDirectory *parent = filesystem;
+	int base = p_path.count("/");
+	int max_bit = base + 1;
+
+	while (path != "res://") {
+		EditorFileSystemDirectory *dir = get_filesystem_path(path);
+		if (dir) {
+			parent = dir;
+			break;
+		}
+		path = path.get_base_dir();
+		base--;
+	}
+
+	for (int i = base; i < max_bit; i++) {
+		EditorFileSystemDirectory *efd = memnew(EditorFileSystemDirectory);
+		efd->parent = parent;
+		efd->name = p_path.get_slice("/", i);
+		parent->subdirs.push_back(efd);
+
+		if (i == base) {
+			parent->subdirs.sort_custom<DirectoryComparator>();
+		}
+		parent = efd;
+	}
+}
+
 ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate) {
 	if (!p_path.is_resource_file() || p_path.begins_with(ProjectSettings::get_singleton()->get_project_data_path())) {
 		// Saved externally (configuration file) or internal file, do not assign an ID.

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -207,6 +207,12 @@ class EditorFileSystem : public Node {
 		ScanProgress get_sub(int p_current, int p_total) const;
 	};
 
+	struct DirectoryComparator {
+		bool operator()(const EditorFileSystemDirectory *p_a, const EditorFileSystemDirectory *p_b) const {
+			return p_a->name.filenocasecmp_to(p_b->name) < 0;
+		}
+	};
+
 	void _save_filesystem_cache();
 	void _save_filesystem_cache(EditorFileSystemDirectory *p_dir, Ref<FileAccess> p_file);
 
@@ -325,6 +331,8 @@ public:
 
 	bool is_group_file(const String &p_path) const;
 	void move_group_file(const String &p_path, const String &p_new_path);
+
+	void add_new_directory(const String &p_path);
 
 	static bool _should_skip_directory(const String &p_path);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1326,6 +1326,15 @@ void FileSystemDock::_fs_changed() {
 	set_process(false);
 }
 
+void FileSystemDock::_directory_created(const String &p_path) {
+	if (!DirAccess::exists(p_path)) {
+		return;
+	}
+	EditorFileSystem::get_singleton()->add_new_directory(p_path);
+	_update_tree(get_uncollapsed_paths());
+	_update_file_list(true);
+}
+
 void FileSystemDock::_set_scanning_mode() {
 	button_hist_prev->set_disabled(true);
 	button_hist_next->set_disabled(true);
@@ -4142,7 +4151,7 @@ FileSystemDock::FileSystemDock() {
 
 	make_dir_dialog = memnew(DirectoryCreateDialog);
 	add_child(make_dir_dialog);
-	make_dir_dialog->connect("dir_created", callable_mp(this, &FileSystemDock::_rescan).unbind(1));
+	make_dir_dialog->connect("dir_created", callable_mp(this, &FileSystemDock::_directory_created));
 
 	make_scene_dialog = memnew(SceneCreateDialog);
 	add_child(make_scene_dialog);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -262,6 +262,7 @@ private:
 	void _toggle_file_display();
 	void _set_file_display(bool p_active);
 	void _fs_changed();
+	void _directory_created(const String &p_path);
 
 	void _select_file(const String &p_path, bool p_select_in_favorites = false);
 	void _tree_activate_file();


### PR DESCRIPTION
Part of #50576
I decided to split #87917 into smaller parts and use a different approach. Instead of guessing new file tree and doing a shadow scan, I skip scanning completely and manually add entries to EditorFileSystem. Hopefully every case in #50576 can be fixed this way.