### PR TITLE
Add pixel snap for `Parallax2D`

### DIFF
--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -31,6 +31,7 @@
 #include "parallax_2d.h"
 
 #include "core/config/project_settings.h"
+#include "scene/main/viewport.h"
 
 void Parallax2D::_notification(int p_what) {
 	switch (p_what) {
@@ -72,7 +73,11 @@ void Parallax2D::_validate_property(PropertyInfo &p_property) const {
 
 void Parallax2D::_camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset, const Point2 &p_adj_screen_pos) {
 	if (!ignore_camera_scroll) {
-		set_screen_offset(p_adj_screen_pos);
+		if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
+			set_screen_offset((p_adj_screen_pos + Vector2(0.5, 0.5)).floor());
+		} else {
+			set_screen_offset(p_adj_screen_pos);
+		}
 	}
 }
 


### PR DESCRIPTION
This is one temporary solution for parallax jittering, partially fixing #94005.

One way to fix the discrepancy between camera and canvas items with odd motion speeds is by manually setting the camera's position to the snapped value, so anything that depends on the camera's position also gets the snapped value. This is a brute force method and may create problems with other systems, so I'd like to avoid it until we know for sure it wouldn't be an issue, or can find an alternative.

`Parallax2D` depends on the camera's position, but sets the node's position every time the camera moves, so there's no harm in passing a snapped value to the parallax node. Until we have a long-term solution, this will prevent jitter for parallax movement while pixel snap is turned on.

After:

https://github.com/godotengine/godot/assets/21325943/ca435465-b578-414d-86cc-8bde84d4a172


