### PR TITLE
[3.x] Fix `AtlasTexture::draw_rect` flipping for non-zero margin

### DIFF
--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -93,15 +93,6 @@ void TextureRect::_notification(int p_what) {
 			} break;
 		}
 
-		Ref<AtlasTexture> p_atlas = texture;
-
-		if (p_atlas.is_valid() && region.has_no_area()) {
-			Size2 scale_size(size.width / texture->get_width(), size.height / texture->get_height());
-
-			offset.width += hflip ? p_atlas->get_margin().get_position().width * scale_size.width * 2 : 0;
-			offset.height += vflip ? p_atlas->get_margin().get_position().height * scale_size.height * 2 : 0;
-		}
-
 		size.width *= hflip ? -1.0f : 1.0f;
 		size.height *= vflip ? -1.0f : 1.0f;
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1013,20 +1013,13 @@ void AtlasTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile
 		return;
 	}
 
-	Rect2 rc = region;
+	Rect2 src_rect = Rect2(0, 0, get_width(), get_height());
 
-	if (rc.size.width == 0) {
-		rc.size.width = atlas->get_width();
+	Rect2 dst;
+	Rect2 src;
+	if (get_rect_region(p_rect, src_rect, dst, src)) {
+		atlas->draw_rect_region(p_canvas_item, dst, src, p_modulate, p_transpose, p_normal_map);
 	}
-
-	if (rc.size.height == 0) {
-		rc.size.height = atlas->get_height();
-	}
-
-	Vector2 scale = p_rect.size / (region.size + margin.size);
-	Rect2 dr(p_rect.position + margin.position * scale, rc.size * scale);
-
-	atlas->draw_rect_region(p_canvas_item, dr, rc, p_modulate, p_transpose, p_normal_map);
 }
 
 Texture::RefineRectResult AtlasTexture::refine_rect_region(Rect2 &r_dst_rect, Rect2 &r_src_rect) const {


### PR DESCRIPTION
3.x version of #93828.
