### PR TITLE
Fix division by zero in aspect ratio calculation

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1786,7 +1786,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			bool symmetric = m->is_alt_pressed();
 
 			Rect2 local_rect = ci->_edit_get_rect();
-			real_t aspect = local_rect.get_size().y / local_rect.get_size().x;
+			real_t aspect = local_rect.has_area() ? (local_rect.get_size().y / local_rect.get_size().x) : (local_rect.get_size().y + 1.0) / (local_rect.get_size().x + 1.0);
 			Point2 current_begin = local_rect.get_position();
 			Point2 current_end = local_rect.get_position() + local_rect.get_size();
 			Point2 max_begin = (symmetric) ? (current_begin + current_end - ci->_edit_get_minimum_size()) / 2.0 : current_end - ci->_edit_get_minimum_size();


### PR DESCRIPTION
# Info

Fixes #93738

A simple approach that protects against division by zero. When `local_rect.has_area()` returns `false`, i.e. width or height (or both) is zero, the aspect ratio calculation is performed on values incremented by 1.

In other cases, division is performed on the original values because (example):

- 50.0 / 100.0 = 0.5
- (50.0 + 1.0) / (100.0 + 1.0) = 0,504950495049505

## Notes

By the way, it appears that the object resizing algorithm does not update the current dimensions for aspect ratio calculation when the `shift` key is pressed. This results in the shape not being adjusted to the current dimensions but to the original ones from the start of the dragging.