### PR TITLE
`ResourceLoader`: Fixup management of thread-specific status

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -304,9 +304,10 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	thread_load_mutex.unlock();
 
 	// Thread-safe either if it's the current thread or a brand new one.
-	bool mq_override_present = false;
+	thread_local bool mq_override_present = false;
 	CallQueue *own_mq_override = nullptr;
 	if (load_nesting == 0) {
+		mq_override_present = false;
 		load_paths_stack = memnew(Vector<String>);
 
 		if (!load_task.dependent_path.is_empty()) {
@@ -325,10 +326,6 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 		DEV_ASSERT(load_task.dependent_path.is_empty());
 	}
 	// --
-
-	if (!Thread::is_main_thread()) {
-		set_current_thread_safe_for_nodes(true);
-	}
 
 	Ref<Resource> res = _load(load_task.remapped_path, load_task.remapped_path != load_task.local_path ? load_task.local_path : String(), load_task.type_hint, load_task.cache_mode, &load_task.error, load_task.use_sub_threads, &load_task.progress);
 	if (mq_override_present) {


### PR DESCRIPTION
- Allows the message queue override to flush after loading each resource, which was the original intent.
   **UPDATE:** The effect of this is that external resources that could be successfully loaded have their deferred setup calls run regardless the load will be reported as failed. This is important because if another simultaneous load will get them from cache while they still exist, they will be guaranteedly "complete." Moreover, such behavior was also the case before those calls were flushed in loader threads. Formerly, they were flushed on the main thread so if some resource would survive an overall failed load, they'd still get that "completeness" guarantee.
- Removes a redundant call to mark the thread as safe-for-nodes.