### PR TITLE
Fix crash on exit with shader editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -679,6 +679,8 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			singleton->active_plugins.clear();
+
 			if (progress_dialog) {
 				progress_dialog->queue_free();
 			}


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/93529

Editor plugins never get removed, so `active_plugins` had a null reference when the inspector is deleted when the editor is closed.
I wanted to remove them instead, but that caused issues with some plugins so I just clear `active_plugins` instead.