### PR TITLE
Implement Node.clear_children

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -236,6 +236,16 @@
 				If the node is not inside the tree, returns [code]false[/code] no matter the value of [member process_mode].
 			</description>
 		</method>
+		<method name="clear_children">
+			<return type="void" />
+			<param index="0" name="deferred" type="bool" default="true" />
+			<param index="1" name="include_internal" type="bool" default="false" />
+			<description>
+				Calls [method queue_free] on all children.
+				If [param deferred] is [code]false[/code], [method remove_child] is called before [method queue_free].
+				If [param include_internal] is [code]false[/code], excludes internal children from being cleared (see [method add_child]'s [code]internal[/code] parameter).
+			</description>
+		</method>
 		<method name="create_tween">
 			<return type="Tween" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1718,6 +1718,36 @@ void Node::remove_child(Node *p_child) {
 	}
 }
 
+void Node::clear_children(bool p_deferred, bool p_include_internal) {
+	ERR_FAIL_COND_MSG(data.inside_tree && !Thread::is_main_thread(), "Removing children from a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"clear_children\").");
+	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy adding/removing children, `clear_children()` can't be called at this time. Consider using `clear_children.call_deferred()` instead.");
+	if (p_deferred) {
+		for (const KeyValue<StringName, Node *> &child : data.children) {
+			if (p_include_internal || child.value->data.internal_mode == INTERNAL_MODE_DISABLED) {
+				child.value->queue_free();
+			}
+		}
+	} else {
+		if (p_include_internal) {
+			for (const KeyValue<StringName, Node *> &child : data.children) {
+				child.value->queue_free();
+				remove_child(child.value);
+			}
+		} else {
+			LocalVector<Node *> nodes_to_remove;
+			for (const KeyValue<StringName, Node *> &child : data.children) {
+				if (child.value->data.internal_mode == INTERNAL_MODE_DISABLED) {
+					child.value->queue_free();
+					nodes_to_remove.push_back(child.value); // Removing it now would invalidate the iterator.
+				}
+			}
+			for (Node *child : nodes_to_remove) {
+				remove_child(child);
+			}
+		}
+	}
+}
+
 void Node::_update_children_cache_impl() const {
 	// Assign children
 	data.children_cache.resize(data.children.size());
@@ -3599,6 +3629,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_parent", "pattern"), &Node::find_parent);
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
+	ClassDB::bind_method(D_METHOD("clear_children", "deferred", "include_internal"), &Node::clear_children, DEFVAL(true), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
 	ClassDB::bind_method(D_METHOD("is_part_of_edited_scene"), &Node::is_part_of_edited_scene);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -455,6 +455,7 @@ public:
 	void add_child(Node *p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(Node *p_sibling, bool p_force_readable_name = false);
 	void remove_child(Node *p_child);
+	void clear_children(bool p_deferred = true, bool p_include_internal = true);
 
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;


### PR DESCRIPTION
Allows to quickly clear out all children of a node.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/764.*