### PR TITLE
Change RTL snap from transform to control

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1248,7 +1248,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						}
 					}
 
-					if (is_inside_tree() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
+					if (is_inside_tree() && get_viewport()->is_snap_controls_to_pixels_enabled()) {
 						fx_offset = (fx_offset + Point2(0.5, 0.5)).floor();
 					}
 


### PR DESCRIPTION
For the longest time `RichTextLabel` has had character FX offset snap behind `rendering/2d/snap/snap_2d_transforms_to_pixel` but that seems like it should be behind `gui/common/snap_controls_to_pixels`.

This changes it to the correct setting. @bruvzg if you know something I don't, please weigh in. Thanks!