### PR TITLE
Revert the default InterpolationType with angle property to Linear

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5084,17 +5084,7 @@ void AnimationTrackEditor::_fetch_value_track_options(const NodePath &p_path, An
 	PropertyInfo h = _find_hint_for_track(animation->get_track_count() - 1, np);
 	animation->remove_track(animation->get_track_count() - 1); // Hack.
 	switch (h.type) {
-		case Variant::FLOAT: {
-#ifdef DISABLE_DEPRECATED
-			bool is_angle = h.type == Variant::FLOAT && h.hint_string.contains("radians_as_degrees");
-#else
-			bool is_angle = h.type == Variant::FLOAT && h.hint_string.contains("radians");
-#endif // DISABLE_DEPRECATED
-			if (is_angle) {
-				*r_interpolation_type = Animation::INTERPOLATION_LINEAR_ANGLE;
-			}
-			[[fallthrough]];
-		}
+		case Variant::FLOAT:
 		case Variant::VECTOR2:
 		case Variant::RECT2:
 		case Variant::VECTOR3:


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/93163

This default was changed in https://github.com/godotengine/godot/pull/86630. There is a faint memory that I did so for some reason because I was not sure at the time whether https://github.com/godotengine/godot/pull/86608 would be merged or not, but I don't remember it well.

As long as there is a Reset track, it is not a problem because it copies the Reset track setting, but it may be fine to revert it since it changes the behavior when a new track is created, which can be confusing.