### PR TITLE
GDScript: Call setter on simple setter chain without getter

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/simple_setter_chain_call_setter.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/simple_setter_chain_call_setter.gd
@@ -1,0 +1,13 @@
+# https://github.com/godotengine/godot/issues/85952
+
+var vec: Vector2 = Vector2.ZERO:
+	set(new_vec):
+		prints("setting vec from", vec, "to", new_vec)
+		if new_vec == Vector2(1, 1):
+			vec = new_vec
+
+func test():
+	vec.x = 2
+	vec.y = 2
+
+	prints("vec is", vec)

--- a/modules/gdscript/tests/scripts/runtime/features/simple_setter_chain_call_setter.out
+++ b/modules/gdscript/tests/scripts/runtime/features/simple_setter_chain_call_setter.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+setting vec from (0, 0) to (2, 0)
+setting vec from (0, 0) to (0, 2)
+vec is (0, 0)


### PR DESCRIPTION
Fixes a bug where a member variable was being set directly before calling the setter.

Fix #85952