### PR TITLE
Remove unused navigation polygon properties

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -1127,13 +1127,6 @@ void NavMap::sync() {
 				new_polygon.points.push_back({ closest_end_point, get_point_key(closest_end_point) });
 				new_polygon.points.push_back({ closest_end_point, get_point_key(closest_end_point) });
 
-				Vector3 center;
-				for (int p = 0; p < 4; ++p) {
-					center += new_polygon.points[p].pos;
-				}
-				new_polygon.center = center / real_t(new_polygon.points.size());
-				new_polygon.clockwise = true;
-
 				// Setup connections to go forward in the link.
 				{
 					gd::Edge::Connection entry_connection;

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -277,9 +277,6 @@ void NavRegion::update_polygons() {
 		polygon.surface_area = _new_polygon_surface_area;
 		_new_region_surface_area += _new_polygon_surface_area;
 
-		Vector3 polygon_center;
-		real_t sum(0);
-
 		for (int j(0); j < navigation_mesh_polygon_size; j++) {
 			int idx = indices[j];
 			if (idx < 0 || idx >= len) {
@@ -290,24 +287,10 @@ void NavRegion::update_polygons() {
 			Vector3 point_position = transform.xform(vertices_r[idx]);
 			polygon.points[j].pos = point_position;
 			polygon.points[j].key = map->get_point_key(point_position);
-
-			polygon_center += point_position; // Composing the center of the polygon
-
-			if (j >= 2) {
-				Vector3 epa = transform.xform(vertices_r[indices[j - 2]]);
-				Vector3 epb = transform.xform(vertices_r[indices[j - 1]]);
-
-				sum += map->get_up().dot((epb - epa).cross(point_position - epa));
-			}
 		}
 
 		if (!valid) {
 			ERR_BREAK_MSG(!valid, "The navigation mesh set in this region is not valid!");
-		}
-
-		polygon.clockwise = sum > 0;
-		if (!navigation_mesh_polygon.is_empty()) {
-			polygon.center = polygon_center / real_t(navigation_mesh_polygon.size());
 		}
 	}
 

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -104,14 +104,8 @@ struct Polygon {
 	/// The points of this `Polygon`
 	LocalVector<Point> points;
 
-	/// Are the points clockwise?
-	bool clockwise;
-
 	/// The edges of this `Polygon`
 	LocalVector<Edge> edges;
-
-	/// The center of this `Polygon`
-	Vector3 center;
 
 	real_t surface_area = 0.0;
 };


### PR DESCRIPTION
Removes unused navigation polygon properties `center` and `clockwise`.

Both are leftover from the old Godot 3 days that used polygon center to polygon center distance for (rather inaccurate) pathfinding cost calculation and the clockwise property for the old string-pulling corridor funnel.

Very minor performance gain as this was not used by anything ever in Godot 4 but was calculated all the time for all the links and polygons.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
