### PR TITLE
GDScript: Allow overriding default values of base class variables

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -691,6 +691,11 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@override">
+			<return type="void" />
+			<description>
+			</description>
+		</annotation>
 		<annotation name="@rpc">
 			<return type="void" />
 			<param index="0" name="mode" type="String" default="&quot;authority&quot;" />

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -33,6 +33,7 @@
 #include "../gdscript.h"
 
 #include "core/config/project_settings.h"
+#include "editor/editor_help.h"
 
 HashMap<String, String> GDScriptDocGen::singletons;
 
@@ -435,7 +436,28 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					prop_doc.default_value = _docvalue_from_expression(m_var->initializer);
 				}
 
-				prop_doc.overridden = false;
+				if (m_var->is_override) {
+					prop_doc.overridden = true;
+
+					const DocTools *dd = EditorHelp::get_doc_data();
+					if (dd) {
+						HashMap<String, DocData::ClassDoc>::ConstIterator E = dd->class_list.find(doc.inherits);
+						while (E && !E->value.name.is_empty()) {
+							bool found = false;
+							for (const DocData::PropertyDoc &property : E->value.properties) {
+								if (property.name == var_name) {
+									prop_doc.overrides = E->value.name;
+									found = true;
+									break;
+								}
+							}
+							if (found) {
+								break;
+							}
+							E = dd->class_list.find(E->value.inherits);
+						}
+					}
+				}
 
 				doc.properties.push_back(prop_doc);
 			} break;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -199,90 +199,143 @@ static GDScriptParser::DataType make_builtin_meta_type(Variant::Type p_type) {
 	return type;
 }
 
