### PR TITLE
Improve button behavior when multiple mouse buttons are used at the same time

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -144,7 +144,9 @@ void BaseButton::_toggled(bool p_pressed) {
 }
 
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
-	if (p_event->is_pressed()) {
+	Ref<InputEventMouseButton> mouse_button = p_event;
+
+	if (p_event->is_pressed() && (mouse_button.is_null() || status.hovering)) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
 		emit_signal(SNAME("button_down"));
@@ -174,12 +176,6 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	}
 
 	if (!p_event->is_pressed()) {
-		Ref<InputEventMouseButton> mouse_button = p_event;
-		if (mouse_button.is_valid()) {
-			if (!has_point(mouse_button->get_position())) {
-				status.hovering = false;
-			}
-		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
 		emit_signal(SNAME("button_up"));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1768,7 +1768,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					Control *control = Object::cast_to<Control>(ci);
 					if (control) {
 						if (control->get_focus_mode() != Control::FOCUS_NONE) {
-							if (control != gui.key_focus) {
+							// Grabbing unhovered focus can cause issues when mouse is dragged
+							// with another button held down.
+							if (control != gui.key_focus && gui.mouse_over_hierarchy.has(control)) {
 								control->grab_focus();
 							}
 							break;


### PR DESCRIPTION
- To emit `pressed`, buttons require that the press was initiated while hovering.
- Controls can't grab focus from a mouse click if they're not hovered.
- Hovers are updated both before and after a handled mouse button event.

Fixes #93395.

An updated MRP that makes testing this even easier: [button_mrp.zip](https://github.com/user-attachments/files/15942556/button_mrp.zip)