### PR TITLE
Fix Bezier track init value on caching without RESET animation

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -691,7 +691,9 @@ bool AnimationMixer::_update_caches() {
 
 						track = track_value;
 
-						track_value->init_value = anim->track_get_key_value(i, 0);
+						bool is_value = track_src_type == Animation::TYPE_VALUE;
+
+						track_value->init_value = is_value ? anim->track_get_key_value(i, 0) : (anim->track_get_key_value(i, 0).operator Array())[0];
 						track_value->init_value.zero();
 
 						track_value->is_init = false;
@@ -703,7 +705,7 @@ bool AnimationMixer::_update_caches() {
 						if (has_reset_anim) {
 							int rt = reset_anim->find_track(path, track_src_type);
 							if (rt >= 0) {
-								if (track_src_type == Animation::TYPE_VALUE) {
+								if (is_value) {
 									if (reset_anim->track_get_key_count(rt) > 0) {
 										track_value->init_value = reset_anim->track_get_key_value(rt, 0);
 									}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93782

Bezier track has a different key value format than the Value track, so init value generation was failing without a RESET animation.