### PR TITLE
Add basic support to evaluate operator value in shader language

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -348,7 +348,7 @@ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataType type, int p_
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
+_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::Scalar> &value, uint8_t *data) {
 	switch (type) {
 		case ShaderLanguage::TYPE_BOOL: {
 			uint32_t *gui = (uint32_t *)data;
@@ -572,7 +572,7 @@ void ShaderData::set_default_texture_parameter(const StringName &p_name, RID p_t
 Variant ShaderData::get_default_parameter(const StringName &p_parameter) const {
 	if (uniforms.has(p_parameter)) {
 		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
-		Vector<ShaderLanguage::ConstantNode::Value> default_value = uniform.default_value;
+		Vector<ShaderLanguage::Scalar> default_value = uniform.default_value;
 		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
 	return Variant();

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -342,7 +342,7 @@ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataType type, int p_
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
+_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::Scalar> &value, uint8_t *data) {
 	switch (type) {
 		case ShaderLanguage::TYPE_BOOL: {
 			uint32_t *gui = (uint32_t *)data;
@@ -566,7 +566,7 @@ void MaterialStorage::ShaderData::set_default_texture_parameter(const StringName
 Variant MaterialStorage::ShaderData::get_default_parameter(const StringName &p_parameter) const {
 	if (uniforms.has(p_parameter)) {
 		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
-		Vector<ShaderLanguage::ConstantNode::Value> default_value = uniform.default_value;
+		Vector<ShaderLanguage::Scalar> default_value = uniform.default_value;
 		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
 	return Variant();

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -185,7 +185,7 @@ static String f2sp0(float p_float) {
 	return num;
 }
 
-static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNode::Value> &p_values) {
+static String get_constant_text(SL::DataType p_type, const Vector<SL::Scalar> &p_values) {
 	switch (p_type) {
 		case SL::TYPE_BOOL:
 			return p_values[0].boolean ? "true" : "false";


### PR DESCRIPTION
This PR adds a basic set of evaluator functions to the shader language. This might be needed in some places, like an array initialization. After this PR got merged, user may define and use basic constant expression like:

```glsl
shader_type spatial;

const int ARRAY_SIZE = 1 + (9 / 3); // evaluates to 4

void fragment() { 
	int array[ARRAY_SIZE] = {0, 0, 0, 0}; // correct
}
```

Also, I've fixed `parse_array_size` function to allow declaring expression inside it:

```glsl
shader_type spatial;

void fragment() {
	int array[1 + 2 / 2] = {0, 0}; // correct
}
```

Also, constant may be used like this:

```glsl
shader_type spatial;

const int SIZE = 3;

void fragment() {
	int array[SIZE + SIZE] = {0, 0, 0, 0, 0, 0}; // correctly evaluates to 6
}
```

Besides array size, the expressions can now be passed to specific built-in functions:

```glsl
const int SIZE = 1;

textureGather(sampler, vec2(0.0), SIZE + 1); // OK
textureGather(sampler, vec2(0.0), SIZE + 4); // FAILED (must be within 0..3 range)
```

Note, the advanced constant constructions like:

```glsl
const int ARRAY_SIZE = ivec2(1, 0).x;

void fragment() {
	int array[ARRAY_SIZE] = {0};
}
```

still doesn't work, I may improve it lately.

- Closes https://github.com/godotengine/godot/issues/72087

PS: Yes, I renamed `ShaderLanguage::ConstantNode::Value` to `ShaderLanguage::Scalar` because it fits better and other nodes may use it, not only constant node (currently an `OperatorNode` will also start to use it).