### PR TITLE
Improve `to_string()` and add it to Resource

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -277,7 +277,7 @@ String InputEventWithModifiers::as_text() const {
 	}
 }
 
-String InputEventWithModifiers::to_string() {
+String InputEventWithModifiers::_to_string() {
 	return as_text();
 }
 
@@ -488,7 +488,7 @@ String InputEventKey::as_text() const {
 	return mods_text.is_empty() ? kc : mods_text + "+" + kc;
 }
 
-String InputEventKey::to_string() {
+String InputEventKey::_to_string() {
 	String p = is_pressed() ? "true" : "false";
 	String e = is_echo() ? "true" : "false";
 
@@ -848,7 +848,7 @@ String InputEventMouseButton::as_text() const {
 	return full_string;
 }
 
-String InputEventMouseButton::to_string() {
+String InputEventMouseButton::_to_string() {
 	String p = is_pressed() ? "true" : "false";
 	String canceled_state = is_canceled() ? "true" : "false";
 	String d = double_click ? "true" : "false";
@@ -988,7 +988,7 @@ String InputEventMouseMotion::as_text() const {
 	return vformat(RTR("Mouse motion at position (%s) with velocity (%s)"), String(get_position()), String(get_velocity()));
 }
 
-String InputEventMouseMotion::to_string() {
+String InputEventMouseMotion::_to_string() {
 	BitField<MouseButtonMask> mouse_button_mask = get_button_mask();
 	String button_mask_string = itos((int64_t)mouse_button_mask);
 
@@ -1184,7 +1184,7 @@ String InputEventJoypadMotion::as_text() const {
 	return vformat(RTR("Joypad Motion on Axis %d (%s) with Value %.2f"), axis, desc, axis_value);
 }
 
-String InputEventJoypadMotion::to_string() {
+String InputEventJoypadMotion::_to_string() {
 	return vformat("InputEventJoypadMotion: axis=%d, axis_value=%.2f", axis, axis_value);
 }
 
@@ -1303,7 +1303,7 @@ String InputEventJoypadButton::as_text() const {
 	return text;
 }
 
-String InputEventJoypadButton::to_string() {
+String InputEventJoypadButton::_to_string() {
 	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventJoypadButton: button_index=%d, pressed=%s, pressure=%.2f", button_index, p, pressure);
 }
@@ -1386,7 +1386,7 @@ String InputEventScreenTouch::as_text() const {
 	return vformat(RTR("Screen %s at (%s) with %s touch points"), status, String(get_position()), itos(index));
 }
 
-String InputEventScreenTouch::to_string() {
+String InputEventScreenTouch::_to_string() {
 	String p = pressed ? "true" : "false";
 	String canceled_state = canceled ? "true" : "false";
 	String double_tap_string = double_tap ? "true" : "false";
@@ -1514,7 +1514,7 @@ String InputEventScreenDrag::as_text() const {
 	return vformat(RTR("Screen dragged with %s touch points at position (%s) with velocity of (%s)"), itos(index), String(get_position()), String(get_velocity()));
 }
 
-String InputEventScreenDrag::to_string() {
+String InputEventScreenDrag::_to_string() {
 	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s), velocity=(%s), pressure=%.2f, tilt=(%s), pen_inverted=(%s)", index, String(get_position()), String(get_relative()), String(get_velocity()), get_pressure(), String(get_tilt()), get_pen_inverted());
 }
 
@@ -1656,7 +1656,7 @@ String InputEventAction::as_text() const {
 	return String();
 }
 
-String InputEventAction::to_string() {
+String InputEventAction::_to_string() {
 	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventAction: action=\"%s\", pressed=%s", action, p);
 }
@@ -1727,7 +1727,7 @@ String InputEventMagnifyGesture::as_text() const {
 	return vformat(RTR("Magnify Gesture at (%s) with factor %s"), String(get_position()), rtos(get_factor()));
 }
 
-String InputEventMagnifyGesture::to_string() {
+String InputEventMagnifyGesture::_to_string() {
 	return vformat("InputEventMagnifyGesture: factor=%.2f, position=(%s)", factor, String(get_position()));
 }
 
@@ -1769,7 +1769,7 @@ String InputEventPanGesture::as_text() const {
 	return vformat(RTR("Pan Gesture at (%s) with delta (%s)"), String(get_position()), String(get_delta()));
 }
 
-String InputEventPanGesture::to_string() {
+String InputEventPanGesture::_to_string() {
 	return vformat("InputEventPanGesture: delta=(%s), position=(%s)", String(get_delta()), String(get_position()));
 }
 
@@ -1850,7 +1850,7 @@ String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }
 
-String InputEventMIDI::to_string() {
+String InputEventMIDI::_to_string() {
 	String ret;
 	switch (message) {
 		case MIDIMessage::NOTE_ON:
@@ -1926,7 +1926,7 @@ String InputEventShortcut::as_text() const {
 	return vformat(RTR("Input Event with Shortcut=%s"), shortcut->get_as_text());
 }
 
-String InputEventShortcut::to_string() {
+String InputEventShortcut::_to_string() {
 	ERR_FAIL_COND_V(shortcut.is_null(), "None");
 
 	return vformat("InputEventShortcut: shortcut=%s", shortcut->get_as_text());

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -146,7 +146,7 @@ public:
 	BitField<KeyModifierMask> get_modifiers_mask() const;
 
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventWithModifiers() {}
 };
@@ -200,7 +200,7 @@ public:
 	virtual String as_text_key_label() const;
 	virtual String as_text_location() const;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	static Ref<InputEventKey> create_reference(Key p_keycode_with_modifier_masks, bool p_physical = false);
 
@@ -263,7 +263,7 @@ public:
 
 	virtual bool is_action_type() const override { return true; }
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::MOUSE_BUTTON; }
 
@@ -308,7 +308,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) override;
 
@@ -337,7 +337,7 @@ public:
 
 	virtual bool is_action_type() const override { return true; }
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	// The default device ID is `InputMap::ALL_DEVICES`.
 	static Ref<InputEventJoypadMotion> create_reference(JoyAxis p_axis, float p_value, int p_device = -1);
@@ -370,7 +370,7 @@ public:
 	virtual bool is_action_type() const override { return true; }
 
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	// The default device ID is `InputMap::ALL_DEVICES`.
 	static Ref<InputEventJoypadButton> create_reference(JoyButton p_btn_index, int p_device = -1);
@@ -404,7 +404,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::SCREEN_TOUCH; }
 
@@ -456,7 +456,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) override;
 
@@ -495,7 +495,7 @@ public:
 	virtual bool is_action_type() const override { return true; }
 
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::ACTION; }
 
@@ -528,7 +528,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::MAGNIFY_GESTURE; }
 
@@ -548,7 +548,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::PAN_GESTURE; }
 
@@ -596,7 +596,7 @@ public:
 	int get_controller_value() const;
 
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::MIDI; }
 
@@ -616,7 +616,7 @@ public:
 	Ref<Shortcut> get_shortcut();
 
 	virtual String as_text() const override;
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	InputEventType get_type() const final override { return InputEventType::SHORTCUT; }
 

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -660,6 +660,10 @@ void Resource::reset_local_to_scene() {
 	// Restores the state as if setup_local_to_scene() hadn't been called.
 }
 
+String Resource::_to_string() {
+	return (name.is_empty() ? "" : String(name) + " ") + "(" + path_cache + "):" + Object::_to_string();
+}
+
 Node *(*Resource::_get_local_scene_func)() = nullptr;
 void (*Resource::_update_configuration_warning)() = nullptr;
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -122,6 +122,7 @@ protected:
 	GDVIRTUAL0(_reset_state);
 
 	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const;
+	virtual String _to_string() override;
 
 public:
 	static Node *(*_get_local_scene_func)(); // Used by the editor.

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1044,7 +1044,7 @@ String Object::to_string() {
 			return ret;
 		}
 	}
-	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
+	return _to_string();
 }
 
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
@@ -1848,6 +1848,10 @@ void Object::clear_internal_resource_paths() {
 
 void Object::notify_property_list_changed() {
 	emit_signal(CoreStringName(property_list_changed));
+}
+
+String Object::_to_string() {
+	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
 }
 
 void Object::_bind_methods() {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -740,6 +740,7 @@ protected:
 	void _notification_backward(int p_notification);
 	virtual void _notification_forwardv(int p_notification) {}
 	virtual void _notification_backwardv(int p_notification) {}
+	virtual String _to_string();
 
 	static void _bind_methods();
 	static void _bind_compatibility_methods() {}
@@ -918,7 +919,7 @@ public:
 		}
 	}
 
-	virtual String to_string();
+	String to_string();
 
 	// Used mainly by script, get and set all INCLUDING string.
 	virtual Variant getvar(const Variant &p_key, bool *r_valid = nullptr) const;

--- a/core/object/script_backtrace.h
+++ b/core/object/script_backtrace.h
@@ -84,5 +84,5 @@ public:
 	Variant get_member_variable_value(int p_frame_index, int p_variable_index) const;
 
 	String format(int p_indent_all = 0, int p_indent_frames = 4) const;
-	virtual String to_string() override { return format(); }
+	virtual String _to_string() override { return format(); }
 };

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -205,7 +205,7 @@ public:
 	bool has_java_method(const StringName &p_method) const;
 
 #ifdef ANDROID_ENABLED
-	virtual String to_string() override;
+	virtual String _to_string() override;
 #endif
 
 	JavaClass();
@@ -232,7 +232,7 @@ public:
 	bool has_java_method(const StringName &p_method) const;
 
 #ifdef ANDROID_ENABLED
-	virtual String to_string() override;
+	virtual String _to_string() override;
 
 	jobject get_instance() { return instance; }
 

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -826,7 +826,7 @@ Ref<JavaClass> JavaClass::get_java_parent_class() const {
 	return ret;
 }
 
-String JavaClass::to_string() {
+String JavaClass::_to_string() {
 	return "<JavaClass:" + java_class_name + ">";
 }
 
@@ -874,11 +874,11 @@ Ref<JavaClass> JavaObject::get_java_class() const {
 	return base_class;
 }
 
-String JavaObject::to_string() {
+String JavaObject::_to_string() {
 	if (base_class.is_valid() && instance) {
 		return "<JavaObject:" + base_class->java_class_name + " \"" + (String)call("toString") + "\">";
 	}
-	return RefCounted::to_string();
+	return RefCounted::_to_string();
 }
 
 bool JavaObject::has_java_method(const StringName &p_method) const {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -459,8 +459,8 @@ Variant Tween::interpolate_variant(const Variant &p_initial_val, const Variant &
 	return ret;
 }
 
-String Tween::to_string() {
-	String ret = Object::to_string();
+String Tween::_to_string() {
+	String ret = Object::_to_string();
 	Node *node = get_bound_node();
 	if (node) {
 		ret += vformat(" (bound to %s)", node->get_name());

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -140,10 +140,9 @@ private:
 
 protected:
 	static void _bind_methods();
+	virtual String _to_string() override;
 
 public:
-	virtual String to_string() override;
-
 	Ref<PropertyTweener> tween_property(const Object *p_target, const NodePath &p_property, Variant p_to, double p_duration);
 	Ref<IntervalTweener> tween_interval(double p_time);
 	Ref<CallbackTweener> tween_callback(const Callable &p_callback);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2765,27 +2765,6 @@ void Node::get_storable_properties(HashSet<StringName> &r_storable_properties) c
 	}
 }
 
-String Node::to_string() {
-	// Keep this method in sync with `Object::to_string`.
-	ERR_THREAD_GUARD_V(String());
-	if (get_script_instance()) {
-		bool valid;
-		String ret = get_script_instance()->to_string(&valid);
-		if (valid) {
-			return ret;
-		}
-	}
-	if (_get_extension() && _get_extension()->to_string) {
-		String ret;
-		GDExtensionBool is_valid;
-		_get_extension()->to_string(_get_extension_instance(), &is_valid, &ret);
-		if (is_valid) {
-			return ret;
-		}
-	}
-	return (get_name() ? String(get_name()) + ":" : "") + Object::to_string();
-}
-
 void Node::set_scene_instance_state(const Ref<SceneState> &p_state) {
 	ERR_THREAD_GUARD
 	data.instance_state = p_state;
@@ -3599,6 +3578,11 @@ void Node::_validate_property(PropertyInfo &p_property) const {
 	if ((p_property.name == "process_thread_group_order" || p_property.name == "process_thread_messages") && data.process_thread_group == PROCESS_THREAD_GROUP_INHERIT) {
 		p_property.usage = 0;
 	}
+}
+
+String Node::_to_string() {
+	ERR_THREAD_GUARD_V(String());
+	return (get_name() ? String(get_name()) + ":" : "") + Object::_to_string();
 }
 
 void Node::input(const Ref<InputEvent> &p_event) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -405,6 +405,7 @@ protected:
 	void _call_unhandled_key_input(const Ref<InputEvent> &p_event);
 
 	void _validate_property(PropertyInfo &p_property) const;
+	virtual String _to_string() override;
 
 	Variant _get_node_rpc_config_bind() const {
 		return get_node_rpc_config().duplicate(true);
@@ -628,8 +629,6 @@ public:
 	bool is_part_of_edited_scene() const { return false; }
 #endif
 	void get_storable_properties(HashSet<StringName> &r_storable_properties) const;
-
-	virtual String to_string() override;
 
 	/* NOTIFICATIONS */
 


### PR DESCRIPTION
Object and Node had some duplicate code in `to_string()` method. I unified it by renaming the virtual `to_string()` to `_to_string()`. The base method runs the repeated code and falls back to the new method.
This means that anything can now override the default `to_string()` in its script. tbh the code looks like something that should be handled by GDVirtual.

I also added custom `_to_string()` to Resource, which returns `Resource Name (path):Object`, e.g.
```
(res://icon.svg):<CompressedTexture2D#-9223369745472882567>
Cool Gradient (res://new_gradient_texture_2d.tres):<GradientTexture2D#-9223369684470925226>
```
It allows to identify stringified resources.