### PR TITLE
Overhaul CanvasItem's `draw` methods documentation

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -30,6 +30,7 @@
 			<param index="2" name="slice_end" type="float" />
 			<param index="3" name="offset" type="float" default="0.0" />
 			<description>
+				?? What
 				Subsequent drawing commands will be ignored unless they fall within the specified animation slice. This is a faster way to implement animations that loop on background rather than redrawing constantly.
 			</description>
 		</method>
@@ -44,6 +45,7 @@
 			<param index="6" name="width" type="float" default="-1.0" />
 			<param index="7" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws an unfilled arc between the given angles with a uniform [param color] and [param width] and optional antialiasing (supported only for positive [param width]). The larger the value of [param point_count], the smoother the curve. See also [method draw_circle].
 				If [param width] is negative, it will be ignored and the arc will be drawn using [constant RenderingServer.PRIMITIVE_LINE_STRIP]. This means that when the CanvasItem is scaled, the arc will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 				The arc is drawn from [param start_angle] towards the value of [param end_angle] so in clockwise direction if [code]start_angle &lt; end_angle[/code] and counter-clockwise otherwise. Passing the same angles but in reversed order will produce the same arc. If absolute difference of [param start_angle] and [param end_angle] is greater than [constant @GDScript.TAU] radians, then a full circle arc is drawn (i.e. arc will not overlap itself).
@@ -57,7 +59,9 @@
 			<param index="3" name="font_size" type="int" default="16" />
 			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws a string first character using a custom font.
+				?? Elaborated on in this PR, but too simple.
+				Draws a single character using the given [param font]. [param char] must be a [String] containing a single character.
+				The character will have its color multiplied by [param modulate].
 			</description>
 		</method>
 		<method name="draw_char_outline" qualifiers="const">
@@ -69,7 +73,9 @@
 			<param index="4" name="size" type="int" default="-1" />
 			<param index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws a string first character outline using a custom font.
+				?? Elaborated on in this PR, but too simple.
+				Draws a single character's outline using the given [param font]. [param char] must be a [String] containing a single character.
+				The character's outline will have its color multiplied by [param modulate].
 			</description>
 		</method>
 		<method name="draw_circle">
@@ -81,9 +87,10 @@
 			<param index="4" name="width" type="float" default="-1.0" />
 			<param index="5" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws a circle. See also [method draw_arc], [method draw_polyline], and [method draw_polygon].
-				If [param filled] is [code]true[/code], the circle will be filled with the [param color] specified. If [param filled] is [code]false[/code], the circle will be drawn as a stroke with the [param color] and [param width] specified.
-				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
+				If [param filled] is [code]true[/code], the circle is filled with the [param color] specified. If [param filled] is [code]false[/code], the circle is drawn as a stroke with the [param color] and [param width] specified.
+				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the [CanvasItem] is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 				If [param antialiased] is [code]true[/code], half transparent "feathers" will be attached to the boundary, making outlines smooth.
 				[b]Note:[/b] [param width] is only effective if [param filled] is [code]false[/code].
 			</description>
@@ -95,6 +102,7 @@
 			<param index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
 			<param index="3" name="texture" type="Texture2D" default="null" />
 			<description>
+				??
 				Draws a colored polygon of any number of points, convex or concave. Unlike [method draw_polygon], a single color must be specified for the whole polygon.
 				[b]Note:[/b] If you frequently redraw the same polygon with a large number of vertices, consider pre-calculating the triangulation with [method Geometry2D.triangulate_polygon] and using [method draw_mesh], [method draw_multimesh], or [method RenderingServer.canvas_item_add_triangle_array].
 			</description>
