### PR TITLE
Fix a bunch of orphan StringName errors at ProjectSettings/Editor exit

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -423,8 +423,8 @@ EditorExport::EditorExport() {
 	save_timer->set_one_shot(true);
 	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
 
-	_export_presets_updated = "export_presets_updated";
-	_export_presets_runnable_updated = "export_presets_runnable_updated";
+	_export_presets_updated = StringName("export_presets_updated", true);
+	_export_presets_runnable_updated = StringName("export_presets_runnable_updated", true);
 
 	singleton = this;
 	set_process(true);

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1968,6 +1968,7 @@ void EditorFileDialog::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults.name, &EditorFileDialog::set_option_name, &EditorFileDialog::get_option_name);
 	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, "values"), defaults.values, &EditorFileDialog::set_option_values, &EditorFileDialog::get_option_values);
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "default"), defaults.default_idx, &EditorFileDialog::set_option_default, &EditorFileDialog::get_option_default);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 void EditorFileDialog::set_show_hidden_files(bool p_show) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -60,6 +60,7 @@
 #include "platform/register_platform_apis.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
+#include "scene/property_list_helper.h"
 #include "scene/register_scene_types.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/theme/theme_db.h"
@@ -793,6 +794,7 @@ void Main::test_cleanup() {
 
 	ResourceLoader::remove_custom_loaders();
 	ResourceSaver::remove_custom_savers();
+	PropertyListHelper::clear_base_helpers();
 
 #ifdef TOOLS_ENABLED
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_EDITOR);
@@ -4246,6 +4248,7 @@ void Main::cleanup(bool p_force) {
 
 	ResourceLoader::remove_custom_loaders();
 	ResourceSaver::remove_custom_savers();
+	PropertyListHelper::clear_base_helpers();
 
 	// Flush before uninitializing the scene, but delete the MessageQueue as late as possible.
 	message_queue->flush();

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -996,6 +996,7 @@ TileMap::TileMap() {
 		base_property_helper.register_property(PropertyInfo(Variant::INT, "z_index"), defaults->get_z_index(), &TileMap::set_layer_z_index, &TileMap::get_layer_z_index);
 		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "navigation_enabled"), defaults->is_navigation_enabled(), &TileMap::set_layer_navigation_enabled, &TileMap::is_layer_navigation_enabled);
 		base_property_helper.register_property(PropertyInfo(Variant::PACKED_INT32_ARRAY, "tile_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Vector<int>(), &TileMap::_set_layer_tile_data, &TileMap::_get_tile_map_data_using_compatibility_format);
+		PropertyListHelper::register_base_helper(&base_property_helper);
 
 		memdelete(defaults);
 	}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1350,6 +1350,7 @@ void FileDialog::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults.name, &FileDialog::set_option_name, &FileDialog::get_option_name);
 	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, "values"), defaults.values, &FileDialog::set_option_values, &FileDialog::get_option_values);
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "default"), defaults.default_idx, &FileDialog::set_option_default, &FileDialog::get_option_default);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 void FileDialog::set_show_hidden_files(bool p_show) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1905,6 +1905,7 @@ void ItemList::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), defaults.icon, &ItemList::set_item_icon, &ItemList::get_item_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "selectable"), defaults.selectable, &ItemList::set_item_selectable, &ItemList::is_item_selectable);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &ItemList::set_item_disabled, &ItemList::is_item_disabled);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 ItemList::ItemList() {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -198,6 +198,7 @@ void MenuButton::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater"), defaults.id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 void MenuButton::set_disable_shortcuts(bool p_disabled) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -577,6 +577,7 @@ void OptionButton::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater"), defaults.id, &OptionButton::_dummy_setter, &OptionButton::get_item_id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &OptionButton::_dummy_setter, &OptionButton::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &OptionButton::_dummy_setter, &OptionButton::is_item_separator);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 void OptionButton::set_disable_shortcuts(bool p_disabled) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2824,6 +2824,7 @@ void PopupMenu::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater"), defaults.id, &PopupMenu::set_item_id, &PopupMenu::get_item_id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &PopupMenu::set_item_disabled, &PopupMenu::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &PopupMenu::set_item_as_separator, &PopupMenu::is_item_separator);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 void PopupMenu::popup(const Rect2i &p_bounds) {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1873,6 +1873,7 @@ void TabBar::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "tooltip"), defaults.tooltip, &TabBar::set_tab_tooltip, &TabBar::get_tab_tooltip);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), defaults.icon, &TabBar::set_tab_icon, &TabBar::get_tab_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabBar::set_tab_disabled, &TabBar::is_tab_disabled);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 TabBar::TabBar() {

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -30,6 +30,19 @@
 
 #include "property_list_helper.h"
 
