### PR TITLE
Add stub method for `mouse_get_position` in headless display server

### DIFF
--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -153,6 +153,7 @@ public:
 	void tts_stop() override {}
 
 	void mouse_set_mode(MouseMode p_mode) override {}
+	Point2i mouse_get_position() const override { return Point2i(); }
 	void clipboard_set(const String &p_text) override {}
 	void clipboard_set_primary(const String &p_text) override {}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93461