### PR TITLE
Properly linearize depth buffer for SSAO when using orthogonal camera

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/ss_effects_downsample.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ss_effects_downsample.glsl
@@ -50,7 +50,7 @@ layout(r16f, set = 2, binding = 3) uniform restrict writeonly image2DArray dest_
 vec4 screen_space_to_view_space_depth(vec4 p_depth) {
 	if (params.orthogonal) {
 		vec4 depth = p_depth * 2.0 - 1.0;
-		return ((depth + (params.z_far + params.z_near) / (params.z_far - params.z_near)) * (params.z_far - params.z_near)) / 2.0;
+		return -(depth * (params.z_far - params.z_near) - (params.z_far + params.z_near)) / 2.0;
 	}
 
 	float depth_linearize_mul = params.z_near;
@@ -68,7 +68,7 @@ vec4 screen_space_to_view_space_depth(vec4 p_depth) {
 float screen_space_to_view_space_depth(float p_depth) {
 	if (params.orthogonal) {
 		float depth = p_depth * 2.0 - 1.0;
-		return ((depth + (params.z_far + params.z_near) / (params.z_far - params.z_near)) * (params.z_far - params.z_near)) / (2.0 * params.z_far);
+		return -(depth * (params.z_far - params.z_near) - (params.z_far + params.z_near)) / 2.0;
 	}
 
 	float depth_linearize_mul = params.z_near;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/94139

The linearization code was up[dated in a few places after the reverse-z change, but it was missed here. 

I validated that GI, DoF, SSR, SSS and SSAO continue to work with this change.

This code is just a copy and paste from the code we use for DoF already. 