### PR TITLE
Compile CSharp project on script change only

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -385,7 +385,29 @@ namespace GodotTools.Build
             if (GodotSharpEditor.Instance.SkipBuildBeforePlaying)
                 return true; // Requested play from an external editor/IDE which already built the project.
 
+            if (IsAssemblyUpToDate())
+                return true;
+
             return BuildProjectBlocking("Debug");
+        }
+
+        public static bool IsAssemblyUpToDate()
+        {
+            var assemblyFilePath = Path.Combine(GodotSharpDirs.ProjectBaseOutputPath, "Debug", $"{GodotSharpDirs.ProjectAssemblyName}.dll");
+            if (!File.Exists(assemblyFilePath))
+                return false;
+
+            if (File.GetLastWriteTime(GodotSharpDirs.ProjectCsProjPath) > LastValidBuildDateTime)
+                return false;
+
+            string projectPath = ProjectSettings.GlobalizePath("res://");
+            foreach (string filePath in Directory.EnumerateFiles(projectPath, "*.cs", SearchOption.AllDirectories))
+            {
+                if (File.GetLastWriteTime(filePath) > LastValidBuildDateTime)
+                    return false;
+            }
+
+            return true;
         }
 
         public static void Initialize()


### PR DESCRIPTION
This implement the proposal https://github.com/godotengine/godot-proposals/issues/2231

When "Run project" is triggered from the editor, a check is added to compare the last write times of all .cs files against the last build time. If any file is newer, the build occurs as usual. Otherwise, the build is skipped, and the project starts immediately.

This should reduce iteration times for C# developers, considering many project runs do not involve C# modifications.

Without this PR:

https://github.com/godotengine/godot/assets/81109165/7008b579-6f4f-4972-b023-65e9e099dd18

With this PR:


https://github.com/godotengine/godot/assets/81109165/9e71f94f-5d34-4173-b61d-25732944cf8b


