### PR TITLE
Lightmapper: Ensure the atlas is big enough to fit padded UV maps

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -233,7 +233,7 @@ Lightmapper::BakeError LightmapperRD::_blit_meshes_into_atlas(int p_max_texture_
 		MeshInstance &mi = mesh_instances.write[m_i];
 		Size2i s = Size2i(mi.data.albedo_on_uv2->get_width(), mi.data.albedo_on_uv2->get_height());
 		sizes.push_back(s);
-		atlas_size = atlas_size.max(s + Size2i(2, 2));
+		atlas_size = atlas_size.max(s + Size2i(2, 2).maxi(p_denoiser_range));
 	}
 
 	int max = nearest_power_of_2_templated(atlas_size.width);


### PR DESCRIPTION
Fixes #94216

Ensures the lightmap atlas has enough space to fit the padded mesh UV maps.