### PR TITLE
[Web][Build] place intermediate files in subdirectories

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -58,7 +58,11 @@ for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 
 build = []
-build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm", "#bin/godot${PROGSUFFIX}.worker.js"]
+build_targets = [
+    "#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.js",
+    "#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.wasm",
+    "#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.worker.js",
+]
 if env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
@@ -80,7 +84,7 @@ if env["dlink_enabled"]:
     sys = sys_env.Program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
-    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
+    wasm = env.add_program("#bin/${PROGSUFFIX}/godot.side${PROGSUFFIX}.wasm", web_files)
     build = sys + [wasm[0]]
 else:
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
@@ -98,14 +102,16 @@ engine = [
     "js/engine/engine.js",
 ]
 externs = [env.File("#platform/web/js/engine/engine.externs.js")]
-js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
+js_engine = env.CreateEngineFile("#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
 env.Depends(js_engine, externs)
 
 wrap_list = [
     build[0],
     js_engine,
 ]
-js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+js_wrapped = env.Textfile(
+    "#bin/${PROGSUFFIX}/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js"
+)
 
 # 0 - unwrapped js file (use wrapped one instead)
 # 1 - wasm file

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -88,7 +88,7 @@ def create_template_zip(env, js, wasm, worker, side):
             "___GODOT_OFFLINE_PAGE___": "offline.html",
             "___GODOT_THREADS_ENABLED___": "true" if env["threads"] else "false",
         }
