### PR TITLE
Fix container minimum size with hidden parent

### DIFF
--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -35,7 +35,7 @@
 Size2 AspectRatioContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -36,7 +36,7 @@ Size2 CenterContainer::get_minimum_size() const {
 	}
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -250,7 +250,7 @@ Size2 FlowContainer::get_minimum_size() const {
 	Size2i minimum;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -122,11 +122,11 @@ void SplitContainerDragger::_notification(int p_what) {
 	}
 }
 
-Control *SplitContainer::_get_sortable_child(int p_idx) const {
+Control *SplitContainer::_get_sortable_child(int p_idx, SortableVisbilityMode p_visibility_mode) const {
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *c = as_sortable_control(get_child(i, false));
+		Control *c = as_sortable_control(get_child(i, false), p_visibility_mode);
 		if (!c) {
 			continue;
 		}
@@ -258,7 +258,8 @@ Size2 SplitContainer::get_minimum_size() const {
 	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? g->get_height() : g->get_width()) : 0;
 
 	for (int i = 0; i < 2; i++) {
-		if (!_get_sortable_child(i)) {
+		Control *child = _get_sortable_child(i, SortableVisbilityMode::VISIBLE);
+		if (!child) {
 			break;
 		}
 
@@ -270,7 +271,7 @@ Size2 SplitContainer::get_minimum_size() const {
 			}
 		}
 
-		Size2 ms = _get_sortable_child(i)->get_combined_minimum_size();
+		Size2 ms = child->get_combined_minimum_size();
 
 		if (vertical) {
 			minimum.height += ms.height;

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -82,7 +82,7 @@ private:
 	Ref<Texture2D> _get_grabber_icon() const;
 	void _compute_middle_sep(bool p_clamp);
 	void _resort();
-	Control *_get_sortable_child(int p_idx) const;
+	Control *_get_sortable_child(int p_idx, SortableVisbilityMode p_visibility_mode = SortableVisbilityMode::VISIBLE_IN_TREE) const;
 
 protected:
 	bool is_fixed = false;


### PR DESCRIPTION
Fixes #93464.

MRP for testing the changed containers: [container-visibility.zip](https://github.com/user-attachments/files/16131760/container-visibility.zip)

The minimum size bug can be a bit fickle to reproduce. In the above MRP, if you change the position of a panel by 1 px it stops reproducing until the inner ColorRect's size is reset, the panel's size is reset, and the ColorRect's size is set again.

Graphs and TabContainer use `SortableVisbilityMode::IGNORE`, I didn't change that as they seem like special cases.