### PR TITLE
Optimize `Node::is_readable_from_caller_thread()` by prioritizing the most common case

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -596,7 +596,7 @@ public:
 			// No thread processing.
 			// Only accessible if node is outside the scene tree
 			// or access will happen from a node-safe thread.
-			return is_current_thread_safe_for_nodes() || !data.inside_tree;
+			return is_current_thread_safe_for_nodes() || unlikely(!data.inside_tree);
 		} else {
 			// Thread processing.
 			return true;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -596,7 +596,7 @@ public:
 			// No thread processing.
 			// Only accessible if node is outside the scene tree
 			// or access will happen from a node-safe thread.
-			return !data.inside_tree || is_current_thread_safe_for_nodes();
+			return is_current_thread_safe_for_nodes() || !data.inside_tree;
 		} else {
 			// Thread processing.
 			return true;


### PR DESCRIPTION
## Perf: Optimize Node::is_readable_from_caller_thread() for common case

This PR aims to reduce CPU usage within the `Node::is_readable_from_caller_thread()` method, which is frequently called by node property accessors like `Node3D::get_position()`.

Profiling revealed very high CPU usage inside `Node3d::get_position()`. This PR reorders the conditions to prioritize the most common case where current thread is safe. 

### Benchmarks

This optimization leads to a significant reduction in CPU usage within the `Node3D::get_position()` method.

**Before:**

![image](https://github.com/godotengine/godot/assets/19844144/6f377e5a-715e-421d-b81a-7781cfa57218)

**After:**

![image](https://github.com/godotengine/godot/assets/19844144/c1601ba1-750e-4e52-84a5-86ad0c576a15)

This change should improve performance, especially in scenes with frequent node property access. 

### Testing

Tested locally with a scene that contains 20K cubes, all of them were moving around.
Profiled application before and after my change. Initial implementation was causing 5.54% of CPU usage on my laptop. Optimized version is using 1.12% of CPU.

Link to the test project: https://github.com/CrazyRoka/godot-benchmark-moving-cubes/tree/main
