### PR TITLE
[WebXR] Fix closure compiler mangling `XRSession.enabledFeatures`

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -320,7 +320,8 @@ const GodotWebXR = {
 					// next reference space.
 					window.setTimeout(function () {
 						const reference_space_c_str = GodotRuntime.allocString(reference_space_type);
-						const enabled_features_c_str = GodotRuntime.allocString(Array.from(session.enabledFeatures).join(','));
+						const enabled_features = 'enabledFeatures' in session ? Array.from(session.enabledFeatures) : [];
+						const enabled_features_c_str = GodotRuntime.allocString(enabled_features.join(','));
 						onstarted(reference_space_c_str, enabled_features_c_str);
 						GodotRuntime.free(reference_space_c_str);
 						GodotRuntime.free(enabled_features_c_str);

--- a/modules/webxr/native/webxr.externs.js
+++ b/modules/webxr/native/webxr.externs.js
@@ -78,6 +78,11 @@ XRSession.prototype.frameRate;
 XRSession.prototype.supportedFrameRates;
 
 /**
+ * @type {Array<string>}
+ */
+XRSession.prototype.enabledFeatures;
+
+/**
  * @type {?function (Event)}
  */
 XRSession.prototype.onend;


### PR DESCRIPTION
Currently, when running a WebXR app with a release build using the Closure compiler, it'll crash on entering an XR session with this error (from Chrome with the WebXR API Emulator):

```
index.js:7340 Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Function.from (<anonymous>)
    at index.js:7340:42
```

This was introduced by PR https://github.com/godotengine/godot/pull/88411, which added a reference to `XRSession.enabledFeatures` (among other things), but I forgot to add it to the `webxr.extern.js` file for the Closure compiler, in order to prevent it from doing its usual name mangling thing.