### PR TITLE
Fix re-import glb model doesn't change the old glb model

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5981,9 +5981,6 @@ void EditorNode::reload_instances_with_path_in_edited_scenes(const String &p_ins
 					is_editable = owner->is_editable_instance(original_node);
 				}
 
-				// For clear instance state for path recaching.
-				instantiated_node->set_scene_instance_state(Ref<SceneState>());
-
 				bool original_node_is_displayed_folded = original_node->is_displayed_folded();
 				bool original_node_scene_instance_load_placeholder = original_node->get_scene_instance_load_placeholder();
 


### PR DESCRIPTION
- Fixes #90241 
- Fixes #90659 
- Fixes #92837

It took me a while to figure this out, but finally, the fix seems easy.

The reason why the model was not updated live in the scene is that the method `EditorNode::get_modified_properties_for_node` was returning all the properties of the nodes, like the `mesh`, when an autoreload had been done at least once. The behavior in place is to overwrite the properties modified by the user with the values in the current scene. This behavior ensures that if a user changes a property manually, the reimportation does not overwrite these properties. However, because Godot thought all the properties were modified by the user, when the new model was loaded, the old mesh property was copied over the new one.

Why did `EditorNode::get_modified_properties_for_node` return properties that were not modified? Because the `instance_state` was set to null in `reload_instances_with_path_in_edited_scenes` for an unknown reason. Since `instance_state` was not set, the method `PropertyUtils::get_property_default_value` was not able to find the source scene, and therefore the default value of the properties.

Before the modification:

https://github.com/godotengine/godot/assets/81109165/49a0a626-e330-4eaf-817b-28fd3ab33cbc

After the modification:

https://github.com/godotengine/godot/assets/81109165/8d7bebb8-2e4b-4a74-ae57-0e3674069a37



MRP to test:
[Test Reimport Blender.zip](https://github.com/user-attachments/files/16118314/Test.Reimport.Blender.zip)

EDIT: Add fixes for #90659 and #92837

*Bugsquad edit to properly use closing keywords.*