### PR TITLE
Remove our `ERR_ON_RENDER_THREAD` guard, it is not reliable

### DIFF
--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -454,7 +454,6 @@ public:
 	_FORCE_INLINE_ XrTime get_predicted_display_time() { return frame_state.predictedDisplayTime; }
 	_FORCE_INLINE_ XrTime get_next_frame_time() { return frame_state.predictedDisplayTime + frame_state.predictedDisplayPeriod; }
 	_FORCE_INLINE_ bool can_render() {
-		ERR_ON_RENDER_THREAD_V(false);
 		return instance != XR_NULL_HANDLE && session != XR_NULL_HANDLE && running && frame_state.shouldRender;
 	}
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -44,14 +44,6 @@
 // Helper macros for code outside of the rendering server, but that is
 // called by the rendering server.
 #ifdef DEBUG_ENABLED
-#define ERR_ON_RENDER_THREAD                                              \
-	RenderingServer *rendering_server = RenderingServer::get_singleton(); \
-	ERR_FAIL_NULL(rendering_server);                                      \
-	ERR_FAIL_COND(rendering_server->is_on_render_thread());
-#define ERR_ON_RENDER_THREAD_V(m_ret)                                     \
-	RenderingServer *rendering_server = RenderingServer::get_singleton(); \
-	ERR_FAIL_NULL_V(rendering_server, m_ret);                             \
-	ERR_FAIL_COND_V(rendering_server->is_on_render_thread(), m_ret);
 #define ERR_NOT_ON_RENDER_THREAD                                          \
 	RenderingServer *rendering_server = RenderingServer::get_singleton(); \
 	ERR_FAIL_NULL(rendering_server);                                      \
@@ -61,8 +53,6 @@
 	ERR_FAIL_NULL_V(rendering_server, m_ret);                             \
 	ERR_FAIL_COND_V(!rendering_server->is_on_render_thread(), m_ret);
 #else
-#define ERR_ON_RENDER_THREAD
-#define ERR_ON_RENDER_THREAD_V(m_ret)
 #define ERR_NOT_ON_RENDER_THREAD
 #define ERR_NOT_ON_RENDER_THREAD_V(m_ret)
 #endif


### PR DESCRIPTION
I introduced the `ERR_ON_RENDER_THREAD` and `ERR_NOT_ON_RENDER_THREAD` guards when adding thread safety to the XR capabilities of Godot.

The problem that we encounter here is when we are not using multithreaded rendering, the main thread and the render thread are the same thread.
Adding a guard that fails when we are on the render thread to make sure a method is only called from the main thread, will give a false positive in this scenario. I'm thus removing `ERR_ON_RENDER_THREAD` as unreliable.

`ERR_NOT_ON_RENDER_THREAD` on the other hand is valid, this ensures code is run from the render thread and will properly guard for that situation.