### PR TITLE
Fix leftover unmatched benchmark end

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2516,7 +2516,6 @@ error:
 		memdelete(message_queue);
 	}
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Core");
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup");
 
 #if defined(STEAMAPI_ENABLED)


### PR DESCRIPTION
* Closes: https://github.com/godotengine/godot/issues/94202

Leftover from:
* https://github.com/godotengine/godot/pull/93933

To confirm, just check the CI unit test runs, they will no longer show the error, unlike the current `master`
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
