### PR TITLE
Implement sprite anchor on Texture2d and derived classes

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -11,6 +11,12 @@
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/2712</link>
 	</tutorials>
 	<methods>
+		<method name="get_pivot" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns this sprite's pivot point, as defined by [member pivot_mode].
+			</description>
+		</method>
 		<method name="get_playing_speed" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -82,9 +88,12 @@
 		<member name="autoplay" type="String" setter="set_autoplay" getter="get_autoplay" default="&quot;&quot;">
 			The key of the animation to play when the scene loads.
 		</member>
-		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
-			If [code]true[/code], texture will be centered.
+		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="false">
+			If [code]true[/code], texture is centered.
 			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, set this property to [code]false[/code], or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</member>
+		<member name="flip_around_pivot" type="bool" setter="set_flip_around_pivot" getter="is_flipped_around_pivot" default="false">
+			If [code]true[/code], the texture is flipped around the current pivot point.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.
@@ -100,6 +109,9 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
+		</member>
+		<member name="pivot_mode" type="int" setter="set_pivot_mode" getter="get_pivot_mode" enum="Texture2D.Pivot" default="3">
+			The sprite's pivot point, relative to the texture.
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.

--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -5,12 +5,16 @@
 	</brief_description>
 	<description>
 		[Texture2D] resource that draws only part of its [member atlas] texture, as defined by the [member region]. An additional [member margin] can also be set, which is useful for small adjustments.
+		An [member anchor] can be set to automatically offset the resource when drawn by a [Sprite2D] or an [AnimatedSprite2D]. The anchor is defined in pixels relative to the top-left corner of the [AtlasTexture].
 		Multiple [AtlasTexture] resources can be cropped from the same [member atlas]. Packing many smaller textures into a singular large texture helps to optimize video memory costs and render calls.
 		[b]Note:[/b] [AtlasTexture] cannot be used in an [AnimatedTexture], and may not tile properly in nodes such as [TextureRect], when inside other [AtlasTexture] resources.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="anchor" type="Vector2" setter="set_anchor" getter="get_anchor" default="Vector2(0, 0)">
+			The pivot point of the texture. In pixels relative to the top-left corner of the [member region]. In case a [member margin] is defined, the anchor point should account for it.
+		</member>
 		<member name="atlas" type="Texture2D" setter="set_atlas" getter="get_atlas">
 			The texture that contains the atlas. Can be any type inheriting from [Texture2D], including another [AtlasTexture].
 		</member>

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -10,6 +10,12 @@
 		<link title="Instancing Demo">https://godotengine.org/asset-library/asset/2716</link>
 	</tutorials>
 	<methods>
+		<method name="get_pivot" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns this sprite's pivot point, as defined by [member pivot_mode].
+			</description>
+		</method>
 		<method name="get_rect" qualifiers="const">
 			<return type="Rect2" />
 			<description>
@@ -50,9 +56,12 @@
 		</method>
 	</methods>
 	<members>
-		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
+		<member name="centered" type="bool" setter="set_centered" getter="is_centered" deprecated="Use [member pivot_mode] instead.">
 			If [code]true[/code], texture is centered.
 			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, set this property to [code]false[/code], or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</member>
+		<member name="flip_around_pivot" type="bool" setter="set_flip_around_pivot" getter="is_flipped_around_pivot" default="false">
+			If [code]true[/code], the texture is flipped around the current pivot point.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.
@@ -72,8 +81,12 @@
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
+		<member name="pivot_mode" type="int" setter="set_pivot_mode" getter="get_pivot_mode" enum="Texture2D.Pivot" default="3">
+			The sprite's pivot point, relative to the texture.
+		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture is cut from a larger atlas texture. See [member region_rect].
+			[b]Note:[/b] When [code]true[/code] with [member pivot_mode] set to [code]Anchor[/code] the texture's anchor is ignored.
 		</member>
 		<member name="region_filter_clip_enabled" type="bool" setter="set_region_filter_clip_enabled" getter="is_region_filter_clip_enabled" default="false">
 			If [code]true[/code], the outermost pixels get blurred out. [member region_enabled] must be [code]true[/code].

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -20,6 +20,7 @@
 		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], the sprite will use [member region_rect] and display only the specified part of its texture.
+			[b]Note:[/b] When [code]true[/code] with [member SpriteBase3D.pivot_mode] set to [code]Anchor[/code] the texture's anchor is ignored.
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -28,6 +28,12 @@
 				Returns the rectangle representing this sprite.
 			</description>
 		</method>
