### PR TITLE
Fix stopping AnimationPlayer doesn't clear cached timeline position

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -308,6 +308,7 @@ void AnimationPlayerEditor::_stop_pressed() {
 		frame->set_value(0);
 		track_editor->set_anim_pos(0);
 	}
+	timeline_position = player->get_current_animation_position();
 	stop->set_icon(stop_icon);
 }
 


### PR DESCRIPTION
Fixes #93771 
Set new pos in ```timeline_position``` after stop/pause an editor