### PR TITLE
C#: Handle compound class filenames.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -345,7 +345,7 @@ void CSharpLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 }
 
 static String get_base_class_name(const String &p_base_class_name, const String p_class_name) {
-	String base_class = pascal_to_pascal_case(p_base_class_name);
+	String base_class = pascal_to_pascal_case(p_base_class_name.split(".").back());
 	if (p_class_name == base_class) {
 		base_class = "Godot." + base_class;
 	}
@@ -387,11 +387,12 @@ String CSharpLanguage::validate_path(const String &p_path) const {
 	String class_name = p_path.get_file().get_basename();
 	List<String> keywords;
 	get_reserved_words(&keywords);
-	if (keywords.find(class_name)) {
-		return RTR("Class name can't be a reserved keyword");
+	Vector<String> segments = class_name.split(".");
+	if (keywords.find(segments.back())) {
+		return RTR("Class name can't contain a reserved keyword: ") + segments.back();
 	}
-	if (!TS->is_valid_identifier(class_name)) {
-		return RTR("Class name must be a valid identifier");
+	if (!TS->is_valid_identifier(segments.back())) {
+		return RTR("Class name must be a valid identifier: ") + segments.back();
 	}
 
 	return "";


### PR DESCRIPTION
This change will separate the individual class names of compound class filenames if they exist, useful with partial classes.

This should allow for filenames like "BaseClass.SubClass.SubsubClass.cs" and other wonderful abominations against nature for partial class use-cases, while still checking each class that the name implies against reserved keywords and for valid unicode characters.

This fixes #93989, which contains an example of a file that this would now begin to work correctly on that doesn't currently work today.

This is also just for creating new script files from within Godot. There are no issues that I've encountered yet with just making the files yourself without using the editor, so this is mostly a convenience fix.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
