### PR TITLE
Fix caret can disappear from script editor on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3807,9 +3807,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		case WM_ACTIVATE: {
 			// Activation can happen just after the window has been created, even before the callbacks are set.
 			// Therefore, it's safer to defer the delivery of the event.
-			if (!windows[window_id].activate_timer_id) {
-				windows[window_id].activate_timer_id = SetTimer(windows[window_id].hWnd, 1, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
-			}
+			// It's important to set an nIDEvent different from the SetTimer for move_timer_id because
+			// if the same nIDEvent is passed, the timer is replaced and the same timer_id is returned.
+			windows[window_id].activate_timer_id = SetTimer(windows[window_id].hWnd, DisplayServerWindows::TIMER_ID_WINDOW_ACTIVATION, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
 			windows[window_id].activate_state = GET_WM_ACTIVATE_STATE(wParam, lParam);
 			return 0;
 		} break;
@@ -4727,7 +4727,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 		case WM_ENTERSIZEMOVE: {
 			Input::get_singleton()->release_pressed_events();
-			windows[window_id].move_timer_id = SetTimer(windows[window_id].hWnd, 1, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
+			windows[window_id].move_timer_id = SetTimer(windows[window_id].hWnd, DisplayServerWindows::TIMER_ID_MOVE_REDRAW, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
 		} break;
 		case WM_EXITSIZEMOVE: {
 			KillTimer(windows[window_id].hWnd, windows[window_id].move_timer_id);

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -332,6 +332,11 @@ class DisplayServerWindows : public DisplayServer {
 	String tablet_driver;
 	Vector<String> tablet_drivers;
 
+	enum TimerID {
+		TIMER_ID_MOVE_REDRAW = 1,
+		TIMER_ID_WINDOW_ACTIVATION = 2,
+	};
+
 	enum {
 		KEY_EVENT_BUFFER_SIZE = 512
 	};


### PR DESCRIPTION
Fixes #92821 
Also probably fixes #92634 but did not find a way to reproduce more than once.

This was not easy to reproduce! To reproduce I did Alt-Tab while resizing the editor windows. And even then, it takes multiple retries to reproduce the problem.

I’m pretty certain that the problem came from a situation where a new `SetTimer` was called before the timer was actually triggered resulting in a situation where `activate_timer_id` and `move_timer_id` had the same `timer_id`. Both `SetTimer` for `activate_timer_id` and `move_timer_id` had the same `nIDEvent`, so the second `SetTimer` replaced the first timer.

Documentation for SetTimer from Microsoft:
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer
![image](https://github.com/godotengine/godot/assets/81109165/c217c32e-4b30-4258-9b50-b61493adf328)

With some debug print line, we can see that the activate timer can in some situations be created before the resize is triggered:
![image](https://github.com/godotengine/godot/assets/81109165/f2c68460-4633-41e6-9296-f98e240a5c96)


I did 2 modifications:
- Changed the `nIDEvent` for `activate_timer_id` to 2.
- When `WM_ACTIVATE` is received but `activate_timer_id != 0`, a new `SetTimer` is created anyway, replacing the first one. That should prevent the weird case where `activate_timer_id` was never triggered and resetted.
