### PR TITLE
Fix audio samples not being able to be "finished"

### DIFF
--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -65,19 +65,7 @@ void AudioDriverWeb::_sample_playback_finished_callback(const char *p_playback_o
 		return;
 	}
 
-	Object *player_object = ObjectDB::get_instance(playback->player_id);
-	if (player_object == nullptr) {
-		return;
-	}
-	Node *player = Object::cast_to<Node>(player_object);
-	if (player == nullptr) {
-		return;
-	}
-
-	const StringName finished = SNAME("finished");
-	if (player->has_signal(finished)) {
-		player->emit_signal(finished);
-	}
+	AudioServer::get_singleton()->stop_sample_playback(playback);
 }
 
 void AudioDriverWeb::_audio_driver_process(int p_from, int p_samples) {

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -152,7 +152,6 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 				Ref<AudioSamplePlayback> sample_playback;
 				sample_playback.instantiate();
 				sample_playback->stream = stream;
-				sample_playback->player_id = node->get_instance_id();
 				stream_playback->set_sample_playback(sample_playback);
 			}
 		} else if (!stream->is_meta_stream()) {
@@ -262,9 +261,6 @@ void AudioStreamPlayerInternal::seek(float p_seconds) {
 void AudioStreamPlayerInternal::stop() {
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->stop_playback_stream(playback);
-		if (_is_sample() && playback->get_sample_playback().is_valid()) {
-			AudioServer::get_singleton()->stop_sample_playback(playback->get_sample_playback());
-		}
 	}
 	stream_playbacks.clear();
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -49,7 +49,6 @@ class AudioSamplePlayback : public RefCounted {
 public:
 	Ref<AudioStream> stream;
 
-	ObjectID player_id;
 	float offset = 0.0f;
 	Vector<AudioFrame> volume_vector;
 	StringName bus;

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -329,6 +329,8 @@ private:
 	friend class AudioDriver;
 	void _driver_process(int p_frames, int32_t *p_buffer);
 
+	LocalVector<Ref<AudioStreamPlayback>> sample_playback_list;
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
Fixes #94226 about issues with `AudioStreamPlayer.playing` always being `true` once started. 

Now, with this PR, I keep a list of currently playing samples and remove them of the list when stopped or when receiving the "finished" callback.