### PR TITLE
Fix crash when p_object is null inside tile source editor inspector plugin.

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -997,6 +997,7 @@ void TileSourceInspectorPlugin::_confirm_change_id() {
 }
 
 bool TileSourceInspectorPlugin::can_handle(Object *p_object) {
+	ERR_FAIL_NULL_V(p_object, false);
 	return p_object->is_class("TileSetAtlasSourceProxyObject") || p_object->is_class("TileSetScenesCollectionProxyObject");
 }
 


### PR DESCRIPTION
Fixes a crash that occurs when p_object is null.
```cpp
* thread #1, name = 'godot.linuxbsd.', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x0)
    frame #0: 0x000055555a464e89 godot.linuxbsd.editor.dev.x86_64.llvm`TileSourceInspectorPlugin::can_handle(this=0x0000555575e3bc00, p_object=0x0000000000000000) at tile_set_editor.cpp:1000:19
   997  }
   998 
   999  bool TileSourceInspectorPlugin::can_handle(Object *p_object) {
-> 1000         return p_object->is_class("TileSetAtlasSourceProxyObject") || p_object->is_class("TileSetScenesCollectionProxyObject");
   1001 }
   1002
   1003 bool TileSourceInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
```