### PR TITLE
Clarify that `ENetConnection`'s `create_host` and `service` must be called on client and server

### DIFF
--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -51,7 +51,7 @@
 			<param index="3" name="data" type="int" default="0" />
 			<description>
 				Initiates a connection to a foreign [param address] using the specified [param port] and allocating the requested [param channels]. Optional [param data] can be passed during connection in the form of a 32 bit integer.
-				[b]Note:[/b] You must call either [method create_host] or [method create_host_bound] before calling this method.
+				[b]Note:[/b] You must call either [method create_host] or [method create_host_bound] on both ends before calling this method.
 			</description>
 		</method>
 		<method name="create_host">
@@ -61,7 +61,9 @@
 			<param index="2" name="in_bandwidth" type="int" default="0" />
 			<param index="3" name="out_bandwidth" type="int" default="0" />
 			<description>
-				Create an ENetHost that will allow up to [param max_peers] connected peers, each allocating up to [param max_channels] channels, optionally limiting bandwidth to [param in_bandwidth] and [param out_bandwidth].
+				Creates an ENetHost that allows up to [param max_peers] connected peers, each allocating up to [param max_channels] channels, optionally limiting bandwidth to [param in_bandwidth] and [param out_bandwidth] (if greater than zero).
+				This method binds a random available dynamic UDP port on the host machine at the [i]unspecified[/i] address. Use [method create_host_bound] to specify the address and port.
+				[b]Note:[/b] It is necessary to create a host in both client and server in order to establish a connection.
 			</description>
 		</method>
 		<method name="create_host_bound">
@@ -73,7 +75,8 @@
 			<param index="4" name="in_bandwidth" type="int" default="0" />
 			<param index="5" name="out_bandwidth" type="int" default="0" />
 			<description>
-				Create an ENetHost like [method create_host] which is also bound to the given [param bind_address] and [param bind_port].
+				Creates an ENetHost bound to the given [param bind_address] and [param bind_port] that allows up to [param max_peers] connected peers, each allocating up to [param max_channels] channels, optionally limiting bandwidth to [param in_bandwidth] and [param out_bandwidth] (if greater than zero).
+				[b]Note:[/b] It is necessary to create a host in both client and server in order to establish a connection.
 			</description>
 		</method>
 		<method name="destroy">
@@ -141,8 +144,9 @@
 			<return type="Array" />
 			<param index="0" name="timeout" type="int" default="0" />
 			<description>
-				Waits for events on the specified host and shuttles packets between the host and its peers, with the given [param timeout] (in milliseconds). The returned [Array] will have 4 elements. An [enum EventType], the [ENetPacketPeer] which generated the event, the event associated data (if any), the event associated channel (if any). If the generated event is [constant EVENT_RECEIVE], the received packet will be queued to the associated [ENetPacketPeer].
+				Waits for events on this connection and shuttles packets between the host and its peers, with the given [param timeout] (in milliseconds). The returned [Array] will have 4 elements. An [enum EventType], the [ENetPacketPeer] which generated the event, the event associated data (if any), the event associated channel (if any). If the generated event is [constant EVENT_RECEIVE], the received packet will be queued to the associated [ENetPacketPeer].
 				Call this function regularly to handle connections, disconnections, and to receive new packets.
+				[b]Note:[/b] This method must be called on both ends involved in the event (sending and receiving hosts).
 			</description>
 		</method>
 		<method name="socket_send">


### PR DESCRIPTION
Context: despite 3 years working coding servers and clients, it took me around **10 hours** to connect two `ENet` peers, and I read docs + ENet website + searched in issues and forums (oof!).

So, in this PR I try to clarify some of things I wish were there.

(In a separate PR I plan on adding an example.)