### PR TITLE
Speed up scene group scanning for text scenes

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1891,7 +1891,7 @@ void EditorFileSystem::_update_scene_groups() {
 			continue;
 		}
 
-		const HashSet<StringName> scene_groups = _get_scene_groups(path);
+		const HashSet<StringName> scene_groups = PackedScene::get_scene_groups(path);
 		if (!scene_groups.is_empty()) {
 			ProjectSettings::get_singleton()->add_scene_groups_cache(path, scene_groups);
 		}
@@ -1933,12 +1933,6 @@ void EditorFileSystem::_get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		_get_all_scenes(p_dir->get_subdir(i), r_list);
 	}
-}
-
-HashSet<StringName> EditorFileSystem::_get_scene_groups(const String &p_path) {
-	Ref<PackedScene> packed_scene = ResourceLoader::load(p_path);
-	ERR_FAIL_COND_V(packed_scene.is_null(), HashSet<StringName>());
-	return packed_scene->get_state()->get_all_groups();
 }
 
 void EditorFileSystem::update_file(const String &p_file) {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -290,7 +290,6 @@ class EditorFileSystem : public Node {
 	void _queue_update_scene_groups(const String &p_path);
 	void _update_scene_groups();
 	void _update_pending_scene_groups();
-	HashSet<StringName> _get_scene_groups(const String &p_path);
 	void _get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet<String> &r_list);
 
 	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2124,6 +2124,56 @@ void PackedScene::recreate_state() {
 #endif
 }
 
+#ifdef TOOLS_ENABLED
+HashSet<StringName> PackedScene::get_scene_groups(const String &p_path) {
+	{
+		Ref<PackedScene> packed_scene = ResourceCache::get_ref(p_path);
+		if (packed_scene.is_valid()) {
+			return packed_scene->get_state()->get_all_groups();
+		}
+	}
+
+	if (p_path.get_extension() == "tscn") {
+		Ref<FileAccess> scene_file = FileAccess::open(p_path, FileAccess::READ);
+		ERR_FAIL_COND_V(scene_file.is_null(), HashSet<StringName>());
+
+		HashSet<StringName> ret;
+		while (!scene_file->eof_reached()) {
+			const String line = scene_file->get_line();
+			if (!line.begins_with("[node")) {
+				continue;
+			}
+
+			int i = line.find("groups=[");
+			if (i == -1) {
+				continue;
+			}
+
+			int j = line.find_char(']', i);
+			while (i < j) {
+				i = line.find_char('"', i);
+				if (i == -1) {
+					break;
+				}
+
+				int k = line.find_char('"', i + 1);
+				if (k == -1) {
+					break;
+				}
+
+				ret.insert(line.substr(i + 1, k - i - 1));
+				i = k + 1;
+			}
+		}
+		return ret;
+	} else {
+		Ref<PackedScene> packed_scene = ResourceLoader::load(p_path);
+		ERR_FAIL_COND_V(packed_scene.is_null(), HashSet<StringName>());
+		return packed_scene->get_state()->get_all_groups();
+	}
+}
+#endif
+
 Ref<SceneState> PackedScene::get_state() const {
 	return state;
 }

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -270,6 +270,7 @@ public:
 		state->set_last_modified_time(p_time);
 	}
 
+	static HashSet<StringName> get_scene_groups(const String &p_path);
 #endif
 	Ref<SceneState> get_state() const;
 


### PR DESCRIPTION
Changes how text scenes are scanned for groups. If the scene is not already loaded, it's loaded as text and parsed manually. It results in visible speedup especially in case of heavy scenes, though not sure if 100% reliable.

Scene group cache has been a source for various performance bugs. Even if they are fixed, the impact can still be noticeable. Which is why we discussed removing the cache completely as an alternative solution. It's not crucial for global groups and the benefits it brings are overshadowed by performance problems.

For now I went with this solution though.