### PR TITLE
Vulkan Volumetric Fog Issue

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -276,6 +276,8 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		}
 	}
 
+	bool can_draw_3d = RSG::scene->is_camera(p_viewport->camera) && !p_viewport->disable_3d;
+
 	if (RSG::scene->is_scenario(p_viewport->scenario)) {
 		RID environment = RSG::scene->scenario_get_environment(p_viewport->scenario);
 		if (RSG::scene->is_environment(environment)) {
@@ -286,10 +288,15 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				// The scene renderer will still copy over the last frame, so we need to clear the render target.
 				force_clear_render_target = true;
 			}
+
+			// Calculate the frames needed for volumetric fog to converge.
+			if (p_viewport->size != p_viewport->old_size && can_draw_3d) {
+				float temporal_amount = RSG::scene->environment_get_volumetric_fog_temporal_reprojection_amount(environment);
+				float convergence_threshold = 0.01f;
+				p_viewport->frames_needed = Math::ceil(Math::log(convergence_threshold) / Math::log(temporal_amount));
+			}
 		}
 	}
-
-	bool can_draw_3d = RSG::scene->is_camera(p_viewport->camera) && !p_viewport->disable_3d;
 
 	if ((scenario_draw_canvas_bg || can_draw_3d) && !p_viewport->render_buffers.is_valid()) {
 		//wants to draw 3D but there is no render buffer, create
@@ -305,6 +312,12 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		if (p_viewport->clear_mode == RS::VIEWPORT_CLEAR_ONLY_NEXT_FRAME) {
 			p_viewport->clear_mode = RS::VIEWPORT_CLEAR_NEVER;
 		}
+	}
+
+	// Redraw until volumetric fog converges.
+	if (p_viewport->frames_needed > 0 && can_draw_3d) {
+		_draw_3d(p_viewport);
+		p_viewport->frames_needed--;
 	}
 
 	if (!scenario_draw_canvas_bg && can_draw_3d) {

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -291,6 +291,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 			// Calculate the frames needed for volumetric fog to converge.
 			if (p_viewport->size != p_viewport->old_size && can_draw_3d) {
+				p_viewport->old_size = p_viewport->size;
 				float temporal_amount = RSG::scene->environment_get_volumetric_fog_temporal_reprojection_amount(environment);
 				float convergence_threshold = 0.01f;
 				p_viewport->frames_needed = Math::ceil(Math::log(convergence_threshold) / Math::log(temporal_amount));

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -55,8 +55,11 @@ public:
 		// use xr interface to override camera positioning and projection matrices and control output
 		bool use_xr = false;
 
+		int frames_needed;
+
 		Size2i internal_size;
 		Size2i size;
+		Size2i old_size;
 		uint32_t view_count;
 		RID camera;
 		RID scenario;


### PR DESCRIPTION
**Issue**
Fixes #62794

**Godot version**
4.x

**System information**
- **OS**: Windows
- **Architecture**: x86_64
- **GPU**: Nvidia 1050ti

**Description**
This fix calculates the number of frames needed, based on the temporal reprojection amount, to redraw until the volumetric fog fully converges.

**Note**: Another issue related to the flickering when adjusting the viewport has already been addressed.

**Changes Made**
- New Variables in renderer_viewport.h:
    -    `int frames_needed;`: Stores the number of frames needed for the volumetric fog to converge.
    -    `Size2i old_size;`: Stores the previous size of the viewport. Used to check if the viewport was resized.

**Additional Information**

https://github.com/godotengine/godot/assets/169231366/5f3ddf00-df2c-47a1-b167-e43b26a5b8ed

