### PR TITLE
Make `push_error` and `push_warning` print name of calling function

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -155,7 +155,7 @@ void _err_print_callstack(const String &p_error, bool p_editor_notify, ErrorHand
 	_err_print_error(__FUNCTION__, __FILE__, __LINE__, p_error + '\n' + callstack, p_editor_notify, p_type);
 }
 
-void _err_print_error_backtrace(const char *filter, const String &p_error, bool p_editor_notify, ErrorHandlerType p_type) {
+void _err_print_error_backtrace(const char *p_filter, const String &p_error, bool p_editor_notify, ErrorHandlerType p_type) {
 	// Print script stack frame, if available.
 	Vector<ScriptLanguage::StackInfo> si;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
@@ -170,7 +170,7 @@ void _err_print_error_backtrace(const char *filter, const String &p_error, bool 
 	Vector<OS::StackInfo> cpp_stack = OS::get_singleton()->get_cpp_stack_info();
 
 	for (int i = 1; i < cpp_stack.size(); ++i) {
-		if (!cpp_stack[i].function.contains(filter)) {
+		if (!cpp_stack[i].function.contains(p_filter)) {
 			String descriptor = OS::get_singleton()->get_debug_descriptor(cpp_stack[i]);
 			if (descriptor.is_empty()) {
 				// If we can't get debug info, just print binary file name and address.

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -130,16 +130,16 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 }
 
 struct FunctionInfo {
-	const char* function;
-	const char* file;
+	const char *function;
+	const char *file;
 	int line;
 	String descriptor;
 };
 
-FunctionInfo calling_function(const char* filter, int frames_to_skip = 0) {
+FunctionInfo calling_function(const char *filter, int frames_to_skip = 0) {
 	constexpr int kBacktraceDepth = 15;
 	constexpr int kDemangledBufferSize = 100;
-	void* backtrace_addrs[kBacktraceDepth];
+	void *backtrace_addrs[kBacktraceDepth];
 	static char s_demangled[kDemangledBufferSize];
 	Dl_info info;
 	FunctionInfo result;
@@ -153,7 +153,7 @@ FunctionInfo calling_function(const char* filter, int frames_to_skip = 0) {
 	} while (i < trace_size && strstr(info.dli_sname, filter));
 
 	int status;
-	char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+	char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
 
 	if (status == 0) {
 		// Have to do it this way to avoid a memory leak, as abi::__cxa_demangle returns a `malloc`ed c-string.
@@ -166,15 +166,13 @@ FunctionInfo calling_function(const char* filter, int frames_to_skip = 0) {
 	free(demangled);
 
 	result.file = info.dli_fname;
-	result.line = static_cast<const char*>(info.dli_saddr) - static_cast<const char*>(info.dli_fbase);
+	result.line = static_cast<const char *>(info.dli_saddr) - static_cast<const char *>(info.dli_fbase);
 
 #ifdef DEBUG_ENABLED
 	if (OS::get_singleton()->get_name() == "macOS") {
 		String pipe;
-		Error error = OS::get_singleton()->execute("atos", { "-o", info.dli_fname, "-l",
-			String::num_uint64(reinterpret_cast<uint64_t>(info.dli_fbase), 16),
-			String::num_uint64(reinterpret_cast<uint64_t>(backtrace_addrs[i]), 16)},
-			&pipe);
+		Error error = OS::get_singleton()->execute("atos", { "-o", info.dli_fname, "-l", String::num_uint64(reinterpret_cast<uint64_t>(info.dli_fbase), 16), String::num_uint64(reinterpret_cast<uint64_t>(backtrace_addrs[i]), 16) },
+				&pipe);
 
 		if (error == OK) {
 			result.descriptor = pipe + " - ";
@@ -185,7 +183,7 @@ FunctionInfo calling_function(const char* filter, int frames_to_skip = 0) {
 	return result;
 }
 
-void _err_print_error_backtrace(const char *filter, const String& p_error, bool p_editor_notify, ErrorHandlerType p_type) {
+void _err_print_error_backtrace(const char *filter, const String &p_error, bool p_editor_notify, ErrorHandlerType p_type) {
 	FunctionInfo info = calling_function(filter, 1);
 	_err_print_error(info.function, info.file, info.line, "", info.descriptor + p_error, p_editor_notify, p_type);
 }

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -69,7 +69,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool p_editor_notify = false, bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool p_editor_notify = false, bool fatal = false);
-void _err_print_error_backtrace(const char* filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_error_backtrace(const char *filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_flush_stdout();
 
 #ifdef __GNUC__

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -70,7 +70,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool p_editor_notify = false, bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool p_editor_notify = false, bool fatal = false);
 void _err_print_callstack(const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
-void _err_print_error_backtrace(const char *filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_error_backtrace(const char *p_filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_flush_stdout();
 
 #ifdef __GNUC__

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -69,6 +69,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool p_editor_notify = false, bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool p_editor_notify = false, bool fatal = false);
+void _err_print_error_backtrace(const char* filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_flush_stdout();
 
 #ifdef __GNUC__

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -69,6 +69,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool p_editor_notify = false, bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool p_editor_notify = false, bool fatal = false);
+void _err_print_callstack(const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_error_backtrace(const char *filter, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_flush_stdout();
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -347,7 +347,7 @@ public:
 		const void *symbol_address;
 	};
 	virtual Vector<StackInfo> get_cpp_stack_info() const { return Vector<StackInfo>(); }
-	virtual String get_debug_descriptor(const StackInfo &info) { return String(); }
+	virtual String get_debug_descriptor(const StackInfo &p_info) { return String(); }
 
 	// Load GDExtensions specific to this platform.
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -339,6 +339,16 @@ public:
 
 	virtual PreferredTextureFormat get_preferred_texture_format() const;
 
+	struct StackInfo {
+		String function;
+		String file;
+		uint64_t offset;
+		const void *load_address;
+		const void *symbol_address;
+	};
+	virtual Vector<StackInfo> get_cpp_stack_info() const { return Vector<StackInfo>(); }
+	virtual String get_debug_descriptor(const StackInfo &info) { return String(); }
+
 	// Load GDExtensions specific to this platform.
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -763,8 +763,8 @@ public:
 		}
 	}
 
-	List(std::initializer_list<T> init) {
-		for (const T &i : init) {
+	List(std::initializer_list<T> p_init) {
+		for (const T &i : p_init) {
 			push_back(i);
 		}
 	}

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -764,7 +764,7 @@ public:
 	}
 
 	List(std::initializer_list<T> init) {
-		for (const auto& i : init) {
+		for (const T &i : init) {
 			push_back(i);
 		}
 	}

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -35,6 +35,8 @@
 #include "core/os/memory.h"
 #include "core/templates/sort_array.h"
 
+#include <initializer_list>
+
 /**
  * Generic Templatized Linked List Implementation.
  * The implementation differs from the STL one because
@@ -758,6 +760,12 @@ public:
 		while (it) {
 			push_back(it->get());
 			it = it->next();
+		}
+	}
+
+	List(std::initializer_list<T> init) {
+		for (const auto& i : init) {
+			push_back(i);
 		}
 	}
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -933,12 +933,7 @@ String VariantUtilityFunctions::str(const Variant **p_args, int p_arg_count, Cal
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
@@ -963,12 +958,7 @@ void VariantUtilityFunctions::print(const Variant **p_args, int p_arg_count, Cal
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	print_line(s);
@@ -979,12 +969,7 @@ void VariantUtilityFunctions::print_rich(const Variant **p_args, int p_arg_count
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	print_line_rich(s);
@@ -998,12 +983,7 @@ void VariantUtilityFunctions::print_verbose(const Variant **p_args, int p_arg_co
 		String s;
 		for (int i = 0; i < p_arg_count; i++) {
 			String os = p_args[i]->operator String();
-
-			if (i == 0) {
-				s = os;
-			} else {
-				s += os;
-			}
+			s += os;
 		}
 
 		// No need to use `print_verbose()` as this call already only happens
@@ -1019,12 +999,7 @@ void VariantUtilityFunctions::printerr(const Variant **p_args, int p_arg_count, 
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	print_error(s);
@@ -1061,12 +1036,7 @@ void VariantUtilityFunctions::printraw(const Variant **p_args, int p_arg_count, 
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	OS::get_singleton()->print("%s", s.utf8().get_data());
@@ -1081,12 +1051,7 @@ void VariantUtilityFunctions::push_error(const Variant **p_args, int p_arg_count
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	_err_print_error_backtrace(FUNCTION_STR, s);
@@ -1101,12 +1066,7 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-
-		if (i == 0) {
-			s = os;
-		} else {
-			s += os;
-		}
+		s += os;
 	}
 
 	_err_print_error_backtrace(FUNCTION_STR, s, false, ERR_HANDLER_WARNING);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1089,7 +1089,7 @@ void VariantUtilityFunctions::push_error(const Variant **p_args, int p_arg_count
 		}
 	}
 
-	ERR_PRINT(s);
+	_err_print_error_backtrace(FUNCTION_STR, s);
 	r_error.error = Callable::CallError::CALL_OK;
 }
 
@@ -1109,7 +1109,7 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 		}
 	}
 
-	WARN_PRINT(s);
+	_err_print_error_backtrace(FUNCTION_STR, s, false, ERR_HANDLER_WARNING);
 	r_error.error = Callable::CallError::CALL_OK;
 }
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -933,7 +933,12 @@ String VariantUtilityFunctions::str(const Variant **p_args, int p_arg_count, Cal
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
@@ -958,7 +963,12 @@ void VariantUtilityFunctions::print(const Variant **p_args, int p_arg_count, Cal
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	print_line(s);
@@ -969,7 +979,12 @@ void VariantUtilityFunctions::print_rich(const Variant **p_args, int p_arg_count
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	print_line_rich(s);
@@ -983,7 +998,12 @@ void VariantUtilityFunctions::print_verbose(const Variant **p_args, int p_arg_co
 		String s;
 		for (int i = 0; i < p_arg_count; i++) {
 			String os = p_args[i]->operator String();
-			s += os;
+
+			if (i == 0) {
+				s = os;
+			} else {
+				s += os;
+			}
 		}
 
 		// No need to use `print_verbose()` as this call already only happens
@@ -999,7 +1019,12 @@ void VariantUtilityFunctions::printerr(const Variant **p_args, int p_arg_count, 
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	print_error(s);
@@ -1036,7 +1061,12 @@ void VariantUtilityFunctions::printraw(const Variant **p_args, int p_arg_count, 
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	OS::get_singleton()->print("%s", s.utf8().get_data());
@@ -1051,7 +1081,12 @@ void VariantUtilityFunctions::push_error(const Variant **p_args, int p_arg_count
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	_err_print_error_backtrace(FUNCTION_STR, s);
@@ -1066,7 +1101,12 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
 		String os = p_args[i]->operator String();
-		s += os;
+
+		if (i == 0) {
+			s = os;
+		} else {
+			s += os;
+		}
 	}
 
 	_err_print_error_backtrace(FUNCTION_STR, s, false, ERR_HANDLER_WARNING);

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -68,10 +68,13 @@
 #include <uvm/uvm_extern.h>
 #endif
 
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
+#include <execinfo.h>
+#endif
+
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <errno.h>
-#include <execinfo.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -1031,6 +1034,7 @@ OS::StackInfo OS_Unix::describe_function(const char *dli_fname, const void *dli_
 	return result;
 }
 
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 Vector<OS::StackInfo> OS_Unix::get_cpp_stack_info() const {
 	constexpr int kMaxBacktraceDepth = 25;
 	void *backtrace_addrs[kMaxBacktraceDepth];
@@ -1048,6 +1052,7 @@ Vector<OS::StackInfo> OS_Unix::get_cpp_stack_info() const {
 
 	return result;
 }
+#endif
 
 UnixTerminalLogger::~UnixTerminalLogger() {}
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1008,24 +1008,24 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	}
 }
 
-OS::StackInfo OS_Unix::describe_function(const Dl_info &info, const void *address) const {
+OS::StackInfo OS_Unix::describe_function(const char *dli_fname, const void *dli_fbase, const char *dli_sname, const void *dli_saddr, const void *address) const {
 	StackInfo result;
 
 	// Demangle C++ symbols
 	int status;
-	char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+	char *demangled = abi::__cxa_demangle(dli_sname, nullptr, nullptr, &status);
 
 	if (status == 0) {
 		result.function = demangled;
 	} else {
-		result.function = info.dli_sname;
+		result.function = dli_sname;
 	}
 	free(demangled);
 
 	// Get file info
-	result.file = info.dli_fname;
-	result.offset = static_cast<const char *>(address) - static_cast<const char *>(info.dli_fbase);
-	result.load_address = info.dli_fbase;
+	result.file = dli_fname;
+	result.offset = static_cast<const char *>(address) - static_cast<const char *>(dli_fbase);
+	result.load_address = dli_fbase;
 	result.symbol_address = address;
 
 	return result;
@@ -1043,7 +1043,7 @@ Vector<OS::StackInfo> OS_Unix::get_cpp_stack_info() const {
 	for (int i = 1; i < trace_size; ++i) {
 		Dl_info info;
 		dladdr(backtrace_addrs[i], &info);
-		result.write[i - 1] = describe_function(info, backtrace_addrs[i]);
+		result.write[i - 1] = describe_function(info.dli_fname, info.dli_fbase, info.dli_sname, info.dli_saddr, backtrace_addrs[i]);
 	}
 
 	return result;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -53,6 +53,8 @@ protected:
 
 	virtual void finalize_core() override;
 
+	virtual StackInfo describe_function(const struct dl_info &info, const void *address) const;
+
 public:
 	OS_Unix();
 
@@ -101,6 +103,8 @@ public:
 
 	virtual String get_executable_path() const override;
 	virtual String get_user_data_dir() const override;
+
+	virtual Vector<StackInfo> get_cpp_stack_info() const override;
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -53,7 +53,11 @@ protected:
 
 	virtual void finalize_core() override;
 
+#ifdef __APPLE__
 	virtual StackInfo describe_function(const struct dl_info &info, const void *address) const;
+#else
+	virtual StackInfo describe_function(const struct Dl_info &info, const void *address) const;
+#endif
 
 public:
 	OS_Unix();

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -53,11 +53,7 @@ protected:
 
 	virtual void finalize_core() override;
 
-#ifdef __APPLE__
-	virtual StackInfo describe_function(const struct dl_info &info, const void *address) const;
-#else
-	virtual StackInfo describe_function(const struct Dl_info &info, const void *address) const;
-#endif
+	virtual StackInfo describe_function(const char *dli_fname, const void *dli_fbase, const char *dli_sname, const void *dli_saddr, const void *address) const;
 
 public:
 	OS_Unix();

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -104,7 +104,9 @@ public:
 	virtual String get_executable_path() const override;
 	virtual String get_user_data_dir() const override;
 
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 	virtual Vector<StackInfo> get_cpp_stack_info() const override;
+#endif
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -49,7 +49,7 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 	if (p_errorexp && p_errorexp[0]) {
 		err_str = String::utf8(p_errorexp);
 	} else {
-		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
+		err_str = String::utf8(p_func) + " (" + String::utf8(p_file) + ": " + itos(p_line) + ") - " + String::utf8(p_error);
 	}
 
 	if (p_editor_notify) {

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -75,6 +75,10 @@ protected:
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;
 
+#ifdef DEBUG_ENABLED
+	virtual String get_debug_descriptor(const StackInfo &info) override;
+#endif
+
 public:
 	virtual void set_cmdline_platform_args(const List<String> &p_args);
 	virtual List<String> get_cmdline_platform_args() const override;

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -76,7 +76,7 @@ protected:
 	virtual void delete_main_loop() override;
 
 #ifdef DEBUG_ENABLED
-	virtual String get_debug_descriptor(const StackInfo &info) override;
+	virtual String get_debug_descriptor(const StackInfo &p_info) override;
 #endif
 
 public:

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -757,6 +757,19 @@ OS::PreferredTextureFormat OS_MacOS::get_preferred_texture_format() const {
 	return PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
 }
 
+#ifdef DEBUG_ENABLED
+String OS_MacOS::get_debug_descriptor(const StackInfo &info) {
+	String pipe;
+	Error error = execute("atos", { "-o", info.file, "-l", String::num_uint64(reinterpret_cast<uint64_t>(info.load_address), 16), String::num_uint64(reinterpret_cast<uint64_t>(info.symbol_address), 16) }, &pipe);
+
+	if (error == OK) {
+		return pipe.strip_edges();
+	} else {
+		return String();
+	}
+}
+#endif
+
 void OS_MacOS::run() {
 	if (!main_loop) {
 		return;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -758,9 +758,9 @@ OS::PreferredTextureFormat OS_MacOS::get_preferred_texture_format() const {
 }
 
 #ifdef DEBUG_ENABLED
-String OS_MacOS::get_debug_descriptor(const StackInfo &info) {
+String OS_MacOS::get_debug_descriptor(const StackInfo &p_info) {
 	String pipe;
-	Error error = execute("atos", { "-o", info.file, "-l", String::num_uint64(reinterpret_cast<uint64_t>(info.load_address), 16), String::num_uint64(reinterpret_cast<uint64_t>(info.symbol_address), 16) }, &pipe);
+	Error error = execute("atos", { "-o", p_info.file, "-l", String::num_uint64(reinterpret_cast<uint64_t>(p_info.load_address), 16), String::num_uint64(reinterpret_cast<uint64_t>(p_info.symbol_address), 16) }, &pipe);
 
 	if (error == OK) {
 		return pipe.strip_edges();


### PR DESCRIPTION
Currently, `push_error` and `push_warning` give themselves as the calling
function, which is not useful for debugging. I have altered these to use the
C stacktrace to get the name of the function that called them. This saves
having to turn these functions into macros, which would require recompiling
every single piece of code that uses them. I have also set it to, when debug
symbols are available, use them with `atos` (available on macOS) to find the
exact source file and line being called from. It should be possible to the same
thing on Linux using `addr2line`, but I don't have a Linux box handy to test
that. I am not sure how you would implement this in Windows.

I have tested this on macOS Sonoma 14.5 (23F79). It should work on any *nix
system. I am not sure about Windows.

Fixes #76770