### PR TITLE
Add "repeat" keyword alias for InputEvent "echo" in the class reference

### DIFF
--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -77,10 +77,11 @@
 				Returns [code]true[/code] if this input event has been canceled.
 			</description>
 		</method>
-		<method name="is_echo" qualifiers="const">
+		<method name="is_echo" qualifiers="const" keywords="is_repeat">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this input event is an echo event (only for events of type [InputEventKey]). Any other event type returns [code]false[/code].
+				Returns [code]true[/code] if this input event is an echo event (only for events of type [InputEventKey]). An echo event is a repeated key event sent when the user is holding down the key. Any other event type returns [code]false[/code].
+				[b]Note:[/b] The rate at which echo events are sent is typically around 20 events per second (after holding down the key for roughly half a second). However, the key repeat delay/speed can be changed by the user or disabled entirely in the operating system settings. To ensure your project works correctly on all configurations, do not assume the user has a specific key repeat configuration in your project's behavior.
 			</description>
 		</method>
 		<method name="is_match" qualifiers="const">

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -59,8 +59,9 @@
 		</method>
 	</methods>
 	<members>
-		<member name="echo" type="bool" setter="set_echo" getter="is_echo" default="false">
-			If [code]true[/code], the key was already pressed before this event. It means the user is holding the key down.
+		<member name="echo" type="bool" setter="set_echo" getter="is_echo" default="false" keywords="repeat">
+			If [code]true[/code], the key was already pressed before this event. An echo event is a repeated key event sent when the user is holding down the key.
+			[b]Note:[/b] The rate at which echo events are sent is typically around 20 events per second (after holding down the key for roughly half a second). However, the key repeat delay/speed can be changed by the user or disabled entirely in the operating system settings. To ensure your project works correctly on all configurations, do not assume the user has a specific key repeat configuration in your project's behavior.
 		</member>
 		<member name="key_label" type="int" setter="set_key_label" getter="get_key_label" enum="Key" default="0">
 			Represents the localized label printed on the key in the current keyboard layout, which corresponds to one of the [enum Key] constants or any valid Unicode character.


### PR DESCRIPTION
"echo" is an uncommon term and the action is most commonly referred to as a "repeated" key press.

This also improves the documentation related to echo behavior.

- See https://github.com/godotengine/godot-proposals/issues/10026.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/5ec801f8-373c-4b33-b59d-3f47df8a1a10)