### PR TITLE
Fix reimport by scan parsing dependency paths incorrectly

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -724,8 +724,9 @@ bool EditorFileSystem::_update_scan_actions() {
 					//must reimport
 					reimports.push_back(full_path);
 					Vector<String> dependencies = _get_dependencies(full_path);
-					for (const String &dependency_path : dependencies) {
-						if (import_extensions.has(dependency_path.get_extension())) {
+					for (const String &dep : dependencies) {
+						const String &dependency_path = dep.contains("::") ? dep.get_slice("::", 0) : dep;
+						if (import_extensions.has(dep.get_extension())) {
 							reimports.push_back(dependency_path);
 						}
 					}
@@ -1748,7 +1749,8 @@ String EditorFileSystem::_get_global_script_class(const String &p_type, const St
 void EditorFileSystem::_update_file_icon_path(EditorFileSystemDirectory::FileInfo *file_info) {
 	String icon_path;
 	if (file_info->script_class_icon_path.is_empty() && !file_info->deps.is_empty()) {
-		const String &script_path = file_info->deps[0]; // Assuming the first dependency is a script.
+		const String &script_dep = file_info->deps[0]; // Assuming the first dependency is a script.
+		const String &script_path = script_dep.contains("::") ? script_dep.get_slice("::", 2) : script_dep;
 		if (!script_path.is_empty()) {
 			String *cached = file_icon_cache.getptr(script_path);
 			if (cached) {


### PR DESCRIPTION
Fix #92250
maybe other reimport related issues?

Resource loader's `get_dependencies` returns a string in the format `uid::type::path` (or path::type, or path only), but this code was not taking it into account.

Invalid strings were being passed into the `reimport_files` function. Since that function supports uids, they are now passed when possible.

The `_update_file_icon_path` function had no symptoms because of missing script uids, but would break when they are added.