### PR TITLE
Improve BitMap error reporting when trying to exceed size limits

### DIFF
--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A two-dimensional array of boolean values, can be used to efficiently store a binary matrix (every matrix element takes only one bit) and query the values using natural cartesian coordinates.
+		[b]Note:[/b] The maximum size of a [BitMap] is [code]2^31 - 8[/code] values (inclusive). For a square bitmap, the maximum size is therefore [code]46340×46340[/code]. For a 1 value-wide or tall bitmap, the maximum size is [code]2147483640×1[/code] or [code]1×2147483640[/code]. Writing the [BitMap] to an image has stricter size restrictions; see [method convert_to_image].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,6 +14,8 @@
 			<return type="Image" />
 			<description>
 				Returns an image of the same size as the bitmap and with a [enum Image.Format] of type [constant Image.FORMAT_L8]. [code]true[/code] bits of the bitmap are being converted into white pixels, and [code]false[/code] bits into black.
+				[b]Note:[/b] For technical reasons, only bitmaps that have [code]2^28[/code] values or fewer can be converted to an [Image]. For a square bitmap, the maximum convertible size is therefore [code]16384×16384[/code]. For a 1 value-wide or tall bitmap, the maximum size is [code]268435456×1[/code] or [code]1×268435456[/code].
+				[b]Note:[/b] If saving the resulting [Image] to a file, keep in mind each file format's limitations. PNG is generally most suited for saving [BitMap]s, as it uses lossless compression and supports images up to 1,000,000 pixels wide or tall.
 			</description>
 		</method>
 		<method name="create">

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -34,10 +34,12 @@
 #include "core/variant/typed_array.h"
 
 void BitMap::create(const Size2i &p_size) {
-	ERR_FAIL_COND(p_size.width < 1);
-	ERR_FAIL_COND(p_size.height < 1);
+	ERR_FAIL_COND_MSG(p_size.width < 1, vformat("The requested BitMap width (%d values) must be at least 1 value.", p_size.width));
+	ERR_FAIL_COND_MSG(p_size.height < 1, vformat("The requested BitMap height (%d values) must be at least 1 value.", p_size.height));
 
-	ERR_FAIL_COND(static_cast<int64_t>(p_size.width) * static_cast<int64_t>(p_size.height) > INT32_MAX);
+	// The maximum BitMap size is `INT32_MAX - 8` because of the bitmask implementation (see `Math::division_round_up()` call below).
+	ERR_FAIL_COND_MSG(static_cast<int64_t>(p_size.width) * static_cast<int64_t>(p_size.height) > (INT32_MAX - 7),
+			vformat(U"The requested BitMap size (%d×%d = %d values) is too large. The total value count must be `2^31 - 8` (2147483640) values or lower.", p_size.width, p_size.height, static_cast<int64_t>(p_size.width) * static_cast<int64_t>(p_size.height)));
 
 	Error err = bitmask.resize(Math::division_round_up(p_size.width * p_size.height, 8));
 	ERR_FAIL_COND(err != OK);
@@ -642,7 +644,8 @@ TypedArray<PackedVector2Array> BitMap::_opaque_to_polygons_bind(const Rect2i &p_
 }
 
 void BitMap::resize(const Size2i &p_new_size) {
-	ERR_FAIL_COND(p_new_size.width < 0 || p_new_size.height < 0);
+	ERR_FAIL_COND_MSG(p_new_size.width < 0, vformat("The requested BitMap width (%d values) must be at least 1 value.", p_new_size.width));
+	ERR_FAIL_COND_MSG(p_new_size.height < 0, vformat("The requested BitMap width (%d values) must be at least 1 value.", p_new_size.height));
 	if (p_new_size == get_size()) {
 		return;
 	}


### PR DESCRIPTION
This also improves the BitMap class documentation.

- See https://github.com/godotengine/godot-proposals/issues/10089.