@@ -109,6 +117,7 @@
 			<param index="5" name="aligned" type="bool" default="true" />
 			<param index="6" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws a dashed line from a 2D point to another, with a given color and width. See also [method draw_line], [method draw_multiline], and [method draw_polyline].
 				If [param width] is negative, then a two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the line parts will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 				[param dash] is the length of each dash in pixels, with the gap between each dash being the same length. If [param aligned] is [code]true[/code], the length of the first and last dashes may be shortened or lengthened to allow the line to begin and end at the precise points defined by [param from] and [param to]. Both ends are always symmetrical when [param aligned] is [code]true[/code]. If [param aligned] is [code]false[/code], all dashes will have the same length, but the line may appear incomplete at the end due to the dash length not dividing evenly into the line length. Only full dashes are drawn when [param aligned] is [code]false[/code].
@@ -119,6 +128,7 @@
 		<method name="draw_end_animation">
 			<return type="void" />
 			<description>
+				?? What.
 				After submitting all animations slices via [method draw_animation_slice], this function can be used to revert drawing to its default state (all subsequent drawing commands will be visible). If you don't care about this particular use case, usage of this function after submitting the slices is not required.
 			</description>
 		</method>
@@ -129,8 +139,8 @@
 			<param index="2" name="src_rect" type="Rect2" />
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws a textured rectangle region of the font texture with LCD subpixel anti-aliasing at a given position, optionally modulated by a color.
-				Texture is drawn using the following blend operation, blend mode of the [CanvasItemMaterial] is ignored:
+				Draws a region of the [param texture] as defined by [param src_rect],  at a given [param rect] position, using LCD subpixel anti-aliasing, and optionally multiplied by the [param modulate] color.
+				The blend mode of the [CanvasItemMaterial] is ignored. Instead, the texture is drawn using the following blend operation:
 				[codeblock]
 				dst.r = texture.r * modulate.r * modulate.a + dst.r * (1.0 - texture.r * modulate.a);
 				dst.g = texture.g * modulate.g * modulate.a + dst.g * (1.0 - texture.g * modulate.a);
@@ -147,8 +157,11 @@
 			<param index="3" name="width" type="float" default="-1.0" />
 			<param index="4" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased. See also [method draw_dashed_line], [method draw_multiline], and [method draw_polyline].
+				??
+				Draws a line from a 2D point to another, with the given color and width.
 				If [param width] is negative, then a two-point primitive will be drawn instead of a four-point one. This means that when the CanvasItem is scaled, the line will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
+				If [param antialiased] is [code]true[/code], the line's edges are antialiased.
+				See also [method draw_dashed_line], [method draw_multiline], and [method draw_polyline].
 			</description>
 		</method>
 		<method name="draw_mesh">
@@ -158,7 +171,7 @@
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws a [Mesh] in 2D, using the provided texture. See [MeshInstance2D] for related documentation.
+				Draws a [Mesh] in 2D with the given [param texture],  optionally transformed by [param transform] and modulated by the [param modulate] color. See [MeshInstance2D] for related documentation.
 			</description>
 		</method>
 		<method name="draw_msdf_texture_rect_region">
@@ -171,9 +184,11 @@
 			<param index="5" name="pixel_range" type="float" default="4.0" />
 			<param index="6" name="scale" type="float" default="1.0" />
 			<description>
