### PR TITLE
Fix TileSetAtlasSourceEditor performing many expensive redraws of the atlas grid.

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -341,25 +341,36 @@ void TileAtlasView::_draw_base_tiles_texture_grid() {
 
 		Size2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 
+		Transform2D global_to_grid_local_xform = base_tiles_texture_grid->get_global_transform().affine_inverse();
+		Rect2 base_rect = global_to_grid_local_xform.xform(get_global_rect());
+
 		// Draw each tile texture region.
-		for (int x = 0; x < grid_size.x; x++) {
-			for (int y = 0; y < grid_size.y; y++) {
+		for (int y = 0; y < grid_size.y; ++y) {
+			for (int x = 0; x < grid_size.x; ++x) {
 				Vector2i origin = margins + (Vector2i(x, y) * (texture_region_size + separation));
 				Vector2i base_tile_coords = tile_set_atlas_source->get_tile_at_coords(Vector2i(x, y));
 				if (base_tile_coords != TileSetSource::INVALID_ATLAS_COORDS) {
 					if (base_tile_coords == Vector2i(x, y)) {
-						// Draw existing tile.
 						Vector2i size_in_atlas = tile_set_atlas_source->get_tile_size_in_atlas(base_tile_coords);
 						Vector2 region_size = texture_region_size * size_in_atlas + separation * (size_in_atlas - Vector2i(1, 1));
-						base_tiles_texture_grid->draw_rect(Rect2i(origin, region_size), Color(1.0, 1.0, 1.0, 0.8), false);
+						Rect2i tile_rect = Rect2i(origin, region_size);
+						if (!redraw_with_clipping || tile_rect.intersects(base_rect)) {
+							// Draw existing tile.
+							base_tiles_texture_grid->draw_rect(tile_rect, Color(1.0, 1.0, 1.0, 0.8), false);
+						}
 					}
 				} else {
-					// Draw the grid.
-					base_tiles_texture_grid->draw_rect(Rect2i(origin, texture_region_size), Color(0.7, 0.7, 0.7, 0.1), false);
+					Rect2i tile_rect = Rect2i(origin, texture_region_size);
+					if (!redraw_with_clipping || tile_rect.intersects(base_rect)) {
+						// Draw the grid.
+						base_tiles_texture_grid->draw_rect(tile_rect, Color(0.7, 0.7, 0.7, 0.1), false);
+					}
 				}
 			}
 		}
 	}
+
+	redraw_with_clipping = false;
 }
 
 void TileAtlasView::_draw_base_tiles_shape_grid() {

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -59,6 +59,8 @@ private:
 	Button *button_center_view = nullptr;
 	CenterContainer *center_container = nullptr;
 	Vector2 panning;
+	bool redraw_with_clipping = false;
+
 	void _update_zoom_and_panning(bool p_zoom_on_mouse_pos = false);
 	void _zoom_widget_changed();
 	void _center_view();
@@ -166,6 +168,8 @@ public:
 
 	// Redraw everything.
 	void queue_redraw();
+
+	void mark_redraw_as_clipping(bool p_is_clipping = true) { redraw_with_clipping = p_is_clipping; }
 
 	TileAtlasView();
 	~TileAtlasView();

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -552,7 +552,7 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_bind_methods() {
 
 void TileSetAtlasSourceEditor::_inspector_property_selected(const String &p_property) {
 	selected_property = p_property;
-	_update_atlas_view();
+	_update_atlas_view(false);
 	_update_current_tile_data_editor();
 }
 
@@ -961,7 +961,7 @@ void TileSetAtlasSourceEditor::_tile_data_editors_tree_selected() {
 	alternative_tiles_control_unscaled->queue_redraw();
 }
 
-void TileSetAtlasSourceEditor::_update_atlas_view() {
+void TileSetAtlasSourceEditor::_update_atlas_view(bool p_with_clipping) {
 	// Update the atlas display.
 	tile_atlas_view->set_atlas_source(*tile_set, tile_set_atlas_source, tile_set_atlas_source_id);
 
@@ -1016,6 +1016,7 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	tile_atlas_control_unscaled->queue_redraw();
 	alternative_tiles_control->queue_redraw();
 	alternative_tiles_control_unscaled->queue_redraw();
+	tile_atlas_view->mark_redraw_as_clipping(p_with_clipping);
 	tile_atlas_view->queue_redraw();
 
 	// Synchronize atlas view.
@@ -1056,7 +1057,6 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_mouse_exited() {
 	hovered_base_tile_coords = TileSetSource::INVALID_ATLAS_COORDS;
 	tile_atlas_control->queue_redraw();
 	tile_atlas_control_unscaled->queue_redraw();
-	tile_atlas_view->queue_redraw();
 }
 
 void TileSetAtlasSourceEditor::_tile_atlas_view_transform_changed() {
@@ -1080,6 +1080,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 		tile_atlas_control_unscaled->queue_redraw();
 		alternative_tiles_control->queue_redraw();
 		alternative_tiles_control_unscaled->queue_redraw();
+		tile_atlas_view->mark_redraw_as_clipping();
 		tile_atlas_view->queue_redraw();
 		return;
 	} else {
@@ -1146,7 +1147,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Update only what's needed.
 					tile_set_changed_needs_update = false;
 					_update_tile_inspector();
-					_update_atlas_view();
+					_update_atlas_view(true);
 					_update_tile_id_label();
 					_update_current_tile_data_editor();
 				}
@@ -1188,7 +1189,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Update only what's needed.
 					tile_set_changed_needs_update = false;
 					_update_tile_inspector();
-					_update_atlas_view();
+					_update_atlas_view(true);
 					_update_tile_id_label();
 					_update_current_tile_data_editor();
 				}
@@ -1199,7 +1200,6 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 			tile_atlas_control_unscaled->queue_redraw();
 			alternative_tiles_control->queue_redraw();
 			alternative_tiles_control_unscaled->queue_redraw();
-			tile_atlas_view->queue_redraw();
 			return;
 		}
 
@@ -1341,12 +1341,6 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Left click released.
 					_end_dragging();
 				}
-				tile_atlas_control->queue_redraw();
-				tile_atlas_control_unscaled->queue_redraw();
-				alternative_tiles_control->queue_redraw();
-				alternative_tiles_control_unscaled->queue_redraw();
-				tile_atlas_view->queue_redraw();
-				return;
 			} else if (mb->get_button_index() == MouseButton::RIGHT) {
 				// Right click pressed.
 				if (mb->is_pressed()) {
@@ -1356,12 +1350,15 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Right click released.
 					_end_dragging();
 				}
+			}
+
+			if (mb->get_button_index() == MouseButton::LEFT || mb->get_button_index() == MouseButton::RIGHT) {
 				tile_atlas_control->queue_redraw();
 				tile_atlas_control_unscaled->queue_redraw();
 				alternative_tiles_control->queue_redraw();
 				alternative_tiles_control_unscaled->queue_redraw();
+				tile_atlas_view->mark_redraw_as_clipping(mb->is_pressed());
 				tile_atlas_view->queue_redraw();
-				return;
 			}
 		}
 	}
