### PR TITLE
Implement LIGHT_INDEX and sample_directional_shadow for Light Shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6943,6 +6943,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("Roughness", "Input/Light", "VisualShaderNodeInput", vformat(input_param_for_light_shader_mode, "roughness", "ROUGHNESS"), { "roughness" }, VisualShaderNode::PORT_TYPE_SCALAR, TYPE_FLAGS_LIGHT, Shader::MODE_SPATIAL));
 	add_options.push_back(AddOption("Specular", "Input/Light", "VisualShaderNodeInput", vformat(input_param_for_light_shader_mode, "specular", "SPECULAR_LIGHT"), { "specular" }, VisualShaderNode::PORT_TYPE_VECTOR_3D, TYPE_FLAGS_LIGHT, Shader::MODE_SPATIAL));
 	add_options.push_back(AddOption("View", "Input/Light", "VisualShaderNodeInput", vformat(input_param_for_fragment_and_light_shader_modes, "view", "VIEW"), { "view" }, VisualShaderNode::PORT_TYPE_VECTOR_3D, TYPE_FLAGS_LIGHT, Shader::MODE_SPATIAL));
+	add_options.push_back(AddOption("LightIndex", "Input/Light", "VisualShaderNodeInput", vformat(input_param_for_light_shader_mode, "light_index", "LIGHT_INDEX"), { "light_index" }, VisualShaderNode::PORT_TYPE_SCALAR, TYPE_FLAGS_LIGHT, Shader::MODE_SPATIAL));
 
 	// CANVASITEM INPUTS
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -53,6 +53,40 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
                 header_data.compute_offset = header_data.line_offset
                 continue
 
+            if line.find("#inline ") != -1:
+                inlineline = line.replace("#inline ", "").strip()[1:-1]
+                noteline = "//inline START for: " + inlineline
+                if header_data.reading == "vertex":
+                    header_data.vertex_lines += [noteline]
+                if header_data.reading == "fragment":
+                    header_data.fragment_lines += [noteline]
+                if header_data.reading == "compute":
+                    header_data.compute_lines += [noteline]
+                header_data.line_offset += 1
+                inlinefile = os.path.relpath(os.path.dirname(filename) + "/" + inlineline)
+                with open(inlinefile, "r", encoding="utf-8") as inlinefs:
+                    inline = inlinefs.readline()
+                    while inline:
+                        inline = inline.replace("\r", "").replace("\n", "")
+                        if header_data.reading == "vertex":
+                            header_data.vertex_lines += [inline]
+                        if header_data.reading == "fragment":
+                            header_data.fragment_lines += [inline]
+                        if header_data.reading == "compute":
+                            header_data.compute_lines += [inline]
+                        inline = inlinefs.readline()
+                        header_data.line_offset += 1
+                noteline = "//inline END for: " + inlineline
+                if header_data.reading == "vertex":
+                    header_data.vertex_lines += [noteline]
+                if header_data.reading == "fragment":
+                    header_data.fragment_lines += [noteline]
+                if header_data.reading == "compute":
+                    header_data.compute_lines += [noteline]
+                header_data.line_offset += 1
+                line = fs.readline()
+                continue
+
             while line.find("#include ") != -1:
                 includeline = line.replace("#include ", "").strip()[1:-1]
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -673,6 +673,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["ATTENUATION"] = "attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
+		actions.renames["LIGHT_INDEX"] = "light_index";
 
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
@@ -710,6 +711,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.usage_defines["SSS_TRANSMITTANCE_DEPTH"] = "#define ENABLE_TRANSMITTANCE\n";
 		actions.usage_defines["BACKLIGHT"] = "#define LIGHT_BACKLIGHT_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+		actions.usage_defines["LIGHT_INDEX"] = "#define LIGHT_INDEX_USED\n";
 
 		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -584,6 +584,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["ATTENUATION"] = "attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
+		actions.renames["LIGHT_INDEX"] = "light_index";
 
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
@@ -621,6 +622,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.usage_defines["SSS_TRANSMITTANCE_DEPTH"] = "#define ENABLE_TRANSMITTANCE\n";
 		actions.usage_defines["BACKLIGHT"] = "#define LIGHT_BACKLIGHT_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+		actions.usage_defines["LIGHT_INDEX"] = "#define LIGHT_INDEX_USED\n";
 
 		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1006,6 +1006,8 @@ layout(location = 2) out vec2 motion_vector;
 #define SPECULAR_SCHLICK_GGX
 #endif
 
+#include "../scene_forward_lights_base_inc.glsl"
+
 #include "../scene_forward_lights_inc.glsl"
 
 #include "../scene_forward_gi_inc.glsl"
@@ -2006,207 +2008,16 @@ void fragment_shader(in SceneData scene_data) {
 				continue; // Statically baked light and object uses lightmap, skip
 			}
 
-			float shadow = 1.0;
+			float shadow = 1.0; // no shadow
 
-			if (directional_lights.data[i].shadow_opacity > 0.001) {
-				float depth_z = -vertex.z;
-				vec3 light_dir = directional_lights.data[i].direction;
-				vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
-
-#define BIAS_FUNC(m_var, m_idx)                                                                 \
-	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
-	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
-	m_var.xyz += normal_bias;
-
-				//version with soft shadows, more expensive
-				if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) {
-					uint blend_count = 0;
-					const uint blend_max = directional_lights.data[i].blend_splits ? 2 : 1;
-
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 0)
-
-						vec4 pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
-						pssm_coord /= pssm_coord.w;
-
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.x;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale1 * test_radius;
-						shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
-						blend_count++;
-					}
-
-					if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 1)
-
-						vec4 pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-						pssm_coord /= pssm_coord.w;
-
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.y;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale2 * test_radius;
-						float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
-
-						if (blend_count == 0) {
-							shadow = s;
-						} else {
-							//blend
-							float blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
-							shadow = mix(shadow, s, blend);
-						}
-
-						blend_count++;
-					}
-
-					if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 2)
-
-						vec4 pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-						pssm_coord /= pssm_coord.w;
-
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.z;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale3 * test_radius;
-						float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
-
-						if (blend_count == 0) {
-							shadow = s;
-						} else {
-							//blend
-							float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
-							shadow = mix(shadow, s, blend);
-						}
-
-						blend_count++;
-					}
-
-					if (blend_count < blend_max) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 3)
-
-						vec4 pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-						pssm_coord /= pssm_coord.w;
-
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.w;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale4 * test_radius;
-						float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
-
-						if (blend_count == 0) {
-							shadow = s;
-						} else {
-							//blend
-							float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
-							shadow = mix(shadow, s, blend);
-						}
-					}
-
-				} else { //no soft shadows
-
-					vec4 pssm_coord;
-					float blur_factor;
-
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 0)
-
-						pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
-						blur_factor = 1.0;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 1)
-
-						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 2)
-
-						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-					} else {
-						vec4 v = vec4(vertex, 1.0);
-
-						BIAS_FUNC(v, 3)
-
-						pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
-					}
-
-					pssm_coord /= pssm_coord.w;
-
-					shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data.taa_frame_count);
-
-					if (directional_lights.data[i].blend_splits) {
-						float pssm_blend;
-						float blur_factor2;
-
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-							vec4 v = vec4(vertex, 1.0);
-							BIAS_FUNC(v, 1)
-							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
-							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-							vec4 v = vec4(vertex, 1.0);
-							BIAS_FUNC(v, 2)
-							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
-							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-							vec4 v = vec4(vertex, 1.0);
-							BIAS_FUNC(v, 3)
-							pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.z - directional_lights.data[i].shadow_split_offsets.z * 0.1, directional_lights.data[i].shadow_split_offsets.z, depth_z);
-							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
-						} else {
-							pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
-							blur_factor2 = 1.0;
-						}
-
-						pssm_coord /= pssm_coord.w;
-
-						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data.taa_frame_count);
-						shadow = mix(shadow, shadow2, pssm_blend);
-					}
-				}
-
-				shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#inline "./scene_forward_clustered_light_dir_shadow_inline.glsl"
 
 #ifdef USE_VERTEX_LIGHTING
