### PR TITLE
Remove duplicate styling from editor

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -227,7 +227,6 @@ a:active {
 	line-height: 1.3;
 	visibility: visible;
 	padding: 4px 6px;
-	visibility: visible;
 }
 		</style>
 	</head>


### PR DESCRIPTION
The \#status-notice styling had a duplicate visibility styling.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
