### PR TITLE
Make viewport grid visible on all three planes in orthogonal camera view

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -311,13 +311,13 @@
 			The grid size in units. Higher values prevent the grid from appearing "cut off" at certain angles, but make the grid more demanding to render. Depending on the camera's position, the grid may not be fully visible since a shader is used to fade it progressively.
 		</member>
 		<member name="editors/3d/grid_xy_plane" type="bool" setter="" getter="">
-			If [code]true[/code], render the grid on an XY plane. This can be useful for 3D side-scrolling games.
+			If [code]true[/code], renders the grid on the XY plane in perspective view. This can be useful for 3D side-scrolling games.
 		</member>
 		<member name="editors/3d/grid_xz_plane" type="bool" setter="" getter="">
-			If [code]true[/code], render the grid on an XZ plane.
+			If [code]true[/code], renders the grid on the XZ plane in perspective view.
 		</member>
 		<member name="editors/3d/grid_yz_plane" type="bool" setter="" getter="">
-			If [code]true[/code], render the grid on a YZ plane. This can be useful for 3D side-scrolling games.
+			If [code]true[/code], renders the grid on the YZ plane in perspective view. This can be useful for 3D side-scrolling games.
 		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
 			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7296,9 +7296,9 @@ void Node3DEditor::_init_grid() {
 	int primary_grid_steps = EDITOR_GET("editors/3d/primary_grid_steps");
 
 	// Which grid planes are enabled? Which should we generate?
-	grid_enable[0] = grid_visible[0] = EDITOR_GET("editors/3d/grid_xy_plane");
-	grid_enable[1] = grid_visible[1] = EDITOR_GET("editors/3d/grid_yz_plane");
-	grid_enable[2] = grid_visible[2] = EDITOR_GET("editors/3d/grid_xz_plane");
+	grid_enable[0] = grid_visible[0] = orthogonal || EDITOR_GET("editors/3d/grid_xy_plane");
+	grid_enable[1] = grid_visible[1] = orthogonal || EDITOR_GET("editors/3d/grid_yz_plane");
+	grid_enable[2] = grid_visible[2] = orthogonal || EDITOR_GET("editors/3d/grid_xz_plane");
 
 	// Offsets division_level for bigger or smaller grids.
 	// Default value is -0.2. -1.0 gives Blender-like behavior, 0.5 gives huge grids.


### PR DESCRIPTION
This PR makes it so that grid visibility is only determined on a per-plane basis in perspective viewports. The rationale is that specifying per-plane grid visibility serves primarily to prevent the rendering of multiple grids that you don't need overlayed on top of each other in perspective mode, like this:
![Screenshot 2024-07-02 124528](https://github.com/godotengine/godot/assets/13228932/ddd00cd4-3b8d-4154-ae5b-81ea88f3cc48)
That is, it only makes sense in an environment where there at least _exists the possibility_ of multiple grids being visible.

In ortho view, only one grid is ever visible. And its visibility is already controllable via two other visibility toggles in the viewport menu and in the view menu. It is even bound to a hotkey.

On the other hand, 3D devs often need grids the ortho views to align or measure. In its current state, Godot doesn't let you see the grid in ortho side view or ortho front view, unless it's _also always visible in perspective view_, even though you might only want a ground plane to be visible in perspective view. This workflow is extremely tedious, and there is no quick toggle that can address that.

This PR makes it so the existing editor settings for per-plane grid visibility essentially become perspective-view-only settings. The ortho view grid visibility would be determined exclusively via the view options. This should have zero to minimal impact on existing ortho-centric workflows. This behaviour is also consistent with other 3D tools and engines.
![grids](https://github.com/godotengine/godot/assets/13228932/f4a5acea-4e91-46be-9f6e-023638c8f89c)

However, in the long run, we should really make the editor render a grid _per-viewport_. Right now, there is one grid instantiated, and in the 4-view layout, its properties are being determined entirely by the primary (top-left) viewport. But that is another bug for another PR.