### PR TITLE
Move GLTFAccessorType into GLTFAccessor

### DIFF
--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -12,7 +12,7 @@
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<members>
-		<member name="accessor_type" type="int" setter="set_accessor_type" getter="get_accessor_type" default="0">
+		<member name="accessor_type" type="int" setter="set_accessor_type" getter="get_accessor_type" enum="GLTFAccessor.GLTFAccessorType" default="0">
 			The GLTF accessor type as an enum. Possible values are 0 for "SCALAR", 1 for "VEC2", 2 for "VEC3", 3 for "VEC4", 4 for "MAT2", 5 for "MAT3", and 6 for "MAT4".
 		</member>
 		<member name="buffer_view" type="int" setter="set_buffer_view" getter="get_buffer_view" default="-1">
@@ -54,8 +54,31 @@
 		<member name="sparse_values_byte_offset" type="int" setter="set_sparse_values_byte_offset" getter="get_sparse_values_byte_offset" default="0">
 			The offset relative to the start of the bufferView in bytes.
 		</member>
-		<member name="type" type="int" setter="set_type" getter="get_type" default="0" deprecated="Use [member accessor_type] instead.">
+		<member name="type" type="int" setter="set_type" getter="get_type" deprecated="Use [member accessor_type] instead.">
 			The GLTF accessor type as an enum. Use [member accessor_type] instead.
 		</member>
 	</members>
