### PR TITLE
Allow moving the editor's bottom panel to the right

### DIFF
--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -57,11 +57,13 @@ class EditorBottomPanel : public PanelContainer {
 	EditorToaster *editor_toaster = nullptr;
 	LinkButton *version_btn = nullptr;
 	Button *expand_button = nullptr;
+	Button *move_button = nullptr;
 	Control *last_opened_control = nullptr;
 
 	void _switch_by_control(bool p_visible, Control *p_control);
 	void _switch_to_item(bool p_visible, int p_idx);
 	void _expand_button_toggled(bool p_pressed);
+	void _move_button_pressed();
 	void _version_button_pressed();
 
 	bool _button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control);

--- a/editor/icons/ExpandBottomRightDock.svg
+++ b/editor/icons/ExpandBottomRightDock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M4.5 12 8 15v-2h5v-2H8V9zm0-8L8 7V5h5V3H8V1zM1 15V1h2v14z"/></svg>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1238,7 +1238,15 @@ void Window::_update_viewport_size() {
 		}
 	}
 
-	notification(NOTIFICATION_WM_SIZE_CHANGED);
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		_propagate_window_notification(this, NOTIFICATION_WM_SIZE_CHANGED);
+	} else {
+#endif
+		notification(NOTIFICATION_WM_SIZE_CHANGED);
+#ifdef TOOLS_ENABLED
+	}
+#endif
 
 	if (embedder) {
 		embedder->_sub_window_update(this);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes (partially) https://github.com/godotengine/godot/issues/26229.

`EditorNode`-splited supported version of https://github.com/godotengine/godot/pull/36040.

This lets people make better use of their display if it's wide enough.

Like the original, the shortcut is <kbd>Shift + F10</kbd>.

Unlike the original, it disallows moving to the right if the screen/window's width isn't at least `1800px`, as well as forbid closing the subpanel when at the right and an ability to collapse the current tab by holding <kbd>Shift</kbd> key while also at the right.

## Preview
*For the second clip, i'm using `1300` as the minimum width for demonstration.*

https://github.com/godotengine/godot/assets/132811907/5bceef55-c688-4157-b76d-9bc654682742

## Note
- `Window` uses `_propagate_window_notification` on editor builds in `_update_viewport_size` to fix broken `NOTIFICATION_WM_SIZE_CHANGED`, it will be removed as soon as the first task was completed (see below).

## TODOs
- [ ] Figure how to set up `NOTIFICATION_WM_SIZE_CHANGED` properly without using `_propagate_window_notification`.
- [ ] Save the setting across restarts.
- [ ] Better icon(s), currently uses generic arrow icon.