### PR TITLE
Add EGL macro check before using `eglGetProcAddress()`

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -296,7 +296,7 @@ RasterizerGLES3::RasterizerGLES3() {
 		}
 	}
 #endif // GL_API_ENABLED
-#ifdef GLES_API_ENABLED
+#if defined(GLES_API_ENABLED) && defined(EGL_ENABLED)
 	if (!gles_over_gl) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			DebugMessageCallbackARB callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallback");
@@ -312,7 +312,7 @@ RasterizerGLES3::RasterizerGLES3() {
 			}
 		}
 	}
-#endif // GLES_API_ENABLED
+#endif // GLES_API_ENABLED && EGL_ENABLED
 #endif // CAN_DEBUG
 
 	{


### PR DESCRIPTION
Add a check for the macro definition `EGL_ENABLED` before using `eglGetProcAddress()`.

Relates to #87981, where I thought that `eglGetProcAddress()` would have been used by the web platform. After more checks, it shouldn't be used.
Complements #93489 for the same reason.