### PR TITLE
Improve Blending Soft Shadow Logic

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1920,7 +1920,7 @@ void fragment_shader(in SceneData scene_data) {
 
 					pssm_coord /= pssm_coord.w;
 
-					shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord);
+					shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * clamp(directional_lights.data[i].soft_shadow_scale * blur_factor, min(float(directional_lights.data[i].blend_splits), directional_lights.data[i].soft_shadow_scale), 100.0), pssm_coord);
 
 					if (directional_lights.data[i].blend_splits) {
 						float pssm_blend;
@@ -1954,7 +1954,7 @@ void fragment_shader(in SceneData scene_data) {
 
 						pssm_coord /= pssm_coord.w;
 
-						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord);
+						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * clamp(directional_lights.data[i].soft_shadow_scale * blur_factor2, min(float(directional_lights.data[i].blend_splits), directional_lights.data[i].soft_shadow_scale), 100.0), pssm_coord);
 						shadow = mix(shadow, shadow2, pssm_blend);
 					}
 				}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1543,7 +1543,7 @@ void main() {
 
 				pssm_coord /= pssm_coord.w;
 
-				shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * float(directional_lights.data[i].blend_splits)), pssm_coord);
+				shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * clamp(directional_lights.data[i].soft_shadow_scale * blur_factor, min(float(directional_lights.data[i].blend_splits), directional_lights.data[i].soft_shadow_scale), 100.0), pssm_coord);
 
 				if (directional_lights.data[i].blend_splits) {
 					float pssm_blend;
@@ -1577,7 +1577,7 @@ void main() {
 
 					pssm_coord /= pssm_coord.w;
 
-					float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * float(directional_lights.data[i].blend_splits)), pssm_coord);
+					float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * clamp(directional_lights.data[i].soft_shadow_scale * blur_factor2, min(float(directional_lights.data[i].blend_splits), directional_lights.data[i].soft_shadow_scale), 100.0), pssm_coord);
 					shadow = mix(shadow, shadow2, pssm_blend);
 				}
 


### PR DESCRIPTION
Prevents Distant Shadow Splits from getting absurdly blurry with Blending Splits when using High Blur Values

Before (blur 10):

![Blur 10 borked](https://github.com/user-attachments/assets/e6a726f3-7a1f-48e8-985b-a3cb2f6c8a53)

After (blur 10):

![Blur 10 fixed](https://github.com/user-attachments/assets/bc3136ee-cb74-4e1b-aee8-40fa7e69bd0e)

Do note that the Peter Panning is caused by https://github.com/godotengine/godot/pull/68339 and also appears with this level of blur with blending splits off on master, as the Bias modifier used doesn't take into account the Soft Shadow Blur Factor that is doing the softness modifications.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
