### PR TITLE
Fix incorrect enabling of post process in OpenGL

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2247,7 +2247,6 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	bool glow_enabled = false;
 	if (p_environment.is_valid()) {
 		glow_enabled = environment_get_glow_enabled(p_environment);
-		rb->ensure_internal_buffers(); // Ensure our intermediate buffer is available if glow is enabled
 		if (glow_enabled) {
 			// If glow is enabled, we apply tonemapping etc. in post, so disable it during rendering
 			apply_color_adjustments_in_post = true;
@@ -2339,7 +2338,6 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	if (render_data.environment.is_valid()) {
 		bool use_bcs = environment_get_adjustments_enabled(render_data.environment);
 		if (use_bcs) {
-			rb->ensure_internal_buffers();
 			apply_color_adjustments_in_post = true;
 		}
 
@@ -2473,6 +2471,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	if (is_reflection_probe) {
 		fbo = GLES3::LightStorage::get_singleton()->reflection_probe_instance_get_framebuffer(render_data.reflection_probe, render_data.reflection_probe_pass);
 	} else {
+		rb->set_apply_color_adjustments_in_post(apply_color_adjustments_in_post);
 		fbo = rb->get_render_fbo();
 	}
 

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -194,7 +194,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 
 	ERR_FAIL_COND(view_count == 0);
 
-	bool use_internal_buffer = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF || needs_internal_buffers;
+	bool use_internal_buffer = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF || apply_color_adjustments_in_post;
 	uint32_t depth_format_size = 3;
 	bool use_multiview = view_count > 1;
 
@@ -558,8 +558,8 @@ void RenderSceneBuffersGLES3::_clear_back_buffers() {
 	}
 }
 
-void RenderSceneBuffersGLES3::ensure_internal_buffers() {
-	needs_internal_buffers = true;
+void RenderSceneBuffersGLES3::set_apply_color_adjustments_in_post(bool p_apply_in_post) {
+	apply_color_adjustments_in_post = p_apply_in_post;
 }
 
 void RenderSceneBuffersGLES3::check_glow_buffers() {

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -50,7 +50,7 @@ public:
 	//bool use_taa = false;
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
-	bool needs_internal_buffers = false;
+	bool apply_color_adjustments_in_post = false;
 
 	RID render_target;
 
@@ -106,12 +106,12 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) override{};
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override{};
 	virtual void set_use_debanding(bool p_use_debanding) override{};
+	void set_apply_color_adjustments_in_post(bool p_apply_in_post);
 
 	void free_render_buffer_data();
 
 	void check_backbuffer(bool p_need_color, bool p_need_depth); // Check if we need to initialize our backbuffer.
 	void check_glow_buffers(); // Check if we need to initialize our glow buffers.
-	void ensure_internal_buffers();
 
 	GLuint get_render_fbo();
 	GLuint get_msaa3d_fbo() {


### PR DESCRIPTION
A recent change (commit 9000a9d36fde7c991e04a5c4cc54ccfad505fb0c) resulted in post processing to always happen in a separate step even when unwanted. This resulted in a 20-30% performance drop on Quest 3 resulting in proper frame rates being unobtainable. It also results in a number of errors as some of the code was not expecting the separate post processing step to happen.

An easy mistake, a call to `ensure_internal_buffers` was performed to easy in our check if glow was enabled.

However there was also a flaw in the implementation as once enabled, you couldn't disable it.

So if a level allowed for glow (or any other post process) to be enabled, and a later level would turn it off, or if this had been turned into a user setting because we can enable it on desktop, it would always be running the separated post process logic.

I've thus done a little extra work to clean this up and make it work consistently. 