### PR TITLE
[3.x] Physics Interpolation - Fix behavior on pause

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -295,6 +295,11 @@ void Camera2D::_notification(int p_what) {
 			_interpolation_data.xform_curr = get_camera_transform();
 			_interpolation_data.xform_prev = _interpolation_data.xform_curr;
 		} break;
+		case NOTIFICATION_PAUSED: {
+			if (is_physics_interpolated_and_enabled()) {
+				_update_scroll();
+			}
+		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!smoothing_active && !is_physics_interpolated_and_enabled()) {
 				_update_scroll();

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -226,6 +226,12 @@ void Camera::_notification(int p_what) {
 				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
 			}
 		} break;
+		case NOTIFICATION_PAUSED: {
+			if (is_physics_interpolated_and_enabled() && is_inside_tree() && is_visible_in_tree()) {
+				_physics_interpolation_ensure_transform_calculated(true);
+				VisualServer::get_singleton()->camera_set_transform(camera, _interpolation_data.camera_xform_interpolated);
+			}
+		} break;
 		case NOTIFICATION_EXIT_WORLD: {
 			if (!get_tree()->is_node_being_edited(this)) {
 				if (is_current()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -131,6 +131,11 @@ void Node::_notification(int p_notification) {
 				data.path_cache = nullptr;
 			}
 		} break;
+		case NOTIFICATION_PAUSED: {
+			if (is_physics_interpolated_and_enabled() && is_inside_tree()) {
+				reset_physics_interpolation();
+			}
+		} break;
 		case NOTIFICATION_PATH_CHANGED: {
 			if (data.path_cache) {
 				memdelete(data.path_cache);


### PR DESCRIPTION
Resets nodes on pause, which prevents them pausing in a glitchy state (where prev and current transforms are different, and no longer being updated).

Fixes https://github.com/godotengine/godot/pull/92391#issuecomment-2179553490

## Notes
* This may not fix *every* scenario for pausing, but should fix the major ones.
* It is possible skinned 2D might need a tweak or any other manually interpolated nodes, but will wait for MRP.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
