### PR TITLE
Clamp bezier handle length to half the length of animation

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1220,7 +1220,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		//insert new point
 		if (mb->get_position().x >= limit && mb->get_position().x < get_size().width && mb->is_command_or_control_pressed()) {
 			float h = (get_size().height / 2.0 - mb->get_position().y) * timeline_v_zoom + timeline_v_scroll;
-			Array new_point = make_default_bezier_key(h);
+			Array new_point = animation->make_default_bezier_key(h);
 
 			real_t time = ((mb->get_position().x - limit) / timeline->get_zoom_scale()) + timeline->get_value();
 			while (animation->track_find_key(selected_track, time, Animation::FIND_MODE_APPROX) != -1) {
@@ -1643,19 +1643,6 @@ void AnimationBezierTrackEdit::_zoom_callback(float p_zoom_factor, Vector2 p_ori
 	queue_redraw();
 }
 
-Array AnimationBezierTrackEdit::make_default_bezier_key(float p_value) {
-	Array new_point;
-	new_point.resize(5);
-
-	new_point[0] = p_value;
-	new_point[1] = -0.25;
-	new_point[2] = 0;
-	new_point[3] = 0.25;
-	new_point[4] = 0;
-
-	return new_point;
-}
-
 float AnimationBezierTrackEdit::get_bezier_key_value(Array p_bezier_key_array) {
 	return p_bezier_key_array[0];
 }
@@ -1675,7 +1662,7 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 					time += 0.001;
 				}
 				float h = (get_size().height / 2.0 - menu_insert_key.y) * timeline_v_zoom + timeline_v_scroll;
-				Array new_point = make_default_bezier_key(h);
+				Array new_point = animation->make_default_bezier_key(h);
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 				undo_redo->create_action(TTR("Add Bezier Point"));
 				undo_redo->add_do_method(animation.ptr(), "track_insert_key", selected_track, time, new_point);
@@ -1877,7 +1864,7 @@ void AnimationBezierTrackEdit::paste_keys(real_t p_ofs, bool p_ofs_valid) {
 
 			Variant value = key.value;
 			if (key.track_type != Animation::TYPE_BEZIER) {
-				value = make_default_bezier_key(key.value);
+				value = animation->make_default_bezier_key(key.value);
 			}
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", selected_track, dst_time, value, key.transition);

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -198,7 +198,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	static Array make_default_bezier_key(float p_value);
 	static float get_bezier_key_value(Array p_bezier_key_array);
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4456,16 +4456,8 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 
 		} break;
 		case Animation::TYPE_BEZIER: {
-			Array array;
-			array.resize(5);
-			array[0] = p_id.value;
-			array[1] = -0.25;
-			array[2] = 0;
-			array[3] = 0.25;
-			array[4] = 0;
-			value = array;
+			value = animation->make_default_bezier_key(p_id.value);
 			bezier_edit_icon->set_disabled(false);
-
 		} break;
 		default: {
 			// Other track types shouldn't use this code path.
@@ -5267,15 +5259,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			NodePath bp;
 			Variant value;
 			_find_hint_for_track(p_track, bp, &value);
-			Array arr;
-			arr.resize(5);
-			arr[0] = value;
-			arr[1] = -0.25;
-			arr[2] = 0;
-			arr[3] = 0.25;
-			arr[4] = 0;
-
-			id.value = arr;
+			id.value = animation->make_default_bezier_key(value);
 		} break;
 		case Animation::TYPE_AUDIO: {
 			Dictionary ak;
@@ -5819,7 +5803,7 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 			if (key_is_bezier && !track_is_bezier) {
 				value = AnimationBezierTrackEdit::get_bezier_key_value(value);
 			} else if (!key_is_bezier && track_is_bezier) {
-				value = AnimationBezierTrackEdit::make_default_bezier_key(value);
+				value = animation->make_default_bezier_key(value);
 			}
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, value, animation->track_get_key_transition(E->key().track, E->key().key));
@@ -5963,7 +5947,7 @@ void AnimationTrackEditor::_anim_paste_keys(float p_ofs, bool p_ofs_valid, int p
 			if (key_is_bezier && !track_is_bezier) {
 				value = AnimationBezierTrackEdit::get_bezier_key_value(value);
 			} else if (!key_is_bezier && track_is_bezier) {
-				value = AnimationBezierTrackEdit::make_default_bezier_key(value);
+				value = animation->make_default_bezier_key(value);
 			}
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, value, key.transition);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3189,6 +3189,20 @@ StringName Animation::method_track_get_name(int p_track, int p_key_idx) const {
 	return pm->methods[p_key_idx].method;
 }
 
+Array Animation::make_default_bezier_key(float p_value) {
+	const double max_width = length / 2.0;
+	Array new_point;
+	new_point.resize(5);
+
+	new_point[0] = p_value;
+	new_point[1] = MAX(-0.25, -max_width);
+	new_point[2] = 0;
+	new_point[3] = MIN(0.25, max_width);
+	new_point[4] = 0;
+
+	return new_point;
+}
+
 int Animation::bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -455,6 +455,7 @@ public:
 	void track_set_interpolation_type(int p_track, InterpolationType p_interp);
 	InterpolationType track_get_interpolation_type(int p_track) const;
 
+	Array make_default_bezier_key(float p_value);
 	int bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
 	void bezier_track_set_key_value(int p_track, int p_index, real_t p_value);
 	void bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle, real_t p_balanced_value_time_ratio = 1.0);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93807 by clamping the new handle length to half the length of the animation.

![image](https://github.com/godotengine/godot/assets/4955051/953127c8-0772-4dec-ac25-f7dcca6afbf5)
