### PR TITLE
Add a button to copy viewport transform to the active `Camera3D`

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -223,6 +223,7 @@ private:
 	EditorSelection *editor_selection = nullptr;
 
 	CheckBox *preview_camera = nullptr;
+	Button *paste_viewport_transform = nullptr;
 	SubViewportContainer *subviewport_container = nullptr;
 
 	MenuButton *view_menu = nullptr;
@@ -427,6 +428,7 @@ private:
 	void _preview_exited_scene();
 	void _toggle_camera_preview(bool);
 	void _toggle_cinema_preview(bool);
+	void _paste_viewport_transform();
 	void _init_gizmo_instance(int p_idx);
 	void _finish_gizmo_instances();
 	void _selection_result_pressed(int);


### PR DESCRIPTION
This QoL enhancement, which adds a button to paste viewport transform to the active camera:

![camera_3d](https://github.com/godotengine/godot/assets/3036176/c89609cb-b8bd-40eb-b49d-2f814dc6bda7)
