### PR TITLE
Fix missing options in Project Import Defaults

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -291,14 +291,18 @@ bool ResourceImporterScene::get_option_visibility(const String &p_path, const St
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		Variant ret = post_importer_plugins.write[i]->get_option_visibility(p_path, animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
-			return ret;
+			if (!ret) {
+				return false;
+			}
 		}
 	}
 
 	for (Ref<EditorSceneFormatImporter> importer : scene_importers) {
 		Variant ret = importer->get_option_visibility(p_path, animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
-			return ret;
+			if (!ret) {
+				return false;
+			}
 		}
 	}
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -431,31 +431,39 @@ void ImportDock::_importer_selected(int i_idx) {
 
 void ImportDock::_preset_selected(int p_idx) {
 	int item_id = preset->get_popup()->get_item_id(p_idx);
+	String setting_name = "importer_defaults/" + params->importer->get_importer_name();
 
 	switch (item_id) {
 		case ITEM_SET_AS_DEFAULT: {
-			Dictionary d;
-
-			for (const PropertyInfo &E : params->properties) {
-				d[E.name] = params->values[E.name];
+			Dictionary import_settings;
+			// When import settings already exist, we will update these settings
+			// to ensure that the dictionary retains settings that are not displayed in the
+			// editor. For Scene, the dictionary is the same for FBX, GLTF, and Blender, but each
+			// file type has some different settings.
+			if (ProjectSettings::get_singleton()->has_setting(setting_name)) {
+				import_settings = GLOBAL_GET(setting_name);
 			}
 
-			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), d);
+			for (const PropertyInfo &E : params->properties) {
+				import_settings[E.name] = params->values[E.name];
+			}
+
+			ProjectSettings::get_singleton()->set(setting_name, import_settings);
 			ProjectSettings::get_singleton()->save();
 			_update_preset_menu();
 		} break;
 		case ITEM_LOAD_DEFAULT: {
-			ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting("importer_defaults/" + params->importer->get_importer_name()));
+			ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting(setting_name));
 
-			Dictionary d = GLOBAL_GET("importer_defaults/" + params->importer->get_importer_name());
-			List<Variant> v;
-			d.get_key_list(&v);
+			Dictionary import_settings = GLOBAL_GET(setting_name);
+			List<Variant> keys;
+			import_settings.get_key_list(&keys);
 
 			if (params->checking) {
 				params->checked.clear();
 			}
-			for (const Variant &E : v) {
-				params->values[E] = d[E];
+			for (const Variant &E : keys) {
+				params->values[E] = import_settings[E];
 				if (params->checking) {
 					params->checked.insert(E);
 				}
@@ -463,7 +471,7 @@ void ImportDock::_preset_selected(int p_idx) {
 			params->update();
 		} break;
 		case ITEM_CLEAR_DEFAULT: {
-			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), Variant());
+			ProjectSettings::get_singleton()->set(setting_name, Variant());
 			ProjectSettings::get_singleton()->save();
 			_update_preset_menu();
 		} break;

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -126,10 +126,9 @@ Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint
 
 Variant EditorSceneFormatImporterFBX2GLTF::get_option_visibility(const String &p_path, bool p_for_animation,
 		const String &p_option, const HashMap<StringName, Variant> &p_options) {
-	if (p_option == "fbx/embedded_image_handling") {
-		return false;
-	}
-	if (p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == EditorSceneFormatImporterUFBX::FBX_IMPORTER_FBX2GLTF && p_option == "fbx/embedded_image_handling") {
+	// Remove all the FBX options except for 'fbx/importer' if the importer is fbx2gltf.
+	// These options are available only for ufbx.
+	if (p_option.begins_with("fbx/") && p_option != "fbx/importer" && p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == EditorSceneFormatImporterUFBX::FBX_IMPORTER_FBX2GLTF) {
 		return false;
 	}
 	return true;

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -76,9 +76,6 @@ Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t
 	if (p_options.has(SNAME("nodes/import_as_skeleton_bones")) ? (bool)p_options[SNAME("nodes/import_as_skeleton_bones")] : false) {
 		state->set_import_as_skeleton_bones(true);
 	}
-	if (p_options.has(SNAME("nodes/import_as_skeleton_bones")) ? (bool)p_options[SNAME("nodes/import_as_skeleton_bones")] : false) {
-		state->set_import_as_skeleton_bones(true);
-	}
 	p_flags |= EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
 	state->set_bake_fps(p_options["animation/fps"]);
 	Error err = fbx->append_from_file(path, state, p_flags, p_path.get_base_dir());
@@ -93,21 +90,17 @@ Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t
 
 Variant EditorSceneFormatImporterUFBX::get_option_visibility(const String &p_path, bool p_for_animation,
 		const String &p_option, const HashMap<StringName, Variant> &p_options) {
-	String file_extension = p_path.get_extension().to_lower();
-	if (file_extension != "fbx" && p_option.begins_with("fbx/")) {
-		return false;
-	}
-	if ((file_extension != "gltf" && file_extension != "glb") && p_option.begins_with("gltf/")) {
-		return false;
-	}
 	return true;
 }
 
 void EditorSceneFormatImporterUFBX::get_import_options(const String &p_path,
 		List<ResourceImporter::ImportOption> *r_options) {
-	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "fbx/importer", PROPERTY_HINT_ENUM, "ufbx,FBX2glTF"), FBX_IMPORTER_UFBX));
-	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::BOOL, "fbx/allow_geometry_helper_nodes"), false));
-	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "fbx/embedded_image_handling", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), FBXState::HANDLE_BINARY_EXTRACT_TEXTURES));
+	// Returns all the options when path is empty because that means it's for the Project Settings.
+	if (p_path.is_empty() || p_path.get_extension().to_lower() == "fbx") {
+		r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "fbx/importer", PROPERTY_HINT_ENUM, "ufbx,FBX2glTF"), FBX_IMPORTER_UFBX));
+		r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::BOOL, "fbx/allow_geometry_helper_nodes"), false));
+		r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "fbx/embedded_image_handling", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), FBXState::HANDLE_BINARY_EXTRACT_TEXTURES));
+	}
 }
 
 void EditorSceneFormatImporterUFBX::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -334,7 +334,8 @@ Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_pa
 }
 
 void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
