### PR TITLE
Fix .blend files with quotation marks in filename fail to import

### DIFF
--- a/modules/gltf/editor/editor_import_blend_runner.h
+++ b/modules/gltf/editor/editor_import_blend_runner.h
@@ -47,6 +47,7 @@ class EditorImportBlendRunner : public Node {
 	void _resources_reimported(const PackedStringArray &p_files);
 	void _kill_blender();
 	void _notification(int p_what);
+	bool _extract_error_message_xml(const Vector<uint8_t> &p_response_data, String &r_error_message);
 
 protected:
 	int rpc_port = 0;

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -132,12 +132,10 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	}
 #endif
 
-	source_global = source_global.c_escape();
-
 	const String blend_basename = p_path.get_file().get_basename();
 	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().path_join(
 			vformat("%s-%s.gltf", blend_basename, p_path.md5_text()));
-	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink).c_escape();
+	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink);
 
 	// Handle configuration options.
 


### PR DESCRIPTION
- Fixes #78447

The main problem was using `c_escape` for paths which add `\` to `'` resulting to an invalid path since `\` is not an escape character in XML.

Also, I added a parse and print for `faultString` if an error occur in Blender/Python.
I also fixed the problem where every call returned 'cannot marshal None unless allow_none is enabled' because the Python method `export_gltf` did not return a value.

Tested:
- Filename with `'`.
- Filename with accents (non standard characters).
- Export without RPC for filename containing `'` (`do_import_direct`).

Example of the blender error message from RPC response:
![image](https://github.com/godotengine/godot/assets/81109165/2aa3a1fd-47de-4e37-8be2-11f848d761a7)
