### PR TITLE
Fix focus shortcut when in the bezier curve editor

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -965,7 +965,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			real_t minimum_value = INFINITY;
 			real_t maximum_value = -INFINITY;
 
-			for (const IntPair &E : selection) {
+			for (const IntPair &E : focused_keys) {
 				IntPair key_pair = E;
 
 				real_t time = animation->track_get_key_time(key_pair.first, key_pair.second);


### PR DESCRIPTION
I was about to make a proposal for adding the ability to focus (by pressing the "F" key) on all the bezier keys in the bezier curve animation editor when no keys are selected, only to find that this seems to have been the intention all along, as seen here:

https://github.com/godotengine/godot/blob/42e5b3ac2da07d2105c775977b39e6949c723ded/editor/animation_bezier_editor.cpp#L940-L945

The problem was that when the view box for the focus was calculated, it was still relying on the `selection` set rather than the `focused_keys` set, which looks a lot like a bug.

This PR fixes that by simply using the `focused_keys` set for calculating the view box instead.

This would also explain the somewhat janky behavior when focusing while having only one key selected, which this `focused_keys` set takes into account by adding the neighboring keys to it. So I guess this PR fixes that too.