### PR TITLE
embree: Fix include order causing unwanted dllexport symbols

### DIFF
--- a/thirdparty/embree/common/tasking/taskschedulerinternal.h
+++ b/thirdparty/embree/common/tasking/taskschedulerinternal.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../../include/embree4/rtcore.h"
 #include "../sys/platform.h"
 #include "../sys/alloc.h"
 #include "../sys/barrier.h"
@@ -12,7 +13,6 @@
 #include "../sys/ref.h"
 #include "../sys/atomic.h"
 #include "../math/range.h"
-#include "../../include/embree4/rtcore.h"
 
 #include <list>
 

--- a/thirdparty/embree/patches/include-order-dllexport-fix.patch
+++ b/thirdparty/embree/patches/include-order-dllexport-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/thirdparty/embree/common/tasking/taskschedulerinternal.h b/thirdparty/embree/common/tasking/taskschedulerinternal.h
+index e72d3b72ba..8e3befb739 100644
+--- a/thirdparty/embree/common/tasking/taskschedulerinternal.h
++++ b/thirdparty/embree/common/tasking/taskschedulerinternal.h
+@@ -3,6 +3,7 @@
+ 
+ #pragma once
+ 
++#include "../../include/embree4/rtcore.h"
+ #include "../sys/platform.h"
+ #include "../sys/alloc.h"
+ #include "../sys/barrier.h"
+@@ -12,7 +13,6 @@
+ #include "../sys/ref.h"
+ #include "../sys/atomic.h"
+ #include "../math/range.h"
+-#include "../../include/embree4/rtcore.h"
+ 
+ #include <list>
+ 


### PR DESCRIPTION
Fixes #94178

(Created upstream PR https://github.com/RenderKit/embree/pull/494)