### PR TITLE
Add Web header to quickly debug the type of an export

### DIFF
--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -151,6 +151,13 @@ bool OS_Web::_check_internal_feature_support(const String &p_feature) {
 	if (godot_js_os_has_feature(p_feature.utf8().get_data())) {
 		return true;
 	}
+
+#ifdef WEB_DLINK_ENABLED
+	if (p_feature == "web_extensions") {
+		return true;
+	}
+#endif
+
 	return false;
 }
 

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -100,6 +100,20 @@ void main_loop_callback() {
 	}
 }
 
+void print_web_header() {
+	String thread_support = OS::get_singleton()->has_feature("threads")
+			? "thread support"
+			: "single-threaded";
+	String dlink_support = OS::get_singleton()->has_feature("web_extensions")
+			? "extension support"
+			: "no extension support";
+
+	print_line(vformat(
+			"Web build features: %s, %s",
+			thread_support,
+			dlink_support));
+}
+
 /// When calling main, it is assumed FS is setup and synced.
 extern EMSCRIPTEN_KEEPALIVE int godot_web_main(int argc, char *argv[]) {
 	os = new OS_Web();
@@ -119,6 +133,8 @@ extern EMSCRIPTEN_KEEPALIVE int godot_web_main(int argc, char *argv[]) {
 		}
 		return EXIT_FAILURE;
 	}
+
+	print_web_header();
 
 	main_started = true;
 


### PR DESCRIPTION
This PR adds "web_extensions" to `OS.has_feature()`. 

It also add an header to the boot sequence of the Web build in order to quickly discriminate which features are enabled for that export.

<img width="641" alt="Capture d’écran, le 2024-07-08 à 09 23 16" src="https://github.com/godotengine/godot/assets/270928/4c409069-82c0-4f7e-9a57-98809ee497c6">
