### PR TITLE
Update canvas layer size and control after project settings changed.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3967,6 +3967,7 @@ void CanvasItemEditor::_update_editor_settings() {
 
 void CanvasItemEditor::_project_settings_changed() {
 	EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+	update_viewport();
 }
 
 void CanvasItemEditor::_notification(int p_what) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1760,6 +1760,11 @@ void Control::_size_changed() {
 	}
 }
 
+void Control::_project_settings_changed() {
+	update_minimum_size();
+	_size_changed();
+}
+
 void Control::_clear_size_warning() {
 	data.size_warning = false;
 }
@@ -3259,6 +3264,10 @@ void Control::_notification(int p_notification) {
 				data.RI = viewport->_gui_add_root_control(this);
 
 				get_parent()->connect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::gui_set_root_order_dirty), CONNECT_REFERENCE_COUNTED);
+
+				if (Engine::get_singleton()->is_editor_hint()) {
+					ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Control::_project_settings_changed));
+				}
 			}
 
 			data.parent_canvas_item = get_parent_item();
@@ -3288,6 +3297,12 @@ void Control::_notification(int p_notification) {
 				get_viewport()->_gui_remove_root_control(data.RI);
 				data.RI = nullptr;
 				get_parent()->disconnect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::gui_set_root_order_dirty));
+			}
+
+			if (Engine::get_singleton()->is_editor_hint()) {
+				if (!Object::cast_to<Control>(get_parent())) {
+					ProjectSettings::get_singleton()->disconnect("settings_changed", callable_mp(this, &Control::_project_settings_changed));
+				}
 			}
 
 			data.parent_canvas_item = nullptr;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -297,6 +297,7 @@ private:
 	void _update_minimum_size_cache();
 	void _update_minimum_size();
 	void _size_changed();
+	void _project_settings_changed();
 
 	void _top_level_changed() override {} // Controls don't need to do anything, only other CanvasItems.
 	void _top_level_changed_on_parent() override;


### PR DESCRIPTION
Fix #69208 

https://github.com/godotengine/godot/assets/63407648/95c1b9a0-84c0-4fe5-a3bc-b31f325c4648


In `canvas_item_editor_plugin`: Call `update_viewport()` in `_project_setting_changed` to redraw viewport after project settings changed.

In `control`: Add a new private function `_project_settings_changed` to update the size and redraw the control. Connect/Disconnect this function to "settings_changed" of `ProjectSettings` when the control enters/exits the canvas.

NOTE 0: The signal name used here is string literal, but some other names are wrapped by `SNAME` or `SceneStringName`. Not sure if we have to make any modifications to keep consistency.

NOTE 1: I'm a bit worried about the performance here. We use "settings_changed" signal here, so any change unrelated to viewport will also trigger a redraw. Should the signal be more fine-grained?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
