### PR TITLE
Core: Fix `Freed Object` booleanization

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -951,7 +951,7 @@ bool Variant::is_zero() const {
 			return *reinterpret_cast<const ::RID *>(_data._mem) == ::RID();
 		}
 		case OBJECT: {
-			return _get_obj().obj == nullptr;
+			return get_validated_object() == nullptr;
 		}
 		case CALLABLE: {
 			return reinterpret_cast<const Callable *>(_data._mem)->is_null();


### PR DESCRIPTION
* This PR only extracts the freed objects booleanization fix from #73896. The operator `==` behavior remains unchanged.
* This is "Option 2. Intuitive and Beginner Friendly" from godotengine/godot-proposals#10098.
* Also the discussion lists other comparison styles. If we go with this option, it probably makes sense to replace cases "3. By `Variant.Type`" with "1. Intuitive".
* I assigned milestone 4.4 because there is no consensus on whether `null == freed` or `null != freed`. If we choose the first, then falsy freed object makes sense. If the second, then truthy freed object makes more sense. It's probably too risky to make such changes for 4.3 at this point.
* For now, this PR can be considered as not breaking compatibility because it only fixes already broken behavior. But if we want other changes, it will be breaking.

```
str(value)                    <null>  <Object#null>  <Freed Object>
var_to_str(value)             null    null           null

true if value else false      false   false          true -> false
true if not value else false  true    true           true
is_instance_valid(value)      false   false          false

value == null                 true    true           true
value == object_null          true    true           true
value == freed_object         true    true           true (same)
                                                     true (other)

is_same(value, null)          true    false          false
is_same(value, object_null)   false   true           false
is_same(value, freed_object)  false   false          true (same)
                                                     false (other)

typeof(value) == TYPE_NIL     true    false          false
typeof(value) == TYPE_OBJECT  false   true           true
value is Object               false   false          Error
```

Test project: [null-vs-freed.zip](https://github.com/user-attachments/files/16078250/null-vs-freed.zip)