### PR TITLE
Fix sprite frame editor crash with null `frames` pointer

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -953,7 +953,7 @@ void SpriteFramesEditor::_sync_animation() {
 }
 
 void SpriteFramesEditor::_select_animation(const String &p_name, bool p_update_node) {
-	if (!frames->has_animation(p_name)) {
+	if (frames.is_null() || !frames->has_animation(p_name)) {
 		return;
 	}
 	edited_anim = p_name;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93845

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
