### PR TITLE
`NavigationServer3D.map_get_closest_point_to_segment` - add an additional shortest distance check

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -644,6 +644,26 @@ Vector3 NavMap::get_closest_point_to_segment(const Vector3 &p_from, const Vector
 				}
 			}
 		}
+		// Finally, check for a case when shortest distance is between some point located on a face's edge and some point located on a line segment.
+		if (!use_collision) {
+			for (size_t point_id = 0; point_id < p.points.size(); point_id += 1) {
+				Vector3 a, b;
+
+				Geometry3D::get_closest_points_between_segments(
+						p_from,
+						p_to,
+						p.points[point_id].pos,
+						p.points[(point_id + 1) % p.points.size()].pos,
+						a,
+						b);
+
+				const real_t d = a.distance_to(b);
+				if (d < closest_point_d) {
+					closest_point_d = d;
+					closest_point = b;
+				}
+			}
+		}
 	}
 
 	return closest_point;


### PR DESCRIPTION
Added an additional shortest distance check for a case when shortest distance is between some point located on a face's edge and some point located on a line segment (thx for the tip @kleonc). 
This is an additional fix to this PR #93227. The fix is pretty naive, but it seems to be working:
![ezgif-3-c06b95379d](https://github.com/godotengine/godot/assets/67547891/da584018-d437-48ec-996a-5b3ede1d35c9)

@smix8 @kleonc 