-				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by a color. See [member FontFile.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
+				??
+				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by the [param modulate] color.
 				If [param outline] is positive, each alpha channel value of pixel in region is set to maximum value of true distance in the [param outline] radius.
 				Value of the [param pixel_range] should the same that was used during distance field texture generation.
+				See [member FontFile.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
 			</description>
 		</method>
 		<method name="draw_multiline">
@@ -183,6 +198,7 @@
 			<param index="2" name="width" type="float" default="-1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws multiple disconnected lines with a uniform [param width] and [param color]. Each line is defined by two consecutive points from [param points] array, i.e. i-th segment consists of [code]points[2 * i][/code], [code]points[2 * i + 1][/code] endpoints. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline] instead.
 				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 				[b]Note:[/b] [param antialiased] is only effective if [param width] is greater than [code]0.0[/code].
@@ -195,6 +211,7 @@
 			<param index="2" name="width" type="float" default="-1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws multiple disconnected lines with a uniform [param width] and segment-by-segment coloring. Each segment is defined by two consecutive points from [param points] array and a corresponding color from [param colors] array, i.e. i-th segment consists of [code]points[2 * i][/code], [code]points[2 * i + 1][/code] endpoints and has [code]colors[i][/code] color. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline_colors] instead.
 				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 				[b]Note:[/b] [param antialiased] is only effective if [param width] is greater than [code]0.0[/code].
@@ -215,6 +232,7 @@
 			<param index="10" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="11" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
+				??
 				Breaks [param text] into lines and draws it using the specified [param font] at the [param pos] (top-left corner). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 			</description>
 		</method>
@@ -234,6 +252,7 @@
 			<param index="11" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="12" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
+				??
 				Breaks [param text] to the lines and draws text outline using the specified [param font] at the [param pos] (top-left corner). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 			</description>
 		</method>
@@ -242,7 +261,7 @@
 			<param index="0" name="multimesh" type="MultiMesh" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Draws a [MultiMesh] in 2D with the provided texture. See [MultiMeshInstance2D] for related documentation.
+				Draws a [MultiMesh] in 2D with the given [param texture]. See [MultiMeshInstance2D] for related documentation.
 			</description>
 		</method>
 		<method name="draw_polygon">
@@ -252,6 +271,7 @@
 			<param index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
 			<param index="3" name="texture" type="Texture2D" default="null" />
 			<description>
+				??
 				Draws a solid polygon of any number of points, convex or concave. Unlike [method draw_colored_polygon], each point's color can be changed individually. See also [method draw_polyline] and [method draw_polyline_colors]. If you need more flexibility (such as being able to use bones), use [method RenderingServer.canvas_item_add_triangle_array] instead.
 				[b]Note:[/b] If you frequently redraw the same polygon with a large number of vertices, consider pre-calculating the triangulation with [method Geometry2D.triangulate_polygon] and using [method draw_mesh], [method draw_multimesh], or [method RenderingServer.canvas_item_add_triangle_array].
 			</description>
@@ -263,6 +283,7 @@
 			<param index="2" name="width" type="float" default="-1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws interconnected line segments with a uniform [param color] and [param width] and optional antialiasing (supported only for positive [param width]). When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline] instead. See also [method draw_polygon].
 				If [param width] is negative, it will be ignored and the polyline will be drawn using [constant RenderingServer.PRIMITIVE_LINE_STRIP]. This means that when the CanvasItem is scaled, the polyline will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 			</description>
@@ -274,6 +295,7 @@
 			<param index="2" name="width" type="float" default="-1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
+				??
 				Draws interconnected line segments with a uniform [param width], point-by-point coloring, and optional antialiasing (supported only for positive [param width]). Colors assigned to line points match by index between [param points] and [param colors], i.e. each line segment is filled with a gradient between the colors of the endpoints. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline_colors] instead. See also [method draw_polygon].
 				If [param width] is negative, it will be ignored and the polyline will be drawn using [constant RenderingServer.PRIMITIVE_LINE_STRIP]. This means that when the CanvasItem is scaled, the polyline will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 			</description>
@@ -285,7 +307,11 @@
 			<param index="2" name="uvs" type="PackedVector2Array" />
 			<param index="3" name="texture" type="Texture2D" default="null" />
 			<description>
-				Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also [method draw_line], [method draw_polyline], [method draw_polygon], and [method draw_rect].
+				??
+				Draws a custom primitive with the given points. Fails if [param points] is empty or its size is greater than 4.
+				The primitive depends on how many points are given: 1 point for a single point, 2 points for a line, 3 points for a triangle, and 4 points for a quad.
+				Optionally, [param texture] can be provided to draw a texture according to the given [param uvs].
+				See also [method draw_line], [method draw_polyline], [method draw_polygon], and [method draw_rect].
 			</description>
 		</method>
 		<method name="draw_rect">
@@ -296,10 +322,12 @@
 			<param index="3" name="width" type="float" default="-1.0" />
 			<param index="4" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws a rectangle. If [param filled] is [code]true[/code], the rectangle will be filled with the [param color] specified. If [param filled] is [code]false[/code], the rectangle will be drawn as a stroke with the [param color] and [param width] specified. See also [method draw_texture_rect].
-				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
-				If [param antialiased] is [code]true[/code], half transparent "feathers" will be attached to the boundary, making outlines smooth.
-				[b]Note:[/b] [param width] is only effective if [param filled] is [code]false[/code].
+				??
+				Draws a rectangle with the given [param color]. See also [method draw_texture_rect].
+				If [param filled] is [code]true[/code], the rectangle will be filled with the [param color] specified. If [param filled] is [code]false[/code], the rectangle is drawn with a stroke with the [param color] and [param width] specified.
+				If [param width] is negative and [param filled] is [code]false[/code], two-point primitives are drawn instead of a four-point ones. This means that when the [CanvasItem] is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
+				If [param antialiased] is [code]true[/code], half-transparent "feathers" will be attached to the boundary, making outlines smooth.
+				[b]Note:[/b] Hollow rectangles drawn with a negative [param width] may not display perfectly. For example, corners may be missing or brighter due to overlapping lines (for a translucent [param color]).
 				[b]Note:[/b] Unfilled rectangles drawn with a negative [param width] may not display perfectly. For example, corners may be missing or brighter due to overlapping lines (for a translucent [param color]).
 			</description>
 		</method>
@@ -309,15 +337,15 @@
 			<param index="1" name="rotation" type="float" default="0.0" />
 			<param index="2" name="scale" type="Vector2" default="Vector2(1, 1)" />
 			<description>
-				Sets a custom transform for drawing via components. Anything drawn afterwards will be transformed by this.
-				[b]Note:[/b] [member FontFile.oversampling] does [i]not[/i] take [param scale] into account. This means that scaling up/down will cause bitmap fonts and rasterized (non-MSDF) dynamic fonts to appear blurry or pixelated. To ensure text remains crisp regardless of scale, you can enable MSDF font rendering by enabling [member ProjectSettings.gui/theme/default_font_multichannel_signed_distance_field] (applies to the default project font only), or enabling [b]Multichannel Signed Distance Field[/b] in the import options of a DynamicFont for custom fonts. On system fonts, [member SystemFont.multichannel_signed_distance_field] can be enabled in the inspector.
+				Sets a custom transform for drawing, using individual components. Anything drawn after calling this method will be translated by [param position], rotated by [param rotation], and scaled by [param scale]. See also [method draw_set_transform_matrix].
+				[b]Note:[/b] [member FontFile.oversampling] does [i]not[/i] take [param scale] into account. A non-default scale will cause bitmap fonts and rasterized (non-MSDF) dynamic fonts to appear blurry or pixelated. To ensure text remains crisp regardless of scale, you can enable MSDF font rendering by enabling [member ProjectSettings.gui/theme/default_font_multichannel_signed_distance_field] (applies to the default project font only), or enabling [member ResourceImporterDynamicFont.multichannel_signed_distance_field] in the import options of a DynamicFont for custom fonts. On system fonts, [member SystemFont.multichannel_signed_distance_field] can be enabled in the Inspector.
 			</description>
 		</method>
 		<method name="draw_set_transform_matrix">
 			<return type="void" />
 			<param index="0" name="xform" type="Transform2D" />
 			<description>
-				Sets a custom transform for drawing via matrix. Anything drawn afterwards will be transformed by this.
+				Sets a custom transform for drawing, using a [Transform2D]. Anything drawn after calling this method will be transformed by [param xform]. See also [method draw_set_transform_matrix].
 			</description>
 		</method>
 		<method name="draw_string" qualifiers="const">
@@ -333,27 +361,29 @@
 			<param index="8" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="9" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draws [param text] using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [param text] using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font).