@@ -1718,7 +1715,7 @@ void TileSetAtlasSourceEditor::_set_selection_from_array(const Array &p_selectio
 	}
 	_update_tile_inspector();
 	_update_tile_id_label();
-	_update_atlas_view();
+	_update_atlas_view(false);
 	_update_current_tile_data_editor();
 }
 
@@ -1933,6 +1930,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(const Ref<In
 		tile_atlas_control_unscaled->queue_redraw();
 		alternative_tiles_control->queue_redraw();
 		alternative_tiles_control_unscaled->queue_redraw();
+		tile_atlas_view->mark_redraw_as_clipping();
 		tile_atlas_view->queue_redraw();
 		return;
 	}
@@ -2109,7 +2107,7 @@ void TileSetAtlasSourceEditor::_tile_set_changed() {
 
 void TileSetAtlasSourceEditor::_tile_proxy_object_changed(const String &p_what) {
 	tile_set_changed_needs_update = false; // Avoid updating too many things.
-	_update_atlas_view();
+	_update_atlas_view(false);
 }
 
 void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(const String &p_what) {
@@ -2227,7 +2225,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 	// Update the selected tile.
 	_update_fix_selected_and_hovered_tiles();
 	_update_tile_id_label();
-	_update_atlas_view();
+	_update_atlas_view(false);
 	_update_atlas_source_inspector();
 	_update_tile_inspector();
 	_update_tile_data_editors();
@@ -2470,7 +2468,7 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 				// Update the selected tile.
 				_update_fix_selected_and_hovered_tiles();
 				_update_tile_id_label();
-				_update_atlas_view();
+				_update_atlas_view(drag_type != DRAG_TYPE_NONE);
 				_update_atlas_source_inspector();
 				_update_tile_inspector();
 				_update_tile_data_editors();
@@ -2517,7 +2515,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector).unbind(1));
 	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_data_editors).unbind(1));
 	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_current_tile_data_editor).unbind(1));
-	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_view).unbind(1));
+	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_view).unbind(1).bind(false));
 	tools_button_group->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_update_toolbar).unbind(1));
 
 	HBoxContainer *toolbox = memnew(HBoxContainer);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -267,7 +267,7 @@ private:
 	void _update_tile_data_editors();
 	void _update_current_tile_data_editor();
 	void _update_manage_tile_properties_button();
-	void _update_atlas_view();
+	void _update_atlas_view(bool p_with_clipping);
 	void _update_toolbar();
 	void _update_buttons();
 


### PR DESCRIPTION
Editing decently sized tile sets is **really** laggy and painful to use. This commit tries to reduce that friction in two ways.

1) Clipping intensive rendering of the potentially thousands of drawn rects to only the visible area and
2) Avoiding some calls to `tile_atlas_view->queue_redraw()` when dragging around in the atlas view editor.

Supersedes #84963 by maintaining the existing rendering logic.

A more comprehensive fix would be to perhaps batch and invalidate this expensive rendering in a more piecewise fashion in some kind of quadtree structure -- in the mean time this PR fixes the performance when zoomed in to reasonable values.