### PR TITLE
Fix info about global library in `add_animation_library` method docs

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -27,6 +27,13 @@
 			<param index="1" name="library" type="AnimationLibrary" />
 			<description>
 				Adds [param library] to the animation player, under the key [param name].
+				AnimationMixer has a global library by default with an empty string as key. For adding an animation to the global library:
+				[codeblocks]
+				[gdscript]
+				var global_library = mixer.get_animation_library("")
+				global_library.add_animation("animation_name", animation_resource)
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="advance">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The information about how to add a Global library is not in the documentation currently.

This PR adds the following information in the add_animation_library method 
in doc/classes/AnimationMixer.xml:
"When name is set to an empty string, the Global library is added."

* *Bugsquad edit, closes: https://github.com/godotengine/godot-docs/issues/9550*