### PR TITLE
Add support for struct uniforms in shaders

### DIFF
--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -87,7 +87,9 @@ private:
 	struct Version {
 		LocalVector<TextureUniformData> texture_uniforms;
 		CharString uniforms;
+		CharString vertex_structs;
 		CharString vertex_globals;
+		CharString fragment_structs;
 		CharString fragment_globals;
 		HashMap<StringName, CharString> code_sections;
 		Vector<CharString> custom_defines;
@@ -124,7 +126,9 @@ private:
 		struct Chunk {
 			enum Type {
 				TYPE_MATERIAL_UNIFORMS,
+				TYPE_VERTEX_STRUCTS,
 				TYPE_VERTEX_GLOBALS,
+				TYPE_FRAGMENT_STRUCTS,
 				TYPE_FRAGMENT_GLOBALS,
 				TYPE_CODE,
 				TYPE_TEXT
@@ -244,7 +248,7 @@ protected:
 public:
 	RID version_create();
 
-	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize = false);
+	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_structs, const String &p_vertex_globals, const String &p_fragment_structs, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize = false);
 
 	bool version_is_valid(RID p_version);
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -103,6 +103,10 @@ flat out vec4 varying_E;
 flat out uvec2 varying_F;
 flat out uvec4 varying_G;
 
+/* clang-format on */
+#STRUCTS
+/* clang-format off */
+
 // This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
 layout(std140) uniform MaterialUniforms{ //ubo:4
@@ -338,6 +342,8 @@ uniform sampler2D specular_texture; //texunit:-7
 uniform sampler2D color_texture; //texunit:0
 
 layout(location = 0) out vec4 frag_color;
+
+#STRUCTS
 
 /* clang-format off */
 // This needs to be outside clang-format so the ubo comment is in the right place

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -21,6 +21,10 @@ layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
+/* clang-format on */
+#STRUCTS
+/* clang-format off */
+
 // This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
 layout(std140) uniform MaterialUniforms{ //ubo:2

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -475,6 +475,10 @@ out highp vec4 shadow_coord4;
 #endif //LIGHT_USE_PSSM4
 #endif
 
+/* clang-format off */
+#STRUCTS
+/* clang-format on */
+
 #ifdef MATERIAL_UNIFORMS_USED
 
 /* clang-format off */
@@ -900,6 +904,10 @@ uniform samplerCube refprobe2_texture; // texunit:-8
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
+
+/* clang-format off */
+#STRUCTS
+/* clang-format on */
 
 /* Material Uniforms */
 #ifdef MATERIAL_UNIFORMS_USED

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -69,6 +69,8 @@ layout(std140) uniform DirectionalLights { //ubo:4
 }
 directional_lights;
 
+#STRUCTS
+
 /* clang-format off */
 
 #ifdef MATERIAL_UNIFORMS_USED

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -106,6 +106,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	void _validate_shader_struct_members(const Dictionary &p_default, Dictionary &p_current) const;
 
 	static void _bind_methods();
 

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -342,7 +342,7 @@ void Fog::FogShaderData::set_code(const String &p_code) {
 		version = fog_singleton->volumetric_fog.shader.version_create();
 	}
 
-	fog_singleton->volumetric_fog.shader.version_set_compute_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_COMPUTE], gen_code.defines);
+	fog_singleton->volumetric_fog.shader.version_set_compute_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_COMPUTE], gen_code.stage_globals[ShaderCompiler::STAGE_COMPUTE], gen_code.defines);
 	ERR_FAIL_COND(!fog_singleton->volumetric_fog.shader.version_is_valid(version));
 
 	ubo_size = gen_code.uniform_total_size;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -125,11 +125,11 @@ void SkyRD::SkyShaderData::set_code(const String &p_code) {
 	}
 
 	print_line("\n**uniforms:\n" + gen_code.uniforms);
