### PR TITLE
add-prevent-retrigger-property

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -61,6 +61,9 @@
 			The time required for the timer to end, in seconds. This property can also be set every time [method start] is called.
 			[b]Note:[/b] Timers can only process once per physics or process frame (depending on the [member process_callback]). An unstable framerate may cause the timer to end inconsistently, which is especially noticeable if the wait time is lower than roughly [code]0.05[/code] seconds. For very short timers, it is recommended to write your own code instead of using a [Timer] node. Timers are also affected by [member Engine.time_scale].
 		</member>
+		<member name="prevent_retrigger" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
+			Prevents the timer from retriggering if already active.
+		</member>
 	</members>
 	<signals>
 		<signal name="timeout">

--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -61,7 +61,7 @@
 			The time required for the timer to end, in seconds. This property can also be set every time [method start] is called.
 			[b]Note:[/b] Timers can only process once per physics or process frame (depending on the [member process_callback]). An unstable framerate may cause the timer to end inconsistently, which is especially noticeable if the wait time is lower than roughly [code]0.05[/code] seconds. For very short timers, it is recommended to write your own code instead of using a [Timer] node. Timers are also affected by [member Engine.time_scale].
 		</member>
-		<member name="prevent_retrigger" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
+		<member name="prevent_retrigger" type="bool" setter="set_prevent_retrigger" getter="is_prevent_retrigger" default="1.0">
 			Prevents the timer from retriggering if already active.
 		</member>
 	</members>

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -105,9 +105,20 @@ bool Timer::has_autostart() const {
 	return autostart;
 }
 
+void Timer::set_prevent_retrigger(bool p_prevent_retrigger) {
+	prevent_retrigger = p_prevent_retrigger;
+}
+
+bool Timer::is_prevent_retrigger() const {
+	return prevent_retrigger;
+}
+
 void Timer::start(double p_time) {
 	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
 
+	if (prevent_retrigger && processing) {
+		return;
+	}
 	if (p_time > 0) {
 		set_wait_time(p_time);
 	}
@@ -213,6 +224,9 @@ void Timer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_timer_process_callback", "callback"), &Timer::set_timer_process_callback);
 	ClassDB::bind_method(D_METHOD("get_timer_process_callback"), &Timer::get_timer_process_callback);
 
+	ClassDB::bind_method(D_METHOD("set_prevent_retrigger", "prevent_retrigger"), &Timer::set_prevent_retrigger);
+	ClassDB::bind_method(D_METHOD("is_prevent_retrigger"), &Timer::is_prevent_retrigger);
+
 	ADD_SIGNAL(MethodInfo("timeout"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_callback", PROPERTY_HINT_ENUM, "Physics,Idle"), "set_timer_process_callback", "get_timer_process_callback");
@@ -220,7 +234,10 @@ void Timer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "is_one_shot");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paused", "is_paused");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "prevent_retrigger"), "set_prevent_retrigger", "is_prevent_retrigger");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "suffix:s", PROPERTY_USAGE_NONE), "", "get_time_left");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "prevent_retrigger", PROPERTY_HINT_NONE, "Prevents the timer from retriggering if already active."), "set_prevent_retrigger", "is_prevent_retrigger");
 
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_IDLE);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -41,6 +41,7 @@ class Timer : public Node {
 	bool autostart = false;
 	bool processing = false;
 	bool paused = false;
+	bool prevent_retrigger = false;
 
 	double time_left = -1.0;
 
@@ -68,6 +69,9 @@ public:
 
 	void set_paused(bool p_paused);
 	bool is_paused() const;
+
+	void set_prevent_retrigger(bool p_paused);
+	bool is_prevent_retrigger() const;
 
 	bool is_stopped() const;
 


### PR DESCRIPTION
This PR adds a new bool property "prevent_retrigger" to the Timer class. This property prevents the timer from being retriggered if it is already running. This can be useful in situations where multiple triggers should be ignored, preventing messy workarounds.

Changes:
- Added "prevent_retrigger" boolean to the Timer class
- Updated _bind_methods() in timer.cpp to include the new property
- Added documentation to the Timer.xml file

Testing:
- Verified that the property appears in the inspector
- Tested the functionality to make sure that the timer does not retrigger when "prevent_retrigger" is set to true 
