### PR TITLE
GDScript: Fix implicit cast to typed array when passing parameter

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -550,9 +550,22 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				return _get_default_variant_for_data_type(return_type);
 			}
 			if (argument_types[i].kind == GDScriptDataType::BUILTIN) {
-				Variant arg;
-				Variant::construct(argument_types[i].builtin_type, arg, &p_args[i], 1, r_err);
-				memnew_placement(&stack[i + 3], Variant(arg));
+				if (argument_types[i].builtin_type == Variant::ARRAY && argument_types[i].has_container_element_type(0)) {
+					const GDScriptDataType &arg_type = argument_types[i].container_element_types[0];
+					Array array(p_args[i]->operator Array(), arg_type.builtin_type, arg_type.native_type, arg_type.script_type);
+					memnew_placement(&stack[i + 3], Variant(array));
+				} else {
+					Variant variant;
+					Variant::construct(argument_types[i].builtin_type, variant, &p_args[i], 1, r_err);
+					if (unlikely(r_err.error)) {
+						r_err.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+						r_err.argument = i;
+						r_err.expected = argument_types[i].builtin_type;
+						call_depth--;
+						return _get_default_variant_for_data_type(return_type);
+					}
+					memnew_placement(&stack[i + 3], Variant(variant));
+				}
 			} else {
 				memnew_placement(&stack[i + 3], Variant(*p_args[i]));
 			}

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_implicit_cast_param.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_implicit_cast_param.gd
@@ -1,0 +1,7 @@
+# GH-93990
+
+func test_param(array: Array[String]) -> void:
+	print(array.get_typed_builtin() == TYPE_STRING)
+
+func test() -> void:
+	test_param(PackedStringArray())

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_implicit_cast_param.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_implicit_cast_param.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+true


### PR DESCRIPTION
* Fixes #93990.

We should add a dedicated method in the future, since we often forget about typed arrays with `Variant::construct()`.