### PR TITLE
Prevent folder names with trailing periods from being used automatically

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -247,7 +247,10 @@ String OS::get_safe_dir_name(const String &p_dir_name, bool p_allow_paths) const
 	for (int i = 0; i < invalid_chars.size(); i++) {
 		safe_dir_name = safe_dir_name.replace(invalid_chars[i], "-");
 	}
-	return safe_dir_name;
+
+	// Trim trailing periods from the returned value as it's not valid for folder names on Windows.
+	// This check is still applied on non-Windows platforms so the returned value is consistent across platforms.
+	return safe_dir_name.rstrip(".");
 }
 
 // Path to data, config, cache, etc. OS-specific folders

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -271,6 +271,7 @@
 		<member name="application/config/custom_user_dir_name" type="String" setter="" getter="" default="&quot;&quot;">
 			This user directory is used for storing persistent data ([code]user://[/code] filesystem). If a custom directory name is defined, this name will be appended to the system-specific user data directory (same parent folder as the Godot configuration folder documented in [method OS.get_user_data_dir]).
 			The [member application/config/use_custom_user_dir] setting must be enabled for this to take effect.
+			[b]Note:[/b] If [member application/config/custom_user_dir_name] contains trailing periods, they will be stripped as folder names ending with a period are not allowed on Windows.
 		</member>
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.


### PR DESCRIPTION
Folder names ending with one or more `.` characters are not allowed on Windows, so this would break writing logs, shader cache and other project-specific files. Trailing periods are now stripped in this case.

On non-Windows platforms, this change still applies in the interest of portability.

This is technically a small breakage on non-Windows platforms because of this, but very few projects had user directory names that ended with `.` anyway (as it didn't work on Windows).

- This closes https://github.com/godotengine/godot/issues/75516.

**Testing project:** [test_project_periods.zip](https://github.com/user-attachments/files/15959791/test_project_periods.zip)