### PR TITLE
Fix thread-use causing navigation source geometry data corruption

### DIFF
--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -852,8 +852,15 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	}
 
 	int outline_count = p_navigation_mesh->get_outline_count();
-	const Vector<Vector<Vector2>> &traversable_outlines = p_source_geometry_data->_get_traversable_outlines();
-	const Vector<Vector<Vector2>> &obstruction_outlines = p_source_geometry_data->_get_obstruction_outlines();
+
+	Vector<Vector<Vector2>> traversable_outlines;
+	Vector<Vector<Vector2>> obstruction_outlines;
+	Vector<NavigationMeshSourceGeometryData2D::ProjectedObstruction> projected_obstructions;
+
+	p_source_geometry_data->get_data(
+			traversable_outlines,
+			obstruction_outlines,
+			projected_obstructions);
 
 	if (outline_count == 0 && traversable_outlines.size() == 0) {
 		return;
@@ -897,8 +904,6 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 		}
 		obstruction_polygon_paths.push_back(clip_path);
 	}
-
-	const Vector<NavigationMeshSourceGeometryData2D::ProjectedObstruction> &projected_obstructions = p_source_geometry_data->_get_projected_obstructions();
 
 	if (!projected_obstructions.is_empty()) {
 		for (const NavigationMeshSourceGeometryData2D::ProjectedObstruction &projected_obstruction : projected_obstructions) {

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -672,10 +672,16 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 		return;
 	}
 
-	const Vector<float> &vertices = p_source_geometry_data->get_vertices();
-	const Vector<int> &indices = p_source_geometry_data->get_indices();
+	Vector<float> source_geometry_vertices;
+	Vector<int> source_geometry_indices;
+	Vector<NavigationMeshSourceGeometryData3D::ProjectedObstruction> projected_obstructions;
 
-	if (vertices.size() < 3 || indices.size() < 3) {
+	p_source_geometry_data->get_data(
+			source_geometry_vertices,
+			source_geometry_indices,
+			projected_obstructions);
+
+	if (source_geometry_vertices.size() < 3 || source_geometry_indices.size() < 3) {
 		return;
 	}
 
@@ -691,10 +697,10 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 
 	bake_state = "Setting up Configuration..."; // step #1
 
-	const float *verts = vertices.ptr();
-	const int nverts = vertices.size() / 3;
-	const int *tris = indices.ptr();
-	const int ntris = indices.size() / 3;
+	const float *verts = source_geometry_vertices.ptr();
+	const int nverts = source_geometry_vertices.size() / 3;
+	const int *tris = source_geometry_indices.ptr();
+	const int ntris = source_geometry_indices.size() / 3;
 
 	float bmin[3], bmax[3];
 	rcCalcBounds(verts, nverts, bmin, bmax);
@@ -817,8 +823,6 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 
 	rcFreeHeightField(hf);
 	hf = nullptr;
-
-	const Vector<NavigationMeshSourceGeometryData3D::ProjectedObstruction> &projected_obstructions = p_source_geometry_data->_get_projected_obstructions();
 
 	// Add obstacles to the source geometry. Those will be affected by e.g. agent_radius.
 	if (!projected_obstructions.is_empty()) {

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
@@ -62,10 +62,10 @@ public:
 	};
 
 	void _set_traversable_outlines(const Vector<Vector<Vector2>> &p_traversable_outlines);
-	const Vector<Vector<Vector2>> &_get_traversable_outlines() const { return traversable_outlines; }
+	const Vector<Vector<Vector2>> &_get_traversable_outlines() const;
 
 	void _set_obstruction_outlines(const Vector<Vector<Vector2>> &p_obstruction_outlines);
-	const Vector<Vector<Vector2>> &_get_obstruction_outlines() const { return obstruction_outlines; }
+	const Vector<Vector<Vector2>> &_get_obstruction_outlines() const;
 
 	void _add_traversable_outline(const Vector<Vector2> &p_shape_outline);
 	void _add_obstruction_outline(const Vector<Vector2> &p_shape_outline);
@@ -88,7 +88,7 @@ public:
 	void add_traversable_outline(const PackedVector2Array &p_shape_outline);
 	void add_obstruction_outline(const PackedVector2Array &p_shape_outline);
 
-	bool has_data() { return traversable_outlines.size(); };
+	bool has_data();
 	void clear();
 	void clear_projected_obstructions();
 
@@ -99,6 +99,9 @@ public:
 	Array get_projected_obstructions() const;
 
 	void merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry);
+
+	void set_data(const Vector<Vector<Vector2>> &p_traversable_outlines, const Vector<Vector<Vector2>> &p_obstruction_outlines, Vector<ProjectedObstruction> &p_projected_obstructions);
+	void get_data(Vector<Vector<Vector2>> &r_traversable_outlines, Vector<Vector<Vector2>> &r_obstruction_outlines, Vector<ProjectedObstruction> &r_projected_obstructions);
 
 	NavigationMeshSourceGeometryData2D() {}
 	~NavigationMeshSourceGeometryData2D() { clear(); }

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
@@ -75,14 +75,14 @@ public:
 	Transform3D root_node_transform;
 
 	void set_vertices(const Vector<float> &p_vertices);
-	const Vector<float> &get_vertices() const { return vertices; }
+	const Vector<float> &get_vertices() const;
 
 	void set_indices(const Vector<int> &p_indices);
-	const Vector<int> &get_indices() const { return indices; }
+	const Vector<int> &get_indices() const;
 
 	void append_arrays(const Vector<float> &p_vertices, const Vector<int> &p_indices);
 
-	bool has_data() { return vertices.size() && indices.size(); };
+	bool has_data();
 	void clear();
 	void clear_projected_obstructions();
 
@@ -97,6 +97,9 @@ public:
 
 	void set_projected_obstructions(const Array &p_array);
 	Array get_projected_obstructions() const;
+
+	void set_data(const Vector<float> &p_vertices, const Vector<int> &p_indices, Vector<ProjectedObstruction> &p_projected_obstructions);
+	void get_data(Vector<float> &r_vertices, Vector<int> &r_indices, Vector<ProjectedObstruction> &r_projected_obstructions);
 
 	NavigationMeshSourceGeometryData3D() {}
 	~NavigationMeshSourceGeometryData3D() { clear(); }


### PR DESCRIPTION
Fixes navigation  source geometry data corruption caused by thread-use that changed vertices or indices while the source geometry data was used in a parsing process or read from by the navmesh baking.

resolves https://github.com/godotengine/godot/issues/90934

Pairs with https://github.com/godotengine/godot/pull/93392


- Extends the existing NavigationMeshSourceGeometryData RW locks to make data thread-safe where relevant.
- Adds C++ functions to `set_data()` and `get_data()` in one call to avoid desync.
- Updates navigation mesh generator baking to use the new, more thread-safe functions.

The issue was the same as with the navigation mesh. If users kept a source geometry object around to add procedual geometry for baking, e.g. with a chunk system, they did run into conflict when using a thread for the procedual "parsing" or baking step by corrupting the source data.

I tested this and the other PR together by baking various large godot 3D demos while also adding custom geometry without a lock issue or crash, still more testing is welcome.

TODO would be to extend to the navigation mesh generator parsing as well but that requires also changing the nodes so postponed for now as that part needs to run single-threaded anyway due to the SceneTree.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
