### PR TITLE
Autocompletion: Make argument option completion possible on script types

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2951,6 +2951,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 				base_type.kind = GDScriptParser::DataType::UNRESOLVED;
 			} break;
+			case GDScriptParser::DataType::SCRIPT: {
+				// TODO: Fully support script types.
+				base_type.kind = GDScriptParser::DataType::NATIVE;
+				base_type.native_type = base_type.script_type->get_instance_base_type();
+			} break;
 			default: {
 				base_type.kind = GDScriptParser::DataType::UNRESOLVED;
 			} break;


### PR DESCRIPTION
Fixes #92878

Argument `_find_argument_options` didn't handle SCRIPT types (it still doesn't fully, but this is mainly to fix the regression without high risk changes). Before #79386 we just used `Node` as type for every get node literal so we never hit that problem.
