### PR TITLE
[CI] Run unit tests on desktop release templates

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -74,16 +74,18 @@ jobs:
           - name: Template w/ Mono (target=template_release)
             cache-name: linux-template-mono
             target: template_release
-            sconsflags: module_mono_enabled=yes
+            sconsflags: module_mono_enabled=yes tests=yes
+            bin: "./bin/godot.linuxbsd.template_release.x86_64.mono"
             build-mono: false
-            tests: false
+            tests: true
             artifact: true
 
           - name: Minimal template (target=template_release, everything disabled)
             cache-name: linux-template-minimal
             target: template_release
-            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no
-            tests: false
+            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no tests=yes
+            bin: "./bin/godot.linuxbsd.template_release.x86_64"
+            tests: true
             artifact: true
 
     steps:
@@ -174,7 +176,6 @@ jobs:
         with:
           bin: ${{ matrix.bin }}
 
-      # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -29,8 +29,9 @@ jobs:
           - name: Template (target=template_release)
             cache-name: macos-template
             target: template_release
-            tests: false
-            sconsflags: debug_symbols=no
+            tests: true
+            sconsflags: debug_symbols=no tests=yes
+            bin: "./bin/godot.macos.template_release.universal"
 
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +85,6 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}
 
-      # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -34,8 +34,9 @@ jobs:
           - name: Template (target=template_release)
             cache-name: windows-template
             target: template_release
-            tests: false
-            sconsflags: debug_symbols=no
+            tests: true
+            sconsflags: debug_symbols=no tests=yes
+            bin: "./bin/godot.windows.template_release.x86_64.console.exe"
 
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +92,6 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}
 
-      # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2589,7 +2589,10 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_secret_character", "character"), &LineEdit::set_secret_character);
 	ClassDB::bind_method(D_METHOD("get_secret_character"), &LineEdit::get_secret_character);
 	ClassDB::bind_method(D_METHOD("menu_option", "option"), &LineEdit::menu_option);
+	// TODO: Properly handle popups when advanced GUI is disabled.
+#ifndef ADVANCED_GUI_DISABLED
 	ClassDB::bind_method(D_METHOD("get_menu"), &LineEdit::get_menu);
+#endif // ADVANCED_GUI_DISABLED
 	ClassDB::bind_method(D_METHOD("is_menu_visible"), &LineEdit::is_menu_visible);
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &LineEdit::set_context_menu_enabled);
 	ClassDB::bind_method(D_METHOD("is_context_menu_enabled"), &LineEdit::is_context_menu_enabled);

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -679,7 +679,10 @@ void MenuBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_menu_hidden", "menu", "hidden"), &MenuBar::set_menu_hidden);
 	ClassDB::bind_method(D_METHOD("is_menu_hidden", "menu"), &MenuBar::is_menu_hidden);
 
+	// TODO: Properly handle popups when advanced GUI is disabled.
+#ifndef ADVANCED_GUI_DISABLED
 	ClassDB::bind_method(D_METHOD("get_menu_popup", "menu"), &MenuBar::get_menu_popup);
