### PR TITLE
Update vertex color import to handle Blender 4.2 upwards

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -188,10 +188,18 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	} else {
 		parameters_map["export_lights"] = false;
 	}
-	if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
-		parameters_map["export_colors"] = true;
+	if (blender_major_version > 4 || (blender_major_version == 4 && blender_minor_version >= 2)) {
+		if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
+			parameters_map["export_vertex_color"] = "MATERIAL";
+		} else {
+			parameters_map["export_vertex_color"] = "NONE";
+		}
 	} else {
-		parameters_map["export_colors"] = false;
+		if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
+			parameters_map["export_colors"] = true;
+		} else {
+			parameters_map["export_colors"] = false;
+		}
 	}
 	if (p_options.has(SNAME("blender/nodes/visible"))) {
 		int32_t visible = p_options["blender/nodes/visible"];


### PR DESCRIPTION
Blender commit https://projects.blender.org/blender/blender/commit/0f0a8df8a922cdb0796c0b3fdbdc5c669efb3059 which is landing in 4.2 deprecated `vertex_colors` GLTF property, use `export_vertex_color` instead.

Fixes: https://github.com/godotengine/godot/issues/93997
Fixes: #92365