-	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
-	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
+	print_line("\n**vertex_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX] + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
+	print_line("\n**fragment_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT] + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
 
-	scene_singleton->sky.sky_shader.shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	scene_singleton->sky.sky_shader.shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 	ERR_FAIL_COND(!scene_singleton->sky.sky_shader.shader.version_is_valid(version));
 
 	ubo_size = gen_code.uniform_total_size;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -175,10 +175,10 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	}
 
 	print_line("\n**uniforms:\n" + gen_code.uniforms);
-	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
-	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
+	print_line("\n**vertex_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX] + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
+	print_line("\n**fragment_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT] + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
-	SceneShaderForwardClustered::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	SceneShaderForwardClustered::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -184,11 +184,10 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	}
 
 	print_line("\n**uniforms:\n" + gen_code.uniforms);
-	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
-	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
+	print_line("\n**vertex_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX] + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
+	print_line("\n**fragment_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT] + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
-
-	SceneShaderForwardMobile::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	SceneShaderForwardMobile::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1532,10 +1532,10 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 	}
 
 	print_line("\n**uniforms:\n" + gen_code.uniforms);
-	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
-	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
+	print_line("\n**vertex_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX] + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
+	print_line("\n**fragment_globals:\n" + gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT] + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
-	canvas_singleton->shader.canvas_shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	canvas_singleton->shader.canvas_shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_structs[ShaderCompiler::STAGE_FRAGMENT], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -65,8 +65,11 @@ private:
 
 	struct Version {
 		CharString uniforms;
+		CharString vertex_structs;
 		CharString vertex_globals;
+		CharString compute_structs;
 		CharString compute_globals;
+		CharString fragment_structs;
 		CharString fragment_globals;
 		HashMap<StringName, CharString> code_sections;
 		Vector<CharString> custom_defines;
@@ -103,8 +106,11 @@ private:
 			enum Type {
 				TYPE_VERSION_DEFINES,
 				TYPE_MATERIAL_UNIFORMS,
+				TYPE_VERTEX_STRUCTS,
 				TYPE_VERTEX_GLOBALS,
+				TYPE_FRAGMENT_STRUCTS,
 				TYPE_FRAGMENT_GLOBALS,
+				TYPE_COMPUTE_STRUCTS,
 				TYPE_COMPUTE_GLOBALS,
 				TYPE_CODE,
 				TYPE_TEXT
@@ -159,8 +165,8 @@ protected:
 public:
 	RID version_create();
 
-	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines);
-	void version_set_compute_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_compute_globals, const Vector<String> &p_custom_defines);
+	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_structs, const String &p_vertex_globals, const String &p_fragment_structs, const String &p_fragment_globals, const Vector<String> &p_custom_defines);
+	void version_set_compute_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_compute_structs, const String &p_compute_globals, const Vector<String> &p_custom_defines);
 
 	_FORCE_INLINE_ RID version_get_shader(RID p_version, int p_variant) {
 		ERR_FAIL_INDEX_V(p_variant, variant_defines.size(), RID());

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -40,6 +40,8 @@ layout(location = 3) out vec2 pixel_size_interp;
 
 #endif
 
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
@@ -254,6 +256,8 @@ layout(location = 3) in vec2 pixel_size_interp;
 #endif
 
 layout(location = 0) out vec4 frag_color;
+
+#STRUCTS
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -105,6 +105,8 @@ layout(set = 0, binding = 3, std140) uniform DirectionalLights {
 }
 directional_lights;
 
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms {

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -76,6 +76,8 @@ layout(r32ui, set = 1, binding = 3) uniform volatile uimage3D density_only_map;
 layout(r32ui, set = 1, binding = 4) uniform volatile uimage3D light_only_map;
 #endif
 
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = 2, binding = 0, std140) uniform MaterialUniforms {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -115,6 +115,8 @@ layout(location = 7) out vec4 screen_position;
 layout(location = 8) out vec4 prev_screen_position;
 #endif
 
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
@@ -949,6 +951,8 @@ layout(location = 13) highp in vec4 specular_light_interp;
 //both required for transmittance to be enabled
 #define LIGHT_TRANSMITTANCE_USED
 #endif
+
+#STRUCTS
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -107,6 +107,9 @@ layout(location = 8) highp out vec4 specular_light_interp;
 
 #include "../scene_forward_vertex_lights_inc.glsl"
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
@@ -742,6 +745,8 @@ ivec2 multiview_uv(ivec2 uv) {
 //both required for transmittance to be enabled
 #define LIGHT_TRANSMITTANCE_USED
 #endif
+
+#STRUCTS
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -167,6 +167,8 @@ layout(set = 2, binding = 1) uniform texture2D height_field_texture;
 
 /* SET 3: MATERIAL */
 
+#STRUCTS
+
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = 3, binding = 0, std140) uniform MaterialUniforms {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -563,9 +563,64 @@ void MaterialStorage::ShaderData::set_default_texture_parameter(const StringName
 	}
 }
 
+static Variant parse_member(const ShaderLanguage::ShaderNode::Uniform::Member &p_member, const ShaderLanguage::Scalar *p_data, uint32_t &r_offset) {
+	if (p_member.type == ShaderLanguage::TYPE_STRUCT) {
+		if (p_member.array_size > 0) {
+			Array array;
+
+			for (int i = 0; i < p_member.array_size; i++) {
+				Dictionary dict;
+
+				for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+					dict[member.name] = parse_member(member, p_data, r_offset);
+				}
+				array.push_back(dict);
+			}
+			return array;
+		}
+		Dictionary dict;
+		for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+			dict[member.name] = parse_member(member, p_data, r_offset);
+		}
+		return dict;
+	}
+	if (p_data != nullptr) {
+		Vector<ShaderLanguage::Scalar> default_value;
+		for (uint32_t i = 0U; i < p_member.comp_count; i++) {
+			default_value.push_back(p_data[r_offset + i]);
+		}
+		r_offset += p_member.comp_count;
+		return ShaderLanguage::constant_value_to_variant(default_value, p_member.type, p_member.array_size, ShaderLanguage::ShaderNode::Uniform::HINT_NONE);
+	}
+	return ShaderLanguage::get_default_datatype_value(p_member.type, p_member.array_size, ShaderLanguage::ShaderNode::Uniform::HINT_NONE);
+}
+
 Variant MaterialStorage::ShaderData::get_default_parameter(const StringName &p_parameter) const {
 	if (uniforms.has(p_parameter)) {
 		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
+
+		if (uniform.type == ShaderLanguage::TYPE_STRUCT) {
+			uint32_t offset = 0U;
+
+			if (uniform.array_size > 0) {
+				Array array;
+
+				for (int i = 0; i < uniform.array_size; i++) {
+					Dictionary dict;
+					for (const ShaderLanguage::ShaderNode::Uniform::Member &member : uniform.members) {
+						dict[member.name] = parse_member(member, uniform.default_value.ptr(), offset);
+					}
+					array.push_back(dict);
+				}
+				return array;
+			}
+			Dictionary dict;
+			for (const ShaderLanguage::ShaderNode::Uniform::Member &member : uniform.members) {
+				dict[member.name] = parse_member(member, uniform.default_value.ptr(), offset);
+			}
+			return dict;
+		}
+
 		Vector<ShaderLanguage::Scalar> default_value = uniform.default_value;
 		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
@@ -723,6 +778,109 @@ bool MaterialStorage::ShaderData::blend_mode_uses_blend_alpha(BlendMode p_mode) 
 ///////////////////////////////////////////////////////////////////////////
 // MaterialStorage::MaterialData
 
+// Finds a size recursively.
+static uint32_t _fill_struct_member_sizes(const ShaderLanguage::ShaderNode::Uniform::Member &p_member, LocalVector<uint32_t> &p_sizes) {
+	const bool is_array = p_member.array_size > 0;
+	const int array_size = MAX(1, p_member.array_size);
+
+	if (p_member.type == ShaderLanguage::TYPE_STRUCT) {
+		uint32_t size = 0U;
+
+		for (int i = 0; i < array_size; i++) {
+			uint32_t struct_size = 0U;
+
+			for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+				struct_size += _fill_struct_member_sizes(member, p_sizes);
+			}
+
+			size += struct_size;
+
+			// Adds an extra offset required for structs.
+			{
+				// `((struct_size + 15) & -16)` calculates a nearest (to a struct size) 16-byte aligned value.
+				uint32_t extra_offset = ((struct_size + 15) & -16) - struct_size;
+
+				p_sizes.ptr()[p_sizes.size() - 1] += extra_offset;
+
+				size += extra_offset;
+			}
+		}
+		return size;
+	}
+
+	uint32_t size = ShaderLanguage::get_datatype_size(p_member.type) * MAX(1, p_member.array_size);
+
+	if (is_array) {
+		// The following code enforces a 16-byte alignment of struct's array members.
+		const int m = 16 * array_size;
+		if ((size % m) != 0) {
+			size += m - (size % m);
+		}
+	}
+
+	p_sizes.push_back(size);
+	return size;
+}
+
+// Fill struct members recursively.
+static uint32_t _fill_struct_member_buffer(const ShaderLanguage::ShaderNode::Uniform::Member &p_member, uint8_t *p_data, const Dictionary &p_dict, const LocalVector<uint32_t> &p_sizes, uint32_t p_index, uint32_t &r_sub_offset, bool p_use_linear_color) {
+	uint32_t index = p_index;
+
+	if (p_member.type == ShaderLanguage::TYPE_STRUCT) {
+		const int array_size = MAX(1, p_member.array_size);
+
+		if (p_member.array_size > 0) {
+			const Array &array = p_dict[p_member.name].get_type() == Variant::ARRAY ? (Array)p_dict[p_member.name] : Array();
+
+			for (int i = 0; i < array_size; i++) {
+				for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+					const Dictionary &dict = (i < array.size() && array[i].get_type() == Variant::DICTIONARY) ? (Dictionary)array[i] : Dictionary();
+
+					index = _fill_struct_member_buffer(member, p_data, dict, p_sizes, index, r_sub_offset, p_use_linear_color);
+				}
+			}
+		} else {
+			for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+				const Dictionary &dict = p_dict[p_member.name].get_type() == Variant::DICTIONARY ? (Dictionary)p_dict[p_member.name] : Dictionary();
+
+				index = _fill_struct_member_buffer(member, p_data, dict, p_sizes, index, r_sub_offset, p_use_linear_color);
+			}
+		}
+	} else {
+		if (p_dict.has(p_member.name)) {
+			// User provided.
+			_fill_std140_variant_ubo_value(p_member.type, p_member.array_size, p_dict[p_member.name], &p_data[r_sub_offset], p_use_linear_color);
+		} else {
+			// Zero because it was not provided.
+			_fill_std140_ubo_empty(p_member.type, p_member.array_size, &p_data[r_sub_offset]);
+		}
+		r_sub_offset += p_sizes[index++];
+	}
+
+	return index;
+}
+
+// Fill struct members to zero recursively.
+static uint32_t _clear_struct_member_buffer(const ShaderLanguage::ShaderNode::Uniform::Member &p_member, uint8_t *p_data, const LocalVector<uint32_t> &p_sizes, uint32_t p_index, uint32_t &r_sub_offset) {
+	uint32_t index = p_index;
+
+	if (p_member.type == ShaderLanguage::TYPE_STRUCT) {
+		const int array_size = MAX(1, p_member.array_size);
+
+		for (int i = 0; i < array_size; i++) {
+			for (const ShaderLanguage::ShaderNode::Uniform::Member &member : p_member.members) {
+				index = _clear_struct_member_buffer(member, p_data, p_sizes, index, r_sub_offset);
+			}
+		}
+	} else {
+		_fill_std140_ubo_empty(p_member.type, p_member.array_size, &p_data[r_sub_offset]);
+
+		r_sub_offset += p_sizes[index++];
+	}
+
+	return index;
+}
+
 void MaterialStorage::MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const HashMap<StringName, Variant> &p_parameters, uint8_t *p_buffer, uint32_t p_buffer_size, bool p_use_linear_color) {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	bool uses_global_buffer = false;
@@ -759,12 +917,42 @@ void MaterialStorage::MaterialData::update_uniform_buffer(const HashMap<StringNa
 			continue;
 		}
 
+		LocalVector<uint32_t> struct_member_size_cache;
+#ifdef DEBUG_ENABLED
+		uint32_t struct_size = 0U;
+#endif
+		// Calculate struct size and member sizes to be used lately.
+		if (E.value.type == ShaderLanguage::TYPE_STRUCT) {
+			const int array_size = MAX(1, E.value.array_size);
+			uint32_t extra_offset = 0U;
+
+			for (int i = 0; i < array_size; i++) {
+				uint32_t struct_size2 = 0U;
+
+				for (const ShaderLanguage::ShaderNode::Uniform::Member &member : E.value.members) {
+					struct_size2 += _fill_struct_member_sizes(member, struct_member_size_cache);
+				}
+				// Finds an extra offset.
+				if (i == 0) {
+					// `((struct_size + 15) & -16)` calculates a nearest (to a struct size) 16-byte aligned value.
+					extra_offset = ((struct_size2 + 15) & -16) - struct_size2;
+				}
+				struct_member_size_cache.ptr()[struct_member_size_cache.size() - 1] += extra_offset;
+#ifdef DEBUG_ENABLED
+				struct_size += struct_size2;
+				struct_size += extra_offset;
+#endif
+			}
+		}
+
 		//regular uniform
 		uint32_t offset = p_uniform_offsets[E.value.order];
 #ifdef DEBUG_ENABLED
 		uint32_t size = 0U;
-		// The following code enforces a 16-byte alignment of uniform arrays.
-		if (E.value.array_size > 0) {
+		if (E.value.type == ShaderLanguage::TYPE_STRUCT) {
+			size += struct_size;
+		} else if (E.value.array_size > 0) {
+			// The following code enforces a 16-byte alignment of uniform arrays.
 			size = ShaderLanguage::get_datatype_size(E.value.type) * E.value.array_size;
 			int m = (16 * E.value.array_size);
 			if ((size % m) != 0U) {
@@ -779,22 +967,48 @@ void MaterialStorage::MaterialData::update_uniform_buffer(const HashMap<StringNa
 		HashMap<StringName, Variant>::ConstIterator V = p_parameters.find(E.key);
 
 		if (V) {
-			//user provided
-			_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, V->value, data, p_use_linear_color);
+			if (E.value.type == ShaderLanguage::TYPE_STRUCT) {
+				uint32_t sub_offset = 0U;
+				uint32_t index = 0U;
 
-		} else if (E.value.default_value.size()) {
-			//default value
-			_fill_std140_ubo_value(E.value.type, E.value.default_value, data);
-			//value=E.value.default_value;
-		} else {
-			//zero because it was not provided
-			if ((E.value.type == ShaderLanguage::TYPE_VEC3 || E.value.type == ShaderLanguage::TYPE_VEC4) && E.value.hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
-				//colors must be set as black, with alpha as 1.0
-				_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, Color(0, 0, 0, 1), data, p_use_linear_color);
+				if (E.value.array_size > 0) {
+					const Array &array = (Array)V->value;
+
+					for (int i = 0; i < E.value.array_size; i++) {
+						const Dictionary &dict = i < array.size() ? (Dictionary)array[i] : Dictionary();
+
+						for (const ShaderLanguage::ShaderNode::Uniform::Member &member : E.value.members) {
+							index = _fill_struct_member_buffer(member, data, dict, struct_member_size_cache, index, sub_offset, p_use_linear_color);
+						}
+					}
+				} else {
+					for (const ShaderLanguage::ShaderNode::Uniform::Member &member : E.value.members) {
+						index = _fill_struct_member_buffer(member, data, V->value, struct_member_size_cache, index, sub_offset, p_use_linear_color);
+					}
+				}
 			} else {
-				//else just zero it out
-				_fill_std140_ubo_empty(E.value.type, E.value.array_size, data);
+				// User provided.
+				_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, V->value, data, p_use_linear_color);
 			}
+		} else if (E.value.default_value.size()) {
+			// Default value.
+			_fill_std140_ubo_value(E.value.type, E.value.default_value, data);
+		} else if (E.value.type == ShaderLanguage::TYPE_STRUCT) {
+			uint32_t sub_offset = 0U;
+			uint32_t index = 0U;
+			const int array_size = MAX(1, E.value.array_size);
+
+			for (int i = 0; i < array_size; i++) {
+				for (const ShaderLanguage::ShaderNode::Uniform::Member &member : E.value.members) {
+					index = _clear_struct_member_buffer(member, data, struct_member_size_cache, index, sub_offset);
+				}
+			}
+		} else if ((E.value.type == ShaderLanguage::TYPE_VEC3 || E.value.type == ShaderLanguage::TYPE_VEC4) && E.value.hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+			// Colors must be set as black, with alpha as 1.0.
+			_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, Color(0, 0, 0, 1), data, p_use_linear_color);
+		} else {
+			// Otherwise, just zero it out.
+			_fill_std140_ubo_empty(E.value.type, E.value.array_size, data);
 		}
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1695,7 +1695,7 @@ void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code) {
 		}
 	}
 