-				diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
-				specular_light *= mix(1.0, shadow, specular_light_interp.a);
+
+			diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
+			specular_light *= mix(1.0, shadow, specular_light_interp.a);
+
 #endif
-
-#undef BIAS_FUNC
-			} // shadows
-
-			if (i < 4) {
-				shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
-			} else {
-				shadow1 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << ((i - 4) * 8);
-			}
 		}
 #endif // SHADOWS_DISABLED
 
@@ -2328,6 +2139,9 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef LIGHT_ANISOTROPY_USED
 					binormal,
 					tangent, anisotropy,
+#endif
+#ifdef LIGHT_INDEX_USED
+					i,
 #endif
 					diffuse_light,
 					specular_light);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_light_dir_shadow_inline.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_light_dir_shadow_inline.glsl
@@ -1,0 +1,195 @@
+// Inlined directional shadow logic, use scene_data_block to access data
+if (directional_lights.data[i].shadow_opacity > 0.001) {
+	float depth_z = -vertex.z;
+	vec3 light_dir = directional_lights.data[i].direction;
+	vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
+
+#define BIAS_FUNC(m_var, m_idx)                                                                 \
+	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
+	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
+	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
+	m_var.xyz += normal_bias;
+
+	//version with soft shadows, more expensive
+	if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) {
+		uint blend_count = 0;
+		const uint blend_max = directional_lights.data[i].blend_splits ? 2 : 1;
+
+		if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 0)
+
+			vec4 pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
+			pssm_coord /= pssm_coord.w;
+
+			float range_pos = dot(directional_lights.data[i].direction, v.xyz);
+			float range_begin = directional_lights.data[i].shadow_range_begin.x;
+			float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+			vec2 tex_scale = directional_lights.data[i].uv_scale1 * test_radius;
+			shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data_block.data.taa_frame_count);
+			blend_count++;
+		}
+
+		if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 1)
+
+			vec4 pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+			pssm_coord /= pssm_coord.w;
+
+			float range_pos = dot(directional_lights.data[i].direction, v.xyz);
+			float range_begin = directional_lights.data[i].shadow_range_begin.y;
+			float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+			vec2 tex_scale = directional_lights.data[i].uv_scale2 * test_radius;
+			float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data_block.data.taa_frame_count);
+
+			if (blend_count == 0) {
+				shadow = s;
+			} else {
+				//blend
+				float blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
+				shadow = mix(shadow, s, blend);
+			}
+
+			blend_count++;
+		}
+
+		if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 2)
+
+			vec4 pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
+			pssm_coord /= pssm_coord.w;
+
+			float range_pos = dot(directional_lights.data[i].direction, v.xyz);
+			float range_begin = directional_lights.data[i].shadow_range_begin.z;
+			float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+			vec2 tex_scale = directional_lights.data[i].uv_scale3 * test_radius;
+			float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data_block.data.taa_frame_count);
+
+			if (blend_count == 0) {
+				shadow = s;
+			} else {
+				//blend
+				float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
+				shadow = mix(shadow, s, blend);
+			}
+
+			blend_count++;
+		}
+
+		if (blend_count < blend_max) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 3)
+
+			vec4 pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+			pssm_coord /= pssm_coord.w;
+
+			float range_pos = dot(directional_lights.data[i].direction, v.xyz);
+			float range_begin = directional_lights.data[i].shadow_range_begin.w;
+			float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+			vec2 tex_scale = directional_lights.data[i].uv_scale4 * test_radius;
+			float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data_block.data.taa_frame_count);
+
+			if (blend_count == 0) {
+				shadow = s;
+			} else {
+				//blend
+				float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
+				shadow = mix(shadow, s, blend);
+			}
+		}
+
+	} else { //no soft shadows
+
+		vec4 pssm_coord;
+		float blur_factor;
+
+		if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 0)
+
+			pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
+			blur_factor = 1.0;
+		} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 1)
+
+			pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
+		} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 2)
+
+			pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
+		} else {
+			vec4 v = vec4(vertex, 1.0);
+
+			BIAS_FUNC(v, 3)
+
+			pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
+		}
+
+		pssm_coord /= pssm_coord.w;
+
+		shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data_block.data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data_block.data.taa_frame_count);
+
+		if (directional_lights.data[i].blend_splits) {
+			float pssm_blend;
+			float blur_factor2;
+
+			if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+				vec4 v = vec4(vertex, 1.0);
+				BIAS_FUNC(v, 1)
+				pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+				pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
+				// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+				blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
+			} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+				vec4 v = vec4(vertex, 1.0);
+				BIAS_FUNC(v, 2)
+				pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
+				pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
+				// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+				blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
+			} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+				vec4 v = vec4(vertex, 1.0);
+				BIAS_FUNC(v, 3)
+				pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+				pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.z - directional_lights.data[i].shadow_split_offsets.z * 0.1, directional_lights.data[i].shadow_split_offsets.z, depth_z);
+				// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+				blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
+			} else {
+				pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+				blur_factor2 = 1.0;
+			}
+
+			pssm_coord /= pssm_coord.w;
+
+			float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data_block.data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data_block.data.taa_frame_count);
+			shadow = mix(shadow, shadow2, pssm_blend);
+		}
+	}
+
+	shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+
+#undef BIAS_FUNC
+} // shadows
+
+if (i < 4) {
+	shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
+} else {
+	shadow1 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << ((i - 4) * 8);
+}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -789,6 +789,8 @@ layout(location = 0) out mediump vec4 frag_color;
 #define SPECULAR_SCHLICK_GGX
 #endif
 
+#include "../scene_forward_lights_base_inc.glsl"
+
 #include "../scene_forward_lights_inc.glsl"
 
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && !defined(USE_VERTEX_LIGHTING)
@@ -1504,110 +1506,16 @@ void main() {
 				continue; //not masked
 			}
 
-			float shadow = 1.0;
+			float shadow = 1.0; // no shadow
 
-			if (directional_lights.data[i].shadow_opacity > 0.001) {
-				float depth_z = -vertex.z;
-
-				vec4 pssm_coord;
-				float blur_factor;
-				vec3 light_dir = directional_lights.data[i].direction;
-				vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
-
-#define BIAS_FUNC(m_var, m_idx)                                                                 \
-	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
-	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
-	m_var.xyz += normal_bias;
-
-				if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 0)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
-					blur_factor = 1.0;
-				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 1)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-					// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-					blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-					;
-				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 2)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-					// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-					blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-				} else {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 3)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-					// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-					blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
-				}
-
-				pssm_coord /= pssm_coord.w;
-
-				shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data.taa_frame_count);
-
-				if (directional_lights.data[i].blend_splits) {
-					float pssm_blend;
-					float blur_factor2;
-
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 1)
-						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 2)
-						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 3)
-						pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.z - directional_lights.data[i].shadow_split_offsets.z * 0.1, directional_lights.data[i].shadow_split_offsets.z, depth_z);
-						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
-						blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
-					} else {
-						pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
-						blur_factor2 = 1.0;
-					}
-
-					pssm_coord /= pssm_coord.w;
-
-					float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data.taa_frame_count);
-					shadow = mix(shadow, shadow2, pssm_blend);
-				}
-
-				shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#inline "./scene_forward_mobile_light_dir_shadow_inline.glsl"
 
 #ifdef USE_VERTEX_LIGHTING
