### PR TITLE
Fix editor needs restart after adding GDExtensions

### DIFF
--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -54,7 +54,7 @@ public:
 	};
 
 private:
-	LoadStatus _load_extension_internal(const Ref<GDExtension> &p_extension);
+	LoadStatus _load_extension_internal(const Ref<GDExtension> &p_extension, bool p_first_load);
 	LoadStatus _unload_extension_internal(const Ref<GDExtension> &p_extension);
 
 #ifdef TOOLS_ENABLED
@@ -85,6 +85,7 @@ public:
 
 	void load_extensions();
 	void reload_extensions();
+	bool ensure_extensions_loaded(const HashSet<String> &p_extensions);
 
 	GDExtensionManager();
 	~GDExtensionManager();

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -271,6 +271,22 @@ void ClassDB::get_extensions_class_list(List<StringName> *p_classes) {
 
 	p_classes->sort_custom<StringName::AlphCompare>();
 }
+
+void ClassDB::get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes) {
+	OBJTYPE_RLOCK;
+
+	for (const KeyValue<StringName, ClassInfo> &E : classes) {
+		if (E.value.api != API_EXTENSION && E.value.api != API_EDITOR_EXTENSION) {
+			continue;
+		}
+		if (!E.value.gdextension || E.value.gdextension->library != p_extension.ptr()) {
+			continue;
+		}
+		p_classes->push_back(E.key);
+	}
+
+	p_classes->sort_custom<StringName::AlphCompare>();
+}
 #endif
 
 void ClassDB::get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -285,6 +285,7 @@ public:
 	static void get_class_list(List<StringName> *p_classes);
 #ifdef TOOLS_ENABLED
 	static void get_extensions_class_list(List<StringName> *p_classes);
+	static void get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes);
 	static ObjectGDExtension *get_placeholder_extension(const StringName &p_class);
 #endif
 	static void get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -56,6 +56,20 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="extension_loaded">
+			<param index="0" name="extension" type="GDExtension" />
+			<description>
+				Emitted after the editor has finished loading a new extension.
+				[b]Note:[/b] This signal is only emitted in editor builds.
+			</description>
+		</signal>
+		<signal name="extension_unloading">
+			<param index="0" name="extension" type="GDExtension" />
+			<description>
+				Emitted before the editor starts unloading an extension.
+				[b]Note:[/b] This signal is only emitted in editor builds.
+			</description>
+		</signal>
 		<signal name="extensions_reloaded">
 			<description>
 				Emitted after the editor has finished reloading one or more extensions.

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -187,7 +187,7 @@ class EditorFileSystem : public Node {
 
 	void _scan_filesystem();
 	void _first_scan_filesystem();
-	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, HashSet<String> &p_existing_class_names);
+	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions);
 
 	HashSet<String> late_update_files;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -481,6 +481,9 @@ void EditorNode::_gdextensions_reloaded() {
 	// In case the developer is inspecting an object that will be changed by the reload.
 	InspectorDock::get_inspector_singleton()->update_tree();
 
+	// Reload script editor to revalidate GDScript if classes are added or removed.
+	ScriptEditor::get_singleton()->reload_scripts(true);
+
 	// Regenerate documentation.
 	EditorHelp::generate_doc();
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -417,6 +417,7 @@ class GDScriptLanguage : public ScriptLanguage {
 	Vector<Variant> global_array;
 	HashMap<StringName, int> globals;
 	HashMap<StringName, Variant> named_globals;
+	Vector<int> global_array_empty_indexes;
 
 	struct CallLevel {
 		Variant *stack = nullptr;
@@ -448,6 +449,7 @@ class GDScriptLanguage : public ScriptLanguage {
 	int _debug_max_call_stack = 0;
 
 	void _add_global(const StringName &p_name, const Variant &p_value);
+	void _remove_global(const StringName &p_name);
 
 	friend class GDScriptInstance;
 
@@ -466,6 +468,11 @@ class GDScriptLanguage : public ScriptLanguage {
 #endif
 
 	HashMap<String, ObjectID> orphan_subclasses;
+
+#ifdef TOOLS_ENABLED
+	void _extension_loaded(const Ref<GDExtension> &p_extension);
+	void _extension_unloading(const Ref<GDExtension> &p_extension);
+#endif
 
 public:
 	int calls;


### PR DESCRIPTION
Fixes #77478

This PR should prevent the need to restart the editor when a new GDExtension is installed or when starting the editor for the first time without the `extension_list.cfg` file.

### Modifications:
- Added a scan for new or invalid extensions before the first scan.
- Added registering and unregistering for extension classes in GDScript globals so scripts can work without restarting the editor.
- Moved the addition and removal of extensions and the writing of `extension_list.cfg` to `GDExtensionManager::ensure_extensions_loaded` to facilitate the emission of the `extensions_reloaded` signal and to call `_reload_all_scripts` when extensions are added or removed.
- Added `ScriptEditor::get_singleton()->reload_scripts` on `extensions_reloaded` in `EditorNode` to revalidate the opened scripts and fix GDScript errors when extensions are added while the editor is running and GDScripts are opened that use classes from the extension.

### Known issues:
- When an extension is removed (removing the .gdextension file) and a scene containing nodes from this extension is opened, the editor crashes. This issue was already present. I'm wondering how to fix this, maybe by reloading the scenes when adding or removing extensions? I could be problematic for the user to always reload scene when reloading extensions??
- The editor crashes when using a class from an extension as the base class for an autoload script with `@tool`. This issue was already present.

### Not tested:
- Extensions with custom resource importers or types.
- Plugin extensions.
- Extension with HotReload.

### MRP used to test this (only built for Windows):
It's based on the MRP from #77478 but modified for Godot 4.3 master.
[test-godot-minimal_repro.zip](https://github.com/user-attachments/files/16111030/test-godot-minimal_repro.zip)