-	particles_storage->particles_shader.shader.version_set_compute_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_COMPUTE], gen_code.defines);
+	particles_storage->particles_shader.shader.version_set_compute_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_structs[ShaderCompiler::STAGE_COMPUTE], gen_code.stage_globals[ShaderCompiler::STAGE_COMPUTE], gen_code.defines);
 	ERR_FAIL_COND(!particles_storage->particles_shader.shader.version_is_valid(version));
 
 	ubo_size = gen_code.uniform_total_size;

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -73,6 +73,7 @@ public:
 		Vector<uint32_t> uniform_offsets;
 		uint32_t uniform_total_size = 0;
 		String uniforms;
+		String stage_structs[STAGE_MAX];
 		String stage_globals[STAGE_MAX];
 
 		HashMap<String, String> code;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1487,8 +1487,14 @@ bool ShaderLanguage::_find_identifier(const BlockNode *p_block, bool p_allow_rea
 	}
 
 	if (shader->uniforms.has(p_identifier)) {
+		if (r_is_const) {
+			*r_is_const = true;
+		}
 		if (r_data_type) {
 			*r_data_type = shader->uniforms[p_identifier].type;
+		}
+		if (r_struct_name) {
+			*r_struct_name = shader->uniforms[p_identifier].struct_name;
 		}
 		if (r_array_size) {
 			*r_array_size = shader->uniforms[p_identifier].array_size;
@@ -4502,10 +4508,303 @@ Variant ShaderLanguage::constant_value_to_variant(const Vector<Scalar> &p_value,
 				break;
 			case ShaderLanguage::TYPE_MAX:
 				break;
+			default: {
+			} break;
 		}
 		return value;
 	}
 	return Variant();
+}
+
+Variant ShaderLanguage::get_default_datatype_value(DataType p_type, int p_array_size, ShaderLanguage::ShaderNode::Uniform::Hint p_hint) {
+	int array_size = p_array_size;
+
+	Variant value;
+	switch (p_type) {
+		case ShaderLanguage::TYPE_BOOL:
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(false);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<bool>::init(&value);
+				VariantDefaultInitializer<bool>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_BVEC2:
+			array_size *= 2;
+
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(false);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<int64_t>::init(&value);
+				VariantDefaultInitializer<int64_t>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_BVEC3:
+			array_size *= 3;
+
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(false);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<int64_t>::init(&value);
+				VariantDefaultInitializer<int64_t>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_BVEC4:
+			array_size *= 4;
+
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(false);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<int64_t>::init(&value);
+				VariantDefaultInitializer<int64_t>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_INT:
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<int64_t>::init(&value);
+				VariantDefaultInitializer<int64_t>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_IVEC2:
+			if (array_size > 0) {
+				array_size *= 2;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector2i>::init(&value);
+				VariantDefaultInitializer<Vector2i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_IVEC3:
+			if (array_size > 0) {
+				array_size *= 3;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector3i>::init(&value);
+				VariantDefaultInitializer<Vector3i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_IVEC4:
+			if (array_size > 0) {
+				array_size *= 4;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector4i>::init(&value);
+				VariantDefaultInitializer<Vector4i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_UINT:
+			if (array_size > 0) {
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0U);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<int64_t>::init(&value);
+				VariantDefaultInitializer<int64_t>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_UVEC2:
+			if (array_size > 0) {
+				array_size *= 2;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0U);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector2i>::init(&value);
+				VariantDefaultInitializer<Vector2i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_UVEC3:
+			if (array_size > 0) {
+				array_size *= 3;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0U);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector3i>::init(&value);
+				VariantDefaultInitializer<Vector3i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_UVEC4:
+			if (array_size > 0) {
+				array_size *= 4;
+
+				PackedInt32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0U);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector4i>::init(&value);
+				VariantDefaultInitializer<Vector4i>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_FLOAT:
+			if (array_size > 0) {
+				PackedFloat32Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(0.0f);
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<float>::init(&value);
+				VariantDefaultInitializer<float>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_VEC2:
+			if (array_size > 0) {
+				PackedVector2Array array;
+				for (int i = 0; i < array_size; i++) {
+					array.push_back(Vector2(0.0f, 0.0f));
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Vector2>::init(&value);
+				VariantDefaultInitializer<Vector2>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_VEC3:
+			if (array_size > 0) {
+				if (p_hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+					PackedColorArray array;
+					for (int i = 0; i < array_size; i++) {
+						array.push_back(Color(0.0f, 0.0f, 0.0f));
+					}
+					value = Variant(array);
+				} else {
+					PackedVector3Array array;
+					for (int i = 0; i < array_size; i++) {
+						array.push_back(Vector3(0.0f, 0.0f, 0.0f));
+					}
+					value = Variant(array);
+				}
+			} else {
+				if (p_hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+					VariantInitializer<Color>::init(&value);
+					VariantDefaultInitializer<Color>::init(&value);
+				} else {
+					VariantInitializer<Vector3>::init(&value);
+					VariantDefaultInitializer<Vector3>::init(&value);
+				}
+			}
+			break;
+		case ShaderLanguage::TYPE_VEC4:
+			if (array_size > 0) {
+				if (p_hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+					PackedColorArray array;
+					for (int i = 0; i < array_size; i++) {
+						array.push_back(Color(0.0f, 0.0f, 0.0f, 0.0f));
+					}
+					value = Variant(array);
+				} else {
+					PackedVector4Array array;
+					for (int i = 0; i < array_size; i++) {
+						array.push_back(Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+					}
+					value = Variant(array);
+				}
+			} else {
+				if (p_hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+					VariantInitializer<Color>::init(&value);
+					VariantDefaultInitializer<Color>::init(&value);
+				} else {
+					VariantInitializer<Vector4>::init(&value);
+					VariantDefaultInitializer<Vector4>::init(&value);
+				}
+			}
+			break;
+		case ShaderLanguage::TYPE_MAT2:
+			if (array_size > 0) {
+				PackedFloat32Array array;
+				for (int i = 0; i < array_size; i++) {
+					for (int j = 0; j < 4; j++) {
+						array.push_back(0.0f);
+					}
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Transform2D>::init(&value);
+				VariantDefaultInitializer<Transform2D>::init(&value);
+			}
+			break;
+		case ShaderLanguage::TYPE_MAT3: {
+			if (array_size > 0) {
+				PackedFloat32Array array;
+				for (int i = 0; i < array_size; i++) {
+					for (int j = 0; j < 9; j++) {
+						array.push_back(0.0f);
+					}
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Basis>::init(&value);
+				VariantDefaultInitializer<Basis>::init(&value);
+			}
+			break;
+		}
+		case ShaderLanguage::TYPE_MAT4: {
+			if (array_size > 0) {
+				PackedFloat32Array array;
+				for (int i = 0; i < array_size; i++) {
+					for (int j = 0; j < 16; j++) {
+						array.push_back(0.0f);
+					}
+				}
+				value = Variant(array);
+			} else {
+				VariantInitializer<Projection>::init(&value);
+				VariantDefaultInitializer<Projection>::init(&value);
+			}
+			break;
+		}
+		default: {
+		} break;
+	}
+	return value;
 }
 
 PropertyInfo ShaderLanguage::uniform_to_property_info(const ShaderNode::Uniform &p_uniform) {
@@ -4729,7 +5028,13 @@ PropertyInfo ShaderLanguage::uniform_to_property_info(const ShaderNode::Uniform 
 			}
 		} break;
 		case ShaderLanguage::TYPE_STRUCT: {
-			// FIXME: Implement this.
+			if (p_uniform.array_size > 0) {
+				pi.type = Variant::ARRAY;
+				pi.hint = PROPERTY_HINT_ARRAY_TYPE;
+				pi.hint_string = "Dictionary";
+			} else {
+				pi.type = Variant::DICTIONARY;
+			}
 		} break;
 		case ShaderLanguage::TYPE_MAX:
 			break;
@@ -8772,6 +9077,61 @@ Error ShaderLanguage::_validate_precision(DataType p_type, DataPrecision p_preci
 	return OK;
 }
 
+Error ShaderLanguage::_validate_uniform_struct(StructNode *p_struct) {
+	for (const MemberNode *mn : p_struct->members) {
+		if (mn->datatype == TYPE_STRUCT) {
+			if (_validate_uniform_struct(shader->structs[mn->struct_name].shader_struct) != OK) {
+				return FAILED;
+			}
+		}
+	}
+
+	if (!p_struct->validated) {
+		p_struct->members.sort_custom<StructNode::MemberNodeSizeComparator>();
+		p_struct->validated = true;
+	}
+
+	return OK;
+}
+
+void ShaderLanguage::_parse_uniform_member(ShaderNode::Uniform::Member &p_member, const StringName &p_struct_name) {
+	for (const MemberNode *mn : shader->structs[p_struct_name].shader_struct->members) {
+		ShaderNode::Uniform::Member member = ShaderNode::Uniform::Member(mn->name, mn->datatype, mn->struct_name, mn->array_size);
+
+		if (mn->datatype == TYPE_STRUCT) {
+			_parse_uniform_member(member, mn->struct_name);
+		} else {
+			member.comp_count += (get_datatype_size(mn->datatype) / 4) * MAX(1, mn->array_size);
+		}
+
+		p_member.comp_count += member.comp_count;
+		p_member.members.push_back(member);
+	}
+}
+
+Error ShaderLanguage::_parse_uniform_struct_initializer(Node *p_current, const ShaderNode::Uniform::Member &p_member, Scalar *p_data, uint32_t &r_offset) {
+	if (p_current->type == Node::NODE_TYPE_OPERATOR) { // sub-struct initializer
+		OperatorNode *op = static_cast<OperatorNode *>(p_current);
+
+		for (int i = 1; i < op->arguments.size(); i++) {
+			if (_parse_uniform_struct_initializer(op->arguments[i], p_member.members.get(i - 1), p_data, r_offset) != OK) {
+				return ERR_PARSE_ERROR;
+			}
+		}
+	} else if (p_current->type == Node::NODE_TYPE_CONSTANT) { // a constant initializer
+		ConstantNode *cn = static_cast<ConstantNode *>(p_current);
+
+		if (!convert_constant(cn, p_member.type, &p_data[r_offset])) {
+			_set_error(vformat(RTR("Can't convert constant to '%s'."), get_datatype_name(p_member.type)));
+			return ERR_PARSE_ERROR;
+		}
+
+		r_offset += (get_datatype_size(p_member.type) / sizeof(Scalar)) * MAX(1, p_member.array_size);
+	}
+
+	return OK;
+}
+
 Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_functions, const Vector<ModeInfo> &p_render_modes, const HashSet<String> &p_shader_types) {
 	Token tk;
 	TkPos prev_pos;
@@ -8966,6 +9326,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 				StructNode *st_node = alloc_node<StructNode>();
 				st.shader_struct = st_node;
+				st_node->pos = _get_tkpos();
 
 				int member_count = 0;
 				HashSet<String> member_names;
@@ -9076,6 +9437,13 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 								tk = _get_token();
 							}
 
+							if (type == TYPE_STRUCT) {
+								member->size = shader->structs[struct_name].shader_struct->size * MAX(1, member->array_size);
+							} else {
+								member->size = get_datatype_size(type) * MAX(1, member->array_size);
+							}
+							st_node->size += member->size;
+
 							if (!fixed_array_size) {
 								array_size = 0;
 							}
@@ -9090,6 +9458,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						} while (tk.type == TK_COMMA); // another member
 					}
 				}
+
 				if (member_count == 0) {
 					_set_error(RTR("Empty structs are not allowed."));
 					return ERR_PARSE_ERROR;
@@ -9253,22 +9622,39 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 #endif // DEBUG_ENABLED
 				}
 
+				StructNode *shader_struct = nullptr;
+				StringName struct_name;
+
 				if (shader->structs.has(tk.text)) {
 					if (is_uniform) {
-						_set_error(vformat(RTR("The '%s' data type is not supported for uniforms."), "struct"));
-						return ERR_PARSE_ERROR;
+						if (uniform_scope == ShaderNode::Uniform::SCOPE_GLOBAL) {
+							_set_error(vformat(RTR("The '%s' qualifier is not supported for uniform structs."), "SCOPE_GLOBAL"));
+							return ERR_PARSE_ERROR;
+						}
+						if (uniform_scope == ShaderNode::Uniform::SCOPE_INSTANCE) {
+							_set_error(vformat(RTR("The '%s' qualifier is not supported for uniform structs."), "SCOPE_INSTANCE"));
+							return ERR_PARSE_ERROR;
+						}
+
+						shader_struct = shader->structs[tk.text].shader_struct;
+						if (_validate_uniform_struct(shader_struct) != OK) {
+							return ERR_PARSE_ERROR;
+						}
+
+						struct_name = tk.text;
+						type = TYPE_STRUCT;
 					} else {
 						_set_error(vformat(RTR("The '%s' data type is not allowed here."), "struct"));
 						return ERR_PARSE_ERROR;
 					}
-				}
+				} else {
+					if (!is_token_datatype(tk.type)) {
+						_set_error(RTR("Expected data type."));
+						return ERR_PARSE_ERROR;
+					}
 
-				if (!is_token_datatype(tk.type)) {
-					_set_error(RTR("Expected data type."));
-					return ERR_PARSE_ERROR;
+					type = get_token_datatype(tk.type);
 				}
-
-				type = get_token_datatype(tk.type);
 
 				if (precision != PRECISION_DEFAULT && _validate_precision(type, precision) != OK) {
 					return ERR_PARSE_ERROR;
@@ -9347,6 +9733,23 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					uniform.array_size = array_size;
 					uniform.group = current_uniform_group_name;
 					uniform.subgroup = current_uniform_subgroup_name;
+
+					if (shader_struct != nullptr) {
+						uniform.struct_name = struct_name;
+
+						for (const MemberNode *mn : shader_struct->members) {
+							ShaderNode::Uniform::Member member = ShaderNode::Uniform::Member(mn->name, mn->datatype, mn->struct_name, mn->array_size);
+
+							if (mn->datatype == TYPE_STRUCT) {
+								_parse_uniform_member(member, mn->struct_name);
+							} else {
+								member.comp_count += (get_datatype_size(mn->datatype) / 4) * MAX(1, mn->array_size);
+							}
+
+							uniform.comp_count += member.comp_count;
+							uniform.members.push_back(member);
+						}
+					}
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
@@ -9772,6 +10175,12 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					//reset scope for next uniform
 
 					if (tk.type == TK_OP_ASSIGN) {
+						// TODO: Remove when it's ready and all bugs fixed.
+						if (uniform.type == TYPE_STRUCT) {
+							_set_error(RTR("Setting default values to uniform struct is not supported."));
+							return ERR_PARSE_ERROR;
+						}
+
 						if (uniform.array_size > 0) {
 							_set_error(RTR("Setting default values to uniform arrays is not supported."));
 							return ERR_PARSE_ERROR;
@@ -9781,18 +10190,38 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						if (!expr) {
 							return ERR_PARSE_ERROR;
 						}
-						if (expr->type != Node::NODE_TYPE_CONSTANT) {
-							_set_error(RTR("Expected constant expression after '='."));
-							return ERR_PARSE_ERROR;
-						}
 
-						ConstantNode *cn = static_cast<ConstantNode *>(expr);
+						if (uniform.type == TYPE_STRUCT) {
+							if (expr->type == Node::NODE_TYPE_OPERATOR && expr->get_datatype_name() == uniform.struct_name) {
+								uniform.default_value.resize(uniform.comp_count);
 
-						uniform.default_value.resize(cn->values.size());
+								uint32_t offset = 0U;
+								OperatorNode *op = static_cast<OperatorNode *>(expr);
 
-						if (!convert_constant(cn, uniform.type, uniform.default_value.ptrw())) {
-							_set_error(vformat(RTR("Can't convert constant to '%s'."), get_datatype_name(uniform.type)));
-							return ERR_PARSE_ERROR;
+								for (int i = 1; i < op->arguments.size(); i++) {
+									if (_parse_uniform_struct_initializer(op->arguments[i], uniform.members.get(i - 1), uniform.default_value.ptrw(), offset) != OK) {
+										return ERR_PARSE_ERROR;
+									}
+								}
+							} else {
+								_set_error(vformat(RTR("Expected '%s' initializer after '='."), uniform.struct_name));
+								return ERR_PARSE_ERROR;
+							}
+						} else {
+							if (uniform.type == TYPE_STRUCT && expr->type == Node::NODE_TYPE_OPERATOR) {
+							} else if (expr->type != Node::NODE_TYPE_CONSTANT) {
+								_set_error(RTR("Expected constant expression after '='."));
+								return ERR_PARSE_ERROR;
+							}
+
+							ConstantNode *cn = static_cast<ConstantNode *>(expr);
+
+							uniform.default_value.resize(cn->values.size());
+
+							if (!convert_constant(cn, uniform.type, uniform.default_value.ptrw())) {
+								_set_error(vformat(RTR("Can't convert constant to '%s'."), get_datatype_name(uniform.type)));
+								return ERR_PARSE_ERROR;
+							}
 						}
 						tk = _get_token();
 					}

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -577,6 +577,7 @@ public:
 		Node *assign_expression = nullptr;
 		Node *call_expression = nullptr;
 		bool has_swizzling_duplicates = false;
+		uint32_t size = 0U;
 
 		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype; }
 		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
@@ -589,8 +590,17 @@ public:
 
 	struct StructNode : public Node {
 		List<MemberNode *> members;
+		uint32_t size = 0U;
+		TkPos pos;
+		bool validated = false;
 		StructNode() :
 				Node(NODE_TYPE_STRUCT) {}
+
+		struct MemberNodeSizeComparator {
+			bool operator()(const MemberNode *p_left, const MemberNode *p_right) const {
+				return p_left->size > p_right->size || p_left->array_size < p_right->array_size;
+			}
+		};
 	};
 
 	struct ShaderNode : public Node {
@@ -669,6 +679,7 @@ public:
 			int texture_order = 0;
 			int texture_binding = 0;
 			DataType type = TYPE_VOID;
+			String struct_name;
 			DataPrecision precision = PRECISION_DEFAULT;
 			int array_size = 0;
 			Vector<Scalar> default_value;
@@ -682,11 +693,29 @@ public:
 			int instance_index = 0;
 			String group;
 			String subgroup;
+			uint32_t comp_count = 0U;
 
 			_FORCE_INLINE_ bool is_texture() const {
 				// Order is assigned to -1 for texture uniforms.
 				return order < 0;
 			}
+
+			struct Member {
+				StringName name;
+				DataType type = TYPE_VOID;
+				String struct_name;
+				int array_size = 0;
+				List<Member> members;
+				uint32_t comp_count = 0U;
+
+				Member() {}
+
+				Member(const StringName &p_name, DataType p_type, const String &p_struct_name, int p_array_size) :
+						name(p_name), type(p_type), struct_name(p_struct_name), array_size(p_array_size) {
+				}
+			};
+
+			List<Member> members;
 
 			Uniform() {
 				hint_range[0] = 0.0f;
@@ -828,6 +857,7 @@ public:
 	static PropertyInfo uniform_to_property_info(const ShaderNode::Uniform &p_uniform);
 	static uint32_t get_datatype_size(DataType p_type);
 	static uint32_t get_datatype_component_count(DataType p_type);
+	static Variant get_default_datatype_value(DataType p_type, int p_array_size, ShaderLanguage::ShaderNode::Uniform::Hint p_hint);
 
 	static void get_keyword_list(List<String> *r_keywords);
 	static bool is_control_flow_keyword(String p_keyword);
@@ -1184,6 +1214,10 @@ private:
 	Error _parse_block(BlockNode *p_block, const FunctionInfo &p_function_info, bool p_just_one = false, bool p_can_break = false, bool p_can_continue = false);
 	String _get_shader_type_list(const HashSet<String> &p_shader_types) const;
 	String _get_qualifier_str(ArgumentQualifier p_qualifier) const;
+
+	Error _validate_uniform_struct(StructNode *p_struct);
+	void _parse_uniform_member(ShaderNode::Uniform::Member &p_member, const StringName &p_struct_name);
+	Error _parse_uniform_struct_initializer(Node *p_current, const ShaderNode::Uniform::Member &p_member, Scalar *p_default_value, uint32_t &r_offset);
 
 	Error _parse_shader(const HashMap<StringName, FunctionInfo> &p_functions, const Vector<ModeInfo> &p_render_modes, const HashSet<String> &p_shader_types);
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/3569

![struct_test](https://github.com/godotengine/godot/assets/3036176/748eb82a-4e3d-4b1f-933b-289f21ff45fb)

Notes:

- This version uses a `Dictionary` type for the uniform type. I did not find the other type which fits better for this. ~Still, the interface sucks and do not auto-reflect the changes made in a shader struct, but at least It's something (user need to manually adds members to it and change their types)~ -> (UPDATE: Dictionary in the inspector now reflects the changes from the shader).

- Structs needs to be declared before `MaterialUniform` in order to they can be used for uniforms, that's why I pushed them under `#STRUCT` statements inside each shader file.

- There are few limitations with this implementation, currently:
	- You cannot assign a default value, e.g:
	```
	struct Foo {
		vec3 v;
	};
	uniform Foo foo = Foo(vec3(0, 1, 0));
	```
	- `instance`/`global` scope initializers are not supported

- Arrays of common datatype in struct are supported (you can pass an array of conformal type):

![struct_alpha_array](https://github.com/godotengine/godot/assets/3036176/a427b9b2-5b45-41e8-8a06-e8d48e8ef7dc)

- Compatibility renderer is supported

- `set_shader_parameter` via script is supported (You need to pass a dictionary, remember).

- UPDATE: You can declare an array of struct, e.g:
	```
	struct Foo {
		vec4 v;
	};
	uniform Foo foos[2];
	```

- UPDATE 2: You can use a struct inside a struct, e.g.:
	```
	struct A {
		float t;
	};
	struct B {
		A a;
	};
	uniform B b;
	```

@QbieShay, @Calinou If you're interested to check and play with it, you're welcome.