### PR TITLE
Move NavRegion connections to NavMap

### DIFF
--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -509,22 +509,31 @@ void GodotNavigationServer3D::region_bake_navigation_mesh(Ref<NavigationMesh> p_
 int GodotNavigationServer3D::region_get_connections_count(RID p_region) const {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_NULL_V(region, 0);
-
-	return region->get_connections_count();
+	NavMap *map = region->get_map();
+	if (map) {
+		return map->get_region_connections_count(region);
+	}
+	return 0;
 }
 
 Vector3 GodotNavigationServer3D::region_get_connection_pathway_start(RID p_region, int p_connection_id) const {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_NULL_V(region, Vector3());
-
-	return region->get_connection_pathway_start(p_connection_id);
+	NavMap *map = region->get_map();
+	if (map) {
+		return map->get_region_connection_pathway_start(region, p_connection_id);
+	}
+	return Vector3();
 }
 
 Vector3 GodotNavigationServer3D::region_get_connection_pathway_end(RID p_region, int p_connection_id) const {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_NULL_V(region, Vector3());
-
-	return region->get_connection_pathway_end(p_connection_id);
+	NavMap *map = region->get_map();
+	if (map) {
+		return map->get_region_connection_pathway_end(region, p_connection_id);
+	}
+	return Vector3();
 }
 
 Vector3 GodotNavigationServer3D::region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const {

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -916,8 +916,9 @@ void NavMap::sync() {
 		_new_pm_edge_free_count = 0;
 
 		// Remove regions connections.
+		region_external_connections.clear();
 		for (NavRegion *region : regions) {
-			region->get_connections().clear();
+			region_external_connections[region] = LocalVector<gd::Edge::Connection>();
 		}
 
 		// Resize the polygon count.
@@ -1051,7 +1052,7 @@ void NavMap::sync() {
 				free_edge.polygon->edges[free_edge.edge].connections.push_back(new_connection);
 
 				// Add the connection to the region_connection map.
-				((NavRegion *)free_edge.polygon->owner)->get_connections().push_back(new_connection);
+				region_external_connections[(NavRegion *)free_edge.polygon->owner].push_back(new_connection);
 				_new_pm_edge_connection_count += 1;
 			}
 		}
@@ -1411,6 +1412,40 @@ void NavMap::clip_path(const LocalVector<gd::NavigationPoly> &p_navigation_polys
 void NavMap::_update_merge_rasterizer_cell_dimensions() {
 	merge_rasterizer_cell_size = cell_size * merge_rasterizer_cell_scale;
 	merge_rasterizer_cell_height = cell_height * merge_rasterizer_cell_scale;
+}
+
+int NavMap::get_region_connections_count(NavRegion *p_region) const {
+	ERR_FAIL_NULL_V(p_region, 0);
+
+	HashMap<NavRegion *, LocalVector<gd::Edge::Connection>>::ConstIterator found_connections = region_external_connections.find(p_region);
+	if (found_connections) {
+		return found_connections->value.size();
+	}
+	return 0;
+}
+
+Vector3 NavMap::get_region_connection_pathway_start(NavRegion *p_region, int p_connection_id) const {
+	ERR_FAIL_NULL_V(p_region, Vector3());
+
+	HashMap<NavRegion *, LocalVector<gd::Edge::Connection>>::ConstIterator found_connections = region_external_connections.find(p_region);
+	if (found_connections) {
+		ERR_FAIL_INDEX_V(p_connection_id, int(found_connections->value.size()), Vector3());
+		return found_connections->value[p_connection_id].pathway_start;
+	}
+
+	return Vector3();
+}
+
+Vector3 NavMap::get_region_connection_pathway_end(NavRegion *p_region, int p_connection_id) const {
+	ERR_FAIL_NULL_V(p_region, Vector3());
+
+	HashMap<NavRegion *, LocalVector<gd::Edge::Connection>>::ConstIterator found_connections = region_external_connections.find(p_region);
+	if (found_connections) {
+		ERR_FAIL_INDEX_V(p_connection_id, int(found_connections->value.size()), Vector3());
+		return found_connections->value[p_connection_id].pathway_end;
+	}
+
+	return Vector3();
 }
 
 NavMap::NavMap() {

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -124,6 +124,8 @@ class NavMap : public NavRid {
 	int pm_edge_connection_count = 0;
 	int pm_edge_free_count = 0;
 
+	HashMap<NavRegion *, LocalVector<gd::Edge::Connection>> region_external_connections;
+
 public:
 	NavMap();
 	~NavMap();
@@ -216,6 +218,10 @@ public:
 	int get_pm_edge_merge_count() const { return pm_edge_merge_count; }
 	int get_pm_edge_connection_count() const { return pm_edge_connection_count; }
 	int get_pm_edge_free_count() const { return pm_edge_free_count; }
+
+	int get_region_connections_count(NavRegion *p_region) const;
+	Vector3 get_region_connection_pathway_start(NavRegion *p_region, int p_connection_id) const;
+	Vector3 get_region_connection_pathway_end(NavRegion *p_region, int p_connection_id) const;
 
 private:
 	void compute_single_step(uint32_t index, NavAgent **agent);

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -44,8 +44,6 @@ void NavRegion::set_map(NavMap *p_map) {
 	map = p_map;
 	polygons_dirty = true;
 
-	connections.clear();
-
 	if (map) {
 		map->add_region(this);
 	}
@@ -103,25 +101,6 @@ void NavRegion::set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) {
 	}
 
 	polygons_dirty = true;
-}
-
-int NavRegion::get_connections_count() const {
-	if (!map) {
-		return 0;
-	}
-	return connections.size();
-}
-
-Vector3 NavRegion::get_connection_pathway_start(int p_connection_id) const {
-	ERR_FAIL_NULL_V(map, Vector3());
-	ERR_FAIL_INDEX_V(p_connection_id, connections.size(), Vector3());
-	return connections[p_connection_id].pathway_start;
-}
-
-Vector3 NavRegion::get_connection_pathway_end(int p_connection_id) const {
-	ERR_FAIL_NULL_V(map, Vector3());
-	ERR_FAIL_INDEX_V(p_connection_id, connections.size(), Vector3());
-	return connections[p_connection_id].pathway_end;
 }
 
 Vector3 NavRegion::get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const {

--- a/modules/navigation/nav_region.h
+++ b/modules/navigation/nav_region.h
@@ -40,7 +40,6 @@
 class NavRegion : public NavBase {
 	NavMap *map = nullptr;
 	Transform3D transform;
-	Vector<gd::Edge::Connection> connections;
 	bool enabled = true;
 
 	bool use_edge_connections = true;
@@ -84,13 +83,6 @@ public:
 	}
 
 	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
-
-	Vector<gd::Edge::Connection> &get_connections() {
-		return connections;
-	}
-	int get_connections_count() const;
-	Vector3 get_connection_pathway_start(int p_connection_id) const;
-	Vector3 get_connection_pathway_end(int p_connection_id) const;
 
 	LocalVector<gd::Polygon> const &get_polygons() const {
 		return polygons;


### PR DESCRIPTION
Moves bookkeeping for connections from region to map where connections are actually made.

This PR primarily prepares the ground for other things. That map and region are always in perfect sync is only workable while everything is single-threaded so having map connections stored on a region is problematic for both async map updates and threaded pathfinding. The regions never actually did anything and connection editing and clearing was already done by the map so having the connections only stored on the region was already weird.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
