### PR TITLE
Fix TileSet property painter popup showing clear color

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -651,7 +651,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	tile_data_editors_tree->add_theme_constant_override("v_separation", 1);
 	tile_data_editors_tree->add_theme_constant_override("h_separation", 3);
 
-	Color group_color = get_theme_color(SNAME("prop_category"), EditorStringName(Editor));
+	Color group_color = get_theme_color(SNAME("separator_color"), EditorStringName(Editor));
 
 	// List of editors.
 	// --- Rendering ---
@@ -2451,6 +2451,8 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 
 			resize_handle = get_editor_theme_icon(SNAME("EditorHandle"));
 			resize_handle_disabled = get_editor_theme_icon(SNAME("EditorHandleDisabled"));
+
+			tile_data_editors_tree->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), "PopupPanel"));
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {


### PR DESCRIPTION
Closes #93278

This problem is usually handled in popups with a separate background panel, but in this case since there's already a panel in the Tree I used that instead. It's now using the same color as every other popup menu in the editor for consistency

| Before | After |
|--------|--------|
| ![before](https://github.com/godotengine/godot/assets/60579014/68225c4d-234f-4cb1-a8b2-6d13479cb554) | ![after](https://github.com/godotengine/godot/assets/60579014/8745fd24-d39f-4c1b-9cda-d9580357924c) |

Wasn't too sure what color to choose for group backgrounds because no other popup menu has sections like that and `prop_category` is way to monochrome for the popup menu color. Would also feel weird to create and expose a new color just for this menu, so I went with `separator_color` for now