### PR TITLE
Fix selecting AnimationTree node not jumping to the bottom panel

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2265,7 +2265,9 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 	}
 
 	// Send the edited object to the plugins.
-	for (EditorPlugin *plugin : available_plugins) {
+	for (int i = available_plugins.size() - 1; i > -1; i--) {
+		EditorPlugin *plugin = available_plugins[i];
+
 		if (active_plugins[owner_id].has(plugin)) {
 			// Plugin was already active, just change the object.
 			plugin->edit(p_object);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/93455
I've fixed this issue.
