### PR TITLE
Fix gap in primitive circular meshes due to floating point error

### DIFF
--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -1039,8 +1039,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 			u = i;
 			u /= radial_segments;
 
-			x = custom_sin(u * Math_TAU);
-			z = custom_cos(u * Math_TAU);
+			x = _custom_sin(u * Math_TAU);
+			z = _custom_cos(u * Math_TAU);
 
 			Vector3 p = Vector3(x * radius, y, z * radius);
 			points.push_back(p);

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -43,26 +43,28 @@
 */
 const double EPSILON = 1e-7;
 
-double remove_negative_zero(double value) {
-    return std::abs(value) < EPSILON ? 0.0 : value;
+static double _remove_negative_zero(double p_value) {
+	return Math::abs(p_value) < EPSILON ? 0.0 : p_value;
 }
 
-double custom_sin(double x) {
-    x = std::fmod(x, Math_TAU);
-    if (x < 0) x += Math_TAU;
-    return remove_negative_zero(std::sin(x));
+static double _custom_sin(double p_x) {
+	p_x = Math::fmod(p_x, Math_TAU);
+	if (p_x < 0) {
+		p_x += Math_TAU;
+	}
+	return _remove_negative_zero(Math::sin(p_x));
 }
 
-double custom_cos(double x) {
-    x = std::fmod(x, Math_TAU);
-    if (x < 0) x += Math_TAU;
-    return remove_negative_zero(std::cos(x));
+static double _custom_cos(double p_x) {
+	p_x = Math::fmod(p_x, Math_TAU);
+	if (p_x < 0) {
+		p_x += Math_TAU;
+	}
+	return _remove_negative_zero(Math::cos(p_x));
 }
 
-Vector3 remove_negative_zero_vector3(const Vector3& v) {
-    return Vector3(remove_negative_zero(v.x),
-                   remove_negative_zero(v.y),
-                   remove_negative_zero(v.z));
+static Vector3 _remove_negative_zero_vector3(const Vector3 &p_v) {
+	return Vector3(_remove_negative_zero(p_v.x), _remove_negative_zero(p_v.y), _remove_negative_zero(p_v.z));
 }
 
 void PrimitiveMesh::_update() const {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -1841,7 +1841,7 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 	prevrow = 0;
 	for (j = 0; j <= (rings + 1); j++) {
 		float v = static_cast<float>(j) / (rings + 1);
-		float phi = M_PI * v;
+		float phi = Math_PI * v;
 		float w = _custom_sin(phi);
 		y = scale * _custom_cos(phi);
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -1841,34 +1841,34 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 
 	thisrow = 0;
 	prevrow = 0;
-	 for (j = 0; j <= (rings + 1); j++) {
-        float v = static_cast<float>(j) / (rings + 1);
-        float phi = M_PI * v;
-        float w = custom_sin(phi);
-        y = scale * custom_cos(phi);
+	for (j = 0; j <= (rings + 1); j++) {
+		float v = static_cast<float>(j) / (rings + 1);
+		float phi = M_PI * v;
+		float w = _custom_sin(phi);
+		y = scale * _custom_cos(phi);
 
-        for (i = 0; i <= radial_segments; i++) {
-            float u = static_cast<float>(i) / radial_segments;
-            float theta = u * Math_TAU;
-            x = custom_sin(theta);
-            z = custom_cos(theta);
+		for (i = 0; i <= radial_segments; i++) {
+			float u = static_cast<float>(i) / radial_segments;
+			float theta = u * Math_TAU;
+			x = _custom_sin(theta);
+			z = _custom_cos(theta);
 
-            Vector3 p;
-            Vector3 normal;
+			Vector3 p;
+			Vector3 normal;
 
-            if (is_hemisphere && y < 0.0) {
-                p = remove_negative_zero_vector3(Vector3(x * radius * w, 0.0, z * radius * w));
-                normal = Vector3(0.0, -1.0, 0.0);
-            } else {
-                p = remove_negative_zero_vector3(Vector3(x * radius * w, y, z * radius * w));
-                normal = remove_negative_zero_vector3(Vector3(x * w * scale, radius * (y / scale), z * w * scale));
-                normal.normalize();
-            }
+			if (is_hemisphere && y < 0.0) {
+				p = _remove_negative_zero_vector3(Vector3(x * radius * w, 0.0, z * radius * w));
+				normal = Vector3(0.0, -1.0, 0.0);
+			} else {
+				p = _remove_negative_zero_vector3(Vector3(x * radius * w, y, z * radius * w));
+				normal = _remove_negative_zero_vector3(Vector3(x * w * scale, radius * (y / scale), z * w * scale));
+				normal.normalize();
+			}
 
-            points.push_back(p);
-            normals.push_back(normal);
-            ADD_TANGENT(remove_negative_zero(z), 0.0, remove_negative_zero(-x), 1.0)
-            uvs.push_back(Vector2(u, v));
+			points.push_back(p);
+			normals.push_back(normal);
+			ADD_TANGENT(_remove_negative_zero(z), 0.0, _remove_negative_zero(-x), 1.0)
+			uvs.push_back(Vector2(u, v));
 			if (p_add_uv2) {
 				float w_h = w * 2.0 * center_h;
 				uv2s.push_back(Vector2(center_h + ((u - 0.5) * w_h), v * height_v));

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -439,8 +439,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 			u = i;
 			u /= radial_segments;
 
-			x = -custom_sin(u * Math_TAU);
-			z = custom_cos(u * Math_TAU);
+			x = -sin(u * Math_TAU);
+			z = cos(u * Math_TAU);
 
 			Vector3 p = Vector3(x * radius * w, y, -z * radius * w);
 			points.push_back(p + Vector3(0.0, 0.5 * height - radius, 0.0));

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -992,8 +992,6 @@ void CylinderMesh::_create_mesh_array(Array &p_arr) const {
 void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments, int rings, bool cap_top, bool cap_bottom, bool p_add_uv2, const float p_uv2_padding) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z, u, v, radius, radius_h;
-	const double EPSILON = 1e-10;
-
 
 	// Only used if we calculate UV2
 	float top_circumference = top_radius * Math_PI * 2.0;


### PR DESCRIPTION
Fixes #93865 
This is my first engine contribution besides docs therefore I have only fixed the sphere mesh for now as I am sure there will be changes needed in my implementation.
- Added 4 functions including `custom_sin` , `custom_cos `, `remove_negative_zero_vector3 `and  `remove_negative_zero`
- Replaced sin and cos with custom functions for fixing the floating point error and used remove_negative_zero for standard 0 comparison 
![image](https://github.com/godotengine/godot/assets/71554089/d82baa94-dda8-421f-bc5b-d13081b5717e)
