### PR TITLE
Fix some TileMapLayer editing problems

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -763,9 +763,13 @@ bool TileMapLayerEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEven
 				}
 
 			} else {
-				// Released
-				_stop_dragging();
+				// Released.
 				drag_erasing = false;
+				if (drag_type == DRAG_TYPE_NONE) {
+					return false;
+				} else {
+					_stop_dragging();
+				}
 			}
 
 			CanvasItemEditor::get_singleton()->update_viewport();

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1889,7 +1889,7 @@ void TileMapLayer::_update_self_texture_repeat(RS::CanvasItemTextureRepeat p_tex
 
 #ifdef TOOLS_ENABLED
 bool TileMapLayer::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-	return get_cell_source_id(local_to_map(p_point)) != TileSet::INVALID_SOURCE;
+	return tile_set.is_valid() && get_cell_source_id(local_to_map(p_point)) != TileSet::INVALID_SOURCE;
 }
 #endif
 


### PR DESCRIPTION
Follow-up to #92016
- fixes error spam when TileMapLayer has no TileSet (regression)
- fixes the dragging bug mentioned in the previous PR