-				diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
-				specular_light *= mix(1.0, shadow, specular_light_interp.a);
-#endif
-#undef BIAS_FUNC
-			}
 
-			if (i < 4) {
-				shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
-			} else {
-				shadow1 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << ((i - 4) * 8);
-			}
+			diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
+			specular_light *= mix(1.0, shadow, specular_light_interp.a);
+
+#endif
 		}
 #endif // SHADOWS_DISABLED
 
@@ -1670,6 +1578,9 @@ void main() {
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
 					binormal, tangent, anisotropy,
+#endif
+#ifdef LIGHT_INDEX_USED
+					i,
 #endif
 					diffuse_light,
 					specular_light);

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_light_dir_shadow_inline.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_light_dir_shadow_inline.glsl
@@ -1,0 +1,99 @@
+// Inlined directional shadow logic, use scene_data_block to access data
+if (directional_lights.data[i].shadow_opacity > 0.001) {
+	float depth_z = -vertex.z;
+
+	vec4 pssm_coord;
+	float blur_factor;
+	vec3 light_dir = directional_lights.data[i].direction;
+	vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
+
+#define BIAS_FUNC(m_var, m_idx)                                                                 \
+	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
+	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
+	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
+	m_var.xyz += normal_bias;
+
+	if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+		vec4 v = vec4(vertex, 1.0);
+
+		BIAS_FUNC(v, 0)
+
+		pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
+		blur_factor = 1.0;
+	} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+		vec4 v = vec4(vertex, 1.0);
+
+		BIAS_FUNC(v, 1)
+
+		pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+		// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+		blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
+		;
+	} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+		vec4 v = vec4(vertex, 1.0);
+
+		BIAS_FUNC(v, 2)
+
+		pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
+		// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+		blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
+	} else {
+		vec4 v = vec4(vertex, 1.0);
+
+		BIAS_FUNC(v, 3)
+
+		pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+		// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+		blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
+	}
+
+	pssm_coord /= pssm_coord.w;
+
+	shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data_block.data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data_block.data.taa_frame_count);
+
+	if (directional_lights.data[i].blend_splits) {
+		float pssm_blend;
+		float blur_factor2;
+
+		if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+			vec4 v = vec4(vertex, 1.0);
+			BIAS_FUNC(v, 1)
+			pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+			pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
+		} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+			vec4 v = vec4(vertex, 1.0);
+			BIAS_FUNC(v, 2)
+			pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
+			pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
+		} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+			vec4 v = vec4(vertex, 1.0);
+			BIAS_FUNC(v, 3)
+			pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+			pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.z - directional_lights.data[i].shadow_split_offsets.z * 0.1, directional_lights.data[i].shadow_split_offsets.z, depth_z);
+			// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+			blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
+		} else {
+			pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+			blur_factor2 = 1.0;
+		}
+
+		pssm_coord /= pssm_coord.w;
+
+		float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data_block.data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord, scene_data_block.data.taa_frame_count);
+		shadow = mix(shadow, shadow2, pssm_blend);
+	}
+
+	shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+
+#undef BIAS_FUNC
+}
+
+if (i < 4) {
+	shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
+} else {
+	shadow1 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << ((i - 4) * 8);
+}

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_base_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_base_inc.glsl
@@ -1,0 +1,526 @@
+// Functions related to lighting that can exist before light_compute and are not renderer specific
+float D_GGX(float cos_theta_m, float alpha) {
+	float a = cos_theta_m * alpha;
+	float k = alpha / (1.0 - cos_theta_m * cos_theta_m + a * a);
+	return k * k * (1.0 / M_PI);
+}
+
+// From Earl Hammon, Jr. "PBR Diffuse Lighting for GGX+Smith Microsurfaces" https://www.gdcvault.com/play/1024478/PBR-Diffuse-Lighting-for-GGX
+float V_GGX(float NdotL, float NdotV, float alpha) {
+	return 0.5 / mix(2.0 * NdotL * NdotV, NdotL + NdotV, alpha);
+}
+
+float D_GGX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float cos_phi, float sin_phi) {
+	float alpha2 = alpha_x * alpha_y;
+	highp vec3 v = vec3(alpha_y * cos_phi, alpha_x * sin_phi, alpha2 * cos_theta_m);
+	highp float v2 = dot(v, v);
+	float w2 = alpha2 / v2;
+	float D = alpha2 * w2 * w2 * (1.0 / M_PI);
+	return D;
+}
+
+float V_GGX_anisotropic(float alpha_x, float alpha_y, float TdotV, float TdotL, float BdotV, float BdotL, float NdotV, float NdotL) {
+	float Lambda_V = NdotL * length(vec3(alpha_x * TdotV, alpha_y * BdotV, NdotV));
+	float Lambda_L = NdotV * length(vec3(alpha_x * TdotL, alpha_y * BdotL, NdotL));
+	return 0.5 / (Lambda_V + Lambda_L);
+}
+
+float SchlickFresnel(float u) {
+	float m = 1.0 - u;
+	float m2 = m * m;
+	return m2 * m2 * m; // pow(m,5)
+}
+
+vec3 F0(float metallic, float specular, vec3 albedo) {
+	float dielectric = 0.16 * specular * specular;
+	// use albedo * metallic as colored specular reflectance at 0 angle for metallic materials;
+	// see https://google.github.io/filament/Filament.md.html
+	return mix(vec3(dielectric), albedo, vec3(metallic));
+}
+
+#ifndef SHADOWS_DISABLED
+
+// Interleaved Gradient Noise
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+float quick_hash(vec2 pos) {
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	return fract(magic.z * fract(dot(pos, magic.xy)));
+}
+
+float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord, float taa_frame_count) {
+	vec2 pos = coord.xy;
+	float depth = coord.z;
+
+	//if only one sample is taken, take it from the center
+	if (sc_directional_soft_shadow_samples() == 0) {
+		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+	}
+
+	mat2 disk_rotation;
+	{
+		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+		float sr = sin(r);
+		float cr = cos(r);
+		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+	}
+
+	float avg = 0.0;
+
+	for (uint i = 0; i < sc_directional_soft_shadow_samples(); i++) {
+		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos + shadow_pixel_size * (disk_rotation * scene_data_block.data.directional_soft_shadow_kernel[i].xy), depth, 1.0));
+	}
+
+	return avg * (1.0 / float(sc_directional_soft_shadow_samples()));
+}
+
+float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec3 coord, float taa_frame_count) {
+	vec2 pos = coord.xy;
+	float depth = coord.z;
+
+	//if only one sample is taken, take it from the center
+	if (sc_soft_shadow_samples() == 0) {
+		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+	}
+
+	mat2 disk_rotation;
+	{
+		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+		float sr = sin(r);
+		float cr = cos(r);
+		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+	}
+
+	float avg = 0.0;
+
+	for (uint i = 0; i < sc_soft_shadow_samples(); i++) {
+		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos + shadow_pixel_size * (disk_rotation * scene_data_block.data.soft_shadow_kernel[i].xy), depth, 1.0));
+	}
+
+	return avg * (1.0 / float(sc_soft_shadow_samples()));
+}
+
+float sample_omni_pcf_shadow(texture2D shadow, float blur_scale, vec2 coord, vec4 uv_rect, vec2 flip_offset, float depth, float taa_frame_count) {
+	//if only one sample is taken, take it from the center
+	if (sc_soft_shadow_samples() == 0) {
+		vec2 pos = coord * 0.5 + 0.5;
+		pos = uv_rect.xy + pos * uv_rect.zw;
+		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+	}
+
+	mat2 disk_rotation;
+	{
+		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+		float sr = sin(r);
+		float cr = cos(r);
+		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+	}
+
+	float avg = 0.0;
+	vec2 offset_scale = blur_scale * 2.0 * scene_data_block.data.shadow_atlas_pixel_size / uv_rect.zw;
+
+	for (uint i = 0; i < sc_soft_shadow_samples(); i++) {
+		vec2 offset = offset_scale * (disk_rotation * scene_data_block.data.soft_shadow_kernel[i].xy);
+		vec2 sample_coord = coord + offset;
+
+		float sample_coord_length_sqaured = dot(sample_coord, sample_coord);
+		bool do_flip = sample_coord_length_sqaured > 1.0;
+
+		if (do_flip) {
+			float len = sqrt(sample_coord_length_sqaured);
+			sample_coord = sample_coord * (2.0 / len - 1.0);
+		}
+
+		sample_coord = sample_coord * 0.5 + 0.5;
+		sample_coord = uv_rect.xy + sample_coord * uv_rect.zw;
+
+		if (do_flip) {
+			sample_coord += flip_offset;
+		}
+		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(sample_coord, depth, 1.0));
+	}
+
+	return avg * (1.0 / float(sc_soft_shadow_samples()));
+}
+
+float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex_scale, float taa_frame_count) {
+	//find blocker
+	float blocker_count = 0.0;
+	float blocker_average = 0.0;
+
+	mat2 disk_rotation;
+	{
+		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+		float sr = sin(r);
+		float cr = cos(r);
+		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+	}
+
+	for (uint i = 0; i < sc_directional_penumbra_shadow_samples(); i++) {
+		vec2 suv = pssm_coord.xy + (disk_rotation * scene_data_block.data.directional_penumbra_shadow_kernel[i].xy) * tex_scale;
+		float d = textureLod(sampler2D(shadow, SAMPLER_LINEAR_CLAMP), suv, 0.0).r;
+		if (d > pssm_coord.z) {
+			blocker_average += d;
+			blocker_count += 1.0;
+		}
+	}
+
+	if (blocker_count > 0.0) {
+		//blockers found, do soft shadow
+		blocker_average /= blocker_count;
+		float penumbra = (-pssm_coord.z + blocker_average) / (1.0 - blocker_average);
+		tex_scale *= penumbra;
+
+		float s = 0.0;
+		for (uint i = 0; i < sc_directional_penumbra_shadow_samples(); i++) {
+			vec2 suv = pssm_coord.xy + (disk_rotation * scene_data_block.data.directional_penumbra_shadow_kernel[i].xy) * tex_scale;
+			s += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(suv, pssm_coord.z, 1.0));
+		}
+
+		return s / float(sc_directional_penumbra_shadow_samples());
+
+	} else {
+		//no blockers found, so no shadow
+		return 1.0;
+	}
+}
+
+#endif // SHADOWS_DISABLED
+
+float get_omni_attenuation(float distance, float inv_range, float decay) {
+	float nd = distance * inv_range;
+	nd *= nd;
+	nd *= nd; // nd^4
+	nd = max(1.0 - nd, 0.0);
+	nd *= nd; // nd^2
+	return nd * pow(max(distance, 0.0001), -decay);
+}
+
+float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal, float taa_frame_count) {
+#ifndef SHADOWS_DISABLED
+	if (omni_lights.data[idx].shadow_opacity > 0.001) {
+		// there is a shadowmap
+		vec2 texel_size = scene_data_block.data.shadow_atlas_pixel_size;
+		vec4 base_uv_rect = omni_lights.data[idx].atlas_rect;
+		base_uv_rect.xy += texel_size;
+		base_uv_rect.zw -= texel_size * 2.0;
+
+		// Omni lights use direction.xy to store to store the offset between the two paraboloid regions
+		vec2 flip_offset = omni_lights.data[idx].direction.xy;
+
+		vec3 local_vert = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
+
+		float shadow_len = length(local_vert); //need to remember shadow len from here
+		vec3 shadow_dir = normalize(local_vert);
+
+		vec3 local_normal = normalize(mat3(omni_lights.data[idx].shadow_matrix) * normal);
+		vec3 normal_bias = local_normal * omni_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(local_normal, shadow_dir)));
+
+		float shadow;
+
+		if (sc_use_light_soft_shadows() && omni_lights.data[idx].soft_shadow_size > 0.0) {
+			//soft shadow
+
+			//find blocker
+
+			float blocker_count = 0.0;
+			float blocker_average = 0.0;
+
+			mat2 disk_rotation;
+			{
+				float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+				float sr = sin(r);
+				float cr = cos(r);
+				disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+			}
+
+			vec3 basis_normal = shadow_dir;
+			vec3 v0 = abs(basis_normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
+			vec3 tangent = normalize(cross(v0, basis_normal));
+			vec3 bitangent = normalize(cross(tangent, basis_normal));
+			float z_norm = 1.0 - shadow_len * omni_lights.data[idx].inv_radius;
+
+			tangent *= omni_lights.data[idx].soft_shadow_size * omni_lights.data[idx].soft_shadow_scale;
+			bitangent *= omni_lights.data[idx].soft_shadow_size * omni_lights.data[idx].soft_shadow_scale;
+
+			for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
+				vec2 disk = disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy;
+
+				vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
+
+				pos = normalize(pos);
+
+				vec4 uv_rect = base_uv_rect;
+
+				if (pos.z >= 0.0) {
+					uv_rect.xy += flip_offset;
+				}
+
+				pos.z = 1.0 + abs(pos.z);
+				pos.xy /= pos.z;
+
+				pos.xy = pos.xy * 0.5 + 0.5;
+				pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;
+
+				float d = textureLod(sampler2D(shadow_atlas, SAMPLER_LINEAR_CLAMP), pos.xy, 0.0).r;
+				if (d > z_norm) {
+					blocker_average += d;
+					blocker_count += 1.0;
+				}
+			}
+
+			if (blocker_count > 0.0) {
+				//blockers found, do soft shadow
+				blocker_average /= blocker_count;
+				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
+				tangent *= penumbra;
+				bitangent *= penumbra;
+
+				z_norm += omni_lights.data[idx].inv_radius * omni_lights.data[idx].shadow_bias;
+
+				shadow = 0.0;
+				for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
+					vec2 disk = disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy;
+					vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
+
+					pos = normalize(pos);
+					pos = normalize(pos + normal_bias);
+
+					vec4 uv_rect = base_uv_rect;
+
+					if (pos.z >= 0.0) {
+						uv_rect.xy += flip_offset;
+					}
+
+					pos.z = 1.0 + abs(pos.z);
+					pos.xy /= pos.z;
+
+					pos.xy = pos.xy * 0.5 + 0.5;
+					pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;
+					shadow += textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(pos.xy, z_norm, 1.0));
+				}
+
+				shadow /= float(sc_penumbra_shadow_samples());
+				shadow = mix(1.0, shadow, omni_lights.data[idx].shadow_opacity);
+
+			} else {
+				//no blockers found, so no shadow
+				shadow = 1.0;
+			}
+		} else {
+			vec4 uv_rect = base_uv_rect;
+
+			vec3 shadow_sample = normalize(shadow_dir + normal_bias);
+			if (shadow_sample.z >= 0.0) {
+				uv_rect.xy += flip_offset;
+				flip_offset *= -1.0;
+			}
+
+			shadow_sample.z = 1.0 + abs(shadow_sample.z);
+			vec2 pos = shadow_sample.xy / shadow_sample.z;
+			float depth = shadow_len - omni_lights.data[idx].shadow_bias;
+			depth *= omni_lights.data[idx].inv_radius;
+			depth = 1.0 - depth;
+			shadow = mix(1.0, sample_omni_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale / shadow_sample.z, pos, uv_rect, flip_offset, depth, taa_frame_count), omni_lights.data[idx].shadow_opacity);
+		}
+
+		return shadow;
+	}
+#endif
+
+	return 1.0;
+}
+
+float light_process_spot_shadow(uint idx, vec3 vertex, vec3 normal, float taa_frame_count) {
+#ifndef SHADOWS_DISABLED
+	if (spot_lights.data[idx].shadow_opacity > 0.001) {
+		vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
+		float light_length = length(light_rel_vec);
+		vec3 spot_dir = spot_lights.data[idx].direction;
+
+		vec3 shadow_dir = light_rel_vec / light_length;
+		vec3 normal_bias = normal * light_length * spot_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(normal, shadow_dir)));
+
+		//there is a shadowmap
+		vec4 v = vec4(vertex + normal_bias, 1.0);
+
+		vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
+		splane.z += spot_lights.data[idx].shadow_bias / (light_length * spot_lights.data[idx].inv_radius);
+		splane /= splane.w;
+
+		float shadow;
+		if (sc_use_light_soft_shadows() && spot_lights.data[idx].soft_shadow_size > 0.0) {
+			//soft shadow
+
+			//find blocker
+			float z_norm = dot(spot_dir, -light_rel_vec) * spot_lights.data[idx].inv_radius;
+
+			vec2 shadow_uv = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
+
+			float blocker_count = 0.0;
+			float blocker_average = 0.0;
+
+			mat2 disk_rotation;
+			{
+				float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
+				float sr = sin(r);
+				float cr = cos(r);
+				disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+			}
+
+			float uv_size = spot_lights.data[idx].soft_shadow_size * z_norm * spot_lights.data[idx].soft_shadow_scale;
+			vec2 clamp_max = spot_lights.data[idx].atlas_rect.xy + spot_lights.data[idx].atlas_rect.zw;
+			for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
+				vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
+				suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
+				float d = textureLod(sampler2D(shadow_atlas, SAMPLER_LINEAR_CLAMP), suv, 0.0).r;
+				if (d > splane.z) {
+					blocker_average += d;
+					blocker_count += 1.0;
+				}
+			}
+
+			if (blocker_count > 0.0) {
+				//blockers found, do soft shadow
+				blocker_average /= blocker_count;
+				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
+				uv_size *= penumbra;
+
+				shadow = 0.0;
+				for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
+					vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
+					suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
+					shadow += textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(suv, splane.z, 1.0));
+				}
+
+				shadow /= float(sc_penumbra_shadow_samples());
+				shadow = mix(1.0, shadow, spot_lights.data[idx].shadow_opacity);
+
+			} else {
+				//no blockers found, so no shadow
+				shadow = 1.0;
+			}
+		} else {
+			//hard shadow
+			vec3 shadow_uv = vec3(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z);
+			shadow = mix(1.0, sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data_block.data.shadow_atlas_pixel_size, shadow_uv, taa_frame_count), spot_lights.data[idx].shadow_opacity);
+		}
+
+		return shadow;
+	}
+
+#endif // SHADOWS_DISABLED
+
+	return 1.0;
+}
+
+vec2 normal_to_panorama(vec3 n) {
+	n = normalize(n);
+	vec2 panorama_coords = vec2(atan(n.x, n.z), acos(-n.y));
+
+	if (panorama_coords.x < 0.0) {
+		panorama_coords.x += M_PI * 2.0;
+	}
+
+	panorama_coords /= vec2(M_PI * 2.0, M_PI);
+	return panorama_coords;
+}
+
+void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
+	vec3 box_extents = reflections.data[ref_index].box_extents;
+	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
+
+	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
+		return;
+	}
+
+	vec3 inner_pos = abs(local_pos / box_extents);
+	float blend = max(inner_pos.x, max(inner_pos.y, inner_pos.z));
+	//make blend more rounded
+	blend = mix(length(inner_pos), blend, blend);
+	blend *= blend;
+	blend = max(0.0, 1.0 - blend);
+
+	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
+
+		vec3 local_ref_vec = (reflections.data[ref_index].local_matrix * vec4(ref_vec, 0.0)).xyz;
+
+		if (reflections.data[ref_index].box_project) { //box project
+
+			vec3 nrdir = normalize(local_ref_vec);
+			vec3 rbmax = (box_extents - local_pos) / nrdir;
+			vec3 rbmin = (-box_extents - local_pos) / nrdir;
+
+			vec3 rbminmax = mix(rbmin, rbmax, greaterThan(nrdir, vec3(0.0, 0.0, 0.0)));
+
+			float fa = min(min(rbminmax.x, rbminmax.y), rbminmax.z);
+			vec3 posonbox = local_pos + nrdir * fa;
+			local_ref_vec = posonbox - reflections.data[ref_index].box_offset;
+		}
+
+		vec4 reflection;
+
+		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier();
+		reflection.rgb *= reflections.data[ref_index].exposure_normalization;
+		if (reflections.data[ref_index].exterior) {
+			reflection.rgb = mix(specular_light, reflection.rgb, blend);
+		}
+
+		reflection.rgb *= reflections.data[ref_index].intensity; //intensity
+		reflection.a = blend;
+		reflection.rgb *= reflection.a;
+
+		reflection_accum += reflection;
+	}
+
+	switch (reflections.data[ref_index].ambient_mode) {
+		case REFLECTION_AMBIENT_DISABLED: {
+			//do nothing
+		} break;
+		case REFLECTION_AMBIENT_ENVIRONMENT: {
+			//do nothing
+			vec3 local_amb_vec = (reflections.data[ref_index].local_matrix * vec4(normal, 0.0)).xyz;
+
+			vec4 ambient_out;
+
+			ambient_out.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_amb_vec, reflections.data[ref_index].index), MAX_ROUGHNESS_LOD).rgb;
+			ambient_out.rgb *= reflections.data[ref_index].exposure_normalization;
+			ambient_out.a = blend;
+			if (reflections.data[ref_index].exterior) {
+				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
+			}
+
+			ambient_out.rgb *= ambient_out.a;
+			ambient_accum += ambient_out;
+		} break;
+		case REFLECTION_AMBIENT_COLOR: {
+			vec4 ambient_out;
+			ambient_out.a = blend;
+			ambient_out.rgb = reflections.data[ref_index].ambient;
+			if (reflections.data[ref_index].exterior) {
+				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
+			}
+			ambient_out.rgb *= ambient_out.a;
+			ambient_accum += ambient_out;
+		} break;
+	}
+}
+
+float blur_shadow(float shadow) {
+	return shadow;
+#if 0
+	//disabling for now, will investigate later
+	float interp_shadow = shadow;
+	if (gl_HelperInvocation) {
+		interp_shadow = -4.0; // technically anything below -4 will do but just to make sure
+	}
+
+	uvec2 fc2 = uvec2(gl_FragCoord.xy);
+	interp_shadow -= dFdx(interp_shadow) * (float(fc2.x & 1) - 0.5);
+	interp_shadow -= dFdy(interp_shadow) * (float(fc2.y & 1) - 0.5);
+
+	if (interp_shadow >= 0.0) {
+		shadow = interp_shadow;
+	}
+	return shadow;
+#endif
+}

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -1,42 +1,38 @@
-// Functions related to lighting
+// Functions related to lighting that require light_compute OR renderer specific functions to work
+float sample_directional_shadow(uint idx, vec3 vertex) {
+	float shadow = 1.0; // no shadow
+#ifndef SHADOWS_DISABLED
+#if defined(LIGHT_INDEX_USED)
 
-float D_GGX(float cos_theta_m, float alpha) {
-	float a = cos_theta_m * alpha;
-	float k = alpha / (1.0 - cos_theta_m * cos_theta_m + a * a);
-	return k * k * (1.0 / M_PI);
-}
+	if (idx >= scene_data_block.data.directional_light_count) {
+		return shadow;
+	}
 
-// From Earl Hammon, Jr. "PBR Diffuse Lighting for GGX+Smith Microsurfaces" https://www.gdcvault.com/play/1024478/PBR-Diffuse-Lighting-for-GGX
-float V_GGX(float NdotL, float NdotV, float alpha) {
-	return 0.5 / mix(2.0 * NdotL * NdotV, NdotL + NdotV, alpha);
-}
+	uint shadow0 = 0;
+	uint shadow1 = 0;
+	uint i = idx;
 
-float D_GGX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float cos_phi, float sin_phi) {
-	float alpha2 = alpha_x * alpha_y;
-	highp vec3 v = vec3(alpha_y * cos_phi, alpha_x * sin_phi, alpha2 * cos_theta_m);
-	highp float v2 = dot(v, v);
-	float w2 = alpha2 / v2;
-	float D = alpha2 * w2 * w2 * (1.0 / M_PI);
-	return D;
-}
+	vec3 normal_interp = vec3(0.0, 1.0, 0.0);
 
