### PR TITLE
[MoltenVK] Fix downscaled hiDPI window pixelation.

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -41,8 +41,8 @@
 
 int main(int argc, char **argv) {
 #if defined(VULKAN_ENABLED)
-	// MoltenVK - enable full component swizzling support.
-	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1);
+	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1); // MoltenVK - enable full component swizzling support.
+	setenv("MVK_CONFIG_SWAPCHAIN_MIN_MAG_FILTER_USE_NEAREST", "0", 1); // MoltenVK - use linear surface scaling. TODO: remove when full DPI scaling is implemented.
 #endif
 
 #if defined(SANITIZERS_ENABLED)


### PR DESCRIPTION
Enables linear (instead of nearest neighbor) downscaling when rendering windows on different DPI displays.

Fixes https://github.com/godotengine/godot/issues/89019