### PR TITLE
Add node active feature and corresponding lifecycle methods

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -238,6 +238,9 @@
 		<member name="docks/scene_tree/center_node_on_reparent" type="bool" setter="" getter="">
 			If [code]true[/code], new node created when reparenting node(s) will be positioned at the average position of the selected node(s).
 		</member>
+		<member name="docks/scene_tree/show_node_active_checkbox" type="bool" setter="" getter="">
+			If [code]true[/code], a checkbox button will appear next to each node in the scene tree which can be used to toggle the [code]node_active[/code] property.
+		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -67,6 +67,24 @@
 				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
 			</description>
 		</method>
+		<method name="_node_active" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the node has become "active in tree", i.e. when [member node_active] has become [code]true[/code], or after the node enters the [SceneTree] if it is active.
+				In the first case, this method is also called if it was previously inactive in tree and has become active as a result of an ancestor becoming active. See [method is_node_active_in_tree].
+				In the second case, this method is run after [method _ready] has finished. You can use this method for conditional initialization.
+				Corresponds to the [constant NOTIFICATION_NODE_ACTIVE] notification in [method Object._notification].
+			</description>
+		</method>
+		<method name="_node_inactive" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the node has become "inactive in tree", i.e. when [member node_active] has become [code]false[/code], or before the node exits the [SceneTree] if it is active.
+				In the first case, this method is also called if it was previously active in tree and has become inactive due to an ancestor becoming inactive. See [method is_node_active_in_tree].
+				You can use this method for lifecycle cleanup, since it is run when this node or an ancestor node was set to inactive, or if this node is about to be removed from the scene.
+				Corresponds to the [constant NOTIFICATION_NODE_INACTIVE] notification in [method Object._notification].
+			</description>
+		</method>
 		<method name="_physics_process" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
@@ -620,6 +638,12 @@
 				Returns [code]true[/code] if the local system is the multiplayer authority of this node.
 			</description>
 		</method>
+		<method name="is_node_active_in_tree" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this node and all of its ancestors have [member node_active] set to [code]true[/code].
+			</description>
+		</method>
 		<method name="is_node_ready" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -1005,6 +1029,11 @@
 			The name of the node. This name must be unique among the siblings (other child nodes from the same parent). When set to an existing sibling's name, the node is automatically renamed.
 			[b]Note:[/b] When changing the name, the following characters will be replaced with an underscore: ([code].[/code] [code]:[/code] [code]@[/code] [code]/[/code] [code]"[/code] [code]%[/code]). In particular, the [code]@[/code] character is reserved for auto-generated names. See also [method String.validate_node_name].
 		</member>
+		<member name="node_active" type="bool" setter="set_node_active" getter="is_node_active_self" default="true">
+			Whether the node should be "active" in the scene. Inactive nodes will not process scripts, will not be visible in the viewport, and will not act as a valid [Camera2D] or [Camera3D].
+			If an ancestor of this node is not active, this node will behave as though it is inactive, even if [member node_active] is [code]true[/code]. See [method is_node_active_in_tree].
+			When [member node_active] changes, [method _node_active] or [method _node_inactive] will be run on this node and on descendant nodes that have had their "active in tree" status changed as a result.
+		</member>
 		<member name="owner" type="Node" setter="set_owner" getter="get_owner">
 			The owner of this node. The owner must be an ancestor of this node. When packing the owner node in a [PackedScene], all the nodes it owns are also saved with it.
 			[b]Note:[/b] In the editor, nodes not owned by the scene root are usually not displayed in the Scene dock, and will [b]not[/b] be saved. To prevent this, remember to set the owner after calling [method add_child]. See also (see [member unique_name_in_owner])
@@ -1066,6 +1095,16 @@
 			<param index="0" name="node" type="Node" />
 			<description>
 				Emitted when the node's editor description field changed.
+			</description>
+		</signal>
+		<signal name="node_active_changed">
+			<description>
+				Emitted when [member node_active] has changed on this node.
+			</description>
+		</signal>
+		<signal name="node_active_in_tree_changed">
+			<description>
+				Emitted when this node's "active in tree" status has changed, i.e. when [member node_active] has changed on this node or any ancestor nodes.
 			</description>
 		</signal>
 		<signal name="ready">
@@ -1170,6 +1209,15 @@
 		</constant>
 		<constant name="NOTIFICATION_ENABLED" value="29">
 			Notification received when the node is enabled again after being disabled. See [constant PROCESS_MODE_DISABLED].
+		</constant>
+		<constant name="NOTIFICATION_NODE_ACTIVE_CHANGED" value="90">
+			Notification received when [member node_active] has changed for this node.
+		</constant>
+		<constant name="NOTIFICATION_NODE_ACTIVE" value="91">
+			Notification received when the node has become active in tree. See [method _node_active].
+		</constant>
+		<constant name="NOTIFICATION_NODE_INACTIVE" value="92">
+			Notification received when the node has become inactive in tree. See [method _node_inactive].
 		</constant>
 		<constant name="NOTIFICATION_RESET_PHYSICS_INTERPOLATION" value="2001">
 			Notification received when [method reset_physics_interpolation] is called on the node or its ancestors.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -621,6 +621,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/start_create_dialog_fully_expanded", false);
 	_initial_set("docks/scene_tree/auto_expand_to_selected", true);
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
+	_initial_set("docks/scene_tree/show_node_active_checkbox", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -101,6 +101,20 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 			}
 		}
 		undo_redo->commit_action();
