### PR TITLE
D3D12: Get rid of `DXIL.dll`!

### DIFF
--- a/drivers/d3d12/dxil_hash.cpp
+++ b/drivers/d3d12/dxil_hash.cpp
@@ -1,0 +1,209 @@
+/**************************************************************************/
+/*  dxil_hash.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// Based on the patched public domain implementation released by Microsoft here:
+// https://github.com/microsoft/hlsl-specs/blob/main/proposals/infra/INF-0004-validator-hashing.md
+
+#include "dxil_hash.h"
+
+#include <memory.h>
+
+#define S11 7
+#define S12 12
+#define S13 17
+#define S14 22
+#define S21 5
+#define S22 9
+#define S23 14
+#define S24 20
+#define S31 4
+#define S32 11
+#define S33 16
+#define S34 23
+#define S41 6
+#define S42 10
+#define S43 15
+#define S44 21
+
+static const BYTE padding[64] = {
+	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+static void FF(UINT &a, UINT b, UINT c, UINT d, UINT x, UINT8 s, UINT ac) {
+	a += ((b & c) | (~b & d)) + x + ac;
+	a = ((a << s) | (a >> (32 - s))) + b;
+}
+
+static void GG(UINT &a, UINT b, UINT c, UINT d, UINT x, UINT8 s, UINT ac) {
+	a += ((b & d) | (c & ~d)) + x + ac;
+	a = ((a << s) | (a >> (32 - s))) + b;
+}
+
+static void HH(UINT &a, UINT b, UINT c, UINT d, UINT x, UINT8 s, UINT ac) {
+	a += (b ^ c ^ d) + x + ac;
+	a = ((a << s) | (a >> (32 - s))) + b;
+}
+
+static void II(UINT &a, UINT b, UINT c, UINT d, UINT x, UINT8 s, UINT ac) {
+	a += (c ^ (b | ~d)) + x + ac;
+	a = ((a << s) | (a >> (32 - s))) + b;
+}
+
+void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash) {
+	UINT leftOver = byteCount & 0x3f;
+	UINT padAmount;
+	bool bTwoRowsPadding = false;
+	if (leftOver < 56) {
+		padAmount = 56 - leftOver;
+	} else {
+		padAmount = 120 - leftOver;
+		bTwoRowsPadding = true;
+	}
+	UINT padAmountPlusSize = padAmount + 8;
+	UINT state[4] = { 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476 };
+	UINT N = (byteCount + padAmountPlusSize) >> 6;
+	UINT offset = 0;
+	UINT NextEndState = bTwoRowsPadding ? N - 2 : N - 1;
+	const BYTE *pCurrData = pData;
+	for (UINT i = 0; i < N; i++, offset += 64, pCurrData += 64) {
+		UINT x[16];
+		const UINT *pX;
+		if (i == NextEndState) {
+			if (!bTwoRowsPadding && i == N - 1) {
+				UINT remainder = byteCount - offset;
+				x[0] = byteCount << 3;
+				memcpy((BYTE *)x + 4, pCurrData, remainder);
+				memcpy((BYTE *)x + 4 + remainder, padding, padAmount);
+				x[15] = 1 | (byteCount << 1);
+			} else if (bTwoRowsPadding) {
+				if (i == N - 2) {
+					UINT remainder = byteCount - offset;
+					memcpy(x, pCurrData, remainder);
+					memcpy((BYTE *)x + remainder, padding, padAmount - 56);
+					NextEndState = N - 1;
+				} else if (i == N - 1) {
+					x[0] = byteCount << 3;
+					memcpy((BYTE *)x + 4, padding + padAmount - 56, 56);
+					x[15] = 1 | (byteCount << 1);
+				}
+			}
+			pX = x;
+		} else {
+			pX = (const UINT *)pCurrData;
+		}
+
+		UINT a = state[0];
+		UINT b = state[1];
+		UINT c = state[2];
+		UINT d = state[3];
+
+		/* Round 1 */
+		FF(a, b, c, d, pX[0], S11, 0xd76aa478); /* 1 */
+		FF(d, a, b, c, pX[1], S12, 0xe8c7b756); /* 2 */
+		FF(c, d, a, b, pX[2], S13, 0x242070db); /* 3 */
+		FF(b, c, d, a, pX[3], S14, 0xc1bdceee); /* 4 */
+		FF(a, b, c, d, pX[4], S11, 0xf57c0faf); /* 5 */
+		FF(d, a, b, c, pX[5], S12, 0x4787c62a); /* 6 */
+		FF(c, d, a, b, pX[6], S13, 0xa8304613); /* 7 */
+		FF(b, c, d, a, pX[7], S14, 0xfd469501); /* 8 */
+		FF(a, b, c, d, pX[8], S11, 0x698098d8); /* 9 */
+		FF(d, a, b, c, pX[9], S12, 0x8b44f7af); /* 10 */
+		FF(c, d, a, b, pX[10], S13, 0xffff5bb1); /* 11 */
+		FF(b, c, d, a, pX[11], S14, 0x895cd7be); /* 12 */
+		FF(a, b, c, d, pX[12], S11, 0x6b901122); /* 13 */
+		FF(d, a, b, c, pX[13], S12, 0xfd987193); /* 14 */
+		FF(c, d, a, b, pX[14], S13, 0xa679438e); /* 15 */
+		FF(b, c, d, a, pX[15], S14, 0x49b40821); /* 16 */
+
+		/* Round 2 */
+		GG(a, b, c, d, pX[1], S21, 0xf61e2562); /* 17 */
+		GG(d, a, b, c, pX[6], S22, 0xc040b340); /* 18 */
+		GG(c, d, a, b, pX[11], S23, 0x265e5a51); /* 19 */
+		GG(b, c, d, a, pX[0], S24, 0xe9b6c7aa); /* 20 */
+		GG(a, b, c, d, pX[5], S21, 0xd62f105d); /* 21 */
+		GG(d, a, b, c, pX[10], S22, 0x2441453); /* 22 */
+		GG(c, d, a, b, pX[15], S23, 0xd8a1e681); /* 23 */
+		GG(b, c, d, a, pX[4], S24, 0xe7d3fbc8); /* 24 */
+		GG(a, b, c, d, pX[9], S21, 0x21e1cde6); /* 25 */
+		GG(d, a, b, c, pX[14], S22, 0xc33707d6); /* 26 */
+		GG(c, d, a, b, pX[3], S23, 0xf4d50d87); /* 27 */
+		GG(b, c, d, a, pX[8], S24, 0x455a14ed); /* 28 */
+		GG(a, b, c, d, pX[13], S21, 0xa9e3e905); /* 29 */
+		GG(d, a, b, c, pX[2], S22, 0xfcefa3f8); /* 30 */
+		GG(c, d, a, b, pX[7], S23, 0x676f02d9); /* 31 */
+		GG(b, c, d, a, pX[12], S24, 0x8d2a4c8a); /* 32 */
+
+		/* Round 3 */
+		HH(a, b, c, d, pX[5], S31, 0xfffa3942); /* 33 */
+		HH(d, a, b, c, pX[8], S32, 0x8771f681); /* 34 */
+		HH(c, d, a, b, pX[11], S33, 0x6d9d6122); /* 35 */
+		HH(b, c, d, a, pX[14], S34, 0xfde5380c); /* 36 */
+		HH(a, b, c, d, pX[1], S31, 0xa4beea44); /* 37 */
+		HH(d, a, b, c, pX[4], S32, 0x4bdecfa9); /* 38 */
+		HH(c, d, a, b, pX[7], S33, 0xf6bb4b60); /* 39 */
+		HH(b, c, d, a, pX[10], S34, 0xbebfbc70); /* 40 */
+		HH(a, b, c, d, pX[13], S31, 0x289b7ec6); /* 41 */
+		HH(d, a, b, c, pX[0], S32, 0xeaa127fa); /* 42 */
+		HH(c, d, a, b, pX[3], S33, 0xd4ef3085); /* 43 */
+		HH(b, c, d, a, pX[6], S34, 0x4881d05); /* 44 */
+		HH(a, b, c, d, pX[9], S31, 0xd9d4d039); /* 45 */
+		HH(d, a, b, c, pX[12], S32, 0xe6db99e5); /* 46 */
+		HH(c, d, a, b, pX[15], S33, 0x1fa27cf8); /* 47 */
+		HH(b, c, d, a, pX[2], S34, 0xc4ac5665); /* 48 */
+
+		/* Round 4 */
+		II(a, b, c, d, pX[0], S41, 0xf4292244); /* 49 */
+		II(d, a, b, c, pX[7], S42, 0x432aff97); /* 50 */
+		II(c, d, a, b, pX[14], S43, 0xab9423a7); /* 51 */
+		II(b, c, d, a, pX[5], S44, 0xfc93a039); /* 52 */
+		II(a, b, c, d, pX[12], S41, 0x655b59c3); /* 53 */
+		II(d, a, b, c, pX[3], S42, 0x8f0ccc92); /* 54 */
+		II(c, d, a, b, pX[10], S43, 0xffeff47d); /* 55 */
+		II(b, c, d, a, pX[1], S44, 0x85845dd1); /* 56 */
+		II(a, b, c, d, pX[8], S41, 0x6fa87e4f); /* 57 */
+		II(d, a, b, c, pX[15], S42, 0xfe2ce6e0); /* 58 */
+		II(c, d, a, b, pX[6], S43, 0xa3014314); /* 59 */
+		II(b, c, d, a, pX[13], S44, 0x4e0811a1); /* 60 */
+		II(a, b, c, d, pX[4], S41, 0xf7537e82); /* 61 */
+		II(d, a, b, c, pX[11], S42, 0xbd3af235); /* 62 */
+		II(c, d, a, b, pX[2], S43, 0x2ad7d2bb); /* 63 */
+		II(b, c, d, a, pX[9], S44, 0xeb86d391); /* 64 */
+
+		state[0] += a;
+		state[1] += b;
+		state[2] += c;
+		state[3] += d;
+	}
+
+	memcpy(pOutHash, state, 16);
+}

