### PR TITLE
[Button] Use `align_to_largest_stylebox` for min. size calculation.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -119,7 +119,7 @@
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="align_to_largest_stylebox" data_type="constant" type="int" default="0">
-			This constant acts as a boolean. If [code]true[/code], text and icon are always aligned to the largest stylebox margins, otherwise it's aligned to the current button state stylebox margins.
+			This constant acts as a boolean. If [code]true[/code], the minimum size of the button and text/icon alignment is always based on the largest stylebox margins, otherwise it's based on the current button state stylebox margins.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -530,7 +530,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		}
 	}
 
-	return _get_largest_stylebox_size() + minsize;
+	return (theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size()) + minsize;
 }
 
 void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93437
