### PR TITLE
Fix editor crash when invalid global class script path

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5527,6 +5527,9 @@ bool GDScriptAnalyzer::check_type_compatibility(const GDScriptParser::DataType &
 				// A script type cannot be a subtype of a GDScript class.
 				return false;
 			}
+			if (p_source.script_type.is_null()) {
+				return false;
+			}
 			if (p_source.is_meta_type) {
 				src_native = p_source.script_type->get_class_name();
 			} else {


### PR DESCRIPTION
Fixes #93410 

Even I was not able to reproduce the problem of editor crashing on opening a script in an external editor, this PR should prevent the editor crash when the `global_script_class_cache.cfg` contains an invalid path.

The PR #92303 should also fix this problem because it removes the invalid global class name at startup but I think adding this validation was an easy fix that could prevent other crashes.

The problem:
![image](https://github.com/godotengine/godot/assets/81109165/36e7a47c-034d-4c78-98e8-9b3624ab9c5b)
