### PR TITLE
Fix text editor stealing focus from "Find in Files" dialog on X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3040,7 +3040,7 @@ void DisplayServerX11::window_set_ime_active(const bool p_active, WindowID p_win
 		XWindowAttributes xwa;
 		XSync(x11_display, False);
 		XGetWindowAttributes(x11_display, wd.x11_xim_window, &xwa);
-		if (xwa.map_state == IsViewable && _window_focus_check()) {
+		if (xwa.map_state == IsViewable) {
 			_set_input_focus(wd.x11_xim_window, RevertToParent);
 		}
 		XSetICFocus(wd.xic);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88847

Works in my testing on Fedora 40 with GNOME using xwayland.

This reverts one of the changes from PR https://github.com/godotengine/godot/pull/86441, but not all of them.

~~Marking as a draft for now, because I'd like to attempt to determine if the original bug that PR https://github.com/godotengine/godot/pull/86441 fixed is still fixed with the changes here. Since this doesn't revert the whole thing, it's possible that bug is still fixed, and everybody wins! However, PR https://github.com/godotengine/godot/pull/86441 didn't fix the X11 bugs that I was personally having - I made that PR on behalf of another user, so I'll need to figure out how to reproduce the original bug.~~

**UPDATE:** I confirmed that this PR doesn't re-introduce at least one of the bugs fixed by PR https://github.com/godotengine/godot/pull/86441. See [this comment](https://github.com/godotengine/godot/pull/93682#issuecomment-2195803492).