### PR TITLE
Use collapsed arrow for `OptionButton` and `EditorResourcePicker`

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -252,5 +252,8 @@
 		<theme_item name="arrow" data_type="icon" type="Texture2D">
 			The arrow icon to be drawn on the right end of the button.
 		</theme_item>
+		<theme_item name="arrow_up" data_type="icon" type="Texture2D">
+			The alternative icon used when the menu is opened.
+		</theme_item>
 	</theme_items>
 </class>

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -184,6 +184,9 @@ void EditorResourcePicker::_update_menu() {
 	Vector2 popup_pos = gt.get_end() - Vector2(ms, 0);
 	edit_menu->set_position(popup_pos);
 	edit_menu->popup();
+	if (has_theme_icon(SNAME("unselect_arrow"))) {
+		edit_button->set_icon(get_theme_icon(SNAME("unselect_arrow")));
+	}
 }
 
 void EditorResourcePicker::_update_menu_items() {
@@ -954,7 +957,12 @@ void EditorResourcePicker::_ensure_resource_menu() {
 	edit_menu->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	add_child(edit_menu);
 	edit_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk));
-	edit_menu->connect("popup_hide", callable_mp((BaseButton *)edit_button, &BaseButton::set_pressed).bind(false));
+	edit_menu->connect("popup_hide", callable_mp(this, &EditorResourcePicker::_popup_hide));
+}
+
+void EditorResourcePicker::_popup_hide() {
+	edit_button->set_icon(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
+	edit_button->set_pressed(false);
 }
 
 void EditorResourcePicker::_gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name) const {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -111,6 +111,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name = "") const;
 	void _duplicate_selected_resources();
 
+	void _popup_hide();
+
 protected:
 	virtual void _update_resource();
 

--- a/editor/icons/GuiDropdownUp.svg
+++ b/editor/icons/GuiDropdownUp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".6" stroke-width="2" d="m4 10 3-3 3 3"/></svg>

--- a/editor/icons/GuiOptionArrowUp.svg
+++ b/editor/icons/GuiOptionArrowUp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 8 4-4 4 4"/></svg>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -820,6 +820,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_color("icon_disabled_color", "OptionButton", p_config.icon_disabled_color);
 
 			p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow_up", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrowUp"), EditorStringName(EditorIcons)));
 			p_theme->set_constant("arrow_margin", "OptionButton", p_config.widget_margin.x - 2 * EDSCALE);
 			p_theme->set_constant("modulate_arrow", "OptionButton", true);
 			p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
@@ -2194,6 +2195,10 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
 			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
 		}
+
+		// EditorResourcePicker.
+		p_theme->set_icon("unselect_arrow", "EditorResourcePicker", p_theme->get_icon(SNAME("GuiDropdownUp"), EditorStringName(EditorIcons)));
+
 		Color si_base_color = p_config.accent_color;
 
 		// Sub-inspector background.

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -124,7 +124,11 @@ void OptionButton::_notification(int p_what) {
 			} else {
 				ofs = Point2(size.width - theme_cache.arrow_icon->get_width() - theme_cache.arrow_margin, int(Math::abs((size.height - theme_cache.arrow_icon->get_height()) / 2)));
 			}
-			theme_cache.arrow_icon->draw(ci, ofs, clr);
+			if (has_theme_icon(SNAME("arrow_up")) && popup->is_visible()) {
+				theme_cache.arrow_up->draw(ci, ofs, clr);
+			} else {
+				theme_cache.arrow_icon->draw(ci, ofs, clr);
+			}
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -565,6 +569,7 @@ void OptionButton::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, OptionButton, h_separation);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, OptionButton, arrow_icon, "arrow");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, OptionButton, arrow_up, "arrow_up");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, OptionButton, arrow_margin);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, OptionButton, modulate_arrow);
 

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -61,6 +61,7 @@ class OptionButton : public Button {
 		int h_separation = 0;
 
 		Ref<Texture2D> arrow_icon;
+		Ref<Texture2D> arrow_up;
 		int arrow_margin = 0;
 		int modulate_arrow = 0;
 	} theme_cache;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -249,6 +249,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("disabled_mirrored", "OptionButton", sb_optbutton_disabled_mirrored);
 
 	theme->set_icon("arrow", "OptionButton", icons["option_button_arrow"]);
+	theme->set_icon("arrow_up", "OptionButton", icons["option_button_arrow_up"]);
 
 	theme->set_font(SceneStringName(font), "OptionButton", Ref<Font>());
 	theme->set_font_size(SceneStringName(font_size), "OptionButton", -1);

--- a/scene/theme/icons/option_button_arrow_up.svg
+++ b/scene/theme/icons/option_button_arrow_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"><path fill="none" stroke="#b2b2b2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".85" stroke-width="2" d="m2 8 4-4 4 4"/></svg>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I made it so the `OptionButton` and `EditorResourcePicker` will use alternative icon when opened.

Closes https://github.com/godotengine/godot-proposals/issues/10073