### PR TITLE
Physics Interpolation - Fix `interpolated_transform_2d`

### DIFF
--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -33,44 +33,14 @@
 #include "core/math/transform_2d.h"
 
 void TransformInterpolator::interpolate_transform_2d(const Transform2D &p_prev, const Transform2D &p_curr, Transform2D &r_result, real_t p_fraction) {
-	// Extract parameters.
-	Vector2 p1 = p_prev.get_origin();
-	Vector2 p2 = p_curr.get_origin();
-
 	// Special case for physics interpolation, if flipping, don't interpolate basis.
 	// If the determinant polarity changes, the handedness of the coordinate system changes.
 	if (_sign(p_prev.determinant()) != _sign(p_curr.determinant())) {
 		r_result.columns[0] = p_curr.columns[0];
 		r_result.columns[1] = p_curr.columns[1];
-		r_result.set_origin(p1.lerp(p2, p_fraction));
+		r_result.set_origin(p_prev.get_origin().lerp(p_curr.get_origin(), p_fraction));
 		return;
 	}
 
-	real_t r1 = p_prev.get_rotation();
-	real_t r2 = p_curr.get_rotation();
-
-	Size2 s1 = p_prev.get_scale();
-	Size2 s2 = p_curr.get_scale();
-
-	// Slerp rotation.
-	Vector2 v1(Math::cos(r1), Math::sin(r1));
-	Vector2 v2(Math::cos(r2), Math::sin(r2));
-
-	real_t dot = v1.dot(v2);
-
-	dot = CLAMP(dot, -1, 1);
-
-	Vector2 v;
-
-	if (dot > 0.9995f) {
-		v = v1.lerp(v2, p_fraction).normalized(); // Linearly interpolate to avoid numerical precision issues.
-	} else {
-		real_t angle = p_fraction * Math::acos(dot);
-		Vector2 v3 = (v2 - v1 * dot).normalized();
-		v = v1 * Math::cos(angle) + v3 * Math::sin(angle);
-	}
-
-	// Construct matrix.
-	r_result = Transform2D(Math::atan2(v.y, v.x), p1.lerp(p2, p_fraction));
-	r_result.scale_basis(s1.lerp(s2, p_fraction));
+	r_result = p_prev.interpolate_with(p_curr, p_fraction);
 }


### PR DESCRIPTION
Uses the skew correct `Transform2D::interpolate_with()` function rather than the bugged 3.x version.

Fixes #93586
Port of #93851

## Notes
* May want to bump this to 4.3 milestone as it is fairly simple and good to fix.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
