### PR TITLE
WASAPI: Delete `audio_client` if initialization failed

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -455,6 +455,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 	Error err = audio_device_init(&audio_output, false, p_reinit);
 	if (err != OK) {
+		finish_output_device();
 		return err;
 	}
 
@@ -495,6 +496,7 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 Error AudioDriverWASAPI::init_input_device(bool p_reinit) {
 	Error err = audio_device_init(&audio_input, true, p_reinit);
 	if (err != OK) {
+		finish_input_device();
 		return err;
 	}
 


### PR DESCRIPTION
Partially fixes: https://chat.godotengine.org/channel/audio?msg=SL25ozxgPm3i9dfhm (There still will be spam in the console until `Windows audio service` will start again, but at least the device will properly initialize after)
Does what the title says, if initialization failed, this pointer is not needed, cause it's invalid. Instead of going with the wrong pointer forever, after the change `AudioDeviceWASAPI` will try to intialize it every time it runs `thread_func`'s while loop's iteration (not ideal, there's probably a better way to handle it, but at least it will wait a 1000 microseconds before trying again).
Couldn't reproduce the issue myself, so didn't test if it works.