### PR TITLE
Fix AStar2D, AStar3D, AStarGrid2D from not returning a path when the destination is disabled/solid even with `allow_partial_path` option

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -319,11 +319,11 @@ Vector3 AStar3D::get_closest_position_in_segment(const Vector3 &p_point) const {
 	return closest_point;
 }
 
-bool AStar3D::_solve(Point *begin_point, Point *end_point) {
+bool AStar3D::_solve(Point *begin_point, Point *end_point, bool p_allow_partial_path) {
 	last_closest_point = nullptr;
 	pass++;
 
-	if (!end_point->enabled) {
+	if (!end_point->enabled && !p_allow_partial_path) {
 		return false;
 	}
 
@@ -443,7 +443,7 @@ Vector<Vector3> AStar3D::get_point_path(int64_t p_from_id, int64_t p_to_id, bool
 	Point *begin_point = a;
 	Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || last_closest_point == nullptr) {
 			return Vector<Vector3>();
@@ -497,7 +497,7 @@ Vector<int64_t> AStar3D::get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_
 	Point *begin_point = a;
 	Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || last_closest_point == nullptr) {
 			return Vector<int64_t>();
@@ -726,7 +726,7 @@ Vector<Vector2> AStar2D::get_point_path(int64_t p_from_id, int64_t p_to_id, bool
 	AStar3D::Point *begin_point = a;
 	AStar3D::Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || astar.last_closest_point == nullptr) {
 			return Vector<Vector2>();
@@ -780,7 +780,7 @@ Vector<int64_t> AStar2D::get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_
 	AStar3D::Point *begin_point = a;
 	AStar3D::Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || astar.last_closest_point == nullptr) {
 			return Vector<int64_t>();
@@ -816,11 +816,11 @@ Vector<int64_t> AStar2D::get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_
 	return path;
 }
 
-bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point) {
+bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, bool p_allow_partial_path) {
 	astar.last_closest_point = nullptr;
 	astar.pass++;
 
-	if (!end_point->enabled) {
+	if (!end_point->enabled && !p_allow_partial_path) {
 		return false;
 	}
 

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -115,7 +115,7 @@ class AStar3D : public RefCounted {
 	HashSet<Segment, Segment> segments;
 	Point *last_closest_point = nullptr;
 
-	bool _solve(Point *begin_point, Point *end_point);
+	bool _solve(Point *begin_point, Point *end_point, bool p_allow_partial_path);
 
 protected:
 	static void _bind_methods();
@@ -171,7 +171,7 @@ class AStar2D : public RefCounted {
 	GDCLASS(AStar2D, RefCounted);
 	AStar3D astar;
 
-	bool _solve(AStar3D::Point *begin_point, AStar3D::Point *end_point);
+	bool _solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, bool p_allow_partial_path);
 
 protected:
 	static void _bind_methods();

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -491,11 +491,11 @@ void AStarGrid2D::_get_nbors(Point *p_point, LocalVector<Point *> &r_nbors) {
 	}
 }
 
-bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point) {
+bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path) {
 	last_closest_point = nullptr;
 	pass++;
 
-	if (_get_solid_unchecked(p_end_point->id)) {
+	if (_get_solid_unchecked(p_end_point->id) && !p_allow_partial_path) {
 		return false;
 	}
 
@@ -647,7 +647,7 @@ Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vec
 	Point *begin_point = a;
 	Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || last_closest_point == nullptr) {
 			return Vector<Vector2>();
@@ -700,7 +700,7 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 	Point *begin_point = a;
 	Point *end_point = b;
 
-	bool found_route = _solve(begin_point, end_point);
+	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || last_closest_point == nullptr) {
 			return TypedArray<Vector2i>();

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -159,8 +159,8 @@ private: // Internal routines.
 
 	void _get_nbors(Point *p_point, LocalVector<Point *> &r_nbors);
 	Point *_jump(Point *p_from, Point *p_to);
+	bool _solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path);
 	Point *_forced_successor(int32_t p_x, int32_t p_y, int32_t p_dx, int32_t p_dy, bool p_inclusive = false);
-	bool _solve(Point *p_begin_point, Point *p_end_point);
 
 protected:
 	static void _bind_methods();

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -143,6 +143,7 @@
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
+				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar2D.new()
@@ -235,6 +236,7 @@
 				Returns an array with the points that are in the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
+				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -172,6 +172,7 @@
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar3D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
+				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar3D.new()
@@ -262,6 +263,7 @@
 				Returns an array with the points that are in the path found by AStar3D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
+				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -79,6 +79,7 @@
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
+				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
 			</description>
 		</method>
 		<method name="get_point_data_in_region" qualifiers="const">
@@ -97,6 +98,7 @@
 				Returns an array with the points that are in the path found by [AStarGrid2D] between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
+				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">


### PR DESCRIPTION
Previously all of the AStar `_solve` methods would terminate early if the destination point was solid/disabled. This caused confusion amongst users who were expecting the `allow_partial_path` option to still return a path even if the destination was solid/disabled. I fixed this by pulling that argument into `_solve` and only terminating early if it was also false, so a path is still returned if the user uses the option. 

I noticed however while working on this that doing this significantly changes performance. I added a comment in the docs on the functions for these to warn users about this. 

This will also happen whenever the end point is not reachable (aka the path is fully blocked off by solid/disabled points), however the code still executes even if `allow_partial_path` is false, as the pathfinding still has to run to determine if it is unreachable. I don't know if there is really a good way to fix this, as the only way to know a point is unreachable is traversing the entire graph anyway. 
I'm not sure if this should also be mentioned somewhere in the documentation though.

Sample output of a microbenchmark when the destination is a solid/disabled point or unreachable
> pathfinding took 15834 microseconds

Compared to when the point is reachable and not solid/disabled
> pathfinding took 259 microseconds

This is with 1139 points in the graph.

Here is a sample project to test this:

[astar_partial_test.zip](https://github.com/user-attachments/files/16185520/astar_partial_test.zip)


[astar_partial_path_fix.webm](https://github.com/user-attachments/assets/0a2dc9e5-a852-4707-b43a-c4473e183eee)

Closes https://github.com/godotengine/godot/issues/93409