+		<method name="get_pivot" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns this sprite's pivot point, as defined by [member pivot_mode].
+			</description>
+		</method>
 		<method name="set_draw_flag">
 			<return type="void" />
 			<param index="0" name="flag" type="int" enum="SpriteBase3D.DrawFlags" />
@@ -60,14 +66,17 @@
 			The billboard mode to use for the sprite. See [enum BaseMaterial3D.BillboardMode] for possible values.
 			[b]Note:[/b] When billboarding is enabled and the material also casts shadows, billboards will face [b]the[/b] camera in the scene when rendering shadows. In scenes with multiple cameras, the intended shadow cannot be determined and this will result in undefined behavior. See [url=https://github.com/godotengine/godot/pull/72638]GitHub Pull Request #72638[/url] for details.
 		</member>
-		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
-			If [code]true[/code], texture will be centered.
+		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="false">
+			If [code]true[/code], texture is centered.
 		</member>
 		<member name="double_sided" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">
 			If [code]true[/code], texture can be seen from the back as well, if [code]false[/code], it is invisible when looking at it from behind.
 		</member>
 		<member name="fixed_size" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
 			If [code]true[/code], the label is rendered at the same size regardless of distance.
+		</member>
+		<member name="flip_around_pivot" type="bool" setter="set_flip_around_pivot" getter="is_flipped_around_pivot" default="false">
+			If [code]true[/code], the texture is flipped around the current pivot point.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.
@@ -85,6 +94,9 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
+		</member>
+		<member name="pivot_mode" type="int" setter="set_pivot_mode" getter="get_pivot_mode" enum="Texture2D.Pivot" default="3">
+			The sprite's pivot point, relative to the texture.
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the sprite to scale it in 3D.

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -48,6 +48,12 @@
 				[b]Note:[/b] This is only used in 2D rendering, not 3D.
 			</description>
 		</method>
+		<method name="_get_anchor" qualifiers="virtual const">
+			<return type="Vector2" />
+			<description>
+				Called when the [Texture2D]'s anchor is queried.
+			</description>
+		</method>
 		<method name="_get_height" qualifiers="virtual const">
 			<return type="int" />
 			<description>
@@ -113,6 +119,12 @@
 				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API.
 			</description>
 		</method>
+		<method name="get_anchor" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the texture pivot point relative to the texture top-left corner, in pixels.
+			</description>
+		</method>
 		<method name="get_height" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -146,4 +158,60 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="PIVOT_ANCHOR" value="0" enum="Pivot">
+			Use the texture's anchor as pivot.
+		</constant>
+		<constant name="PIVOT_FREE" value="1" enum="Pivot">
+			Use the node's offset as pivot.
+		</constant>
+		<constant name="PIVOT_FREE_RELATIVE" value="2" enum="Pivot">
+			Use the node's offset multiplied by the texture's size as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed. This is caused by their position being between pixels. To prevent this, use [constant PIVOT_FREE] instead, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_CENTER" value="3" enum="Pivot">
+			Use the texture's center as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_TOP_LEFT" value="4" enum="Pivot">
+			Use the texture's top left corner as pivot.
+		</constant>
+		<constant name="PIVOT_TOP_CENTER" value="5" enum="Pivot">
+			Use the center of the texture's top edge as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_TOP_RIGHT" value="6" enum="Pivot">
+			Use the texture's top right corner as pivot.
+		</constant>
+		<constant name="PIVOT_CENTER_RIGHT" value="7" enum="Pivot">
+			Use the center of the texture's right edge as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_BOTTOM_RIGHT" value="8" enum="Pivot">
+			Use the texture's bottom right corner as pivot.
+		</constant>
+		<constant name="PIVOT_BOTTOM_CENTER" value="9" enum="Pivot">
+			Use the center of the texture's bottom edge as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_BOTTOM_LEFT" value="10" enum="Pivot">
+			Use the texture's bottom left corner as pivot.
+		</constant>
+		<constant name="PIVOT_CENTER_LEFT" value="11" enum="Pivot">
+			Use the center of the texture's left edge as pivot.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+		<constant name="PIVOT_LEGACY_CENTER" value="12" enum="Pivot">
+			Use the center of the texture and the node's offset as pivot.
+			This is a compatibility mode for sprites that still use the [member Sprite2D.centered] property.
+
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, use a different pivot mode, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+		</constant>
+	</constants>
 </class>

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -218,10 +218,7 @@ void Sprite2DEditor::_update_mesh_data() {
 				if (node->is_flipped_v()) {
 					vtx.y = rect.size.y - vtx.y;
 				}
-				vtx += node->get_offset();
-				if (node->is_centered()) {
-					vtx -= rect.size / 2.0;
-				}
+				vtx += node->get_pivot();
 
 				computed_vertices.push_back(vtx);
 			}
@@ -266,10 +263,7 @@ void Sprite2DEditor::_update_mesh_data() {
 				}
 				// Don't bake offset to Polygon2D which has offset property.
 				if (selected_menu_item != MENU_OPTION_CONVERT_TO_POLYGON_2D) {
-					vtx += node->get_offset();
-				}
-				if (node->is_centered()) {
-					vtx -= rect.size / 2.0;
+					vtx += node->get_pivot();
 				}
 
 				col.write[i] = vtx;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -98,10 +98,7 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 	}
 	Size2 s = t->get_size();
 
