### PR TITLE
Implement a new property named `ScrollContainer.max_size`

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -46,6 +46,9 @@
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
 			Controls whether horizontal scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.
 		</member>
+		<member name="max_size" type="Vector2" setter="set_max_size" getter="get_max_size" default="Vector2(0, 0)">
+			If greater than [code]0[/code] on either axis, the container will expand on that axis to fit its children, up to the specified maximum size. If the contents are bigger than the maximum size, the scroll bars will appear (unless disabled).
+		</member>
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 			Deadzone for touch scrolling. Lower deadzone makes the scrolling more sensitive.
 		</member>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -57,9 +57,13 @@ Size2 ScrollContainer::get_minimum_size() const {
 
 	if (horizontal_scroll_mode == SCROLL_MODE_DISABLED) {
 		min_size.x = MAX(min_size.x, largest_child_min_size.x);
+	} else if (max_size.x > 0.0) {
+		min_size.x = MIN(max_size.x, largest_child_min_size.x);
 	}
 	if (vertical_scroll_mode == SCROLL_MODE_DISABLED) {
 		min_size.y = MAX(min_size.y, largest_child_min_size.y);
+	} else if (max_size.y > 0.0) {
+		min_size.y = MIN(max_size.y, largest_child_min_size.y);
 	}
 
 	bool h_scroll_show = horizontal_scroll_mode == SCROLL_MODE_SHOW_ALWAYS || (horizontal_scroll_mode == SCROLL_MODE_AUTO && largest_child_min_size.x > min_size.x);
@@ -242,6 +246,20 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 		return;
 	}
+}
+
+void ScrollContainer::set_max_size(const Size2 &p_max_size) {
+	if (max_size == p_max_size) {
+		return;
+	}
+	max_size = p_max_size.maxf(0.0);
+	ERR_FAIL_COND(p_max_size.height < 0 || p_max_size.width < 0);
+	update_minimum_size();
+	queue_sort();
+}
+
+Size2 ScrollContainer::get_max_size() const {
+	return max_size;
 }
 
 void ScrollContainer::_update_scrollbar_position() {
@@ -565,6 +583,9 @@ VScrollBar *ScrollContainer::get_v_scroll_bar() {
 }
 
 void ScrollContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_max_size", "value"), &ScrollContainer::set_max_size);
+	ClassDB::bind_method(D_METHOD("get_max_size"), &ScrollContainer::get_max_size);
+
 	ClassDB::bind_method(D_METHOD("set_h_scroll", "value"), &ScrollContainer::set_h_scroll);
 	ClassDB::bind_method(D_METHOD("get_h_scroll"), &ScrollContainer::get_h_scroll);
 
@@ -596,6 +617,7 @@ void ScrollContainer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("scroll_started"));
 	ADD_SIGNAL(MethodInfo("scroll_ended"));
 
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "max_size"), "set_max_size", "get_max_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "follow_focus"), "set_follow_focus", "is_following_focus");
 
 	ADD_GROUP("Scroll", "scroll_");

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -52,6 +52,8 @@ private:
 
 	mutable Size2 largest_child_min_size; // The largest one among the min sizes of all available child controls.
 
+	Size2 max_size;
+
 	void update_scrollbars();
 
 	Vector2 drag_speed;
@@ -90,6 +92,9 @@ protected:
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
+
+	void set_max_size(const Size2 &p_max_size);
+	Size2 get_max_size() const;
 
 	void set_h_scroll(int p_pos);
 	int get_h_scroll() const;


### PR DESCRIPTION
Gives the programmer more settings as to how their ScrollContainers act.