### PR TITLE
Editor: Fix `EditorHelpBitTooltip` for Signals dock

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3761,11 +3761,24 @@ EditorHelpBit::EditorHelpBit(const String &p_symbol) {
 
 /// EditorHelpBitTooltip ///
 
+void EditorHelpBitTooltip::_start_timer() {
+	if (timer->is_inside_tree() && timer->is_stopped()) {
+		timer->start();
+	}
+}
+
 void EditorHelpBitTooltip::_safe_queue_free() {
 	if (_pushing_input > 0) {
 		_need_free = true;
 	} else {
 		queue_free();
+	}
+}
+
+void EditorHelpBitTooltip::_target_gui_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventMouse> mouse_event = p_event;
+	if (mouse_event.is_valid()) {
+		_start_timer();
 	}
 }
 
@@ -3775,7 +3788,7 @@ void EditorHelpBitTooltip::_notification(int p_what) {
 			timer->stop();
 			break;
 		case NOTIFICATION_WM_MOUSE_EXIT:
-			timer->start();
+			_start_timer();
 			break;
 	}
 }
@@ -3783,7 +3796,7 @@ void EditorHelpBitTooltip::_notification(int p_what) {
 // Forwards non-mouse input to the parent viewport.
 void EditorHelpBitTooltip::_input_from_window(const Ref<InputEvent> &p_event) {
 	if (p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
-		hide(); // Will be deleted on its timer.
+		_safe_queue_free();
 	} else {
 		const Ref<InputEventMouse> mouse_event = p_event;
 		if (mouse_event.is_null()) {
@@ -3801,7 +3814,7 @@ void EditorHelpBitTooltip::_input_from_window(const Ref<InputEvent> &p_event) {
 void EditorHelpBitTooltip::show_tooltip(EditorHelpBit *p_help_bit, Control *p_target) {
 	ERR_FAIL_NULL(p_help_bit);
 	EditorHelpBitTooltip *tooltip = memnew(EditorHelpBitTooltip(p_target));
-	p_help_bit->connect("request_hide", callable_mp(static_cast<Window *>(tooltip), &Window::hide)); // Will be deleted on its timer.
+	p_help_bit->connect("request_hide", callable_mp(tooltip, &EditorHelpBitTooltip::_safe_queue_free));
 	tooltip->add_child(p_help_bit);
 	p_target->get_viewport()->add_child(tooltip);
 	p_help_bit->update_content_height();
@@ -3858,8 +3871,8 @@ EditorHelpBitTooltip::EditorHelpBitTooltip(Control *p_target) {
 	add_child(timer);
 
 	ERR_FAIL_NULL(p_target);
-	p_target->connect(SceneStringName(mouse_entered), callable_mp(timer, &Timer::stop));
-	p_target->connect(SceneStringName(mouse_exited), callable_mp(timer, &Timer::start).bind(-1));
+	p_target->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorHelpBitTooltip::_start_timer));
+	p_target->connect(SceneStringName(gui_input), callable_mp(this, &EditorHelpBitTooltip::_target_gui_input));
 }
 
 #if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -329,7 +329,9 @@ class EditorHelpBitTooltip : public PopupPanel {
 	int _pushing_input = 0;
 	bool _need_free = false;
 
+	void _start_timer();
 	void _safe_queue_free();
+	void _target_gui_input(const Ref<InputEvent> &p_event);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
* Fixes #93698.
* Alternative to #93943.
* As for #92382, I can't confirm with this PR step 4 `Be confused for a few seconds --> Popup pops up again`. Once a tooltip is hidden, it does not appear again until you move the cursor.