### PR TITLE
ResourceLoader.load_threaded_get_status: clarify progress parameter type

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -96,7 +96,7 @@
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
-				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
+				An array variable can optionally be passed via [param progress], and will return a one-element float array in the range of 0.0 to 1.0 containing the percentage of completion of the threaded loading request.
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>


### PR DESCRIPTION
This time doing it correctly:

This PR supersedes #93886 (again apologies for closing that one immediately) and clarifies the progress array parameter in ResourceLoader.load_threaded_get_status to include its type and range.

References and closes https://github.com/godotengine/godot/issues/88765
