### PR TITLE
Style: Format `.yaml`/`.yml` files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,72 +1,72 @@
 name: Bug report
 description: Report a bug in Godot
+
 body:
+  - type: markdown
+    attributes:
+      value: |
+        When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
+        - Write a descriptive issue title above.
+        - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
+        - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
+        - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
+        - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
 
-- type: markdown
-  attributes:
-    value: |
-      When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
-      - Write a descriptive issue title above.
-      - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
-      - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-      - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
-      - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
+  - type: textarea
+    attributes:
+      label: Tested versions
+      description: |
+        To properly fix a bug, we need to identify if the bug was recently introduced in the engine, or if it was always present.
+        - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
+        - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
+        - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
+      placeholder: |
 
-- type: textarea
-  attributes:
-    label: Tested versions
-    description: |
-      To properly fix a bug, we need to identify if the bug was recently introduced in the engine, or if it was always present.
-      - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
-      - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
-      - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
-    placeholder: |
+        - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2 snapshots.
+        - Not reproducible in: 4.1.3.stable, 4.2.dev4 and earlier 4.2 snapshots.
+    validations:
+      required: true
 
-      - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2 snapshots.
-      - Not reproducible in: 4.1.3.stable, 4.2.dev4 and earlier 4.2 snapshots.
-  validations:
-    required: true
+  - type: input
+    attributes:
+      label: System information
+      description: |
+        - Specify the OS version, and when relevant hardware information.
+        - For issues that are likely OS-specific and/or graphics-related, please specify the CPU model and architecture.
+        - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
+        - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
+        - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
+      placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
+    validations:
+      required: true
 