-float V_GGX_anisotropic(float alpha_x, float alpha_y, float TdotV, float TdotL, float BdotV, float BdotL, float NdotV, float NdotL) {
-	float Lambda_V = NdotL * length(vec3(alpha_x * TdotV, alpha_y * BdotV, NdotV));
-	float Lambda_L = NdotV * length(vec3(alpha_x * TdotL, alpha_y * BdotL, NdotL));
-	return 0.5 / (Lambda_V + Lambda_L);
-}
+// Inlined directional shadows
+#ifdef USING_MOBILE_RENDERER
 
-float SchlickFresnel(float u) {
-	float m = 1.0 - u;
-	float m2 = m * m;
-	return m2 * m2 * m; // pow(m,5)
-}
+#inline "./forward_mobile/scene_forward_mobile_light_dir_shadow_inline.glsl"
 
-vec3 F0(float metallic, float specular, vec3 albedo) {
-	float dielectric = 0.16 * specular * specular;
-	// use albedo * metallic as colored specular reflectance at 0 angle for metallic materials;
-	// see https://google.github.io/filament/Filament.md.html
-	return mix(vec3(dielectric), albedo, vec3(metallic));
+#else
+
+#inline "./forward_clustered/scene_forward_clustered_light_dir_shadow_inline.glsl"
+
+#endif // USING_MOBILE_RENDERER
+
+	if (idx < 4) {
+		shadow = float(shadow0 >> (idx * 8u) & 0xFFu) / 255.0;
+	} else {
+		shadow = float(shadow1 >> ((idx - 4u) * 8u) & 0xFFu) / 255.0;
+	}
+#endif // LIGHT_INDEX_USED
+#endif // SHADOWS_DISABLED
+	return shadow;
 }
 
 void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, uint orms, float specular_amount, vec3 albedo, inout float alpha,
