### PR TITLE
Add default keyboard shortcuts to various actions in the 3D editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6181,15 +6181,15 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_submenu_node_item(TTRC("Display Advanced..."), display_submenu, VIEW_DISPLAY_ADVANCED);
 
 	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment")), VIEW_ENVIRONMENT);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos")), VIEW_GIZMOS);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment"), KeyModifierMask::CMD_OR_CTRL | Key::E), VIEW_ENVIRONMENT);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos"), KeyModifierMask::CMD_OR_CTRL | Key::F), VIEW_GIZMOS);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_transform_gizmo", TTRC("View Transform Gizmo")), VIEW_TRANSFORM_GIZMO);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid")), VIEW_GRID);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information")), VIEW_INFORMATION);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time")), VIEW_FRAME_TIME);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid"), KeyModifierMask::CMD_OR_CTRL | Key::L), VIEW_GRID);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::I), VIEW_INFORMATION);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::M), VIEW_FRAME_TIME);
 	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ENVIRONMENT), true);
 	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTRC("Half Resolution")), VIEW_HALF_RESOLUTION);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTRC("Half Resolution"), KeyModifierMask::CMD_OR_CTRL | Key::U), VIEW_HALF_RESOLUTION);
 	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_listener", TTRC("Audio Listener")), VIEW_AUDIO_LISTENER);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_doppler", TTRC("Enable Doppler")), VIEW_AUDIO_DOPPLER);
@@ -6198,7 +6198,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID), true);
 
 	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT_ARRAY("spatial_editor/view_cinematic_preview", TTR("Cinematic Preview"), { int32_t(Key::KP_0) }), VIEW_CINEMATIC_PREVIEW);
 
 	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
@@ -9923,7 +9923,7 @@ Node3DEditor::Node3DEditor() {
 	p->add_shortcut(ED_SHORTCUT("spatial_editor/transform_dialog", TTRC("Transform Dialog...")), MENU_TRANSFORM_DIALOG);
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTRC("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
+	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTRC("Configure Snap..."), KeyModifierMask::CMD_OR_CTRL | Key::NUMBERSIGN), MENU_TRANSFORM_CONFIGURE_SNAP);
 
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed));
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5800,7 +5800,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_submenu_node_item(TTRC("Smart Snapping"), smartsnap_config_popup);
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/configure_snap", TTRC("Configure Snap...")), SNAP_CONFIGURE);
+	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/configure_snap", TTRC("Configure Snap..."), KeyModifierMask::CMD_OR_CTRL | Key::NUMBERSIGN), SNAP_CONFIGURE);
 
 	main_menu_hbox->add_child(memnew(VSeparator));
 
@@ -5881,8 +5881,8 @@ CanvasItemEditor::CanvasItemEditor() {
 	grid_menu->add_radio_check_item(TTRC("Show When Snapping"), GRID_VISIBILITY_SHOW_WHEN_SNAPPING);
 	grid_menu->add_radio_check_item(TTRC("Hide"), GRID_VISIBILITY_HIDE);
 	grid_menu->add_separator();
-	grid_menu->add_shortcut(ED_SHORTCUT("canvas_item_editor/toggle_grid", TTRC("Toggle Grid"), KeyModifierMask::CMD_OR_CTRL | Key::APOSTROPHE));
-	p->add_submenu_node_item(TTRC("Grid"), grid_menu);
+	grid_menu->add_shortcut(ED_SHORTCUT("canvas_item_editor/toggle_grid", TTRC("Toggle Grid"), Key::NUMBERSIGN));
+	p->add_submenu_node_item(TTR("Grid"), grid_menu);
 
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_helpers", TTRC("Show Helpers"), Key::H), SHOW_HELPERS);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_rulers", TTRC("Show Rulers")), SHOW_RULERS);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/93578
(can be merged independently).

This also changes the 2D editor Toggle Grid shortcut to match the 3D editor one.
(Out of curiosity, is <kbd>Ctrl + Apostrophe</kbd> standard for toggling grids in any app? If so, we can readd it as an alternative second shortcut in both the 2D and 3D editors.)

New shortcuts:

- <kbd>Ctrl + E</kbd>: View Environment
- <kbd>Ctrl + F</kbd>: View Gizmos
- <kbd>Ctrl + L</kbd>: View Grid
- <kbd>Ctrl + Shift + I</kbd>: View Information
- <kbd>Ctrl + Shift + M</kbd>: View Frame Time
- <kbd>Ctrl + U</kbd>: Half Resolution
- <kbd>Numpad 0</kbd>: Cinematic Preview
  - Note that if using **Emulate Numpad**, the shortcut won't work to leave the cinematic preview due to https://github.com/godotengine/godot/issues/93677.
    - Fixed by https://github.com/godotengine/godot/pull/93724.

In both the 2D and 3D editors, this shortcut was also added:

- <kbd>Ctrl + #:</kbd> Configure Snap

**Edit:** Cinematic Preview shortcut was changed from <kbd>Ctrl + Alt + R</kbd> to <kbd>Numpad 0</kbd> to match Blender. I'd like to make Focus Selection support <kbd>Numpad Period</kbd> to match Blender, but it doesn't seem to work for some reason, regardless of the **Emulate Numpad** editor setting (I'm testing with a physical numpad).