### PR TITLE
Save all scenes and scripts before exporting a project

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1907,8 +1907,10 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	scene->propagate_notification(NOTIFICATION_EDITOR_POST_SAVE);
 }
 
-void EditorNode::save_all_scenes() {
-	project_run_bar->stop_playing();
+void EditorNode::save_all_scenes(bool p_stop_playing) {
+	if (p_stop_playing) {
+		project_run_bar->stop_playing();
+	}
 	_save_all_scenes();
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -902,7 +902,7 @@ public:
 
 	PopupMenu *get_export_as_menu();
 
-	void save_all_scenes();
+	void save_all_scenes(bool p_stop_playing = true);
 	void save_scene_if_open(const String &p_scene_path);
 	void save_scene_list(const HashSet<String> &p_scene_paths);
 	void save_before_run();

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1135,6 +1135,9 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 	Dictionary fd_option = export_project->get_selected_options();
 	bool export_debug = fd_option.get(TTR("Export With Debug"), true);
 
+	// Save all scenes before initiating project export, so that unsaved changes are included in the exported project.
+	EditorNode::get_singleton()->save_all_scenes(false);
+
 	Error err = platform->export_project(current, export_debug, current->get_export_path(), 0);
 	result_dialog_log->clear();
 	if (err != ERR_SKIP) {


### PR DESCRIPTION
- Alternative to https://github.com/godotengine/godot/pull/41312.

This ensures unsaved changes are represented in the exported project.

`EditorNode::save_all_scenes()` now accepts an optional argument to avoid stopping the running project. This prevents the running project from being stopped if was being run from the editor at the time of exporting.

- This closes https://github.com/godotengine/godot-proposals/issues/3605.
