### PR TITLE
Windows: Fix build error due to missing definition of Texture2D

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -38,6 +38,7 @@
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
+#include "scene/resources/texture.h"
 
 #if defined(VULKAN_ENABLED)
 #include "rendering_context_driver_vulkan_windows.h"


### PR DESCRIPTION
For some reason, now I'm getting a compile error about `Texture2D` being an incomplete type when used in `DisplayServerWindows::create_status_indicator()`. This is a cure.