### PR TITLE
Fix `rand_weighted` incorrectly returning -1

### DIFF
--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -60,6 +60,11 @@ int64_t RandomPCG::rand_weighted(const Vector<float> &p_weights) {
 		}
 	}
 
+	for (int64_t i = weights_size - 1; i >= 0; --i) {
+		if (weights[i] > 0) {
+			return i;
+		}
+	}
 	return -1;
 }
 


### PR DESCRIPTION
Since `randf` returns a value between 0.0 and 1.0 **inclusive**, `rand_weighted` returns -1 if `randf` is exactly 1.0, as the `remaining_distance` will be exactly 0.0 in the last iteration of the loop, but not less than 0.0. That's why an additional loop is needed to return the index of the last non-zero weight if that (very rare) case happens.