+Vector<PropertyListHelper *> PropertyListHelper::base_helpers; // static
+
+void PropertyListHelper::clear_base_helpers() { // static
+	for (PropertyListHelper *helper : base_helpers) {
+		helper->clear();
+	}
+	base_helpers.clear();
+}
+
+void PropertyListHelper::register_base_helper(PropertyListHelper *p_helper) { // static
+	base_helpers.push_back(p_helper);
+}
+
 const PropertyListHelper::Property *PropertyListHelper::_get_property(const String &p_property, int *r_index) const {
 	const Vector<String> components = p_property.rsplit("/", true, 1);
 	if (components.size() < 2 || !components[0].begins_with(prefix)) {
@@ -176,9 +189,8 @@ bool PropertyListHelper::property_get_revert(const String &p_property, Variant &
 	return false;
 }
 
-PropertyListHelper::~PropertyListHelper() {
-	// No object = it's the main helper. Do a cleanup.
-	if (!object && is_initialized()) {
+void PropertyListHelper::clear() {
+	if (is_initialized()) {
 		memdelete(array_length_getter);
 
 		for (const KeyValue<String, Property> &E : property_list) {
@@ -187,5 +199,6 @@ PropertyListHelper::~PropertyListHelper() {
 				memdelete(E.value.getter);
 			}
 		}
+		property_list.clear();
 	}
 }

--- a/scene/property_list_helper.h
+++ b/scene/property_list_helper.h
@@ -42,6 +42,8 @@ class PropertyListHelper {
 		MethodBind *getter = nullptr;
 	};
 
+	static Vector<PropertyListHelper *> base_helpers;
+
 	String prefix;
 	MethodBind *array_length_getter = nullptr;
 	HashMap<String, Property> property_list;
@@ -53,6 +55,9 @@ class PropertyListHelper {
 	int _call_array_length_getter() const;
 
 public:
+	static void clear_base_helpers();
+	static void register_base_helper(PropertyListHelper *p_helper);
+
 	void set_prefix(const String &p_prefix);
 	template <typename G>
 	void set_array_length_getter(G p_array_length_getter) {
@@ -83,7 +88,7 @@ public:
 	bool property_can_revert(const String &p_property) const;
 	bool property_get_revert(const String &p_property, Variant &r_value) const;
 
-	~PropertyListHelper();
+	void clear();
 };
 
 #endif // PROPERTY_LIST_HELPER_H

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -741,6 +741,7 @@ void AudioStreamRandomizer::_bind_methods() {
 	base_property_helper.set_array_length_getter(&AudioStreamRandomizer::get_streams_count);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), defaults.stream, &AudioStreamRandomizer::set_stream, &AudioStreamRandomizer::get_stream);
 	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "weight", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), defaults.weight, &AudioStreamRandomizer::set_stream_probability_weight, &AudioStreamRandomizer::get_stream_probability_weight);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 AudioStreamRandomizer::AudioStreamRandomizer() {


### PR DESCRIPTION
This fixes all the orphan node errors on exit of Project Settings dialog, and at the editor exit from an empty project the only error still exist is:

![изображение](https://github.com/godotengine/godot/assets/3036176/0dd325c0-7db1-4708-86fc-b2809739ed7a)

(I did not find a source yet) 

Note: This target to (close) https://github.com/godotengine/godot/issues/92726, but because of the single orphan Node string it is still incomplete...