### PR TITLE
Add comment for editor particles Restart Emission shortcut not using Cmd on macOS

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6446,6 +6446,7 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT("editor/ungroup_selected_nodes", TTR("Ungroup Selected Node(s)"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::G);
 
 	// Used in the GPUParticles/CPUParticles 2D/3D editor plugins.
+	// The shortcut is Ctrl + R even on macOS, as Cmd + R is used to run the current scene on macOS.
 	ED_SHORTCUT("particles/restart_emission", TTR("Restart Emission"), KeyModifierMask::CTRL | Key::R);
 
 	FileAccess::set_backup_save(EDITOR_GET("filesystem/on_save/safe_save_on_backup_then_rename"));


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/92134.

This is done to avoid a conflict, but it's not obvious when looking at the code.