### PR TITLE
Improve Editor Inspector/Theme item lookup performance

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -291,6 +291,29 @@ StringName ClassDB::get_parent_class_nocheck(const StringName &p_class) {
 	return ti->inherits;
 }
 
+bool ClassDB::get_inheritance_chain_nocheck(const StringName &p_class, Vector<StringName> &r_result) {
+	OBJTYPE_RLOCK;
+
+	ClassInfo *start = classes.getptr(p_class);
+	if (!start) {
+		return false;
+	}
+
+	int classes_to_add = 0;
+	for (ClassInfo *ti = start; ti; ti = ti->inherits_ptr) {
+		classes_to_add++;
+	}
+
+	int64_t old_size = r_result.size();
+	r_result.resize(old_size + classes_to_add);
+	StringName *w = r_result.ptrw() + old_size;
+	for (ClassInfo *ti = start; ti; ti = ti->inherits_ptr) {
+		*w++ = ti->name;
+	}
+
+	return true;
+}
+
 StringName ClassDB::get_compatibility_remapped_class(const StringName &p_class) {
 	if (classes.has(p_class)) {
 		return p_class;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -282,6 +282,7 @@ public:
 	static void get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);
+	static bool get_inheritance_chain_nocheck(const StringName &p_class, Vector<StringName> &r_result);
 	static StringName get_parent_class(const StringName &p_class);
 	static StringName get_compatibility_remapped_class(const StringName &p_class);
 	static bool class_exists(const StringName &p_class);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -487,7 +487,7 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
 	}
 
-	List<Ref<Theme>> editor_themes;
+	Vector<Ref<Theme>> editor_themes;
 	editor_themes.push_back(theme);
 	editor_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
 
@@ -556,7 +556,7 @@ void EditorNode::update_preview_themes(int p_mode) {
 		return; // Too early.
 	}
 
-	List<Ref<Theme>> preview_themes;
+	Vector<Ref<Theme>> preview_themes;
 
 	switch (p_mode) {
 		case CanvasItemEditor::THEME_PREVIEW_PROJECT:

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -205,7 +205,7 @@ void ThemeEditorPreview::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			List<Ref<Theme>> preview_themes;
+			Vector<Ref<Theme>> preview_themes;
 			preview_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
 			ThemeDB::get_singleton()->create_theme_context(preview_root, preview_themes);
 		} break;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -190,7 +190,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
 	}
 
-	List<Ref<Theme>> editor_themes;
+	Vector<Ref<Theme>> editor_themes;
 	editor_themes.push_back(theme);
 	editor_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
 

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -797,13 +797,13 @@ Ref<Font> Label3D::_get_font_or_default() const {
 	}
 
 	const StringName theme_name = SceneStringName(font);
-	List<StringName> theme_types;
-	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+	Vector<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), theme_types);
 
 	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
