### PR TITLE
OpenXR: Couple of small fixes on the action map

### DIFF
--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -176,6 +176,10 @@
 				Triggers a haptic pulse on a device associated with this interface.
 				[param action_name] is the name of the action for this pulse.
 				[param tracker_name] is optional and can be used to direct the pulse to a specific device provided that device is bound to this haptic.
+				[param frequency] is the frequency of the pulse, set to [code]0.0[/code] to have the system use a default frequency.
+				[param amplitude] is the amplitude of the pulse between [code]0.0[/code] and [code]1.0[/code].
+				[param duration_sec] is the duration of the pulse in seconds.
+				[param delay_sec] is a delay in seconds before the pulse is given.
 			</description>
 		</method>
 		<method name="uninitialize">

--- a/doc/classes/XRNode3D.xml
+++ b/doc/classes/XRNode3D.xml
@@ -38,6 +38,10 @@
 			<description>
 				Triggers a haptic pulse on a device associated with this interface.
 				[param action_name] is the name of the action for this pulse.
+				[param frequency] is the frequency of the pulse, set to [code]0.0[/code] to have the system use a default frequency.
+				[param amplitude] is the amplitude of the pulse between [code]0.0[/code] and [code]1.0[/code].
+				[param duration_sec] is the duration of the pulse in seconds.
+				[param delay_sec] is a delay in seconds before the pulse is given.
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/action_map/openxr_interaction_profile.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile.cpp
@@ -127,9 +127,12 @@ Ref<OpenXRInteractionProfile> OpenXRInteractionProfile::new_profile(const char *
 
 void OpenXRInteractionProfile::set_interaction_profile_path(const String p_input_profile_path) {
 	OpenXRInteractionProfileMetadata *pmd = OpenXRInteractionProfileMetadata::get_singleton();
-	ERR_FAIL_NULL(pmd);
-
-	interaction_profile_path = pmd->check_profile_name(p_input_profile_path);
+	if (pmd) {
+		interaction_profile_path = pmd->check_profile_name(p_input_profile_path);
+	} else {
+		// OpenXR module not enabled, ignore checks.
+		interaction_profile_path = p_input_profile_path;
+	}
 	emit_changed();
 }
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -248,7 +248,7 @@ void OpenXRActionMapEditor::_on_interaction_profile_selected(const String p_path
 
 void OpenXRActionMapEditor::_load_action_map(const String p_path, bool p_create_new_if_missing) {
 	Error err = OK;
-	action_map = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE, &err);
+	action_map = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	if (err != OK) {
 		if ((err == ERR_FILE_NOT_FOUND || err == ERR_CANT_OPEN) && p_create_new_if_missing) {
 			action_map.instantiate();
@@ -257,10 +257,16 @@ void OpenXRActionMapEditor::_load_action_map(const String p_path, bool p_create_
 			// Save it immediately
 			err = ResourceSaver::save(action_map, p_path);
 			if (err != OK) {
-				// show warning but continue
+				// Show warning but continue.
 				EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), edited_path, error_names[err]));
+			} else {
+				// Reload so it's cached.
+				action_map = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+				if (err != OK) {
+					// Show warning but continue.
+					EditorNode::get_singleton()->show_warning(vformat(TTR("Error reloading file %s: %s"), edited_path, error_names[err]));
+				}
 			}
-
 		} else {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Error loading %s: %s."), edited_path, error_names[err]));
 


### PR DESCRIPTION
This PR makes 3 changes:

1. CTRL-S and running your project now saves outstanding changes to the action map
2. Opening the action map resource file no longer looses content if OpenXR is not enabled (important for projects that switch between XR and non-XR modes)
3. Added a bit of documentation on haptic pulses (not really related but ran into it)

Fixes https://github.com/godotengine/godot/issues/90696