@@ -57,6 +53,9 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 B, vec3 T, float anisotropy,
+#endif
+#ifdef LIGHT_INDEX_USED
+		uint light_index,
 #endif
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 
@@ -255,298 +254,6 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 #endif //defined(LIGHT_CODE_USED)
 }
 
-#ifndef SHADOWS_DISABLED
-
-// Interleaved Gradient Noise
-// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
-float quick_hash(vec2 pos) {
-	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
-	return fract(magic.z * fract(dot(pos, magic.xy)));
-}
-
-float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord, float taa_frame_count) {
-	vec2 pos = coord.xy;
-	float depth = coord.z;
-
-	//if only one sample is taken, take it from the center
-	if (sc_directional_soft_shadow_samples() == 0) {
-		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
-	}
-
-	mat2 disk_rotation;
-	{
-		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-		float sr = sin(r);
-		float cr = cos(r);
-		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-	}
-
-	float avg = 0.0;
-
-	for (uint i = 0; i < sc_directional_soft_shadow_samples(); i++) {
-		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos + shadow_pixel_size * (disk_rotation * scene_data_block.data.directional_soft_shadow_kernel[i].xy), depth, 1.0));
-	}
-
-	return avg * (1.0 / float(sc_directional_soft_shadow_samples()));
-}
-
-float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec3 coord, float taa_frame_count) {
-	vec2 pos = coord.xy;
-	float depth = coord.z;
-
-	//if only one sample is taken, take it from the center
-	if (sc_soft_shadow_samples() == 0) {
-		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
-	}
-
-	mat2 disk_rotation;
-	{
-		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-		float sr = sin(r);
-		float cr = cos(r);
-		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-	}
-
-	float avg = 0.0;
-
-	for (uint i = 0; i < sc_soft_shadow_samples(); i++) {
-		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos + shadow_pixel_size * (disk_rotation * scene_data_block.data.soft_shadow_kernel[i].xy), depth, 1.0));
-	}
-
-	return avg * (1.0 / float(sc_soft_shadow_samples()));
-}
-
-float sample_omni_pcf_shadow(texture2D shadow, float blur_scale, vec2 coord, vec4 uv_rect, vec2 flip_offset, float depth, float taa_frame_count) {
-	//if only one sample is taken, take it from the center
-	if (sc_soft_shadow_samples() == 0) {
-		vec2 pos = coord * 0.5 + 0.5;
-		pos = uv_rect.xy + pos * uv_rect.zw;
-		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
-	}
-
-	mat2 disk_rotation;
-	{
-		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-		float sr = sin(r);
-		float cr = cos(r);
-		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-	}
-
-	float avg = 0.0;
-	vec2 offset_scale = blur_scale * 2.0 * scene_data_block.data.shadow_atlas_pixel_size / uv_rect.zw;
-
-	for (uint i = 0; i < sc_soft_shadow_samples(); i++) {
-		vec2 offset = offset_scale * (disk_rotation * scene_data_block.data.soft_shadow_kernel[i].xy);
-		vec2 sample_coord = coord + offset;
-
-		float sample_coord_length_sqaured = dot(sample_coord, sample_coord);
-		bool do_flip = sample_coord_length_sqaured > 1.0;
-
-		if (do_flip) {
-			float len = sqrt(sample_coord_length_sqaured);
-			sample_coord = sample_coord * (2.0 / len - 1.0);
-		}
-
-		sample_coord = sample_coord * 0.5 + 0.5;
-		sample_coord = uv_rect.xy + sample_coord * uv_rect.zw;
-
-		if (do_flip) {
-			sample_coord += flip_offset;
-		}
-		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(sample_coord, depth, 1.0));
-	}
-
-	return avg * (1.0 / float(sc_soft_shadow_samples()));
-}
-
-float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex_scale, float taa_frame_count) {
-	//find blocker
-	float blocker_count = 0.0;
-	float blocker_average = 0.0;
-
-	mat2 disk_rotation;
-	{
-		float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-		float sr = sin(r);
-		float cr = cos(r);
-		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-	}
-
-	for (uint i = 0; i < sc_directional_penumbra_shadow_samples(); i++) {
-		vec2 suv = pssm_coord.xy + (disk_rotation * scene_data_block.data.directional_penumbra_shadow_kernel[i].xy) * tex_scale;
-		float d = textureLod(sampler2D(shadow, SAMPLER_LINEAR_CLAMP), suv, 0.0).r;
-		if (d > pssm_coord.z) {
-			blocker_average += d;
-			blocker_count += 1.0;
-		}
-	}
-
-	if (blocker_count > 0.0) {
-		//blockers found, do soft shadow
-		blocker_average /= blocker_count;
-		float penumbra = (-pssm_coord.z + blocker_average) / (1.0 - blocker_average);
-		tex_scale *= penumbra;
-
-		float s = 0.0;
-		for (uint i = 0; i < sc_directional_penumbra_shadow_samples(); i++) {
-			vec2 suv = pssm_coord.xy + (disk_rotation * scene_data_block.data.directional_penumbra_shadow_kernel[i].xy) * tex_scale;
-			s += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(suv, pssm_coord.z, 1.0));
-		}
-
-		return s / float(sc_directional_penumbra_shadow_samples());
-
-	} else {
-		//no blockers found, so no shadow
-		return 1.0;
-	}
-}
-
-#endif // SHADOWS_DISABLED
-
-float get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
-}
-
-float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal, float taa_frame_count) {
-#ifndef SHADOWS_DISABLED
-	if (omni_lights.data[idx].shadow_opacity > 0.001) {
-		// there is a shadowmap
-		vec2 texel_size = scene_data_block.data.shadow_atlas_pixel_size;
-		vec4 base_uv_rect = omni_lights.data[idx].atlas_rect;
-		base_uv_rect.xy += texel_size;
-		base_uv_rect.zw -= texel_size * 2.0;
-
-		// Omni lights use direction.xy to store to store the offset between the two paraboloid regions
-		vec2 flip_offset = omni_lights.data[idx].direction.xy;
-
-		vec3 local_vert = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
-
-		float shadow_len = length(local_vert); //need to remember shadow len from here
-		vec3 shadow_dir = normalize(local_vert);
-
-		vec3 local_normal = normalize(mat3(omni_lights.data[idx].shadow_matrix) * normal);
-		vec3 normal_bias = local_normal * omni_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(local_normal, shadow_dir)));
-
-		float shadow;
-
-		if (sc_use_light_soft_shadows() && omni_lights.data[idx].soft_shadow_size > 0.0) {
-			//soft shadow
-
-			//find blocker
-
-			float blocker_count = 0.0;
-			float blocker_average = 0.0;
-
-			mat2 disk_rotation;
-			{
-				float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-				float sr = sin(r);
-				float cr = cos(r);
-				disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-			}
-
-			vec3 basis_normal = shadow_dir;
-			vec3 v0 = abs(basis_normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
-			vec3 tangent = normalize(cross(v0, basis_normal));
-			vec3 bitangent = normalize(cross(tangent, basis_normal));
-			float z_norm = 1.0 - shadow_len * omni_lights.data[idx].inv_radius;
-
-			tangent *= omni_lights.data[idx].soft_shadow_size * omni_lights.data[idx].soft_shadow_scale;
-			bitangent *= omni_lights.data[idx].soft_shadow_size * omni_lights.data[idx].soft_shadow_scale;
-
-			for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
-				vec2 disk = disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy;
-
-				vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
-
-				pos = normalize(pos);
-
-				vec4 uv_rect = base_uv_rect;
-
-				if (pos.z >= 0.0) {
-					uv_rect.xy += flip_offset;
-				}
-
-				pos.z = 1.0 + abs(pos.z);
-				pos.xy /= pos.z;
-
-				pos.xy = pos.xy * 0.5 + 0.5;
-				pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;
-
-				float d = textureLod(sampler2D(shadow_atlas, SAMPLER_LINEAR_CLAMP), pos.xy, 0.0).r;
-				if (d > z_norm) {
-					blocker_average += d;
-					blocker_count += 1.0;
-				}
-			}
-
-			if (blocker_count > 0.0) {
-				//blockers found, do soft shadow
-				blocker_average /= blocker_count;
-				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
-				tangent *= penumbra;
-				bitangent *= penumbra;
-
-				z_norm += omni_lights.data[idx].inv_radius * omni_lights.data[idx].shadow_bias;
-
-				shadow = 0.0;
-				for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
-					vec2 disk = disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy;
-					vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
-
-					pos = normalize(pos);
-					pos = normalize(pos + normal_bias);
-
-					vec4 uv_rect = base_uv_rect;
-
-					if (pos.z >= 0.0) {
-						uv_rect.xy += flip_offset;
-					}
-
-					pos.z = 1.0 + abs(pos.z);
-					pos.xy /= pos.z;
-
-					pos.xy = pos.xy * 0.5 + 0.5;
-					pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;
-					shadow += textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(pos.xy, z_norm, 1.0));
-				}
-
-				shadow /= float(sc_penumbra_shadow_samples());
-				shadow = mix(1.0, shadow, omni_lights.data[idx].shadow_opacity);
-
-			} else {
-				//no blockers found, so no shadow
-				shadow = 1.0;
-			}
-		} else {
-			vec4 uv_rect = base_uv_rect;
-
-			vec3 shadow_sample = normalize(shadow_dir + normal_bias);
-			if (shadow_sample.z >= 0.0) {
-				uv_rect.xy += flip_offset;
-				flip_offset *= -1.0;
-			}
-
-			shadow_sample.z = 1.0 + abs(shadow_sample.z);
-			vec2 pos = shadow_sample.xy / shadow_sample.z;
-			float depth = shadow_len - omni_lights.data[idx].shadow_bias;
-			depth *= omni_lights.data[idx].inv_radius;
-			depth = 1.0 - depth;
-			shadow = mix(1.0, sample_omni_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale / shadow_sample.z, pos, uv_rect, flip_offset, depth, taa_frame_count), omni_lights.data[idx].shadow_opacity);
-		}
-
-		return shadow;
-	}
-#endif
-
-	return 1.0;
-}
-
 void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo, inout float alpha,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