+	} else if (p_id == BUTTON_ACTIVE) {
+		undo_redo->create_action(TTR("Toggle Node Active"));
+		_toggle_active(n);
+		List<Node *> selection = editor_selection->get_selected_node_list();
+		if (selection.size() > 1 && selection.find(n) != nullptr) {
+			for (Node *nv : selection) {
+				ERR_FAIL_NULL(nv);
+				if (nv == n) {
+					continue;
+				}
+				_toggle_active(nv);
+			}
+		}
+		undo_redo->commit_action();
 	} else if (p_id == BUTTON_LOCK) {
 		undo_redo->create_action(TTR("Unlock Node"));
 		undo_redo->add_do_method(n, "remove_meta", "_edit_lock_");
@@ -214,6 +228,20 @@ void SceneTreeEditor::_toggle_visible(Node *p_node) {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->add_do_method(p_node, "set_visible", !v);
 		undo_redo->add_undo_method(p_node, "set_visible", v);
+	}
+}
+
+void SceneTreeEditor::_toggle_active(Node *p_node) {
+	if (p_node->has_method("is_node_active_self") && p_node->has_method("set_node_active")) {
+		bool currentlyActive = bool(p_node->call("is_node_active_self"));
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		if (currentlyActive) {
+			undo_redo->add_do_method(p_node, "set_node_active", false);
+			undo_redo->add_undo_method(p_node, "set_node_active", true);
+		} else {
+			undo_redo->add_do_method(p_node, "set_node_active", true);
+			undo_redo->add_undo_method(p_node, "set_node_active", false);
+		}
 	}
 }
 
@@ -445,6 +473,16 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			_update_visibility_color(p_node, item);
 		}
 
+		if (p_node->has_method("is_node_active_self") && p_node->has_method("set_node_active")) {
+			bool show_node_active_checkbox = EDITOR_GET("docks/scene_tree/show_node_active_checkbox").operator bool();
+			_set_node_active_checkbox_enabled(item, p_node, show_node_active_checkbox);
+
+			const Callable active_in_tree_changed = callable_mp(this, &SceneTreeEditor::_node_active_in_tree_changed);
+			if (!p_node->is_connected(SceneStringName(node_active_in_tree_changed), active_in_tree_changed)) {
+				p_node->connect(SceneStringName(node_active_in_tree_changed), active_in_tree_changed.bind(p_node));
+			}
+		}
+
 		if (p_node->is_class("AnimationMixer")) {
 			bool is_pinned = AnimationPlayerEditor::get_singleton()->get_editing_node() == p_node && AnimationPlayerEditor::get_singleton()->is_pinned();
 
@@ -588,9 +626,81 @@ void SceneTreeEditor::_update_visibility_color(Node *p_node, TreeItem *p_item) {
 	}
 }
 
