### PR TITLE
GDScript: Add tests for calling with wrong arguments in Callable.callv() when passing a readonly (const) Array

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/callv_readonly_array.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/callv_readonly_array.gd
@@ -1,0 +1,26 @@
+var array_var: Array = ["one", "two", "three", "four"]
+const array_const: Array = ["one", "two", "three", "four"]
+
+var array_nested_var: Array = [["one"], ["two"], ["three"], ["four"]]
+const array_nested_const: Array = [["one"], ["two"], ["three"], ["four"]]
+
+
+func test():
+    Utils.check(array_const.is_read_only() == true)
+    Utils.check(array_nested_const.is_read_only() == true)
+
+    print("TEST Callable::callv")
+    print_four_variants.callv(array_var)
+    print_four_variants.callv(array_const)
+    print_four_variants.callv(array_nested_var)
+    print_four_variants.callv(array_nested_const)
+
+    print("TEST Object::callv")
+    self.callv("print_four_variants", array_var)
+    self.callv("print_four_variants", array_const)
+    self.callv("print_four_variants", array_nested_var)
+    self.callv("print_four_variants", array_nested_const)
+
+
+func print_four_variants(v1, v2, v3, v4):
+    print("%s %s %s %s" % [v1, v2, v3, v4])

--- a/modules/gdscript/tests/scripts/runtime/features/callv_readonly_array.out
+++ b/modules/gdscript/tests/scripts/runtime/features/callv_readonly_array.out
@@ -1,0 +1,11 @@
+GDTEST_OK
+TEST Callable::callv
+one two three four
+one two three four
+["one"] ["two"] ["three"] ["four"]
+["one"] ["two"] ["three"] ["four"]
+TEST Object::callv
+one two three four
+one two three four
+["one"] ["two"] ["three"] ["four"]
+["one"] ["two"] ["three"] ["four"]


### PR DESCRIPTION
Use a duplicate of the passed array when it is read-only.

Prior to this fix, when the array was marked as read-only, the temporary address of `p_arguments->read_only` was used for all parameters. Consequently, this caused all parameters to reference the last element of the array.

Fixes #93600.
