### PR TITLE
[3.x] Fix lost old callback when continuous call `requestRenderAndNotify`

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
@@ -869,7 +869,7 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	 */
 	public interface EGLConfigChooser {
 		/**
-		 * Choose a configuration from the list. Implementors typically
+		 * Choose a configuration from the list. Implementers typically
 		 * implement this method by calling
 		 * {@link EGL10#eglChooseConfig} and iterating through the results. Please consult the
 		 * EGL specification available from The Khronos Group to learn how to call eglChooseConfig.
@@ -1673,7 +1673,24 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				mWantRenderNotification = true;
 				mRequestRender = true;
 				mRenderComplete = false;
-				mFinishDrawingRunnable = finishDrawing;
+
+				// fix lost old callback when continuous call requestRenderAndNotify
+				//
+				// If continuous call requestRenderAndNotify before trigger old
+				// callback, old callback will lose, cause VRI will wait for SV's
+				// draw to finish forever not calling finishDraw.
+				// https://android.googlesource.com/platform/frameworks/base/+/044fce0b826f2da3a192aac56785b5089143e693%5E%21/
+				//+++++++++++++++++++++++++++++++++++++++++++++++++++
+				final Runnable oldCallback = mFinishDrawingRunnable;
+				mFinishDrawingRunnable = () -> {
+					if (oldCallback != null) {
+						oldCallback.run();
+					}
+					if (finishDrawing != null) {
+						finishDrawing.run();
+					}
+				};
+				//----------------------------------------------------
 
 				sGLThreadManager.notifyAll();
 			}
@@ -1938,4 +1955,3 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	private int mEGLContextClientVersion;
 	private boolean mPreserveEGLContextOnPause;
 }
-


### PR DESCRIPTION
I have run `git diff`, the file is identical to `master` branch.
Tested on MacOS and Android Adreno 6xx with GLES 3.0