### PR TITLE
Fix parsing of `4.` in Expression

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -30,12 +30,7 @@
 
 #include "expression.h"
 
-#include "core/io/marshalls.h"
-#include "core/math/math_funcs.h"
 #include "core/object/class_db.h"
-#include "core/object/ref_counted.h"
-#include "core/os/os.h"
-#include "core/variant/variant_parser.h"
 
 Error Expression::_get_token(Token &r_token) {
 	while (true) {
@@ -392,7 +387,6 @@ Error Expression::_get_token(Token &r_token) {
 								if (is_digit(c)) {
 								} else if (c == 'e') {
 									reading = READING_EXP;
-
 								} else {
 									reading = READING_DONE;
 								}
@@ -419,7 +413,9 @@ Error Expression::_get_token(Token &r_token) {
 						is_first_char = false;
 					}
 
-					str_ofs--;
+					if (c != 0) {
+						str_ofs--;
+					}
 
 					r_token.type = TK_CONSTANT;
 

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -122,6 +122,59 @@ TEST_CASE("[Expression] Floating-point arithmetic") {
 			"Float multiplication-addition-subtraction-division should return the expected result.");
 }
 
+TEST_CASE("[Expression] Floating-point notation") {
+	Expression expression;
+
+	CHECK_MESSAGE(
+			expression.parse("2.") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(2.0),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse("(2.)") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(2.0),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse(".3") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(0.3),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse("2.+5.") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(7.0),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse(".3-.8") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(-0.5),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse("2.+.2") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(2.2),
+			"The expression should return the expected result.");
+
+	CHECK_MESSAGE(
+			expression.parse(".0*0.") == OK,
+			"The expression should parse successfully.");
+	CHECK_MESSAGE(
+			double(expression.execute()) == doctest::Approx(0.0),
+			"The expression should return the expected result.");
+}
+
 TEST_CASE("[Expression] Scientific notation") {
 	Expression expression;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92895

`Expression` has a bug handling numbers at the end of an expression. It always puts the last character back in the stream.

Unlike other unexpected characters, reading an end-of-string does not move the cursor, so we should not move the cursor back in this case.

For example `1e5` should produce two tokens `CONSTANT(10000)` and `EOF`, but it's actually three tokens `CONSTANT(10000)`, `CONSTANT(5)` and `EOF`. A standalone `4.` is similar, it was parsed into `CONSTANT(4.0)`, `PERIOD`, and `EOF`. This sequence is invalid, thus the error.