### PR TITLE
[Editor] Handle imported resource dependencies.

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -221,6 +221,17 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 	return OK;
 }
 
+Error ConfigFile::load_with_parser(const String &p_path, VariantParser::ResourceParser *p_res_parser) {
+	Error err;
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
+
+	if (f.is_null()) {
+		return err;
+	}
+
+	return _internal_load(p_path, f, p_res_parser);
+}
+
 Error ConfigFile::load(const String &p_path) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
@@ -267,11 +278,11 @@ Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass
 	return _internal_load(p_path, fae);
 }
 
-Error ConfigFile::_internal_load(const String &p_path, Ref<FileAccess> f) {
+Error ConfigFile::_internal_load(const String &p_path, Ref<FileAccess> f, VariantParser::ResourceParser *p_res_parser) {
 	VariantParser::StreamFile stream;
 	stream.f = f;
 
-	Error err = _parse(p_path, &stream);
+	Error err = _parse(p_path, &stream, p_res_parser);
 
 	return err;
 }
@@ -282,7 +293,7 @@ Error ConfigFile::parse(const String &p_data) {
 	return _parse("<string>", &stream);
 }
 
-Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) {
+Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream, VariantParser::ResourceParser *p_res_parser) {
 	String assign;
 	Variant value;
 	VariantParser::Tag next_tag;
@@ -297,7 +308,7 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		Error err = VariantParser::parse_tag_assign_eof(p_stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		Error err = VariantParser::parse_tag_assign_eof(p_stream, lines, error_text, next_tag, assign, value, p_res_parser, true);
 		if (err == ERR_FILE_EOF) {
 			return OK;
 		} else if (err != OK) {

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -43,10 +43,10 @@ class ConfigFile : public RefCounted {
 
 	PackedStringArray _get_sections() const;
 	PackedStringArray _get_section_keys(const String &p_section) const;
-	Error _internal_load(const String &p_path, Ref<FileAccess> f);
+	Error _internal_load(const String &p_path, Ref<FileAccess> f, VariantParser::ResourceParser *p_res_parser = nullptr);
 	Error _internal_save(Ref<FileAccess> file);
 
-	Error _parse(const String &p_path, VariantParser::Stream *p_stream);
+	Error _parse(const String &p_path, VariantParser::Stream *p_stream, VariantParser::ResourceParser *p_res_parser = nullptr);
 
 protected:
 	static void _bind_methods();
@@ -66,6 +66,7 @@ public:
 
 	Error save(const String &p_path);
 	Error load(const String &p_path);
+	Error load_with_parser(const String &p_path, VariantParser::ResourceParser *p_res_parser);
 	Error parse(const String &p_data);
 
 	String encode_to_text() const; // used by exporter

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -235,6 +235,27 @@ bool ResourceFormatImporter::recognize_path(const String &p_path, const String &
 	return FileAccess::exists(p_path + ".import");
 }
 
+bool ResourceFormatImporter::get_import_can_have_dependencies(const String &p_path) const {
+	Ref<ResourceImporter> importer;
+
+	if (FileAccess::exists(p_path + ".import")) {
+		PathAndType pat;
+		Error err = _get_path_and_type(p_path, pat);
+
+		if (err == OK) {
+			importer = get_importer_by_name(pat.importer);
+		}
+	} else {
+		importer = get_importer_by_extension(p_path.get_extension().to_lower());
+	}
+
+	if (importer.is_valid()) {
+		return importer->can_have_dependencies();
+	} else {
+		return false;
+	}
+}
+
 Error ResourceFormatImporter::get_import_order_threads_and_importer(const String &p_path, int &r_order, bool &r_can_threads, String &r_importer) const {
 	r_order = 0;
 	r_importer = "";

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -80,6 +80,7 @@ public:
 
 	virtual int get_import_order(const String &p_path) const override;
 
+	bool get_import_can_have_dependencies(const String &p_path) const;
 	Error get_import_order_threads_and_importer(const String &p_path, int &r_order, bool &r_can_threads, String &r_importer) const;
 
 	String get_internal_resource_path(const String &p_path) const;
@@ -118,6 +119,7 @@ public:
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
 	virtual int get_import_order() const { return IMPORT_ORDER_DEFAULT; }
+	virtual bool can_have_dependencies() const { return false; }
 	virtual int get_format_version() const { return 0; }
 
 	struct ImportOption {

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -120,6 +120,12 @@
 		<link title="Import plugins">$DOCS_URL/tutorials/plugins/editor/import_plugins.html</link>
 	</tutorials>
 	<methods>
+		<method name="_can_have_dependencies" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code], if importer config can depend on other imported resources.
+			</description>
+		</method>
 		<method name="_can_import_threaded" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -38,6 +38,7 @@
 #include "core/os/thread_safe.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/safe_refcount.h"
+#include "core/variant/variant_parser.h"
 #include "scene/main/node.h"
 
 class FileAccess;
@@ -171,6 +172,12 @@ class EditorFileSystem : public Node {
 		~ScannedDirectory();
 	};
 
+	struct ResDependencies {
+		Vector<String> res_paths;
+	};
+
+	static Error _parse_resource_deps(void *p_data, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
+
 	bool use_threads = false;
 	Thread thread;
 	static void _thread_func(void *_userdata);
@@ -255,7 +262,9 @@ class EditorFileSystem : public Node {
 
 	void _update_extensions();
 
+	Vector<String> _reimport_file_get_dependencies(const String &p_file, const HashSet<String> &p_owners = HashSet<String>());
 	Error _reimport_file(const String &p_file, const HashMap<StringName, Variant> &p_custom_options = HashMap<StringName, Variant>(), const String &p_custom_importer = String(), Variant *generator_parameters = nullptr, bool p_update_file_system = true);
+
 	Error _reimport_group(const String &p_group_file, const Vector<String> &p_files);
 
 	bool _test_for_reimport(const String &p_path, bool p_only_imported_files);
@@ -268,9 +277,17 @@ class EditorFileSystem : public Node {
 		String path;
 		String importer;
 		bool threaded = false;
+		bool no_sort = false;
 		int order = 0;
+		int index = 0;
 		bool operator<(const ImportFile &p_if) const {
-			return order == p_if.order ? (importer < p_if.importer) : (order < p_if.order);
+			if (no_sort) {
+				return index < p_if.index;
+			} else if (order == p_if.order) {
+				return importer < p_if.importer;
+			} else {
+				return order < p_if.order;
+			}
 		}
 	};
 

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -112,6 +112,14 @@ int EditorImportPlugin::get_import_order() const {
 	ERR_FAIL_V_MSG(-1, "Unimplemented _get_import_order in add-on.");
 }
 
+bool EditorImportPlugin::can_have_dependencies() const {
+	bool ret;
+	if (GDVIRTUAL_CALL(_can_have_dependencies, ret)) {
+		return ret;
+	}
+	return false;
+}
+
 void EditorImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, int p_preset) const {
 	Array needed;
 	needed.push_back("name");
@@ -221,6 +229,7 @@ void EditorImportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_priority)
 	GDVIRTUAL_BIND(_get_import_order)
 	GDVIRTUAL_BIND(_get_option_visibility, "path", "option_name", "options")
+	GDVIRTUAL_BIND(_can_have_dependencies)
 	GDVIRTUAL_BIND(_import, "source_file", "save_path", "options", "platform_variants", "gen_files");
 	GDVIRTUAL_BIND(_can_import_threaded);
 	ClassDB::bind_method(D_METHOD("append_import_external_resource", "path", "custom_options", "custom_importer", "generator_parameters"), &EditorImportPlugin::_append_import_external_resource, DEFVAL(Dictionary()), DEFVAL(String()), DEFVAL(Variant()));

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -51,6 +51,7 @@ protected:
 	GDVIRTUAL0RC(float, _get_priority)
 	GDVIRTUAL0RC(int, _get_import_order)
 	GDVIRTUAL3RC(bool, _get_option_visibility, String, StringName, Dictionary)
+	GDVIRTUAL0RC(bool, _can_have_dependencies)
 	GDVIRTUAL5RC(Error, _import, String, String, Dictionary, TypedArray<String>, TypedArray<String>)
 	GDVIRTUAL0RC(bool, _can_import_threaded)
 
@@ -67,6 +68,7 @@ public:
 	virtual String get_resource_type() const override;
 	virtual float get_priority() const override;
 	virtual int get_import_order() const override;
+	virtual bool can_have_dependencies() const override;
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -44,6 +44,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual bool can_have_dependencies() const override { return true; }
 
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -48,6 +48,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual bool can_have_dependencies() const override { return true; }
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -44,6 +44,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual bool can_have_dependencies() const override { return true; }
 
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92297
Fixes https://github.com/godotengine/godot/issues/80237

Probably not the best way to solve it, but I do not see any other way to do it without breaking compatibility since existing fonts can depend on other fonts as fallbacks.

- Before reimporting all resources, preloads `.import` file and checks it for `Resource` (added `ResourceImporter::can_have_dependencies` method to only do it for relevant types).
- Ensures resources found in step one are imported before dependent file (disables threaded loading and forces specific order for these files).