-	List<Ref<Theme>> themes = global_context->get_themes();
+	Vector<Ref<Theme>> themes = global_context->get_themes();
 	if (Engine::get_singleton()->is_editor_hint()) {
-		themes.push_front(ThemeDB::get_singleton()->get_project_theme());
+		themes.insert(0, ThemeDB::get_singleton()->get_project_theme());
 	}
 
 	for (const Ref<Theme> &theme : themes) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2575,8 +2575,8 @@ Ref<Texture2D> Control::get_theme_icon(const StringName &p_name, const StringNam
 		return data.theme_icon_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<Texture2D> icon = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 	data.theme_icon_cache[p_theme_type][p_name] = icon;
 	return icon;
@@ -2599,8 +2599,8 @@ Ref<StyleBox> Control::get_theme_stylebox(const StringName &p_name, const String
 		return data.theme_style_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<StyleBox> style = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 	data.theme_style_cache[p_theme_type][p_name] = style;
 	return style;
@@ -2623,8 +2623,8 @@ Ref<Font> Control::get_theme_font(const StringName &p_name, const StringName &p_
 		return data.theme_font_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<Font> font = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 	data.theme_font_cache[p_theme_type][p_name] = font;
 	return font;
@@ -2647,8 +2647,8 @@ int Control::get_theme_font_size(const StringName &p_name, const StringName &p_t
 		return data.theme_font_size_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	int font_size = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 	data.theme_font_size_cache[p_theme_type][p_name] = font_size;
 	return font_size;
@@ -2671,8 +2671,8 @@ Color Control::get_theme_color(const StringName &p_name, const StringName &p_the
 		return data.theme_color_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Color color = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 	data.theme_color_cache[p_theme_type][p_name] = color;
 	return color;
@@ -2695,8 +2695,8 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_th
 		return data.theme_constant_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	int constant = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 	data.theme_constant_cache[p_theme_type][p_name] = constant;
 	return constant;
@@ -2741,8 +2741,8 @@ bool Control::has_theme_icon(const StringName &p_name, const StringName &p_theme
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 }
 
@@ -2758,8 +2758,8 @@ bool Control::has_theme_stylebox(const StringName &p_name, const StringName &p_t
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 }
 
@@ -2775,8 +2775,8 @@ bool Control::has_theme_font(const StringName &p_name, const StringName &p_theme
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 }
 
@@ -2792,8 +2792,8 @@ bool Control::has_theme_font_size(const StringName &p_name, const StringName &p_
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 }
 
@@ -2809,8 +2809,8 @@ bool Control::has_theme_color(const StringName &p_name, const StringName &p_them
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 }
 
@@ -2826,8 +2826,8 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 		}
 	}
 
-	List<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2159,8 +2159,8 @@ Ref<Texture2D> Window::get_theme_icon(const StringName &p_name, const StringName
 		return theme_icon_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<Texture2D> icon = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 	theme_icon_cache[p_theme_type][p_name] = icon;
 	return icon;
@@ -2183,8 +2183,8 @@ Ref<StyleBox> Window::get_theme_stylebox(const StringName &p_name, const StringN
 		return theme_style_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<StyleBox> style = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 	theme_style_cache[p_theme_type][p_name] = style;
 	return style;
@@ -2207,8 +2207,8 @@ Ref<Font> Window::get_theme_font(const StringName &p_name, const StringName &p_t
 		return theme_font_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Ref<Font> font = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 	theme_font_cache[p_theme_type][p_name] = font;
 	return font;
@@ -2231,8 +2231,8 @@ int Window::get_theme_font_size(const StringName &p_name, const StringName &p_th
 		return theme_font_size_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	int font_size = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 	theme_font_size_cache[p_theme_type][p_name] = font_size;
 	return font_size;
@@ -2255,8 +2255,8 @@ Color Window::get_theme_color(const StringName &p_name, const StringName &p_them
 		return theme_color_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	Color color = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 	theme_color_cache[p_theme_type][p_name] = color;
 	return color;
@@ -2279,8 +2279,8 @@ int Window::get_theme_constant(const StringName &p_name, const StringName &p_the
 		return theme_constant_cache[p_theme_type][p_name];
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	int constant = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 	theme_constant_cache[p_theme_type][p_name] = constant;
 	return constant;
@@ -2325,8 +2325,8 @@ bool Window::has_theme_icon(const StringName &p_name, const StringName &p_theme_
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 }
 
@@ -2342,8 +2342,8 @@ bool Window::has_theme_stylebox(const StringName &p_name, const StringName &p_th
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 }
 
@@ -2359,8 +2359,8 @@ bool Window::has_theme_font(const StringName &p_name, const StringName &p_theme_
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 }
 
@@ -2376,8 +2376,8 @@ bool Window::has_theme_font_size(const StringName &p_name, const StringName &p_t
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 }
 
@@ -2393,8 +2393,8 @@ bool Window::has_theme_color(const StringName &p_name, const StringName &p_theme
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 }
 
@@ -2410,8 +2410,8 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 		}
 	}
 
-	List<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, &theme_types);
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3468,13 +3468,13 @@ Ref<Font> TextMesh::_get_font_or_default() const {
 	}
 
 	StringName theme_name = "font";
-	List<StringName> theme_types;
-	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+	Vector<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), theme_types);
 
 	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
-	List<Ref<Theme>> themes = global_context->get_themes();
+	Vector<Ref<Theme>> themes = global_context->get_themes();
 	if (Engine::get_singleton()->is_editor_hint()) {
-		themes.push_front(ThemeDB::get_singleton()->get_project_theme());
+		themes.insert(0, ThemeDB::get_singleton()->get_project_theme());
 	}
 
 	for (const Ref<Theme> &theme : themes) {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2890,13 +2890,13 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 	}
 
 	StringName theme_name = "font";
-	List<StringName> theme_types;
-	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+	Vector<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), theme_types);
 
 	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
-	List<Ref<Theme>> themes = global_context->get_themes();
+	Vector<Ref<Theme>> themes = global_context->get_themes();
 	if (Engine::get_singleton()->is_editor_hint()) {
-		themes.push_front(ThemeDB::get_singleton()->get_project_theme());
+		themes.insert(0, ThemeDB::get_singleton()->get_project_theme());
 	}
 
 	for (const Ref<Theme> &theme : themes) {
@@ -3259,8 +3259,8 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 	}
 
 	StringName theme_name = "font";
-	List<StringName> theme_types;
-	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+	Vector<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), theme_types);
 
 	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
 	for (const Ref<Theme> &theme : global_context->get_themes()) {

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1250,14 +1250,12 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 	}
 }
 
