### PR TITLE
Android: Fix crashes and ANRs reported by the Google Play Console

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1391,6 +1391,12 @@
 			Enabling this can greatly improve the responsiveness to input, specially in devices that need to run multiple physics frames per visible (process) frame, because they can't run at the target frame rate.
 			[b]Note:[/b] Currently implemented only on Android.
 		</member>
+		<member name="input_devices/buffering/android/use_accumulated_input" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], multiple input events will be accumulated into a single input event when possible.
+		</member>
+		<member name="input_devices/buffering/android/use_input_buffering" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], input events will be buffered prior to being dispatched.
+		</member>
 		<member name="input_devices/compatibility/legacy_just_pressed_behavior" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], [method Input.is_action_just_pressed] and [method Input.is_action_just_released] will only return [code]true[/code] if the action is still in the respective state, i.e. an action that is pressed [i]and[/i] released on the same frame will be missed.
 			If [code]false[/code], no input will be lost.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -474,6 +474,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
 
+#ifdef ANDROID_ENABLED
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_accumulated_input", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_input_buffering", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+#endif
+
 	// Inspector
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/show_low_level_opentype_features", false, "")

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2939,6 +2939,8 @@ Error Main::setup2(bool p_show_boot_logo) {
 			id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_mouse_from_touch", true)));
 		}
 
+		GLOBAL_DEF("input_devices/buffering/android/use_accumulated_input", true);
+		GLOBAL_DEF("input_devices/buffering/android/use_input_buffering", true);
 		GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_long_press_as_right_click", false);
 		GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
 		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "input_devices/pointing/android/rotary_input_scroll_axis", PROPERTY_HINT_ENUM, "Horizontal,Vertical"), 1);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -909,13 +909,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	// Benchmark tracking must be done after `OS::get_singleton()->initialize()` as on some
 	// platforms, it's used to set up the time utilities.
-	OS::get_singleton()->benchmark_begin_measure("Startup", "Total");
-	OS::get_singleton()->benchmark_begin_measure("Startup", "Setup");
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Main::Setup");
 
 	engine = memnew(Engine);
 
 	MAIN_PRINT("Main: Initialize CORE");
-	OS::get_singleton()->benchmark_begin_measure("Startup", "Core");
 
 	register_core_types();
 	register_core_driver_types();
@@ -2453,8 +2451,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
 	set_current_thread_safe_for_nodes(false);
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Core");
-
 #if defined(STEAMAPI_ENABLED)
 	if (editor || project_manager) {
 		steam_tracker = memnew(SteamTracker);
@@ -2465,7 +2461,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		return setup2();
 	}
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup");
 	return OK;
 
 error:
@@ -2519,7 +2515,7 @@ error:
 	}
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Core");
-	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup");
 
 #if defined(STEAMAPI_ENABLED)
 	if (steam_tracker) {
@@ -2553,6 +2549,8 @@ Error _parse_resource_dummy(void *p_data, VariantParser::Stream *p_stream, Ref<R
 }
 
 Error Main::setup2(bool p_show_boot_logo) {
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Main::Setup2");
+
 	Thread::make_main_thread(); // Make whatever thread call this the main thread.
 	set_current_thread_safe_for_nodes(true);
 
@@ -3149,7 +3147,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup2");
 
 	return OK;
 }
@@ -3230,6 +3228,8 @@ static MainTimerSync main_timer_sync;
 // and should move on to `OS::run`, and EXIT_FAILURE otherwise for
 // an early exit with that error code.
 int Main::start() {
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Main::Start");
+
 	ERR_FAIL_COND_V(!_start_success, false);
 
 	bool has_icon = false;
@@ -3953,7 +3953,7 @@ int Main::start() {
 		}
 	}
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Total");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Start");
 	OS::get_singleton()->benchmark_dump();
 
 	return EXIT_SUCCESS;
