### PR TITLE
Windows: Keep client rect when changing window frame flags

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -497,7 +497,7 @@ class DisplayServerWindows : public DisplayServer {
 	void _drag_event(WindowID p_window, float p_x, float p_y, int idx);
 	void _touch_event(WindowID p_window, bool p_pressed, float p_x, float p_y, int idx);
 
-	void _update_window_style(WindowID p_window, bool p_repaint = true);
+	void _update_window_style(WindowID p_window, bool p_repaint = true, bool p_keep_client_rect = false);
 	void _update_window_mouse_passthrough(WindowID p_window);
 
 	void _update_real_mouse_position(WindowID p_window);


### PR DESCRIPTION
Fixes #81640 by recalculating the window size when changing window flags. This also preserves the position of the client area, so that the window content will not move around. Both `Window.unresizeable` and `Window.borderless` flags are affected.

If the window is currently minimized or maximized, it attempts to update the "normal" window size and position using `SetWindowPlacement`. (This does not work for maximized unresizable window because they are not actually maximized.)

Manual test: [Resize Border - pr93441 manual test.zip](https://github.com/user-attachments/files/15938085/Resize.Border.-.pr93441.manual.test.zip) (Run the project, click a button and check the output.)
There are several test cases that are expected to fail (maximized unresizable window as stated above).