### PR TITLE
Fix type-limits warning in `windows_utils`

### DIFF
--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -220,7 +220,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 
 		int original_path_size = pdb_info.path.utf8().length();
 		// Double-check file bounds.
-		ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
+		ERR_FAIL_UNSIGNED_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
 
 		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
 		file->seek(pdb_info.address);


### PR DESCRIPTION
# Info

This fix allows Godot to be compiled for `platform=windows dev_mode=true` with `x86_64-w64-mingw32-g++`

> scons platform=windows target=editor dev_build=true dev_mode=true

```
Using MinGW, arch x86_64
Building for platform "windows", architecture "x86_64", target "editor".
NOTE: Developer build, with debug optimization level and debug symbols (unless overridden).
```

Tested with `x86_64-w64-mingw32-g++ (GCC) 13-posix` on `WSL2 (Win10) + Ubuntu 24.04`

## Before

```
In file included from ./core/string/char_utils.h:34,
                 from ./core/string/ustring.h:36,
                 from platform/windows/windows_utils.h:36,
                 from platform/windows/windows_utils.cpp:31:
platform/windows/windows_utils.cpp: In static member function 'static Error WindowsUtils::copy_and_rename_pdb(const String&)':
./core/error/error_macros.h:168:32: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
  168 |         if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
      |                      ~~~~~~~~~~^~~
./core/typedefs.h:277:41: note: in definition of macro 'unlikely'
  277 | #define unlikely(x) __builtin_expect(!!(x), 0)
      |                                         ^
platform/windows/windows_utils.cpp:223:17: note: in expansion of macro 'ERR_FAIL_INDEX_V_MSG'
  223 |                 ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
      |                 ^~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
scons: *** [platform/windows/windows_utils.windows.editor.dev.x86_64.o] Error 1
```

## Notes

I see @Repiteo has this fix in his [PR](https://github.com/godotengine/godot/pull/91692), but it's part of a larger commit and so far in Draft mode, so I thought at least this would go through because it's the only thing that breaks compilation.