### PR TITLE
Windows: Restore to windowed mode using `SW_NORMAL`

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2008,7 +2008,7 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 	}
 
 	if (p_mode == WINDOW_MODE_WINDOWED) {
-		ShowWindow(wd.hWnd, SW_RESTORE);
+		ShowWindow(wd.hWnd, SW_NORMAL);
 		wd.maximized = false;
 		wd.minimized = false;
 	}


### PR DESCRIPTION
If window was maximized before minimizing, restoring the window afterwards using SW_RESTORE seems to cause the window to forget its original size and position before being maximized, causing the window to fill the screen instead.

Fixes #93488