### PR TITLE
Change "sample" to "stream" in AudioStreamWAV documentation

### DIFF
--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -29,10 +29,10 @@
 			Audio format. See [enum Format] constants for values.
 		</member>
 		<member name="loop_begin" type="int" setter="set_loop_begin" getter="get_loop_begin" default="0">
-			The loop start point (in number of samples, relative to the beginning of the sample). This information will be imported automatically from the WAV file if present.
+			The loop start point (in number of samples, relative to the beginning of the stream). This information will be imported automatically from the WAV file if present.
 		</member>
 		<member name="loop_end" type="int" setter="set_loop_end" getter="get_loop_end" default="0">
-			The loop end point (in number of samples, relative to the beginning of the sample). This information will be imported automatically from the WAV file if present.
+			The loop end point (in number of samples, relative to the beginning of the stream). This information will be imported automatically from the WAV file if present.
 		</member>
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamWAV.LoopMode" default="0">
 			The loop mode. This information will be imported automatically from the WAV file if present. See [enum LoopMode] constants for values.


### PR DESCRIPTION
Previously, `AudioStreamWAV.loop_begin` had this as its description:
> The loop start point (in number of samples, relative to the beginning of the sample).

and likewise for `AudioStreamWAV.loop_end`.

Unless I'm misunderstanding what this is trying to say, I believe the word "stream" is a better fit. While some may think that "sample" can refer to the audio being stored in the stream, [it has a well-defined meaning as a single point of data](https://en.wikipedia.org/wiki/Sampling_(signal_processing)):
> **A sample is a value of the [sound] signal at a point in time and/or space; this definition differs from the term's usage in statistics, which refers to a set of such values.**

The existing documentation uses the term "sample" correctly earlier in the sentence. Replacing the second instance of the word with "stream" makes it more clear what the variable means.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
