### PR TITLE
[Web] Remove unnecessary `EMCC_FORCE_STDLIBS` in dlink builds

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -71,8 +71,6 @@ if env["dlink_enabled"]:
     sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
     sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
     sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
-    # Force exporting the standard library (printf, malloc, etc.)
-    sys_env["ENV"]["EMCC_FORCE_STDLIBS"] = "libc,libc++,libc++abi"
     sys_env["CCFLAGS"].remove("-fvisibility=hidden")
     sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
 


### PR DESCRIPTION
As discussed with [upstream](https://github.com/emscripten-core/emscripten/issues/22161#issuecomment-2200772378), the C/C++ standard library is always fully included when building with `MAIN_MODULE=1` (not subject to DCE), so using `EMCC_FORCE_STDLIBS` is not necessary in our case.

This also, incidentally, fixes non-threaded dlink builds without having to wait for https://github.com/emscripten-core/emscripten/pull/22171 to be released.