### PR TITLE
Fix undo/redo not working when in animation library editor

### DIFF
--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -108,6 +108,8 @@ class AnimationLibraryEditor : public AcceptDialog {
 
 	void _file_popup_selected(int p_id);
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 	bool updating = false;
 
 protected:


### PR DESCRIPTION
When the `AnimationLibraryEditor` is focused (accessed through the "Manage Animations..." button in when clicking the "Animation" button up top in the animation dock) you currently can't use undo/redo.

This PR fixes that by largely copy-pasting exactly what's currently being done for [`ProjectSettingsEditor`](https://github.com/godotengine/godot/blob/e6448ca0aa050b71cb40d9658b7233b8ec7f7382/editor/project_settings_editor.cpp#L245-L261) and [`EditorSettingsDialog`](https://github.com/godotengine/godot/blob/e6448ca0aa050b71cb40d9658b7233b8ec7f7382/editor/editor_settings_dialog.cpp#L178-L194), where it implements `Node::shortcut_input` and simply performs the undo/redo itself.

I'll admit that this feels like a bit of a hack, but with `AnimationLibraryEditor` not having any menu or shortcuts of its own, this seemed to be the only real option available.

If there's some other way of just propagating the shortcut to the main window somehow I'm all ears. The shortcut context stuff seems to mostly just be relevant if there are actual shortcuts tied to the `Control`, which again is not the case here.