### PR TITLE
Early return in `_update_children_cache_impl` when not in main thread

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1636,6 +1636,9 @@ void Node::remove_child(Node *p_child) {
 }
 
 void Node::_update_children_cache_impl() const {
+	if (!Thread::is_main_thread()) {
+		return;
+	}
 	// Assign children
 	data.children_cache.resize(data.children.size());
 	int idx = 0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93917

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