+				If [param width] is greater than or equal to [code]0.0[/code], the text is clipped if it exceeds the specified width.
+				The text has its color multiplied by [param modulate].
 				[b]Example:[/b] Draw "Hello world", using the project's default font:
 				[codeblocks]
 				[gdscript]
-				# If using this method in a script that redraws constantly, move the
-				# `default_font` declaration to a member variable assigned in `_ready()`
-				# so the Control is only created once.
 				var default_font = ThemeDB.fallback_font
 				var default_font_size = ThemeDB.fallback_font_size
-				draw_string(default_font, Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, default_font_size)
+				draw_string(default_font, Vector2(64, 64),
+				        "Hello world", HORIZONTAL_ALIGNMENT_LEFT,
+				        -1, default_font_size
+				)
 				[/gdscript]
 				[csharp]
-				// If using this method in a script that redraws constantly, move the
-				// `default_font` declaration to a member variable assigned in `_Ready()`
-				// so the Control is only created once.
 				Font defaultFont = ThemeDB.FallbackFont;
 				int defaultFontSize = ThemeDB.FallbackFontSize;
-				DrawString(defaultFont, new Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, defaultFontSize);
+				DrawString(defaultFont, new Vector2(64, 64),
+				    "Hello world", HORIZONTAL_ALIGNMENT_LEFT,
+				    -1, defaultFontSize
+				);
 				[/csharp]
 				[/codeblocks]