-	Point2 ofs = offset;
-	if (centered) {
-		ofs -= s / 2;
-	}
+	Point2 ofs = _get_pivot(t, s, offset, pivot_mode);
 
 	if (s == Size2(0, 0)) {
 		s = Size2(1, 1);
@@ -110,10 +107,49 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 	return Rect2(ofs, s);
 }
 
+Point2 AnimatedSprite2D::_get_pivot(const Ref<Texture2D> &p_texture, const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode) const {
+	Point2 pivot = TexturePivotUtils::get_pivot(p_texture, p_size, p_offset, p_mode);
+
+	if (flip_around_pivot) {
+		if (hflip) {
+			pivot.x = (p_size.width + pivot.x) * -1;
+		}
+		if (vflip) {
+			pivot.y = (p_size.height + pivot.y) * -1;
+		}
+	}
+
+	return pivot;
+}
+
 void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 	if (!frames.is_valid()) {
 		return;
 	}
+
+	if (p_property.name == "offset") {
+		if (pivot_mode != Texture2D::PIVOT_FREE && pivot_mode != Texture2D::PIVOT_FREE_RELATIVE) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+
+		if (pivot_mode == Texture2D::PIVOT_FREE) {
+			p_property.hint_string = "suffix:px";
+		} else if (pivot_mode == Texture2D::PIVOT_FREE_RELATIVE) {
+			p_property.hint_string = "suffix:* size";
+		}
+	}
+
+#ifndef DISABLE_DEPRECATED
+	// The centered property is supported for compatibility reason but shouldn't be used directly.
+	if (p_property.name == "centered") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	// In legacy center mode, the offset field is needed.
+	if (p_property.name == "offset" && pivot_mode == Texture2D::PIVOT_LEGACY_CENTER) {
+		p_property.usage = PROPERTY_USAGE_DEFAULT;
+		p_property.hint_string = "suffix:px";
+	}
+#endif
 
 	if (p_property.name == "animation") {
 		List<StringName> names;
@@ -261,23 +297,20 @@ void AnimatedSprite2D::_notification(int p_what) {
 			RID ci = get_canvas_item();
 
 			Size2 s = texture->get_size();
-			Point2 ofs = offset;
-			if (centered) {
-				ofs -= s / 2;
-			}
+			Point2 ofs = _get_pivot(texture, s, offset, pivot_mode);
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
 				ofs = (ofs + Point2(0.5, 0.5)).floor();
 			}
 
-			Rect2 dst_rect(ofs, s);
-
 			if (hflip) {
-				dst_rect.size.x = -dst_rect.size.x;
+				s.x = -s.x;
 			}
 			if (vflip) {
-				dst_rect.size.y = -dst_rect.size.y;
+				s.y = -s.y;
 			}
+
+			Rect2 dst_rect(ofs, s);
 
 			texture->draw_rect_region(ci, dst_rect, Rect2(Vector2(), texture->get_size()), Color(1, 1, 1), false);
 		} break;
@@ -380,18 +413,53 @@ float AnimatedSprite2D::get_playing_speed() const {
 	return speed_scale * custom_speed_scale;
 }
 
