### PR TITLE
Allow tool scripts to alter transform of Node3DEditorViewport camera

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -445,6 +445,11 @@ private:
 	Transform3D to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();
 
+	// These allow tool scripts to set the 3D cursor location by updating the camera transform.
+	Transform3D last_camera_transform;
+	bool _camera_moved_externally();
+	void _apply_camera_transform_to_cursor();
+
 	void _surface_mouse_enter();
 	void _surface_mouse_exit();
 	void _surface_focus_enter();


### PR DESCRIPTION
I'd like my plugin/tool script to be able to move the 3d editor's camera. Same as some comments in several issues, e.g.
https://github.com/godotengine/godot-proposals/issues/1302#issuecomment-1318809092
https://github.com/godotengine/godot-proposals/issues/3287#issuecomment-2099717479
https://github.com/godotengine/godot-proposals/issues/3164#issuecomment-1180515690

As others have found, moving/rotating the camera only works temporarily, it springs back to original transform as soon as you pan or navigate. 

Cause:
Looking at node_3d_editor_plugin I see it's because camera is updated from a "cursor" and cursor is not exposed to tool script. 

Proposed approach:
Rather than expose new methods or properties to script, I thought it would be simplest to have node_3d_editor_plugin look for external changes to the camera transform, and if any occur, to update its cursor to match the manually updated camera position. Seems to work fine.

Before:
![problem-demo](https://github.com/godotengine/godot/assets/1498979/3f65ba92-7e24-440c-9354-4e91ae00a9d8)

After:
![working-demo](https://github.com/godotengine/godot/assets/1498979/7332b2b7-2c19-4491-b6fc-e6cfed658e85)

Repro project:
[cam-move-test.zip](https://github.com/user-attachments/files/15942839/cam-move-test.zip)
