### PR TITLE
Fix error message being printed when importing an OBJ with no surfaces

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -425,9 +425,13 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 				}
 
 				if (!current_material.is_empty()) {
-					mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+					if (mesh->get_surface_count() >= 1) {
+						mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+					}
 				} else if (!current_group.is_empty()) {
-					mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
+					if (mesh->get_surface_count() >= 1) {
+						mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
+					}
 				}
 				Array array = surf_tool->commit_to_arrays();
 


### PR DESCRIPTION
An OBJ with no surfaces is valid, and typically happens when you import an OBJ mesh with no associated MTL file.

Previously, this was printed every time you imported such an OBJ:

```
ERROR: Index p_surface = -1 is out of bounds (surfaces.size() = 0).
   at: set_surface_name (./scene/resources/3d/importer_mesh.cpp:216)
```

**Testing project:** [test_obj_import_no_surfaces.zip](https://github.com/user-attachments/files/16134553/test_obj_import_no_surfaces.zip)
