### PR TITLE
Improve `String::sprintf` performance

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5678,7 +5678,7 @@ String String::sprintf(const Array &values, bool *error) const {
 					in_decimals = false;
 					break;
 				default:
-					formatted += chr(c);
+					formatted += c;
 			}
 		}
 	}


### PR DESCRIPTION
`String::sprintf` was allocating an extra string for each character not part of a formatted value, updated to append the characters directly to the output string instead.

Performance impact will vary depending on the format string, should be more improvement for longer strings with fewer replacements.  `sprintf` time was reduced by around 50-75% for the examples below:

```
extends Node

func _ready() -> void:
	test_string_format("Short string: %d", "Short string")
	test_string_format("Longer string:                                                             %d", "Long string")

func test_string_format(format_string : String, name : String):
	var start_ms = Time.get_ticks_msec()
	for i in 1000000:
		var result = format_string % i
	var end_ms = Time.get_ticks_msec()
	print("%s: %dms" % [name, end_ms - start_ms])
```

old:
```
Short string: 2012ms
Long string: 7515ms
```

new:
```
Short string: 1016ms
Long string: 1950ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