--- a/drivers/d3d12/dxil_hash.h
+++ b/drivers/d3d12/dxil_hash.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  dxil_hash.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DXIL_HASH_H
+#define DXIL_HASH_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash);
+
+#endif // DXIL_HASH_H

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -71,10 +71,6 @@ const GUID CLSID_D3D12DeviceFactoryGodot = { 0x114863bf, 0xc386, 0x4aee, { 0xb3,
 const GUID CLSID_D3D12DebugGodot = { 0xf2352aeb, 0xdd84, 0x49fe, { 0xb9, 0x7b, 0xa9, 0xdc, 0xfd, 0xcc, 0x1b, 0x4f } };
 const GUID CLSID_D3D12SDKConfigurationGodot = { 0x7cda6aca, 0xa03e, 0x49c8, { 0x94, 0x58, 0x03, 0x34, 0xd2, 0x0e, 0x07, 0xce } };
 
-extern "C" {
-char godot_nir_arch_name[32];
-}
-
 #ifdef PIX_ENABLED
 #if defined(__GNUC__)
 #define _MSC_VER 1800
@@ -86,10 +82,7 @@ char godot_nir_arch_name[32];
 #endif
 #endif
 
-RenderingContextDriverD3D12::RenderingContextDriverD3D12() {
-	CharString cs = Engine::get_singleton()->get_architecture_name().ascii();
-	memcpy(godot_nir_arch_name, (const char *)cs.get_data(), cs.size());
-}
+RenderingContextDriverD3D12::RenderingContextDriverD3D12() {}
 
 RenderingContextDriverD3D12::~RenderingContextDriverD3D12() {
 	if (lib_d3d12) {

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -36,6 +36,7 @@
 #include "thirdparty/zlib/zlib.h"
 
 #include "d3d12_godot_nir_bridge.h"
+#include "dxil_hash.h"
 #include "rendering_context_driver_d3d12.h"
 
 // No point in fighting warnings in Mesa.
@@ -59,7 +60,6 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#include "dxil_validator.h"
 #include "nir_spirv.h"
 #include "nir_to_dxil.h"
 #include "spirv_to_dxil.h"
@@ -2867,23 +2867,6 @@ static uint32_t SHADER_STAGES_BIT_OFFSET_INDICES[RenderingDevice::SHADER_STAGE_M
 	/* SHADER_STAGE_COMPUTE */ 2,
 };
 
-dxil_validator *RenderingDeviceDriverD3D12::_get_dxil_validator_for_current_thread() {
-	MutexLock lock(dxil_mutex);
-
-	int thread_idx = WorkerThreadPool::get_singleton()->get_thread_index();
-	if (dxil_validators.has(thread_idx)) {
-		return dxil_validators[thread_idx];
-	}
-
-#ifdef DEV_ENABLED
-	print_verbose("Creating DXIL validator for worker thread index " + itos(thread_idx));
-#endif
-
-	dxil_validator *dxil_validator = dxil_create_validator(nullptr);
-	dxil_validators.insert(thread_idx, dxil_validator);
-	return dxil_validator;
-}
-
 uint32_t RenderingDeviceDriverD3D12::_shader_patch_dxil_specialization_constant(
 		PipelineSpecializationConstantType p_type,
 		const void *p_value,
@@ -3006,40 +2989,20 @@ bool RenderingDeviceDriverD3D12::_shader_apply_specialization_constants(
 		ShaderStage stage = E.key;
 		if ((stages_re_sign_mask & (1 << stage))) {
 			Vector<uint8_t> &bytecode = E.value;
-			bool sign_ok = _shader_sign_dxil_bytecode(stage, bytecode);
-			ERR_FAIL_COND_V(!sign_ok, false);
+			_shader_sign_dxil_bytecode(stage, bytecode);
 		}
 	}
 
 	return true;
 }
 
-bool RenderingDeviceDriverD3D12::_shader_sign_dxil_bytecode(ShaderStage p_stage, Vector<uint8_t> &r_dxil_blob) {
-	dxil_validator *validator = _get_dxil_validator_for_current_thread();
-	if (!validator) {
-		if (is_in_developer_mode()) {
-			return true;
-		} else {
-			OS::get_singleton()->alert("Shader validation failed: DXIL.dll was not found, and developer mode is disabled.\n\nClick OK to exit.");
-			CRASH_NOW();
-		}
-	}
-
-	char *err = nullptr;
-	bool res = dxil_validate_module(validator, r_dxil_blob.ptrw(), r_dxil_blob.size(), &err);
-	if (!res) {
-		if (err) {
-			ERR_FAIL_COND_V_MSG(!res, false, "Shader signing invocation at stage " + String(SHADER_STAGE_NAMES[p_stage]) + " failed:\n" + String(err));
-		} else {
-			ERR_FAIL_COND_V_MSG(!res, false, "Shader signing invocation at stage " + String(SHADER_STAGE_NAMES[p_stage]) + " failed.");
-		}
-	}
-
-	return true;
+void RenderingDeviceDriverD3D12::_shader_sign_dxil_bytecode(ShaderStage p_stage, Vector<uint8_t> &r_dxil_blob) {
+	uint8_t *w = r_dxil_blob.ptrw();
+	compute_dxil_hash(w + 20, r_dxil_blob.size() - 20, w + 4);
 }
 
 String RenderingDeviceDriverD3D12::shader_get_binary_cache_key() {
-	return "D3D12-SV" + uitos(ShaderBinary::VERSION) + "-" + itos(shader_capabilities.shader_model) + (is_in_developer_mode() ? "dev" : "");
+	return "D3D12-SV" + uitos(ShaderBinary::VERSION) + "-" + itos(shader_capabilities.shader_model);
 }
 
 Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(VectorView<ShaderStageSPIRVData> p_spirv, const String &p_shader_name) {
@@ -3307,10 +3270,7 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 			nir_to_dxil_options nir_to_dxil_options = {};
 			nir_to_dxil_options.environment = DXIL_ENVIRONMENT_VULKAN;
 			nir_to_dxil_options.shader_model_max = shader_model_d3d_to_dxil(shader_capabilities.shader_model);
-			dxil_validator *validator = _get_dxil_validator_for_current_thread();
-			if (validator) {
-				nir_to_dxil_options.validator_version_max = dxil_get_validator_version(validator);
-			}
+			nir_to_dxil_options.validator_version_max = NO_DXIL_VALIDATION;
 			nir_to_dxil_options.godot_nir_callbacks = &godot_nir_callbacks;
 
 			dxil_logger logger = {};
@@ -3361,8 +3321,7 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 	for (KeyValue<ShaderStage, Vector<uint8_t>> &E : dxil_blobs) {
 		ShaderStage stage = E.key;
 		Vector<uint8_t> &dxil_blob = E.value;
-		bool sign_ok = _shader_sign_dxil_bytecode(stage, dxil_blob);
-		ERR_FAIL_COND_V(!sign_ok, Vector<uint8_t>());
+		_shader_sign_dxil_bytecode(stage, dxil_blob);
 	}
 
 	// Build the root signature.
@@ -6287,15 +6246,6 @@ RenderingDeviceDriverD3D12::RenderingDeviceDriverD3D12(RenderingContextDriverD3D
 }
 
 RenderingDeviceDriverD3D12::~RenderingDeviceDriverD3D12() {
-	{
-		MutexLock lock(dxil_mutex);
-		for (const KeyValue<int, dxil_validator *> &E : dxil_validators) {
-			if (E.value) {
-				dxil_destroy_validator(E.value);
-			}
-		}
-	}
-
 	glsl_type_singleton_decref();
 }
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -79,7 +79,6 @@ using Microsoft::WRL::ComPtr;
 #define CUSTOM_INFO_QUEUE_ENABLED 0
 #endif
 
-struct dxil_validator;
 class RenderingContextDriverD3D12;
 
 // Design principles:
@@ -692,10 +691,6 @@ private:
 		uint32_t root_signature_crc = 0;
 	};
 
-	Mutex dxil_mutex;
-	HashMap<int, dxil_validator *> dxil_validators; // One per WorkerThreadPool thread used for shader compilation, plus one (-1) for all the other.
-
-	dxil_validator *_get_dxil_validator_for_current_thread();
 	uint32_t _shader_patch_dxil_specialization_constant(
 			PipelineSpecializationConstantType p_type,
 			const void *p_value,
@@ -706,7 +701,7 @@ private:
 			const ShaderInfo *p_shader_info,
 			VectorView<PipelineSpecializationConstant> p_specialization_constants,
 			HashMap<ShaderStage, Vector<uint8_t>> &r_final_stages_bytecode);
-	bool _shader_sign_dxil_bytecode(ShaderStage p_stage, Vector<uint8_t> &r_dxil_blob);
+	void _shader_sign_dxil_bytecode(ShaderStage p_stage, Vector<uint8_t> &r_dxil_blob);
 
 public:
 	virtual String shader_get_binary_cache_key() override final;

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -25,12 +25,6 @@ if deps_folder:
 else:
     deps_folder = os.path.join("bin", "build_deps")
 
-# DirectX Shader Compiler
-# Check for latest version: https://github.com/microsoft/DirectXShaderCompiler/releases/latest
-dxc_version = "v1.8.2403.2"
-dxc_filename = "dxc_2024_03_29.zip"
-dxc_archive = os.path.join(deps_folder, dxc_filename)
-dxc_folder = os.path.join(deps_folder, "dxc")
 # Mesa NIR
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
 mesa_version = "23.1.9"
@@ -54,25 +48,8 @@ agility_sdk_folder = os.path.join(deps_folder, "agility_sdk")
 if not os.path.exists(deps_folder):
     os.makedirs(deps_folder)
 
-# DirectX Shader Compiler
-print("\x1b[1m[1/4] DirectX Shader Compiler\x1b[0m")
-if os.path.isfile(dxc_archive):
-    os.remove(dxc_archive)
-print(f"Downloading DirectX Shader Compiler {dxc_filename} ...")
-urllib.request.urlretrieve(
-    f"https://github.com/microsoft/DirectXShaderCompiler/releases/download/{dxc_version}/{dxc_filename}",
-    dxc_archive,
-)
-if os.path.exists(dxc_folder):
-    print(f"Removing existing local DirectX Shader Compiler installation in {dxc_folder} ...")
-    shutil.rmtree(dxc_folder)
-print(f"Extracting DirectX Shader Compiler {dxc_filename} to {dxc_folder} ...")
-shutil.unpack_archive(dxc_archive, dxc_folder)
-os.remove(dxc_archive)
-print(f"DirectX Shader Compiler {dxc_filename} installed successfully.\n")
-
 # Mesa NIR
-print("\x1b[1m[2/4] Mesa NIR\x1b[0m")
+print("\x1b[1m[1/3] Mesa NIR\x1b[0m")
 if os.path.isfile(mesa_archive):
     os.remove(mesa_archive)
 print(f"Downloading Mesa NIR {mesa_filename} ...")
@@ -99,7 +76,7 @@ if dlltool == "":
     dlltool = shutil.which("x86_64-w64-mingw32-dlltool") or ""
 has_mingw = gendef != "" and dlltool != ""
 
-print("\x1b[1m[3/4] WinPixEventRuntime\x1b[0m")
+print("\x1b[1m[2/3] WinPixEventRuntime\x1b[0m")
 if os.path.isfile(pix_archive):
     os.remove(pix_archive)
 print(f"Downloading WinPixEventRuntime {pix_version} ...")
@@ -130,7 +107,7 @@ else:
 print(f"WinPixEventRuntime {pix_version} installed successfully.\n")
 
 # DirectX 12 Agility SDK
-print("\x1b[1m[4/4] DirectX 12 Agility SDK\x1b[0m")
+print("\x1b[1m[3/3] DirectX 12 Agility SDK\x1b[0m")
 if os.path.isfile(agility_sdk_archive):
     os.remove(agility_sdk_archive)
 print(f"Downloading DirectX 12 Agility SDK {agility_sdk_version} ...")

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -108,18 +108,6 @@ if env["d3d12"]:
     # Used in cases where we can have multiple archs side-by-side.
     arch_bin_dir = "#bin/" + env["arch"]
 
-    # DXC
-    if env["dxc_path"] != "" and os.path.exists(env["dxc_path"]):
-        dxc_dll = "dxil.dll"
-        # Whether this one is loaded from arch-specific directory or not can be determined at runtime.
-        # Let's copy to both and let the user decide the distribution model.
-        for v in ["#bin", arch_bin_dir]:
-            env.Command(
-                v + "/" + dxc_dll,
-                env["dxc_path"] + "/bin/" + dxc_arch_subdir + "/" + dxc_dll,
-                Copy("$TARGET", "$SOURCE"),
-            )
-
     # Agility SDK
     if env["agility_sdk_path"] != "" and os.path.exists(env["agility_sdk_path"]):
         agility_dlls = ["D3D12Core.dll", "d3d12SDKLayers.dll"]

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -214,11 +214,6 @@ def get_opts():
             os.path.join(d3d12_deps_folder, "mesa"),
         ),
         (
-            "dxc_path",
-            "Path to the DirectX Shader Compiler distribution (required for D3D12)",
-            os.path.join(d3d12_deps_folder, "dxc"),
-        ),
-        (
             "agility_sdk_path",
             "Path to the Agility SDK distribution (optional for D3D12)",
             os.path.join(d3d12_deps_folder, "agility_sdk"),

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -26,7 +26,7 @@
 			If set to [code]1[/code], ANGLE libraries are exported with the exported application. If set to [code]0[/code], ANGLE libraries are exported only if [member ProjectSettings.rendering/gl_compatibility/driver] is set to [code]"opengl3_angle"[/code].
 		</member>
 		<member name="application/export_d3d12" type="int" setter="" getter="">
-			If set to [code]1[/code], Direct3D 12 runtime (DXIL, Agility SDK, PIX) libraries are exported with the exported application. If set to [code]0[/code], Direct3D 12 libraries are exported only if [member ProjectSettings.rendering/rendering_device/driver] is set to [code]"d3d12"[/code].
+			If set to [code]1[/code], the Direct3D 12 runtime libraries (Agility SDK, PIX) are exported with the exported application. If set to [code]0[/code], Direct3D 12 libraries are exported only if [member ProjectSettings.rendering/rendering_device/driver] is set to [code]"d3d12"[/code].
 		</member>
 		<member name="application/file_description" type="String" setter="" getter="">
 			File description to be presented to users. Required. See [url=https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block]StringFileInfo[/url].

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -208,18 +208,14 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 
 	int export_d3d12 = p_preset->get("application/export_d3d12");
 	bool agility_sdk_multiarch = p_preset->get("application/d3d12_agility_sdk_multiarch");
-	bool include_dxil_libs = false;
+	bool include_d3d12_extra_libs = false;
 	if (export_d3d12 == 0) {
-		include_dxil_libs = (String(GLOBAL_GET("rendering/rendering_device/driver.windows")) == "d3d12") && (String(GLOBAL_GET("rendering/renderer/rendering_method")) != "gl_compatibility");
+		include_d3d12_extra_libs = (String(GLOBAL_GET("rendering/rendering_device/driver.windows")) == "d3d12") && (String(GLOBAL_GET("rendering/renderer/rendering_method")) != "gl_compatibility");
 	} else if (export_d3d12 == 1) {
-		include_dxil_libs = true;
+		include_d3d12_extra_libs = true;
 	}
-	if (include_dxil_libs) {
+	if (include_d3d12_extra_libs) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (da->file_exists(template_path.get_base_dir().path_join("dxil." + arch + ".dll"))) {
-			da->make_dir_recursive(p_path.get_base_dir().path_join(arch));
-			da->copy(template_path.get_base_dir().path_join("dxil." + arch + ".dll"), p_path.get_base_dir().path_join(arch).path_join("dxil.dll"), get_chmod_flags());
-		}
 		if (da->file_exists(template_path.get_base_dir().path_join("D3D12Core." + arch + ".dll"))) {
 			if (agility_sdk_multiarch) {
 				da->make_dir_recursive(p_path.get_base_dir().path_join(arch));


### PR DESCRIPTION
This finally allows Godot editor and games to ship with Direct3D 12 without any separate library.

This is thanks to https://devblogs.microsoft.com/directx/open-sourcing-dxil-validator-hash/.

- Partners with https://github.com/godotengine/godot-nir-static/pull/15.
- **UPDATE:** Partners with https://github.com/godotengine/godot-docs/pull/9593.

**UPDATE:** Testing procedure: clearing the shader cache of a project, disabling dev mode on Windows, patching code to generate wrong hashes and verify D3D12 complains, taking code back to normal, clearing shader cache again and verifying the game works with shaders and all.