### PR TITLE
Fix RichTextLabel + `ui_down` scrolling too far

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2098,7 +2098,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 				handled = true;
 			}
 			if (k->is_action("ui_down", true) && vscroll->is_visible_in_tree()) {
-				vscroll->scroll(vscroll->get_value() + theme_cache.normal_font->get_height(theme_cache.normal_font_size));
+				vscroll->scroll(theme_cache.normal_font->get_height(theme_cache.normal_font_size));
 				handled = true;
 			}
 			if (k->is_action("ui_home", true) && vscroll->is_visible_in_tree()) {


### PR DESCRIPTION
**Issue:** 
Using the down key (ui_down) made rich text labels such as the in-editor documentation scroll way too far down.
The scroll amount effectively doubled every time.

I did not find an open issue for this, but this is an easy fix.

**Godot-Versions**:
Bug introduced in #90988 / 30356a488fab1af657c238f9b6a3b0803e243b38
First release with the bug: 4.3-dev6

**Cause of issue:**
A recent commit replaced an absolute scroll values with relative ones, but in the case of ui_down did not remove the now superfluous current value.

**How to check this PR:**
Use the down key / ui_down (_not the mouse wheel_) in the in-editor documentation. Without this PR the scroll amount doubles, i.e. jumping from the middle to the end.
With this PR the documentation scrolls as expected.