### PR TITLE
Add `nothreads` feature tag to signify lack of `THREADS_ENABLED`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -513,6 +513,10 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "threads") {
 		return true;
 	}
+#else
+	if (p_feature == "nothreads") {
+		return true;
+	}
 #endif
 
 	if (_check_internal_feature_support(p_feature)) {


### PR DESCRIPTION
As talked about in #93556.

This adds a new feature tag to `OS::has_feature` called `nothreads`, which complements the existing `threads` feature tag that's meant to signify whether the particular builds has `THREADS_ENABLED` defined or not, meaning whether it's been built with `threads=yes`.

This can help define things that should only apply to single-threaded builds (likely web builds), like project settings overrides or specific GDExtension binaries.