+#endif // ADVANCED_GUI_DISABLED
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "start_index"), "set_start_index", "get_start_index");

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -173,7 +173,10 @@ bool MenuButton::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void MenuButton::_bind_methods() {
+	// TODO: Properly handle popups when advanced GUI is disabled.
+#ifndef ADVANCED_GUI_DISABLED
 	ClassDB::bind_method(D_METHOD("get_popup"), &MenuButton::get_popup);
+#endif // ADVANCED_GUI_DISABLED
 	ClassDB::bind_method(D_METHOD("show_popup"), &MenuButton::show_popup);
 	ClassDB::bind_method(D_METHOD("set_switch_on_hover", "enable"), &MenuButton::set_switch_on_hover);
 	ClassDB::bind_method(D_METHOD("is_switch_on_hover"), &MenuButton::is_switch_on_hover);

--- a/tests/core/io/test_http_client.h
+++ b/tests/core/io/test_http_client.h
@@ -35,6 +35,8 @@
 
 #include "tests/test_macros.h"
 
+#include "modules/modules_enabled.gen.h"
+
 namespace TestHTTPClient {
 
 TEST_CASE("[HTTPClient] Instantiation") {
@@ -90,6 +92,7 @@ TEST_CASE("[HTTPClient] verify_headers") {
 	ERR_PRINT_ON;
 }
 
+#if defined(MODULE_MBEDTLS_ENABLED) || defined(WEB_ENABLED)
 TEST_CASE("[HTTPClient] connect_to_host") {
 	Ref<HTTPClient> client = HTTPClient::create();
 	String host = "https://www.example.com";
@@ -100,6 +103,7 @@ TEST_CASE("[HTTPClient] connect_to_host") {
 	Error err = client->connect_to_host(host, port, tls_options);
 	CHECK_MESSAGE(err == OK, "Expected OK for successful connection");
 }
+#endif // MODULE_MBEDTLS_ENABLED || WEB_ENABLED
 
 } // namespace TestHTTPClient
 

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -37,6 +37,8 @@
 #include "tests/test_utils.h"
 #include "thirdparty/doctest/doctest.h"
 
+#include "modules/modules_enabled.gen.h"
+
 namespace TestImage {
 
 TEST_CASE("[Image] Instantiation") {
@@ -107,6 +109,7 @@ TEST_CASE("[Image] Saving and loading") {
 			image->get_data() == image_load->get_data(),
 			"The loaded image should have the same data as the one that got saved.");
 
+#ifdef MODULE_BMP_ENABLED
 	// Load BMP
 	Ref<Image> image_bmp = memnew(Image());
 	Ref<FileAccess> f_bmp = FileAccess::open(TestUtils::get_data_path("images/icon.bmp"), FileAccess::READ, &err);
@@ -117,7 +120,9 @@ TEST_CASE("[Image] Saving and loading") {
 	CHECK_MESSAGE(
 			image_bmp->load_bmp_from_buffer(data_bmp) == OK,
 			"The BMP image should load successfully.");
+#endif // MODULE_BMP_ENABLED
 
+#ifdef MODULE_JPG_ENABLED
 	// Load JPG
 	Ref<Image> image_jpg = memnew(Image());
 	Ref<FileAccess> f_jpg = FileAccess::open(TestUtils::get_data_path("images/icon.jpg"), FileAccess::READ, &err);
@@ -128,7 +133,9 @@ TEST_CASE("[Image] Saving and loading") {
 	CHECK_MESSAGE(
 			image_jpg->load_jpg_from_buffer(data_jpg) == OK,
 			"The JPG image should load successfully.");
+#endif // MODULE_JPG_ENABLED
 
+#ifdef MODULE_WEBP_ENABLED
 	// Load WebP
 	Ref<Image> image_webp = memnew(Image());
 	Ref<FileAccess> f_webp = FileAccess::open(TestUtils::get_data_path("images/icon.webp"), FileAccess::READ, &err);
@@ -139,6 +146,7 @@ TEST_CASE("[Image] Saving and loading") {
 	CHECK_MESSAGE(
 			image_webp->load_webp_from_buffer(data_webp) == OK,
 			"The WebP image should load successfully.");
+#endif // MODULE_WEBP_ENABLED
 
 	// Load PNG
 	Ref<Image> image_png = memnew(Image());
@@ -151,6 +159,7 @@ TEST_CASE("[Image] Saving and loading") {
 			image_png->load_png_from_buffer(data_png) == OK,
 			"The PNG image should load successfully.");
 
+#ifdef MODULE_TGA_ENABLED
 	// Load TGA
 	Ref<Image> image_tga = memnew(Image());
 	Ref<FileAccess> f_tga = FileAccess::open(TestUtils::get_data_path("images/icon.tga"), FileAccess::READ, &err);
@@ -161,6 +170,7 @@ TEST_CASE("[Image] Saving and loading") {
 	CHECK_MESSAGE(
 			image_tga->load_tga_from_buffer(data_tga) == OK,
 			"The TGA image should load successfully.");
+#endif // MODULE_TGA_ENABLED
 }
 
 TEST_CASE("[Image] Basic getters") {

--- a/tests/scene/test_graph_node.h
+++ b/tests/scene/test_graph_node.h
@@ -42,7 +42,7 @@ TEST_CASE("[GraphNode][SceneTree]") {
 	SUBCASE("[GraphNode] Graph Node only child on delete should not cause error.") {
 		// Setup.
 		GraphNode *test_node = memnew(GraphNode);
-		test_child->set_name("Graph Node");
+		test_node->set_name("Graph Node");
 		Control *test_child = memnew(Control);
 		test_child->set_name("child");
 		test_node->add_child(test_child);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -30,6 +30,8 @@
 
 #include "test_main.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #ifdef TOOLS_ENABLED
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -103,8 +105,6 @@
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"
 #include "tests/scene/test_camera_2d.h"
-#include "tests/scene/test_code_edit.h"
-#include "tests/scene/test_color_picker.h"
 #include "tests/scene/test_control.h"
 #include "tests/scene/test_curve.h"
 #include "tests/scene/test_curve_2d.h"
@@ -118,7 +118,6 @@
 #include "tests/scene/test_packed_scene.h"
 #include "tests/scene/test_path_2d.h"
 #include "tests/scene/test_sprite_frames.h"
-#include "tests/scene/test_text_edit.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"
 #include "tests/scene/test_viewport.h"
@@ -128,19 +127,29 @@
 #include "tests/servers/test_text_server.h"
 #include "tests/test_validate_testing.h"
 
+#ifndef ADVANCED_GUI_DISABLED
+#include "tests/scene/test_code_edit.h"
+#include "tests/scene/test_color_picker.h"
+#include "tests/scene/test_graph_node.h"
+#include "tests/scene/test_text_edit.h"
+#endif // ADVANCED_GUI_DISABLED
+
 #ifndef _3D_DISABLED
-#include "tests/scene/test_arraymesh.h"
-#include "tests/scene/test_camera_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "tests/scene/test_navigation_agent_2d.h"
 #include "tests/scene/test_navigation_agent_3d.h"
 #include "tests/scene/test_navigation_obstacle_2d.h"
 #include "tests/scene/test_navigation_obstacle_3d.h"
 #include "tests/scene/test_navigation_region_2d.h"
 #include "tests/scene/test_navigation_region_3d.h"
-#include "tests/scene/test_path_3d.h"
-#include "tests/scene/test_primitives.h"
 #include "tests/servers/test_navigation_server_2d.h"
 #include "tests/servers/test_navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
+
+#include "tests/scene/test_arraymesh.h"
+#include "tests/scene/test_camera_3d.h"
+#include "tests/scene/test_path_3d.h"
+#include "tests/scene/test_primitives.h"
 #endif // _3D_DISABLED
 
 #include "modules/modules_tests.gen.h"


### PR DESCRIPTION
The resulting artifacts are a bit larger, but I'd argue it's worth the cost to help identifying various issues in release templates and tests, I'd really prefer having a debug template build as well to run unit tests on but I think that's a bit excessive

The fixes for the minimal UI build are largely band-aids, I've not attempted to fix or really test the viability of the `disable_advanced_gui` mode beyond making it run correctly in tests, though I might try work some on that later, but it's outside of what my general use cases personally are

~The second commit shouldn't be controversial but kept it separate just in case, both of them entirely depend on `PopupMenu` so it doesn't really make sense to have them exposed in this case~

I haven't tested other combinations of build options to identify possible edge cases, but this makes the minimal release (and debug) templates test fully

Can reduce the scope and just run/compile tests on the Linux builds, if desired, haven't run into any platform specific issues in the tests when running this, but I think it's worth the few megabytes to catch any weird platform specific issues that might crop up
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
