### PR TITLE
Change GUI controls pixel snap to round halfway towards positive infinity (`floor(x + 0.5)`)

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -696,7 +696,7 @@ void Control::_update_canvas_item_transform() {
 
 	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
 	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
-		xform[2] = xform[2].round();
+		xform[2] = (xform[2] + Vector2(0.5, 0.5)).floor();
 	}
 
 	RenderingServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);


### PR DESCRIPTION
This is the same thing as #93740 but for GUI controls, for consistency.