### PR TITLE
Fix orphan StringName's in ShaderLanguage 

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10837,4 +10837,5 @@ ShaderLanguage::ShaderLanguage() {
 
 ShaderLanguage::~ShaderLanguage() {
 	clear();
+	global_func_set.clear();
 }


### PR DESCRIPTION
As noted by @akien-mga in https://github.com/godotengine/godot/issues/92726#issuecomment-2145566459