### PR TITLE
Optimize `get_path()` in EditorFileSystemDirectory

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -94,25 +94,35 @@ String EditorFileSystemDirectory::get_file(int p_idx) const {
 }
 
 String EditorFileSystemDirectory::get_path() const {
-	String p;
-	const EditorFileSystemDirectory *d = this;
-	while (d->parent) {
-		p = d->name.path_join(p);
-		d = d->parent;
+	int parents = 0;
+	const EditorFileSystemDirectory *efd = this;
+	// Determine the level of nesting.
+	while (efd->parent) {
+		parents++;
+		efd = efd->parent;
 	}
 
-	return "res://" + p;
+	if (parents == 0) {
+		return "res://";
+	}
+
+	// Using PackedStringArray, because the path is built in reverse order.
+	PackedStringArray path_bits;
+	// Allocate an array based on nesting. It will store path bits.
+	path_bits.resize(parents + 2); // Last String is empty, so paths end with /.
+	String *path_write = path_bits.ptrw();
+	path_write[0] = "res:/";
+
+	efd = this;
+	for (int i = parents; i > 0; i--) {
+		path_write[i] = efd->name;
+		efd = efd->parent;
+	}
+	return String("/").join(path_bits);
 }
 
 String EditorFileSystemDirectory::get_file_path(int p_idx) const {
-	String file = get_file(p_idx);
-	const EditorFileSystemDirectory *d = this;
-	while (d->parent) {
-		file = d->name.path_join(file);
-		d = d->parent;
-	}
-
-	return "res://" + file;
+	return get_path().path_join(get_file(p_idx));
 }
 
 Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {


### PR DESCRIPTION
EditorFileSystemDirectory's `get_path()` works by traversing its parent directories and concatenating strings. It's horribly inefficient, but seems to be called a lot during scans.

I optimized it using PackedStringArray (the path is built in reverse order, so couldn't really use StringBuilder) and the optimized version seems to be ~150% faster. This of course depends on nesting level, I tested with 6 levels of nesting.

Alternative is adding a cached path String to each EditorFileSystemDirectory, which would be even faster, but use more memory.