### PR TITLE
Fix thread-use causing navigation polygon data corruption

### DIFF
--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -1010,8 +1010,7 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	}
 
 	if (new_baked_outlines.size() == 0) {
-		p_navigation_mesh->set_vertices(Vector<Vector2>());
-		p_navigation_mesh->clear_polygons();
+		p_navigation_mesh->clear();
 		return;
 	}
 
@@ -1045,8 +1044,7 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	TPPLPartition tpart;
 	if (tpart.ConvexPartition_HM(&tppl_in_polygon, &tppl_out_polygon) == 0) { //failed!
 		ERR_PRINT("NavigationPolygon Convex partition failed. Unable to create a valid NavigationMesh from defined polygon outline paths.");
-		p_navigation_mesh->set_vertices(Vector<Vector2>());
-		p_navigation_mesh->clear_polygons();
+		p_navigation_mesh->clear();
 		return;
 	}
 
@@ -1071,11 +1069,7 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 		new_polygons.push_back(new_polygon);
 	}
 
-	p_navigation_mesh->set_vertices(new_vertices);
-	p_navigation_mesh->clear_polygons();
-	for (int i = 0; i < new_polygons.size(); i++) {
-		p_navigation_mesh->add_polygon(new_polygons[i]);
-	}
+	p_navigation_mesh->set_data(new_vertices, new_polygons);
 }
 
 #endif // CLIPPER2_ENABLED

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -84,11 +84,11 @@ void NavRegion::set_transform(Transform3D p_transform) {
 
 void NavRegion::set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) {
 #ifdef DEBUG_ENABLED
-	if (map && !Math::is_equal_approx(double(map->get_cell_size()), double(p_navigation_mesh->get_cell_size()))) {
+	if (map && p_navigation_mesh.is_valid() && !Math::is_equal_approx(double(map->get_cell_size()), double(p_navigation_mesh->get_cell_size()))) {
 		ERR_PRINT_ONCE(vformat("Attempted to update a navigation region with a navigation mesh that uses a `cell_size` of %s while assigned to a navigation map set to a `cell_size` of %s. The cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function. The cell size for default navigation maps can also be changed in the ProjectSettings.", double(p_navigation_mesh->get_cell_size()), double(map->get_cell_size())));
 	}
 
-	if (map && !Math::is_equal_approx(double(map->get_cell_height()), double(p_navigation_mesh->get_cell_height()))) {
+	if (map && p_navigation_mesh.is_valid() && !Math::is_equal_approx(double(map->get_cell_height()), double(p_navigation_mesh->get_cell_height()))) {
 		ERR_PRINT_ONCE(vformat("Attempted to update a navigation region with a navigation mesh that uses a `cell_height` of %s while assigned to a navigation map set to a `cell_height` of %s. The cell height for navigation maps can be changed by using the NavigationServer map_set_cell_height() function. The cell height for default navigation maps can also be changed in the ProjectSettings.", double(p_navigation_mesh->get_cell_height()), double(map->get_cell_height())));
 	}
 #endif // DEBUG_ENABLED

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -36,6 +36,7 @@
 
 class NavigationPolygon : public Resource {
 	GDCLASS(NavigationPolygon, Resource);
+	RWLock rwlock;
 
 	Vector<Vector2> vertices;
 	struct Polygon {
@@ -152,6 +153,9 @@ public:
 	Vector2 get_baking_rect_offset() const;
 
 	void clear();
+
+	void set_data(const Vector<Vector2> &p_vertices, const Vector<Vector<int>> &p_polygons);
+	void get_data(Vector<Vector2> &r_vertices, Vector<Vector<int>> &r_polygons);
 
 	NavigationPolygon() {}
 	~NavigationPolygon() {}


### PR DESCRIPTION
Fixes navigation polygon  data corruption caused by thread-use that changed vertices or polygons while the navigation polygon was processed, e.g. by server region sync, navmesh baking or user thread updates.

- Adds NavigationPolygon RW locks to make data thread-safe where relevant.
- Adds NavigationMesh C++ functions to `set_data()` and `get_data()` in one call to avoid desync.
- Updates navigation mesh generator baking to use the new, more thread-safe functions.

Trio with https://github.com/godotengine/godot/pull/93392 and https://github.com/godotengine/godot/pull/93407

The NavigationPolygon has the same problematic legacy API as the NavigationMesh where it is possible to set vertices and polygon indices that are not in sync due to both using different functions with no real validation.

When user-threads were manipulating the resource there was opportunity to read the resource while another thread changed the data in the middle. This was very common in large projects when users would reuse the same navigation mesh resource and started the next update as soon as they set the navigation mesh on a region, not knowing that it takes some time for the sync to happen.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
