### PR TITLE
SCons: Default `optimize` to `auto`, fixing `target`/`dev_build` inference for Web

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -200,7 +200,10 @@ opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectur
 opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
 opts.Add(
     EnumVariable(
-        "optimize", "Optimization level", "speed_trace", ("none", "custom", "debug", "speed", "speed_trace", "size")
+        "optimize",
+        "Optimization level (by default inferred from 'target' and 'dev_build')",
+        "auto",
+        ("auto", "none", "custom", "debug", "speed", "speed_trace", "size"),
     )
 )
 opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", False))
@@ -466,14 +469,15 @@ env.editor_build = env["target"] == "editor"
 env.dev_build = env["dev_build"]
 env.debug_features = env["target"] in ["editor", "template_debug"]
 
-if env.dev_build:
-    opt_level = "none"
-elif env.debug_features:
-    opt_level = "speed_trace"
-else:  # Release
-    opt_level = "speed"
+if env["optimize"] == "auto":
+    if env.dev_build:
+        opt_level = "none"
+    elif env.debug_features:
+        opt_level = "speed_trace"
+    else:  # Release
+        opt_level = "speed"
+    env["optimize"] = ARGUMENTS.get("optimize", opt_level)
 
-env["optimize"] = ARGUMENTS.get("optimize", opt_level)
 env["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", env.dev_build)
 
 if env.editor_build:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -78,6 +78,7 @@ def get_flags():
         # -Os reduces file size by around 5 MiB over -O3. -Oz only saves about
         # 100 KiB over -Os, which does not justify the negative impact on
         # run-time performance.
+        # Note that this overrides the "auto" behavior for target/dev_build.
         "optimize": "size",
     }
 


### PR DESCRIPTION
- Fixes #94087.

This is a bit awkward because we can't have both a custom default value provided by each platform's `get_opts`, and still use some platform-agnostic "auto" behavior in SConstruct. So with this approach we go back to the 4.2 behavior where the web platform's `get_opts` simply overrides whatever is in `optimize`, unless it's specified on the command line.

I think it's an ok compromise for now, especially given how the web platform is sensitive to binary size. But it's a quirk worth knowing and documenting for people trying to debug web exports. (See also #91800.)

@dsnopek @Faless @adamscott Could also be considered to fix - #93476 by reintroducing the previous behavior, i.e. dev builds for web will still use `-Os` like in 4.2. Web builds with `optimize=none` will likely still be broken, but they're probably simply way too big for browsers to handle?