### PR TITLE
`EditorExportPlugin` docs: Workaround for customized texture behavior

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -34,9 +34,16 @@
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="path" type="String" />
 			<description>
-				Customize a resource. If changes are made to it, return the same or a new resource. Otherwise, return [code]null[/code].
-				The [i]path[/i] argument is only used when customizing an actual file, otherwise this means that this resource is part of another one and it will be empty.
+				Customize a resource. If changes are made to it, return the same or a new resource. Otherwise, return [code]null[/code]. When a new resource is returned, [param resource] will be replaced by a copy of the new resource.
+				The [param path] argument is only used when customizing an actual file, otherwise this means that this resource is part of another one and it will be empty.
 				Implementing this method is required if [method _begin_customize_resources] returns [code]true[/code].
+				[b]Note:[/b] When customizing any of the following types and returning another resource, the other resource should not be skipped using [method skip] in [method _export_file]:
+				- [AtlasTexture]
+				- [CompressedCubemap]
+				- [CompressedCubemapArray]
+				- [CompressedTexture2D]
+				- [CompressedTexture2DArray]
+				- [CompressedTexture3D]
 			</description>
 		</method>
 		<method name="_customize_scene" qualifiers="virtual">


### PR DESCRIPTION
EditorExportPlugin docs: Workaround for #94045. Describes behaviour of customizing texture resources.

The list of types that should not be both customized and skipped was created through trial-and-error with the following import types:

- AnimationLibrary
- BitMap
- Translation
- CompressedCubemap
- CompressedCubemapArray
- FontFile
- FontFile
- FontFile
- RDShaderFile
- Image
- AudioStreamMP3
- AudioStreamWAV
- ArrayMesh
- PackedScene
- CompressedTexture2D
- CompressedTexture2DArray
- CompressedTexture3D
- AtlasTexture
- AudioStreamOggVorbis

The reason `skip()` should not be called is because the original resource will now point to the `.ctex` (or equivalent) file of the resource that replaced it. In this scenario, the `.ctex` file that was initially referenced by the original resource will no longer be included in the project.

From a usability perspective, there should be no difference between the way that different resources are handled, so I believe this is not a complete solution to the original issue. That said, my hope is that this documentation addition will at least bring `EditorExportPlugin` to a more usable state.