### PR TITLE
Fix signal tooltip not leaving

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -900,8 +900,8 @@ Control *ConnectionsDockTree::make_custom_tooltip(const String &p_text) const {
 	}
 
 	EditorHelpBit *help_bit = memnew(EditorHelpBit(p_text));
-	EditorHelpBitTooltip::show_tooltip(help_bit, const_cast<ConnectionsDockTree *>(this));
-	return memnew(Control); // Make the standard tooltip invisible.
+	callable_mp(help_bit, &EditorHelpBit::update_content_height).call_deferred();
+	return help_bit;
 }
 
 struct _ConnectionsDockMethodInfoSort {


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/93698
- fixes https://github.com/godotengine/godot/issues/92382

Changes it to use the regular tooltip system.
It wasn't working since the tree doesn't emit `mouse_exit` signals whenever different items are hovered, and the `EditorHelpBitTooltip` system expected that.

This also affects the behavior when not in single window mode, it should be better.