### PR TITLE
Fix AnimationMixer docs example code for `get_root_motion_rotation_accumulator`

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -182,10 +182,10 @@
 				func _process(delta):
 				    if Input.is_action_just_pressed("animate"):
 				        state_machine.travel("Animate")
-				    var current_root_motion_rotation_accumulator: Quaternion = animation_tree.get_root_motion_Quaternion_accumulator()
+				    var current_root_motion_rotation_accumulator: Quaternion = animation_tree.get_root_motion_rotation_accumulator()
 				    var difference: Quaternion = prev_root_motion_rotation_accumulator.inverse() * current_root_motion_rotation_accumulator
 				    prev_root_motion_rotation_accumulator = current_root_motion_rotation_accumulator
-				    transform.basis *= difference
+				    transform.basis *=  Basis(difference)
 				[/gdscript]
 				[/codeblocks]
 				However, if the animation loops, an unintended discrete change may occur, so this is only useful for some simple use cases.


### PR DESCRIPTION
Fixes #93821
-Changed `get_root_motion_Quaternion_accumulator` to `get_root_motion_rotation_accumulator`
-Changed  `transform.basis *= difference` to `transform.basis *= Basis(difference)`