### PR TITLE
Fix GPUParticles Inherit Velocity breaking with physics movement

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -688,6 +688,7 @@ void GPUParticles2D::_notification(int p_what) {
 				RS::get_singleton()->particles_set_speed_scale(particles, 0);
 			}
 			set_process_internal(true);
+			set_physics_process_internal(true);
 			previous_position = get_global_position();
 		} break;
 
@@ -711,15 +712,6 @@ void GPUParticles2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			const Vector3 velocity = Vector3((get_global_position() - previous_position).x, (get_global_position() - previous_position).y, 0.0) /
-					get_process_delta_time();
-
-			if (velocity != previous_velocity) {
-				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);
-				previous_velocity = velocity;
-			}
-			previous_position = get_global_position();
-
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
@@ -738,6 +730,19 @@ void GPUParticles2D::_notification(int p_what) {
 					}
 				}
 			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			// Update velocity in physics process, so that velocity calculations remain correct
+			// if the physics tick rate is lower than the rendered framerate (especially without physics interpolation).
+			const Vector3 velocity = Vector3((get_global_position() - previous_position).x, (get_global_position() - previous_position).y, 0.0) /
+					get_physics_process_delta_time();
+
+			if (velocity != previous_velocity) {
+				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);
+				previous_velocity = velocity;
+			}
+			previous_position = get_global_position();
 		} break;
 	}
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -459,14 +459,6 @@ void GPUParticles3D::_notification(int p_what) {
 		// Use internal process when emitting and one_shot is on so that when
 		// the shot ends the editor can properly update.
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			const Vector3 velocity = (get_global_position() - previous_position) / get_process_delta_time();
-
-			if (velocity != previous_velocity) {
-				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);
-				previous_velocity = velocity;
-			}
-			previous_position = get_global_position();
-
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
@@ -487,8 +479,21 @@ void GPUParticles3D::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			// Update velocity in physics process, so that velocity calculations remain correct
+			// if the physics tick rate is lower than the rendered framerate (especially without physics interpolation).
+			const Vector3 velocity = (get_global_position() - previous_position) / get_physics_process_delta_time();
+
+			if (velocity != previous_velocity) {
+				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);
+				previous_velocity = velocity;
+			}
+			previous_position = get_global_position();
+		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(false);
+			set_physics_process_internal(false);
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
@@ -499,6 +504,7 @@ void GPUParticles3D::_notification(int p_what) {
 			}
 			previous_position = get_global_transform().origin;
 			set_process_internal(true);
+			set_physics_process_internal(true);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
GPUParticles' Inherit Velocity property used to act strangely if the physics tick rate was lower than the rendered FPS, as velocity was tracked in the process and not in the physics process. This means that on certain rendered frames, the velocity was effectively 0 since there was no movement since the last rendered frame.

- This closes https://github.com/godotengine/godot/issues/87662.

**Testing project:** [Updated.Inherit.Velocity.MRP.zip](https://github.com/godotengine/godot/files/14075571/Updated.Inherit.Velocity.MRP.zip)

## Preview

### 120 FPS, 60 TPS

*This is where the issue is fixed.*

#### Before

https://github.com/godotengine/godot/assets/180032/13f104b4-e1a1-43df-96e6-eceb813c1487

#### After

https://github.com/godotengine/godot/assets/180032/393bbb2c-9a03-4724-9f81-27558cc504ac

### 60 FPS, 60 TPS

*Same as before, no changes in behavior.*

#### Before

https://github.com/godotengine/godot/assets/180032/cbc06c60-3e86-4616-8cad-1a4dab0c4be7

#### After

https://github.com/godotengine/godot/assets/180032/2b4ad2bc-16f6-44ab-aabf-7e988fa447b7

### 120 FPS, 120 TPS

*Same as before, no changes in behavior.*

#### Before

https://github.com/godotengine/godot/assets/180032/c27e5c71-2619-4659-8ea9-58fe748d8634

#### After

https://github.com/godotengine/godot/assets/180032/67712166-19aa-4d9c-9df6-36f163cac42c

