### PR TITLE
Fix determining the availability of a new version

### DIFF
--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -146,7 +146,7 @@ void EngineUpdateLabel::_http_request_completed(int p_result, int p_response_cod
 			break;
 		}
 
-		if (int(release_type) == int(current_version_type) && release_index < current_version_index) {
+		if (int(release_type) == int(current_version_type) && release_index <= current_version_index) {
 			break;
 		}
 


### PR DESCRIPTION
Fixed that:

![image](https://github.com/godotengine/godot/assets/1756388/980849ba-3b51-4aac-a3f5-b0317e592adc)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/93390*