### PR TITLE
Fix compatibility renderer `depth_prepass_alpha`

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1420,7 +1420,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 #else
 				bool force_alpha = false;
 #endif
-				if (!force_alpha && (surf->flags & GeometryInstanceSurface::FLAG_PASS_OPAQUE)) {
+				if (!force_alpha && (surf->flags & (GeometryInstanceSurface::FLAG_PASS_DEPTH | GeometryInstanceSurface::FLAG_PASS_OPAQUE))) {
 					rl->add_element(surf);
 				}
 				if (force_alpha || (surf->flags & GeometryInstanceSurface::FLAG_PASS_ALPHA)) {


### PR DESCRIPTION
In compatibility mode, when using `render_mode depth_prepass_alpha;` in Shader, the depth pre pass is not work.

I tested minimal project in Forward+ mode, _Nsight_ showed that a depth pre pass was performed. But I didn't see it in compatibility mode. So I modified the OpenGL part according to the code like render_forward_clustered.

Minimum test project:
[test_depth_prepass_alpha_compatibility.zip](https://github.com/user-attachments/files/16096703/test_depth_prepass_alpha_compatibility.zip)
