### PR TITLE
Autocompletion: Don't use `in` operator to decide over variant lookup

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1959,11 +1959,14 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 						break;
 					}
 
-					if (base.value.in(index.value)) {
-						Variant value = base.value.get(index.value);
-						r_type = _type_from_variant(value, p_context);
-						found = true;
-						break;
+					{
+						bool valid;
+						Variant value = base.value.get(index.value, &valid);
+						if (valid) {
+							r_type = _type_from_variant(value, p_context);
+							found = true;
+							break;
+						}
 					}
 
 					// Look if it is a dictionary node.


### PR DESCRIPTION
Fixes #93799

The `in` operator is not directly linked to whether `get` will have success. E.g. for arrays the `in` operator searches for values while `get` works with an index.

Instead we can just try to `get` and only use the result if successful.
