### PR TITLE
RichTextLabel: Fix missing function bindings for internal real-time fx

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -372,6 +372,14 @@
 				Adds a [code skip-lint][dropcap][/code] tag to the tag stack. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.
 			</description>
 		</method>
+		<method name="push_fade">
+			<return type="void" />
+			<param index="0" name="start_index" type="int" />
+			<param index="1" name="length" type="int" />
+			<description>
+				Adds a [code skip-lint][fade][/code] tag to the tag stack. 
+			</description>
+		</method>
 		<method name="push_fgcolor">
 			<return type="void" />
 			<param index="0" name="fgcolor" type="Color" />
@@ -480,6 +488,24 @@
 				Adds a [code skip-lint][p][/code] tag to the tag stack.
 			</description>
 		</method>
+		<method name="push_pulse">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<param index="1" name="frequency" type="float" />
+			<param index="2" name="ease" type="float" />
+			<description>
+				Adds a [code skip-lint][pulse][/code] tag to the tag stack.
+			</description>
+		</method>
+		<method name="push_shake">
+			<return type="void" />
+			<param index="0" name="strength" type="int" />
+			<param index="1" name="rate" type="float" />
+			<param index="2" name="connected" type="bool" />
+			<description>
+				Adds a [code skip-lint][shake][/code] tag to the tag stack.
+			</description>
+		</method>
 		<method name="push_strikethrough">
 			<return type="void" />
 			<description>
@@ -495,10 +521,28 @@
 				Adds a [code skip-lint][table=columns,inline_align][/code] tag to the tag stack. Use [method set_table_column_expand] to set column expansion ratio. Use [method push_cell] to add cells.
 			</description>
 		</method>
+		<method name="push_tornado">
+			<return type="void" />
+			<param index="0" name="frequency" type="float" />
+			<param index="1" name="radius" type="float" />
+			<param index="2" name="connected" type="bool" />
+			<description>
+				Adds a [code skip-lint][tornado][/code] tag to the tag stack.
+			</description>
+		</method>
 		<method name="push_underline">
 			<return type="void" />
 			<description>
 				Adds a [code skip-lint][u][/code] tag to the tag stack.
+			</description>
+		</method>
+		<method name="push_wave">
+			<return type="void" />
+			<param index="0" name="frequency" type="float" />
+			<param index="1" name="amplitude" type="float" />
+			<param index="2" name="connected" type="bool" />
+			<description>
+				Adds a [code skip-lint][wave][/code] tag to the tag stack.
 			</description>
 		</method>
 		<method name="remove_paragraph">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5920,6 +5920,11 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_cell_border_color", "color"), &RichTextLabel::set_cell_border_color);
 	ClassDB::bind_method(D_METHOD("set_cell_size_override", "min_size", "max_size"), &RichTextLabel::set_cell_size_override);
 	ClassDB::bind_method(D_METHOD("set_cell_padding", "padding"), &RichTextLabel::set_cell_padding);
+	ClassDB::bind_method(D_METHOD("push_fade", "start_index", "length"), &RichTextLabel::push_fade);
+	ClassDB::bind_method(D_METHOD("push_shake", "strength", "rate", "connected"), &RichTextLabel::push_shake);
+	ClassDB::bind_method(D_METHOD("push_wave", "frequency", "amplitude", "connected"), &RichTextLabel::push_wave);
+	ClassDB::bind_method(D_METHOD("push_tornado", "frequency", "radius", "connected"), &RichTextLabel::push_tornado);
+	ClassDB::bind_method(D_METHOD("push_pulse", "color", "frequency", "ease"), &RichTextLabel::push_pulse);
 	ClassDB::bind_method(D_METHOD("push_cell"), &RichTextLabel::push_cell);
 	ClassDB::bind_method(D_METHOD("push_fgcolor", "fgcolor"), &RichTextLabel::push_fgcolor);
 	ClassDB::bind_method(D_METHOD("push_bgcolor", "bgcolor"), &RichTextLabel::push_bgcolor);


### PR DESCRIPTION
This should help users who want to use GDScript in conjunction with internal real time effects `wave`, `tornado`, `rainbow`, `fade`, `pulse` and `shake`. Tested using a simple GDScript scene and seems to work without issue. 

Fixes #77120