### PR TITLE
Disable window resizing in Movie Maker mode by default

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1462,6 +1462,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/initial_screen", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), 0);
 
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
+	GLOBAL_DEF_BASIC("display/window/size/resizable.movie", false);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
 	GLOBAL_DEF("display/window/size/transparent", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -876,6 +876,9 @@
 			[b]Note:[/b] Certain window managers can be configured to ignore the non-resizable status of a window. Do not rely on this setting as a guarantee that the window will [i]never[/i] be resizable.
 			[b]Note:[/b] This setting is ignored on iOS.
 		</member>
+		<member name="display/window/size/resizable.movie" type="bool" setter="" getter="" default="false">
+			[url=$DOCS_URL/tutorials/animation/creating_movies.html]Movie Maker mode[/url]-specific override for the [member display/window/size/resizable] project setting. The window is non-resizable by default in this mode to prevent accidental resizing during movie recording, which can affect the visual output.
+		</member>
 		<member name="display/window/size/transparent" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables a window manager hint that the main window background [i]can[/i] be transparent. This does not make the background actually transparent. For the background to be transparent, the root viewport must also be made transparent by enabling [member rendering/viewport/transparent_background].
 			[b]Note:[/b] To use a transparent splash screen, set [member application/boot_splash/bg_color] to [code]Color(0, 0, 0, 0)[/code].


### PR DESCRIPTION
This prevents the window from being accidentally resized during recording, which can change the visual output in unexpected ways.

This is a project setting override, so the previous behavior can be restored in the project settings if desired.

We might want to do something similar for `application/config/auto_accept_quit`, which would prevent using the "close" button or <kbd>Alt + F4</kbd> to exit recording (which can be frustrating for long video recordings if done accidentally). This one would be more controversial, as the only way to exit the project during movie recording would be to press <kbd>F8</kbd> in the editor, or have the project exit itself for some reason (e.g. using AnimationPlayer's **Movie Quit on Finish** property).

I suppose for that particular use case, we may want a dedicated solution that shows a confirmation dialog if `NOTIFICATION_WM_CLOSE_REQUEST` is received while Movie Maker mode is active. `OS.alert()` would be ideal for this as it's blocking and doesn't affect the main window's visuals, but it has no way to ask for "Yes/No" options currently. Maybe we could require the user to press the Close button twice in a short succession (with the window title changing the first time you press it).