### PR TITLE
Use backslashes in absolute paths copied from the FileSystem dock on Windows

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2512,7 +2512,13 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_COPY_ABSOLUTE_PATH: {
 			if (!p_selected.is_empty()) {
 				const String &fpath = p_selected[0];
+#ifdef WINDOWS_ENABLED
+				// Replace forward slashes with backslashes to make copying to other programs easier,
+				// as many Windows programs only accept paths with backslashes.
+				const String absolute_path = ProjectSettings::get_singleton()->globalize_path(fpath).replace("/", "\\");
+#else
 				const String absolute_path = ProjectSettings::get_singleton()->globalize_path(fpath);
+#endif
 				DisplayServer::get_singleton()->clipboard_set(absolute_path);
 			}
 		} break;


### PR DESCRIPTION
This results in paths that can be readily pasted in more Windows programs compared to paths with forward slashes.

As evidenced by https://github.com/godotengine/godot-proposals/issues/10036#issuecomment-2187512224, there are a handful of cases where paths with backslashes are not compatible, but it's much rarer than cases where paths with forward slashes are not allowed. Old/legacy apps tend to be particularly stingy here.

- This closes https://github.com/godotengine/godot-proposals/issues/10036.
