### PR TITLE
Disable `*glGetProcAddress()` on the web

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -72,7 +72,7 @@
 
 #if !defined(IOS_ENABLED) && !defined(WEB_ENABLED)
 // We include EGL below to get debug callback on GLES2 platforms,
-// but EGL is not available on iOS.
+// but EGL is not available on iOS or the web.
 #define CAN_DEBUG
 #endif
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -207,11 +207,10 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-sMAX_WEBGL_VERSION=2"])
         # Allow use to take control of swapping WebGL buffers.
         env.Append(LINKFLAGS=["-sOFFSCREEN_FRAMEBUFFER=1"])
-        # Breaking change since emscripten 3.1.51
-        # https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3151---121323
+        # Disables the use of *glGetProcAddress() which is inefficient.
+        # See https://emscripten.org/docs/tools_reference/settings_reference.html#gl-enable-get-proc-address
         if cc_semver >= (3, 1, 51):
-            # Enables the use of *glGetProcAddress()
-            env.Append(LINKFLAGS=["-sGL_ENABLE_GET_PROC_ADDRESS=1"])
+            env.Append(LINKFLAGS=["-sGL_ENABLE_GET_PROC_ADDRESS=0"])
 
     if env["javascript_eval"]:
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])

--- a/platform/web/platform_gl.h
+++ b/platform/web/platform_gl.h
@@ -35,6 +35,10 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
+// Make using *glGetProcAddress() an error on the web.
+#define glGetProcAddress(n) static_assert(false, "Usage of glGetProcessAddress() on the web is a bug.")
+#define eglGetProcAddress(n) static_assert(false, "Usage of eglGetProcessAddress() on the web is a bug.")
+
 #include "platform/web/godot_webgl2.h"
 
 #endif // PLATFORM_GL_H


### PR DESCRIPTION
In PR https://github.com/godotengine/godot/pull/87981, we added the Emscripten flag (supported in 3.1.51 or later) to enable `glGetProcAddress()` on the web.

However, we shouldn't need it (since the GL functions are "statically linked" on the web) and it's known to be inefficient.

See these references from the Emscripten docs:

- ["Optimizing WebGL"](https://emscripten.org/docs/optimizing/Optimizing-WebGL.html?highlight=glgetprocaddress): ![Selection_166](https://github.com/godotengine/godot/assets/191561/f48f3bcf-d655-4e8f-abc6-52d8f888c16b)
- ["Compiler Settings"](https://emscripten.org/docs/tools_reference/settings_reference.html#gl-enable-get-proc-address): ![Selection_167](https://github.com/godotengine/godot/assets/191561/df16c47b-a874-430d-9d18-370893d56c51)

This PR explicitly disables the feature (rather than just reverting PR https://github.com/godotengine/godot/pull/87981) since the docs say it's enabled by default - since that didn't seem to be the case originally, either the docs are wrong or the default may have changed?

Marking as draft because I haven't had much time to test it yet. It succeeds in compiling and seems to work, but I'd like to be more sure that everything is good. :-)