### PR TITLE
Windows: Try harder to use the best native window icon

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -297,6 +297,8 @@ typedef struct {
 	ICONDIRENTRY idEntries[1]; // An entry for each image (idCount of 'em)
 } ICONDIR, *LPICONDIR;
 
+class WindowsNativeIcons;
+
 class DisplayServerWindows : public DisplayServer {
 	// No need to register with GDCLASS, it's platform-specific and nothing is added.
 
@@ -459,7 +461,7 @@ class DisplayServerWindows : public DisplayServer {
 	HHOOK mouse_monitor = nullptr;
 	List<WindowID> popup_list;
 	uint64_t time_since_popup = 0;
-	Ref<Image> icon;
+	WindowsNativeIcons *native_icons = nullptr;
 
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect);
 	WindowID window_id_counter = MAIN_WINDOW_ID;
@@ -519,6 +521,8 @@ class DisplayServerWindows : public DisplayServer {
 
 	LRESULT _handle_early_window_message(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	Point2i _get_screens_origin() const;
+
+	void _update_icon();
 
 	enum class WinKeyModifierMask {
 		ALT_GR = (1 << 1),


### PR DESCRIPTION
For `set_native_icon`, instead of loading only the 16px and the largest icon, it now loads all sizes available in the icon file. We handle `WM_GETICON` to provide the best candidate icon, taking into account the requested DPI.

For `set_icon`, the behaviour is unchanged -- the icon is scaled to 32px (multiplied by DPI scaling).

Also took the opportunity to consolidate some duplicated icon conversion code.

---

I used a hack when calculating the big icon size on Windows 10 and above in order to match the taskbar icon size. (See https://github.com/tringi/win32-dpi/blob/master/README.md)

I encountered some weird behaviour when testing with the Project Manager (calling `set_native_icon` from main.cpp) -- for reason I cannot explain Windows decides to use only the small icon for the taskbar. It doesn't happen when running a project though. Needs more testing by others, especially on Windows 11. (I only tested on Windows 10.)

Fixes #85864

CC @bruvzg
