### PR TITLE
Fix debugger call stack not selecting nodes in remote scene tree (reverted)

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -446,7 +446,13 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 		v = Object::cast_to<EncodedObjectAsID>(v)->get_object_id();
 		h = PROPERTY_HINT_OBJECT_ID;
 		hs = var.type_hint;
+
+		// Makes the call stack select the node in the remote tree. See https://github.com/godotengine/godot/issues/79477
+		if (n == "self") {
+			_object_selected(v);
+		}
 	}
+
 	String type;
 	switch (var.type) {
 		case 0:


### PR DESCRIPTION
Fix #79477

The actual author of this changes is saierXP: https://github.com/godotengine/godot/issues/79477#issuecomment-1638125911, im just finishing the job.

<br>

Before:

https://github.com/godotengine/godot/assets/44306054/09b8a766-ff5d-422d-b40e-ab94d2b531e6

<br>

After:

https://github.com/godotengine/godot/assets/44306054/3f2ea9a5-7b91-4dcc-93db-4cb4f9081e7c

