### PR TITLE
Optimize `GDScriptInstance::notification` for better performance

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2080,20 +2080,22 @@ void GDScriptInstance::notification(int p_notification, bool p_reversed) {
 	//notification is not virtual, it gets called at ALL levels just like in C.
 	Variant value = p_notification;
 	const Variant *args[1] = { &value };
+	const StringName &notification_str = GDScriptLanguage::get_singleton()->strings._notification;
 
-	List<GDScript *> pl;
-	GDScript *sptr = script.ptr();
-	while (sptr) {
-		if (p_reversed) {
-			pl.push_back(sptr);
-		} else {
-			pl.push_front(sptr);
-		}
-		sptr = sptr->_base;
+	LocalVector<GDScript *> script_stack;
+	uint32_t script_count = 0;
+	for (GDScript *sptr = script.ptr(); sptr; sptr = sptr->_base, ++script_count) {
+		script_stack.push_back(sptr);
 	}
-	for (GDScript *sc : pl) {
+
+	const int start = p_reversed ? 0 : script_count - 1;
+	const int end = p_reversed ? script_count : -1;
+	const int step = p_reversed ? 1 : -1;
+
+	for (int idx = start; idx != end; idx += step) {
+		GDScript *sc = script_stack[idx];
 		if (likely(sc->valid)) {
-			HashMap<StringName, GDScriptFunction *>::Iterator E = sc->member_functions.find(GDScriptLanguage::get_singleton()->strings._notification);
+			HashMap<StringName, GDScriptFunction *>::Iterator E = sc->member_functions.find(notification_str);
 			if (E) {
 				Callable::CallError err;
 				E->value->call(this, args, 1, err);


### PR DESCRIPTION
# Optimize GDScriptInstance::notification for better performance

This PR optimizes the `GDScriptInstance::notification` function to improve performance and reduce CPU usage.

## Changes

- Replace `List<GDScript *>` with a `LocalVector<GDScript *>` to reduce allocations and deallocations.
- Minimize List `push_front()` and `push_back()` operations by reusing the LocalVector across calls.
- Add `unlikely()` hint for vector growth condition to optimize the common case.
- Reduce overall CPU usage in notification traversal.

## Performance Impact

- Eliminates the need for frequent `List` operations, which were causing significant CPU usage.
- Reduces memory allocations by reusing the vector across calls.
- Improves cache efficiency by using a contiguous memory structure (Vector) instead of a linked list.

## Testing

- Tested locally with a scene that contains 20K cubes, all of them were moving around. 
- Profiled application before and after my change. Initial implementation was causing 3.35% of CPU usage on my laptop. Optimized version is using 0.5% of CPU.

## Profiling data with current mainline
![image](https://github.com/godotengine/godot/assets/19844144/9923e3a3-026d-453b-a218-8033b356b57e)

## Profiling data with my changes
![image](https://github.com/godotengine/godot/assets/19844144/ee51cc28-1b49-47bf-8b9f-7f00fa03c121)

This optimization should significantly reduce the CPU time spent in `GDScriptInstance::notification`, particularly for projects with frequent notifications or deep GDScript inheritance hierarchies.