-void Theme::get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variation, List<StringName> *p_list) {
-	ERR_FAIL_NULL(p_list);
-
+void Theme::get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variation, Vector<StringName> &r_result) {
 	// Build the dependency chain for type variations.
 	if (p_type_variation != StringName()) {
 		StringName variation_name = p_type_variation;
 		while (variation_name != StringName()) {
-			p_list->push_back(variation_name);
+			r_result.push_back(variation_name);
 			variation_name = get_type_variation_base(variation_name);
 
 			// If we have reached the base type dependency, it's safe to stop (assuming no funny business was done to the Theme).
@@ -1268,7 +1266,7 @@ void Theme::get_type_dependencies(const StringName &p_base_type, const StringNam
 	}
 
 	// Continue building the chain using native class hierarchy.
-	ThemeDB::get_singleton()->get_native_type_dependencies(p_base_type, p_list);
+	ThemeDB::get_singleton()->get_native_type_dependencies(p_base_type, r_result);
 }
 
 // Internal methods for getting lists as a Vector of String (compatible with public API).

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -216,7 +216,7 @@ public:
 	void add_type(const StringName &p_theme_type);
 	void remove_type(const StringName &p_theme_type);
 	void get_type_list(List<StringName> *p_list) const;
-	void get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variant, List<StringName> *p_list);
+	void get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variant, Vector<StringName> &r_result);
 
 	void merge_with(const Ref<Theme> &p_other);
 	void clear();

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -46,26 +46,29 @@ class ThemeContext;
 // Macros for binding theme items of this class. This information is used for the documentation, theme
 // overrides, etc. This is also the basis for theme cache.
 
-#define BIND_THEME_ITEM(m_data_type, m_class, m_prop)                                                                   \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop, [](Node *p_instance) { \
-		m_class *p_cast = Object::cast_to<m_class>(p_instance);                                                         \
-		p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, _scs_create(#m_prop));                         \
-	})
+#define BIND_THEME_ITEM(m_data_type, m_class, m_prop)                                                       \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop,            \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
+			})
 
