### PR TITLE
Fix GridContainer minimum size when there's a hidden parent

### DIFF
--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -279,7 +279,7 @@ Size2 GridContainer::get_minimum_size() const {
 
 	int valid_controls_index = 0;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}


### PR DESCRIPTION
When calculating minimum size, GridContainer only looks at children that are returned from `as_sortable_control()`. That defaults to only showing children visible in the tree, so if the grid has a hidden parent the minimum size becomes (0, 0).

After this change only the child itself needs to be visible, making `GridContainer::get_minimum_size()` behave the same way as other controls.

Fixes #91722.