### PR TITLE
Make errors on `RefCounted.free()` more accurate

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -763,7 +763,7 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 		}
 		if (is_ref_counted()) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-			ERR_FAIL_V_MSG(Variant(), "Can't 'free' a reference.");
+			ERR_FAIL_V_MSG(Variant(), "Can't free a RefCounted object.");
 		}
 
 		if (_lock_index.get() > 1) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1794,7 +1794,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else if (methodstr == "free") {
 						if (err.error == Callable::CallError::CALL_ERROR_INVALID_METHOD) {
 							if (base->is_ref_counted()) {
-								err_text = "Attempted to free a reference.";
+								err_text = "Attempted to free a RefCounted object.";
 								OPCODE_BREAK;
 							} else if (base->get_type() == Variant::OBJECT) {
 								err_text = "Attempted to free a locked object (calling or emitting).";
@@ -1885,7 +1885,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else if (methodstr == "free") {
 						if (err.error == Callable::CallError::CALL_ERROR_INVALID_METHOD) {
 							if (base->is_ref_counted()) {
-								err_text = "Attempted to free a reference.";
+								err_text = "Attempted to free a RefCounted object.";
 								OPCODE_BREAK;
 							} else if (base->get_type() == Variant::OBJECT) {
 								err_text = "Attempted to free a locked object (calling or emitting).";


### PR DESCRIPTION
When attempting to call `free()` on a `RefCounted` object, GDScript complains that you have tried to free "a reference."

`Reference` was renamed to `RefCounted` in Godot 4. Therefore, the wording warrants an update, for consistency and clarity.