### PR TITLE
Add a check to prevent user to call `AStarGrid2D::update` when its not needed

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -122,6 +122,10 @@ AStarGrid2D::CellShape AStarGrid2D::get_cell_shape() const {
 }
 
 void AStarGrid2D::update() {
+	if (!dirty) {
+		return;
+	}
+
 	points.clear();
 
 	const int32_t end_x = region.get_end().x;


### PR DESCRIPTION
I think it's a good small fix to softly prevent user to call it in unappropriated place/time.
