### PR TITLE
Let EditorLog use the right call queue for thread safety

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -58,8 +58,8 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 
 	MessageType message_type = p_type == ERR_HANDLER_WARNING ? MSG_TYPE_WARNING : MSG_TYPE_ERROR;
 
-	if (self->current != Thread::get_caller_id()) {
-		callable_mp(self, &EditorLog::add_message).call_deferred(err_str, message_type);
+	if (!Thread::is_main_thread()) {
+		MessageQueue::get_main_singleton()->push_callable(callable_mp(self, &EditorLog::add_message), err_str, message_type);
 	} else {
 		self->add_message(err_str, message_type);
 	}
@@ -557,8 +557,6 @@ EditorLog::EditorLog() {
 	eh.errfunc = _error_handler;
 	eh.userdata = this;
 	add_error_handler(&eh);
-
-	current = Thread::get_caller_id();
 }
 
 void EditorLog::deinit() {

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -156,8 +156,6 @@ private:
 
 	ErrorHandlerList eh;
 
-	Thread::ID current;
-
 	//void _dragged(const Point2& p_ofs);
 	void _meta_clicked(const String &p_meta);
 	void _clear_request();


### PR DESCRIPTION
This is a complement to f61c63e3a1d525ccc204f64ad813c4ba77077468.

The `current` member was removed because in modern Godot you don't need to record the id of the main thread. That line comes from very long ago.