### PR TITLE
Fix inconsistent behavior of Bezier editor undo operations upon selection of different animation

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1096,7 +1096,8 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 							for (int i = 0; i < animation->track_get_key_count(track); ++i) {
 								undo_redo->add_undo_method(
 										this,
-										"_bezier_track_insert_key",
+										"_bezier_track_insert_key_at_anim",
+										animation,
 										track,
 										animation->track_get_key_time(track, i),
 										animation->bezier_track_get_key_value(track, i),
@@ -1370,7 +1371,8 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					key[0] = h;
 					undo_redo->add_do_method(
 							this,
-							"_bezier_track_insert_key",
+							"_bezier_track_insert_key_at_anim",
+							animation,
 							E->get().first,
 							newpos,
 							key[0],
@@ -1391,7 +1393,8 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					Array key = animation->track_get_key_value(E->get().first, E->get().second);
 					undo_redo->add_undo_method(
 							this,
-							"_bezier_track_insert_key",
+							"_bezier_track_insert_key_at_anim",
+							animation,
 							E->get().first,
 							oldpos,
 							key[0],
@@ -1409,7 +1412,8 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
 					undo_redo->add_undo_method(
 							this,
-							"_bezier_track_insert_key",
+							"_bezier_track_insert_key_at_anim",
+							animation,
 							amr.track,
 							amr.time,
 							key[0],
@@ -1931,10 +1935,9 @@ void AnimationBezierTrackEdit::delete_selection() {
 	}
 }
 
-void AnimationBezierTrackEdit::_bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode) {
-	ERR_FAIL_COND(animation.is_null());
-	int idx = animation->bezier_track_insert_key(p_track, p_time, p_value, p_in_handle, p_out_handle);
-	animation->bezier_track_set_key_handle_mode(p_track, idx, p_handle_mode);
+void AnimationBezierTrackEdit::_bezier_track_insert_key_at_anim(const Ref<Animation> &p_anim, int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode) {
+	int idx = p_anim->bezier_track_insert_key(p_track, p_time, p_value, p_in_handle, p_out_handle);
+	p_anim->bezier_track_set_key_handle_mode(p_track, idx, p_handle_mode);
 }
 
 void AnimationBezierTrackEdit::_bind_methods() {
@@ -1943,7 +1946,7 @@ void AnimationBezierTrackEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_select_at_anim"), &AnimationBezierTrackEdit::_select_at_anim);
 	ClassDB::bind_method(D_METHOD("_update_hidden_tracks_after"), &AnimationBezierTrackEdit::_update_hidden_tracks_after);
 	ClassDB::bind_method(D_METHOD("_update_locked_tracks_after"), &AnimationBezierTrackEdit::_update_locked_tracks_after);
-	ClassDB::bind_method(D_METHOD("_bezier_track_insert_key"), &AnimationBezierTrackEdit::_bezier_track_insert_key);
+	ClassDB::bind_method(D_METHOD("_bezier_track_insert_key_at_anim"), &AnimationBezierTrackEdit::_bezier_track_insert_key_at_anim);
 
 	ADD_SIGNAL(MethodInfo("select_key", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "single"), PropertyInfo(Variant::INT, "track")));
 	ADD_SIGNAL(MethodInfo("deselect_key", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::INT, "track")));

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -222,7 +222,7 @@ public:
 	void paste_keys(real_t p_ofs, bool p_ofs_valid);
 	void delete_selection();
 
-	void _bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode);
+	void _bezier_track_insert_key_at_anim(const Ref<Animation> &p_anim, int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode);
 
 	AnimationBezierTrackEdit();
 };


### PR DESCRIPTION
Fixes #93859.

~This PR removes the method `_bezier_track_insert_key` in the `AnimationBezierEditor` and adds a method `bezier_track_insert_key_with_handle_mode` in `Animation`. This new method is then called in the undo/redo operations, such that the correct animation is always tracked.~

This PR adds the animation as a parameter to a method `_bezier_track_insert_key_at_anim` (before `_bezier_track_insert_key`) in the `AnimationBezierEditor`, such that it is tracked when used in UndoRedo operations.