### PR TITLE
[Editor] Unload addons when using `--import` or `--quit`.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3340,13 +3340,17 @@ void EditorNode::_exit_editor(int p_exit_code) {
 	dim_editor(true);
 
 	// Unload addons before quitting to allow cleanup.
+	unload_editor_addons();
+
+	get_tree()->quit(p_exit_code);
+}
+
+void EditorNode::unload_editor_addons() {
 	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
 		print_verbose(vformat("Unloading addon: %s", E.key));
 		remove_editor_plugin(E.value, false);
 		memdelete(E.value);
 	}
-
-	get_tree()->quit(p_exit_code);
 }
 
 void EditorNode::_discard_changes(const String &p_str) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -908,6 +908,7 @@ public:
 	void save_before_run();
 	void try_autosave();
 	void restart_editor();
+	void unload_editor_addons();
 
 	void dim_editor(bool p_dimming);
 	bool is_editor_dimmed() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4176,7 +4176,13 @@ bool Main::iteration() {
 		movie_writer->add_frame();
 	}
 
+#ifdef TOOLS_ENABLED
+	bool quit_after_timeout = false;
+#endif
 	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {
+#ifdef TOOLS_ENABLED
+		quit_after_timeout = true;
+#endif
 		exit = true;
 	}
 
@@ -4206,6 +4212,12 @@ bool Main::iteration() {
 			ERR_FAIL_V_MSG(true,
 					"Command line option --build-solutions was passed, but the build callback failed. Aborting.");
 		}
+	}
+#endif
+
+#ifdef TOOLS_ENABLED
+	if (exit && quit_after_timeout && EditorNode::get_singleton()) {
+		EditorNode::get_singleton()->unload_editor_addons();
 	}
 #endif
 


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/93238, see https://github.com/godotengine/godot/pull/93238#issuecomment-2186974151