-- type: input
-  attributes:
-    label: System information
-    description: |
-      - Specify the OS version, and when relevant hardware information.
-      - For issues that are likely OS-specific and/or graphics-related, please specify the CPU model and architecture.
-      - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
-      - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
-      - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
-    placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: |
+        Describe your issue briefly. What doesn't work, and how do you expect it to work instead?
+        You can include images or videos with drag and drop, and format code blocks or logs with <code>\`\`\`</code> tags, on separate lines before and after the text. (Use <code>\`\`\`gdscript</code> to add GDScript syntax highlighting.)
+        Please do not add code examples or error messages as screenshots, but as text, this helps searching for issues and testing the code. If you are reporting a bug in the editor interface, like the script editor, please provide both a screenshot *and* the text of the code to help with testing.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Issue description
-    description: |
-      Describe your issue briefly. What doesn't work, and how do you expect it to work instead?
-      You can include images or videos with drag and drop, and format code blocks or logs with <code>\`\`\`</code> tags, on separate lines before and after the text. (Use <code>\`\`\`gdscript</code> to add GDScript syntax highlighting.)
-      Please do not add code examples or error messages as screenshots, but as text, this helps searching for issues and testing the code. If you are reporting a bug in the editor interface, like the script editor, please provide both a screenshot *and* the text of the code to help with testing.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: |
+        List of steps or sample code that reproduces the issue. Having reproducible issues is a prerequisite for contributors to be able to solve them.
+        If you include a minimal reproduction project below, you can detail how to use it here.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Steps to reproduce
-    description: |
-      List of steps or sample code that reproduces the issue. Having reproducible issues is a prerequisite for contributors to be able to solve them.
-      If you include a minimal reproduction project below, you can detail how to use it here.
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Minimal reproduction project (MRP)
-    description: |
-      - A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
-      - Having an MRP is very important for contributors to be able to reproduce the bug in the same way that you are experiencing it. When testing a potential fix for the issue, contributors will use the MRP to validate that the fix is working as intended.
-      - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
-      - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**
-      - **Note for C# users:** If your issue is *not* C#-specific, please upload a minimal reproduction project written in GDScript. This will make it easier for contributors to reproduce the issue locally as not everyone has a .NET setup available.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Minimal reproduction project (MRP)
+      description: |
+        - A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
+        - Having an MRP is very important for contributors to be able to reproduce the bug in the same way that you are experiencing it. When testing a potential fix for the issue, contributors will use the MRP to validate that the fix is working as intended.
+        - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
+        - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**
+        - **Note for C# users:** If your issue is *not* C#-specific, please upload a minimal reproduction project written in GDScript. This will make it easier for contributors to reproduce the issue locally as not everyone has a .NET setup available.
+    validations:
+      required: true

--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,15 +1,17 @@
 name: Download Godot artifact
 description: Download the Godot artifact.
+
 inputs:
   name:
     description: The artifact name.
-    default: "${{ github.job }}"
+    default: ${{ github.job }}
   path:
     description: The path to download and extract to.
     required: true
-    default: "./"
+    default: ./
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Download Godot Artifact
       uses: actions/download-artifact@v4

--- a/.github/actions/godot-api-dump/action.yml
+++ b/.github/actions/godot-api-dump/action.yml
@@ -1,11 +1,13 @@
 name: Dump Godot API
 description: Dump Godot API for GDExtension
+
 inputs:
   bin:
     description: The path to the Godot executable
     required: true
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     # Dump GDExtension interface and API
     - name: Dump GDExtension interface and API for godot-cpp build
@@ -19,5 +21,5 @@ runs:
     - name: Upload API dump
       uses: ./.github/actions/upload-artifact
       with:
-        name: 'godot-api-dump'
-        path: './godot-api/*'
+        name: godot-api-dump
+        path: ./godot-api/*

--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -1,9 +1,10 @@
 name: Build Godot
 description: Build Godot with the provided options.
+
 inputs:
   target:
     description: Build target (editor, template_release, template_debug).
-    default: "editor"
+    default: editor
   tests:
     description: Unit tests.
     default: false
@@ -13,25 +14,26 @@ inputs:
     required: false
   sconsflags:
     description: Additional SCons flags.
-    default: ""
+    default: ''
     required: false
   scons-cache:
     description: The SCons cache path.
-    default: "${{ github.workspace }}/.scons-cache/"
+    default: ${{ github.workspace }}/.scons-cache/
   scons-cache-limit:
     description: The SCons cache size limit.
     # actions/cache has 10 GiB limit, and GitHub runners have a 14 GiB disk.
     # Limit to 7 GiB to avoid having the extracted cache fill the disk.
     default: 7168
+
 runs:
-  using: "composite"
+  using: composite
   steps:
-    - name: Scons Build
+    - name: SCons Build
       shell: sh
       env:
-          SCONSFLAGS: ${{ inputs.sconsflags }}
-          SCONS_CACHE: ${{ inputs.scons-cache }}
-          SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
+        SCONSFLAGS: ${{ inputs.sconsflags }}
+        SCONS_CACHE: ${{ inputs.scons-cache }}
+        SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
       run: |
         echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
 

--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -3,18 +3,19 @@ description: Restore Godot build cache.
 inputs:
   cache-name:
     description: The cache base name (job name by default).
-    default: "${{github.job}}"
+    default: ${{ github.job }}
   scons-cache:
     description: The SCons cache path.
-    default: "${{github.workspace}}/.scons-cache/"
+    default: ${{ github.workspace }}/.scons-cache/
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Restore SCons cache directory
       uses: actions/cache/restore@v4
       with:
-        path: ${{inputs.scons-cache}}
-        key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+        path: ${{ inputs.scons-cache }}
+        key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
 
         # We try to match an existing cache to restore from it. Each potential key is checked against
         # all existing caches as a prefix. E.g. 'linux-template-minimal' would match any cache that
@@ -28,7 +29,7 @@ runs:
         #   4. A partial match for the same base branch only (not ideal, matches any PR with the same base branch).
 
         restore-keys: |
-          ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
-          ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-refs/heads/${{env.GODOT_BASE_BRANCH}}
-          ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}
+          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
+          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}
+          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-refs/heads/${{ env.GODOT_BASE_BRANCH }}
+          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -3,15 +3,16 @@ description: Save Godot build cache.
 inputs:
   cache-name:
     description: The cache base name (job name by default).
-    default: "${{github.job}}"
+    default: ${{ github.job }}
   scons-cache:
     description: The SCons cache path.
-    default: "${{github.workspace}}/.scons-cache/"
+    default: ${{ github.workspace }}/.scons-cache/
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Save SCons cache directory
       uses: actions/cache/save@v4
       with:
-        path: ${{inputs.scons-cache}}
-        key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+        path: ${{ inputs.scons-cache }}
+        key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/actions/godot-converter-test/action.yml
+++ b/.github/actions/godot-converter-test/action.yml
@@ -1,11 +1,13 @@
 name: Test Godot project converter
 description: Test the Godot project converter.
+
 inputs:
   bin:
     description: The path to the Godot executable
     required: true
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Test 3-to-4 conversion
       shell: sh

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -1,17 +1,19 @@
 name: Setup Python and SCons
 description: Setup Python, install the pip version of SCons.
+
 inputs:
   python-version:
     description: The Python version to use.
-    default: "3.x"
+    default: 3.x
   python-arch:
     description: The Python architecture.
-    default: "x64"
+    default: x64
   scons-version:
     description: The SCons version to use.
-    default: "4.8.0"
+    default: 4.8.0
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Set up Python 3.x
       uses: actions/setup-python@v5

--- a/.github/actions/godot-project-test/action.yml
+++ b/.github/actions/godot-project-test/action.yml
@@ -1,11 +1,13 @@
 name: Test Godot project
 description: Run the test Godot project.
+
 inputs:
   bin:
     description: The path to the Godot executable
     required: true
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     # Download and extract zip archive with project, folder is renamed to be able to easy change used project
     - name: Download test project

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,15 +1,17 @@
 name: Upload Godot artifact
 description: Upload the Godot artifact.
+
 inputs:
   name:
     description: The artifact name.
-    default: "${{ github.job }}"
+    default: ${{ github.job }}
   path:
     description: The path to upload.
     required: true
-    default: "bin/*"
+    default: bin/*
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Upload Godot Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -9,12 +9,12 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-android
   cancel-in-progress: true
 
 jobs:
   build-android:
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-20.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -39,7 +39,8 @@ jobs:
             sconsflags: arch=arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -7,18 +7,19 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   # Used for the godot-cpp checkout.
-  GODOT_CPP_BRANCH: '4.3'
+  GODOT_CPP_BRANCH: 4.3
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-cpp-tests
   cancel-in-progress: true
 
 jobs:
   godot-cpp-tests:
-    runs-on: "ubuntu-20.04"
-    name: "Build and test Godot CPP"
+    runs-on: ubuntu-20.04
+    name: Build and test Godot CPP
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -31,15 +32,15 @@ jobs:
         with:
           repository: godotengine/godot-cpp
           ref: ${{ env.GODOT_CPP_BRANCH }}
-          submodules: 'recursive'
-          path: 'godot-cpp'
+          submodules: recursive
+          path: godot-cpp
 
       # Download generated API dump
       - name: Download GDExtension interface and API dump
         uses: ./.github/actions/download-artifact
         with:
-          name: 'godot-api-dump'
-          path: './godot-api'
+          name: godot-api-dump
+          path: ./godot-api
 
       # Extract and override existing files with generated files
       - name: Extract GDExtension interface and API dump
@@ -58,11 +59,11 @@ jobs:
           cd ../..
 
   gdextension-c-compile:
-    runs-on: "ubuntu-20.04"
-    name: "Check GDExtension header with a C compiler"
+    runs-on: 'ubuntu-20.04'
+    name: 'Check GDExtension header with a C compiler'
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Run C compiler on gdextension_interface.h"
+      - name: 'Run C compiler on gdextension_interface.h'
         run: |
           gcc -c core/extension/gdextension_interface.h

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -9,16 +9,17 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-ios
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-ios
   cancel-in-progress: true
 
 jobs:
   ios-template:
-    runs-on: "macos-latest"
+    runs-on: macos-latest
     name: Template (target=template_release)
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -12,12 +12,12 @@ env:
   TSAN_OPTIONS: suppressions=misc/error_suppressions/tsan.txt
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-linux
   cancel-in-progress: true
 
 jobs:
   build-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-20.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -27,7 +27,7 @@ jobs:
             cache-name: linux-editor-mono
             target: editor
             sconsflags: module_mono_enabled=yes
-            bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
+            bin: ./bin/godot.linuxbsd.editor.x86_64.mono
             build-mono: true
             tests: false # Disabled due freeze caused by mix Mono build and CI
             doc-test: true
@@ -40,7 +40,7 @@ jobs:
             target: editor
             # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
             sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=gold
-            bin: "./bin/godot.linuxbsd.editor.dev.double.x86_64.san"
+            bin: ./bin/godot.linuxbsd.editor.dev.double.x86_64.san
             build-mono: false
             tests: true
             proj-test: true
@@ -53,7 +53,7 @@ jobs:
             cache-name: linux-editor-llvm-sanitizers
             target: editor
             sconsflags: dev_build=yes use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
-            bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
+            bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
             build-mono: false
             tests: true
             # Skip 2GiB artifact speeding up action.
@@ -66,36 +66,37 @@ jobs:
             target: editor
             tests: true
             sconsflags: dev_build=yes use_tsan=yes use_llvm=yes linker=lld
-            bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
+            bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Template w/ Mono (target=template_release)
+          - name: Template w/ Mono (target=template_release, tests=yes)
             cache-name: linux-template-mono
             target: template_release
-            sconsflags: module_mono_enabled=yes tests=yes
-            bin: "./bin/godot.linuxbsd.template_release.x86_64.mono"
+            sconsflags: module_mono_enabled=yes
+            bin: ./bin/godot.linuxbsd.template_release.x86_64.mono
             build-mono: false
             tests: true
             artifact: true
 
-          - name: Minimal template (target=template_release, everything disabled)
+          - name: Minimal template (target=template_release, tests=yes, everything disabled)
             cache-name: linux-template-minimal
             target: template_release
-            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no tests=yes
-            bin: "./bin/godot.linuxbsd.template_release.x86_64"
+            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no
+            bin: ./bin/godot.linuxbsd.template_release.x86_64
             tests: true
             artifact: true
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       # Need newer mesa for lavapipe to work properly.
       - name: Linux dependencies for tests
-        if: ${{ matrix.proj-test }}
+        if: matrix.proj-test
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB8B81E14DA65431D7504EA8F63F0F2B90935439
@@ -120,11 +121,11 @@ jobs:
         continue-on-error: true
 
       - name: Setup Python and SCons
-        if: ${{ ! matrix.legacy-scons }}
+        if: '!matrix.legacy-scons'
         uses: ./.github/actions/godot-deps
 
       - name: Setup Python and SCons (legacy versions)
-        if: ${{ matrix.legacy-scons }}
+        if: matrix.legacy-scons
         uses: ./.github/actions/godot-deps
         with:
           # Sync with Ensure*Version in SConstruct.
@@ -149,48 +150,48 @@ jobs:
         continue-on-error: true
 
       - name: Generate C# glue
-        if: ${{ matrix.build-mono }}
+        if: matrix.build-mono
         run: |
           ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue
 
       - name: Build .NET solutions
-        if: ${{ matrix.build-mono }}
+        if: matrix.build-mono
         run: |
           ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
 
       - name: Prepare artifact
-        if: ${{ matrix.artifact }}
+        if: matrix.artifact
         run: |
           strip bin/godot.*
           chmod +x bin/godot.*
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
+        if: matrix.artifact
         with:
           name: ${{ matrix.cache-name }}
 
       - name: Dump Godot API
         uses: ./.github/actions/godot-api-dump
-        if: ${{ matrix.api-dump }}
+        if: matrix.api-dump
         with:
           bin: ${{ matrix.bin }}
 
       - name: Unit tests
-        if: ${{ matrix.tests }}
+        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
           ${{ matrix.bin }} --headless --test --force-colors
 
       - name: .NET source generators tests
-        if: ${{ matrix.build-mono }}
+        if: matrix.build-mono
         run: |
           dotnet test modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests
 
       # Check class reference
       - name: Check for class reference updates
-        if: ${{ matrix.doc-test }}
+        if: matrix.doc-test
         run: |
           echo "Running --doctool to see if this changes the public API without updating the documentation."
           echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
@@ -199,20 +200,20 @@ jobs:
 
       # Check API backwards compatibility
       - name: Check for GDExtension compatibility
-        if: ${{ matrix.api-compat }}
+        if: matrix.api-compat
         run: |
           ./misc/scripts/validate_extension_api.sh "${{ matrix.bin }}"
 
       # Download and run the test project
       - name: Test Godot project
         uses: ./.github/actions/godot-project-test
-        if: ${{ matrix.proj-test }}
+        if: matrix.proj-test
         with:
           bin: ${{ matrix.bin }}
 
       # Test the project converter
       - name: Test project converter
         uses: ./.github/actions/godot-converter-test
-        if: ${{ matrix.proj-conv }}
+        if: matrix.proj-conv
         with:
           bin: ${{ matrix.bin }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -9,12 +9,12 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-macos
   cancel-in-progress: true
 
 jobs:
   build-macos:
-    runs-on: "macos-latest"
+    runs-on: macos-latest
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -24,17 +24,18 @@ jobs:
             cache-name: macos-editor
             target: editor
             tests: true
-            bin: "./bin/godot.macos.editor.universal"
+            bin: ./bin/godot.macos.editor.universal
 
-          - name: Template (target=template_release)
+          - name: Template (target=template_release, tests=yes)
             cache-name: macos-template
             target: template_release
             tests: true
-            sconsflags: debug_symbols=no tests=yes
-            bin: "./bin/godot.macos.template_release.universal"
+            sconsflags: debug_symbols=no
+            bin: ./bin/godot.macos.template_release.universal
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -86,7 +87,7 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: ${{ matrix.tests }}
+        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -2,51 +2,45 @@ name: 🔗 GHA
 on: [push, pull_request]
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-runner
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-runner
   cancel-in-progress: true
 
 jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
+    if: '!vars.DISABLE_GODOT_CI'
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 
   # Second stage: Run all the builds and some of the tests.
 
   android-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🤖 Android
     needs: static-checks
     uses: ./.github/workflows/android_builds.yml
 
   ios-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🍏 iOS
     needs: static-checks
     uses: ./.github/workflows/ios_builds.yml
 
   linux-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🐧 Linux
     needs: static-checks
     uses: ./.github/workflows/linux_builds.yml
 
   macos-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🍎 macOS
     needs: static-checks
     uses: ./.github/workflows/macos_builds.yml
 
   windows-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🏁 Windows
     needs: static-checks
     uses: ./.github/workflows/windows_builds.yml
 
   web-build:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🌐 Web
     needs: static-checks
     uses: ./.github/workflows/web_builds.yml
@@ -56,7 +50,6 @@ jobs:
   # Can be turned off for PRs that intentionally break compat with godot-cpp,
   # until both the upstream PR and the matching godot-cpp changes are merged.
   godot-cpp-test:
-    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🪲 Godot CPP
     # This can be changed to depend on another platform, if we decide to use it for
     # godot-cpp instead. Make sure to move the .github/actions/godot-api-dump step

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-static
   cancel-in-progress: true
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
       - name: Style checks via pre-commit
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --verbose --files ${{ env.CHANGED_FILES }}
+          extra_args: --files ${{ env.CHANGED_FILES }}
 
       - name: Python builders checks via pytest
         run: |

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -8,15 +8,15 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes strict_checks=yes
   EM_VERSION: 3.1.64
-  EM_CACHE_FOLDER: "emsdk-cache"
+  EM_CACHE_FOLDER: emsdk-cache
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-web
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-web
   cancel-in-progress: true
 
 jobs:
   web-template:
-    runs-on: "ubuntu-22.04"
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -37,16 +37,17 @@ jobs:
             artifact: true
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Emscripten latest
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: ${{env.EM_VERSION}}
-          actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
-          cache-key: emsdk-${{ matrix.cache-name }}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          version: ${{ env.EM_VERSION }}
+          actions-cache-folder: ${{ env.EM_CACHE_FOLDER }}
+          cache-key: emsdk-${{ matrix.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
 
       - name: Verify Emscripten setup
         run: |
@@ -77,6 +78,6 @@ jobs:
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
+        if: matrix.artifact
         with:
           name: ${{ matrix.cache-name }}

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -7,17 +7,17 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{github.workspace}}/"
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-windows
   cancel-in-progress: true
 
 jobs:
   build-windows:
     # Windows 10 with latest image
-    runs-on: "windows-latest"
+    runs-on: windows-latest
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -29,7 +29,7 @@ jobs:
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
-            bin: "./bin/godot.windows.editor.x86_64.exe"
+            bin: ./bin/godot.windows.editor.x86_64.exe
             artifact: true
 
           - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
@@ -39,16 +39,17 @@ jobs:
             sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes
             bin: ./bin/godot.windows.editor.x86_64.llvm.exe
 
-          - name: Template (target=template_release)
+          - name: Template (target=template_release, tests=yes)
             cache-name: windows-template
             target: template_release
             tests: true
-            sconsflags: debug_symbols=no tests=yes
-            bin: "./bin/godot.windows.template_release.x86_64.console.exe"
+            sconsflags: debug_symbols=no
+            bin: ./bin/godot.windows.template_release.x86_64.console.exe
             artifact: true
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -73,7 +74,7 @@ jobs:
           target: angle/angle.zip
 
       - name: Extract pre-built ANGLE static libraries
-        run: Expand-Archive -Force angle/angle.zip ${{github.workspace}}/
+        run: Expand-Archive -Force angle/angle.zip ${{ github.workspace }}/
 
       - name: Setup MSVC problem matcher
         uses: ammaraskar/msvc-problem-matcher@master
@@ -104,7 +105,7 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: ${{ matrix.tests }}
+        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,16 +96,21 @@ repos:
         language: node
         entry: eslint
         files: ^(platform/web/js/|modules/|misc/dist/html/).*\.(js|html)$
-        args: [--fix, --no-warn-ignored, --no-config-lookup, --config, platform/web/eslint.config.cjs]
+        args:
+          - --fix,
+          - --no-warn-ignored,
+          - --no-config-lookup,
+          - --config,
+          - platform/web/eslint.config.cjs,
         additional_dependencies:
           - '@eslint/js@^9.3.0'
           - '@html-eslint/eslint-plugin@^0.24.1'
           - '@html-eslint/parser@^0.24.1'
           - '@stylistic/eslint-plugin@^2.1.0'
-          - 'eslint@^9.3.0'
-          - 'eslint-plugin-html@^8.1.1'
-          - 'globals@^15.3.0'
-          - 'espree@^10.0.1'
+          - eslint@^9.3.0
+          - eslint-plugin-html@^8.1.1
+          - globals@^15.3.0
+          - espree@^10.0.1
 
       - id: jsdoc
         name: jsdoc
@@ -123,7 +128,7 @@ repos:
           - -d
           - dry-run
         pass_filenames: false
-        additional_dependencies: ['jsdoc@^4.0.3']
+        additional_dependencies: [jsdoc@^4.0.3]
 
       - id: svgo
         name: svgo
@@ -131,7 +136,7 @@ repos:
         entry: svgo
         files: \.svg$
         args: [--quiet, --config, misc/utility/svgo.config.mjs]
-        additional_dependencies: ["svgo@3.3.2"]
+        additional_dependencies: [svgo@3.3.2]
 
       - id: copyright-headers
         name: copyright-headers
@@ -179,7 +184,7 @@ repos:
         language: python
         entry: python misc/scripts/dotnet_format.py
         types_or: [c#]
-
+#
 # End of upstream Godot pre-commit hooks.
 #
 # Keep this separation to let downstream forks add their own hooks to this file,


### PR DESCRIPTION
Updates the formatting across all of our `.yaml`/`.yml` files. The changes were entirely syntactic/stylistic, with one exception: `runner.yml` only needed the `vars.DISABLE_GODOT_CI` conditional once, so the others have been removed.