### PR TITLE
Fix symbol lookup for native enums

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3657,11 +3657,21 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					return OK;
 				}
 
-				StringName enum_name = ClassDB::get_integer_constant_enum(class_name, p_symbol, true);
-				if (enum_name != StringName()) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+				List<StringName> enums;
+				ClassDB::get_enum_list(class_name, &enums);
+				for (const StringName &E : enums) {
+					if (E == p_symbol) {
+						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+						r_result.class_name = base_type.native_type;
+						r_result.class_member = p_symbol;
+						return OK;
+					}
+				}
+
+				if (!String(ClassDB::get_integer_constant_enum(class_name, p_symbol, true)).is_empty()) {
+					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 					r_result.class_name = base_type.native_type;
-					r_result.class_member = enum_name;
+					r_result.class_member = p_symbol;
 					return OK;
 				}
 
@@ -3734,6 +3744,15 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.class_member = p_symbol;
 					return OK;
 				}
+			} break;
+			case GDScriptParser::DataType::ENUM: {
+				if (base_type.enum_values.has(p_symbol)) {
+					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+					r_result.class_name = String(base_type.native_type).get_slicec('.', 0);
+					r_result.class_member = p_symbol;
+					return OK;
+				}
+				base_type.kind = GDScriptParser::DataType::UNRESOLVED;
 			} break;
 			default: {
 				base_type.kind = GDScriptParser::DataType::UNRESOLVED;


### PR DESCRIPTION
Before:

![enum_fix_before](https://github.com/godotengine/godot/assets/3036176/827af357-3890-47cb-ab53-42293b1eabac)

After:

![enum_fix_after](https://github.com/godotengine/godot/assets/3036176/72263f64-3e51-4bcc-a6f4-edb73e6e3a4a)

Also fixes integer constant symbol lookup (currently it targets to an enum name rather than a constant inside that enum):

![constant_fix](https://github.com/godotengine/godot/assets/3036176/2f4e8d23-b2c2-4b45-b7ac-2ab9f785c589)