-bool GDScriptAnalyzer::has_member_name_conflict_in_script_class(const StringName &p_member_name, const GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_member) {
-	if (p_class->members_indices.has(p_member_name)) {
-		int index = p_class->members_indices[p_member_name];
-		const GDScriptParser::ClassNode::Member *member = &p_class->members[index];
+GDScriptAnalyzer::MemberConflict GDScriptAnalyzer::_check_member_conflict_gdscript(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type) {
+	if (p_class->has_member(p_member_name)) {
+		const GDScriptParser::ClassNode::Member found_member = p_class->get_member(p_member_name);
 
-		if (member->type == GDScriptParser::ClassNode::Member::VARIABLE ||
-				member->type == GDScriptParser::ClassNode::Member::CONSTANT ||
-				member->type == GDScriptParser::ClassNode::Member::ENUM ||
-				member->type == GDScriptParser::ClassNode::Member::ENUM_VALUE ||
-				member->type == GDScriptParser::ClassNode::Member::CLASS ||
-				member->type == GDScriptParser::ClassNode::Member::SIGNAL) {
-			return true;
+		if (p_member_node->type == GDScriptParser::Node::FUNCTION) {
+			if (found_member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
+				return MemberConflict::OVERRIDE;
+			}
+		} else if (p_member_node->type == GDScriptParser::Node::VARIABLE) {
+			const GDScriptParser::VariableNode *variable = static_cast<const GDScriptParser::VariableNode *>(p_member_node);
+			if (variable->is_override) {
+				if (found_member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
+					if (found_member.variable->is_static) {
+						push_error(R"(A variable cannot override a static variable.)", p_member_node);
+						return MemberConflict::FOUND;
+					}
+					if (r_override_type) {
+						*r_override_type = found_member.variable->datatype;
+					}
+					return MemberConflict::OVERRIDE;
+				} else {
+					push_error(vformat("(A variable cannot override %s.)", found_member.get_type_name()), p_member_node);
+					return MemberConflict::FOUND;
+				}
+			} else if (found_member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
+				push_error(R"(Use explicit "@override" if you want to override the variable.)", p_member_node);
+				return MemberConflict::FOUND;
+			}
 		}
-		if (p_member->type != GDScriptParser::Node::FUNCTION && member->type == GDScriptParser::ClassNode::Member::FUNCTION) {
-			return true;
-		}
+
+		return MemberConflict::FOUND;
 	}
 
-	return false;
+	return MemberConflict::NOT_FOUND;
 }
 
-bool GDScriptAnalyzer::has_member_name_conflict_in_native_type(const StringName &p_member_name, const StringName &p_native_type_string) {
-	if (ClassDB::has_signal(p_native_type_string, p_member_name)) {
-		return true;
-	}
-	if (ClassDB::has_property(p_native_type_string, p_member_name)) {
-		return true;
-	}
-	if (ClassDB::has_integer_constant(p_native_type_string, p_member_name)) {
-		return true;
-	}
+GDScriptAnalyzer::MemberConflict GDScriptAnalyzer::_check_member_conflict_native(const StringName &p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type) {
 	if (p_member_name == CoreStringName(script)) {
-		return true;
+		return MemberConflict::FOUND; // Never allowed to override.
 	}
 
-	return false;
+	GDScriptParser::ClassNode::Member::Type found_member_type = GDScriptParser::ClassNode::Member::UNDEFINED;
+	const char *found_member_type_name = nullptr;
+
+	if (ClassDB::has_property(p_class, p_member_name)) {
+		found_member_type = GDScriptParser::ClassNode::Member::VARIABLE;
+		found_member_type_name = "variable";
+	} else if (ClassDB::has_method(p_class, p_member_name)) {
+		found_member_type = GDScriptParser::ClassNode::Member::FUNCTION;
+		found_member_type_name = "function";
+	} else if (ClassDB::has_signal(p_class, p_member_name)) {
+		found_member_type = GDScriptParser::ClassNode::Member::SIGNAL;
+		found_member_type_name = "signal";
+	} else if (ClassDB::has_integer_constant(p_class, p_member_name)) {
+		found_member_type = GDScriptParser::ClassNode::Member::CONSTANT;
+		found_member_type_name = "constant";
+	}
+
+	if (found_member_type != GDScriptParser::ClassNode::Member::UNDEFINED) {
+		if (p_member_node->type == GDScriptParser::Node::FUNCTION) {
+			if (found_member_type == GDScriptParser::ClassNode::Member::FUNCTION) {
+				return MemberConflict::OVERRIDE;
+			}
+		} else if (p_member_node->type == GDScriptParser::Node::VARIABLE) {
+			const GDScriptParser::VariableNode *variable = static_cast<const GDScriptParser::VariableNode *>(p_member_node);
+			if (variable->is_override) {
+				if (found_member_type == GDScriptParser::ClassNode::Member::VARIABLE) {
+					// NOTE: Native static properties are not currently supported.
+					if (r_override_type) {
+						const MethodBind *getter = ClassDB::get_method(p_class, ClassDB::get_property_getter(p_class, p_member_name));
+						if (getter) {
+							*r_override_type = type_from_property(getter->get_return_info());
+						}
+					}
+					return MemberConflict::OVERRIDE;
+				} else {
+					push_error(vformat("(A variable cannot override %s.)", found_member_type_name), p_member_node);
+					return MemberConflict::FOUND;
+				}
+			} else if (found_member_type == GDScriptParser::ClassNode::Member::VARIABLE) {
+				push_error(R"(Use an explicit "@override" if you want to override the variable.)", p_member_node);
+				return MemberConflict::FOUND;
+			}
+		}
+
+		return MemberConflict::FOUND;
+	}
+
+	return MemberConflict::NOT_FOUND;
 }
 
-Error GDScriptAnalyzer::check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string) {
-	if (has_member_name_conflict_in_native_type(p_member_name, p_native_type_string)) {
-		push_error(vformat(R"(Member "%s" redefined (original in native class '%s'))", p_member_name, p_native_type_string), p_member_node);
-		return ERR_PARSE_ERROR;
-	}
-
-	if (class_exists(p_member_name)) {
-		push_error(vformat(R"(The member "%s" shadows a native class.)", p_member_name), p_member_node);
-		return ERR_PARSE_ERROR;
-	}
-
+void GDScriptAnalyzer::check_member_conflict(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type) {
+	// First, check built-in types and native classes. These names are not allowed to be shadowed.
 	if (GDScriptParser::get_builtin_type(p_member_name) < Variant::VARIANT_MAX) {
 		push_error(vformat(R"(The member "%s" cannot have the same name as a builtin type.)", p_member_name), p_member_node);
-		return ERR_PARSE_ERROR;
+		return;
+	}
+	if (class_exists(p_member_name)) {
+		push_error(vformat(R"(The member "%s" shadows a native class.)", p_member_name), p_member_node);
+		return;
 	}
 
-	return OK;
-}
+	MemberConflict member_conflict = MemberConflict::NOT_FOUND;
 
-Error GDScriptAnalyzer::check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node) {
-	// TODO check outer classes for static members only
-	const GDScriptParser::DataType *current_data_type = &p_class_node->base_type;
+	// TODO: Check outer classes for static members only.
+
+	const GDScriptParser::DataType *current_data_type = &p_class->base_type;
 	while (current_data_type && current_data_type->kind == GDScriptParser::DataType::Kind::CLASS) {
-		GDScriptParser::ClassNode *current_class_node = current_data_type->class_type;
-		if (has_member_name_conflict_in_script_class(p_member_name, current_class_node, p_member_node)) {
-			String parent_class_name = current_class_node->fqcn;
-			if (current_class_node->identifier != nullptr) {
-				parent_class_name = current_class_node->identifier->name;
+		GDScriptParser::ClassNode *current_class = current_data_type->class_type;
+		member_conflict = _check_member_conflict_gdscript(current_class, p_member_name, p_member_node, r_override_type);
+		if (member_conflict == MemberConflict::FOUND) {
+			String parent_class_name = current_class->fqcn;
+			if (current_class->identifier != nullptr) {
+				parent_class_name = current_class->identifier->name;
 			}
-			push_error(vformat(R"(The member "%s" already exists in parent class %s.)", p_member_name, parent_class_name), p_member_node);
-			return ERR_PARSE_ERROR;
+			push_error(vformat(R"(The member "%s" already exists in base class "%s".)", p_member_name, parent_class_name), p_member_node);
+			return;
+		} else if (member_conflict == MemberConflict::OVERRIDE) {
+			break;
 		}
-		current_data_type = &current_class_node->base_type;
+		current_data_type = &current_class->base_type;
 	}
 
-	// No need for native class recursion because Node exposes all Object's properties.
-	if (current_data_type && current_data_type->kind == GDScriptParser::DataType::Kind::NATIVE) {
-		if (current_data_type->native_type != StringName()) {
-			return check_native_member_name_conflict(
-					p_member_name,
-					p_member_node,
-					current_data_type->native_type);
+	// No need for recursion because `ClassDB` methods have parameter `p_no_inheritance = false`.
+	if (member_conflict == MemberConflict::NOT_FOUND && current_data_type && current_data_type->kind == GDScriptParser::DataType::Kind::NATIVE) {
+		member_conflict = _check_member_conflict_native(current_data_type->native_type, p_member_name, p_member_node, r_override_type);
+		if (member_conflict == MemberConflict::FOUND) {
+			push_error(vformat(R"(The member "%s" already exists in base class "%s".)", p_member_name, current_data_type->native_type), p_member_node);
+			return;
 		}
 	}
 
-	return OK;
+	if (p_member_node->type == GDScriptParser::Node::VARIABLE && static_cast<const GDScriptParser::VariableNode *>(p_member_node)->is_override) {
+		if (member_conflict == MemberConflict::NOT_FOUND) {
+			push_error(vformat(R"(Could not find variable "%s" to override in base class.)", p_member_name), p_member_node);
+		}
+	}
 }
 
 void GDScriptAnalyzer::get_class_node_current_scope_classes(GDScriptParser::ClassNode *p_node, List<GDScriptParser::ClassNode *> *p_list) {
@@ -947,20 +1000,36 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 			}
 		}
 #endif
+
 		switch (member.type) {
 			case GDScriptParser::ClassNode::Member::VARIABLE: {
 				bool previous_static_context = static_context;
 				static_context = member.variable->is_static;
 
-				check_class_member_name_conflict(p_class, member.variable->identifier->name, member.variable);
+				// Apply `@override` annotations before `check_class_member_name_conflict()`. No `break` to check duplicates.
+				for (GDScriptParser::AnnotationNode *&E : member.variable->annotations) {
+					if (E->name == SNAME("@override")) {
+						resolve_annotation(E);
+						E->apply(parser, member.variable, p_class);
+					}
+				}
+
+				GDScriptParser::DataType override_type;
+				check_member_conflict(p_class, member.variable->identifier->name, member.variable, &override_type);
 
 				member.variable->set_datatype(resolving_datatype);
 				resolve_variable(member.variable, false);
 				resolve_pending_lambda_bodies();
 
+				if (member.variable->is_override) {
+					if (member.variable->datatype_specifier && member.variable->datatype != override_type) {
+						push_error(vformat(R"(The overridden variable "%s" must have the same type as the base variable, i.e. "%s".)", member.variable->identifier->name, override_type.to_string()), member.variable);
+					}
+				}
+
 				// Apply annotations.
 				for (GDScriptParser::AnnotationNode *&E : member.variable->annotations) {
-					if (E->name != SNAME("@warning_ignore")) {
+					if (E->name != SNAME("@warning_ignore") && E->name != SNAME("@override")) {
 						resolve_annotation(E);
 						E->apply(parser, member.variable, p_class);
 					}
@@ -1007,7 +1076,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 #endif
 			} break;
 			case GDScriptParser::ClassNode::Member::CONSTANT: {
-				check_class_member_name_conflict(p_class, member.constant->identifier->name, member.constant);
+				check_member_conflict(p_class, member.constant->identifier->name, member.constant);
 				member.constant->set_datatype(resolving_datatype);
 				resolve_constant(member.constant, false);
 
@@ -1018,7 +1087,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				}
 			} break;
 			case GDScriptParser::ClassNode::Member::SIGNAL: {
-				check_class_member_name_conflict(p_class, member.signal->identifier->name, member.signal);
+				check_member_conflict(p_class, member.signal->identifier->name, member.signal);
 
 				member.signal->set_datatype(resolving_datatype);
 
@@ -1048,7 +1117,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				}
 			} break;
 			case GDScriptParser::ClassNode::Member::ENUM: {
-				check_class_member_name_conflict(p_class, member.m_enum->identifier->name, member.m_enum);
+				check_member_conflict(p_class, member.m_enum->identifier->name, member.m_enum);
 
 				member.m_enum->set_datatype(resolving_datatype);
 				GDScriptParser::DataType enum_type = make_enum_type(member.m_enum->identifier->name, p_class->fqcn, true);
@@ -1113,7 +1182,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				member.enum_value.identifier->set_datatype(resolving_datatype);
 
 				if (member.enum_value.custom_value) {
-					check_class_member_name_conflict(p_class, member.enum_value.identifier->name, member.enum_value.custom_value);
+					check_member_conflict(p_class, member.enum_value.identifier->name, member.enum_value.custom_value);
 
 					const GDScriptParser::EnumNode *prev_enum = current_enum;
 					current_enum = member.enum_value.parent_enum;
@@ -1129,7 +1198,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 						member.enum_value.resolved = true;
 					}
 				} else {
-					check_class_member_name_conflict(p_class, member.enum_value.identifier->name, member.enum_value.parent_enum);
+					check_member_conflict(p_class, member.enum_value.identifier->name, member.enum_value.parent_enum);
 
 					if (member.enum_value.index > 0) {
 						const GDScriptParser::EnumNode::Value &prev_value = member.enum_value.parent_enum->values[member.enum_value.index - 1];
@@ -1147,7 +1216,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				member.enum_value.identifier->set_datatype(make_enum_type(UNNAMED_ENUM, p_class->fqcn, false));
 			} break;
 			case GDScriptParser::ClassNode::Member::CLASS:
-				check_class_member_name_conflict(p_class, member.m_class->identifier->name, member.m_class);
+				check_member_conflict(p_class, member.m_class->identifier->name, member.m_class);
 				// If it's already resolving, that's ok.
 				if (!member.m_class->base_type.is_resolving()) {
 					resolve_class_inheritance(member.m_class, p_source);

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -46,11 +46,14 @@ class GDScriptAnalyzer {
 	List<GDScriptParser::LambdaNode *> pending_body_resolution_lambdas;
 	bool static_context = false;
 
-	// Tests for detecting invalid overloading of script members
-	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node, const GDScriptParser::Node *p_member);
-	static _FORCE_INLINE_ bool has_member_name_conflict_in_native_type(const StringName &p_name, const StringName &p_native_type_string);
-	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
-	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
+	enum class MemberConflict {
+		NOT_FOUND,
+		OVERRIDE,
+		FOUND,
+	};
+	_FORCE_INLINE_ MemberConflict _check_member_conflict_gdscript(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type);
+	_FORCE_INLINE_ MemberConflict _check_member_conflict_native(const StringName &p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type);
+	void check_member_conflict(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type = nullptr);
 
 	void get_class_node_current_scope_classes(GDScriptParser::ClassNode *p_node, List<GDScriptParser::ClassNode *> *p_list);
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -99,6 +99,7 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
+		register_annotation(MethodInfo("@override"), AnnotationInfo::VARIABLE, &GDScriptParser::override_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
 		register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);
@@ -4121,8 +4122,34 @@ bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node
 		push_error(R"("@onready" annotation can only be used once per variable.)", p_annotation);
 		return false;
 	}
+
 	variable->onready = true;
 	current_class->onready_used = true;
+	return true;
+}
+
+bool GDScriptParser::override_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@override" annotation can only be applied to class variables.)");
+
+	VariableNode *variable = static_cast<VariableNode *>(p_target);
+	if (variable->is_static) {
+		push_error(R"("@override" annotation cannot be applied to a static variable.)", p_annotation);
+		return false;
+	}
+	if (variable->is_override) {
+		push_error(R"("@override" annotation can only be used once per variable.)", p_annotation);
+		return false;
+	}
+	if (variable->property != VariableNode::PROP_NONE) {
+		push_error(R"(An overridden variable cannot have a setter or getter.)", p_annotation);
+		return false;
+	}
+	if (variable->initializer == nullptr) {
+		push_error(R"(An overridden variable must have an initializer.)", p_annotation);
+		return false;
+	}
+
+	variable->is_override = true;
 	return true;
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1257,6 +1257,7 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool is_override = false;
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
@@ -1496,6 +1497,7 @@ private:
 	bool tool_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool override_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_base_enum.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_base_enum.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-The member "V" already exists in parent class A.
+The member "V" already exists in base class "A".

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Member "script" redefined (original in native class 'Node')
+The member "script" already exists in base class "Node".

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-The member "overload_me" already exists in parent class A.
+The member "overload_me" already exists in base class "A".


### PR DESCRIPTION
* Closes godotengine/godot-proposals#338.

```gdscript
@override var script_var: int = f(2)
@onready @override var name: StringName = &"Test"
```

![](https://github.com/godotengine/godot/assets/47700418/56400f58-bdf8-4b10-8a1c-dafc1fcbd493)

TODO: Implement proposal godotengine/godot-proposals#8045 (only possible for inline setters/getters).