@@ -4221,7 +4221,7 @@ void Main::force_redraw() {
  * The order matters as some of those steps are linked with each other.
  */
 void Main::cleanup(bool p_force) {
-	OS::get_singleton()->benchmark_begin_measure("Shutdown", "Total");
+	OS::get_singleton()->benchmark_begin_measure("Shutdown", "Main::Cleanup");
 	if (!p_force) {
 		ERR_FAIL_COND(!_start_success);
 	}
@@ -4379,7 +4379,7 @@ void Main::cleanup(bool p_force) {
 
 	unregister_core_types();
 
-	OS::get_singleton()->benchmark_end_measure("Shutdown", "Total");
+	OS::get_singleton()->benchmark_end_measure("Shutdown", "Main::Cleanup");
 	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -24,6 +24,10 @@
         android:hasFragileUserData="false"
         android:requestLegacyExternalStorage="false"
         tools:ignore="GoogleAppIndexingWarning" >
+        <profileable
+            android:shell="true"
+            android:enabled="true"
+            tools:targetApi="29" />
 
         <!-- Records the version of the Godot editor used for building -->
         <meta-data

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -7,7 +7,7 @@ ext.versions = [
     targetSdk          : 34,
     buildTools         : '34.0.0',
     kotlinVersion      : '1.9.20',
-    fragmentVersion    : '1.6.2',
+    fragmentVersion    : '1.7.1',
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation "androidx.fragment:fragment:$versions.fragmentVersion"
     implementation project(":lib")
 
-    implementation "androidx.window:window:1.2.0"
+    implementation "androidx.window:window:1.3.0"
     implementation "androidx.core:core-splashscreen:$versions.splashscreenVersion"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 }

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -117,6 +117,10 @@ open class GodotEditor : GodotActivity() {
 		val longPressEnabled = enableLongPressGestures()
 		val panScaleEnabled = enablePanAndScaleGestures()
 
+		val useInputBuffering = useInputBuffering()
+		val useAccumulatedInput = useAccumulatedInput()
+		GodotLib.updateInputDispatchSettings(useAccumulatedInput, useInputBuffering)
+
 		checkForProjectPermissionsToEnable()
 
 		runOnUiThread {
@@ -124,6 +128,7 @@ open class GodotEditor : GodotActivity() {
 			godotFragment?.godot?.renderView?.inputHandler?.apply {
 				enableLongPress(longPressEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
+				enableInputDispatchToRenderThread(!useInputBuffering && !useAccumulatedInput)
 			}
 		}
 	}
@@ -273,6 +278,13 @@ open class GodotEditor : GodotActivity() {
 	 */
 	protected open fun enablePanAndScaleGestures() =
 		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/enable_pan_and_scale_gestures"))
+
+	/**
+	 * Use input buffering for the Godot Android editor.
+	 */
+	protected open fun useInputBuffering() = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/use_input_buffering"))
+
+	protected open fun useAccumulatedInput() = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/use_accumulated_input"))
 
 	/**
 	 * Whether we should launch the new godot instance in an adjacent window

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
@@ -30,6 +30,8 @@
 
 package org.godotengine.editor
 
+import org.godotengine.godot.GodotLib
+
 /**
  * Drives the 'run project' window of the Godot Editor.
  */
@@ -39,9 +41,13 @@ class GodotGame : GodotEditor() {
 
 	override fun overrideOrientationRequest() = false
 
-	override fun enableLongPressGestures() = false
+	override fun enableLongPressGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 
-	override fun enablePanAndScaleGestures() = false
+	override fun enablePanAndScaleGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
+
+	override fun useInputBuffering() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/buffering/android/use_input_buffering"))
+
+	override fun useAccumulatedInput() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/buffering/android/use_accumulated_input"))
 
 	override fun checkForProjectPermissionsToEnable() {
 		// Nothing to do.. by the time we get here, the project permissions will have already

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -42,6 +42,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Messenger;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -203,6 +204,12 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 			if (godotContainerLayout == null) {
 				throw new IllegalStateException("Unable to initialize engine render view");
 			}
+		} catch (IllegalStateException e) {
+			Log.e(TAG, "Engine initialization failed", e);
+			final String errorMessage = TextUtils.isEmpty(e.getMessage())
+					? getString(R.string.error_engine_setup_message)
+					: e.getMessage();
+			godot.alert(errorMessage, getString(R.string.text_error_title), godot::forceQuit);
 		} catch (IllegalArgumentException ignored) {
 			final Activity activity = getActivity();
 			Intent notifierIntent = new Intent(activity, activity.getClass());

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -121,7 +121,7 @@ public class GodotIO {
 
 			activity.startActivity(intent);
 			return 0;
-		} catch (ActivityNotFoundException e) {
+		} catch (Exception e) {
 			Log.e(TAG, "Unable to open uri " + uriString, e);
 			return 1;
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -240,4 +240,11 @@ public class GodotLib {
 	 * @see GodotRenderer#onActivityPaused()
 	 */
 	public static native void onRendererPaused();
+
+	/**
+	 * Invoked on the GL thread to update the input dispatch settings
+	 * @param useAccumulatedInput True to use accumulated input, false otherwise
+	 * @param useInputBuffering True to use input buffering, false otherwise
+	 */
+	public static native void updateInputDispatchSettings(boolean useAccumulatedInput, boolean useInputBuffering);
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
@@ -1704,15 +1704,6 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				mHasSurface = true;
 				mFinishedCreatingEglSurface = false;
 				sGLThreadManager.notifyAll();
-				while (mWaitingForSurface
-						&& !mFinishedCreatingEglSurface
-						&& !mExited) {
-					try {
-						sGLThreadManager.wait();
-					} catch (InterruptedException e) {
-						Thread.currentThread().interrupt();
-					}
-				}
 			}
 		}
 
@@ -1723,13 +1714,6 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				}
 				mHasSurface = false;
 				sGLThreadManager.notifyAll();
-				while((!mWaitingForSurface) && (!mExited)) {
-					try {
-						sGLThreadManager.wait();
-					} catch (InterruptedException e) {
-						Thread.currentThread().interrupt();
-					}
-				}
 			}
 		}
 
@@ -1740,16 +1724,6 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				}
 				mRequestPaused = true;
 				sGLThreadManager.notifyAll();
-				while ((! mExited) && (! mPaused)) {
-					if (LOG_PAUSE_RESUME) {
-						Log.i("Main thread", "onPause waiting for mPaused.");
-					}
-					try {
-						sGLThreadManager.wait();
-					} catch (InterruptedException ex) {
-						Thread.currentThread().interrupt();
-					}
-				}
 			}
 		}
 
@@ -1762,16 +1736,6 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				mRequestRender = true;
 				mRenderComplete = false;
 				sGLThreadManager.notifyAll();
-				while ((! mExited) && mPaused && (!mRenderComplete)) {
-					if (LOG_PAUSE_RESUME) {
-						Log.i("Main thread", "onResume waiting for !mPaused.");
-					}
-					try {
-						sGLThreadManager.wait();
-					} catch (InterruptedException ex) {
-						Thread.currentThread().interrupt();
-					}
-				}
 			}
 		}
 
