### PR TITLE
Add optional count argument to `Semaphore::post`

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  core_bind.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+namespace core_bind {
+
+void Semaphore::_post_bind_compat_93605() {
+	post(1);
+}
+
+void Semaphore::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("post"), &Semaphore::_post_bind_compat_93605);
+}
+
+}; // namespace core_bind
+
+#endif

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "core_bind.h"
+#include "core_bind.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
@@ -1210,14 +1211,15 @@ bool Semaphore::try_wait() {
 	return semaphore.try_wait();
 }
 
-void Semaphore::post() {
-	semaphore.post();
+void Semaphore::post(int p_count) {
+	ERR_FAIL_COND(p_count <= 0);
+	semaphore.post(p_count);
 }
 
 void Semaphore::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("wait"), &Semaphore::wait);
 	ClassDB::bind_method(D_METHOD("try_wait"), &Semaphore::try_wait);
-	ClassDB::bind_method(D_METHOD("post"), &Semaphore::post);
+	ClassDB::bind_method(D_METHOD("post", "count"), &Semaphore::post, DEFVAL(1));
 }
 
 ////// Mutex //////

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -390,12 +390,17 @@ class Semaphore : public RefCounted {
 	GDCLASS(Semaphore, RefCounted);
 	::Semaphore semaphore;
 
+protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	void _post_bind_compat_93605();
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
 
 public:
 	void wait();
 	bool try_wait();
-	void post();
+	void post(int p_count = 1);
 };
 
 class Thread : public RefCounted {

--- a/doc/classes/Semaphore.xml
+++ b/doc/classes/Semaphore.xml
@@ -17,8 +17,9 @@
 	<methods>
 		<method name="post">
 			<return type="void" />
+			<param index="0" name="count" type="int" default="1" />
 			<description>
-				Lowers the [Semaphore], allowing one more thread in.
+				Lowers the [Semaphore], allowing one thread in, or more if [param count] is specified.
 			</description>
 		</method>
 		<method name="try_wait">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -41,3 +41,10 @@ Validate extension JSON: Error: Field 'classes/VisualShaderNodeTexture2DArray/pr
 
 Allow setting a cubemap as default parameter to shader.
 Compatibility methods registered.
+
+
+GH-93605
+--------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Semaphore/methods/post': arguments
+
+Optional arguments added. Compatibility methods registered.


### PR DESCRIPTION
Implements a new optional argument in Semaphore.post to allow resuming multiple threads at once.