### PR TITLE
Add duplicate animation for SpriteFrames

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -39,6 +39,14 @@
 				Removes all animations. An empty [code]default[/code] animation will be created.
 			</description>
 		</method>
+		<method name="duplicate_animation">
+			<return type="void" />
+			<param index="0" name="anim_from" type="StringName" />
+			<param index="1" name="anim_to" type="StringName" />
+			<description>
+				Duplicates the animation [param anim_from] to a new animation named [param anim_to]. Fails if [param anim_to] already exists, or if [param anim_from] does not exist.
+			</description>
+		</method>
 		<method name="get_animation_loop" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="anim" type="StringName" />

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -121,6 +121,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	Vector<int> selection;
 
 	Button *add_anim = nullptr;
+	Button *duplicate_anim = nullptr;
 	Button *delete_anim = nullptr;
 	SpinBox *anim_speed = nullptr;
 	Button *anim_loop = nullptr;
@@ -210,6 +211,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_selected();
 	void _animation_name_edited();
 	void _animation_add();
+	void _animation_duplicate();
 	void _animation_remove();
 	void _animation_remove_confirmed();
 	void _animation_search_text_changed(const String &p_text);

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -106,6 +106,12 @@ bool SpriteFrames::has_animation(const StringName &p_anim) const {
 	return animations.has(p_anim);
 }
 
+void SpriteFrames::duplicate_animation(const StringName &p_from, const StringName &p_to) {
+	ERR_FAIL_COND_MSG(!animations.has(p_from), vformat("SpriteFrames doesn't have animation '%s'.", p_from));
+	ERR_FAIL_COND_MSG(animations.has(p_to), vformat("Animation '%s' already exists.", p_to));
+	animations[p_to] = animations[p_from];
+}
+
 void SpriteFrames::remove_animation(const StringName &p_anim) {
 	animations.erase(p_anim);
 }
@@ -246,6 +252,7 @@ void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx,
 void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "anim"), &SpriteFrames::add_animation);
 	ClassDB::bind_method(D_METHOD("has_animation", "anim"), &SpriteFrames::has_animation);
+	ClassDB::bind_method(D_METHOD("duplicate_animation", "anim_from", "anim_to"), &SpriteFrames::duplicate_animation);
 	ClassDB::bind_method(D_METHOD("remove_animation", "anim"), &SpriteFrames::remove_animation);
 	ClassDB::bind_method(D_METHOD("rename_animation", "anim", "newname"), &SpriteFrames::rename_animation);
 

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -60,6 +60,7 @@ protected:
 public:
 	void add_animation(const StringName &p_anim);
 	bool has_animation(const StringName &p_anim) const;
+	void duplicate_animation(const StringName &p_from, const StringName &p_to);
 	void remove_animation(const StringName &p_anim);
 	void rename_animation(const StringName &p_prev, const StringName &p_next);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This is a continue work of #80380.
Close godotengine/godot-proposals#3942.


https://github.com/godotengine/godot/assets/63407648/77c66294-8581-4d06-9b33-39c1105576e4

