### PR TITLE
Fix "icon" parameter in EditorPlugin.add_custom_type is not optional but doc says it is

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -444,7 +444,7 @@
 			<param index="2" name="script" type="Script" />
 			<param index="3" name="icon" type="Texture2D" />
 			<description>
-				Adds a custom type, which will appear in the list of nodes or resources. An icon can be optionally passed.
+				Adds a custom type, which will appear in the list of nodes or resources.
 				When a given node or resource is selected, the base type will be instantiated (e.g. "Node3D", "Control", "Resource"), then the script will be loaded and set to this object.
 				[b]Note:[/b] The base type is the base engine class which this type's class hierarchy inherits, not any custom type parent classes.
 				You can use the virtual method [method _handles] to check if your custom object is being edited by checking the script or using the [code]is[/code] keyword.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

fixed an error in doc/classes/EditorPlugin.xml: "icon" parameter in EditorPlugin.add_custom_type is not optional, but documentation says it is.
Removed the line "An icon can be optionally passed." and added this "An editor error is generated when this function is called without the icon parameter."
