### PR TITLE
GDScript: Fix call hint appearance for complex callees

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -303,7 +303,9 @@ String GDScriptDocGen::docvalue_from_expression(const GDP::ExpressionNode *p_exp
 		} break;
 		case GDP::Node::CALL: {
 			const GDP::CallNode *call = static_cast<const GDP::CallNode *>(p_expression);
-			return call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
+			if (call->get_callee_type() == GDP::Node::IDENTIFIER) {
+				return call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
+			}
 		} break;
 		case GDP::Node::DICTIONARY: {
 			const GDP::DictionaryNode *dict = static_cast<const GDP::DictionaryNode *>(p_expression);
@@ -314,9 +316,11 @@ String GDScriptDocGen::docvalue_from_expression(const GDP::ExpressionNode *p_exp
 			return id->name;
 		} break;
 		default: {
-			return "<unknown>";
+			// Nothing to do.
 		} break;
 	}
+
+	return "<unknown>";
 }
 
 void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_class) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -832,7 +832,7 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 					const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(par->initializer);
 					if (call->is_constant && call->reduced) {
 						def_val = call->reduced_value.get_construct_string();
-					} else {
+					} else if (call->get_callee_type() == GDScriptParser::Node::IDENTIFIER) {
 						def_val = call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
 					}
 				} break;


### PR DESCRIPTION
The editor and documentation display incorrect call hints if callee is a more complex expression than just an identifier.