### PR TITLE
Fix preloading a zip in the web editor

### DIFF
--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -35,6 +35,7 @@
 #include "core/config/engine.h"
 #include "core/io/resource_loader.h"
 #include "main/main.h"
+#include "scene/main/scene_tree.h"
 
 #include <emscripten/emscripten.h>
 #include <stdlib.h>
@@ -130,7 +131,7 @@ extern EMSCRIPTEN_KEEPALIVE int godot_web_main(int argc, char *argv[]) {
 	if (Engine::get_singleton()->is_project_manager_hint() && FileAccess::exists("/tmp/preload.zip")) {
 		PackedStringArray ps;
 		ps.push_back("/tmp/preload.zip");
-		os->get_main_loop()->emit_signal(SNAME("files_dropped"), ps, -1);
+		SceneTree::get_singleton()->get_root()->emit_signal(SNAME("files_dropped"), ps);
 	}
 #endif
 	emscripten_set_main_loop(main_loop_callback, -1, false);


### PR DESCRIPTION
When the versions went from 3 to 4 the `MainLoop` no longer responds to the `files_dropped` signal. This change sends the `files_dropped` signal to the root window and causes it to open the import dialog box.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/85855*