### PR TITLE
Add life_cycle Property to ProjectSettings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1432,6 +1432,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::DICTIONARY, "application/config/name_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT), "");
 	GLOBAL_DEF_BASIC("application/config/version", "");
+	GLOBAL_DEF("application/config/life_cycle", "");
 	GLOBAL_DEF_INTERNAL(PropertyInfo(Variant::STRING, "application/config/tags"), PackedStringArray());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res"), "");
 	GLOBAL_DEF("application/run/disable_stdout", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -309,6 +309,9 @@
 		<member name="application/config/version" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's human-readable version identifier. This is used by exporters if the version identifier isn't overridden there. If [member application/config/version] is an empty string and the version identifier isn't overridden in an exporter, the exporter will use [code]1.0.0[/code] as a version identifier.
 		</member>
+		<member name="application/config/life_cycle" type="String" setter="" getter="" default="&quot;&quot;">
+			The project's life cycle stage. This can be used to indicate the current stage of the project such as "Development", "Testing", or "Release".
+		</member>
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>


### PR DESCRIPTION
This pull request adds a new property "application/config/life_cycle" to the ProjectSettings class.

### Changes
- Added GLOBAL_DEF("application/config/life_cycle", "");
- Updated ProjectSettings.xml to include the new property documentation.

### Property Details
- `application/config/life_cycle`: A string property that indicates the current life cycle stage of the project.

### Motivation
This property provides a way to specify and track the current stage of the project life cycle.