### PR TITLE
Implement InputEventPanGesture and InputEventMagnifyGesture for X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4771,6 +4771,75 @@ void DisplayServerX11::process_events() {
 						}
 					} break;
 #endif
+					case XI_GesturePinchBegin: {
+						xi.old_pinch_scale = 1.0; // the scale is 1.0 at the start of the gesture
+					}
+						[[fallthrough]];
+					case XI_GesturePinchUpdate:
+					case XI_GesturePinchEnd: {
+						if (ime_window_event || ignore_events) {
+							break;
+						}
+
+						XIGesturePinchEvent *pinch_event = reinterpret_cast<XIGesturePinchEvent *>(event_data);
+
+						Vector2 position = Vector2(pinch_event->event_x, pinch_event->event_y);
+						float scale_delta = pinch_event->scale - xi.old_pinch_scale;
+
+						// Using XQueryPointer is the only way I found to get the current key modifier state, there might be a better way
+						Window _root, _child;
+						int _root_x, _root_y;
+						int _win_x, _win_y;
+						unsigned int modifiers_mask;
+						XQueryPointer(x11_display, window_get_native_handle(WINDOW_HANDLE, window_id),
+								&_root, &_child, &_root_x, &_root_y, &_win_x, &_win_y, &modifiers_mask);
+
+						Ref<InputEventMagnifyGesture> magnify_gesture;
+						magnify_gesture.instantiate();
+
+						magnify_gesture->set_window_id(window_id);
+
+						magnify_gesture->set_position(position);
+						magnify_gesture->set_factor(1.0 + scale_delta);
+
+						_get_key_modifier_state(modifiers_mask, magnify_gesture);
+
+						Input::get_singleton()->parse_input_event(magnify_gesture);
+
+						xi.old_pinch_scale = pinch_event->scale;
+					} break;
+					case XI_GestureSwipeBegin:
+					case XI_GestureSwipeUpdate:
+					case XI_GestureSwipeEnd: {
+						if (ime_window_event || ignore_events) {
+							break;
+						}
+
+						XIGestureSwipeEvent *swipe_event = reinterpret_cast<XIGestureSwipeEvent *>(event_data);
+
+						Vector2 position = Vector2(swipe_event->event_x, swipe_event->event_y);
+						Vector2 delta = Vector2(swipe_event->delta_x, swipe_event->delta_y);
+
+						// Using XQueryPointer is the only way I found to get the current key modifier state, there might be a better way
+						Window _root, _child;
+						int _root_x, _root_y;
+						int _win_x, _win_y;
+						unsigned int modifiers_mask;
+						XQueryPointer(x11_display, window_get_native_handle(WINDOW_HANDLE, window_id),
+								&_root, &_child, &_root_x, &_root_y, &_win_x, &_win_y, &modifiers_mask);
+
+						Ref<InputEventPanGesture> pan_gesture;
+						pan_gesture.instantiate();
+
+						pan_gesture->set_window_id(window_id);
+
+						pan_gesture->set_position(position);
+						pan_gesture->set_delta(delta);
+
+						_get_key_modifier_state(modifiers_mask, pan_gesture);
+
+						Input::get_singleton()->parse_input_event(pan_gesture);
+					} break;
 				}
 			}
 		}
@@ -6234,6 +6303,13 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 			}
 #endif
 
+			XISetMask(all_event_mask.mask, XI_GesturePinchBegin);
+			XISetMask(all_event_mask.mask, XI_GesturePinchUpdate);
+			XISetMask(all_event_mask.mask, XI_GesturePinchEnd);
+			XISetMask(all_event_mask.mask, XI_GestureSwipeBegin);
+			XISetMask(all_event_mask.mask, XI_GestureSwipeUpdate);
+			XISetMask(all_event_mask.mask, XI_GestureSwipeEnd);
+
 			XISelectEvents(x11_display, wd.x11_window, &all_event_mask, 1);
 		}
 
