### PR TITLE
RenderingDevice: Leave handling of compressed block granularity to the driver

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1617,9 +1617,6 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 		thread_local LocalVector<RDD::BufferTextureCopyRegion> command_buffer_texture_copy_regions_vector;
 		command_buffer_texture_copy_regions_vector.clear();
 
-		uint32_t block_w = 0, block_h = 0;
-		get_compressed_image_format_block_dimensions(tex->format, block_w, block_h);
-
 		uint32_t w = tex->width;
 		uint32_t h = tex->height;
 		uint32_t d = tex->depth;
@@ -1635,8 +1632,8 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 			copy_region.texture_region_size.z = d;
 			command_buffer_texture_copy_regions_vector.push_back(copy_region);
 
-			w = MAX(block_w, w >> 1);
-			h = MAX(block_h, h >> 1);
+			w = (w >> 1);
+			h = (h >> 1);
 			d = MAX(1u, d >> 1);
 		}
 
@@ -1652,6 +1649,10 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 
 		const uint8_t *read_ptr = driver->buffer_map(tmp_buffer);
 		ERR_FAIL_NULL_V(read_ptr, Vector<uint8_t>());
+
+		uint32_t block_w = 0;
+		uint32_t block_h = 0;
+		get_compressed_image_format_block_dimensions(tex->format, block_w, block_h);
 
 		Vector<uint8_t> buffer_data;
 		uint32_t tight_buffer_size = get_image_format_required_size(tex->format, tex->width, tex->height, tex->depth, tex->mipmaps);


### PR DESCRIPTION
Fixes the following Vulkan validation error in `command_copy_texture_to_buffer()`:
```
drivers\vulkan\rendering_context_driver_vulkan.cpp:304 - VALIDATION - Message Id Number: 1465181769 | Message Id Name: VUID-vkCmdCopyImageToBuffer-imageSubresource-07971
	Validation Error: [ VUID-vkCmdCopyImageToBuffer-imageSubresource-07971 ] Object 0: handle = 0x1a304de76f0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xc39db0000004713, name = RID:670869596676284, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x5754e649 | vkCmdCopyImageToBuffer(): pRegions[10] imageOffset.x (0) and (imageExtent.width + imageOffset.x) (4) must be >= zero or <= image subresource width (2). The Vulkan spec states: For each element of pRegions, imageOffset.x and (imageExtent.width + imageOffset.x) must both be greater than or equal to 0 and less than or equal to the width of the specified imageSubresource of srcImage (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdCopyImageToBuffer-imageSubresource-07971)
	Objects - 2
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1799672985328
		Object[1] - VK_OBJECT_TYPE_IMAGE, Handle 880975995174143763, Name "RID:670869596676284"
```

The issue is that Vulkan expects the dimensions be passed there without stepifying to the block size.

This PR changes the implicit contract between `RenderingDevice` and `RenderingDeviceDriver` so drivers now have to be aware that they will get logical sizes and they have to perform the rounding to physical block size according to what the underlying graphics API expects. That's OK for Vulkan, for obvious reasons, and also fine for Direct3D 12 because `RenderingDeviceDriverD3D12` performs the rounding itself so it doesn' really care. I'd just like to let @stuartcarnie know so he can adapt the Metal RDD to this "spec" change.