### PR TITLE
SCons: Fix build fetching `git_timestamp` if git `log.showsignature=true`

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -268,7 +268,7 @@ def get_version_info(module_version_string="", silent=False):
     if os.path.exists(".git"):
         try:
             version_info["git_timestamp"] = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=format:%ct", githash]
+                ["git", "log", "-1", "--pretty=format:%ct", "--no-show-signature", githash]
             ).decode("utf-8")
         except (subprocess.CalledProcessError, OSError):
             # `git` not found in PATH.


### PR DESCRIPTION
Hi!

This PR fixes the build system if git config has the log.showsignature option set to true.

Without it, for me, the `core/version_hash.gen.cpp`  file was generate like this:
```cpp
#include "core/version.h"

const char *const VERSION_HASH = "16f98cd7079c2b22248ec358371f17bca355e42e";
const uint64_t VERSION_TIMESTAMP = gpg: Signature faite le lun 08 jui 2024 19:13:45 CEST
gpg:                avec la clef RSA E7E863960AC92F726F9A45CDC3336907360768E1
gpg:                issuer "rverschelde@gmail.com"
gpg: Impossible de vérifier la signature : Pas de clef publique
1720458825;
```