### PR TITLE
Include "PopupMenu" labels in POT gen

### DIFF
--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -200,6 +200,7 @@ PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlug
 	lookup_properties.insert("title");
 	lookup_properties.insert("filters");
 	lookup_properties.insert("script");
+	lookup_properties.insert("item_*/text");
 
 	// Exception list (to prevent false positives).
 	exception_list.insert("LineEdit", { "text" });


### PR DESCRIPTION
When generating the POT file, text labels given to `PopupMenu` items were not being detected as translatable strings. I found that these appear to be serialized as:

```
item_0/text = "MY_LABEL"
item_0/id = 1
```

After some digging i found that adding `item_*/text` to `lookup_properties` results in them being added to the generated template.