@@ -1793,19 +1757,6 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				}
 
 				sGLThreadManager.notifyAll();
-
-				// Wait for thread to react to resize and render a frame
-				while (! mExited && !mPaused && !mRenderComplete
-						&& ableToDraw()) {
-					if (LOG_SURFACE) {
-						Log.i("Main thread", "onWindowResize waiting for render complete from tid=" + getId());
-					}
-					try {
-						sGLThreadManager.wait();
-					} catch (InterruptedException ex) {
-						Thread.currentThread().interrupt();
-					}
-				}
 			}
 		}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -44,7 +44,7 @@ import org.godotengine.godot.GodotLib
  * @See https://developer.android.com/reference/android/view/GestureDetector.SimpleOnGestureListener
  * @See https://developer.android.com/reference/android/view/ScaleGestureDetector.OnScaleGestureListener
  */
-internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureListener {
+internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) : SimpleOnGestureListener(), OnScaleGestureListener {
 
 	companion object {
 		private val TAG = GodotGestureHandler::class.java.simpleName
@@ -65,13 +65,13 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 	private var lastDragY: Float = 0.0f
 
 	override fun onDown(event: MotionEvent): Boolean {
-		GodotInputHandler.handleMotionEvent(event, MotionEvent.ACTION_DOWN, nextDownIsDoubleTap)
+		inputHandler.handleMotionEvent(event, MotionEvent.ACTION_DOWN, nextDownIsDoubleTap)
 		nextDownIsDoubleTap = false
 		return true
 	}
 
 	override fun onSingleTapUp(event: MotionEvent): Boolean {
-		GodotInputHandler.handleMotionEvent(event)
+		inputHandler.handleMotionEvent(event)
 		return true
 	}
 
@@ -85,10 +85,10 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		}
 
 		// Cancel the previous down event
-		GodotInputHandler.handleMotionEvent(event, MotionEvent.ACTION_CANCEL)
+		inputHandler.handleMotionEvent(event, MotionEvent.ACTION_CANCEL)
 
 		// Turn a context click into a single tap right mouse button click.
-		GodotInputHandler.handleMouseEvent(
+		inputHandler.handleMouseEvent(
 			event,
 			MotionEvent.ACTION_DOWN,
 			MotionEvent.BUTTON_SECONDARY,
@@ -104,7 +104,7 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 
 		if (!hasCapture) {
 			// Dispatch a mouse relative ACTION_UP event to signal the end of the capture
-			GodotInputHandler.handleMouseEvent(MotionEvent.ACTION_UP, true)
+			inputHandler.handleMouseEvent(MotionEvent.ACTION_UP, true)
 		}
 		pointerCaptureInProgress = hasCapture
 	}
@@ -131,9 +131,9 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 			if (contextClickInProgress || GodotInputHandler.isMouseEvent(event)) {
 				// This may be an ACTION_BUTTON_RELEASE event which we don't handle,
 				// so we convert it to an ACTION_UP event.
-				GodotInputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
 			} else {
-				GodotInputHandler.handleTouchEvent(event)
+				inputHandler.handleTouchEvent(event)
 			}
 			pointerCaptureInProgress = false
 			dragInProgress = false
@@ -148,7 +148,7 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 
 	private fun onActionMove(event: MotionEvent): Boolean {
 		if (contextClickInProgress) {
-			GodotInputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
+			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
 			return true
 		} else if (!scaleInProgress) {
 			// The 'onScroll' event is triggered with a long delay.
@@ -158,7 +158,7 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 			if (lastDragX != event.getX(0) || lastDragY != event.getY(0)) {
 				lastDragX = event.getX(0)
 				lastDragY = event.getY(0)
-				GodotInputHandler.handleMotionEvent(event)
+				inputHandler.handleMotionEvent(event)
 				return true
 			}
 		}
@@ -168,9 +168,9 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 	override fun onDoubleTapEvent(event: MotionEvent): Boolean {
 		if (event.actionMasked == MotionEvent.ACTION_UP) {
 			nextDownIsDoubleTap = false
-			GodotInputHandler.handleMotionEvent(event)
+			inputHandler.handleMotionEvent(event)
 		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && !panningAndScalingEnabled) {
-			GodotInputHandler.handleMotionEvent(event)
+			inputHandler.handleMotionEvent(event)
 		}
 
 		return true
@@ -191,7 +191,7 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 			if (dragInProgress || lastDragX != 0.0f || lastDragY != 0.0f) {
 				if (originEvent != null) {
 					// Cancel the drag
-					GodotInputHandler.handleMotionEvent(originEvent, MotionEvent.ACTION_CANCEL)
+					inputHandler.handleMotionEvent(originEvent, MotionEvent.ACTION_CANCEL)
 				}
 				dragInProgress = false
 				lastDragX = 0.0f
@@ -202,12 +202,12 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		val x = terminusEvent.x
 		val y = terminusEvent.y
 		if (terminusEvent.pointerCount >= 2 && panningAndScalingEnabled && !pointerCaptureInProgress && !dragInProgress) {
-			GodotLib.pan(x, y, distanceX / 5f, distanceY / 5f)
+			inputHandler.handlePanEvent(x, y, distanceX / 5f, distanceY / 5f)
 		} else if (!scaleInProgress) {
 			dragInProgress = true
 			lastDragX = terminusEvent.getX(0)
 			lastDragY = terminusEvent.getY(0)
-			GodotInputHandler.handleMotionEvent(terminusEvent)
+			inputHandler.handleMotionEvent(terminusEvent)
 		}
 		return true
 	}
@@ -218,11 +218,7 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		}
 
 		if (detector.scaleFactor >= 0.8f && detector.scaleFactor != 1f && detector.scaleFactor <= 1.2f) {
-			GodotLib.magnify(
-					detector.focusX,
-					detector.focusY,
-					detector.scaleFactor
-			)
+			inputHandler.handleMagnifyEvent(detector.focusX, detector.focusY, detector.scaleFactor)
 		}
 		return true
 	}

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -93,8 +93,8 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 	@Override
 	public void beforeTextChanged(final CharSequence pCharSequence, final int start, final int count, final int after) {
 		for (int i = 0; i < count; ++i) {
-			GodotLib.key(KeyEvent.KEYCODE_DEL, 0, 0, true, false);
-			GodotLib.key(KeyEvent.KEYCODE_DEL, 0, 0, false, false);
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_DEL, 0, 0, true, false);
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_DEL, 0, 0, false, false);
 
 			if (mHasSelection) {
 				mHasSelection = false;
@@ -115,8 +115,8 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 				// Return keys are handled through action events
 				continue;
 			}
-			GodotLib.key(0, character, 0, true, false);
-			GodotLib.key(0, character, 0, false, false);
+			mRenderView.getInputHandler().handleKeyEvent(0, character, 0, true, false);
+			mRenderView.getInputHandler().handleKeyEvent(0, character, 0, false, false);
 		}
 	}
 
