### PR TITLE
CI: Add editor target to Android builds config

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -13,9 +13,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  android-template:
+  build-android:
     runs-on: "ubuntu-20.04"
-    name: Template (target=template_release)
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Editor (target=editor)
+            cache-name: android-editor
+            target: editor
+            tests: false
+            sconsflags: arch=arm64 production=yes
+
+          - name: Template arm32 (target=template_release, arch=arm32)
+            cache-name: android-template-arm32
+            target: template_release
+            tests: false
+            sconsflags: arch=arm32
+
+          - name: Template arm64 (target=template_release, arch=arm64)
+            cache-name: android-template-arm64
+            target: template_release
+            tests: false
+            sconsflags: arch=arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -30,33 +51,38 @@ jobs:
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
-      - name: Compilation (arm32)
+      - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm32
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
           platform: android
-          target: template_release
-          tests: false
-
-      - name: Compilation (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-          platform: android
-          target: template_release
-          tests: false
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
 
       - name: Generate Godot templates
+        if: matrix.target == 'template_release'
         run: |
           cd platform/android/java
           ./gradlew generateGodotTemplates
           cd ../../..
           ls -l bin/
 
+      - name: Generate Godot editor
+        if: matrix.target == 'editor'
+        run: |
+          cd platform/android/java
+          ./gradlew generateGodotEditor
+          cd ../../..
+          ls -l bin/android_editor_builds/
+
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
+        with:
+          name: ${{ matrix.cache-name }}


### PR DESCRIPTION
The configuration was updated to generate:
- Godot Android Editor build
- Godot Android template build for arm32
- Godot Android template build for arm64

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
