### PR TITLE
Remove editor pseudolocalization debug feature

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -752,10 +752,10 @@ StringName TranslationServer::tool_translate(const StringName &p_message, const 
 	if (tool_translation.is_valid()) {
 		StringName r = tool_translation->get_message(p_message, p_context);
 		if (r) {
-			return editor_pseudolocalization ? tool_pseudolocalize(r) : r;
+			return r;
 		}
 	}
-	return editor_pseudolocalization ? tool_pseudolocalize(p_message) : p_message;
+	return p_message;
 }
 
 StringName TranslationServer::tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
@@ -854,10 +854,6 @@ void TranslationServer::set_pseudolocalization_enabled(bool p_enabled) {
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
-}
-
-void TranslationServer::set_editor_pseudolocalization(bool p_enabled) {
-	editor_pseudolocalization = p_enabled;
 }
 
 void TranslationServer::reload_pseudolocalization() {

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -94,7 +94,6 @@ class TranslationServer : public Object {
 	bool pseudolocalization_fake_bidi_enabled = false;
 	bool pseudolocalization_override_enabled = false;
 	bool pseudolocalization_skip_placeholders_enabled = false;
-	bool editor_pseudolocalization = false;
 	float expansion_ratio = 0.0;
 	String pseudolocalization_prefix;
 	String pseudolocalization_suffix;
@@ -170,7 +169,6 @@ public:
 
 	bool is_pseudolocalization_enabled() const;
 	void set_pseudolocalization_enabled(bool p_enabled);
-	void set_editor_pseudolocalization(bool p_enabled);
 	void reload_pseudolocalization();
 
 	String standardize_locale(const String &p_locale) const;

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -623,10 +623,6 @@
 			The custom editor scale factor to use. This can be used for displays with very high DPI where a scale factor of 200% is not sufficient.
 			[b]Note:[/b] Only effective if [member interface/editor/display_scale] is set to [b]Custom[/b].
 		</member>
-		<member name="interface/editor/debug/enable_pseudolocalization" type="bool" setter="" getter="">
-			If [code]true[/code], lengthens the editor's localizable strings and replaces their characters with accented variants. This allows spotting non-localizable strings easily, while also ensuring the UI layout doesn't break when strings are made longer (as many languages require strings to be longer).
-			This is a debugging feature and should only be enabled when working on the editor itself.
-		</member>
 		<member name="interface/editor/display_scale" type="int" setter="" getter="">
 			The display scale factor to use for the editor interface. Higher values are more suited to hiDPI/Retina displays.
 			If set to [b]Auto[/b], the editor scale is automatically determined based on the screen resolution and reported display DPI. This heuristic is not always ideal, which means you can get better results by setting the editor scale manually.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -423,9 +423,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/engine_version_update_mode", int(default_update_mode), "Disable Update Checks,Check Newest Preview,Check Newest Stable,Check Newest Patch"); // Uses EngineUpdateLabel::UpdateMode.
 	}
 
-	_initial_set("interface/editor/debug/enable_pseudolocalization", false);
-	set_restart_if_changed("interface/editor/debug/enable_pseudolocalization", true);
-	// Use pseudolocalization in editor.
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_native_file_dialogs", false, "", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
@@ -1098,7 +1095,6 @@ fail:
 }
 
 void EditorSettings::setup_language() {
-	TranslationServer::get_singleton()->set_editor_pseudolocalization(get("interface/editor/debug/enable_pseudolocalization"));
 	String lang = get("interface/editor/editor_language");
 	if (lang == "en") {
 		return; // Default, nothing to do.


### PR DESCRIPTION
We've seen multiple users enable it by mistake and get utterly confused, reporting as a bug that the interface text is garbled, or not managing to get back to the settings to toggle it off:
- #55829 
- #87430 
- #93545 

On the other hand we haven't really seen much use of the feature by editor UI developers, so we can likely simply remove it.

If there's a need eventually, we can re-add it as a command line option (which is also better than an editor setting as one would typically want to toggle it during development).

- Closes #81794 by outright removing the feature.