### PR TITLE
Add `inherit_visibility_layer` to CanvasItem

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1559,6 +1559,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"), 1);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM, "Disable,Enable,Mirror"), 0);
 
+	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::BOOL, "rendering/2d/visibility/inherit_visibility_layer"), false);
+
 	GLOBAL_DEF("collada/use_ambient", false);
 
 	// Input settings

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -588,6 +588,9 @@
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
 			Allows the current node to clip child nodes, essentially acting as a mask.
 		</member>
+		<member name="inherit_visibility_layer" type="bool" setter="set_inherit_visibility_layer" getter="is_inherit_visibility_layer" default="false">
+			If [code]true[/code], this [CanvasItem] inherits the visibility layers of its parent.
+		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
 		</member>
@@ -617,7 +620,7 @@
 			If [code]true[/code], the parent [CanvasItem]'s [member material] property is used as this one's material.
 		</member>
 		<member name="visibility_layer" type="int" setter="set_visibility_layer" getter="get_visibility_layer" default="1">
-			The rendering layer in which this [CanvasItem] is rendered by [Viewport] nodes. A [Viewport] will render a [CanvasItem] if it and all its parents share a layer with the [Viewport]'s canvas cull mask.
+			The rendering layer in which this [CanvasItem] is rendered by [Viewport] nodes. A [Viewport] will render a [CanvasItem] if it and all its parents share a layer with the [Viewport]'s canvas cull mask. If [member inherit_visibility_layer] is set to [code]true[/code], its parent's [member visibility_layer] is used instead.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
 			If [code]true[/code], this [CanvasItem] is drawn. The node is only visible if all of its ancestors are visible as well (in other words, [method is_visible_in_tree] must return [code]true[/code]).

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2372,6 +2372,9 @@
 			[b]Note:[/b] [Control] nodes are snapped to the nearest pixel by default. This is controlled by [member gui/common/snap_controls_to_pixels].
 			[b]Note:[/b] It is not recommended to use this setting together with [member rendering/2d/snap/snap_2d_transforms_to_pixel], as movement may appear even less smooth. Prefer only enabling that setting instead.
 		</member>
+		<member name="rendering/2d/visibility/inherit_visibility_layer" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], [CanvasItem] nodes inherit the visibility layers of their parent nodes by default.
+		</member>
 		<member name="rendering/anti_aliasing/quality/msaa_2d" type="int" setter="" getter="" default="0">
 			Sets the number of MSAA samples to use for 2D/Canvas rendering (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware, especially integrated graphics due to their limited memory bandwidth. This has no effect on shader-induced aliasing or texture aliasing.
 			[b]Note:[/b] MSAA is only supported in the Forward+ and Mobile rendering methods, not Compatibility.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -515,6 +515,14 @@
 				Sets the index for the [CanvasItem].
 			</description>
 		</method>
+		<method name="canvas_item_set_inherit_visibility_layer">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled] is [code]true[/code], the given canvas item inherits its parent's visibility layers. Equivalent to [member CanvasItem.inherit_visibility_layer].
+			</description>
+		</method>
 		<method name="canvas_item_set_interpolated">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -367,6 +367,8 @@ void EditorNode::_update_from_settings() {
 		scene_root->set_default_canvas_item_texture_repeat(tr);
 	}
 
+	CanvasItem::set_default_inherit_visibility_layer(GLOBAL_GET("rendering/2d/visibility/inherit_visibility_layer"));
+
 	RS::DOFBokehShape dof_shape = RS::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
 	RS::get_singleton()->camera_attributes_set_dof_blur_bokeh_shape(dof_shape);
 	RS::DOFBlurQuality dof_quality = RS::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3925,6 +3925,7 @@ int Main::start() {
 					Viewport::DefaultCanvasItemTextureFilter(texture_filter));
 			sml->get_root()->set_default_canvas_item_texture_repeat(
 					Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
+			CanvasItem::set_default_inherit_visibility_layer(GLOBAL_GET("rendering/2d/visibility/inherit_visibility_layer"));
 		}
 
 #ifdef TOOLS_ENABLED

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -58,6 +58,16 @@ Transform2D CanvasItem::_edit_get_transform() const {
 }
 #endif
 
