### PR TITLE
Fix node's gizmo will be blocked by certain materials

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -875,7 +875,6 @@ void EditorNode3DGizmoPlugin::create_material(const String &p_name, const Color 
 		material->set_albedo(color);
 		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 		material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-		material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 1);
 		material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
 		material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93547

Just like https://github.com/godotengine/godot/blob/25ff1306d62b8eb0487608b2a9bed0644e2fce17/scene/3d/physics/ray_cast_3d.cpp#L471-L481

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
