### PR TITLE
Wayland: Switch pointer position handling to doubles

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1412,10 +1412,10 @@ void WaylandThread::_wl_pointer_on_motion(void *data, struct wl_pointer *wl_poin
 	PointerData &pd = ss->pointer_data_buffer;
 
 	// TODO: Scale only when sending the Wayland message.
-	pd.position.x = wl_fixed_to_int(surface_x);
-	pd.position.y = wl_fixed_to_int(surface_y);
+	pd.position.x = wl_fixed_to_double(surface_x);
+	pd.position.y = wl_fixed_to_double(surface_y);
 
-	pd.position = scale_vector2i(pd.position, window_state_get_scale_factor(ws));
+	pd.position *= window_state_get_scale_factor(ws);
 
 	pd.motion_time = time;
 }
@@ -1528,7 +1528,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 		mm->set_position(pd.position);
 		mm->set_global_position(pd.position);
 
-		Vector2i pos_delta = pd.position - old_pd.position;
+		Vector2 pos_delta = pd.position - old_pd.position;
 
 		if (old_pd.relative_motion_time != pd.relative_motion_time) {
 			uint32_t time_delta = pd.relative_motion_time - old_pd.relative_motion_time;
@@ -1645,7 +1645,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 
 				// We have to set the last position pressed here as we can't take for
 				// granted what the individual events might have seen due to them not having
-				// a garaunteed order.
+				// a guaranteed order.
 				if (mb->is_pressed()) {
 					pd.last_pressed_position = pd.position;
 				}
@@ -2372,9 +2372,9 @@ void WaylandThread::_wp_tablet_tool_on_motion(void *data, struct zwp_tablet_tool
 
 	double scale_factor = window_state_get_scale_factor(ws);
 
-	td.position.x = wl_fixed_to_int(x);
-	td.position.y = wl_fixed_to_int(y);
-	td.position = scale_vector2i(td.position, scale_factor);
+	td.position.x = wl_fixed_to_double(x);
+	td.position.y = wl_fixed_to_double(y);
+	td.position *= scale_factor;
 
 	td.motion_time = OS::get_singleton()->get_ticks_msec();
 }
@@ -2509,7 +2509,7 @@ void WaylandThread::_wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_
 		mm->set_relative(td.position - old_td.position);
 		mm->set_relative_screen_position(mm->get_relative());
 
-		Vector2i pos_delta = td.position - old_td.position;
+		Vector2 pos_delta = td.position - old_td.position;
 		uint32_t time_delta = td.motion_time - old_td.motion_time;
 		mm->set_velocity((Vector2)pos_delta / time_delta);
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -295,7 +295,7 @@ public:
 	};
 
 	struct PointerData {
-		Point2i position;
+		Point2 position;
 		uint32_t motion_time = 0;
 
 		// Relative motion has its own optional event and so needs its own time.
@@ -305,7 +305,7 @@ public:
 		BitField<MouseButtonMask> pressed_button_mask;
 
 		MouseButton last_button_pressed = MouseButton::NONE;
-		Point2i last_pressed_position;
+		Point2 last_pressed_position;
 
 		// This is needed to check for a new double click every time.
 		bool double_click_begun = false;
@@ -325,14 +325,14 @@ public:
 	};
 
 	struct TabletToolData {
-		Point2i position;
+		Point2 position;
 		Vector2 tilt;
 		uint32_t pressure = 0;
 
 		BitField<MouseButtonMask> pressed_button_mask;
 
 		MouseButton last_button_pressed = MouseButton::NONE;
-		Point2i last_pressed_position;
+		Point2 last_pressed_position;
 
 		bool double_click_begun = false;
 


### PR DESCRIPTION
This reduces even further the amount of work we have to do when scaling and potentially improves input accuracy as now the input code is free from any form of rounding.