+bool CanvasItem::default_inherit_visibility_layer = false;
+
+bool CanvasItem::is_default_inherit_visibility_layer() {
+	return default_inherit_visibility_layer;
+}
+
+void CanvasItem::set_default_inherit_visibility_layer(bool p_enable) {
+	default_inherit_visibility_layer = p_enable;
+}
+
 bool CanvasItem::is_visible_in_tree() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return visible && parent_visible_in_tree;
@@ -1260,6 +1270,8 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_visibility_layer"), &CanvasItem::get_visibility_layer);
 	ClassDB::bind_method(D_METHOD("set_visibility_layer_bit", "layer", "enabled"), &CanvasItem::set_visibility_layer_bit);
 	ClassDB::bind_method(D_METHOD("get_visibility_layer_bit", "layer"), &CanvasItem::get_visibility_layer_bit);
+	ClassDB::bind_method(D_METHOD("set_inherit_visibility_layer", "enabled"), &CanvasItem::set_inherit_visibility_layer);
+	ClassDB::bind_method(D_METHOD("is_inherit_visibility_layer"), &CanvasItem::is_inherit_visibility_layer);
 
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &CanvasItem::set_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_texture_filter"), &CanvasItem::get_texture_filter);
@@ -1281,6 +1293,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "clip_children", PROPERTY_HINT_ENUM, "Disabled,Clip Only,Clip + Draw"), "set_clip_children_mode", "get_clip_children_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_layer", PROPERTY_HINT_LAYERS_2D_RENDER), "set_visibility_layer", "get_visibility_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "inherit_visibility_layer"), "set_inherit_visibility_layer", "is_inherit_visibility_layer");
 
 	ADD_GROUP("Ordering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
@@ -1422,6 +1435,17 @@ bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	ERR_FAIL_UNSIGNED_INDEX_V(p_visibility_layer, 32, false);
 	return (visibility_layer & (1 << p_visibility_layer));
+}
+
+void CanvasItem::set_inherit_visibility_layer(bool p_enable) {
+	ERR_THREAD_GUARD;
+	inherit_visibility_layer = p_enable;
+	RenderingServer::get_singleton()->canvas_item_set_inherit_visibility_layer(canvas_item, p_enable);
+}
+
+bool CanvasItem::is_inherit_visibility_layer() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return inherit_visibility_layer;
 }
 
 void CanvasItem::_refresh_texture_filter_cache() const {
@@ -1568,6 +1592,7 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() const {
 CanvasItem::CanvasItem() :
 		xform_change(this) {
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();
+	RenderingServer::get_singleton()->canvas_item_set_inherit_visibility_layer(canvas_item, inherit_visibility_layer);
 }
 
 CanvasItem::~CanvasItem() {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -73,6 +73,9 @@ public:
 		CLIP_CHILDREN_MAX,
 	};
 
+	static bool is_default_inherit_visibility_layer();
+	static void set_default_inherit_visibility_layer(bool p_enable);
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -90,6 +93,8 @@ private:
 
 	int light_mask = 1;
 	uint32_t visibility_layer = 1;
+	static bool default_inherit_visibility_layer;
+	bool inherit_visibility_layer = is_default_inherit_visibility_layer();
 
 	int z_index = 0;
 	bool z_relative = true;
@@ -257,6 +262,8 @@ public:
 
 	void set_visibility_layer(uint32_t p_visibility_layer);
 	uint32_t get_visibility_layer() const;
+	void set_inherit_visibility_layer(bool p_enable);
+	bool is_inherit_visibility_layer() const;
 
 	void set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_enable);
 	bool get_visibility_layer_bit(uint32_t p_visibility_layer) const;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -51,7 +51,7 @@ void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas
 	memset(z_last_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
 
 	for (int i = 0; i < p_child_item_count; i++) {
-		_cull_canvas_item(p_child_items[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, true, p_canvas_cull_mask, Point2(), 1, nullptr);
+		_cull_canvas_item(p_child_items[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, true, p_canvas_cull_mask, Point2(), 1, nullptr, 0xffffffff);
 	}
 
 	RendererCanvasRender::Item *list = nullptr;
@@ -79,11 +79,18 @@ void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas
 	}
 }
 
-void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, const Transform2D &p_transform, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int p_z) {
+void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, const Transform2D &p_transform, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int p_z, uint32_t p_canvas_cull_mask, uint32_t p_parent_visibility_layer) {
 	int child_item_count = p_canvas_item->child_items.size();
 	RendererCanvasCull::Item **child_items = p_canvas_item->child_items.ptrw();
 	for (int i = 0; i < child_item_count; i++) {
 		int abs_z = 0;
+
+		uint32_t visibility_layer = p_canvas_item->inherit_visibility_layer ? p_parent_visibility_layer : p_canvas_item->visibility_layer;
+
+		if (!(visibility_layer & p_canvas_cull_mask)) {
+			continue;
+		}
+
 		if (child_items[i]->visible) {
 			if (r_items) {
 				r_items[r_index] = child_items[i];
@@ -111,7 +118,7 @@ void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, const Tran
 			r_index++;
 
 			if (child_items[i]->sort_y) {
-				_collect_ysort_children(child_items[i], p_transform * child_items[i]->xform_curr, child_items[i]->use_parent_material ? p_material_owner : child_items[i], p_modulate * child_items[i]->modulate, r_items, r_index, abs_z);
+				_collect_ysort_children(child_items[i], p_transform * child_items[i]->xform_curr, child_items[i]->use_parent_material ? p_material_owner : child_items[i], p_modulate * child_items[i]->modulate, r_items, r_index, abs_z, p_canvas_cull_mask, visibility_layer);
 			}
 		}
 	}
@@ -236,14 +243,16 @@ void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *
 	}
 }
 
-void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item) {
+void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item, uint32_t p_parent_visibility_layer) {
 	Item *ci = p_canvas_item;
 
 	if (!ci->visible) {
 		return;
 	}
 
-	if (!(ci->visibility_layer & p_canvas_cull_mask)) {
+	uint32_t visibility_layer = ci->inherit_visibility_layer ? p_parent_visibility_layer : ci->visibility_layer;
+
+	if (!(visibility_layer & p_canvas_cull_mask)) {
 		return;
 	}
 
@@ -358,7 +367,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		if (p_allow_y_sort) {
 			if (ci->ysort_children_count == -1) {
 				ci->ysort_children_count = 0;
-				_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), nullptr, ci->ysort_children_count, p_z);
+				_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), nullptr, ci->ysort_children_count, p_z, p_canvas_cull_mask, visibility_layer);
 			}
 
 			child_item_count = ci->ysort_children_count + 1;
