### PR TITLE
Fix crash on shader constant initialization on MinGW compiler

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1445,8 +1445,12 @@ bool ShaderLanguage::_find_identifier(const BlockNode *p_block, bool p_allow_rea
 			*r_struct_name = shader->constants[p_identifier].struct_name;
 		}
 		if (r_constant_value) {
-			if (shader->constants[p_identifier].initializer && shader->constants[p_identifier].initializer->values.size() == 1) {
-				*r_constant_value = shader->constants[p_identifier].initializer->values[0];
+			if (shader->constants[p_identifier].initializer && shader->constants[p_identifier].initializer->type == Node::NODE_TYPE_CONSTANT) {
+				ConstantNode *cnode = static_cast<ConstantNode *>(shader->constants[p_identifier].initializer);
+
+				if (cnode->values.size() == 1) {
+					*r_constant_value = cnode->values[0];
+				}
 			}
 		}
 		if (r_type) {
@@ -9443,7 +9447,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									}
 								}
 
-								constant.initializer = static_cast<ConstantNode *>(expr);
+								constant.initializer = expr;
 
 								if (!_compare_datatypes(type, struct_name, 0, expr->get_datatype(), expr->get_datatype_name(), expr->get_array_size())) {
 									return ERR_PARSE_ERROR;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -620,7 +620,7 @@ public:
 			DataType type;
 			StringName struct_name;
 			DataPrecision precision;
-			ConstantNode *initializer = nullptr;
+			Node *initializer = nullptr;
 			int array_size;
 		};
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/93387 (only the crash, the constants parsing should be rewritten in future). As a workaround, it works.