### PR TITLE
Fix edited node being removed before editor plugin handles focus loss

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -772,7 +772,6 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			// Reselect
 			if (Engine::get_singleton()->is_editor_hint()) {
 				selected_from_canvas = true;
-				EditorNode::get_singleton()->edit_node(item);
 			}
 		}
 	}


### PR DESCRIPTION
`CanvasItemEditor::_select_click_on_item` was causing `EditorNode::_plugin_over_edit` to be called before focus exit had time to propagate to `SpriteFramesEditor::_animation_speed_changed`.

Fixes #93817.

The defer is needed, but I'm not sure if this is the best place to put it.
