### PR TITLE
[C#] Fix `get_property_list` get wrong order of properties

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1515,9 +1515,10 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 		}
 	}
 
+	props.reverse();
 	for (PropertyInfo &prop : props) {
 		validate_property(prop);
-		p_properties->push_back(prop);
+		p_properties->push_front(prop);
 	}
 }
 


### PR DESCRIPTION
Fixes #70146 
`CSharpInstance` add the properties to the properties list in a wrong order.
