### PR TITLE
Fix subwindow titlebar redraw on oversampling change.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -309,7 +309,8 @@ void Viewport::_sub_window_update(Window *p_window) {
 	int index = _sub_window_find(p_window);
 	ERR_FAIL_COND(index == -1);
 
-	const SubWindow &sw = gui.sub_windows[index];
+	SubWindow &sw = gui.sub_windows.write[index];
+	sw.pending_window_update = false;
 
 	Transform2D pos;
 	pos.set_origin(p_window->get_position());
@@ -972,6 +973,14 @@ void Viewport::update_canvas_items() {
 		return;
 	}
 
+	if (is_embedding_subwindows()) {
+		for (Viewport::SubWindow w : gui.sub_windows) {
+			if (w.window && !w.pending_window_update) {
+				w.pending_window_update = true;
+				callable_mp(this, &Viewport::_sub_window_update).call_deferred(w.window);
+			}
+		}
+	}
 	_update_canvas_items(this);
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -340,6 +340,7 @@ private:
 		Window *window = nullptr;
 		RID canvas_item;
 		Rect2i parent_safe_rect;
+		bool pending_window_update = false;
 	};
 
 	// VRS


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76450