### PR TITLE
Add remove root node method to `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -447,6 +447,12 @@
 				Reloads the scene at the given path.
 			</description>
 		</method>
+		<method name="remove_root_node">
+			<return type="void" />
+			<description>
+				Removes the scene's root node, leaving it empty and prompting to create a new one.
+			</description>
+		</method>
 		<method name="restart_editor">
 			<return type="void" />
 			<param index="0" name="save" type="bool" default="true" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -387,6 +387,11 @@ void EditorInterface::add_root_node(Node *p_node) {
 	EditorSceneTabs::get_singleton()->update_scene_tabs();
 }
 
+void EditorInterface::remove_root_node() {
+	EditorNode::get_singleton()->set_edited_scene(nullptr);
+	EditorSceneTabs::get_singleton()->update_scene_tabs();
+}
+
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
 	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
 }
@@ -913,6 +918,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 
 	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorInterface::add_root_node);
+	ClassDB::bind_method(D_METHOD("remove_root_node"), &EditorInterface::remove_root_node);
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -183,6 +183,7 @@ public:
 	Node *get_edited_scene_root() const;
 
 	void add_root_node(Node *p_node);
+	void remove_root_node();
 
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

~~Requires and includes: https://github.com/godotengine/godot/pull/109049~~

The opposite of `add_root_node()`

Allows you to create plugin buttons that work with undo/redo that do this:

https://github.com/godotengine/godot/assets/105675984/7b39e238-0e59-4b59-b9e7-4c7a9efadc10

