### PR TITLE
[Windows] Disable G-SYNC in windowed mode

### DIFF
--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -78,7 +78,7 @@ private:
 	int glx_minor, glx_major;
 
 private:
-	void _nvapi_disable_threaded_optimization();
+	void _nvapi_setup_profile();
 	int _find_or_create_display(GLWindow &win);
 	Error _create_context(GLWindow &win, GLDisplay &gl_display);
 


### PR DESCRIPTION
In response to https://github.com/godotengine/godot/issues/93155

G-SYNC (NVIDIA's VRR) is known to be buggy on windowed mode in Windows. While the driver only enables G-SYNC for full screen mode by default, users can toggle it on for windowed mode too, resulting in unstable refresh rates during Editor usage.

This patch extends Godot's NVIDIA profile to force the default full screen mode only G-SYNC with Godot.


*Production edit:*
- This fixes https://github.com/godotengine/godot/issues/38219 on NVIDIA GPUs.
- May fix #93155