### PR TITLE
Make AnimationTrackCaches invalid when animation is added

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -150,6 +150,7 @@ void AnimationMixer::_animation_set_cache_update() {
 				ad.name = key;
 				ad.last_update = animation_set_update_pass;
 				animation_set.insert(ad.name, ad);
+				cache_valid = false; // No need to delete the cache, but it must be updated to add track caches.
 			} else {
 				AnimationData &ad = animation_set[key];
 				if (ad.last_update != animation_set_update_pass) {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/92249

https://github.com/godotengine/godot/pull/86715/files#diff-8e8def668b2df75cec75f2dc07225717bdeebe58daad5fbf3fad3dfab101f64fL420 makes it so that the cache is not deleted more than necessary when playing back animations, but does nothing about the cache when animations are added, so the track cache is not generated for the added animations. In this case, it is not necessary to delete the cache, but it is necessary to trigger an update.