### PR TITLE
Add button unit test

### DIFF
--- a/tests/scene/test_button.h
+++ b/tests/scene/test_button.h
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  test_button.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_BUTTON_H
+#define TEST_BUTTON_H
+
+#include "scene/gui/button.h"
+#include "scene/main/window.h"
+
+#include "tests/test_macros.h"
+
+namespace TestButton {
+TEST_CASE("[SceneTree][Button] is_hovered()") {
+	// Create new button instance.
+	Button *button = memnew(Button);
+	CHECK(button != nullptr);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Set up button's size and position.
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Button should initially be not hovered.
+	CHECK(button->is_hovered() == false);
+
+	// Simulate mouse entering the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+	CHECK(button->is_hovered() == true);
+
+	// Simulate mouse exiting the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(150, 150), MouseButtonMask::NONE, Key::NONE);
+	CHECK(button->is_hovered() == false);
+
+	memdelete(button);
+}
+
+} //namespace TestButton
+#endif // TEST_BUTTON_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -104,6 +104,7 @@
 #include "tests/scene/test_animation.h"
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"
+#include "tests/scene/test_button.h"
 #include "tests/scene/test_camera_2d.h"
 #include "tests/scene/test_control.h"
 #include "tests/scene/test_curve.h"


### PR DESCRIPTION
This is part of issue #43440 

Added a unit test for the is_hovered() method that covers when a button is first initialized, hovered over, and when the mouse exits the button.