-				See also [method Font.draw_string].
+				See also [method draw_string_outline] and [method Font.draw_string]. For more than one line, use [method draw_multiline_string].
 			</description>
 		</method>
 		<method name="draw_string_outline" qualifiers="const">
@@ -370,7 +400,10 @@
 			<param index="9" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="10" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draws [param text] outline using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [param text] outline using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font).
+				If [param width] is greater than or equal to [code]0.0[/code], the text is clipped if it exceeds the specified width.
+				The text has its color multiplied by [param modulate].
+				See also [method draw_string]. For more than one line, use [method draw_multiline_string_outline].
 			</description>
 		</method>
 		<method name="draw_style_box">
@@ -378,7 +411,7 @@
 			<param index="0" name="style_box" type="StyleBox" />
 			<param index="1" name="rect" type="Rect2" />
 			<description>
-				Draws a styled rectangle.
+				Draws arectangle with the given [param style_box]. See [StyleBox] for more information.
 			</description>
 		</method>
 		<method name="draw_texture">
@@ -387,7 +420,7 @@
 			<param index="1" name="position" type="Vector2" />
 			<param index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws a texture at a given position.
+				Draws [param texture] at a given [param position] relative to this item. The texture has its color multiplied by [param modulate].
 			</description>
 		</method>
 		<method name="draw_texture_rect">
@@ -398,7 +431,11 @@
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="transpose" type="bool" default="false" />
 			<description>
-				Draws a textured rectangle at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. See also [method draw_rect] and [method draw_texture_rect_region].
+				Draws a rectangle with the given [param texture].
+				?? If [param tile] is [code]true[/code] and [param rect] exceeds the texture's size, the texture is repeated to fill the rectangle.
+				The texture has its color multiplied by [param modulate].
+				If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped.
+				See also [method draw_rect] and [method draw_texture_rect_region].
 			</description>
 		</method>
 		<method name="draw_texture_rect_region">
@@ -410,7 +447,11 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. See also [method draw_texture_rect].
+				?? Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped.
+				Draws a rectangle with the given [param texture], using only the texture region specified by [param src_rect].
+				The texture has its color multiplied by [param modulate].
+				If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped.
+				See also [method draw_texture_rect].
 			</description>
 		</method>
 		<method name="force_update_transform">


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/93735, https://github.com/godotengine/godot/pull/89256, https://github.com/godotengine/godot/pull/87440 and many others.

Draft because it's not enough.

This PR aims to overhaul **CanvasItem**'s class reference in an attempt to be more... comprehensible and easy to understand. Reasons are the same as prior PRs so I'm not sure I should explain myself too much here.