### PR TITLE
Add shortcut for Lookup symbol in Script Editor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2200,7 +2200,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 	if (p_color || p_open_docs || p_goto_definition) {
 		context_menu->add_separator();
 		if (p_open_docs) {
-			context_menu->add_item(TTR("Lookup Symbol"), LOOKUP_SYMBOL);
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/lookup_symbol"), LOOKUP_SYMBOL);
 		}
 		if (p_color) {
 			context_menu->add_item(TTR("Pick Color"), EDIT_PICK_COLOR);
@@ -2350,6 +2350,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	edit_hb->add_child(goto_menu);
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
+	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/lookup_symbol"), LOOKUP_SYMBOL);
 	goto_menu->get_popup()->add_separator();
 
 	goto_menu->get_popup()->add_submenu_node_item(TTR("Bookmarks"), bookmarks_menu);
@@ -2531,6 +2532,7 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_function", "macos", KeyModifierMask::CTRL | KeyModifierMask::META | Key::J);
 
 	ED_SHORTCUT("script_text_editor/goto_line", TTR("Go to Line..."), KeyModifierMask::CMD_OR_CTRL | Key::L);
+	ED_SHORTCUT("script_text_editor/lookup_symbol", TTR("Lookup Symbol"));
 
 	ED_SHORTCUT("script_text_editor/toggle_breakpoint", TTR("Toggle Breakpoint"), Key::F9);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/toggle_breakpoint", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);


### PR DESCRIPTION
The "Lookup Symbol" did not have the possibility to assign a shortcut. Each time, I needed to right-click and use the context menu. To make the shortcut works, I added the menu in "Go to" because I think it's the best fit even it's not perfect.

In Visual Studio, the default shortcut the F12 which is already used for Continue in Godot. I did not put a default shortcut key value to be sure I don't break anything and because I don't known which key combination could be interesting.

![image](https://github.com/godotengine/godot/assets/81109165/b63f77a4-4c3e-4a7f-a297-5ab773158896)

![image](https://github.com/godotengine/godot/assets/81109165/14913b9a-545f-4553-b040-b503a72a087f)

![image](https://github.com/godotengine/godot/assets/81109165/c8b07dd7-4692-4517-815b-73af4f282da5)

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/86773*