### PR TITLE
`ResourceLoader`: Support polling and get-before-complete on the main thread

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -174,6 +174,7 @@ private:
 		String type_hint;
 		float progress = 0.0f;
 		float max_reported_progress = 0.0f;
+		uint64_t last_progress_check_main_thread_frame = UINT64_MAX;
 		ThreadLoadStatus status = THREAD_LOAD_IN_PROGRESS;
 		ResourceFormatLoader::CacheMode cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE;
 		Error error = OK;
@@ -196,6 +197,8 @@ private:
 	static HashMap<String, LoadToken *> user_load_tokens;
 
 	static float _dependency_get_progress(const String &p_path);
+
+	static bool _ensure_load_progress();
 
 public:
 	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -87,7 +87,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns the resource loaded by [method load_threaded_request].
-				If this is called before the loading thread is done (i.e. [method load_threaded_get_status] is not [constant THREAD_LOAD_LOADED]), the calling thread will be blocked until the resource has finished loading.
+				If this is called before the loading thread is done (i.e. [method load_threaded_get_status] is not [constant THREAD_LOAD_LOADED]), the calling thread will be blocked until the resource has finished loading. However, it's recommended to use [method load_threaded_get_status] to known when the load has actually completed.
 			</description>
 		</method>
 		<method name="load_threaded_get_status">
@@ -97,6 +97,7 @@
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
+				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>
 		<method name="load_threaded_request">


### PR DESCRIPTION
Fixes #92844.

In #92844 it was told that, in reality, polling in a loop in a single frame was never actually supported and that the MRP worked on earlier versions because on them the engine wasn't fully using the freedom such a constraint gave until recently. Therefore, my first idea was to consider the issue a documentation problem.

However, I realized that it was not that hard to support both suboptimal usages (polling in a loop and getting the result before the load completed). And so is that this PR does.

I'm labeling this as enhancement because, again, those usages were never supported and this PR is making them officially supported _for the first time_. Nonetheless, I'm also warning about them in the docs.