### PR TITLE
Remove superfluous non-working sample playing check

### DIFF
--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -276,9 +276,6 @@ bool AudioStreamPlayerInternal::is_playing() const {
 		if (AudioServer::get_singleton()->is_playback_active(playback)) {
 			return true;
 		}
-		if (AudioServer::get_singleton()->is_sample_playback_active(playback)) {
-			return true;
-		}
 	}
 	return false;
 }


### PR DESCRIPTION
This PR removes lines that were:
1. not working properly;
2. are not needed anyway.

Fixes #93420