### PR TITLE
Add Expand/Collapse Branch right click option to remote scene view

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -124,6 +124,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, Mou
 	item_menu->clear();
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CopyNodePath")), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
+	item_menu->add_icon_item(get_editor_theme_icon(SNAME("Collapse")), TTR("Expand/Collapse Branch"), ITEM_MENU_EXPAND_COLLAPSE);
 	item_menu->set_position(get_screen_position() + get_local_mouse_position());
 	item_menu->reset_size();
 	item_menu->popup();
@@ -359,6 +360,21 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 			}
 			DisplayServer::get_singleton()->clipboard_set(text);
 		} break;
+		case ITEM_MENU_EXPAND_COLLAPSE: {
+			TreeItem *s_item = get_selected();
+
+			if (!s_item) {
+				s_item = get_root();
+				if (!s_item) {
+					break;
+				}
+			}
+
+			bool collapsed = s_item->is_any_collapsed();
+			s_item->set_collapsed_recursive(!collapsed);
+
+			ensure_cursor_is_visible();
+		}
 	}
 }
 

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -43,6 +43,7 @@ private:
 	enum ItemMenu {
 		ITEM_MENU_SAVE_REMOTE_NODE,
 		ITEM_MENU_COPY_NODE_PATH,
+		ITEM_MENU_EXPAND_COLLAPSE,
 	};
 
 	ObjectID inspected_object_id;


### PR DESCRIPTION
This adds the Expand/Collapse Branch option to the right click menu in the remote scene view.

https://github.com/user-attachments/assets/8d41907e-c8ce-4f02-b773-b26f1aea655c

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8359.*

---

**Note:** it feels like there is some room for improvement in the code for actions in the remote view. They are basically copies of functions in scene_tree_dock.cpp, but I'm not sure how this would best be refactored to be reused. Also the same functionality for Expanding/Collapsing a node also exists through "Ctrl+Shift+Click" on the expand arrow, but seems to have another code path than the one in scene_tree_dock.cpp.