### PR TITLE
Fix Subviewport keeps using removed Camera3D child.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4251,8 +4251,7 @@ bool Viewport::_camera_3d_add(Camera3D *p_camera) {
 void Viewport::_camera_3d_remove(Camera3D *p_camera) {
 	camera_3d_set.erase(p_camera);
 	if (camera_3d == p_camera) {
-		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
-		camera_3d = nullptr;
+		_camera_3d_set(nullptr);
 	}
 }
 


### PR DESCRIPTION
Fix #92869 

`_camera_3d_remove()` changed `camera_3d` directly instead of calling `_camera_3d_set()`, which failed to change the `camera` in `RendererViewport`. Now use `_camera_3d_set()` instead.

https://github.com/godotengine/godot/assets/63407648/9ec33f83-dd50-4229-a77f-40dce2ca323d

