### PR TITLE
[Web] Add "threads"/"nothreads" feature tags to export presets

### DIFF
--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -334,9 +334,13 @@ void EditorExportPlatformWeb::get_preset_features(const Ref<EditorExportPreset> 
 	if (p_preset->get("vram_texture_compression/for_desktop")) {
 		r_features->push_back("s3tc");
 	}
-
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		r_features->push_back("etc2");
+	}
+	if (p_preset->get("variant/thread_support").operator bool()) {
+		r_features->push_back("threads");
+	} else {
+		r_features->push_back("nothreads");
 	}
 	r_features->push_back("wasm32");
 }
@@ -345,7 +349,7 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/extensions_support"), false)); // Export type.
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/extensions_support"), false)); // GDExtension support.
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/thread_support"), false)); // Thread support (i.e. run with or without COEP/COOP headers).
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_desktop"), true)); // S3TC
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer


### PR DESCRIPTION
This allows selecting threads/nothreads gdextensions at export time (see https://github.com/godotengine/godot-cpp/pull/1451).

As per my comment (https://github.com/godotengine/godot-cpp/pull/1451#issuecomment-2086493923) it would be nice to provide also a `nothreads` feature flag to avoid relying on ordering in the `gdextension` file (and improve detection when using auto prefix).

See https://github.com/Faless/godot/commit/a17b075739c5b967f09063612b332e0514555a03 for the relevant changes (happy to attach them to this PR).