@@ -694,103 +401,11 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
 #endif
+#ifdef LIGHT_INDEX_USED
+			idx,
+#endif
 			diffuse_light,
 			specular_light);
-}
-
-float light_process_spot_shadow(uint idx, vec3 vertex, vec3 normal, float taa_frame_count) {
-#ifndef SHADOWS_DISABLED
-	if (spot_lights.data[idx].shadow_opacity > 0.001) {
-		vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
-		float light_length = length(light_rel_vec);
-		vec3 spot_dir = spot_lights.data[idx].direction;
-
-		vec3 shadow_dir = light_rel_vec / light_length;
-		vec3 normal_bias = normal * light_length * spot_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(normal, shadow_dir)));
-
-		//there is a shadowmap
-		vec4 v = vec4(vertex + normal_bias, 1.0);
-
-		vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
-		splane.z += spot_lights.data[idx].shadow_bias / (light_length * spot_lights.data[idx].inv_radius);
-		splane /= splane.w;
-
-		float shadow;
-		if (sc_use_light_soft_shadows() && spot_lights.data[idx].soft_shadow_size > 0.0) {
-			//soft shadow
-
-			//find blocker
-			float z_norm = dot(spot_dir, -light_rel_vec) * spot_lights.data[idx].inv_radius;
-
-			vec2 shadow_uv = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
-
-			float blocker_count = 0.0;
-			float blocker_average = 0.0;
-
-			mat2 disk_rotation;
-			{
-				float r = quick_hash(gl_FragCoord.xy + vec2(taa_frame_count * 5.588238)) * 2.0 * M_PI;
-				float sr = sin(r);
-				float cr = cos(r);
-				disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
-			}
-
-			float uv_size = spot_lights.data[idx].soft_shadow_size * z_norm * spot_lights.data[idx].soft_shadow_scale;
-			vec2 clamp_max = spot_lights.data[idx].atlas_rect.xy + spot_lights.data[idx].atlas_rect.zw;
-			for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
-				vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
-				suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
-				float d = textureLod(sampler2D(shadow_atlas, SAMPLER_LINEAR_CLAMP), suv, 0.0).r;
-				if (d > splane.z) {
-					blocker_average += d;
-					blocker_count += 1.0;
-				}
-			}
-
-			if (blocker_count > 0.0) {
-				//blockers found, do soft shadow
-				blocker_average /= blocker_count;
-				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
-				uv_size *= penumbra;
-
-				shadow = 0.0;
-				for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
-					vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
-					suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
-					shadow += textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(suv, splane.z, 1.0));
-				}
-
-				shadow /= float(sc_penumbra_shadow_samples());
-				shadow = mix(1.0, shadow, spot_lights.data[idx].shadow_opacity);
-
-			} else {
-				//no blockers found, so no shadow
-				shadow = 1.0;
-			}
-		} else {
-			//hard shadow
-			vec3 shadow_uv = vec3(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z);
-			shadow = mix(1.0, sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data_block.data.shadow_atlas_pixel_size, shadow_uv, taa_frame_count), spot_lights.data[idx].shadow_opacity);
-		}
-
-		return shadow;
-	}
-
-#endif // SHADOWS_DISABLED
-
-	return 1.0;
-}
-
-vec2 normal_to_panorama(vec3 n) {
-	n = normalize(n);
-	vec2 panorama_coords = vec2(atan(n.x, n.z), acos(-n.y));
-
-	if (panorama_coords.x < 0.0) {
-		panorama_coords.x += M_PI * 2.0;
-	}
-
-	panorama_coords /= vec2(M_PI * 2.0, M_PI);
-	return panorama_coords;
 }
 
 void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float shadow, vec3 albedo, inout float alpha,
