### PR TITLE
Fix AnimationPlayer `blend_times` sorting

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -95,9 +95,9 @@ private:
 		}
 		bool operator<(const BlendKey &bk) const {
 			if (from == bk.from) {
-				return to < bk.to;
+				return StringName::AlphCompare()(to, bk.to);
 			} else {
-				return from < bk.from;
+				return StringName::AlphCompare()(from, bk.from);
 			}
 		}
 	};


### PR DESCRIPTION
Fixes #76491 

The current operator< for `BlendKeys` compares to/from pointers resulting in nondeterministic behavior. You can see this represented in the `.tscn` file of anything with lots of `blend_times` resulting in file changes which leads to extra noise in your git commits.

This PR uses`StringName::AlphaCompare` when making to/from comparisons in order preform a lexicographic order sort rather than one determined by memory location.
