### PR TITLE
Physics Interpolation: Fix behavior on pause

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -302,6 +302,12 @@ void Camera2D::_notification(int p_what) {
 			_interpolation_data.xform_prev = _interpolation_data.xform_curr;
 		} break;
 
+		case NOTIFICATION_PAUSED: {
+			if (is_physics_interpolated_and_enabled()) {
+				_update_scroll();
+			}
+		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if ((!position_smoothing_enabled && !is_physics_interpolated_and_enabled()) || _is_editing_in_editor()) {
 				_update_scroll();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -177,6 +177,12 @@ void Node::_notification(int p_notification) {
 			}
 		} break;
 
+		case NOTIFICATION_PAUSED: {
+			if (is_physics_interpolated_and_enabled() && is_inside_tree()) {
+				reset_physics_interpolation();
+			}
+		} break;
+
 		case NOTIFICATION_PATH_RENAMED: {
 			if (data.path_cache) {
 				memdelete(data.path_cache);


### PR DESCRIPTION
This is a straightforward port of 

- https://github.com/godotengine/godot/pull/93382

to 4.x, minus the 3D changes.

The 3D changes will be incorporated into the 3D physics interpolation PR for 4.x (not merged yet).