### PR TITLE
Wayland: Scale relative pointer motion

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2049,8 +2049,13 @@ void WaylandThread::_wp_relative_pointer_on_relative_motion(void *data, struct z
 
 	PointerData &pd = ss->pointer_data_buffer;
 
+	WindowState *ws = wl_surface_get_window_state(ss->pointed_surface);
+	ERR_FAIL_NULL(ws);
+
 	pd.relative_motion.x = wl_fixed_to_double(dx);
 	pd.relative_motion.y = wl_fixed_to_double(dy);
+
+	pd.relative_motion *= window_state_get_scale_factor(ws);
 
 	pd.relative_motion_time = uptime_lo;
 }


### PR DESCRIPTION
Fixes #93981.

Oops, forgot to do that. Motion-dependent stuff should now work properly when using scaled displays.

---

I'll eventually look into transforming the input events in a generic way inside `WaylandThread::push_message`, as this won't be the last time we forget to scale an event, I'm sure of it. I hope that's a good idea.