-void AnimatedSprite2D::set_centered(bool p_center) {
-	if (centered == p_center) {
+#ifndef DISABLE_DEPRECATED
+void AnimatedSprite2D::set_centered(bool p_centered) {
+	if (p_centered && pivot_mode == Texture2D::PIVOT_LEGACY_CENTER) {
 		return;
 	}
 
-	centered = p_center;
+	if (!p_centered && pivot_mode == Texture2D::PIVOT_FREE) {
+		return;
+	}
+
+	pivot_mode = p_centered ? Texture2D::PIVOT_LEGACY_CENTER : Texture2D::PIVOT_FREE;
+
 	queue_redraw();
-	item_rect_changed();
+	notify_property_list_changed();
 }
 
 bool AnimatedSprite2D::is_centered() const {
-	return centered;
+	return pivot_mode == Texture2D::PIVOT_LEGACY_CENTER;
+}
+#endif
+
+void AnimatedSprite2D::set_pivot_mode(Texture2D::Pivot p_mode) {
+	if (pivot_mode == p_mode) {
+		return;
+	}
+
+	pivot_mode = p_mode;
+	queue_redraw();
+	notify_property_list_changed();
+}
+
+Texture2D::Pivot AnimatedSprite2D::get_pivot_mode() const {
+	return pivot_mode;
+}
+
+Point2 AnimatedSprite2D::get_pivot() const {
+	if (frames.is_null() || !frames->has_animation(animation)) {
+		return Point2();
+	}
+
+	Ref<Texture2D> texture = frames->get_frame_texture(animation, frame);
+	if (texture.is_null()) {
+		return Point2();
+	}
+
+	Size2 size = texture->get_size();
+	return _get_pivot(texture, size, offset, pivot_mode);
 }
 
 void AnimatedSprite2D::set_offset(const Point2 &p_offset) {
@@ -432,6 +500,18 @@ void AnimatedSprite2D::set_flip_v(bool p_flip) {
 
 bool AnimatedSprite2D::is_flipped_v() const {
 	return vflip;
+}
+
+void AnimatedSprite2D::set_flip_around_pivot(bool p_flip) {
+	if (flip_around_pivot == p_flip) {
+		return;
+	}
+
+	flip_around_pivot = p_flip;
+	queue_redraw();
+}
+bool AnimatedSprite2D::is_flipped_around_pivot() const {
+	return flip_around_pivot;
 }
 
 void AnimatedSprite2D::_res_changed() {
@@ -621,8 +701,14 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pause"), &AnimatedSprite2D::pause);
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite2D::stop);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &AnimatedSprite2D::set_centered);
 	ClassDB::bind_method(D_METHOD("is_centered"), &AnimatedSprite2D::is_centered);
+#endif
+
+	ClassDB::bind_method(D_METHOD("set_pivot_mode", "pivot"), &AnimatedSprite2D::set_pivot_mode);
+	ClassDB::bind_method(D_METHOD("get_pivot_mode"), &AnimatedSprite2D::get_pivot_mode);
+	ClassDB::bind_method(D_METHOD("get_pivot"), &AnimatedSprite2D::get_pivot);
 
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &AnimatedSprite2D::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &AnimatedSprite2D::get_offset);
@@ -632,6 +718,9 @@ void AnimatedSprite2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_flip_v", "flip_v"), &AnimatedSprite2D::set_flip_v);
 	ClassDB::bind_method(D_METHOD("is_flipped_v"), &AnimatedSprite2D::is_flipped_v);
+
+	ClassDB::bind_method(D_METHOD("set_flip_around_pivot", "flip_around_pivot"), &AnimatedSprite2D::set_flip_around_pivot);
+	ClassDB::bind_method(D_METHOD("is_flipped_around_pivot"), &AnimatedSprite2D::is_flipped_around_pivot);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite2D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite2D::get_frame);
@@ -658,11 +747,20 @@ void AnimatedSprite2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame_progress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_frame_progress", "get_frame_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");
-	ADD_GROUP("Offset", "");
+	ADD_GROUP("Pivot", "");
+#ifndef DISABLE_DEPRECATED
+	// The centered property is only defined for compatibility reason.
+	// In that case, when true, it results in a `PIVOT_LEGACY_CENTER` mode,
+	// which shouldn't be supported once the centered property is completely removed.
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "pivot_mode", PROPERTY_HINT_ENUM, "Anchor,Free,Free Relative,Center,Top Left,Top Center,Top Right,Center Right,Bottom Right,Bottom Center,Bottom Left,Center Left,Legacy Center"), "set_pivot_mode", "get_pivot_mode");
+#else
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "pivot_mode", PROPERTY_HINT_ENUM, "Anchor,Free,Free Relative,Center,Top Left,Top Center,Top Right,Center Right,Bottom Right,Bottom Center,Bottom Left,Center Left"), "set_pivot_mode", "get_pivot_mode");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_around_pivot"), "set_flip_around_pivot", "is_flipped_around_pivot");
 }
 
 AnimatedSprite2D::AnimatedSprite2D() {

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -33,6 +33,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/sprite_frames.h"
+#include "scene/resources/texture_pivot_utils.h"
 
 class AnimatedSprite2D : public Node2D {
 	GDCLASS(AnimatedSprite2D, Node2D);
@@ -46,7 +47,7 @@ class AnimatedSprite2D : public Node2D {
 	float speed_scale = 1.0;
 	float custom_speed_scale = 1.0;
 
-	bool centered = true;
+	Texture2D::Pivot pivot_mode = Texture2D::PIVOT_CENTER;
 	Point2 offset;
 
 	real_t frame_speed_scale = 1.0;
@@ -54,6 +55,7 @@ class AnimatedSprite2D : public Node2D {
 
 	bool hflip = false;
 	bool vflip = false;
+	bool flip_around_pivot = false;
 
 	void _res_changed();
 
@@ -62,6 +64,7 @@ class AnimatedSprite2D : public Node2D {
 	void _stop_internal(bool p_reset);
 
 	Rect2 _get_rect() const;
+	Point2 _get_pivot(const Ref<Texture2D> &p_texture, const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode) const;
 
 protected:
 #ifndef DISABLE_DEPRECATED
@@ -113,8 +116,14 @@ public:
 	float get_speed_scale() const;
 	float get_playing_speed() const;
 
-	void set_centered(bool p_center);
+#ifndef DISABLE_DEPRECATED
+	void set_centered(bool p_centered);
 	bool is_centered() const;
+#endif
+
+	void set_pivot_mode(Texture2D::Pivot p_pivot);
+	Texture2D::Pivot get_pivot_mode() const;
+	Point2 get_pivot() const;
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
@@ -124,6 +133,9 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
+
+	void set_flip_around_pivot(bool p_flip);
+	bool is_flipped_around_pivot() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -33,6 +33,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/texture.h"
+#include "scene/resources/texture_pivot_utils.h"
 
 class Sprite2D : public Node2D {
 	GDCLASS(Sprite2D, Node2D);
@@ -41,11 +42,12 @@ class Sprite2D : public Node2D {
 	Color specular_color;
 	real_t shininess = 0.0;
 
-	bool centered = true;
+	Texture2D::Pivot pivot_mode = Texture2D::PIVOT_CENTER;
 	Point2 offset;
 
 	bool hflip = false;
 	bool vflip = false;
+	bool flip_around_pivot = false;
 	bool region_enabled = false;
 	Rect2 region_rect;
 	bool region_filter_clip_enabled = false;
@@ -56,6 +58,7 @@ class Sprite2D : public Node2D {
 	int hframes = 1;
 
 	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip_enabled) const;
+	Point2 _get_pivot(const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode) const;
 
 	void _texture_changed();
 
@@ -85,8 +88,14 @@ public:
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
 
-	void set_centered(bool p_center);
+#ifndef DISABLE_DEPRECATED
+	void set_centered(bool p_centered);
 	bool is_centered() const;
+#endif
+
+	void set_pivot_mode(Texture2D::Pivot p_pivot);
+	Texture2D::Pivot get_pivot_mode() const;
+	Point2 get_pivot() const;
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
@@ -96,6 +105,9 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
+
+	void set_flip_around_pivot(bool p_flip);
+	bool is_flipped_around_pivot() const;
 
 	void set_region_enabled(bool p_enabled);
 	bool is_region_enabled() const;

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -33,6 +33,7 @@
 
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/sprite_frames.h"
+#include "scene/resources/texture_pivot_utils.h"
 
 class SpriteBase3D : public GeometryInstance3D {
 	GDCLASS(SpriteBase3D, GeometryInstance3D);
@@ -66,11 +67,12 @@ private:
 	List<SpriteBase3D *> children;
 	List<SpriteBase3D *>::Element *pI = nullptr;
 
-	bool centered = true;
+	Texture2D::Pivot pivot_mode = Texture2D::PIVOT_CENTER;
 	Point2 offset;
 
 	bool hflip = false;
 	bool vflip = false;
+	bool flip_around_pivot = false;
 
 	Color modulate = Color(1, 1, 1, 1);
 	int render_priority = 0;
@@ -118,10 +120,17 @@ protected:
 	uint32_t mesh_surface_format = 0;
 
 	void _queue_redraw();
+	virtual Point2 _get_pivot(const Ref<Texture2D> &p_texture, const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode) const;
 
 public:
-	void set_centered(bool p_center);
+#ifndef DISABLE_DEPRECATED
+	void set_centered(bool p_centered);
 	bool is_centered() const;
+#endif
+
+	void set_pivot_mode(Texture2D::Pivot p_pivot);
+	Texture2D::Pivot get_pivot_mode() const;
+	virtual Point2 get_pivot() const;
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
@@ -131,6 +140,9 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
+
+	void set_flip_around_pivot(bool p_flip);
+	bool is_flipped_around_pivot() const;
 
 	void set_render_priority(int p_priority);
 	int get_render_priority() const;
@@ -193,10 +205,13 @@ class Sprite3D : public SpriteBase3D {
 protected:
 	virtual void _draw() override;
 	static void _bind_methods();
+	virtual Point2 _get_pivot(const Ref<Texture2D> &p_texture, const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode) const override;
 
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	virtual Point2 get_pivot() const override;
+
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
 
@@ -255,6 +270,8 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	virtual Point2 get_pivot() const override;
+
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1686,6 +1686,14 @@ int CanvasTexture::get_height() const {
 	}
 }
 
+Point2 CanvasTexture::get_anchor() const {
+	if (diffuse_texture.is_valid()) {
+		return diffuse_texture->get_anchor();
+	} else {
+		return Point2();
+	}
+}
+
 bool CanvasTexture::is_pixel_opaque(int p_x, int p_y) const {
 	if (diffuse_texture.is_valid()) {
 		return diffuse_texture->is_pixel_opaque(p_x, p_y);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -430,6 +430,7 @@ public:
 
 	virtual int get_width() const override;
 	virtual int get_height() const override;
+	virtual Point2 get_anchor() const override;
 
 	virtual bool is_pixel_opaque(int p_x, int p_y) const override;
 	virtual bool has_alpha() const override;

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -113,6 +113,18 @@ Rect2 AtlasTexture::get_margin() const {
 	return margin;
 }
 
+void AtlasTexture::set_anchor(const Point2 &p_anchor) {
+	if (anchor == p_anchor) {
+		return;
+	}
+	anchor = p_anchor;
+	emit_changed();
+}
+
+Point2 AtlasTexture::get_anchor() const {
+	return anchor;
+}
+
 void AtlasTexture::set_filter_clip(const bool p_enable) {
 	filter_clip = p_enable;
 	emit_changed();
@@ -145,12 +157,15 @@ void AtlasTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &AtlasTexture::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &AtlasTexture::get_margin);
 
+	ClassDB::bind_method(D_METHOD("set_anchor", "anchor"), &AtlasTexture::set_anchor);
+
 	ClassDB::bind_method(D_METHOD("set_filter_clip", "enable"), &AtlasTexture::set_filter_clip);
 	ClassDB::bind_method(D_METHOD("has_filter_clip"), &AtlasTexture::has_filter_clip);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "atlas", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_atlas", "get_atlas");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region", PROPERTY_HINT_NONE, "suffix:px"), "set_region", "get_region");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "margin", PROPERTY_HINT_NONE, "suffix:px"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "anchor", PROPERTY_HINT_NONE, "suffix:px"), "set_anchor", "get_anchor");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_clip"), "set_filter_clip", "has_filter_clip");
 }
 
@@ -158,8 +173,9 @@ void AtlasTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_m
 	if (atlas.is_null()) {
 		return;
 	}
+
 	const Rect2 rc = _get_region_rect();
-	atlas->draw_rect_region(p_canvas_item, Rect2(p_pos + margin.position, rc.size), rc, p_modulate, p_transpose, filter_clip);
+	atlas->draw_rect_region(p_canvas_item, Rect2(p_pos + margin.position - anchor, rc.size), rc, p_modulate, p_transpose, filter_clip);
 }
 
 void AtlasTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -44,6 +44,12 @@ int Texture2D::get_height() const {
 	return ret;
 }
 
+Point2 Texture2D::get_anchor() const {
+	Point2 ret;
+	GDVIRTUAL_CALL(_get_anchor, ret);
+	return ret;
+}
+
 Size2 Texture2D::get_size() const {
 	return Size2(get_width(), get_height());
 }
@@ -61,10 +67,10 @@ bool Texture2D::has_alpha() const {
 }
 
 void Texture2D::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
-	if (GDVIRTUAL_CALL(_draw, p_canvas_item, p_pos, p_modulate, p_transpose)) {
+	if (GDVIRTUAL_CALL(_draw, p_canvas_item, p_pos - get_anchor(), p_modulate, p_transpose)) {
 		return;
 	}
-	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, get_size()), get_rid(), false, p_modulate, p_transpose);
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos - get_anchor(), get_size()), get_rid(), false, p_modulate, p_transpose);
 }
 
 void Texture2D::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