@@ -6627,8 +6703,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 
 	{
-		int version_major = 2; // Report 2.2 as supported by engine, but should work with 2.1 or 2.0 library as well.
-		int version_minor = 2;
+		int version_major = 2; // Report 2.4 as supported by engine, but should work with older 2.x versions as well.
+		int version_minor = 4;
 		int rc = XIQueryVersion(x11_display, &version_major, &version_minor);
 		print_verbose(vformat("Xinput %d.%d detected.", version_major, version_minor));
 		if (rc != Success || (version_major < 2)) {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -286,6 +286,7 @@ class DisplayServerX11 : public DisplayServer {
 		Vector2 relative_motion;
 		Vector2 raw_pos;
 		Vector2 old_raw_pos;
+		double old_pinch_scale;
 		::Time last_relative_time;
 	} xi;
 

--- a/thirdparty/linuxbsd_headers/README.md
+++ b/thirdparty/linuxbsd_headers/README.md
@@ -73,7 +73,7 @@ Patches:
   * Xcursor: 1.2.0
   * Xext: 1.3.5
   * Xinerama: 1.1.4
-  * Xi: 1.7.10
+  * Xi: 1.8.0
   * Xlib: 1.6.9
   * Xrandr: 1.5.2
   * Xrender: 0.9.10

--- a/thirdparty/linuxbsd_headers/X11/extensions/XInput2.h
+++ b/thirdparty/linuxbsd_headers/X11/extensions/XInput2.h
@@ -153,6 +153,14 @@ typedef struct
     int         num_touches;
 } XITouchClassInfo;
 
+/* new in XI 2.4 */
+typedef struct
+{
+    int         type;
+    int         sourceid;
+    int         num_touches;
+} XIGestureClassInfo;
+
 typedef struct
 {
     int                 deviceid;
@@ -360,6 +368,62 @@ typedef struct {
     BarrierEventID eventid;
 } XIBarrierEvent;
 
+typedef struct {
+    int           type;         /* GenericEvent */
+    unsigned long serial;       /* # of last request processed by server */
+    Bool          send_event;   /* true if this came from a SendEvent request */
+    Display       *display;     /* Display the event was read from */
+    int           extension;    /* XI extension offset */
+    int           evtype;
+    Time          time;
+    int           deviceid;
+    int           sourceid;
+    int           detail;
+    Window        root;
+    Window        event;
+    Window        child;
+    double        root_x;
+    double        root_y;
+    double        event_x;
+    double        event_y;
+    double        delta_x;
+    double        delta_y;
+    double        delta_unaccel_x;
+    double        delta_unaccel_y;
+    double        scale;
+    double        delta_angle;
+    int           flags;
+    XIModifierState     mods;
+    XIGroupState        group;
+} XIGesturePinchEvent;
+
+typedef struct {
+    int           type;         /* GenericEvent */
+    unsigned long serial;       /* # of last request processed by server */
+    Bool          send_event;   /* true if this came from a SendEvent request */
+    Display       *display;     /* Display the event was read from */
+    int           extension;    /* XI extension offset */
+    int           evtype;
+    Time          time;
+    int           deviceid;
+    int           sourceid;
+    int           detail;
+    Window        root;
+    Window        event;
+    Window        child;
+    double        root_x;
+    double        root_y;
+    double        event_x;
+    double        event_y;
+    double        delta_x;
+    double        delta_y;
+    double        delta_unaccel_x;
+    double        delta_unaccel_y;
+    int           flags;
+    XIModifierState     mods;
+    XIGroupState        group;
+} XIGestureSwipeEvent;
+
 _XFUNCPROTOBEGIN
 
 extern Bool     XIQueryPointer(
@@ -553,6 +617,30 @@ extern int XIGrabTouchBegin(
     XIGrabModifiers     *modifiers_inout
 );
 
+extern int XIGrabPinchGestureBegin(
+    Display*            display,
+    int                 deviceid,
+    Window              grab_window,
+    int                 grab_mode,
+    int                 paired_device_mode,
+    int                 owner_events,
+    XIEventMask         *mask,
+    int                 num_modifiers,
+    XIGrabModifiers     *modifiers_inout
+);
+
+extern int XIGrabSwipeGestureBegin(
+    Display*            display,
+    int                 deviceid,
+    Window              grab_window,
+    int                 grab_mode,
+    int                 paired_device_mode,
+    int                 owner_events,
+    XIEventMask         *mask,
+    int                 num_modifiers,
+    XIGrabModifiers     *modifiers_inout
+);
+
 extern Status XIUngrabButton(
     Display*            display,
     int                 deviceid,
@@ -588,6 +676,22 @@ extern Status XIUngrabFocusIn(
 );
 
 extern Status XIUngrabTouchBegin(
+    Display*            display,
+    int                 deviceid,
+    Window              grab_window,
+    int                 num_modifiers,
+    XIGrabModifiers     *modifiers
+);
+
+extern Status XIUngrabPinchGestureBegin(
+    Display*            display,
+    int                 deviceid,
+    Window              grab_window,
+    int                 num_modifiers,
+    XIGrabModifiers     *modifiers
+);
+
+extern Status XIUngrabSwipeGestureBegin(
     Display*            display,
     int                 deviceid,
     Window              grab_window,


### PR DESCRIPTION
Implementation of InputEventPanGesture and InputEventMagnifyGesture for the X11 platform.
Updates the https://github.com/godotengine/godot/issues/13139 tracker for X11 Linux/BSD.

Tested on a ThinkPad x260 (classic Synaptics TouchPad), works great.

### References 
- https://gitlab.freedesktop.org/xorg/lib/libxi/-/merge_requests/5
- https://gitlab.freedesktop.org/xorg/lib/libxi/-/merge_requests/5 