### PR TITLE
Make inspector spacing more themable

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -2087,6 +2087,9 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 
 	// Editor inspector.
 	{
+		// Vertical separation between inspector categories and sections.
+		p_theme->set_constant("v_separation", "EditorInspector", 0);
+
 		// EditorProperty.
 
 		Ref<StyleBoxFlat> style_property_bg = p_config.base_style->duplicate();
@@ -2128,6 +2131,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		Ref<StyleBoxFlat> inspector_indent_style = make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
 		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
 		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
+		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
 
 		Color prop_category_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
 		Color prop_section_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
@@ -2145,6 +2149,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		Ref<StyleBoxFlat> category_bg = p_config.base_style->duplicate();
 		category_bg->set_bg_color(prop_category_color);
 		category_bg->set_border_color(prop_category_color);
+		category_bg->set_content_margin_all(0);
 		p_theme->set_stylebox("bg", "EditorInspectorCategory", category_bg);
 
 		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);


### PR DESCRIPTION
Some tweaks to make it easier to establish visual hierarchy in the inspector:

| Before | After |
|--------|--------|
| ![before](https://github.com/godotengine/godot/assets/60579014/cf0f693e-fc05-4646-a6bc-926fa74aaa39) | ![after](https://github.com/godotengine/godot/assets/60579014/38712f66-dccd-45cb-8ecd-922dff724a55) |


- Takes the content margins of `EditorInspectorCategory/styles/bg` into account when calculating `EditorInspectorCategory` min height to allow independent padding inside of it. It was only controllable through `Tree` v_separation, making it impossible to set independently from all of the trees in the editor
- Exposes `EditorInspector` main vbox separation to theming to allow space between inspector categories and sections
- Makes horizontal spacing of `EditorInspectorSection` themable (space between the arrow and the text)
- Ensures that text is vertically centered in categories and sections (with `floor()` they were 1px shy, you can notice if you look real close at those category sections on the left picture)

Note: when using vertical separation there's double separation below some node categories (like Node and Node3D) because there's a 0-height vbox hidden in there (not yet sure what it's for, probably some warning). I think VBoxContainer shouldn't do separation between 0-size controls, this is perhaps something to fix in a future PR

I also want to make section backgrounds themable to support rounded corners but they are drawn immediately through `draw_rect` because they're using different alphas depending on the nesting level. Maybe I should generate 5-6 stylebox variations for different levels. Something for a future PR as well