@@ -371,13 +380,12 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			ci->ysort_parent_abs_z_index = parent_z;
 			child_items[0] = ci;
 			int i = 1;
-			_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), child_items, i, p_z);
-
+			_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), child_items, i, p_z, p_canvas_cull_mask, visibility_layer);
 			SortArray<Item *, ItemPtrSort> sorter;
 			sorter.sort(child_items, child_item_count);
 
 			for (i = 0; i < child_item_count; i++) {
-				_cull_canvas_item(child_items[i], final_xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, child_items[i]->ysort_parent_abs_z_index, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, false, p_canvas_cull_mask, child_items[i]->repeat_size, child_items[i]->repeat_times, child_items[i]->repeat_source_item);
+				_cull_canvas_item(child_items[i], final_xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, child_items[i]->ysort_parent_abs_z_index, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, false, p_canvas_cull_mask, child_items[i]->repeat_size, child_items[i]->repeat_times, child_items[i]->repeat_source_item, visibility_layer);
 			}
 		} else {
 			RendererCanvasRender::Item *canvas_group_from = nullptr;
@@ -401,14 +409,14 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			if (!child_items[i]->behind && !use_canvas_group) {
 				continue;
 			}
-			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, true, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, true, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item, visibility_layer);
 		}
 		_attach_canvas_item_for_draw(ci, p_canvas_clip, r_z_list, r_z_last_list, final_xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from);
 		for (int i = 0; i < child_item_count; i++) {
 			if (child_items[i]->behind || use_canvas_group) {
 				continue;
 			}
-			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, true, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, true, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item, visibility_layer);
 		}
 	}
 }
