### PR TITLE
GDScript: Fix "Mismatched external parser" for autoloads

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -329,9 +329,9 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 			String path = p_value;
 			if (path.begins_with("*")) {
 				autoload.is_singleton = true;
-				autoload.path = path.substr(1);
+				autoload.path = path.substr(1).simplify_path();
 			} else {
-				autoload.path = path;
+				autoload.path = path.simplify_path();
 			}
 			add_autoload(autoload);
 		} else if (p_name.operator String().begins_with("global_group/")) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -413,7 +413,7 @@ Error GDScriptParser::parse_binary(const Vector<uint8_t> &p_binary, const String
 	}
 
 	tokenizer = buffer_tokenizer;
-	script_path = p_script_path;
+	script_path = p_script_path.simplify_path();
 	current = tokenizer->scan();
 	// Avoid error or newline as the first token.
 	// The latter can mess with the parser when opening files filled exclusively with comments and newlines.


### PR DESCRIPTION
* Fixes #94098.

MRP: [autoload-path-mrp.zip](https://github.com/user-attachments/files/16143106/autoload-path-mrp.zip)

GDScript makes the assumption that some core APIs (like `Resource.get_path()`, `ScriptServer`, `AutoloadInfo`) return already simplified paths. I checked the usage and I think this is the most appropriate place to fix the bug.

This PR also resolves the inconsistency between `parse()` and `parse_binary()` introduced in #87124[^1]:

https://github.com/godotengine/godot/blob/82cedc83c9069125207c128f9a07ce3d82c317cc/modules/gdscript/gdscript_parser.cpp#L358-L362

https://github.com/godotengine/godot/blob/82cedc83c9069125207c128f9a07ce3d82c317cc/modules/gdscript/gdscript_parser.cpp#L415-L417

[^1]: Formally, the bug was introduced in #87634, since it was merged 1 day later. In any case, I think this is an accidental mistake due to parallel development.