### PR TITLE
Add support for generating LODs and shadow mesh in PrimitiveMesh

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -18,7 +18,7 @@
 		<method name="get_mesh_arrays" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns mesh arrays used to constitute surface of [Mesh]. The result can be passed to [method ArrayMesh.add_surface_from_arrays] to create a new surface. For example:
+				Returns mesh arrays used to constitute surface of [Mesh]. This takes [member add_uv2] into account, but not [member generate_lods] or [member generate_shadow_mesh]. The result can be passed to [method ArrayMesh.add_surface_from_arrays] to create a new surface. For example:
 				[codeblocks]
 				[gdscript]
 				var c = CylinderMesh.new()
@@ -50,6 +50,14 @@
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
+		</member>
+		<member name="generate_lods" type="bool" setter="set_generate_lods" getter="is_generating_lods" default="false">
+			If [code]true[/code], generates automatic mesh LOD based on the mesh's contents using [url=https://github.com/zeux/meshoptimizer]meshoptimizer[/url]. This works best on primitive meshes with smooth curved geometry such as [CapsuleMesh], [SphereMesh], and [TorusMesh].
+			[b]Note:[/b] Generating LODs slows down the mesh [i]generation[/i] process, so avoid enabling this property if the mesh's properties change during gameplay.
+		</member>
+		<member name="generate_shadow_mesh" type="bool" setter="set_generate_shadow_mesh" getter="is_generating_shadow_mesh" default="false">
+			If [code]true[/code], generates a shadow mesh with vertices welded together to improve rendering efficiency.
+			[b]Note:[/b] Generating a shadow mesh slows down the mesh [i]generation[/i] process, so avoid enabling this property if the mesh's properties change during gameplay.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The current [Material] of the primitive mesh.

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -58,6 +58,8 @@ private:
 
 	bool add_uv2 = false;
 	float uv2_padding = 2.0;
+	bool generate_lods = false;
+	bool generate_shadow_mesh = false;
 
 	// make sure we do an update after we've finished constructing our object
 	mutable bool pending_request = true;
@@ -109,6 +111,12 @@ public:
 
 	void set_uv2_padding(float p_padding);
 	float get_uv2_padding() const { return uv2_padding; }
+
+	void set_generate_lods(bool p_enable);
+	bool is_generating_lods() const { return generate_lods; }
+
+	void set_generate_shadow_mesh(bool p_enable);
+	bool is_generating_shadow_mesh() const { return generate_shadow_mesh; }
 
 	void request_update();
 


### PR DESCRIPTION
This can improve rendering performance with complex meshes, particularly SphereMesh, CapsuleMesh and TorusMesh.

This is disabled by default to ensure meshes are created as quickly as possible (and to avoid breaking custom shaders that displace vertices).

- This closes https://github.com/godotengine/godot-proposals/issues/6279.

## Preview

*Look at the primitive count in the top-right corner of the editor.*

### LOD/shadow mesh disabled

![LOD/shadow mesh disabled](https://github.com/godotengine/godot/assets/180032/1d09d803-a61c-4a6a-b95e-b67d6e5d7299)

### LOD/shadow mesh enabled

![LOD/shadow mesh enabled](https://github.com/godotengine/godot/assets/180032/73675f9d-28fe-47ab-bf39-e1fe37a45281)

### LOD/shadow mesh enabled (Mesh LOD Threshold = 4 pixels)

![LOD/shadow mesh enabled (Mesh LOD Threshold = 4 pixels)
](https://github.com/godotengine/godot/assets/180032/83f9b573-008d-478b-82af-34d28ecf350a)