### PR TITLE
Hide unused category vboxes in inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3133,6 +3133,7 @@ void EditorInspector::update_tree() {
 		// Recreate the category vbox if it was reset.
 		if (category_vbox == nullptr) {
 			category_vbox = memnew(VBoxContainer);
+			category_vbox->hide();
 			main_vbox->add_child(category_vbox);
 		}
 
@@ -3205,6 +3206,7 @@ void EditorInspector::update_tree() {
 
 		// If we did not find a section to add the property to, add it to the category vbox instead (the category vbox handles margins correctly).
 		if (current_vbox == main_vbox) {
+			category_vbox->show();
 			current_vbox = category_vbox;
 		}
 


### PR DESCRIPTION
Only show category vboxes that have children (when a category has properties outside of any section) to prevent unnecessary margins mentioned in #93435

| Before | After |
|--------|--------|
| ![before](https://github.com/godotengine/godot/assets/60579014/4e306424-8eab-4aab-ab33-04d4cd6bd608) | ![after](https://github.com/godotengine/godot/assets/60579014/3d3eb7db-8ab0-440f-a2b2-c179a934c013) |

Note: this has no effect on the default theme because the default theme has a separation of `0`