-        html = env.Substfile(target="#bin/godot${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict)
+        html = env.Substfile(target="#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict)
         in_files.append(html)
         out_files.append(zip_dir.File(binary_name + ".html"))
         # And logo/favicon
@@ -98,7 +98,7 @@ def create_template_zip(env, js, wasm, worker, side):
         out_files.append(zip_dir.File("favicon.png"))
         # PWA
         service_worker = env.Substfile(
-            target="#bin/godot${PROGSUFFIX}.service.worker.js",
+            target="#bin/${PROGSUFFIX}/godot${PROGSUFFIX}.service.worker.js",
             source=service_worker,
             SUBST_DICT=subst_dict,
         )
@@ -127,7 +127,7 @@ def create_template_zip(env, js, wasm, worker, side):
 
 
 def get_template_zip_path(env):
-    return "#bin/.web_zip"
+    return "#bin/.zip${PROGSUFFIX}"
 
 
 def add_js_libraries(env, libraries):


### PR DESCRIPTION
# Info

Currently, when compiling several versions of the web export, temporary files remain in the target `bin` directory. In addition, some of them get mixed with others in the shared `bin/.web_zip` folder.

My suggestion for a fix is to put the temporary files in separate subfolders, so that only the final `zip` file is in the main `bin` directory after compilation.

## Before

```
./
├── godot.side.web.template_release.wasm32.dlink.wasm*
├── godot.side.web.template_release.wasm32.nothreads.dlink.wasm*
├── godot.web.editor.wasm32.engine.js
├── godot.web.editor.wasm32.html
├── godot.web.editor.wasm32.js
├── godot.web.editor.wasm32.nothreads.engine.js
├── godot.web.editor.wasm32.nothreads.html
├── godot.web.editor.wasm32.nothreads.js
├── godot.web.editor.wasm32.nothreads.service.worker.js
├── godot.web.editor.wasm32.nothreads.wasm*
├── godot.web.editor.wasm32.nothreads.wrapped.js
├── godot.web.editor.wasm32.nothreads.zip
├── godot.web.editor.wasm32.service.worker.js
├── godot.web.editor.wasm32.wasm*
├── godot.web.editor.wasm32.worker.js
├── godot.web.editor.wasm32.wrapped.js
├── godot.web.editor.wasm32.zip
├── godot.web.template_release.wasm32.dlink.engine.js
├── godot.web.template_release.wasm32.dlink.js
├── godot.web.template_release.wasm32.dlink.wasm*
├── godot.web.template_release.wasm32.dlink.worker.js
├── godot.web.template_release.wasm32.dlink.wrapped.js
├── godot.web.template_release.wasm32.dlink.zip
├── godot.web.template_release.wasm32.engine.js
├── godot.web.template_release.wasm32.js
├── godot.web.template_release.wasm32.nothreads.dlink.engine.js
├── godot.web.template_release.wasm32.nothreads.dlink.js
├── godot.web.template_release.wasm32.nothreads.dlink.wasm*
├── godot.web.template_release.wasm32.nothreads.dlink.wrapped.js
├── godot.web.template_release.wasm32.nothreads.dlink.zip
├── godot.web.template_release.wasm32.nothreads.engine.js
├── godot.web.template_release.wasm32.nothreads.js
├── godot.web.template_release.wasm32.nothreads.wasm*
├── godot.web.template_release.wasm32.nothreads.wrapped.js
├── godot.web.template_release.wasm32.nothreads.zip
├── godot.web.template_release.wasm32.wasm*
├── godot.web.template_release.wasm32.worker.js
├── godot.web.template_release.wasm32.wrapped.js
├── godot.web.template_release.wasm32.zip
└── .web_zip/
    ├── favicon.png
    ├── godot.audio.worklet.js
    ├── godot.editor.audio.worklet.js
    ├── godot.editor.html
    ├── godot.editor.js
    ├── godot.editor.wasm*
    ├── godot.editor.worker.js
    ├── godot.html
    ├── godot.js
    ├── godot.offline.html
    ├── godot.service.worker.js
    ├── godot.side.wasm*
    ├── godot.wasm*
    ├── godot.worker.js
    ├── logo.svg
    ├── manifest.json
    ├── offline.html
    └── service.worker.js

1 directory, 57 files
```

## After

```
./
├── godot.web.editor.wasm32.nothreads.zip
├── godot.web.editor.wasm32.zip
├── godot.web.template_release.wasm32.dlink.zip
├── godot.web.template_release.wasm32.nothreads.dlink.zip
├── godot.web.template_release.wasm32.nothreads.zip
├── godot.web.template_release.wasm32.zip
├── .web.editor.wasm32/
│   ├── godot.web.editor.wasm32.engine.js
│   ├── godot.web.editor.wasm32.html
│   ├── godot.web.editor.wasm32.js
│   ├── godot.web.editor.wasm32.service.worker.js
│   ├── godot.web.editor.wasm32.wasm*
│   ├── godot.web.editor.wasm32.worker.js
│   └── godot.web.editor.wasm32.wrapped.js
├── .web.editor.wasm32.nothreads/
│   ├── godot.web.editor.wasm32.nothreads.engine.js
│   ├── godot.web.editor.wasm32.nothreads.html
│   ├── godot.web.editor.wasm32.nothreads.js
│   ├── godot.web.editor.wasm32.nothreads.service.worker.js
│   ├── godot.web.editor.wasm32.nothreads.wasm*
│   └── godot.web.editor.wasm32.nothreads.wrapped.js
├── .web.template_release.wasm32/
│   ├── godot.web.template_release.wasm32.engine.js
│   ├── godot.web.template_release.wasm32.js
│   ├── godot.web.template_release.wasm32.wasm*
│   ├── godot.web.template_release.wasm32.worker.js
│   └── godot.web.template_release.wasm32.wrapped.js
├── .web.template_release.wasm32.dlink/
│   ├── godot.side.web.template_release.wasm32.dlink.wasm*
│   ├── godot.web.template_release.wasm32.dlink.engine.js
│   ├── godot.web.template_release.wasm32.dlink.js
│   ├── godot.web.template_release.wasm32.dlink.wasm*
│   ├── godot.web.template_release.wasm32.dlink.worker.js
│   └── godot.web.template_release.wasm32.dlink.wrapped.js
├── .web.template_release.wasm32.nothreads/
│   ├── godot.web.template_release.wasm32.nothreads.engine.js
│   ├── godot.web.template_release.wasm32.nothreads.js
│   ├── godot.web.template_release.wasm32.nothreads.wasm*
│   └── godot.web.template_release.wasm32.nothreads.wrapped.js
├── .web.template_release.wasm32.nothreads.dlink/
│   ├── godot.side.web.template_release.wasm32.nothreads.dlink.wasm*
│   ├── godot.web.template_release.wasm32.nothreads.dlink.engine.js
│   ├── godot.web.template_release.wasm32.nothreads.dlink.js
│   ├── godot.web.template_release.wasm32.nothreads.dlink.wasm*
│   └── godot.web.template_release.wasm32.nothreads.dlink.wrapped.js
├── .zip.web.editor.wasm32/
│   ├── favicon.png
│   ├── godot.editor.audio.worklet.js
│   ├── godot.editor.html
│   ├── godot.editor.js
│   ├── godot.editor.wasm*
│   ├── godot.editor.worker.js
│   ├── logo.svg
│   ├── manifest.json
│   ├── offline.html
│   └── service.worker.js
├── .zip.web.editor.wasm32.nothreads/
│   ├── favicon.png
│   ├── godot.editor.audio.worklet.js
│   ├── godot.editor.html
│   ├── godot.editor.js
│   ├── godot.editor.wasm*
│   ├── logo.svg
│   ├── manifest.json
│   ├── offline.html
│   └── service.worker.js
├── .zip.web.template_release.wasm32/
│   ├── godot.audio.worklet.js
│   ├── godot.html
│   ├── godot.js
│   ├── godot.offline.html
│   ├── godot.service.worker.js
│   ├── godot.wasm*
│   └── godot.worker.js
├── .zip.web.template_release.wasm32.dlink/
│   ├── godot.audio.worklet.js
│   ├── godot.html
│   ├── godot.js
│   ├── godot.offline.html
│   ├── godot.service.worker.js
│   ├── godot.side.wasm*
│   ├── godot.wasm*
│   └── godot.worker.js
├── .zip.web.template_release.wasm32.nothreads/
│   ├── godot.audio.worklet.js
│   ├── godot.html
│   ├── godot.js
│   ├── godot.offline.html
│   ├── godot.service.worker.js
│   └── godot.wasm*
└── .zip.web.template_release.wasm32.nothreads.dlink/
    ├── godot.audio.worklet.js
    ├── godot.html
    ├── godot.js
    ├── godot.offline.html
    ├── godot.service.worker.js
    ├── godot.side.wasm*
    └── godot.wasm*

12 directories, 86 files
```
