### PR TITLE
Clarify `get_executable_path` documentation for Mac

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -283,7 +283,7 @@
 			<return type="String" />
 			<description>
 				Returns the file path to the current engine executable.
-				[b]Note:[/b] On macOS, always use [method create_instance] instead of relying on executable path.
+				[b]Note:[/b] On macOS, if you want to launch another instance of Godot, always use [method create_instance] instead of relying on the executable path.
 			</description>
 		</method>
 		<method name="get_granted_permissions" qualifiers="const">


### PR DESCRIPTION
[This page of the documentation](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-executable-path) has the following blurb:

```
String get_executable_path ( ) const

Returns the path to the current engine executable.

Note: On macOS, always use create_instance instead of relying on executable path.
```

This makes it sound like it's wrong to _ever_ use `get_executable_path` on macOS, but it's actually only if you're attempting to launch another instance of Godot that you should opt for `create_instance`. If you're instead doing something like trying to resolve `res://`, it seems like it's okay to use `get_executable_path`.