### PR TITLE
Add Home/End to text caret movements on macOS

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -636,6 +636,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::A | KeyModifierMask::CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT | KeyModifierMask::CMD_OR_CTRL));
+	inputs.push_back(InputEventKey::create_reference(Key::HOME));
 	default_builtin_cache.insert("ui_text_caret_line_start.macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
@@ -645,6 +646,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::E | KeyModifierMask::CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL));
+	inputs.push_back(InputEventKey::create_reference(Key::END));
 	default_builtin_cache.insert("ui_text_caret_line_end.macos", inputs);
 
 	// Text Caret Movement Page Up/Down
@@ -665,6 +667,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::CMD_OR_CTRL));
+	inputs.push_back(InputEventKey::create_reference(Key::HOME | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_document_start.macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
@@ -673,6 +676,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::CMD_OR_CTRL));
+	inputs.push_back(InputEventKey::create_reference(Key::END | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_document_end.macos", inputs);
 
 	// Text Caret Addition Below/Above


### PR DESCRIPTION
Fixes #90826.

This adds the Home and End keys to the default bindings for the `ui_text_caret_line_start` and `ui_text_caret_line_end` shortcuts respectively, for macOS.

While it's true (as discussed in #90826) that this isn't the primary shortcut for this on macOS, it is nevertheless supported by pretty much every other text editor out there, including macOS' native text fields, macOS TextEdit, VS Code, Sublime Text, JetBrains products, and I'm sure many others. There's no real reason why Godot shouldn't also have this in the bindings by default.

I also threw in bindings for `ui_text_caret_document_start` and `ui_text_caret_document_end`, since they sort of go hand-in-hand. This was however slightly more fragmented across the various applications. macOS TextEdit and Sublime Text binds this as Ctrl+Home/End, whereas JetBrains products binds this as Cmd+Home/End, and VS Code binds neither of these. I opted to go with Cmd+Home/End, since other similar caret movements in Godot also used the Cmd modifier.