### PR TITLE
CI: Keep GHA artifacts for 60 days

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -16,4 +16,5 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
-        retention-days: 14
+        # Default is 90 days.
+        retention-days: 60


### PR DESCRIPTION
We instruct users to use artifacts to test PRs, but as they expire in 2 weeks, they're often no longer available if the PR hasn't been rebased recently.

Let's try a longer limit (picking 60 days for now) and see if we run into storage limits, in which case we might need to bring it down again.

Ideally, I'd like to have a system that aims to maximize the retention for the _last_ build of open PRs, but deletes artifacts faster for merged/closed PRs or old force pushed commits, so we don't unnecessarily clog GitHub disk space and waste energy. If someone wants to look into whether this kind of conditionals / cleaning jobs could be added, that would be interesting.