### PR TITLE
Fix slow import when window is unfocused

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1988,7 +1988,7 @@ void EditorFileSystem::_update_scene_groups() {
 		}
 
 		if (ep) {
-			ep->step(efd->files[index]->file, step_count++);
+			ep->step(efd->files[index]->file, step_count++, false);
 		}
 	}
 
@@ -2706,6 +2706,16 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 	EditorProgress *ep = memnew(EditorProgress("reimport", TTR("(Re)Importing Assets"), p_files.size()));
 
+	// The method reimport_files runs on the main thread, and if VSync is enabled
+	// or Update Continuously is disabled, Main::Iteration takes longer each frame.
+	// Each EditorProgress::step can trigger a redraw, and when there are many files to import,
+	// this could lead to a slow import process, especially when the editor is unfocused.
+	// Temporarily disabling VSync and low_processor_usage_mode while reimporting fixes this.
+	const bool old_low_processor_usage_mode = OS::get_singleton()->is_in_low_processor_usage_mode();
+	const DisplayServer::VSyncMode old_vsync_mode = DisplayServer::get_singleton()->window_get_vsync_mode(DisplayServer::MAIN_WINDOW_ID);
+	OS::get_singleton()->set_low_processor_usage_mode(false);
+	DisplayServer::get_singleton()->window_set_vsync_mode(DisplayServer::VSyncMode::VSYNC_DISABLED);
+
 	Vector<ImportFile> reimport_files;
 
 	HashSet<String> groups_to_reimport;
@@ -2836,6 +2846,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 			}
 		}
 	}
+	ep->step(TTR("Finalizing Asset Import..."), p_files.size());
 
 	ResourceUID::get_singleton()->update_cache(); // After reimporting, update the cache.
 	_save_filesystem_cache();
@@ -2843,6 +2854,11 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	memdelete_notnull(ep);
 
 	_process_update_pending();
+
+	// Revert to previous values to restore editor settings for VSync and Update Continuously.
+	OS::get_singleton()->set_low_processor_usage_mode(old_low_processor_usage_mode);
+	DisplayServer::get_singleton()->window_set_vsync_mode(old_vsync_mode);
+
 	importing = false;
 
 	ep = memnew(EditorProgress("reimport", TTR("(Re)Importing Assets"), p_files.size()));

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -202,14 +202,13 @@ void ProgressDialog::add_task(const String &p_task, const String &p_label, int p
 bool ProgressDialog::task_step(const String &p_task, const String &p_state, int p_step, bool p_force_redraw) {
 	ERR_FAIL_COND_V(!tasks.has(p_task), canceled);
 
+	Task &t = tasks[p_task];
 	if (!p_force_redraw) {
 		uint64_t tus = OS::get_singleton()->get_ticks_usec();
-		if (tus - last_progress_tick < 200000) { //200ms
+		if (tus - t.last_progress_tick < 200000) { //200ms
 			return canceled;
 		}
 	}
-
-	Task &t = tasks[p_task];
 	if (p_step < 0) {
 		t.progress->set_value(t.progress->get_value() + 1);
 	} else {
@@ -217,7 +216,7 @@ bool ProgressDialog::task_step(const String &p_task, const String &p_state, int 
 	}
 
 	t.state->set_text(p_state);
-	last_progress_tick = OS::get_singleton()->get_ticks_usec();
+	t.last_progress_tick = OS::get_singleton()->get_ticks_usec();
 	_update_ui();
 
 	return canceled;
@@ -252,7 +251,6 @@ ProgressDialog::ProgressDialog() {
 	main->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	set_exclusive(true);
 	set_flag(Window::FLAG_POPUP, false);
-	last_progress_tick = 0;
 	singleton = this;
 	cancel_hb = memnew(HBoxContainer);
 	main->add_child(cancel_hb);

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -71,13 +71,13 @@ class ProgressDialog : public PopupPanel {
 		VBoxContainer *vb = nullptr;
 		ProgressBar *progress = nullptr;
 		Label *state = nullptr;
+		uint64_t last_progress_tick = 0;
 	};
 	HBoxContainer *cancel_hb = nullptr;
 	Button *cancel = nullptr;
 
 	HashMap<String, Task> tasks;
 	VBoxContainer *main = nullptr;
-	uint64_t last_progress_tick;
 
 	LocalVector<Window *> host_windows;
 


### PR DESCRIPTION
Fixes #93877

Effectively, the importation speed was dependent on the `VSync` and `Update continuously` settings. That was because there is a lot of progress popup update while importing scenes. Disabling `VSync` and `Update continuously` settings while importing files accelerated the importation process on my computer and I got the same speed now when the editor is focused or not. On my computer, it accelerated the importation of the MRP project from 132 sec. to 88 sec. even when focused.

At the same time, I made a couple of little tweaks in the progress popups to prevent redrawing at each step progress passing `p_force_redraw` to false to `step` method.
There was also a bug in `ProgressDialog` when more then one step was present. If the second task was updated quickly or with `p_force_redraw` at true, the first step was never updated if the first task was using `p_force_redraw` at false. That was because `last_progress_tick` was global and always updated only for the second task. When `task_step` was called for the first task, `last_progress_tick` was always up to date causing it to return and not update the step.