### PR TITLE
Fix adding a translation CSV results in errors on initial import for many types of resources

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2072,7 +2072,6 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 	}
 
 	if (updated) {
-		_process_update_pending();
 		if (update_files_icon_cache) {
 			_update_files_icon_path();
 		} else {
@@ -2080,7 +2079,10 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 				_update_file_icon_path(fi);
 			}
 		}
-		call_deferred(SNAME("emit_signal"), "filesystem_changed"); //update later
+		if (!is_scanning()) {
+			_process_update_pending();
+			call_deferred(SNAME("emit_signal"), "filesystem_changed"); //update later
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #93704

@mihe was right, #92320 did not fix the problem. In fact, there were two problems with CSV importation, and #92320 solved only one of them.

The remaining problem was caused by the creation of the translation file in `res://`, which triggered `update_files` and then `_update_pending_scene_groups`. This caused `_update_pending_scene_groups` to load all the scenes during the first scan before all the resources were imported. On the first scan, without the .godot folder, all the scenes are processed. `_update_pending_scene_groups` must be called after all resources are loaded.

At first, I tested only adding `!first_scan` condition before `_process_update_pending`. It worked when starting the MRP project without the .godot folder. But if I started an empty project and pasted the CSV file and a scene with resources at the same time, the same problem occurred. So the fix is to never call `_process_update_pending` while scanning. Anway, it should be called at the end of the scanning, once all the resources are loaded.

Note: I think #93723 could also fix this problem because with these modifications, scene are not loaded anymore to find the groups.

Tested with the MRP from #93704 and #83200.