### PR TITLE
Clarify lightmap rebaking being required for LightmapProbe changes

### DIFF
--- a/doc/classes/LightmapProbe.xml
+++ b/doc/classes/LightmapProbe.xml
@@ -4,8 +4,9 @@
 		Represents a single manually placed probe for dynamic object lighting with [LightmapGI].
 	</brief_description>
 	<description>
-		[LightmapProbe] represents the position of a single manually placed probe for dynamic object lighting with [LightmapGI].
+		[LightmapProbe] represents the position of a single manually placed probe for dynamic object lighting with [LightmapGI]. Lightmap probes affect the lighting of [GeometryInstance3D]-derived nodes that have their [member GeometryInstance3D.gi_mode] set to [constant GeometryInstance3D.GI_MODE_DYNAMIC].
 		Typically, [LightmapGI] probes are placed automatically by setting [member LightmapGI.generate_probes_subdiv] to a value other than [constant LightmapGI.GENERATE_PROBES_DISABLED]. By creating [LightmapProbe] nodes before baking lightmaps, you can add more probes in specific areas for greater detail, or disable automatic generation and rely only on manually placed probes instead.
+		[b]Note:[/b] [LightmapProbe] nodes that are placed after baking lightmaps are ignored by dynamic objects. You must bake lightmaps again after creating or modifying [LightmapProbe]s for the probes to be effective.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
- See https://github.com/godotengine/godot-benchmarks/pull/74.
