### PR TITLE
Core: Add `[[nodiscard]]` to string-like classes/structs

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2266,7 +2266,7 @@ void Image::initialize_data(const char **p_xpm) {
 		switch (status) {
 			case READING_HEADER: {
 				String line_str = line_ptr;
-				line_str.replace_char('\t', ' ');
+				line_str = line_str.replace_char('\t', ' ');
 
 				size_width = line_str.get_slicec(' ', 0).to_int();
 				size_height = line_str.get_slicec(' ', 1).to_int();

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -32,7 +32,7 @@
 
 #include "core/string/ustring.h"
 
-struct IPAddress {
+struct [[nodiscard]] IPAddress {
 private:
 	union {
 		uint8_t field8[16];

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1195,7 +1195,7 @@ String ResourceLoaderBinary::recognize_script_class(Ref<FileAccess> p_f) {
 		return "";
 	}
 
-	get_unicode_string(); // type
+	_ALLOW_DISCARD_ get_unicode_string(); // type
 
 	f->get_64(); // Metadata offset
 	uint32_t flags = f->get_32();

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -33,7 +33,7 @@
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
 
-class NodePath {
+class [[nodiscard]] NodePath {
 	struct Data {
 		SafeRefCount refcount;
 		Vector<StringName> path;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -37,7 +37,7 @@
 
 class Main;
 
-class StringName {
+class [[nodiscard]] StringName {
 	struct Table;
 
 	struct _Data {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -127,7 +127,7 @@ constexpr int64_t str_compare(const L *l_ptr, const R *r_ptr) {
 /*************************************************************************/
 
 template <typename T>
-class CharProxy {
+class [[nodiscard]] CharProxy {
 	friend String;
 	friend CharStringT<T>;
 
@@ -170,7 +170,7 @@ public:
 /*************************************************************************/
 
 template <typename T>
-class CharStringT {
+class [[nodiscard]] CharStringT {
 	CowData<T> _cowdata;
 	static constexpr T _null = 0;
 
@@ -265,7 +265,7 @@ using Char16String = CharStringT<char16_t>;
 /*  String                                                               */
 /*************************************************************************/
 
-class String {
+class [[nodiscard]] String {
 	CowData<char32_t> _cowdata;
 	static constexpr char32_t _null = 0;
 	static constexpr char32_t _replacement_char = 0xfffd;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -59,7 +59,8 @@ static String _get_parent_class_of_script(const String &p_path) {
 
 	// Inherits from a built-in class.
 	if (base.is_null()) {
-		script->get_language()->get_global_class_name(script->get_path(), &class_name);
+		// We only care about the referenced class_name.
+		_ALLOW_DISCARD_ script->get_language()->get_global_class_name(script->get_path(), &class_name);
 		return class_name;
 	}
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2854,7 +2854,8 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 			if (subclass->extends_used) {
 				if (!subclass->extends_path.is_empty()) {
 					if (subclass->extends.is_empty()) {
-						get_global_class_name(subclass->extends_path, r_base_type);
+						// We only care about the referenced class_name.
+						_ALLOW_DISCARD_ get_global_class_name(subclass->extends_path, r_base_type);
 						subclass = nullptr;
 						break;
 					} else {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -489,7 +489,8 @@ bool GDScriptWorkspace::can_rename(const LSP::TextDocumentPositionParams &p_doc_
 
 	String path = get_file_path(p_doc_pos.textDocument.uri);
 	if (const ExtendGDScriptParser *parser = get_parse_result(path)) {
-		parser->get_identifier_under_position(p_doc_pos.position, r_range);
+		// We only care about the range.
+		_ALLOW_DISCARD_ parser->get_identifier_under_position(p_doc_pos.position, r_range);
 		r_symbol = *reference_symbol;
 		return true;
 	}
@@ -847,9 +848,7 @@ Error GDScriptWorkspace::resolve_signature(const LSP::TextDocumentPositionParams
 	return ERR_METHOD_NOT_FOUND;
 }
 
-GDScriptWorkspace::GDScriptWorkspace() {
-	ProjectSettings::get_singleton()->get_resource_path();
-}
+GDScriptWorkspace::GDScriptWorkspace() {}
 
 GDScriptWorkspace::~GDScriptWorkspace() {
 	HashSet<String> cached_parsers;

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -41,10 +41,7 @@ bool AnimationLibrary::is_valid_library_name(const String &p_name) {
 }
 
 String AnimationLibrary::validate_library_name(const String &p_name) {
-	String name = p_name;
-	static const char *characters = "/:,[";
-	name.replace_chars(characters, '_');
-	return name;
+	return p_name.replace_chars("/:,[", '_');
 }
 
 Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animation> &p_animation) {

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1563,7 +1563,8 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 
 	shader = parser.get_shader();
 	function = nullptr;
-	_dump_node_code(shader, 1, r_gen_code, *p_actions, actions, false);
+	// Return value only relevant within nested calls.
+	_ALLOW_DISCARD_ _dump_node_code(shader, 1, r_gen_code, *p_actions, actions, false);
 
 	return OK;
 }

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -552,7 +552,8 @@ void ShaderPreprocessor::process_else(Tokenizer *p_tokenizer) {
 	if (skip) {
 		Vector<String> ends;
 		ends.push_back("endif");
-		next_directive(p_tokenizer, ends);
+		// Legacy return value.
+		_ALLOW_DISCARD_ next_directive(p_tokenizer, ends);
 	}
 }
 
@@ -847,7 +848,8 @@ void ShaderPreprocessor::start_branch_condition(Tokenizer *p_tokenizer, bool p_s
 		ends.push_back("elif");
 		ends.push_back("else");
 		ends.push_back("endif");
-		next_directive(p_tokenizer, ends);
+		// Legacy return value.
+		_ALLOW_DISCARD_ next_directive(p_tokenizer, ends);
 	}
 }
 


### PR DESCRIPTION
Expands the codebase's `[[nodiscard]]` coverage by including the string-like classes/structs: `String`, `StringName`, `NodePath`, `CharString`, `Char16String`, `StaticCString` and `IPAddress`.

The majority of instances of strings are already handling return values correctly, but a few instances (`image.cpp` & `text_server_adv.cpp`) were fixed to properly assign the expected value. Otherwise, `_ALLOW_DISCARD_` was prepended, alongside a comment explaining why when applicable. There were a handful of cases where I wasn't entirely sure of the function's purpose; those have been marked with `TODO` comments.