### PR TITLE
Add missing audio bus button styles

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -91,17 +91,26 @@ void EditorAudioBus::_notification(int p_what) {
 			Color mute_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(2.35, 1.03, 1.03);
 			Color bypass_color = EditorThemeManager::is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(1.03, 2.04, 2.35);
 			float darkening_factor = EditorThemeManager::is_dark_theme() ? 0.15 : 0.65;
+			Color solo_color_darkened = solo_color.darkened(darkening_factor);
+			Color mute_color_darkened = mute_color.darkened(darkening_factor);
+			Color bypass_color_darkened = bypass_color.darkened(darkening_factor);
 
-			Ref<StyleBoxFlat>(solo->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(solo_color.darkened(darkening_factor));
-			Ref<StyleBoxFlat>(mute->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(mute_color.darkened(darkening_factor));
-			Ref<StyleBoxFlat>(bypass->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(bypass_color.darkened(darkening_factor));
+			Ref<StyleBoxFlat>(solo->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(solo_color_darkened);
+			Ref<StyleBoxFlat>(mute->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(mute_color_darkened);
+			Ref<StyleBoxFlat>(bypass->get_theme_stylebox(SceneStringName(pressed)))->set_border_color(bypass_color_darkened);
+			Ref<StyleBoxFlat>(solo->get_theme_stylebox("hover_pressed"))->set_border_color(solo_color_darkened);
+			Ref<StyleBoxFlat>(mute->get_theme_stylebox("hover_pressed"))->set_border_color(mute_color_darkened);
+			Ref<StyleBoxFlat>(bypass->get_theme_stylebox("hover_pressed"))->set_border_color(bypass_color_darkened);
 
 			solo->set_button_icon(get_editor_theme_icon(SNAME("AudioBusSolo")));
 			solo->add_theme_color_override("icon_pressed_color", solo_color);
+			solo->add_theme_color_override("icon_hover_pressed_color", solo_color_darkened);
 			mute->set_button_icon(get_editor_theme_icon(SNAME("AudioBusMute")));
 			mute->add_theme_color_override("icon_pressed_color", mute_color);
+			mute->add_theme_color_override("icon_hover_pressed_color", mute_color_darkened);
 			bypass->set_button_icon(get_editor_theme_icon(SNAME("AudioBusBypass")));
 			bypass->add_theme_color_override("icon_pressed_color", bypass_color);
+			bypass->add_theme_color_override("icon_hover_pressed_color", bypass_color_darkened);
 
 			bus_options->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
@@ -841,13 +850,18 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 		child->begin_bulk_theme_override();
 		child->add_theme_style_override(CoreStringName(normal), sbempty);
 		child->add_theme_style_override("hover", sbempty);
+		child->add_theme_style_override("hover_mirrored", sbempty);
 		child->add_theme_style_override("focus", sbempty);
+		child->add_theme_style_override("focus_mirrored", sbempty);
 
 		Ref<StyleBoxFlat> sbflat = memnew(StyleBoxFlat);
 		sbflat->set_content_margin_all(0);
 		sbflat->set_bg_color(Color(1, 1, 1, 0));
 		sbflat->set_border_width(Side::SIDE_BOTTOM, Math::round(3 * EDSCALE));
 		child->add_theme_style_override(SceneStringName(pressed), sbflat);
+		child->add_theme_style_override("pressed_mirrored", sbflat);
+		child->add_theme_style_override("hover_pressed", sbflat);
+		child->add_theme_style_override("hover_pressed_mirrored", sbflat);
 
 		child->end_bulk_theme_override();
 	}


### PR DESCRIPTION
These were missing hover-pressed and mirrored variations and were falling back to FlatButton styles

Before:

https://github.com/godotengine/godot/assets/60579014/1899f13b-c37c-4346-b2cc-13ce07ff634d

After:

https://github.com/godotengine/godot/assets/60579014/3a25e8a8-58cb-4ccf-b2ae-22ce6c5263f7