+	<constants>
+		<constant name="TYPE_SCALAR" value="0" enum="GLTFAccessorType">
+			Accessor type "SCALAR". For the glTF object model, this can be used to map to a single float, int, or bool value, or a float array.
+		</constant>
+		<constant name="TYPE_VEC2" value="1" enum="GLTFAccessorType">
+			Accessor type "VEC2". For the glTF object model, this maps to "float2", represented in the glTF JSON as an array of two floats.
+		</constant>
+		<constant name="TYPE_VEC3" value="2" enum="GLTFAccessorType">
+			Accessor type "VEC3". For the glTF object model, this maps to "float3", represented in the glTF JSON as an array of three floats.
+		</constant>
+		<constant name="TYPE_VEC4" value="3" enum="GLTFAccessorType">
+			Accessor type "VEC4". For the glTF object model, this maps to "float4", represented in the glTF JSON as an array of four floats.
+		</constant>
+		<constant name="TYPE_MAT2" value="4" enum="GLTFAccessorType">
+			Accessor type "MAT2". For the glTF object model, this maps to "float2x2", represented in the glTF JSON as an array of four floats.
+		</constant>
+		<constant name="TYPE_MAT3" value="5" enum="GLTFAccessorType">
+			Accessor type "MAT3". For the glTF object model, this maps to "float3x3", represented in the glTF JSON as an array of nine floats.
+		</constant>
+		<constant name="TYPE_MAT4" value="6" enum="GLTFAccessorType">
+			Accessor type "MAT4". For the glTF object model, this maps to "float4x4", represented in the glTF JSON as an array of sixteen floats.
+		</constant>
+	</constants>
 </class>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -934,58 +934,58 @@ Error GLTFDocument::_encode_accessors(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-String GLTFDocument::_get_accessor_type_name(const GLTFAccessorType p_accessor_type) {
-	if (p_accessor_type == GLTFAccessorType::TYPE_SCALAR) {
+String GLTFDocument::_get_accessor_type_name(const GLTFAccessor::GLTFAccessorType p_accessor_type) {
+	if (p_accessor_type == GLTFAccessor::TYPE_SCALAR) {
 		return "SCALAR";
 	}
-	if (p_accessor_type == GLTFAccessorType::TYPE_VEC2) {
+	if (p_accessor_type == GLTFAccessor::TYPE_VEC2) {
 		return "VEC2";
 	}
-	if (p_accessor_type == GLTFAccessorType::TYPE_VEC3) {
+	if (p_accessor_type == GLTFAccessor::TYPE_VEC3) {
 		return "VEC3";
 	}
-	if (p_accessor_type == GLTFAccessorType::TYPE_VEC4) {
+	if (p_accessor_type == GLTFAccessor::TYPE_VEC4) {
 		return "VEC4";
 	}
 
-	if (p_accessor_type == GLTFAccessorType::TYPE_MAT2) {
+	if (p_accessor_type == GLTFAccessor::TYPE_MAT2) {
 		return "MAT2";
 	}
-	if (p_accessor_type == GLTFAccessorType::TYPE_MAT3) {
+	if (p_accessor_type == GLTFAccessor::TYPE_MAT3) {
 		return "MAT3";
 	}
-	if (p_accessor_type == GLTFAccessorType::TYPE_MAT4) {
+	if (p_accessor_type == GLTFAccessor::TYPE_MAT4) {
 		return "MAT4";
 	}
 	ERR_FAIL_V("SCALAR");
 }
 
-GLTFAccessorType GLTFDocument::_get_accessor_type_from_str(const String &p_string) {
+GLTFAccessor::GLTFAccessorType GLTFDocument::_get_accessor_type_from_str(const String &p_string) {
 	if (p_string == "SCALAR") {
-		return GLTFAccessorType::TYPE_SCALAR;
+		return GLTFAccessor::TYPE_SCALAR;
 	}
 
 	if (p_string == "VEC2") {
-		return GLTFAccessorType::TYPE_VEC2;
+		return GLTFAccessor::TYPE_VEC2;
 	}
 	if (p_string == "VEC3") {
-		return GLTFAccessorType::TYPE_VEC3;
+		return GLTFAccessor::TYPE_VEC3;
 	}
 	if (p_string == "VEC4") {
-		return GLTFAccessorType::TYPE_VEC4;
+		return GLTFAccessor::TYPE_VEC4;
 	}
 
 	if (p_string == "MAT2") {
-		return GLTFAccessorType::TYPE_MAT2;
+		return GLTFAccessor::TYPE_MAT2;
 	}
 	if (p_string == "MAT3") {
-		return GLTFAccessorType::TYPE_MAT3;
+		return GLTFAccessor::TYPE_MAT3;
 	}
 	if (p_string == "MAT4") {
-		return GLTFAccessorType::TYPE_MAT4;
+		return GLTFAccessor::TYPE_MAT4;
 	}
 
-	ERR_FAIL_V(GLTFAccessorType::TYPE_SCALAR);
+	ERR_FAIL_V(GLTFAccessor::TYPE_SCALAR);
 }
 
 Error GLTFDocument::_parse_accessors(Ref<GLTFState> p_state) {
@@ -1088,7 +1088,7 @@ String GLTFDocument::_get_component_type_name(const uint32_t p_component) {
 	return "<Error>";
 }
 
-Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_src, const int p_count, const GLTFAccessorType p_accessor_type, const int p_component_type, const bool p_normalized, const int p_byte_offset, const bool p_for_vertex, GLTFBufferViewIndex &r_accessor, const bool p_for_vertex_indices) {
+Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_src, const int p_count, const GLTFAccessor::GLTFAccessorType p_accessor_type, const int p_component_type, const bool p_normalized, const int p_byte_offset, const bool p_for_vertex, GLTFBufferViewIndex &r_accessor, const bool p_for_vertex_indices) {
 	const int component_count_for_type[7] = {
 		1, 2, 3, 4, 4, 9, 16
 	};
@@ -1103,18 +1103,18 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 	switch (p_component_type) {
 		case COMPONENT_TYPE_BYTE:
 		case COMPONENT_TYPE_UNSIGNED_BYTE: {
-			if (p_accessor_type == TYPE_MAT2) {
+			if (p_accessor_type == GLTFAccessor::TYPE_MAT2) {
 				skip_every = 2;
 				skip_bytes = 2;
 			}
-			if (p_accessor_type == TYPE_MAT3) {
+			if (p_accessor_type == GLTFAccessor::TYPE_MAT3) {
 				skip_every = 3;
 				skip_bytes = 1;
 			}
 		} break;
 		case COMPONENT_TYPE_SHORT:
 		case COMPONENT_TYPE_UNSIGNED_SHORT: {
-			if (p_accessor_type == TYPE_MAT3) {
+			if (p_accessor_type == GLTFAccessor::TYPE_MAT3) {
 				skip_every = 6;
 				skip_bytes = 4;
 			}
@@ -1296,7 +1296,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 	return OK;
 }
 
-Error GLTFDocument::_decode_buffer_view(Ref<GLTFState> p_state, double *p_dst, const GLTFBufferViewIndex p_buffer_view, const int p_skip_every, const int p_skip_bytes, const int p_element_size, const int p_count, const GLTFAccessorType p_accessor_type, const int p_component_count, const int p_component_type, const int p_component_size, const bool p_normalized, const int p_byte_offset, const bool p_for_vertex) {
+Error GLTFDocument::_decode_buffer_view(Ref<GLTFState> p_state, double *p_dst, const GLTFBufferViewIndex p_buffer_view, const int p_skip_every, const int p_skip_bytes, const int p_element_size, const int p_count, const GLTFAccessor::GLTFAccessorType p_accessor_type, const int p_component_count, const int p_component_type, const int p_component_size, const bool p_normalized, const int p_byte_offset, const bool p_for_vertex) {
 	const Ref<GLTFBufferView> bv = p_state->buffer_views[p_buffer_view];
 
 	int stride = p_element_size;
@@ -1427,12 +1427,12 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> p_state, const GLTF
 	switch (a->component_type) {
 		case COMPONENT_TYPE_BYTE:
 		case COMPONENT_TYPE_UNSIGNED_BYTE: {
-			if (a->accessor_type == TYPE_MAT2) {
+			if (a->accessor_type == GLTFAccessor::TYPE_MAT2) {
 				skip_every = 2;
 				skip_bytes = 2;
 				element_size = 8; //override for this case
 			}
-			if (a->accessor_type == TYPE_MAT3) {
+			if (a->accessor_type == GLTFAccessor::TYPE_MAT3) {
 				skip_every = 3;
 				skip_bytes = 1;
 				element_size = 12; //override for this case
@@ -1440,7 +1440,7 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> p_state, const GLTF
 		} break;
 		case COMPONENT_TYPE_SHORT:
 		case COMPONENT_TYPE_UNSIGNED_SHORT: {
-			if (a->accessor_type == TYPE_MAT3) {
+			if (a->accessor_type == GLTFAccessor::TYPE_MAT3) {
 				skip_every = 6;
 				skip_bytes = 4;
 				element_size = 16; //override for this case
@@ -1474,7 +1474,7 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> p_state, const GLTF
 		indices.resize(a->sparse_count);
 		const int indices_component_size = _get_component_type_size(a->sparse_indices_component_type);
 
-		Error err = _decode_buffer_view(p_state, indices.ptrw(), a->sparse_indices_buffer_view, 0, 0, indices_component_size, a->sparse_count, TYPE_SCALAR, 1, a->sparse_indices_component_type, indices_component_size, false, a->sparse_indices_byte_offset, false);
+		Error err = _decode_buffer_view(p_state, indices.ptrw(), a->sparse_indices_buffer_view, 0, 0, indices_component_size, a->sparse_count, GLTFAccessor::TYPE_SCALAR, 1, a->sparse_indices_component_type, indices_component_size, false, a->sparse_indices_byte_offset, false);
 		if (err != OK) {
 			return Vector<double>();
 		}
@@ -1536,7 +1536,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_ints(Ref<GLTFState> p_state,
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_SCALAR;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_SCALAR;
 	int component_type;
 	if (max_index > 65535 || p_for_vertex) {
 		component_type = GLTFDocument::COMPONENT_TYPE_INT;
@@ -1650,7 +1650,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec2(Ref<GLTFState> p_state,
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC2;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC2;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -1703,7 +1703,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_color(Ref<GLTFState> p_state
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC4;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -1770,7 +1770,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_weights(Ref<GLTFState> p_sta
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC4;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -1821,7 +1821,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_joints(Ref<GLTFState> p_stat
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC4;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_UNSIGNED_SHORT;
 
 	accessor->max = type_max;
@@ -1874,7 +1874,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_quaternions(Ref<GLTFState> p
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC4;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -1949,7 +1949,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_floats(Ref<GLTFState> p_stat
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_SCALAR;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_SCALAR;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -1999,7 +1999,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec3(Ref<GLTFState> p_state,
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC3;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC3;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -2075,7 +2075,7 @@ GLTFAccessorIndex GLTFDocument::_encode_sparse_accessor_as_vec3(Ref<GLTFState> p
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_VEC3;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_VEC3;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	sparse_accessor->normalized = false;
@@ -2103,7 +2103,7 @@ GLTFAccessorIndex GLTFDocument::_encode_sparse_accessor_as_vec3(Ref<GLTFState> p
 		} else {
 			sparse_accessor->sparse_indices_component_type = GLTFDocument::COMPONENT_TYPE_UNSIGNED_SHORT;
 		}
-		if (_encode_buffer_view(p_state, changed_indices.ptr(), changed_indices.size(), GLTFAccessorType::TYPE_SCALAR, sparse_accessor->sparse_indices_component_type, sparse_accessor->normalized, sparse_accessor->sparse_indices_byte_offset, false, buffer_view_i_indices) != OK) {
+		if (_encode_buffer_view(p_state, changed_indices.ptr(), changed_indices.size(), GLTFAccessor::TYPE_SCALAR, sparse_accessor->sparse_indices_component_type, sparse_accessor->normalized, sparse_accessor->sparse_indices_byte_offset, false, buffer_view_i_indices) != OK) {
 			return -1;
 		}
 		// We use changed_indices.size() here, because we must pass the number of vec3 values rather than the number of components.
@@ -2180,7 +2180,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_xform(Ref<GLTFState> p_state
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 	int64_t size = p_state->buffers[0].size();
-	const GLTFAccessorType accessor_type = GLTFAccessorType::TYPE_MAT4;
+	const GLTFAccessor::GLTFAccessorType accessor_type = GLTFAccessor::TYPE_MAT4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	accessor->max = type_max;
@@ -2234,9 +2234,9 @@ Vector<Color> GLTFDocument::_decode_accessor_as_color(Ref<GLTFState> p_state, co
 	}
 
 	const int accessor_type = p_state->accessors[p_accessor]->accessor_type;
-	ERR_FAIL_COND_V(!(accessor_type == TYPE_VEC3 || accessor_type == TYPE_VEC4), ret);
+	ERR_FAIL_COND_V(!(accessor_type == GLTFAccessor::TYPE_VEC3 || accessor_type == GLTFAccessor::TYPE_VEC4), ret);
 	int vec_len = 3;
-	if (accessor_type == TYPE_VEC4) {
+	if (accessor_type == GLTFAccessor::TYPE_VEC4) {
 		vec_len = 4;
 	}
 

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -111,7 +111,7 @@ private:
 	int _get_component_type_size(const int p_component_type);
 	Error _parse_scenes(Ref<GLTFState> p_state);
 	Error _parse_nodes(Ref<GLTFState> p_state);
-	String _get_accessor_type_name(const GLTFAccessorType p_accessor_type);
+	String _get_accessor_type_name(const GLTFAccessor::GLTFAccessorType p_accessor_type);
 	String _sanitize_animation_name(const String &p_name);
 	String _gen_unique_animation_name(Ref<GLTFState> p_state, const String &p_name);
 	String _sanitize_bone_name(const String &p_name);
@@ -131,13 +131,13 @@ private:
 	void _compute_node_heights(Ref<GLTFState> p_state);
 	Error _parse_buffers(Ref<GLTFState> p_state, const String &p_base_path);
 	Error _parse_buffer_views(Ref<GLTFState> p_state);
-	GLTFAccessorType _get_accessor_type_from_str(const String &p_string);
+	GLTFAccessor::GLTFAccessorType _get_accessor_type_from_str(const String &p_string);
 	Error _parse_accessors(Ref<GLTFState> p_state);
 	Error _decode_buffer_view(Ref<GLTFState> p_state, double *p_dst,
 			const GLTFBufferViewIndex p_buffer_view,
 			const int p_skip_every, const int p_skip_bytes,
 			const int p_element_size, const int p_count,
-			const GLTFAccessorType p_accessor_type, const int p_component_count,
+			const GLTFAccessor::GLTFAccessorType p_accessor_type, const int p_component_count,
 			const int p_component_type, const int p_component_size,
 			const bool p_normalized, const int p_byte_offset,
 			const bool p_for_vertex);
@@ -266,7 +266,7 @@ private:
 			const Vector<Transform3D> p_attribs,
 			const bool p_for_vertex);
 	Error _encode_buffer_view(Ref<GLTFState> p_state, const double *p_src,
-			const int p_count, const GLTFAccessorType p_accessor_type,
+			const int p_count, const GLTFAccessor::GLTFAccessorType p_accessor_type,
 			const int p_component_type, const bool p_normalized,
 			const int p_byte_offset, const bool p_for_vertex,
 			GLTFBufferViewIndex &r_accessor, const bool p_for_indices = false);

--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -31,6 +31,14 @@
 #include "gltf_accessor.h"
 
 void GLTFAccessor::_bind_methods() {
+	BIND_ENUM_CONSTANT(TYPE_SCALAR);
+	BIND_ENUM_CONSTANT(TYPE_VEC2);
+	BIND_ENUM_CONSTANT(TYPE_VEC3);
+	BIND_ENUM_CONSTANT(TYPE_VEC4);
+	BIND_ENUM_CONSTANT(TYPE_MAT2);
+	BIND_ENUM_CONSTANT(TYPE_MAT3);
+	BIND_ENUM_CONSTANT(TYPE_MAT4);
+
 	ClassDB::bind_method(D_METHOD("get_buffer_view"), &GLTFAccessor::get_buffer_view);
 	ClassDB::bind_method(D_METHOD("set_buffer_view", "buffer_view"), &GLTFAccessor::set_buffer_view);
 	ClassDB::bind_method(D_METHOD("get_byte_offset"), &GLTFAccessor::get_byte_offset);
@@ -43,8 +51,8 @@ void GLTFAccessor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_count", "count"), &GLTFAccessor::set_count);
 	ClassDB::bind_method(D_METHOD("get_accessor_type"), &GLTFAccessor::get_accessor_type);
 	ClassDB::bind_method(D_METHOD("set_accessor_type", "accessor_type"), &GLTFAccessor::set_accessor_type);
-	ClassDB::bind_method(D_METHOD("get_type"), &GLTFAccessor::get_accessor_type);
-	ClassDB::bind_method(D_METHOD("set_type", "type"), &GLTFAccessor::set_accessor_type);
+	ClassDB::bind_method(D_METHOD("get_type"), &GLTFAccessor::get_type);
+	ClassDB::bind_method(D_METHOD("set_type", "type"), &GLTFAccessor::set_type);
 	ClassDB::bind_method(D_METHOD("get_min"), &GLTFAccessor::get_min);
 	ClassDB::bind_method(D_METHOD("set_min", "min"), &GLTFAccessor::set_min);
 	ClassDB::bind_method(D_METHOD("get_max"), &GLTFAccessor::get_max);
@@ -67,8 +75,8 @@ void GLTFAccessor::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "component_type"), "set_component_type", "get_component_type"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "normalized"), "set_normalized", "get_normalized"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "count"), "set_count", "get_count"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "accessor_type"), "set_accessor_type", "get_accessor_type"); // GLTFAccessorType
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // Deprecated, GLTFAccessorType
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "accessor_type"), "set_accessor_type", "get_accessor_type"); // GLTFAccessor::GLTFAccessorType
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_type", "get_type"); // Deprecated, int for GLTFAccessor::GLTFAccessorType
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT64_ARRAY, "min"), "set_min", "get_min"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT64_ARRAY, "max"), "set_max", "get_max"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sparse_count"), "set_sparse_count", "get_sparse_count"); // int
@@ -119,11 +127,19 @@ void GLTFAccessor::set_count(int p_count) {
 	count = p_count;
 }
 
-int GLTFAccessor::get_accessor_type() {
+GLTFAccessor::GLTFAccessorType GLTFAccessor::get_accessor_type() {
+	return accessor_type;
+}
+
+void GLTFAccessor::set_accessor_type(GLTFAccessorType p_accessor_type) {
+	accessor_type = p_accessor_type;
+}
+
+int GLTFAccessor::get_type() {
 	return (int)accessor_type;
 }
 
-void GLTFAccessor::set_accessor_type(int p_accessor_type) {
+void GLTFAccessor::set_type(int p_accessor_type) {
 	accessor_type = (GLTFAccessorType)p_accessor_type; // TODO: Register enum
 }
 

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -35,19 +35,20 @@
 
 #include "core/io/resource.h"
 
-enum GLTFAccessorType {
-	TYPE_SCALAR,
-	TYPE_VEC2,
-	TYPE_VEC3,
-	TYPE_VEC4,
-	TYPE_MAT2,
-	TYPE_MAT3,
-	TYPE_MAT4,
-};
-
 struct GLTFAccessor : public Resource {
 	GDCLASS(GLTFAccessor, Resource);
 	friend class GLTFDocument;
+
+public:
+	enum GLTFAccessorType {
+		TYPE_SCALAR,
+		TYPE_VEC2,
+		TYPE_VEC3,
+		TYPE_VEC4,
+		TYPE_MAT2,
+		TYPE_MAT3,
+		TYPE_MAT4,
+	};
 
 private:
 	GLTFBufferViewIndex buffer_view = -1;
@@ -84,8 +85,11 @@ public:
 	int get_count();
 	void set_count(int p_count);
 
-	int get_accessor_type();
-	void set_accessor_type(int p_accessor_type);
+	GLTFAccessorType get_accessor_type();
+	void set_accessor_type(GLTFAccessorType p_accessor_type);
+
+	int get_type();
+	void set_type(int p_accessor_type);
 
 	Vector<double> get_min();
 	void set_min(Vector<double> p_min);
@@ -111,5 +115,7 @@ public:
 	int get_sparse_values_byte_offset();
 	void set_sparse_values_byte_offset(int p_sparse_values_byte_offset);
 };
+
+VARIANT_ENUM_CAST(GLTFAccessor::GLTFAccessorType);
 
 #endif // GLTF_ACCESSOR_H


### PR DESCRIPTION
Follow-up to PR #90560. Should be merged for 4.3.

Apologies for the last minute 4.3 PR, but I was working on implementing the glTF object model in Godot and I noticed that in order to bind this enum to a method it has to exist inside of a class. If I try to do this outside of the class, the class reference that ends up generated is incorrect.

Then I realized I should also use the enum for the existing `accessor_type` property. However, changing the type of a property breaks compatibility, so changing this property breaks compatibility as of #90560, which was merged in Godot 4.3, but it does not break compatibility since Godot 4.2, so we can still improve this before Godot 4.3 is released.

This PR also adds detailed documentation for the accessor types including how they map to the glTF object model.