### PR TITLE
[Editor] Update font preview directly instead of invalidating property list.

### DIFF
--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -935,6 +935,12 @@ void FontPreview::_notification(int p_what) {
 				font->draw_string(get_canvas_item(), Point2(0, font->get_height(font_size) + 2 * EDSCALE), TTR("Unable to preview font"), HORIZONTAL_ALIGNMENT_CENTER, get_size().x, font_size, text_color);
 			}
 		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (prev_font.is_valid()) {
+				prev_font->disconnect_changed(callable_mp(this, &FontPreview::_preview_changed));
+			}
+		} break;
 	}
 }
 
@@ -945,7 +951,17 @@ Size2 FontPreview::get_minimum_size() const {
 }
 
 void FontPreview::set_data(const Ref<Font> &p_f) {
+	if (prev_font.is_valid()) {
+		prev_font->disconnect_changed(callable_mp(this, &FontPreview::_preview_changed));
+	}
 	prev_font = p_f;
+	if (prev_font.is_valid()) {
+		prev_font->connect_changed(callable_mp(this, &FontPreview::_preview_changed));
+	}
+	queue_redraw();
+}
+
+void FontPreview::_preview_changed() {
 	queue_redraw();
 }
 

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -225,6 +225,8 @@ protected:
 
 	Ref<Font> prev_font;
 
+	void _preview_changed();
+
 public:
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -3213,7 +3213,6 @@ void SystemFont::_update_base_font() {
 	}
 
 	_invalidate_rids();
-	notify_property_list_changed();
 }
 
 void SystemFont::reset_state() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93932
Supersede https://github.com/godotengine/godot/pull/93965