### PR TITLE
Ignore trailing slashes in new project’s path when disabling Create Folder

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -315,6 +315,8 @@ void ProjectDialog::_create_dir_toggled(bool p_pressed) {
 			target_path = target_path.path_join(last_custom_target_dir);
 		}
 	} else {
+		// Strip any trailing slash.
+		target_path = target_path.rstrip("/\\");
 		// Save and remove target dir name.
 		if (target_path.get_file() == auto_dir) {
 			last_custom_target_dir = "";


### PR DESCRIPTION
In the “Create New Project” dialog, disabling the “Create Folder” slider with a trailing slash in the project path would cause it to incorrectly identify the last path component as the substring following the slash, in other words, an empty string.

By first discarding any trailing slashes when disabling the slider, the project dialog will now identify and pop the last path component as usual even when a trailing slash is present.

Fixes #93973

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
