### PR TITLE
Fix clang linkflags on macos build

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -195,32 +195,19 @@ def configure(env: "SConsEnvironment"):
     env.Append(CPPDEFINES=["MACOS_ENABLED", "UNIX_ENABLED", "COREAUDIO_ENABLED", "COREMIDI_ENABLED"])
     env.Append(
         LINKFLAGS=[
-            "-framework",
-            "Cocoa",
-            "-framework",
-            "Carbon",
-            "-framework",
-            "AudioUnit",
-            "-framework",
-            "CoreAudio",
-            "-framework",
-            "CoreMIDI",
-            "-framework",
-            "IOKit",
-            "-framework",
-            "GameController",
-            "-framework",
-            "CoreHaptics",
-            "-framework",
-            "CoreVideo",
-            "-framework",
-            "AVFoundation",
-            "-framework",
-            "CoreMedia",
-            "-framework",
-            "QuartzCore",
-            "-framework",
-            "Security",
+            "-Wl,-framework,Cocoa",
+            "-Wl,-framework,Carbon",
+            "-Wl,-framework,AudioUnit",
+            "-Wl,-framework,CoreAudio",
+            "-Wl,-framework,CoreMIDI",
+            "-Wl,-framework,IOKit",
+            "-Wl,-framework,GameController",
+            "-Wl,-framework,CoreHaptics",
+            "-Wl,-framework,CoreVideo",
+            "-Wl,-framework,AVFoundation",
+            "-Wl,-framework,CoreMedia",
+            "-Wl,-framework,QuartzCore",
+            "-Wl,-framework,Security",
         ]
     )
     env.Append(LIBS=["pthread", "z"])
@@ -235,11 +222,11 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
         env.Prepend(CPPPATH=["#thirdparty/angle/include"])
 
-    env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
+    env.Append(LINKFLAGS=["-Wl,-rpath,@executable_path/../Frameworks", "-Wl,-rpath,@executable_path"])
 
     if env["vulkan"]:
         env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
-        env.Append(LINKFLAGS=["-framework", "Metal", "-framework", "IOSurface"])
+        env.Append(LINKFLAGS=["-Wl,-framework,Metal", "-Wl,-framework,IOSurface"])
         if not env["use_volk"]:
             env.Append(LINKFLAGS=["-lMoltenVK"])
 


### PR DESCRIPTION
Fixes #36720 as PR was reverted (#36795)
This should work when cross-compiling from Linux (haven't tested)

I was having the same issue on my mac with clang build working on my godot fork (4.2 branch)

clang: error: no such file or directory: 'Carbon'
clang: error: no such file or directory: 'AudioUnit'
clang: error: no such file or directory: 'CoreAudio'
clang: error: no such file or directory: 'CoreMIDI'
clang: error: no such file or directory: 'IOKit'
clang: error: no such file or directory: 'ForceFeedback'
clang: error: no such file or directory: 'CoreVideo'
clang: error: no such file or directory: 'AVFoundation'
clang: error: no such file or directory: 'CoreMedia'
clang: error: no such file or directory: 'QuartzCore'
clang: error: no such file or directory: 'Security'
clang: error: no such file or directory: '@executable_path/../Frameworks'
clang: error: no such file or directory: 'Metal'


`scons dev_build=yes use_llvm=yes linker=lld verbose=yes` gives:
clang++ -obin/godot.macos.editor.dev.arm64 -ld_classic -Xlinker -no_deduplicate -arch arm64 -mmacosx-version-min=11.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk Cocoa Carbon AudioUnit CoreAudio CoreMIDI IOKit ForceFeedback CoreVideo AVFoundation CoreMedia QuartzCore Security @executable_path/../Frameworks -rpath @executable_path Metal -framework IOSurface -lMoltenVK -L/Users/nordup/VulkanSDK/1.3.280.1/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/ -pthread ... -lz -lzmq -lstdc++ -lsodium -lpthread

You can see that "-framework" and "-path" flags are not passed

> Tested on
> System Version: macOS 14.5 (23F79)
> 
> SCons by Steven Knight et al.:
>         SCons: v4.7.0.265be6883fadbb5a545612265acc919595158366, Sun, 17 Mar 2024 17:33:54 -0700, by bdbaddog on M1Dog2021
>         SCons path: ['/opt/homebrew/Cellar/scons/4.7.0/libexec/lib/python3.12/site-packages/SCons']
> 
> Xcode 15.4
> Build version 15F31d
> 
> Apple clang version 15.0.0 (clang-1500.3.9.4)
> Target: arm64-apple-darwin23.5.0