### PR TITLE
Force unstretched integer scaling to be precise

### DIFF
--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -78,7 +78,7 @@ protected:
 	RasterizerSceneGLES3 *scene = nullptr;
 	static RasterizerGLES3 *singleton;
 
-	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
+	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, Size2i p_viewport_size, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
 
 public:
 	RendererUtilities *get_utilities() { return utilities; }

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1115,8 +1115,14 @@ void Window::_update_viewport_size() {
 
 	if (content_scale_mode == CONTENT_SCALE_MODE_DISABLED || content_scale_size.x == 0 || content_scale_size.y == 0) {
 		font_oversampling = content_scale_factor;
-		final_size = size;
-		final_size_override = Size2(size) / content_scale_factor;
+		if (Math::floor(content_scale_factor) == content_scale_factor) {
+			final_size_override = (Size2(size) / content_scale_factor).floor();
+			final_size = Size2(final_size_override) * content_scale_factor;
+			attach_to_screen_rect = Rect2(Point2i(), final_size);
+		} else {
+			final_size = size;
+			final_size_override = Size2(size) / content_scale_factor;
+		}
 	} else {
 		//actual screen video mode
 		Size2 video_mode = size;


### PR DESCRIPTION
Both viewport size and 2D size override are limited to integer for now, therefore having a window size that is not divisible by the scale factor may cause scaling artifacts.

We can prevent this by shrinking the usable window viewport down to the nearest size that is fully divisible by the scale factor. Only apply this for integer scale factors, as this is mostly useless for fractional scale factors.

(In theory scale factors like 1.5 could also benefit from this kind of rounding, but this will require changing viewport size to accept floating point sizes to be really useful.)

---

Fixes #79726

Unresolved defects with OpenGL rendering:

- [x] With OpenGL rendering, the viewport sticks to the bottom of the window instead of the top, causing unpleasant jiggling when resizing the window..
- [x] With OpenGL rendering (again), the viewport is not cleared, so sometimes you can see leftover or garbage pixels on the edges when the shrinkage is being applied.

I think both of the above should be corrected in https://github.com/godotengine/godot/blob/4ab8fb809396fa38ba929fec97cfcb7193f1c44d/drivers/gles3/rasterizer_gles3.cpp#L369 but I don't see how I can get the actual GL viewport size there... I would appreciate some help.