### PR TITLE
Fix SSR orientation issues when using orthogonal camera

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -90,7 +90,7 @@ void main() {
 	if (sc_multiview) {
 		view_dir = normalize(vertex + scene_data.eye_offset[params.view_index].xyz);
 	} else {
-		view_dir = normalize(vertex);
+		view_dir = params.orthogonal ? vec3(0.0, 0.0, -1.0) : normalize(vertex);
 	}
 	vec3 ray_dir = normalize(reflect(view_dir, normal));
 

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_inc.glsl
@@ -20,7 +20,7 @@ vec3 reconstructCSPosition(vec2 screen_pos, float z) {
 		return pos.xyz;
 	} else {
 		if (params.orthogonal) {
-			return vec3((screen_pos.xy * params.proj_info.xy + params.proj_info.zw), z);
+			return vec3(-(screen_pos.xy * params.proj_info.xy + params.proj_info.zw), z);
 		} else {
 			return vec3((screen_pos.xy * params.proj_info.xy + params.proj_info.zw) * z, z);
 		}


### PR DESCRIPTION
- Fixes: #79002 

Negative view space reconstruction was causing reversed screen space reflection rotations when using the orthogonal camera. The fix should not affect perspective.