+void SceneTreeEditor::_set_node_active_checkbox_enabled(TreeItem *p_item, Node *p_node, bool p_enabled) {
+	int idx = p_item->get_button_by_id(0, BUTTON_ACTIVE);
+	if (p_enabled) {
+		if (idx == -1) {
+			// Only add checkbox if it does not exist.
+			bool is_active = p_node->call("is_node_active_self");
+			if (is_active) {
+				p_item->add_button(0, get_editor_theme_icon(SNAME("GuiChecked")), BUTTON_ACTIVE, false, TTR("Toggle Node Active"));
+			} else {
+				p_item->add_button(0, get_editor_theme_icon(SNAME("GuiUnchecked")), BUTTON_ACTIVE, false, TTR("Toggle Node Active"));
+			}
+		}
+	} else {
+		if (idx != -1) {
+			// Only erase checkbox if it exists.
+			p_item->erase_button(0, idx);
+		}
+	}
+}
+
+void SceneTreeEditor::_node_active_in_tree_changed(Node *p_node) {
+	if (!p_node || (p_node != get_scene_node() && !p_node->get_owner())) {
+		return;
+	}
+
+	TreeItem *item = _find(tree->get_root(), p_node->get_path());
+
+	if (!item) {
+		return;
+	}
+
+	bool show_node_active_checkbox = EDITOR_GET("docks/scene_tree/show_node_active_checkbox").operator bool();
+	if (!show_node_active_checkbox) {
+		return;
+	}
+
+	int idx = item->get_button_by_id(0, BUTTON_ACTIVE);
+	ERR_FAIL_COND(idx == -1);
+
+	bool node_active = false;
+
+	if (p_node->has_method("is_node_active_self")) {
+		node_active = p_node->call("is_node_active_self");
+		if (p_node->is_class("CanvasItem") || p_node->is_class("CanvasLayer") || p_node->is_class("Window")) {
+			CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
+		}
+	}
+
+	if (node_active) {
+		item->set_button(0, idx, get_editor_theme_icon(SNAME("GuiChecked")));
+	} else {
+		item->set_button(0, idx, get_editor_theme_icon(SNAME("GuiUnchecked")));
+	}
+
+	if (p_node->call("can_process")) {
+		_clear_item_custom_color(item);
+	} else {
+		_set_item_custom_color(item, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+	}
+
+	if (p_node->has_method("is_visible") && p_node->has_method("set_visible") && p_node->has_signal(SceneStringName(visibility_changed))) {
+		_node_visibility_changed(p_node);
+	}
+}
+
 void SceneTreeEditor::_set_item_custom_color(TreeItem *p_item, Color p_color) {
 	p_item->set_custom_color(0, p_color);
 	p_item->set_meta(SNAME("custom_color"), p_color);
+}
+
+void SceneTreeEditor::_clear_item_custom_color(TreeItem *p_item) {
+	if (p_item->has_meta(SNAME("custom_color"))) {
+		p_item->clear_custom_color(0);
+		p_item->remove_meta(SNAME("custom_color"));
+	}
 }
 
 void SceneTreeEditor::_node_script_changed(Node *p_node) {
@@ -614,6 +724,12 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 	if (p_node->has_signal(SceneStringName(visibility_changed))) {
 		if (p_node->is_connected(SceneStringName(visibility_changed), callable_mp(this, &SceneTreeEditor::_node_visibility_changed))) {
 			p_node->disconnect(SceneStringName(visibility_changed), callable_mp(this, &SceneTreeEditor::_node_visibility_changed));
+		}
+	}
+
+	if (p_node->has_signal(SceneStringName(node_active_in_tree_changed))) {
+		if (p_node->is_connected(SceneStringName(node_active_in_tree_changed), callable_mp(this, &SceneTreeEditor::_node_active_in_tree_changed))) {
+			p_node->disconnect(SceneStringName(node_active_in_tree_changed), callable_mp(this, &SceneTreeEditor::_node_active_in_tree_changed));
 		}
 	}
 
@@ -965,6 +1081,12 @@ void SceneTreeEditor::_notification(int p_what) {
 			tree->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 			_update_tree();
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("docks/scene_tree")) {
+				_update_tree();
+			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -1842,6 +1964,8 @@ SceneTreeDialog::SceneTreeDialog() {
 	// Disable the OK button when no node is selected.
 	get_ok_button()->set_disabled(!tree->get_selected());
 	tree->connect("node_selected", callable_mp(this, &SceneTreeDialog::_selected_changed));
+
+	EDITOR_DEF("docks/scene_tree/show_node_active_checkbox", true);
 }
 
 SceneTreeDialog::~SceneTreeDialog() {

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -56,6 +56,7 @@ class SceneTreeEditor : public Control {
 		BUTTON_GROUPS = 7,
 		BUTTON_PIN = 8,
 		BUTTON_UNIQUE = 9,
+		BUTTON_ACTIVE = 10,
 	};
 
 	Tree *tree = nullptr;
@@ -121,12 +122,16 @@ class SceneTreeEditor : public Control {
 
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _toggle_visible(Node *p_node);
+	void _toggle_active(Node *p_node);
 	void _cell_multi_selected(Object *p_object, int p_cell, bool p_selected);
 	void _update_selection(TreeItem *item);
 	void _node_script_changed(Node *p_node);
+	void _set_node_active_checkbox_enabled(TreeItem *p_item, Node *p_node, bool p_enabled);
+	void _node_active_in_tree_changed(Node *p_node);
 	void _node_visibility_changed(Node *p_node);
 	void _update_visibility_color(Node *p_node, TreeItem *p_item);
 	void _set_item_custom_color(TreeItem *p_item, Color p_color);
+	void _clear_item_custom_color(TreeItem *p_item);
 	void _update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _queue_update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _tree_scroll_to_item(ObjectID p_item_id);

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -365,6 +365,16 @@ void Camera2D::_notification(int p_what) {
 			callable_mp(this, &Camera2D::_reset_just_exited).call_deferred();
 		} break;
 
+		case NOTIFICATION_NODE_ACTIVE_CHANGED: {
+			bool enabled_and_active = is_enabled();
+
+			if (enabled_and_active && !viewport->get_camera_2d()) {
+				make_current();
+			} else if (!enabled_and_active && is_current()) {
+				clear_current();
+			}
+		} break;
+
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_DRAW: {
 			if (!is_inside_tree() || !_is_editing_in_editor()) {
@@ -497,15 +507,17 @@ void Camera2D::set_enabled(bool p_enabled) {
 		return;
 	}
 
-	if (enabled && !viewport->get_camera_2d()) {
+	bool enabled_and_active = is_enabled();
+
+	if (enabled_and_active && !viewport->get_camera_2d()) {
 		make_current();
-	} else if (!enabled && is_current()) {
+	} else if (!enabled_and_active && is_current()) {
 		clear_current();
 	}
 }
 
 bool Camera2D::is_enabled() const {
-	return enabled;
+	return enabled && is_node_active_in_tree();
 }
 
 Camera2D::Camera2DProcessCallback Camera2D::get_process_callback() const {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -62,6 +62,7 @@ private:
 	bool force_change = false;
 	bool current = false;
 	Viewport *viewport = nullptr;
+	bool added_to_camera_set = false;
 
 	ProjectionType mode = PROJECTION_PERSPECTIVE;
 
@@ -134,6 +135,8 @@ protected:
 	void _update_camera();
 	virtual void _request_camera_update();
 	void _update_camera_mode();
+	void _add_camera_to_set();
+	void _remove_camera_from_set();
 
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -234,6 +234,14 @@ void Node3D::_notification(int p_what) {
 				data.client_physics_interpolation_data->global_xform_prev = data.client_physics_interpolation_data->global_xform_curr;
 			}
 		} break;
+
+		case NOTIFICATION_NODE_ACTIVE_CHANGED: {
+			ERR_THREAD_GUARD;
+
+			if (is_inside_tree()) {
+				_propagate_visibility_changed();
+			}
+		} break;
 	}
 }
 
@@ -907,7 +915,7 @@ void Node3D::_propagate_visibility_changed() {
 #endif
 
 	for (Node3D *c : data.children) {
-		if (!c || !c->data.visible) {
+		if (!c || !c->is_visible()) {
 			continue;
 		}
 		c->_propagate_visibility_changed();
@@ -948,7 +956,7 @@ bool Node3D::is_visible_in_tree() const {
 	const Node3D *s = this;
 
 	while (s) {
-		if (!s->data.visible) {
+		if (!s->is_visible() || !s->is_node_active_self()) {
 			return false;
 		}
 		s = s->data.parent;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -60,7 +60,7 @@ Transform2D CanvasItem::_edit_get_transform() const {
 
 bool CanvasItem::is_visible_in_tree() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return visible && parent_visible_in_tree;
+	return visible && parent_visible_in_tree && is_node_active_in_tree();
 }
 
 void CanvasItem::_propagate_visibility_changed(bool p_parent_visible_in_tree) {
@@ -384,6 +384,13 @@ void CanvasItem::_notification(int p_what) {
 			ERR_MAIN_THREAD_GUARD;
 
 			emit_signal(SceneStringName(visibility_changed));
+		} break;
+		case NOTIFICATION_NODE_ACTIVE_CHANGED: {
+			ERR_THREAD_GUARD;
+
+			if (is_inside_tree()) {
+				_propagate_visibility_changed(parent_visible_in_tree);
+			}
 		} break;
 		case NOTIFICATION_WORLD_2D_CHANGED: {
 			ERR_MAIN_THREAD_GUARD;

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -57,9 +57,9 @@ void CanvasLayer::set_visible(bool p_visible) {
 	for (int i = 0; i < get_child_count(); i++) {
 		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 		if (c) {
-			RenderingServer::get_singleton()->canvas_item_set_visible(c->get_canvas_item(), p_visible && c->is_visible());
+			RenderingServer::get_singleton()->canvas_item_set_visible(c->get_canvas_item(), is_visible() && c->is_visible());
 
-			c->_propagate_visibility_changed(p_visible);
+			c->_propagate_visibility_changed(is_visible());
 		}
 	}
 }
@@ -73,7 +73,7 @@ void CanvasLayer::hide() {
 }
 
 bool CanvasLayer::is_visible() const {
-	return visible;
+	return visible && is_node_active_in_tree();
 }
 
 void CanvasLayer::set_transform(const Transform2D &p_xform) {
@@ -198,6 +198,19 @@ void CanvasLayer::_notification(int p_what) {
 			viewport = RID();
 			_update_follow_viewport(false);
 		} break;
+
+		case NOTIFICATION_NODE_ACTIVE_CHANGED: {
+			emit_signal(SceneStringName(visibility_changed));
+
+			for (int i = 0; i < get_child_count(); i++) {
+				CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
+				if (c) {
+					RenderingServer::get_singleton()->canvas_item_set_visible(c->get_canvas_item(), is_visible() && c->is_visible());
+
+					c->_propagate_visibility_changed(is_visible());
+				}
+			}
+		}
 	}
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -97,6 +97,14 @@ void Node::_notification(int p_notification) {
 				}
 			}
 
+			if (data.node_active) {
+				if (data.parent) {
+					data.parent_active_in_tree = data.parent->is_node_active_in_tree();
+				} else {
+					data.parent_active_in_tree = true;
+				}
+			}
+
 			if (data.physics_interpolation_mode == PHYSICS_INTERPOLATION_MODE_INHERIT) {
 				bool interpolate = true; // Root node default is for interpolation to be on.
 				if (data.parent) {
@@ -223,6 +231,23 @@ void Node::_notification(int p_notification) {
 			}
 
 			GDVIRTUAL_CALL(_ready);
+		} break;
+
+		case NOTIFICATION_NODE_ACTIVE: {
+			if (data.completed_active_callback) {
+				// We've already run the callback.
+				// This can happen if a user sets node_active in _ready() before the lifecycle call starts.
+				return;
+			}
+			data.completed_active_callback = true;
+
+			GDVIRTUAL_CALL(_node_active);
+		} break;
+
+		case NOTIFICATION_NODE_INACTIVE: {
+			data.completed_active_callback = false;
+
+			GDVIRTUAL_CALL(_node_inactive);
 		} break;
 
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -366,6 +391,12 @@ void Node::_propagate_after_exit_tree() {
 }
 
 void Node::_propagate_exit_tree() {
+	// For lifecycle consistency, run the inactive signal.
+	// Note we don't actually disable the node so that tab switching in the editor doesn't change node state.
+	if (is_node_active_in_tree()) {
+		notification(NOTIFICATION_NODE_INACTIVE);
+	}
+
 	//block while removing children
 
 #ifdef DEBUG_ENABLED
@@ -413,6 +444,24 @@ void Node::_propagate_exit_tree() {
 	data.ready_notified = false;
 	data.tree = nullptr;
 	data.depth = -1;
+}
+
+void Node::_propagate_initial_node_active() {
+	if (is_node_active_in_tree()) {
+		notification(NOTIFICATION_NODE_ACTIVE);
+	} else {
+		// No need to check further down.
+		return;
+	}
+
+	// Block while checking children.
+	data.blocked++;
+
+	for (KeyValue<StringName, Node *> &K : data.children) {
+		K.value->_propagate_initial_node_active();
+	}
+
+	data.blocked--;
 }
 
 void Node::_propagate_physics_interpolated(bool p_interpolated) {
@@ -679,6 +728,86 @@ void Node::set_process_mode(ProcessMode p_mode) {
 #endif
 }
 
+void Node::set_node_active(bool p_enabled) {
+	ERR_THREAD_GUARD
+	if (data.node_active == p_enabled) {
+		return;
+	}
+
+	if (!is_inside_tree()) {
+		data.node_active = p_enabled;
+		return;
+	}
+
+	bool prev_can_process = can_process();
+	bool prev_enabled = _is_enabled();
+
+	if (p_enabled) {
+		if (data.parent) {
+			data.parent_active_in_tree = data.parent->is_node_active_in_tree();
+		} else {
+			data.parent_active_in_tree = true;
+		}
+	}
+
+	data.node_active = p_enabled;
+
+	bool next_can_process = can_process();
+	bool next_enabled = _is_enabled();
+
+	int pause_notification = 0;
+
+	if (prev_can_process && !next_can_process) {
+		pause_notification = NOTIFICATION_PAUSED;
+	} else if (!prev_can_process && next_can_process) {
+		pause_notification = NOTIFICATION_UNPAUSED;
+	}
+
+	int enabled_notification = 0;
+
+	if (prev_enabled && !next_enabled) {
+		enabled_notification = NOTIFICATION_DISABLED;
+	} else if (!prev_enabled && next_enabled) {
+		enabled_notification = NOTIFICATION_ENABLED;
+	}
+
+	_propagate_node_active(p_enabled, false, pause_notification, enabled_notification);
+
+	notification(NOTIFICATION_NODE_ACTIVE_CHANGED);
+	emit_signal(SceneStringName(node_active_changed));
+}
+
+void Node::_propagate_node_active(bool p_enabled, bool p_set_parent_active, int p_pause_notification, int p_enabled_notification) {
+	if (p_set_parent_active) {
+		data.parent_active_in_tree = p_enabled;
+	}
+
+	if (p_pause_notification != 0) {
+		notification(p_pause_notification);
+	}
+
+	if (p_enabled_notification != 0) {
+		notification(p_enabled_notification);
+	}
+
+	if (p_enabled) {
+		notification(NOTIFICATION_NODE_ACTIVE);
+	} else {
+		notification(NOTIFICATION_NODE_INACTIVE);
+	}
+	emit_signal(SceneStringName(node_active_in_tree_changed));
+
+	data.blocked++;
+	for (KeyValue<StringName, Node *> &K : data.children) {
+		Node *c = K.value;
+		if (c->data.node_active) {
+			// Only active children will change based on parent changing.
+			c->_propagate_node_active(p_enabled, true, p_pause_notification, p_enabled_notification);
+		}
+	}
+	data.blocked--;
+}
+
 void Node::_propagate_pause_notification(bool p_enable) {
 	bool prev_can_process = _can_process(!p_enable);
 	bool next_can_process = _can_process(p_enable);
@@ -865,6 +994,11 @@ bool Node::can_process() const {
 }
 
 bool Node::_can_process(bool p_paused) const {
+	if (!_is_node_active_in_tree()) {
+		// Active state being disabled overrides process_mode
+		return false;
+	}
+
 	ProcessMode process_mode;
 
 	if (data.process_mode == PROCESS_MODE_INHERIT) {
@@ -950,12 +1084,25 @@ bool Node::_is_enabled() const {
 		process_mode = data.process_mode;
 	}
 
-	return (process_mode != PROCESS_MODE_DISABLED);
+	return (process_mode != PROCESS_MODE_DISABLED && _is_node_active_in_tree());
 }
 
 bool Node::is_enabled() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), false);
 	return _is_enabled();
+}
+
+bool Node::is_node_active_in_tree() const {
+	ERR_THREAD_GUARD_V(false);
+	return _is_node_active_in_tree();
+}
+
+bool Node::_is_node_active_in_tree() const {
+	return is_node_active_self() && data.parent_active_in_tree;
+}
+
+bool Node::is_node_active_self() const {
+	return data.node_active;
 }
 
 double Node::get_physics_process_delta_time() const {
@@ -3256,6 +3403,9 @@ void Node::_set_tree(SceneTree *p_tree) {
 			_propagate_ready(); //reverse_notification(NOTIFICATION_READY);
 		}
 
+		// Send initial lifecycle notification after ready but on each time a tree is set.
+		_propagate_initial_node_active();
+
 		tree_changed_b = data.tree;
 	}
 
@@ -3640,6 +3790,9 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_mode", "mode"), &Node::set_process_mode);
 	ClassDB::bind_method(D_METHOD("get_process_mode"), &Node::get_process_mode);
 	ClassDB::bind_method(D_METHOD("can_process"), &Node::can_process);
+	ClassDB::bind_method(D_METHOD("set_node_active", "enable"), &Node::set_node_active);
+	ClassDB::bind_method(D_METHOD("is_node_active_in_tree"), &Node::is_node_active_in_tree);
+	ClassDB::bind_method(D_METHOD("is_node_active_self"), &Node::is_node_active_self);
 
 	ClassDB::bind_method(D_METHOD("set_process_thread_group", "mode"), &Node::set_process_thread_group);
 	ClassDB::bind_method(D_METHOD("get_process_thread_group"), &Node::get_process_thread_group);
@@ -3772,6 +3925,9 @@ void Node::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_POST_ENTER_TREE);
 	BIND_CONSTANT(NOTIFICATION_DISABLED);
 	BIND_CONSTANT(NOTIFICATION_ENABLED);
+	BIND_CONSTANT(NOTIFICATION_NODE_ACTIVE_CHANGED);
+	BIND_CONSTANT(NOTIFICATION_NODE_ACTIVE);
+	BIND_CONSTANT(NOTIFICATION_NODE_INACTIVE);
 	BIND_CONSTANT(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 
 	BIND_CONSTANT(NOTIFICATION_EDITOR_PRE_SAVE);
@@ -3836,6 +3992,8 @@ void Node::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_exited"));
 	ADD_SIGNAL(MethodInfo("child_entered_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
 	ADD_SIGNAL(MethodInfo("child_exiting_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
+	ADD_SIGNAL(MethodInfo("node_active_changed"));
+	ADD_SIGNAL(MethodInfo("node_active_in_tree_changed"));
 
 	ADD_SIGNAL(MethodInfo("child_order_changed"));
 	ADD_SIGNAL(MethodInfo("replacing_by", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
@@ -3846,6 +4004,8 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "scene_file_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_scene_file_path", "get_scene_file_path");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "owner", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_owner", "get_owner");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer", PROPERTY_HINT_RESOURCE_TYPE, "MultiplayerAPI", PROPERTY_USAGE_NONE), "", "get_multiplayer");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "node_active", PROPERTY_HINT_NONE, ""), "set_node_active", "is_node_active_self");
 
 	ADD_GROUP("Process", "process_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Inherit,Pausable,When Paused,Always,Disabled"), "set_process_mode", "get_process_mode");
@@ -3871,6 +4031,8 @@ void Node::_bind_methods() {
 	GDVIRTUAL_BIND(_enter_tree);
 	GDVIRTUAL_BIND(_exit_tree);
 	GDVIRTUAL_BIND(_ready);
+	GDVIRTUAL_BIND(_node_active);
+	GDVIRTUAL_BIND(_node_inactive);
 	GDVIRTUAL_BIND(_get_configuration_warnings);
 	GDVIRTUAL_BIND(_input, "event");
 	GDVIRTUAL_BIND(_shortcut_input, "event");
@@ -3905,6 +4067,10 @@ Node::Node() {
 
 	data.physics_process_internal = false;
 	data.process_internal = false;
+
+	data.node_active = true;
+	data.parent_active_in_tree = true;
+	data.completed_active_callback = false;
 
 	data.input = false;
 	data.shortcut_input = false;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -215,6 +215,10 @@ private:
 		bool physics_process_internal : 1;
 		bool process_internal : 1;
 
+		bool node_active : 1;
+		bool parent_active_in_tree : 1;
+		bool completed_active_callback : 1;
+
 		bool input : 1;
 		bool shortcut_input : 1;
 		bool unhandled_input : 1;
@@ -280,9 +284,11 @@ private:
 	void _propagate_ready();
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
+	void _propagate_initial_node_active();
 	void _propagate_physics_interpolated(bool p_interpolated);
 	void _propagate_physics_interpolation_reset_requested(bool p_requested);
 	void _propagate_process_owner(Node *p_owner, int p_pause_notification, int p_enabled_notification);
+	void _propagate_node_active(bool p_enabled, bool p_set_parent_active, int p_pause_notification, int p_enabled_notification);
 	void _propagate_groups_dirty();
 	void _propagate_translation_domain_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
@@ -304,6 +310,7 @@ private:
 
 	_FORCE_INLINE_ bool _can_process(bool p_paused) const;
 	_FORCE_INLINE_ bool _is_enabled() const;
+	_FORCE_INLINE_ bool _is_node_active_in_tree() const;
 
 	void _release_unique_name_in_owner();
 	void _acquire_unique_name_in_owner();
@@ -383,6 +390,8 @@ protected:
 	GDVIRTUAL0(_enter_tree)
 	GDVIRTUAL0(_exit_tree)
 	GDVIRTUAL0(_ready)
+	GDVIRTUAL0(_node_active)
+	GDVIRTUAL0(_node_inactive)
 	GDVIRTUAL0RC(Vector<String>, _get_configuration_warnings)
 
 	GDVIRTUAL1(_input, Ref<InputEvent>)
@@ -413,6 +422,9 @@ public:
 		NOTIFICATION_POST_ENTER_TREE = 27,
 		NOTIFICATION_DISABLED = 28,
 		NOTIFICATION_ENABLED = 29,
+		NOTIFICATION_NODE_ACTIVE_CHANGED = 90,
+		NOTIFICATION_NODE_ACTIVE = 91,
+		NOTIFICATION_NODE_INACTIVE = 92,
 		NOTIFICATION_RESET_PHYSICS_INTERPOLATION = 2001, // A GodotSpace Odyssey.
 		// Keep these linked to Node.
 		NOTIFICATION_WM_MOUSE_ENTER = 1002,
@@ -670,6 +682,10 @@ public:
 	ProcessMode get_process_mode() const;
 	bool can_process() const;
 	bool can_process_notification(int p_what) const;
+
+	void set_node_active(bool p_enable);
+	bool is_node_active_in_tree() const;
+	bool is_node_active_self() const;
 
 	void set_physics_interpolation_mode(PhysicsInterpolationMode p_mode);
 	PhysicsInterpolationMode get_physics_interpolation_mode() const { return data.physics_interpolation_mode; }

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -37,6 +37,8 @@ SceneStringNames::SceneStringNames() {
 	draw = StaticCString::create("draw");
 	hidden = StaticCString::create("hidden");
 	visibility_changed = StaticCString::create("visibility_changed");
+	node_active_changed = StaticCString::create("node_active_changed");
+	node_active_in_tree_changed = StaticCString::create("node_active_in_tree_changed");
 	input_event = StaticCString::create("input_event");
 	shader = StaticCString::create("shader");
 	tree_entered = StaticCString::create("tree_entered");
@@ -82,6 +84,8 @@ SceneStringNames::SceneStringNames() {
 	updated = StaticCString::create("updated");
 
 	_ready = StaticCString::create("_ready");
+	_node_active = StaticCString::create("_node_active");
+	_node_inactive = StaticCString::create("_node_inactive");
 
 	screen_entered = StaticCString::create("screen_entered");
 	screen_exited = StaticCString::create("screen_exited");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -55,6 +55,8 @@ public:
 	StringName draw;
 	StringName hidden;
 	StringName visibility_changed;
+	StringName node_active_changed;
+	StringName node_active_in_tree_changed;
 	StringName input_event;
 	StringName gui_input;
 	StringName item_rect_changed;
@@ -104,6 +106,8 @@ public:
 	StringName area_shape_exited;
 
 	StringName _ready;
+	StringName _node_active;
+	StringName _node_inactive;
 
 	StringName screen_entered;
 	StringName screen_exited;

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -892,6 +892,39 @@ TEST_CASE("[SceneTree][Node] Test the process priority") {
 	memdelete(node4);
 }
 
+TEST_CASE("[SceneTree][Node] Test node active operations") {
+	TestNode *node = memnew(TestNode);
+	SceneTree::get_singleton()->get_root()->add_child(node);
+
+	TestNode *child = memnew(TestNode);
+	node->add_child(child);
+
+	SUBCASE("Default active state") {
+		CHECK(node->is_node_active_self());
+		CHECK(node->is_node_active_in_tree());
+		CHECK(child->is_node_active_in_tree());
+		CHECK(node->can_process());
+	}
+
+	SUBCASE("Active changed") {
+		node->set_node_active(false);
+
+		CHECK_FALSE(node->is_node_active_self());
+		CHECK_FALSE(node->is_node_active_in_tree());
+		CHECK(child->is_node_active_self());
+		CHECK_FALSE(child->is_node_active_in_tree());
+		CHECK_FALSE(node->can_process());
+
+		node->set_node_active(true);
+
+		CHECK(node->is_node_active_self());
+		CHECK(node->is_node_active_in_tree());
+		CHECK(child->is_node_active_in_tree());
+	}
+
+	memdelete(node);
+}
+
 } // namespace TestNode
 
 #endif // TEST_NODE_H


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7715 and is based on suggestions from users in that discussion :)

This change aims to accomplish 3 things:

1. Add a faster/more convenient way to disable a Node for debugging and gameplay purposes. See [here](https://github.com/godotengine/godot-proposals/issues/7715#issuecomment-2189010809). 
2. Provide the groundwork for a more universal disable feature that can simplify workflows and eventually replace some existing "enabled" toggles. See [here](https://github.com/godotengine/godot-proposals/issues/7715#issuecomment-2132425518). 
4. Provide new initialization and cleanup methods (i.e. lifecycle calls) that are dependent on active state so that users can run code only when a node is supposed to have an impact in the scene. See [here](https://github.com/godotengine/godot-proposals/issues/7715#issuecomment-2179562835).

I should also note that this PR is meant to pair nicely with and build upon the work of @torcado194 since it is distinct from https://github.com/godotengine/godot/pull/92377 due to working in both runtime and the editor, and leaving references to disabled nodes intact.

**Active Concept**

All nodes now have a property called `node_active` which determines their active state:

![image](https://github.com/godotengine/godot/assets/11141862/07cb0041-e1ff-4a63-b15b-622664ea3b5e)

Similar to visibility, if an ancestor node is inactive, the child behaves as though it is inactive as well. To match visibility, a new method called `is_node_active_in_tree()` exists to check whether it should behave as active or inactive. 

From discussions in https://github.com/godotengine/godot-proposals/issues/7715 we wanted an easy way to toggle/preview active state but some people noted a lot of icons in the scene tree already, so @snowdrama suggested an icon filter as seen [here](https://github.com/godotengine/godot-proposals/issues/7715#issuecomment-2150990948). It's a great idea that should definitely be added imo but it's probably best as it's own PR, so for now I added a new editor setting called `show_node_active_checkbox` which toggles the icon and is *off* by default to alleviate concerns of clutter. Here is that in action:

https://github.com/godotengine/godot/assets/11141862/02675524-d614-44db-8d10-c6a5833f2d27

An inactive node is not visible, does not process scripts/physics/collision/lighting/etc., and will not work as a valid camera (a special case because it did not previously check `can_process`). It works directly from the editor via these new buttons, a tool script that sets the `node_active` property, or from the inspector:

https://github.com/godotengine/godot/assets/11141862/c42c9141-1d63-43c2-b6ba-f844ac6c4d89

It also works in runtime! Simply set the `node_active` property or (in C++) use `set_node_active` to toggle it. You can connect to the `node_active_changed` signal to get a callback when the property has changed, or the `node_active_in_tree_changed` to get a callback when its "active in tree" status has changed. Here a script enables a node during a certain time frame and then turns it off again:

https://github.com/godotengine/godot/assets/11141862/5c9a4601-9615-44a1-a985-769739b7ec14

**Lifecycle Methods**

Thanks to feedback from @passivestar and others in the proposal, another useful aspect of this feature is new lifecycle methods for users to run initialization/cleanup code that is dependent on active state. The new `_node_active()` call is run when a node becomes active in tree or after `_ready()` when it enters the tree (if active). The `_node_inactive()` call is run when a node becomes inactive in tree or before `_exit_tree()` when exiting the tree (if it was active before that point). Now, users can run code like this:

```
func _ready():
	print("_ready")

func _enter_tree():
	print("_enter_tree")

func _exit_tree():
	print("_exit_tree")

func _node_active():
	print("_node_active");
	
func _node_inactive():
	print("_node_inactive");
```

And like before, it works both in the editor and in runtime:

https://github.com/godotengine/godot/assets/11141862/bb8dd374-6b8f-4d82-87d9-2f77fed1815f

Ultimately, this means you can put setup steps in `_node_active` so that code runs when it becomes active, not when the scene starts. This is useful for say an object that is culled by distance so that it only has an impact when the player gets closer to it rather than it having to do additional work to check whether it is culled in `_ready()`. 

There is room for further work here like adding a parameter to signal calling so that inactive objects do not receive them, but for now this is a good starting point for people to play with and covers the main use cases discussed in the proposal.

**Other Notes**

I generated and wrote out documentation descriptions for the new methods, notifications, and properties so let me know if that looks good and if there's other documentation I should edit as a result of this change. For example, it might be good to mention active state in the visibility section of the docs, but I wasn't sure how much I should mess with for now. I'm happy to help write explanations in the doc site as well to help explain the feature since I know communication of something like this is very important. I also added new test cases just to cover some simple scenarios but I can add more if necessary.

Thanks to everyone that helped shape this PR and I know that since this is a hefty change it will take some time to review/merge but I'm happy to clarify anything and make any necessary adjustments :) I'm hoping this will improve lots of workflows down the line, so let me know how it works during your testing! Thank you!