### PR TITLE
Optimize `Object::notification` method performance

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -863,16 +863,25 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 void Object::notification(int p_notification, bool p_reversed) {
 	if (p_reversed) {
+		_notification_fast<true>(p_notification);
+	} else {
+		_notification_fast<false>(p_notification);
+	}
+}
+
+template <bool t_reversed>
+void Object::_notification_fast(int p_notification) {
+	if constexpr (t_reversed) {
 		if (script_instance) {
-			script_instance->notification(p_notification, p_reversed);
+			script_instance->notification(p_notification, t_reversed);
 		}
 	} else {
-		_notificationv(p_notification, p_reversed);
+		_notificationv(p_notification, t_reversed);
 	}
 
 	if (_extension) {
 		if (_extension->notification2) {
-			_extension->notification2(_extension_instance, p_notification, static_cast<GDExtensionBool>(p_reversed));
+			_extension->notification2(_extension_instance, p_notification, static_cast<GDExtensionBool>(t_reversed));
 #ifndef DISABLE_DEPRECATED
 		} else if (_extension->notification) {
 			_extension->notification(_extension_instance, p_notification);
@@ -880,11 +889,11 @@ void Object::notification(int p_notification, bool p_reversed) {
 		}
 	}
 
-	if (p_reversed) {
-		_notificationv(p_notification, p_reversed);
+	if constexpr (t_reversed) {
+		_notificationv(p_notification, t_reversed);
 	} else {
 		if (script_instance) {
-			script_instance->notification(p_notification, p_reversed);
+			script_instance->notification(p_notification, t_reversed);
 		}
 	}
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -676,6 +676,9 @@ private:
 
 	Object(bool p_reference);
 
+	template <bool t_reversed>
+	void _notification_fast(int p_notification);
+
 protected:
 	_FORCE_INLINE_ bool _instance_binding_reference(bool p_reference) {
 		bool can_die = true;


### PR DESCRIPTION
# Revision 1
## Optimize Object::notification method performance

This PR optimizes the `Object::notification()` function by splitting it into two specialized functions: `notification_forward()` and `notification_reverse()`. This change significantly reduces the CPU usage of this frequently called function.

Key changes:
- Split `Object::notification()` into `notification_forward()` and `notification_reverse()`
- Update `notification()` to act as a simple dispatcher to the appropriate specialized function

# Revision 2
## Refactor Object::notification using if constexpr and templates

Key changes:
- Implemented the optimization using C++17's `if constexpr` and template specialization.
- The compiler now generates separate, optimized code paths for reversed and non-reversed cases.

### Before
Before: 5.7% CPU usage inside Object::notification(). Hotspot is referring to [this line](https://github.com/godotengine/godot/blob/e55db9009973f5315bfd235273b3c1323deb7f10/core/object/object.cpp#L837).

![image](https://github.com/user-attachments/assets/11fd7080-939a-4265-a900-20a8247130a0)

### After
After: 1.49% CPU usage inside Object::_notification_fast()

![image](https://github.com/user-attachments/assets/4dd189b5-1b3e-4d90-9df1-bfdaeda383db)

---

![image](https://github.com/user-attachments/assets/229af564-37df-4762-81b4-6c6adaf12bc0)

This optimization results in a significant reduction in CPU usage for this function.

The performance improvement is achieved by:
1. Eliminating conditional branching within the function
2. Allowing better compiler optimizations for each specialized case
3. Improving code locality and potential for inlining

### Testing
Tested locally with a scene that contains 20K cubes, all of them were moving around.
Link to the test project: https://github.com/CrazyRoka/godot-benchmark-moving-cubes/tree/main