### PR TITLE
Improve `JSON::stringify` performance

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -47,42 +47,47 @@ const char *JSON::tk_name[TK_MAX] = {
 	"EOF",
 };
 
-String JSON::_make_indent(const String &p_indent, int p_size) {
-	return p_indent.repeat(p_size);
+void JSON::_add_indent(String &r_result, const String &p_indent, int p_size) {
+	for (int i = 0; i < p_size; i++) {
+		r_result += p_indent;
+	}
 }
 
-String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision) {
-	ERR_FAIL_COND_V_MSG(p_cur_indent > Variant::MAX_RECURSION_DEPTH, "...", "JSON structure is too deep. Bailing.");
-
-	String colon = ":";
-	String end_statement = "";
-
-	if (!p_indent.is_empty()) {
-		colon += " ";
-		end_statement += "\n";
+void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision) {
+	if (p_cur_indent > Variant::MAX_RECURSION_DEPTH) {
+		r_result += "...";
+		ERR_FAIL_MSG("JSON structure is too deep. Bailing.");
 	}
+
+	const char *colon = p_indent.is_empty() ? ":" : ": ";
+	const char *end_statement = p_indent.is_empty() ? "" : "\n";
 
 	switch (p_var.get_type()) {
 		case Variant::NIL:
-			return "null";
+			r_result += "null";
+			return;
 		case Variant::BOOL:
-			return p_var.operator bool() ? "true" : "false";
+			r_result += p_var.operator bool() ? "true" : "false";
+			return;
 		case Variant::INT:
-			return itos(p_var);
+			r_result += itos(p_var);
+			return;
 		case Variant::FLOAT: {
 			double num = p_var;
 
 			// Only for exactly 0. If we have approximately 0 let the user decide how much
 			// precision they want.
 			if (num == double(0)) {
-				return String("0.0");
+				r_result += "0.0";
+				return;
 			}
 
 			double magnitude = std::log10(Math::abs(num));
 			int total_digits = p_full_precision ? 17 : 14;
 			int precision = MAX(1, total_digits - (int)Math::floor(magnitude));
 
-			return String::num(num, precision);
+			r_result += String::num(num, precision);
+			return;
 		}
 		case Variant::PACKED_INT32_ARRAY:
 		case Variant::PACKED_INT64_ARRAY:
@@ -91,13 +96,19 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 		case Variant::PACKED_STRING_ARRAY:
 		case Variant::ARRAY: {
 			Array a = p_var;
-			if (a.is_empty()) {
-				return "[]";
+			if (p_markers.has(a.id())) {
+				r_result += "\"[...]\"";
+				ERR_FAIL_MSG("Converting circular structure to JSON.");
 			}
-			String s = "[";
-			s += end_statement;
 
-			ERR_FAIL_COND_V_MSG(p_markers.has(a.id()), "\"[...]\"", "Converting circular structure to JSON.");
+			if (a.is_empty()) {
+				r_result += "[]";
+				return;
+			}
+
+			r_result += '[';
+			r_result += end_statement;
+
 			p_markers.insert(a.id());
 
 			bool first = true;
@@ -105,21 +116,27 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 				if (first) {
 					first = false;
 				} else {
-					s += ",";
-					s += end_statement;
+					r_result += ',';
+					r_result += end_statement;
 				}
-				s += _make_indent(p_indent, p_cur_indent + 1) + _stringify(var, p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				_add_indent(r_result, p_indent, p_cur_indent + 1);
+				_stringify(r_result, var, p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
 			}
-			s += end_statement + _make_indent(p_indent, p_cur_indent) + "]";
+			r_result += end_statement;
+			_add_indent(r_result, p_indent, p_cur_indent);
+			r_result += ']';
 			p_markers.erase(a.id());
-			return s;
+			return;
 		}
 		case Variant::DICTIONARY: {
-			String s = "{";
-			s += end_statement;
 			Dictionary d = p_var;
+			if (p_markers.has(d.id())) {
+				r_result += "\"{...}\"";
+				ERR_FAIL_MSG("Converting circular structure to JSON.");
+			}
 
-			ERR_FAIL_COND_V_MSG(p_markers.has(d.id()), "\"{...}\"", "Converting circular structure to JSON.");
+			r_result += '{';
+			r_result += end_statement;
 			p_markers.insert(d.id());
 
 			LocalVector<Variant> keys = d.get_key_list();
@@ -129,24 +146,30 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 			}
 
 			bool first_key = true;
-			for (const Variant &E : keys) {
+			for (const Variant &key : keys) {
 				if (first_key) {
 					first_key = false;
 				} else {
-					s += ",";
-					s += end_statement;
+					r_result += ',';
+					r_result += end_statement;
 				}
-				s += _make_indent(p_indent, p_cur_indent + 1) + _stringify(String(E), p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
-				s += colon;
-				s += _stringify(d[E], p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				_add_indent(r_result, p_indent, p_cur_indent + 1);
+				_stringify(r_result, String(key), p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				r_result += colon;
+				_stringify(r_result, d[key], p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
 			}
 
-			s += end_statement + _make_indent(p_indent, p_cur_indent) + "}";
+			r_result += end_statement;
+			_add_indent(r_result, p_indent, p_cur_indent);
+			r_result += '}';
 			p_markers.erase(d.id());
-			return s;
+			return;
 		}
 		default:
-			return "\"" + String(p_var).json_escape() + "\"";
+			r_result += '"';
+			r_result += String(p_var).json_escape();
+			r_result += '"';
+			return;
 	}
 }
 
@@ -568,10 +591,10 @@ String JSON::get_parsed_text() const {
 }
 
 String JSON::stringify(const Variant &p_var, const String &p_indent, bool p_sort_keys, bool p_full_precision) {
-	Ref<JSON> json;
-	json.instantiate();
+	String result;
 	HashSet<const void *> markers;
-	return json->_stringify(p_var, p_indent, 0, p_sort_keys, markers, p_full_precision);
+	_stringify(result, p_var, p_indent, 0, p_sort_keys, markers, p_full_precision);
+	return result;
 }
 
 Variant JSON::parse_string(const String &p_json_string) {

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -71,8 +71,8 @@ class JSON : public Resource {
 
 	static const char *tk_name[];
 
-	static String _make_indent(const String &p_indent, int p_size);
-	static String _stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision = false);
+	static void _add_indent(String &r_result, const String &p_indent, int p_size);
+	static void _stringify(String &r_result, const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision = false);
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);
 	static Error _parse_array(Array &array, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);


### PR DESCRIPTION
- Changed `stringify` to call static function `_stringify` directly, instead of creating JSON object
- Changed `colon` and `end_statement` from `String` to `const char *` to avoid extra allocations in each `_stringify` call
- Pass result `String` reference to each `_stringify` call to append to instead of allocating new `String` in each call

These changes make `JSON::stringify` around 2-3x faster in most cases

Compared with gdscript below:
```
func _ready() -> void:
	var d : Dictionary = {
		"int": 4,
		"float": 1.23,
		"string": "test",
		"array": [1,2,3,4,5],
		"bool": true,
		"null": null
	}
	var ia = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30]
	var sa = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"]
	var s = "test"
	var f = 1.2345
	var i = 100
	var b = true
	var n = null
	
	run_test(d, "Dictionary (indent)", "\t")
	run_test(d, "Dictionary (no indent)")
	run_test(ia, "int Array (indent)", "\t")
	run_test(ia, "int Array (no indent)")
	run_test(sa, "String Array (indent)", "\t")
	run_test(sa, "String Array (no indent)")
	run_test(s, "String")
	run_test(f, "float")
	run_test(i, "int")
	run_test(b, "bool")
	run_test(n, "null")
	
func run_test(obj, obj_name : String, indent : String = ""):
	var start_ms = Time.get_ticks_msec()
	for i in 1000000:
		JSON.stringify(obj, indent)
	var end_ms = Time.get_ticks_msec()
	print("%s %dms" % [obj_name, end_ms - start_ms])
```

old
```
Dictionary (indent) 16457ms
Dictionary (no indent) 11121ms
int Array (indent) 17641ms
int Array (no indent) 7691ms
String Array (indent) 11741ms
String Array (no indent) 8103ms
String 1068ms
float 1000ms
int 575ms
bool 568ms
null 560ms
```

new
```
Dictionary (indent) 6185ms
Dictionary (no indent) 5786ms
int Array (indent) 4920ms
int Array (no indent) 4275ms
String Array (indent) 3760ms
String Array (no indent) 3544ms
String 508ms
float 643ms
int 233ms
bool 213ms
null 204ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
