### PR TITLE
Infer array length from custom array if no vertex array is provided

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1401,6 +1401,7 @@ int32_t RenderingServer::_get_vertex_to_custom_array_length_factor(uint32_t p_fo
 			return s;
 		} break;
 		default: {
+			ERR_FAIL_V_MSG(0, "Invalid texture type.");
 		}
 	}
 }

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1401,7 +1401,7 @@ int32_t RenderingServer::_get_vertex_to_custom_array_length_factor(uint32_t p_fo
 			return s;
 		} break;
 		default: {
-			ERR_FAIL_V_MSG(0, "Invalid texture type.");
+			ERR_FAIL_V_MSG(0, "Invalid custom format type.");
 		}
 	}
 }

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -388,6 +388,7 @@ public:
 	/// Returns stride
 	virtual void mesh_surface_make_offsets_from_format(uint64_t p_format, int p_vertex_len, int p_index_len, uint32_t *r_offsets, uint32_t &r_vertex_element_size, uint32_t &r_normal_element_size, uint32_t &r_attrib_element_size, uint32_t &r_skin_element_size) const;
 	virtual Error mesh_create_surface_data_from_arrays(SurfaceData *r_surface_data, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint64_t p_compress_format = 0);
+	int32_t _get_vertex_to_custom_array_length_factor(uint32_t p_format, int p_array_index);
 	Array mesh_create_arrays_from_surface_data(const SurfaceData &p_data) const;
 	Array mesh_surface_get_arrays(RID p_mesh, int p_surface) const;
 	TypedArray<Array> mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_surface) const;


### PR DESCRIPTION
While the `RenderingServer::mesh_create_surface_data_from_arrays` method does support vertexless meshes (see #62046 and #83446), it enforces that the size of custom arrays is dependent on the size of the vertex array. This effectively means  that custom arrays cannot be used in vertexless meshes.

This commit changes the way the array length is computed so that if no vertex array is provided, its length will be inferred from the custom arrays, if provided. It therefore adds support for custom arrays in vertexless meshes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
