### PR TITLE
Fix a couple GCC 14 `-Wmaybe-uninitialized` warnings

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -106,7 +106,7 @@ Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	}
 
 	uint32_t size = 0;
-	uint8_t ipv6[16];
+	uint8_t ipv6[16] = {};
 	rb.read(ipv6, 16, true);
 	packet_ip.set_ipv6(ipv6);
 	rb.read((uint8_t *)&packet_port, 4, true);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -169,7 +169,7 @@ struct Texture {
 		TYPE_3D
 	};
 
-	Type type;
+	Type type = TYPE_2D;
 	RS::TextureLayeredType layered_type = RS::TEXTURE_LAYERED_2D_ARRAY;
 
 	GLenum target = GL_TEXTURE_2D;


### PR DESCRIPTION
Started getting these warnings today on Fedora 40 with a `dev_build=yes scu_build=yes`.

The PackedPeerUDP one sounds like a GCC false positive, so alternative we could silence it... but the quick workaround of initing the array may not be too terrible?
*Edit:* Alvin on RC pointed out this may be this GCC regression indeed: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107751