### PR TITLE
Deprecate force_native in favor of embed_mode

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -583,6 +583,9 @@
 		<member name="current_screen" type="int" setter="set_current_screen" getter="get_current_screen">
 			The screen the window is currently on.
 		</member>
+		<member name="embed_mode" type="int" setter="set_embed_mode" getter="get_embed_mode" enum="Window.EmbedMode" default="0">
+			Changes the behavior of how the window will embed in its parent window.
+		</member>
 		<member name="exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">
 			If [code]true[/code], the [Window] will be in exclusive mode. Exclusive windows are always on top of their parent and will block all input going to the parent [Window].
 			Needs [member transient] enabled to work.
@@ -592,7 +595,8 @@
 			[b]Note:[/b] This property is implemented only on macOS.
 			[b]Note:[/b] This property only works with native windows.
 		</member>
-		<member name="force_native" type="bool" setter="set_force_native" getter="get_force_native" default="false">
+		<member name="force_native" type="bool" setter="set_force_native" getter="get_force_native" default="false" deprecated="">
+			[b]Note[/b] This method has been deprecated. Please use [member embed_mode] instead.
 			If [code]true[/code], native window will be used regardless of parent viewport and project settings.
 		</member>
 		<member name="initial_position" type="int" setter="set_initial_position" getter="get_initial_position" enum="Window.WindowInitialPosition" default="0">
@@ -841,6 +845,15 @@
 		</constant>
 		<constant name="FLAG_MAX" value="8" enum="Flags">
 			Max value of the [enum Flags].
