### PR TITLE
Fix atlas texture positioning in circular TextureProgressBar

### DIFF
--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -31,7 +31,6 @@
 #include "texture_progress_bar.h"
 
 #include "core/config/engine.h"
-#include "scene/resources/atlas_texture.h"
 
 void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
 	_set_texture(&under, p_texture);
@@ -513,15 +512,6 @@ void TextureProgressBar::_notification(int p_what) {
 								}
 								pts.push_back(to);
 
-								Ref<AtlasTexture> atlas_progress = progress;
-								bool valid_atlas_progress = atlas_progress.is_valid() && atlas_progress->get_atlas().is_valid();
-								Rect2 region_rect;
-								Size2 atlas_size;
-								if (valid_atlas_progress) {
-									region_rect = atlas_progress->get_region();
-									atlas_size = atlas_progress->get_atlas()->get_size();
-								}
-
 								Vector<Point2> uvs;
 								Vector<Point2> points;
 								for (const float &f : pts) {
@@ -530,10 +520,6 @@ void TextureProgressBar::_notification(int p_what) {
 										continue;
 									}
 									points.push_back(progress_offset + Point2(uv.x * s.x, uv.y * s.y));
-									if (valid_atlas_progress) {
-										uv.x = Math::remap(uv.x, 0, 1, region_rect.position.x / atlas_size.x, (region_rect.position.x + region_rect.size.x) / atlas_size.x);
-										uv.y = Math::remap(uv.y, 0, 1, region_rect.position.y / atlas_size.y, (region_rect.position.y + region_rect.size.y) / atlas_size.y);
-									}
 									uvs.push_back(uv);
 								}
 
@@ -541,10 +527,6 @@ void TextureProgressBar::_notification(int p_what) {
 								if (points.size() >= 2) {
 									Point2 center_point = get_relative_center();
 									points.push_back(progress_offset + s * center_point);
-									if (valid_atlas_progress) {
-										center_point.x = Math::remap(center_point.x, 0, 1, region_rect.position.x / atlas_size.x, (region_rect.position.x + region_rect.size.x) / atlas_size.x);
-										center_point.y = Math::remap(center_point.y, 0, 1, region_rect.position.y / atlas_size.y, (region_rect.position.y + region_rect.size.y) / atlas_size.y);
-									}
 									uvs.push_back(center_point);
 
 									Vector<Color> colors;


### PR DESCRIPTION
In 4.2 TextureProgressBar needed to position its atlas texture, but in 4.3 `draw_polygon()` handles it.

Fixes #93462.