### PR TITLE
Fix custom resources often missing from Quick Load dialog

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -326,8 +326,8 @@ void EditorFileSystem::_scan_filesystem() {
 					FileCache fc;
 					fc.type = split[1];
 					if (fc.type.contains("/")) {
-						fc.type = fc.type.get_slice("/", 0);
-						fc.resource_script_class = fc.type.get_slice("/", 1);
+						fc.type = split[1].get_slice("/", 0);
+						fc.resource_script_class = split[1].get_slice("/", 1);
 					}
 					fc.uid = split[2].to_int();
 					fc.modification_time = split[3].to_int();


### PR DESCRIPTION
Fixes #93813 

Fixed the assignment to ```fc.resource_script_class``` and ```fc.type```