### PR TITLE
Force the editor to redraw N frames until volumetric fog fully converges

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -276,6 +276,8 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		}
 	}
 
+	bool can_draw_3d = RSG::scene->is_camera(p_viewport->camera) && !p_viewport->disable_3d;
+
 	if (RSG::scene->is_scenario(p_viewport->scenario)) {
 		RID environment = RSG::scene->scenario_get_environment(p_viewport->scenario);
 		if (RSG::scene->is_environment(environment)) {
@@ -286,10 +288,16 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				// The scene renderer will still copy over the last frame, so we need to clear the render target.
 				force_clear_render_target = true;
 			}
+
+			// Calculate the frames needed for volumetric fog to converge
+			if (p_viewport->size != p_viewport->old_size && can_draw_3d) {
+				p_viewport->old_size = p_viewport->size;
+				float temporal_amount = RSG::scene->environment_get_volumetric_fog_temporal_reprojection_amount(environment);
+				float convergence_threshold = 0.01f;
+				p_viewport->frames_needed = Math::ceil(Math::log(convergence_threshold) / Math::log(temporal_amount));
+			}
 		}
 	}
-
-	bool can_draw_3d = RSG::scene->is_camera(p_viewport->camera) && !p_viewport->disable_3d;
 
 	if ((scenario_draw_canvas_bg || can_draw_3d) && !p_viewport->render_buffers.is_valid()) {
 		//wants to draw 3D but there is no render buffer, create
@@ -305,6 +313,12 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		if (p_viewport->clear_mode == RS::VIEWPORT_CLEAR_ONLY_NEXT_FRAME) {
 			p_viewport->clear_mode = RS::VIEWPORT_CLEAR_NEVER;
 		}
+	}
+
+	// Redraw until volumetric fog converges
+	if (p_viewport->frames_needed > 0 && can_draw_3d) {
+		_draw_3d(p_viewport);
+		p_viewport->frames_needed--;
 	}
 
 	if (!scenario_draw_canvas_bg && can_draw_3d) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -55,8 +55,11 @@ public:
 		// use xr interface to override camera positioning and projection matrices and control output
 		bool use_xr = false;
 
+		int frames_needed;
+
 		Size2i internal_size;
 		Size2i size;
+		Size2i old_size;
 		uint32_t view_count;
 		RID camera;
 		RID scenario;


### PR DESCRIPTION
**Issue**
Fixes #62794

**Godot version**
4.x

**System information**
- **OS**: Windows
- **Architecture**: x86_64
- **GPU**: Nvidia 1050ti

**Description**
This fix calculates the number of frames needed, based on the temporal reprojection amount, to redraw until the volumetric fog fully converges.

**Note**: Another issue related to the flickering when adjusting the viewport has already been addressed.

**Changes Made**
- New Variables in renderer_viewport.h:
    -    `int frames_needed;`: Stores the number of frames needed for the volumetric fog to converge.
    -    `Size2i old_size;`: Stores the previous size of the viewport. Used to check if the viewport was resized.

**Additional Information**

https://github.com/godotengine/godot/assets/169231366/5f3ddf00-df2c-47a1-b167-e43b26a5b8ed


As @Calinou mentioned:

> Resizing the viewport is not the only thing that can require reconverging volumetric fog.
>
> A lot of other things can require redrawing for the volumetric fog preview to remain accurate. In order of importance (from most to least important):
>
> - Toggling volumetric fog or changing one of its properties.
> - Hiding or showing a FogVolume node, or changing one of its material properties.
> - Hiding or showing a light that effects volumetric fog, or changing one of its properties.
> - Hiding or showing a mesh that blocked a light (through shadows), and where the shadow was visible in the volumetric fog.
>
> This is a lot to keep track of, so it might be better to always redraw for the volumetric fog duration whenever volumetric fog is enabled. We should try to do this only if something 3D-related happened though, so that UI-only updates do not force a full redraw of both 2D and 3D (they are always drawn at the same time).
>
> Also, we'll need several other things that keep track of a "frames needed" variables in the future, such as:
>
> - Temporal antialiasing/FSR2 (8 frames for TAA, variable for FSR2 according to the viewport's 3D resolution scale).
> - SSIL (1 frame delay after a viewport resize).
> - SDFGI (30 frames delay, adjustable in project settings).
>
> You don't need to implement these in this PR; it's just a note for later to make sure we don't need to copy-paste too much code around.
