### PR TITLE
Make Basis Universal import quiet unless engine is in verbose mode

### DIFF
--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -65,6 +65,12 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 	params.m_multithreading = true;
 	params.m_check_for_alpha = false;
 
+	if (!OS::get_singleton()->is_stdout_verbose()) {
+		params.m_print_stats = false;
+		params.m_compute_stats = false;
+		params.m_status_output = false;
+	}
+
 	basisu::job_pool job_pool(OS::get_singleton()->get_processor_count());
 	params.m_pJob_pool = &job_pool;
 


### PR DESCRIPTION
This makes Basis Universal stdout match other compression modes.

Previously, this was printed on every Basis Universal import:

```
Total basis file slices: 1
Slice: 0, alpha: 1, orig width/height: 96x16384, width/height: 96x16384, first_block: 0, image_index: 0, mip_level: 0, iframe: 0
```
