### PR TITLE
Reuse old fog buffer when adjusting viewport to eliminate flickering

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1201,9 +1201,12 @@ void RenderForwardClustered::_update_volumetric_fog(Ref<RenderSceneBuffersRD> p_
 
 	if (p_render_buffers->has_custom_data(RB_SCOPE_FOG)) {
 		Ref<RendererRD::Fog::VolumetricFog> fog = p_render_buffers->get_custom_data(RB_SCOPE_FOG);
-		//validate
-		if (p_environment.is_null() || !environment_get_volumetric_fog_enabled(p_environment) || fog->width != target_width || fog->height != target_height || fog->depth != get_volumetric_fog_depth()) {
+
+		if (p_environment.is_null() || !environment_get_volumetric_fog_enabled(p_environment)) {
 			p_render_buffers->set_custom_data(RB_SCOPE_FOG, Ref<RenderBufferCustomDataRD>());
+
+		} else if (p_environment.is_valid() || environment_get_volumetric_fog_enabled(p_environment) || fog->width != target_width || fog->height != target_height || fog->depth != get_volumetric_fog_depth()) {
+			p_render_buffers->set_custom_data(RB_SCOPE_FOG, previous_fog);
 		}
 	}
 
@@ -1224,6 +1227,7 @@ void RenderForwardClustered::_update_volumetric_fog(Ref<RenderSceneBuffersRD> p_
 
 	if (p_render_buffers->has_custom_data(RB_SCOPE_FOG)) {
 		Ref<RendererRD::Fog::VolumetricFog> fog = p_render_buffers->get_custom_data(RB_SCOPE_FOG);
+		previous_fog = fog;
 
 		RendererRD::Fog::VolumetricFogSettings settings;
 		settings.rb_size = size;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -589,6 +589,8 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 	/* Volumetric fog */
 	RID shadow_sampler;
 
+	Ref<RendererRD::Fog::VolumetricFog> previous_fog;
+
 	void _update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
 
 	/* Render shadows */


### PR DESCRIPTION
**Issue**
#63739

**Godot version**
4.x

**System information**
- **OS**: Windows
- **Architecture**: x86_64
- **GPU**: Nvidia 1050ti

**Description**
This fix reuses the previous fog buffer when viewport size is updating, eliminating the flickering.

**Changes Made**
- New Variable in render_forward_clustered.h:
    -    `Ref<RendererRD::Fog::VolumetricFog> previous_fog;`

**Additional Information**

**Before**

https://github.com/godotengine/godot/assets/169231366/ff527d98-6a18-4602-9a78-efdb3939bd7c

**After**

https://github.com/godotengine/godot/assets/169231366/d6c0869a-83c8-4af2-80aa-11c977c1578b