@@ -97,6 +103,7 @@ Ref<Resource> Texture2D::create_placeholder() const {
 void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_width"), &Texture2D::get_width);
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture2D::get_height);
+	ClassDB::bind_method(D_METHOD("get_anchor"), &Texture2D::get_anchor);
 	ClassDB::bind_method(D_METHOD("get_size"), &Texture2D::get_size);
 	ClassDB::bind_method(D_METHOD("has_alpha"), &Texture2D::has_alpha);
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "position", "modulate", "transpose"), &Texture2D::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
@@ -109,12 +116,29 @@ void Texture2D::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_width);
 	GDVIRTUAL_BIND(_get_height);
+	GDVIRTUAL_BIND(_get_anchor);
 	GDVIRTUAL_BIND(_is_pixel_opaque, "x", "y");
 	GDVIRTUAL_BIND(_has_alpha);
 
 	GDVIRTUAL_BIND(_draw, "to_canvas_item", "pos", "modulate", "transpose")
 	GDVIRTUAL_BIND(_draw_rect, "to_canvas_item", "rect", "tile", "modulate", "transpose")
 	GDVIRTUAL_BIND(_draw_rect_region, "to_canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv");
+
+	BIND_ENUM_CONSTANT(PIVOT_ANCHOR);
+	BIND_ENUM_CONSTANT(PIVOT_FREE);
+	BIND_ENUM_CONSTANT(PIVOT_FREE_RELATIVE);
+	BIND_ENUM_CONSTANT(PIVOT_CENTER);
+	BIND_ENUM_CONSTANT(PIVOT_TOP_LEFT);
+	BIND_ENUM_CONSTANT(PIVOT_TOP_CENTER);
+	BIND_ENUM_CONSTANT(PIVOT_TOP_RIGHT);
+	BIND_ENUM_CONSTANT(PIVOT_CENTER_RIGHT);
+	BIND_ENUM_CONSTANT(PIVOT_BOTTOM_RIGHT);
+	BIND_ENUM_CONSTANT(PIVOT_BOTTOM_CENTER);
+	BIND_ENUM_CONSTANT(PIVOT_BOTTOM_LEFT);
+	BIND_ENUM_CONSTANT(PIVOT_CENTER_LEFT);
+#ifndef DISABLE_DEPRECATED
+	BIND_ENUM_CONSTANT(PIVOT_LEGACY_CENTER);
+#endif
 }
 
 Texture2D::Texture2D() {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -59,6 +59,7 @@ protected:
 
 	GDVIRTUAL0RC(int, _get_width)
 	GDVIRTUAL0RC(int, _get_height)
+	GDVIRTUAL0RC(Point2, _get_anchor)
 	GDVIRTUAL2RC(bool, _is_pixel_opaque, int, int)
 	GDVIRTUAL0RC(bool, _has_alpha)
 
@@ -67,8 +68,28 @@ protected:
 	GDVIRTUAL6C(_draw_rect_region, RID, Rect2, Rect2, Color, bool, bool)
 
 public:
+	enum Pivot {
+		PIVOT_ANCHOR,
+		PIVOT_FREE,
+		PIVOT_FREE_RELATIVE,
+		PIVOT_CENTER,
+		PIVOT_TOP_LEFT,
+		PIVOT_TOP_CENTER,
+		PIVOT_TOP_RIGHT,
+		PIVOT_CENTER_RIGHT,
+		PIVOT_BOTTOM_RIGHT,
+		PIVOT_BOTTOM_CENTER,
+		PIVOT_BOTTOM_LEFT,
+		PIVOT_CENTER_LEFT
+#ifndef DISABLE_DEPRECATED
+		,
+		PIVOT_LEGACY_CENTER
+#endif
+	};
+
 	virtual int get_width() const;
 	virtual int get_height() const;
+	virtual Point2 get_anchor() const;
 	virtual Size2 get_size() const;
 
 	virtual bool is_pixel_opaque(int p_x, int p_y) const;
@@ -143,5 +164,7 @@ public:
 	virtual Vector<Ref<Image>> get_data() const;
 	virtual Ref<Resource> create_placeholder() const;
 };
