### PR TITLE
Fix crash in Node3DEditorViewport selecting on empty scene

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1043,6 +1043,9 @@ void Node3DEditorViewport::_select_region() {
 	Vector<Node *> selected;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
+	if (edited_scene == nullptr) {
+		return;
+	}
 
 	for (int i = 0; i < instances.size(); i++) {
 		Node3D *sp = Object::cast_to<Node3D>(ObjectDB::get_instance(instances[i]));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93403

Also affects 4.2.2-stable.