-#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name)                                                   \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name, [](Node *p_instance) { \
-		m_class *p_cast = Object::cast_to<m_class>(p_instance);                                                             \
-		p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, _scs_create(m_item_name));                         \
-	})
+#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name)                                   \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name,        \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
+			})
 
 // Macro for binding theme items used by this class, but defined/binded by other classes. This is primarily used for
 // the theme cache. Can also be used to list such items in documentation.
 
-#define BIND_THEME_ITEM_EXT(m_data_type, m_class, m_prop, m_item_name, m_type_name)                                                               \
-	ThemeDB::get_singleton()->bind_class_external_item(m_data_type, get_class_static(), #m_prop, m_item_name, m_type_name, [](Node *p_instance) { \
-		m_class *p_cast = Object::cast_to<m_class>(p_instance);                                                                                   \
-		p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, _scs_create(m_item_name), _scs_create(m_type_name));                     \
-	})
+#define BIND_THEME_ITEM_EXT(m_data_type, m_class, m_prop, m_item_name, m_type_name)                                        \
+	ThemeDB::get_singleton()->bind_class_external_item(m_data_type, get_class_static(), #m_prop, m_item_name, m_type_name, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {                           \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                                    \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);                \
+			})
 
 class ThemeDB : public Object {
 	GDCLASS(ThemeDB, Object);
@@ -97,7 +100,7 @@ class ThemeDB : public Object {
 	// Binding of theme items to Node classes.
 
 public:
-	typedef std::function<void(Node *)> ThemeItemSetter;
+	typedef std::function<void(Node *, const StringName &, const StringName &)> ThemeItemSetter;
 
 	struct ThemeItemBind {
 		Theme::DataType data_type;
@@ -154,11 +157,11 @@ public:
 	void set_fallback_stylebox(const Ref<StyleBox> &p_stylebox);
 	Ref<StyleBox> get_fallback_stylebox();
 
-	void get_native_type_dependencies(const StringName &p_base_type, List<StringName> *p_list);
+	void get_native_type_dependencies(const StringName &p_base_type, Vector<StringName> &r_result);
 
 	// Global theme contexts.
 
-	ThemeContext *create_theme_context(Node *p_node, List<Ref<Theme>> &p_themes);
+	ThemeContext *create_theme_context(Node *p_node, Vector<Ref<Theme>> &p_themes);
 	void destroy_theme_context(Node *p_node);
 
 	ThemeContext *get_theme_context(Node *p_node) const;
@@ -191,7 +194,7 @@ class ThemeContext : public Object {
 	// Themes are stacked in the order of relevance, for easy iteration.
 	// This means that the first theme is the one you should check first,
 	// and the last theme is the fallback theme where every lookup ends.
-	List<Ref<Theme>> themes;
+	Vector<Ref<Theme>> themes;
 
 	void _emit_changed();
 
@@ -199,8 +202,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_themes(List<Ref<Theme>> &p_themes);
-	List<Ref<Theme>> get_themes() const;
+	void set_themes(Vector<Ref<Theme>> &p_themes);
+	const Vector<Ref<Theme>> get_themes() const;
 	Ref<Theme> get_fallback_theme() const;
 };
 

--- a/scene/theme/theme_owner.cpp
+++ b/scene/theme/theme_owner.cpp
@@ -199,7 +199,7 @@ void ThemeOwner::propagate_theme_changed(Node *p_to_node, Node *p_owner_node, bo
 
 // Theme lookup.
 
-void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const StringName &p_theme_type, List<StringName> *r_list) const {
+void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const StringName &p_theme_type, Vector<StringName> &r_result) const {
 	const Control *for_c = Object::cast_to<Control>(p_for_node);
 	const Window *for_w = Object::cast_to<Window>(p_for_node);
 	ERR_FAIL_COND_MSG(!for_c && !for_w, "Only Control and Window nodes and derivatives can be polled for theming.");
@@ -224,7 +224,7 @@ void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const Strin
 		while (owner_node) {
 			Ref<Theme> owner_theme = _get_owner_node_theme(owner_node);
 			if (owner_theme.is_valid() && owner_theme->get_type_variation_base(type_variation) != StringName()) {
-				owner_theme->get_type_dependencies(type_name, type_variation, r_list);
+				owner_theme->get_type_dependencies(type_name, type_variation, r_result);
 				return;
 			}
 
@@ -235,21 +235,21 @@ void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const Strin
 		ThemeContext *global_context = _get_active_owner_context();
 		for (const Ref<Theme> &theme : global_context->get_themes()) {
 			if (theme.is_valid() && theme->get_type_variation_base(type_variation) != StringName()) {
-				theme->get_type_dependencies(type_name, type_variation, r_list);
+				theme->get_type_dependencies(type_name, type_variation, r_result);
 				return;
 			}
 		}
 
 		// If nothing was found, get the native dependencies for the current class.
-		ThemeDB::get_singleton()->get_native_type_dependencies(type_name, r_list);
+		ThemeDB::get_singleton()->get_native_type_dependencies(type_name, r_result);
 		return;
 	}
 
 	// Otherwise, get the native dependencies for the provided theme type.
-	ThemeDB::get_singleton()->get_native_type_dependencies(p_theme_type, r_list);
+	ThemeDB::get_singleton()->get_native_type_dependencies(p_theme_type, r_result);
 }
 
-Variant ThemeOwner::get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const List<StringName> &p_theme_types) {
+Variant ThemeOwner::get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types) {
 	ERR_FAIL_COND_V_MSG(p_theme_types.is_empty(), Variant(), "At least one theme type must be specified.");
 
 	// First, look through each control or window node in the branch, until no valid parent can be found.
@@ -285,7 +285,7 @@ Variant ThemeOwner::get_theme_item_in_types(Theme::DataType p_data_type, const S
 	return global_context->get_fallback_theme()->get_theme_item(p_data_type, p_name, StringName());
 }
 
-bool ThemeOwner::has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const List<StringName> &p_theme_types) {
+bool ThemeOwner::has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types) {
 	ERR_FAIL_COND_V_MSG(p_theme_types.is_empty(), false, "At least one theme type must be specified.");
 
 	// First, look through each control or window node in the branch, until no valid parent can be found.

--- a/scene/theme/theme_owner.h
+++ b/scene/theme/theme_owner.h
@@ -69,10 +69,10 @@ public:
 
 	// Theme lookup.
 
-	void get_theme_type_dependencies(const Node *p_for_node, const StringName &p_theme_type, List<StringName> *r_list) const;
+	void get_theme_type_dependencies(const Node *p_for_node, const StringName &p_theme_type, Vector<StringName> &r_result) const;
 
-	Variant get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const List<StringName> &p_theme_types);
-	bool has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const List<StringName> &p_theme_types);
+	Variant get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types);
+	bool has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types);
 
 	float get_theme_default_base_scale();
 	Ref<Font> get_theme_default_font();


### PR DESCRIPTION
Changes to reduce the latency between changing node selection in the editor and seeing the new node reflected in the Inspector tab

- Use `Vector` instead of `List` for `ThemeOwner::get_theme_type_dependencies` and related functions
- Use `Vector` instead of `List` for `ThemeContext::themes`, `set_themes()`, and `get_themes()`
- Add `ClassDB:get_inheritance_chain_nocheck` to get all parent/ancestor classes at once, to avoid repeated `ClassDB` locking overhead
- Update `BIND_THEME_ITEM` macros and `ThemeDB::update_class_instance_items` to use provided `StringNames` for call to `ThemeItemSetter`, instead of creating a new `StringName` in each call

These changes reduce the time taken by `EditorInspector::update_tree` by around 30-35%.  This should noticeably improve the delays/freezes in #93402, though there's still a lot going on when updating the Inspector. Still could be slow for some nodes, and would depend on CPU.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