-	if (p_path.get_extension().to_lower() != "blend") {
+	// Returns all the options when path is empty because that means it's for the Project Settings.
+	if (!p_path.is_empty() && p_path.get_extension().to_lower() != "blend") {
 		return;
 	}
 #define ADD_OPTION_BOOL(PATH, VALUE) \

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -84,8 +84,12 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 
 void EditorSceneFormatImporterGLTF::get_import_options(const String &p_path,
 		List<ResourceImporter::ImportOption> *r_options) {
-	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/naming_version", PROPERTY_HINT_ENUM, "Godot 4.1 or 4.0,Godot 4.2 or later"), 1));
-	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/embedded_image_handling", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), GLTFState::HANDLE_BINARY_EXTRACT_TEXTURES));
+	String file_extension = p_path.get_extension().to_lower();
+	// Returns all the options when path is empty because that means it's for the Project Settings.
+	if (p_path.is_empty() || file_extension == "gltf" || file_extension == "glb") {
+		r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/naming_version", PROPERTY_HINT_ENUM, "Godot 4.1 or 4.0,Godot 4.2 or later"), 1));
+		r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/embedded_image_handling", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), GLTFState::HANDLE_BINARY_EXTRACT_TEXTURES));
+	}
 }
 
 void EditorSceneFormatImporterGLTF::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
@@ -98,10 +102,6 @@ void EditorSceneFormatImporterGLTF::handle_compatibility_options(HashMap<StringN
 
 Variant EditorSceneFormatImporterGLTF::get_option_visibility(const String &p_path, bool p_for_animation,
 		const String &p_option, const HashMap<StringName, Variant> &p_options) {
-	String file_extension = p_path.get_extension().to_lower();
-	if ((file_extension != "gltf" && file_extension != "glb") && p_option.begins_with("gltf/")) {
-		return false;
-	}
 	return true;
 }
 


### PR DESCRIPTION
- Fixes #89379

Some modifications were made in https://github.com/godotengine/godot/commit/04d43947bff4de9db8d7005862a1d895b6703fbc that lead to remove some options in Project Settings. Also, some options like Blender specific parameters were never in the Project Import Defaults, which I guess was an error.

The premise I took was to put every options possible for all different file extension in the Project Import Defaults. This was the case in 4.2 except for .blend.

### Modifications:
- Fixed `ResourceImporterScene::get_option_visibility` to check all plugins and importers. Previously, the method would return the result from `get_option_visibility` at the first importer, leading to only processing the first plugin or importer. Now, all are processed until a return value of false is encountered.
- `EditorSceneFormatImporterFBX2GLTF::get_option_visibility` returned false for only one the ufbx options if FBX2GLTF is enabled.
- The validations that determine if an option is available or not has been moved in `get_import_options` methods and always returns all the option when the path is empty (aka Project Import Defaults).
- The missing options for FBX and GLTF are now available in Scene and Animation Library in Project Import Defaults.
- Blender options are now available in Project Import Defaults.
- Fixed 'Set as Default for Scene' where options not displayed were reverted.

### Others found issues:
- Edited, these options does not makes sense for Blender: ~~When importing from Blender, the options `gltf/naming_version` and `gltf/embedded_image_handling` are not used even if they were shown in 4.2. I could add these options for Blender, at least `embedded_image_handling` like it was done for ufbx??~~
- When changing a value in the options (Project settings and file Import options), `get_option_visibility` are not recalled so that means that to see the effects of `EditorSceneFormatImporterBlend::get_option_visibility` or `EditorSceneFormatImporterFBX2GLTF::get_option_visibility`, the user needs to close the panel and reopen it. That could cause error if the user change the fbx/importer from FBX2GLTF to ufbx and tries to reimport. The 2 missing options will cause an error during importation.


### Project settings:
4.2
![image](https://github.com/godotengine/godot/assets/81109165/b9ffe110-bb39-4888-b9f0-f594212ceb17)

This PR:
![image](https://github.com/godotengine/godot/assets/81109165/7b142cd6-e4ad-4adb-be7f-d1fb7c76852b)
![image](https://github.com/godotengine/godot/assets/81109165/f16a5188-4055-4275-9e73-92d5a4d8ca49)

### FBX Import options
4.2
![image](https://github.com/godotengine/godot/assets/81109165/0fb592e3-c141-4869-9a6c-82a06cf8def0)

This PR
![image](https://github.com/godotengine/godot/assets/81109165/bbb73dee-07db-4330-af49-c1ade9ee5eff)

EDIT: stroked out the issue with Blender options.