+
+VARIANT_ENUM_CAST(Texture2D::Pivot);
 
 #endif // TEXTURE_H

--- a/scene/resources/texture_pivot_utils.h
+++ b/scene/resources/texture_pivot_utils.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  atlas_texture.h                                                       */
+/*  texture_pivot_utils.h                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,58 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef ATLAS_TEXTURE_H
-#define ATLAS_TEXTURE_H
+#ifndef TEXTURE_PIVOT_UTILS_H
+#define TEXTURE_PIVOT_UTILS_H
 
 #include "scene/resources/texture.h"
 
-class AtlasTexture : public Texture2D {
-	GDCLASS(AtlasTexture, Texture2D);
-	RES_BASE_EXTENSION("atlastex");
-
-	Rect2 _get_region_rect() const;
-
-protected:
-	Ref<Texture2D> atlas;
-	Rect2 region;
-	Rect2 margin;
-	Point2 anchor;
-	bool filter_clip = false;
-
-	static void _bind_methods();
-
+class TexturePivotUtils {
 public:
-	virtual int get_width() const override;
-	virtual int get_height() const override;
-	virtual RID get_rid() const override;
-
-	virtual bool has_alpha() const override;
-
-	void set_atlas(const Ref<Texture2D> &p_atlas);
-	Ref<Texture2D> get_atlas() const;
-
-	void set_region(const Rect2 &p_region);
-	Rect2 get_region() const;
-
-	void set_margin(const Rect2 &p_margin);
-	Rect2 get_margin() const;
-
-	virtual void set_anchor(const Point2 &p_anchor);
-	virtual Point2 get_anchor() const override;
-
-	void set_filter_clip(const bool p_enable);
-	bool has_filter_clip() const;
-
-	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
-	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
-	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;
-	virtual bool get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const override;
-
-	bool is_pixel_opaque(int p_x, int p_y) const override;
-
-	virtual Ref<Image> get_image() const override;
-
-	AtlasTexture();
+	static Point2 get_pivot(const Ref<Texture2D> &p_texture, const Size2 &p_size, const Point2 &p_offset, Texture2D::Pivot p_mode);
 };
-
-#endif // ATLAS_TEXTURE_H
+#endif // TEXTURE_PIVOT_UTILS_H


### PR DESCRIPTION
_Production edit_: 
- _Closes https://github.com/godotengine/godot-proposals/issues/9222_
- _Closes https://github.com/godotengine/godot-proposals/issues/7844_


Hello there, 

I'm currently in the process of learning Godot and found out that the 2d sprite system was not supporting sprite pivots (a common feature used by many artists and games). This PR is an attempt at providing a solution for that missing feature.

### Other Solutions Tried

Before going all out with a change in the core engine I tried several other options that unfortunately ended in failures, I'll sum them up here: 
1. Building a GD script associated with a custom data structure storing the sprites pivot using the resource name as key, that script would hook on the `AnimatedSprite2D::changed` event to change the `offset` for the current frame. Unfortunaly, the event comes one frame late and make it impossible to properly assign the pivot to the right frame.
2. Building a C++ GDExtension that would define an `AnimatedSprite2DWithAnchor` class, derived from `AnimatedSprite2D`, in order to override the current frame computation process and set the offset based on data from the same kind of additional data structure. The issue here was most methods in `AnimatedSprite2D` are not virtual and can't be overriden. 

Also, all those attemps were focused on animation, and would have not applied to `Sprite2D` instances using the same sprite.

### The PR

Ultimately I went with an engine change so that `Sprite2D`, `Sprite3D`, `AnimatedSprite2D` and `AnimatedSprite3D` could handle sprites' anchors. 
This PR Includes:
- `Texture2D` now defines a `get_anchor` method that can be used to retrieve the sprite pivot.
- `Texture2D` also defines a `Pivot` enumeration as well as a `get_pivot` static method that allows all consumers of textures to compute a pivot for a texture based on the specified mode.
- `AtlasTexture` also defines an `anchor` property to set the pivot point.
- `Sprite2D`, `Sprite3D`, `AnimatedSprite2D` and `AnimatedSprite3D` expose the following new properties:  `pivot_mode`, that defines which pivot that node uses, and `flip_around_pivot` that defines how `flip_h` and `flip_v` behave regarding to the pivot, if enabled the flip is performed around the pivot point.

![2D Editor Preview](https://github.com/godotengine/godot/assets/247140/67d38064-012c-4a62-8266-507fae7e8dea)
![Inspector preview](https://github.com/godotengine/godot/assets/247140/7701f7f1-94f1-44a7-bc8f-dab283741a49)

As for how I imported a spritesheet with those data in Godot, I've made some changes to the [texture packer importer](https://godotengine.org/asset-library/asset/1503) to support the new anchor field, which is provided with a custom exporter in TexturePacker that extends the Godot one to add the anchors (sources for both can be provided if needed). 