@@ -584,6 +592,13 @@ uint32_t RendererCanvasCull::canvas_item_get_visibility_layer(RID p_item) {
 	if (!canvas_item)
 		return 0;
 	return canvas_item->visibility_layer;
+}
+
+void RendererCanvasCull::canvas_item_set_inherit_visibility_layer(RID p_item, bool p_enable) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->inherit_visibility_layer = p_enable;
 }
 
 void RendererCanvasCull::canvas_item_set_clip(RID p_item, bool p_clip) {

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -55,6 +55,7 @@ public:
 		int ysort_index;
 		int ysort_parent_abs_z_index; // Absolute Z index of parent. Only populated and used when y-sorting.
 		uint32_t visibility_layer = 0xffffffff;
+		bool inherit_visibility_layer;
 
 		Vector<Item *> child_items;
 
@@ -87,6 +88,7 @@ public:
 			ysort_pos = Vector2();
 			ysort_index = 0;
 			ysort_parent_abs_z_index = 0;
+			inherit_visibility_layer = false;
 		}
 	};
 
@@ -187,7 +189,7 @@ public:
 
 private:
 	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
-	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item);
+	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item, uint32_t p_parent_visibility_layer);
 
 	static constexpr int z_range = RS::CANVAS_ITEM_Z_MAX - RS::CANVAS_ITEM_Z_MIN + 1;
 
@@ -218,6 +220,7 @@ public:
 
 	void canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer);
 	uint32_t canvas_item_get_visibility_layer(RID p_item);
+	void canvas_item_set_inherit_visibility_layer(RID p_item, bool p_enable);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_set_clip(RID p_item, bool p_clip);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -874,6 +874,7 @@ public:
 	FUNC2(canvas_item_set_light_mask, RID, int)
 
 	FUNC2(canvas_item_set_visibility_layer, RID, uint32_t)
+	FUNC2(canvas_item_set_inherit_visibility_layer, RID, bool)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3219,6 +3219,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visible", "item", "visible"), &RenderingServer::canvas_item_set_visible);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_light_mask", "item", "mask"), &RenderingServer::canvas_item_set_light_mask);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visibility_layer", "item", "visibility_layer"), &RenderingServer::canvas_item_set_visibility_layer);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_inherit_visibility_layer", "item", "enabled"), &RenderingServer::canvas_item_set_inherit_visibility_layer);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_transform", "item", "transform"), &RenderingServer::canvas_item_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_clip", "item", "clip"), &RenderingServer::canvas_item_set_clip);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_distance_field_mode", "item", "enabled"), &RenderingServer::canvas_item_set_distance_field_mode);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1451,6 +1451,7 @@ public:
 	virtual void canvas_item_set_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_self_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_visibility_layer) = 0;
+	virtual void canvas_item_set_inherit_visibility_layer(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10014

I'm not set on the name or the enum values, so I'd like to hear what others think. I did some preliminary tests and it seems to work as I'd expect so no issues so far, but please tell me if I missed anything big. I'm sure there's plenty I could have done better here.

I added a project setting so that it remains the old behavior by default for now to avoid breaking compatibility.