### PR TITLE
Fix crash in the TileMapLayer editor when using editable children

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -3630,9 +3630,16 @@ TileMapLayer *TileMapLayerEditor::_get_edited_layer() const {
 
 void TileMapLayerEditor::_find_tile_map_layers_in_scene(Node *p_current, const Node *p_owner, Vector<TileMapLayer *> &r_list) const {
 	ERR_FAIL_COND(!p_current || !p_owner);
-	if (p_current != p_owner && p_current->get_owner() != p_owner) {
-		return;
+
+	if (p_current != p_owner) {
+		if (!p_current->get_owner()) {
+			return;
+		}
+		if (p_current->get_owner() != p_owner && !p_owner->is_editable_instance(p_current->get_owner())) {
+			return;
+		}
 	}
+
 	TileMapLayer *layer = Object::cast_to<TileMapLayer>(p_current);
 	if (layer) {
 		r_list.append(layer);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93790