### PR TITLE
Fix physics tick counter

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -758,12 +758,13 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 
 		bool was_pressed = action_state.cache.pressed;
 		_update_action_cache(E.key, action_state);
+		// As input may come in part way through a physics tick, the earliest we can react to it is the next physics tick.
 		if (action_state.cache.pressed && !was_pressed) {
-			action_state.pressed_physics_frame = Engine::get_singleton()->get_physics_frames();
+			action_state.pressed_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 			action_state.pressed_process_frame = Engine::get_singleton()->get_process_frames();
 		}
 		if (!action_state.cache.pressed && was_pressed) {
-			action_state.released_physics_frame = Engine::get_singleton()->get_physics_frames();
+			action_state.released_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 			action_state.released_process_frame = Engine::get_singleton()->get_process_frames();
 		}
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4043,6 +4043,7 @@ bool Main::iteration() {
 		}
 
 		Engine::get_singleton()->_in_physics = true;
+		Engine::get_singleton()->_physics_frames++;
 
 		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
@@ -4090,7 +4091,6 @@ bool Main::iteration() {
 
 		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
 		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-		Engine::get_singleton()->_physics_frames++;
 
 		Engine::get_singleton()->_in_physics = false;
 	}

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -108,7 +108,7 @@ protected:
 	struct InterpolationData {
 		Transform2D xform_curr;
 		Transform2D xform_prev;
-		uint32_t last_update_physics_tick = 0;
+		uint32_t last_update_physics_tick = UINT32_MAX; // Ensure tick 0 is detected as a change.
 	} _interpolation_data;
 
 	void _ensure_update_interpolation_data();

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -671,8 +671,6 @@ void NavigationAgent2D::_update_navigation() {
 		return;
 	}
 
-	update_frame_id = Engine::get_singleton()->get_physics_frames();
-
 	Vector2 origin = agent_parent->get_global_position();
 
 	bool reload_path = false;
@@ -767,7 +765,6 @@ void NavigationAgent2D::_request_repath() {
 	target_reached = false;
 	navigation_finished = false;
 	last_waypoint_reached = false;
-	update_frame_id = 0;
 }
 
 bool NavigationAgent2D::_is_last_waypoint() const {

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -91,8 +91,6 @@ class NavigationAgent2D : public Node {
 	bool target_reached = false;
 	bool navigation_finished = true;
 	bool last_waypoint_reached = false;
-	// No initialized on purpose
-	uint32_t update_frame_id = 0;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -737,8 +737,6 @@ void NavigationAgent3D::_update_navigation() {
 		return;
 	}
 
-	update_frame_id = Engine::get_singleton()->get_physics_frames();
-
 	Vector3 origin = agent_parent->get_global_position();
 
 	bool reload_path = false;
@@ -835,7 +833,6 @@ void NavigationAgent3D::_request_repath() {
 	target_reached = false;
 	navigation_finished = false;
 	last_waypoint_reached = false;
-	update_frame_id = 0;
 }
 
 bool NavigationAgent3D::_is_last_waypoint() const {

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -98,8 +98,6 @@ class NavigationAgent3D : public Node {
 	bool target_reached = false;
 	bool navigation_finished = true;
 	bool last_waypoint_reached = false;
-	// No initialized on purpose
-	uint32_t update_frame_id = 0;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;


### PR DESCRIPTION
The counter is now incremented at the start of a physics tick rather than the end.

- Fixes https://github.com/godotengine/godot/issues/92903

This is a port of

- https://github.com/godotengine/godot/pull/92941

to the `master` branch.

In the navigation agents `update_frame_id` is actually unused, unlike in 3.x (why?), so it could also be removed.