@@ -903,105 +518,8 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
 #endif
-			diffuse_light, specular_light);
-}
-
-void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
-	vec3 box_extents = reflections.data[ref_index].box_extents;
-	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
-
-	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
-		return;
-	}
-
-	vec3 inner_pos = abs(local_pos / box_extents);
-	float blend = max(inner_pos.x, max(inner_pos.y, inner_pos.z));
-	//make blend more rounded
-	blend = mix(length(inner_pos), blend, blend);
-	blend *= blend;
-	blend = max(0.0, 1.0 - blend);
-
-	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
-
-		vec3 local_ref_vec = (reflections.data[ref_index].local_matrix * vec4(ref_vec, 0.0)).xyz;
-
-		if (reflections.data[ref_index].box_project) { //box project
-
-			vec3 nrdir = normalize(local_ref_vec);
-			vec3 rbmax = (box_extents - local_pos) / nrdir;
-			vec3 rbmin = (-box_extents - local_pos) / nrdir;
-
-			vec3 rbminmax = mix(rbmin, rbmax, greaterThan(nrdir, vec3(0.0, 0.0, 0.0)));
-
-			float fa = min(min(rbminmax.x, rbminmax.y), rbminmax.z);
-			vec3 posonbox = local_pos + nrdir * fa;
-			local_ref_vec = posonbox - reflections.data[ref_index].box_offset;
-		}
-
-		vec4 reflection;
-
-		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier();
-		reflection.rgb *= reflections.data[ref_index].exposure_normalization;
-		if (reflections.data[ref_index].exterior) {
-			reflection.rgb = mix(specular_light, reflection.rgb, blend);
-		}
-
-		reflection.rgb *= reflections.data[ref_index].intensity; //intensity
-		reflection.a = blend;
-		reflection.rgb *= reflection.a;
-
-		reflection_accum += reflection;
-	}
-
-	switch (reflections.data[ref_index].ambient_mode) {
-		case REFLECTION_AMBIENT_DISABLED: {
-			//do nothing
-		} break;
-		case REFLECTION_AMBIENT_ENVIRONMENT: {
-			//do nothing
-			vec3 local_amb_vec = (reflections.data[ref_index].local_matrix * vec4(normal, 0.0)).xyz;
-
-			vec4 ambient_out;
-
-			ambient_out.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_amb_vec, reflections.data[ref_index].index), MAX_ROUGHNESS_LOD).rgb;
-			ambient_out.rgb *= reflections.data[ref_index].exposure_normalization;
-			ambient_out.a = blend;
-			if (reflections.data[ref_index].exterior) {
-				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
-			}
-
-			ambient_out.rgb *= ambient_out.a;
-			ambient_accum += ambient_out;
-		} break;
-		case REFLECTION_AMBIENT_COLOR: {
-			vec4 ambient_out;
-			ambient_out.a = blend;
-			ambient_out.rgb = reflections.data[ref_index].ambient;
-			if (reflections.data[ref_index].exterior) {
-				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
-			}
-			ambient_out.rgb *= ambient_out.a;
-			ambient_accum += ambient_out;
-		} break;
-	}
-}
-
-float blur_shadow(float shadow) {
-	return shadow;
-#if 0
-	//disabling for now, will investigate later
-	float interp_shadow = shadow;
-	if (gl_HelperInvocation) {
-		interp_shadow = -4.0; // technically anything below -4 will do but just to make sure
-	}
-
-	uvec2 fc2 = uvec2(gl_FragCoord.xy);
-	interp_shadow -= dFdx(interp_shadow) * (float(fc2.x & 1) - 0.5);
-	interp_shadow -= dFdy(interp_shadow) * (float(fc2.y & 1) - 0.5);
-
-	if (interp_shadow >= 0.0) {
-		shadow = interp_shadow;
-	}
-	return shadow;
+#ifdef LIGHT_INDEX_USED
+			idx,
 #endif
+			diffuse_light, specular_light);
 }

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3509,6 +3509,8 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "frexp", TYPE_VEC3, { TYPE_VEC3, TYPE_IVEC3, TYPE_VOID }, { "x", "exp" }, TAG_GLOBAL, true },
 	{ "frexp", TYPE_VEC4, { TYPE_VEC4, TYPE_IVEC4, TYPE_VOID }, { "x", "exp" }, TAG_GLOBAL, true },
 