@@ -127,18 +127,16 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 			if (characters != null) {
 				for (int i = 0; i < characters.length(); i++) {
 					final int character = characters.codePointAt(i);
-					GodotLib.key(0, character, 0, true, false);
-					GodotLib.key(0, character, 0, false, false);
+					mRenderView.getInputHandler().handleKeyEvent(0, character, 0, true, false);
+					mRenderView.getInputHandler().handleKeyEvent(0, character, 0, false, false);
 				}
 			}
 		}
 
 		if (pActionID == EditorInfo.IME_ACTION_DONE) {
 			// Enter key has been pressed
-			mRenderView.queueOnRenderThread(() -> {
-				GodotLib.key(KeyEvent.KEYCODE_ENTER, 0, 0, true, false);
-				GodotLib.key(KeyEvent.KEYCODE_ENTER, 0, 0, false, false);
-			});
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_ENTER, 0, 0, true, false);
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_ENTER, 0, 0, false, false);
 			mRenderView.getView().requestFocus();
 			return true;
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
@@ -81,7 +81,8 @@ fun beginBenchmarkMeasure(scope: String, label: String) {
  *
  * * Note: Only enabled on 'editorDev' build variant.
  */
-fun endBenchmarkMeasure(scope: String, label: String) {
+@JvmOverloads
+fun endBenchmarkMeasure(scope: String, label: String, dumpBenchmark: Boolean = false) {
 	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
 		return
 	}
@@ -93,6 +94,10 @@ fun endBenchmarkMeasure(scope: String, label: String) {
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 		Trace.endAsyncSection("[$scope] $label", 0)
 	}
+
+	if (dumpBenchmark) {
+		dumpBenchmark()
+	}
 }
 
 /**
@@ -102,11 +107,11 @@ fun endBenchmarkMeasure(scope: String, label: String) {
  * * Note: Only enabled on 'editorDev' build variant.
  */
 @JvmOverloads
-fun dumpBenchmark(fileAccessHandler: FileAccessHandler?, filepath: String? = benchmarkFile) {
+fun dumpBenchmark(fileAccessHandler: FileAccessHandler? = null, filepath: String? = benchmarkFile) {
 	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
 		return
 	}
-	if (!useBenchmark) {
+	if (!useBenchmark || benchmarkTracker.isEmpty()) {
 		return
 	}
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -549,4 +549,11 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIE
 		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_PAUSED);
 	}
 }
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateInputDispatchSettings(JNIEnv *env, jclass clazz, jboolean p_use_accumulated_input, jboolean p_use_input_buffering) {
+	if (Input::get_singleton()) {
+		Input::get_singleton()->set_use_accumulated_input(p_use_accumulated_input);
+		Input::get_singleton()->set_use_input_buffering(p_use_input_buffering);
+	}
+}
 }

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -69,6 +69,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onNightModeChanged(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIEnv *env, jclass clazz);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateInputDispatchSettings(JNIEnv *env, jclass clazz, jboolean p_use_accumulated_input, jboolean p_use_input_buffering);
 }
 
 #endif // JAVA_GODOT_LIB_JNI_H


### PR DESCRIPTION
- Add support for dispatching input on the render thread (UI thread is the current default) when `input_buffering` and `accumulated_input` are disabled. At the expense of latency, this helps prevent 'heavy' applications / games from blocking the UI thread (the default behavior)  which may cause the application to ANR.

- Remove GLSurfaceView logic causing the UI thread to wait on the GL thread during lifecycle events. The removed logic would cause the UI thread to ANR when the GL thread is blocked.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
