### PR TITLE
SCons: Fix output with `vsproj=yes`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1040,9 +1040,9 @@ SConscript("platform/" + env["platform"] + "/SCsub")  # Build selected platform.
 
 # Microsoft Visual Studio Project Generation
 if env["vsproj"]:
+    methods.generate_cpp_hint_file("cpp.hint")
     env["CPPPATH"] = [Dir(path) for path in env["CPPPATH"]]
     methods.generate_vs_project(env, ARGUMENTS, env["vsproj_name"])
-    methods.generate_cpp_hint_file("cpp.hint")
 
 # Check for the existence of headers
 conf = Configure(env)

--- a/methods.py
+++ b/methods.py
@@ -676,6 +676,17 @@ def generate_cpp_hint_file(filename):
         try:
             with open(filename, "w", encoding="utf-8", newline="\n") as fd:
                 fd.write("#define GDCLASS(m_class, m_inherits)\n")
+                for name in ["GDVIRTUAL", "EXBIND", "MODBIND"]:
+                    for count in range(13):
+                        for suffix in ["", "R", "C", "RC"]:
+                            fd.write(f"#define {name}{count}{suffix}(")
+                            if "R" in suffix:
+                                fd.write("m_ret, ")
+                            fd.write("m_name")
+                            for idx in range(1, count + 1):
+                                fd.write(f", type{idx}")
+                            fd.write(")\n")
+
         except OSError:
             print_warning("Could not write cpp.hint file.")
 
@@ -1034,7 +1045,7 @@ def dump(env):
 # skip the build process. This lets project files be quickly generated even if there are build errors.
 #
 # To generate AND build from the command line:
-#   scons vsproj=yes vsproj_gen_only=yes
+#   scons vsproj=yes vsproj_gen_only=no
 def generate_vs_project(env, original_args, project_name="godot"):
     # Augmented glob_recursive that also fills the dirs argument with traversed directories that have content.
     def glob_recursive_2(pattern, dirs, node="."):
@@ -1502,7 +1513,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
         proj_template = proj_template.replace("%%DEFAULT_ITEMS%%", "\n    ".join(all_items))
         proj_template = proj_template.replace("%%PROPERTIES%%", "\n  ".join(properties))
 
-        with open(f"{project_name}.vcxproj", "w", encoding="utf-8", newline="\n") as f:
+        with open(f"{project_name}.vcxproj", "w", encoding="utf-8", newline="\r\n") as f:
             f.write(proj_template)
 
     if not get_bool(original_args, "vsproj_props_only", False):

--- a/misc/msvs/vcxproj.filters.template
+++ b/misc/msvs/vcxproj.filters.template
@@ -7,11 +7,8 @@
     <Filter Include="Header Files">
       <UniqueIdentifier>%%UUID2%%</UniqueIdentifier>
     </Filter>
-    <Filter Include="Resource Files">
+    <Filter Include="Other Files">
       <UniqueIdentifier>%%UUID3%%</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Scripts">
-      <UniqueIdentifier>%%UUID4%%</UniqueIdentifier>
     </Filter>
     %%FILTERS%%
   </ItemGroup>


### PR DESCRIPTION
A handful of tweaks/fixes all related to passing `vsproj=yes` to SCons:
- Ensure `*.vcsproj.filters` has a designated section for "Other Files". On live, the files designated to it (`.glsl`, `.natvis`) wouldn't appear at all[^1].
- Ensure `*.sln` is written with `CRLF` line-endings.
- Fix comment giving the wrong input for generating & building from cl.
- Expand `cpp.hint` defines to include `GDVIRTUAL`, `EXBIND`, and `MODBIND`.
- Generate `cpp.hint` before vsproj; previously wouldn't get built at all unless `vsproj_gen_only=no`.

[^1]: https://chat.godotengine.org/channel/buildsystem?msg=krbx6pCcdAFBczb9T