### PR TITLE
Quaternions: Handle 180 degree arcs in the shortest arc constructor better

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -140,25 +140,7 @@ struct _NO_DISCARD_ Quaternion {
 		w = p_q.w;
 	}
 
-	Quaternion(const Vector3 &p_v0, const Vector3 &p_v1) { // Shortest arc.
-		Vector3 c = p_v0.cross(p_v1);
-		real_t d = p_v0.dot(p_v1);
-
-		if (d < -1.0f + (real_t)CMP_EPSILON) {
-			x = 0;
-			y = 1;
-			z = 0;
-			w = 0;
-		} else {
-			real_t s = Math::sqrt((1.0f + d) * 2.0f);
-			real_t rs = 1.0f / s;
-
-			x = c.x * rs;
-			y = c.y * rs;
-			z = c.z * rs;
-			w = s * 0.5f;
-		}
-	}
+	Quaternion(const Vector3 &p_v0, const Vector3 &p_v1); // Shortest arc.
 };
 
 real_t Quaternion::dot(const Quaternion &p_q) const {

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -235,6 +235,36 @@ TEST_CASE("[Quaternion] Construct Basis Axes") {
 	CHECK(q[3] == doctest::Approx(0.8582598));
 }
 
+TEST_CASE("[Quaternion] Construct Shortest Arc For 180 Degree Arc") {
+	Vector3 up(0, 1, 0);
+	Vector3 down(0, -1, 0);
+	Vector3 left(-1, 0, 0);
+	Vector3 right(1, 0, 0);
+	Vector3 forward(0, 0, -1);
+	Vector3 back(0, 0, 1);
+
+	// When we have a 180 degree rotation quaternion which was defined as
+	// A to B, logically when we transform A we expect to get B.
+	Quaternion left_to_right(left, right);
+	CHECK(left_to_right.xform(left).is_equal_approx(right));
+	CHECK(Quaternion(right, left).xform(right).is_equal_approx(left));
+	CHECK(Quaternion(up, down).xform(up).is_equal_approx(down));
+	CHECK(Quaternion(down, up).xform(down).is_equal_approx(up));
+	CHECK(Quaternion(forward, back).xform(forward).is_equal_approx(back));
+	CHECK(Quaternion(back, forward).xform(back).is_equal_approx(forward));
+
+	// With (arbitrary) opposite vectors that are not axis-aligned as parameters
+	Vector3 diagonal_up = Vector3(1.2, 2.3, 4.5).normalized();
+	Vector3 diagonal_down = -diagonal_up;
+	Quaternion q1(diagonal_up, diagonal_down);
+	CHECK(q1.xform(diagonal_down).is_equal_approx(diagonal_up));
+	CHECK(q1.xform(diagonal_up).is_equal_approx(diagonal_down));
+
+	// When the two vectors lie on the XZ plane, the rotation axis should be the
+	// Y-axis for backwards compatibility.
+	CHECK(left_to_right.get_axis().is_equal_approx(up));
+}
+
 TEST_CASE("[Quaternion] Get Euler Orders") {
 	double x = Math::deg_to_rad(30.0);
 	double y = Math::deg_to_rad(45.0);


### PR DESCRIPTION
This PR resolves #80249, where the problem was that the shortest arc quaternion constructor didn't work well when asked to make a 180° quaternion (which is notably ambiguous because there's no single shortest arc for a 180° rotation). Previously only the case where both input vectors lay on the XZ plane was handled correctly, and any other pair of input vectors would give a completely incorrect result. Now any pair of vectors should give a sensible result.

The main part of the implementation is by @krisutofu, but he did not have the time to do the pull request. I've also added a unit test, although it's fairly basic due to my limited understanding of the inner workings of quaternions.

Some notes:
 - The implementation required a helper function, but I wasn't sure whether it would be better to make it a C-style static function or a C++-style private function (which are both *kind of* the same concept). I used a static function but let me know if a private function is preferred.
 - The big `try_set_perpendicular_to` line is so long it's kind of ugly, but that's clang-tidy's handywork.