### PR TITLE
Preserve existing alpha channel when using Normal Map Invert Y import option

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -558,7 +558,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 			for (int i = 0; i < width; i++) {
 				for (int j = 0; j < height; j++) {
 					const Color color = target_image->get_pixel(i, j);
-					target_image->set_pixel(i, j, Color(color.r, 1 - color.g, color.b));
+					target_image->set_pixel(i, j, Color(color.r, 1 - color.g, color.b, color.a));
 				}
 			}
 		}


### PR DESCRIPTION
While normal maps with RGTC compression cannot contain an alpha channel, it *is* possible for Godot to read non-RGTC normal maps that can contain an alpha channel that custom shaders can read. This is the case both in 2D (where VRAM compression and therefore RGTC is generally not used in the first place) and 3D.

~~The green channel inversion is premultiplied by alpha to avoid green outlines in the transition between opaque and transparent pixels, particularly in generated mipmaps.~~
**Edit:** Premultiplication is no longer done (see below), so this PR just preserves the alpha channel and makes no other changes.

The visual output for opaque images (including RGTC normal maps) is unaffected by this change.

I noticed this while testing https://github.com/godotengine/godot/pull/91284 (which doesn't have that issue with the alpha channel).

**Testing project:** [test_normal_map_invert_y_alpha.zip](https://github.com/user-attachments/files/16035636/test_normal_map_invert_y_alpha.zip)

## Preview

*The normal map is used as an albedo texture for easier visibility.*

Before | After
-|-
![Screenshot_20240628_204018 png webp](https://github.com/godotengine/godot/assets/180032/67a64a05-8a4a-425d-bfe4-4f93f6551e8a) | ![Screenshot_20240628_204156 png webp](https://github.com/godotengine/godot/assets/180032/4571ea47-4389-4eb1-8dce-5e178406e085)!

Note that the "After" screenshot has green outlines visible on the mipmaps, but I believe this is more an issue of how mipmap generation is done. The outline goes away if we premultiply the green channel inversion by the alpha channel, but this breaks use cases other than usage as albedo (which I don't think will be frequent):

![Screenshot_20240628_204423 png webp](https://github.com/godotengine/godot/assets/180032/7013d00a-ffcc-4619-bf79-e6bb20c7a3dd)

Non-inverted normal map for reference:

![Screenshot_20240628_204010 png webp](https://github.com/godotengine/godot/assets/180032/d426b3b3-ff5d-4fb5-b0cf-6c3fd9ee327f)

