### PR TITLE
Fix incorrect size calculation when position is set on resized

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1744,10 +1744,10 @@ void Control::_size_changed() {
 			// so an up to date global transform could be obtained when handling these.
 			_notify_transform();
 
+			item_rect_changed(size_changed);
 			if (size_changed) {
 				notification(NOTIFICATION_RESIZED);
 			}
-			item_rect_changed(size_changed);
 		}
 
 		if (pos_changed && !size_changed) {


### PR DESCRIPTION
Fix #92929 
Fix #15061

## 92929

https://github.com/godotengine/godot/assets/63407648/0955fdc5-b251-4d03-a216-f1395b8e2122

## 15061

https://github.com/godotengine/godot/assets/63407648/b41fc0ee-e210-4e21-a869-618041e3b26e


## Report

UPD: The following analysis is based on issue 92929.
The problem was caused by the order of notification. 

### Settings:
For two nodes in the following structure:
```plaintext
- Parent[Control]
  - Child[ColorRect]
```
Parent was attached a user script that will update Child's position when receiving Parent's `resized` signal.

### Before:
```plaintext
-> Parent's size changed. Call Parent's `_size_changed`. 
    -> Parent emits `resized` signal.
        -> Trigger userscript. Call Child's  `_set_position`.
        -> Child uses stale data to calculate offsets. (ERROR here)
    -> Parent emits `item_rect_changed` signal.
        -> Trigger Child's `_size_changed`.
        -> Child uses the wrong data to update. (And will not trigger redrawing)
```
### After:
```plaintext
-> Parent's size changed. Call Parent's `_size_changed`. 
    -> Parent emits `item_rect_changed` signal.
        -> Trigger Child's `_size_changed`.
        -> Update Child's data.
    -> Parent emits `resized` signal.
        -> Trigger user script. Call Child's  `_set_position`.
        -> Child uses the updated data.
```

## Note
I sensed some danger here. I'm not sure if we have specification on the emitting order of `resized` signal and `item_rect_changed` signal. This may break some parts/projects that rely on the order of these two notifications.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