+	{ "sample_directional_shadow", TYPE_FLOAT, { TYPE_UINT, TYPE_VEC3, TYPE_VOID }, { "idx", "vertex" }, TAG_GLOBAL, true },
+
 	{ nullptr, TYPE_VOID, { TYPE_VOID }, { "" }, TAG_GLOBAL, false }
 };
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -206,6 +206,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["CLIP_SPACE_FAR"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ALPHA"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["LIGHT_INDEX"] = constt(ShaderLanguage::TYPE_UINT);
 
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].can_discard = true;
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].main_function = true;


### PR DESCRIPTION
Provides feature [8872 ](https://github.com/godotengine/godot-proposals/issues/8872) please like that proposal if you want to see this merged, this PR has more attention than the proposal.

In a nutshell:

1. Adds a Light Shader LIGHT_INDEX for all forward light_compute lights.
2. Adds sample_directional_shadow method exposed to the Light shader that can make use of LIGHT_INDEX
3. Reorders the forward light glsl shader so shadows are reachable from the Light shaders and moves the directional light shadow sampling logic out of the forward_mobile/forward_clustered glsl
4. Fixes the new USE_VERTEX_LIGHTING which appears to have leaked inside the directional shadow sampling logic! Moves the diffuse and specular logic out of the directional shadow sampling code

I opened this PR mainly to get feedback and see if there was an appetite for it. I also wanted to understand if there was any specific profiling necessary.

This change works for the forward clustered + mobile pipeline and has been tested on both with USE_VERTEX_LIGHTING. I dont imagine anyone using the compatibility pipeline will be using Godot's light shaders so that flow is out of scope.