### PR TITLE
Bring back `engine_version` property to VisualShader

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -187,6 +187,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="engine_version" type="Dictionary" setter="set_engine_version" getter="get_engine_version" default="{}">
+			The Godot version this [VisualShader] was designed for, in the form of a [Dictionary] with [code]major[/code] and [code]minor[/code] keys with integer values. Example: [code]{"major": 4, "minor": 3}[/code]
+			This is used by the editor to convert visual shaders from older Godot versions.
+		</member>
 		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
 			The offset vector of the whole graph.
 		</member>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1526,6 +1526,24 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 		visual_shader->set_graph_offset(graph->get_scroll_offset() / EDSCALE);
 		_set_mode(visual_shader->get_mode());
 
+#ifndef DISABLE_DEPRECATED
+		Dictionary engine_version = Engine::get_singleton()->get_version_info();
+		const Dictionary vs_version = visual_shader->get_engine_version();
+
+		if (vs_version.is_empty()) {
+			visual_shader->update_engine_version(engine_version);
+		} else {
+			LocalVector<String> components = { "major", "minor" };
+			for (const String &component : components) {
+				if ((int)vs_version.get(component, 0) != (int)engine_version.get(component, 0)) {
+					visual_shader->update_engine_version(engine_version);
+					print_line(vformat(TTR("The shader (\"%s\") has been updated to correspond Godot %s.%s version."), visual_shader->get_path(), engine_version["major"], engine_version["minor"]));
+					break;
+				}
+			}
+		}
+#endif
+
 		_update_nodes();
 	} else {
 		if (visual_shader.is_valid()) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -832,6 +832,41 @@ VisualShader::Type VisualShader::get_shader_type() const {
 	return current_type;
 }
 
+void VisualShader::set_engine_version(const Dictionary &p_engine_version) {
+	ERR_FAIL_COND(!p_engine_version.has("major"));
+	ERR_FAIL_COND(!p_engine_version.has("minor"));
+	engine_version["major"] = p_engine_version["major"];
+	engine_version["minor"] = p_engine_version["minor"];
+}
+
+Dictionary VisualShader::get_engine_version() const {
+	return engine_version;
+}
+
+#ifndef DISABLE_DEPRECATED
+
+void VisualShader::update_engine_version(const Dictionary &p_new_version) {
+	/* Uncomment when its needed.
+	int old_major = engine_version.get("major", 0);
+	int old_minor = engine_version.get("minor", 0);
+
+	int new_major = p_new_version.get("major", 0);
+	int new_minor = p_new_version.get("minor", 0);
+
+
+	if ((old_major == 0 || old_major == 4) && (old_minor == 0 || old_minor == 3) && (new_major >= 4 && new_minor >= 4)) {
+		for (int i = 0; i < TYPE_MAX; i++) {
+			for (KeyValue<int, Node> &E : graph[i].nodes) {
+			}
+		}
+	}
+	*/
+
+	set_engine_version(p_new_version);
+}
+
+#endif /* DISABLE_DEPRECATED */
+
 void VisualShader::add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) {
 	ERR_FAIL_COND(!p_name.is_valid_identifier());
 	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
@@ -2912,6 +2947,9 @@ void VisualShader::rebuild() {
 void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &VisualShader::set_mode);
 
+	ClassDB::bind_method(D_METHOD("set_engine_version", "version"), &VisualShader::set_engine_version);
+	ClassDB::bind_method(D_METHOD("get_engine_version"), &VisualShader::get_engine_version);
+
 	ClassDB::bind_method(D_METHOD("add_node", "type", "node", "position", "id"), &VisualShader::add_node);
 	ClassDB::bind_method(D_METHOD("get_node", "type", "id"), &VisualShader::get_node);
 
@@ -2946,6 +2984,7 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_graph_offset", "get_graph_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "engine_version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_engine_version", "get_engine_version");
 
 	ADD_PROPERTY_DEFAULT("code", ""); // Inherited from Shader, prevents showing default code as override in docs.
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -42,7 +42,7 @@ class VisualShaderNode;
 class VisualShader : public Shader {
 	GDCLASS(VisualShader, Shader);
 
-	friend class VisualShaderNodeVersionChecker;
+	Dictionary engine_version;
 
 public:
 	enum Type {
@@ -176,6 +176,13 @@ protected:
 	virtual void reset_state() override;
 
 public: // internal methods
+	void set_engine_version(const Dictionary &p_version);
+	Dictionary get_engine_version() const;
+
+#ifndef DISABLE_DEPRECATED
+	void update_engine_version(const Dictionary &p_new_version);
+#endif /* DISABLE_DEPRECATED */
+
 	void set_shader_type(Type p_type);
 	Type get_shader_type() const;
 


### PR DESCRIPTION
I think we need to take a decision to bring it back, because otherwise we cannot track the version and do the updates on user shaders when compatibility going to breach. Should be merged to 4.3.

- Reverts https://github.com/godotengine/godot/pull/61888