### PR TITLE
Allow using stage functions inside custom shader functions

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -859,6 +859,7 @@ public:
 
 		Vector<Argument> arguments;
 		DataType return_type = TYPE_VOID;
+		String skip_function;
 	};
 
 	struct ModeInfo {

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -284,6 +284,7 @@ ShaderTypes::ShaderTypes() {
 
 	{
 		ShaderLanguage::StageFunctionInfo func;
+		func.skip_function = "vertex";
 		func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("sdf_pos", ShaderLanguage::TYPE_VEC2));
 		func.return_type = ShaderLanguage::TYPE_FLOAT; //whether it could emit
 		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["texture_sdf"] = func;
@@ -297,6 +298,7 @@ ShaderTypes::ShaderTypes() {
 
 	{
 		ShaderLanguage::StageFunctionInfo func;
+		func.skip_function = "vertex";
 		func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("uv", ShaderLanguage::TYPE_VEC2));
 		func.return_type = ShaderLanguage::TYPE_VEC2; //whether it could emit
 		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["screen_uv_to_sdf"] = func;


### PR DESCRIPTION
This is to allow SDF functions (in canvas_item) as well as `emit_particle` (in particle shaders) to be used in custom shader functions. Closes https://github.com/godotengine/godot-proposals/discussions/10047
