### PR TITLE
Add `Mesh.create_convex_shapes()` to expose convex decomposition for scripts

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -120,6 +120,13 @@
 				If [param simplify] is [code]true[/code], the geometry can be further simplified to reduce the number of vertices. Disabled by default.
 			</description>
 		</method>
+		<method name="create_convex_shapes" qualifiers="const">
+			<return type="Array" />
+			<param index="0" name="settings" type="MeshConvexDecompositionSettings" default="null" />
+			<description>
+				Creates one or more [ConvexPolygonShape3D] collision shapes calculated from the mesh geometry via convex decomposition. The convex decomposition operation can be controlled with parameters from the optional [param settings].
+			</description>
+		</method>
 		<method name="create_outline" qualifiers="const">
 			<return type="Mesh" />
 			<param index="0" name="margin" type="float" />

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -199,6 +199,7 @@ public:
 #ifndef _3D_DISABLED
 	Vector<Ref<Shape3D>> convex_decompose(const Ref<MeshConvexDecompositionSettings> &p_settings) const;
 	Ref<ConvexPolygonShape3D> create_convex_shape(bool p_clean = true, bool p_simplify = false) const;
+	Array create_convex_shapes(const Ref<MeshConvexDecompositionSettings> &p_settings) const;
 	Ref<ConcavePolygonShape3D> create_trimesh_shape() const;
 #endif // _3D_DISABLED
 


### PR DESCRIPTION
Adds `Mesh.create_convex_shapes()` functions so scripts can make use of the convex decomposition with `MeshConvexDecompositionSettings` parameters.

Usage example:
```gdscript
var torus: TorusMesh = TorusMesh.new()
var settings: MeshConvexDecompositionSettings = MeshConvexDecompositionSettings.new()
settings.max_convex_hulls = 10
settings.max_concavity = 0.001
var convex_shapes: Array = torus.create_convex_shapes(settings)
print(convex_shapes)
```

In the past due to all the other engine functions using types that do not work with script bindings the only function exposed for scripting that could work with the `MeshConvexDecompositionSettings` parameters was the `MeshInstance3D.create_multiple_convex_collisions(settings)` function changed/added by https://github.com/godotengine/godot/pull/72152.

That MeshInstance3D function always had the down-side of being an extra node and also creating new StaticBody3D and CollisionShape3D nodes for compatibility instead of just the collision shapes. This caused a number of frequent complains from users that needed convex decomposition of meshes for procedural stuff but were only interested in the resulting shapes, not all the performance costing unneeded extras.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
