### PR TITLE
Fix `AtlasTexture::draw_rect` flipping for non-zero margin

### DIFF
--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -30,7 +30,6 @@
 
 #include "texture_rect.h"
 
-#include "scene/resources/atlas_texture.h"
 #include "servers/rendering_server.h"
 
 void TextureRect::_notification(int p_what) {
@@ -90,15 +89,6 @@ void TextureRect::_notification(int p_what) {
 					region.position = ((scaled_tex_size - size) / scale).abs() / 2.0f;
 					region.size = size / scale;
 				} break;
-			}
-
-			Ref<AtlasTexture> p_atlas = texture;
-
-			if (p_atlas.is_valid() && !region.has_area()) {
-				Size2 scale_size(size.width / texture->get_width(), size.height / texture->get_height());
-
-				offset.width += hflip ? p_atlas->get_margin().get_position().width * scale_size.width * 2 : 0;
-				offset.height += vflip ? p_atlas->get_margin().get_position().height * scale_size.height * 2 : 0;
 			}
 
 			size.width *= hflip ? -1.0f : 1.0f;

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -164,20 +164,13 @@ void AtlasTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile
 		return;
 	}
 
-	Rect2 rc = region;
+	Rect2 src_rect = Rect2(0, 0, get_width(), get_height());
 
-	if (rc.size.width == 0) {
-		rc.size.width = atlas->get_width();
+	Rect2 dr;
+	Rect2 src_c;
+	if (get_rect_region(p_rect, src_rect, dr, src_c)) {
+		atlas->draw_rect_region(p_canvas_item, dr, src_c, p_modulate, p_transpose, filter_clip);
 	}
-
-	if (rc.size.height == 0) {
-		rc.size.height = atlas->get_height();
-	}
-
-	Vector2 scale = p_rect.size / (region.size + margin.size);
-	Rect2 dr(p_rect.position + margin.position * scale, rc.size * scale);
-
-	atlas->draw_rect_region(p_canvas_item, dr, rc, p_modulate, p_transpose, filter_clip);
 }
 
 void AtlasTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
@@ -188,9 +181,9 @@ void AtlasTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, cons
 
 	Rect2 dr;
 	Rect2 src_c;
-	get_rect_region(p_rect, p_src_rect, dr, src_c);
-
-	atlas->draw_rect_region(p_canvas_item, dr, src_c, p_modulate, p_transpose, filter_clip);
+	if (get_rect_region(p_rect, p_src_rect, dr, src_c)) {
+		atlas->draw_rect_region(p_canvas_item, dr, src_c, p_modulate, p_transpose, filter_clip);
+	}
 }
 
 bool AtlasTexture::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const {


### PR DESCRIPTION
`AtlasTexture::draw_rect` was incorrectly handling flipping an `AtlasTexture` with non-zero margins (flipping is done by passing a destination rect with negative width/height).
This was noticable e.g. in `TextureRect` (which included incorrect workaround for that) when `stretch_mode != STRETCH_KEEP_ASPECT_COVERED` as that's when it uses `CanvasItem::draw_texture_rect` (which ends up calling `AtlasTexture::draw_rect`).

This PR makes `AtlasTexture::draw_rect` use `AtlasTexture::get_rect_region` to handle flipping logic etc. the same way as in `AtlasTexture::draw_rect_region`.

Properly fixes #37526 (#37615 was incorrect, it only made the issue hardly noticable for the test case reported in there specifically because of almost equal top/bottom margins; see the red/green discrepancy in the image below).

Modified MRP from #37526 with the examples below: [Testing-AtlasTextureFlip4x.zip](https://github.com/user-attachments/files/16058122/Testing-AtlasTextureFlip4x.zip)

- `TextureRect` incorrectly flipping `AtlasTexture` with non-equal top/bottom margins (`TestScene.tscn`):

| Before<br>(v4.3.beta2.official [b75f0485b]) | After<br>(this PR) |
|--------|--------|
|![Godot_v4 3-beta2_win64_vaIC5W3pzx](https://github.com/godotengine/godot/assets/9283098/84397b64-5556-440f-8ada-0baba9bdfc7a)|![godot windows editor dev x86_64_zBcu4z2BjY](https://github.com/godotengine/godot/assets/9283098/0824d197-5c3a-488c-8ddf-6fc405d4d45b)|

Setup:
![TyxBmLYhEm](https://github.com/godotengine/godot/assets/9283098/fda6545f-aff6-482d-bf32-7e4f91b87206)|![Godot_v4 3-beta2_win64_hEvhJsY6Px](https://github.com/godotengine/godot/assets/9283098/0329d841-ae14-4b4d-b7c4-b7e142053c09)
-|-

- Animating the margin, also comparing with Sprite2D (`TestSceneWithAnim.tscn`):

| Before<br>(v4.3.beta2.official [b75f0485b]) | After<br>(this PR) |
|--------|--------|
|![nnLhZSL9Es](https://github.com/godotengine/godot/assets/9283098/a79a72d2-04e5-4914-96ae-0e8e79ada4d3)|![MAqzaBMVTp](https://github.com/godotengine/godot/assets/9283098/7ed0862d-e5a0-4595-ae5d-8df8b96a7be2)|
