### PR TITLE
Lookup method also in base scripts of a PlaceHolderScriptInstance

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -697,7 +697,13 @@ bool PlaceHolderScriptInstance::has_method(const StringName &p_method) const {
 	}
 
 	if (script.is_valid()) {
-		return script->has_method(p_method);
+		Ref<Script> scr = script;
+		while (scr.is_valid()) {
+			if (scr->has_method(p_method)) {
+				return true;
+			}
+			scr = scr->get_base_script();
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
- Changes the `PlaceHolderScriptInstance::has_method` implementation to match `GDScriptInstance::has_method` and `CSharpScriptInstance::has_method`.
- Fixes https://github.com/godotengine/godot/issues/93438.