### PR TITLE
Clean up RenderDataExtension's descriptions

### DIFF
--- a/doc/classes/RenderDataExtension.xml
+++ b/doc/classes/RenderDataExtension.xml
@@ -12,24 +12,25 @@
 		<method name="_get_camera_attributes" qualifiers="virtual const">
 			<return type="RID" />
 			<description>
-				Implement this in GDExtension to return the [RID] for the implementations camera attributes object.
+				Implement this in GDExtension to return the [RID] for the implementation's camera attributes object.
 			</description>
 		</method>
 		<method name="_get_environment" qualifiers="virtual const">
 			<return type="RID" />
 			<description>
+				Implement this in GDExtension to return the [RID] of the implementation's environment object.
 			</description>
 		</method>
 		<method name="_get_render_scene_buffers" qualifiers="virtual const">
 			<return type="RenderSceneBuffers" />
 			<description>
-				Implement this in GDExtension to return the [RID] of the implementations environment object.
+				Implement this in GDExtension to return the implementation's [RenderSceneBuffers] object.
 			</description>
 		</method>
 		<method name="_get_render_scene_data" qualifiers="virtual const">
 			<return type="RenderSceneData" />
 			<description>
-				Implement this in GDExtension to return the implementations [RenderSceneDataExtension] object.
+				Implement this in GDExtension to return the implementation's [RenderSceneDataExtension] object.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
This PR does 3 things:
First, the description of "_get_render_scene_buffers" was clearly meant to be for "_get_environment", so I moved that description to the right spot.
Second, I added a new description for "_get_render_scene_buffers" based on the descriptions of the other methods.
Third, I added apostrophes to all instances of "implementations".
Hope this helps!