### PR TITLE
Fix editor inspector crashing when the old object is no longer valid

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3579,7 +3579,9 @@ void EditorInspector::edit(Object *p_object) {
 
 	next_object = p_object; // Some plugins need to know the next edited object when clearing the inspector.
 	if (object) {
-		object->disconnect(CoreStringName(property_list_changed), callable_mp(this, &EditorInspector::_changed_callback));
+		if (likely(Variant(object).get_validated_object())) {
+			object->disconnect(CoreStringName(property_list_changed), callable_mp(this, &EditorInspector::_changed_callback));
+		}
 		_clear();
 	}
 	per_array_page.clear();


### PR DESCRIPTION
This fixes a crash when the editor inspector tries to edit a new object when the old object is an invalid instance. See the stack trace below. I ran into this situation when closing the editor with a complex scene open. Since this is editor code that only runs once in awhile, it's not performance critical. I tested that this fix is correct by adding an else statement and confirmed that it reached there.

```
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] 1   libsystem_platform.dylib            0x0000000186977584 _sigtramp + 56
[2] EditorInspector::edit(Object*) (in godot.macos.editor.arm64) + 384
[3] EditorInspector::_notification(int) (in godot.macos.editor.arm64) + 324
[4] EditorInspector::EditorInspector()
[5] Object::_predelete() (in godot.macos.editor.arm64) + 132
[6] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[7] Object::_predelete() (in godot.macos.editor.arm64) + 132
[8] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[9] Object::_predelete() (in godot.macos.editor.arm64) + 132
[10] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[11] Object::_predelete() (in godot.macos.editor.arm64) + 132
[12] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[13] Object::_predelete() (in godot.macos.editor.arm64) + 132
[14] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[15] Panel::Panel()
[16] Object::_predelete() (in godot.macos.editor.arm64) + 132
[17] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[18] Object::_predelete() (in godot.macos.editor.arm64) + 132
[19] Node::_notification(int) (in godot.macos.editor.arm64) + 384
[20] Object::_predelete() (in godot.macos.editor.arm64) + 132
[21] SceneTree::finalize() (in godot.macos.editor.arm64) + 64
[22] OS_MacOS::run() (in godot.macos.editor.arm64) + 408
[23] main (in godot.macos.editor.arm64) + 392
[24] 24  dyld                                0x00000001865be0e0 start + 2360
-- END OF BACKTRACE --
```