### PR TITLE
Editor_description documentation for 3.x

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -781,6 +781,9 @@
 			Sets this node's name as a unique name in its [member owner]. This allows the node to be accessed as [code]%Name[/code] instead of the full path, from any node within that scene.
 			If another node with the same owner already had that name declared as unique, that other node's name will no longer be set as having a unique name.
 		</member>
+		<member name="editor_description" type="String" setter="set_editor_description" getter="get_editor_description" default="&quot;&quot;">
+			An optional description to the node. It will be displayed as a tooltip when hovering over the node in the editor's Scene dock.
+		</member>
 	</members>
 	<signals>
 		<signal name="child_entered_tree">
@@ -800,6 +803,12 @@
 		<signal name="child_order_changed">
 			<description>
 				Emitted when the list of children is changed. This happens when child nodes are added, moved, or removed.
+			</description>
+		</signal>
+		<signal name="editor_description_changed">
+			<param index="0" name="node" type="Node" />
+			<description>
+				Emitted when the node's editor description field changed.
 			</description>
 		</signal>
 		<signal name="ready">


### PR DESCRIPTION
Documentation for editor_description that was missing for 3.x . In master this issue was solved, even thought the property already existed in 3.x. The documentation is the same as for the master, just copied and pasted from that.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