+		</constant>
+		<constant name="EMBED_DEFAULT" value="0" enum="EmbedMode">
+			Embeds based on the parent window's [member Viewport.gui_embed_subwindows] property.
+		</constant>
+		<constant name="EMBED_FORCE_EMBED" value="1" enum="EmbedMode">
+			Forcefully embeds the window in the parent window if no parent window is willing to embed it.
+		</constant>
+		<constant name="EMBED_FORCE_NATIVE" value="2" enum="EmbedMode">
+			Forcefully makes a native window if native windows are supported. See also [constant DisplayServer.FEATURE_SUBWINDOWS]
 		</constant>
 		<constant name="CONTENT_SCALE_MODE_DISABLED" value="0" enum="ContentScaleMode">
 			The content will not be scaled to match the [Window]'s size.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3921,7 +3921,7 @@ bool EditorNode::is_scene_open(const String &p_path) {
 }
 
 bool EditorNode::is_multi_window_enabled() const {
-	return !SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable");
+	return !SceneTree::get_singleton()->get_root()->has_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable");
 }
 
 void EditorNode::fix_dependencies(const String &p_for_file) {
@@ -4472,7 +4472,7 @@ void EditorNode::request_instantiate_scenes(const Vector<String> &p_files) {
 }
 
 String EditorNode::get_multiwindow_support_tooltip_text() const {
-	if (SceneTree::get_singleton()->get_root()->is_embedding_subwindows()) {
+	if (SceneTree::get_singleton()->get_root()->has_subwindows()) {
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SUBWINDOWS)) {
 			return TTR("Multi-window support is not available because the `--single-window` command line argument was used to start the editor.");
 		} else {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1004,7 +1004,7 @@ void ProjectExportDialog::_tree_popup_edited(bool p_arrow_clicked) {
 	Rect2 bounds = include_files->get_custom_popup_rect();
 	bounds.position += get_global_canvas_transform().get_origin();
 	bounds.size *= get_global_canvas_transform().get_scale();
-	if (!is_embedding_subwindows()) {
+	if (!has_subwindows()) {
 		bounds.position += get_position();
 	}
 	file_mode_popup->popup(bounds);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -973,7 +973,7 @@ void Viewport::update_canvas_items() {
 		return;
 	}
 
-	if (is_embedding_subwindows()) {
+	if (has_subwindows()) {
 		for (Viewport::SubWindow w : gui.sub_windows) {
 			if (w.window && !w.pending_window_update) {
 				w.pending_window_update = true;
@@ -1995,7 +1995,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			Viewport *embedder = nullptr;
 			Vector2 viewport_pos;
 
-			if (is_embedding_subwindows()) {
+			if (has_subwindows()) {
 				embedder = this;
 				viewport_pos = mpos;
 			} else {
@@ -2996,7 +2996,7 @@ void Viewport::_update_mouse_over() {
 		return;
 	}
 
-	if (get_tree()->get_root()->is_embedding_subwindows() || is_sub_viewport()) {
+	if (get_tree()->get_root()->has_subwindows() || is_sub_viewport()) {
 		// Use embedder logic for calculating mouse position.
 		_update_mouse_over(gui.last_mouse_pos);
 	} else {
@@ -3015,7 +3015,7 @@ void Viewport::_update_mouse_over() {
 
 void Viewport::_update_mouse_over(Vector2 p_pos) {
 	// Look for embedded windows at mouse position.
-	if (is_embedding_subwindows()) {
+	if (has_subwindows()) {
 		for (int i = gui.sub_windows.size() - 1; i >= 0; i--) {
 			Window *sw = gui.sub_windows[i].window;
 			Rect2 swrect = Rect2(sw->get_position(), sw->get_size());
@@ -3239,7 +3239,7 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		_update_mouse_over();
 	}
 
-	if (is_embedding_subwindows() && _sub_windows_forward_input(ev)) {
+	if (has_subwindows() && _sub_windows_forward_input(ev)) {
 		set_input_as_handled();
 		return;
 	}
@@ -3818,7 +3818,7 @@ void Viewport::set_embedding_subwindows(bool p_embed) {
 				break;
 			}
 			vp = vp->get_parent()->get_viewport();
-			if (vp->is_embedding_subwindows()) {
+			if (vp->has_subwindows()) {
 				for (int i = 0; i < vp->gui.sub_windows.size(); i++) {
 					if (is_ancestor_of(vp->gui.sub_windows[i].window)) {
 						// Prevent change when this viewport has child windows that are displayed in an ancestor viewport.
@@ -3862,6 +3862,10 @@ void Viewport::set_embedding_subwindows(bool p_embed) {
 bool Viewport::is_embedding_subwindows() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return gui.embed_subwindows_hint;
+}
+
+bool Viewport::has_subwindows() const {
+	return gui.sub_windows.size() != 0;
 }
 
 TypedArray<Window> Viewport::get_embedded_subwindows() const {
@@ -5139,7 +5143,7 @@ Transform2D SubViewport::get_screen_transform_internal(bool p_absolute_position)
 
 Transform2D SubViewport::get_popup_base_transform() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
-	if (is_embedding_subwindows()) {
+	if (has_subwindows()) {
 		return Transform2D();
 	}
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -499,6 +499,7 @@ public:
 	RID get_viewport_rid() const;
 
 	void set_world_2d(const Ref<World2D> &p_world_2d);
+
 	Ref<World2D> get_world_2d() const;
 	Ref<World2D> find_world_2d() const;
 
@@ -656,6 +657,7 @@ public:
 	void set_embedding_subwindows(bool p_embed);
 	bool is_embedding_subwindows() const;
 	TypedArray<Window> get_embedded_subwindows() const;
+	bool has_subwindows() const;
 	void subwindow_set_popup_safe_rect(Window *p_window, const Rect2i &p_rect);
 	Rect2i subwindow_get_popup_safe_rect(Window *p_window) const;
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -65,6 +65,12 @@ public:
 		FLAG_MAX = DisplayServer::WINDOW_FLAG_MAX,
 	};
 
+	enum EmbedMode {
+		EMBED_DEFAULT,
+		EMBED_FORCE_EMBED,
+		EMBED_FORCE_NATIVE
+	};
+
 	enum ContentScaleMode {
 		CONTENT_SCALE_MODE_DISABLED,
 		CONTENT_SCALE_MODE_CANVAS_ITEMS,
@@ -122,7 +128,7 @@ private:
 	bool visible = true;
 	bool focused = false;
 	WindowInitialPosition initial_position = WINDOW_INITIAL_POSITION_ABSOLUTE;
-	bool force_native = false;
+	EmbedMode embed_mode = EMBED_DEFAULT;
 
 	bool use_font_oversampling = false;
 	bool transient = false;
@@ -276,8 +282,11 @@ public:
 	void set_initial_position(WindowInitialPosition p_initial_position);
 	WindowInitialPosition get_initial_position() const;
 
-	void set_force_native(bool p_force_native);
+	void set_force_native(bool p_force_native); // Deprecated, use embed_mode
 	bool get_force_native() const;
+
+	void set_embed_mode(EmbedMode p_embed_mode);
+	EmbedMode get_embed_mode() const;
 
 	void set_current_screen(int p_screen);
 	int get_current_screen() const;
@@ -487,6 +496,7 @@ public:
 
 VARIANT_ENUM_CAST(Window::Mode);
 VARIANT_ENUM_CAST(Window::Flags);
+VARIANT_ENUM_CAST(Window::EmbedMode);
 VARIANT_ENUM_CAST(Window::ContentScaleMode);
 VARIANT_ENUM_CAST(Window::ContentScaleAspect);
 VARIANT_ENUM_CAST(Window::ContentScaleStretch);


### PR DESCRIPTION
This PR allows forcefully embedding windows.
It is meant to overcome when plugin developers do not have control whether `embed_subwindows` is set to true or false. You can now override it inside the new `Window.embed_mode` property.
`Window.force_native` has been deprecated.