### PR TITLE
Windows: Fix arch detection via `VCTOOLSINSTALLDIR` if not first in `PATH`

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -142,8 +142,9 @@ def detect_build_env_arch():
         if os.getenv("VCTOOLSINSTALLDIR"):
             host_path_index = os.getenv("PATH").upper().find(os.getenv("VCTOOLSINSTALLDIR").upper() + "BIN\\HOST")
             if host_path_index > -1:
-                first_path_arch = os.getenv("PATH").split(";")[0].rsplit("\\", 1)[-1].lower()
-                return msvc_target_aliases[first_path_arch]
+                first_path_arch = os.getenv("PATH")[host_path_index:].split(";")[0].rsplit("\\", 1)[-1].lower()
+                if first_path_arch in msvc_target_aliases.keys():
+                    return msvc_target_aliases[first_path_arch]
 
     msys_target_aliases = {
         "mingw32": "x86_32",


### PR DESCRIPTION
Trying to invoke `scons` on Windows with `VCTOOLSINSTALLDIR` set (as is the case in the default VS / GDK command prompts) resulted in the following error for me:

```bash
KeyError: 'bin':
  ...
  File "C:\git\godot\.\platform\windows\detect.py", line 144:
    return msvc_target_aliases[first_path_arch]
```

Turns out we have this piece of code in the Windows platform [detect.py](https://github.com/godotengine/godot/blob/6b281c0c07b07f2142b1fc8a6b3158091a9b124c/platform/windows/detect.py), trying to determine the `arch`:
https://github.com/godotengine/godot/blob/6b281c0c07b07f2142b1fc8a6b3158091a9b124c/platform/windows/detect.py#L141-L146

Here is what this tries to do:
- It checks if `VCTOOLSINSTALLDIR` is set 
  (which for me has a value like `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\`).
- if so, it appends `BIN\HOST` to that value and searches for it in `PATH` and if found, saves the starting index of that in `PATH`.
- It should find a value like `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\Hostx64\x64` in `PATH`; it now tries to extract the arch bit in `...\Hostx64\...` (`x64`).

However, there are 2 errors here:

1. Line 145 does not actually use the found index in the `PATH`. `os.getenv("PATH").split(";")[0]` just gets the first element of `PATH`, then `.rsplit("\\", 1)[-1]` cuts parts of. For me, this resulted in a value of `bin` instead of `x64`, as `VCTOOLSINSTALLDIR` was not the first in `PATH`. Changing it to `os.getenv("PATH")[host_path_index:]...` to actually start at the found index fixes this and resolves the error.
2. There is a missing guard to check whether the found arch actually exists in the dict before returning it. All other similar places in the file have such guards. So, I added one here with `if first_path_arch in msvc_target_aliases.keys()`, which would at least have prevented this error.

This seems to have been introduced in https://github.com/godotengine/godot/pull/64921.
