### PR TITLE
Optimize base and shadow meshes for vertex cache

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2544,6 +2544,8 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 					}
 				}
 
+				src_mesh_node->get_mesh()->optimize_indices_for_cache();
+
 				if (generate_lods) {
 					Array skin_pose_transform_array = _get_skinned_pose_transforms(src_mesh_node);
 					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle, skin_pose_transform_array, raycast_normals);

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -256,6 +256,33 @@ void ImporterMesh::set_surface_material(int p_surface, const Ref<Material> &p_ma
 	mesh.unref();
 }
 
+void ImporterMesh::optimize_indices_for_cache() {
+	if (!SurfaceTool::optimize_vertex_cache_func) {
+		return;
+	}
+
+	for (int i = 0; i < surfaces.size(); i++) {
+		if (surfaces[i].primitive != Mesh::PRIMITIVE_TRIANGLES) {
+			continue;
+		}
+
+		Vector<Vector3> vertices = surfaces[i].arrays[RS::ARRAY_VERTEX];
+		PackedInt32Array indices = surfaces[i].arrays[RS::ARRAY_INDEX];
+
+		unsigned int index_count = indices.size();
+		unsigned int vertex_count = vertices.size();
+
+		if (index_count == 0) {
+			continue;
+		}
+
+		int *indices_ptr = indices.ptrw();
+		SurfaceTool::optimize_vertex_cache_func((unsigned int *)indices_ptr, (const unsigned int *)indices_ptr, index_count, vertex_count);
+
+		surfaces.write[i].arrays[RS::ARRAY_INDEX] = indices;
+	}
+}
+
 #define VERTEX_SKIN_FUNC(bone_count, vert_idx, read_array, write_array, transform_array, bone_array, weight_array) \
 	Vector3 transformed_vert;                                                                                      \
 	for (unsigned int weight_idx = 0; weight_idx < bone_count; weight_idx++) {                                     \
@@ -822,6 +849,10 @@ void ImporterMesh::create_shadow_mesh() {
 				index_wptr[j] = vertex_remap[index];
 			}
 
+			if (SurfaceTool::optimize_vertex_cache_func) {
+				SurfaceTool::optimize_vertex_cache_func((unsigned int *)index_wptr, (const unsigned int *)index_wptr, index_count, new_vertices.size());
+			}
+
 			new_surface[RS::ARRAY_INDEX] = new_indices;
 
 			// Make sure the same LODs as the full version are used.
@@ -838,6 +869,10 @@ void ImporterMesh::create_shadow_mesh() {
 					int index = index_rptr[k];
 					ERR_FAIL_INDEX(index, vertex_count);
 					index_wptr[k] = vertex_remap[index];
+				}
+
+				if (SurfaceTool::optimize_vertex_cache_func) {
+					SurfaceTool::optimize_vertex_cache_func((unsigned int *)index_wptr, (const unsigned int *)index_wptr, index_count, new_vertices.size());
 				}
 
 				lods[surfaces[i].lods[j].distance] = new_indices;

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -114,6 +114,8 @@ public:
 
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 
+	void optimize_indices_for_cache();
+
 	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle, Array p_skin_pose_transform_array, bool p_raycast_normals = false);
 
 	void create_shadow_mesh();


### PR DESCRIPTION
Previously, vertex cache optimization was ran for the LOD meshes, but was never ran for the base mesh or for the shadow meshes, including shadow LOD chain (shadow LOD chain would sometimes get implicitly optimized for vertex cache as a byproduct of base LOD optimization, but not always). This could significantly affect the rendering performance of geometry heavy scenes, especially for depth or shadow passes where the fragment load is light.

This PR unconditionally runs the optimization for base mesh before further processing, and for any generated shadow index buffers; if meshoptimizer module is not loaded, we silently skip the processing. Note that this is the same algorithm we already use for LOD index buffers.

I generally treat this optimization as "always on, do no harm" - it only changes the order of triangles, which is generally speaking indeterminate on import, and is fairly quick. For a sense of scale, this is ~6x faster than tangent generation, ~25x faster than LOD generation (before my previous optimization PR, so maybe ~10x after?), and consequently should not change the import time much. I've tested this with DragonAttenuation model (https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/DragonAttenuation) and didn't see overall import time change in a statistically measurable way. The appearance of any model should be the same, this only changes the submitted triangle order within each mesh, which has no impact on opaque meshes and should not make transparent meshes worse in that the order of triangles on them could not be relied upon anyway.

![image](https://github.com/user-attachments/assets/ee4fea69-510b-4e97-bd17-e06a5bc0091a)

As any hardware performance optimization, this is hard to measure well. On a scene with 28 clones of the model above, with some objects closer to camera (LOD 0) and some further away, my aggregate measurements on NVidia RTX 4090 make that scene ~17% faster in terms of full frame time to render. Most of the gains are just from the shadow mesh optimization (it's something like 11% for shadow mesh optimization and 6% extra on top from base mesh optimization) - depth pre-pass and shadow passes tend to be vertex/raster bound, and the shadow mesh is rendered multiple times, so that makes sense. Note that other meshes may display no performance gains (for example, if a mesh is fairly low-poly, or if the scene has been preprocessed with tools like [gltfpack](https://github.com/zeux/meshoptimizer/tree/master/gltf#-gltfpack) that generate optimal order, the gains will be small to non-existent), and could also display larger performance gains (as the original order can be more pathologically bad depending on the exporter). Realistically I would not expect a double digit performance improvement here on any realistic scenes, but the gains are free.

![image](https://github.com/user-attachments/assets/e8f6fa8b-023e-4575-872c-7a52b37f50db)

The measurements quoted above are with VSync disabled using full frame FPS, if we measure the GPU time on the individual passes (using Godot's Visual Profiler), the relative gains are more significant - note that I'm using the numbers as displayed by the profiler (2 decimal digits), my GPU is clearly too fast for this :stuck_out_tongue_closed_eyes::

Pass | Time (Before) | Time (After) | Improvement (%) |
-|-|-|-
Depth Pre-Pass | 0.09 ms | 0.06 ms | ~33% |
Shadows | 0.12 ms | 0.09 ms | ~25% |
Opaque Pass | 0.18 ms | 0.15 ms | ~16% |
(Total) 3D Scene | 0.44 ms | 0.34 ms | ~22%
