### PR TITLE
Support custom compiler arguments in dotnet build

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -924,6 +924,12 @@
 			[b]Note:[/b] The [b]Adaptive[/b] and [b]Mailbox[/b] V-Sync modes are only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 			[b]Note:[/b] This property is only read when the project starts. To change the V-Sync mode at runtime, call [method DisplayServer.window_set_vsync_mode] instead.
 		</member>
+		<member name="dotnet/build/custom_compiler_arguments" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			Allows specifying additional compiler arguments for [code]dotnet[/code] when building inside the editor.
+		</member>
+		<member name="dotnet/build/custom_publish_arguments" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			Allows specifying additional compiler arguments for [code]dotnet[/code] when exporting.
+		</member>
 		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] and [code].sln[/code] files. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
 		</member>

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -119,6 +119,8 @@ void CSharpLanguage::init() {
 #ifdef TOOLS_ENABLED
 	GLOBAL_DEF("dotnet/project/solution_directory", "");
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "dotnet/project/assembly_reload_attempts", PROPERTY_HINT_RANGE, "1,16,1,or_greater"), 3);
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "dotnet/build/custom_compiler_arguments"), PackedStringArray());
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "dotnet/build/custom_publish_arguments"), PackedStringArray());
 #endif
 
 #ifdef TOOLS_ENABLED

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -22,6 +22,9 @@ namespace GodotTools.Build
         // TODO Use List once we have proper serialization
         public Godot.Collections.Array CustomProperties { get; private set; } = new();
 
+        // Arguments specified by the user in ProjectSettings. Passed last to the build process to override any previous arguments.
+        public Godot.Collections.Array CustomArguments { get; private set; } = new();
+
         public string LogsDirPath => GodotSharpDirs.LogsDirPathFor(Solution, Configuration);
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -285,6 +285,8 @@ namespace GodotTools.Build
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
 
+            AddCustomBuildArguments(buildInfo, publish: false);
+
             return buildInfo;
         }
 
@@ -309,6 +311,8 @@ namespace GodotTools.Build
 
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
+
+            AddCustomBuildArguments(buildInfo, publish: true);
 
             return buildInfo;
         }
@@ -348,6 +352,24 @@ namespace GodotTools.Build
             }
 
             return true;
+        }
+
+        private static void AddCustomBuildArguments(BuildInfo buildInfo, bool publish)
+        {
+            string[] arguments = (string[])ProjectSettings.GetSetting("dotnet/build/custom_compiler_arguments");
+            if (publish)
+            {
+                arguments = (string[])ProjectSettings.GetSetting("dotnet/build/custom_publish_arguments");
+            }
+            if (arguments == null)
+            {
+                return;
+            }
+
+            foreach (string arg in arguments)
+            {
+                buildInfo.CustomArguments.Add(arg);
+            }
         }
 
         private static bool GenerateXCFramework(List<string> outputPaths, string xcFrameworkPath)

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -187,6 +187,12 @@ namespace GodotTools.Build
             {
                 arguments.Add("-p:" + (string)customProperty);
             }
+
+            // Custom arguments (override previous)
+            foreach (var customArgument in buildInfo.CustomArguments)
+            {
+                arguments.Add((string)customArgument);
+            }
         }
 
         private static void BuildPublishArguments(BuildInfo buildInfo, Collection<string> arguments,
@@ -232,6 +238,12 @@ namespace GodotTools.Build
             foreach (var customProperty in buildInfo.CustomProperties)
             {
                 arguments.Add("-p:" + (string)customProperty);
+            }
+
+            // Custom arguments (override previous)
+            foreach (var customArgument in buildInfo.CustomArguments)
+            {
+                arguments.Add((string)customArgument);
             }
 
             // Publish output directory


### PR DESCRIPTION
# Proposal to Enable Custom Compiler Arguments in dotnet build

## The What
This pull request allows users to pass additional compiler arguments to the `dotnet build` process to enhance flexibility and potentially reduce build times.

This implementation is based on the proposal by @paulloz. It emerged after the rejection of my previous attempt to address build times, which rightly so got rejected after careful review by @raulsntos (see [original proposal](https://github.com/godotengine/godot/pull/93310)).

## In Detail

### Changes to Project Settings
- Added new settings:
```
dotnet/build/custom_compiler_arguments
dotnet/build/custom_publish_arguments
```


### Modifications to Build Process
- **BuildInfo.cs**: Added a new property CustomArguments.
- **BuildManager.cs**: Introduced a new method AddCustomBuildArguments(BuildInfo buildInfo, bool publish) to parse the custom arguments from ProjectSettings.
- Applied this method in CreateBuildInfo and CreatePublishBuildInfo.
- **BuildSystem/BuildArguments**: Integrated the custom arguments from BuildInfo.

## Demonstration
The custom arguments are hidden by default and can be found under "Advanced settings" for Mono builds:

![image](https://github.com/godotengine/godot/assets/84077629/03447e31-99e5-4c74-bca5-7bd5094c8168)

Both Build and Rebuild processes respect the custom compiler arguments:

![image](https://github.com/godotengine/godot/assets/84077629/2c88d194-80b0-4320-b898-2bdb77df7ff7)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10028*