### PR TITLE
Core: Change BitField internal value to `uint64_t`

### DIFF
--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -116,27 +116,27 @@ struct VariantCaster<const T &> {
 	template <>                                                                                                                             \
 	struct VariantCaster<BitField<m_enum>> {                                                                                                \
 		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) {                                                             \
-			return BitField<m_enum>(p_variant.operator int64_t());                                                                          \
+			return BitField<m_enum>(p_variant.operator uint64_t());                                                                         \
 		}                                                                                                                                   \
 	};                                                                                                                                      \
 	template <>                                                                                                                             \
 	struct PtrToArg<BitField<m_enum>> {                                                                                                     \
 		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {                                                                 \
-			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));                                                             \
+			return BitField<m_enum>(*reinterpret_cast<const uint64_t *>(p_ptr));                                                            \
 		}                                                                                                                                   \
-		typedef int64_t EncodeT;                                                                                                            \
+		typedef uint64_t EncodeT;                                                                                                           \
 		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, const void *p_ptr) {                                                      \
-			*(int64_t *)p_ptr = p_val;                                                                                                      \
+			*(uint64_t *)p_ptr = (uint64_t)p_val;                                                                                           \
 		}                                                                                                                                   \
 	};                                                                                                                                      \
 	template <>                                                                                                                             \
 	struct ZeroInitializer<BitField<m_enum>> {                                                                                              \
-		static void initialize(BitField<m_enum> &value) { value = 0; }                                                                      \
+		static void initialize(BitField<m_enum> &value) { value = (m_enum)0; }                                                              \
 	};                                                                                                                                      \
 	template <>                                                                                                                             \
 	struct VariantInternalAccessor<BitField<m_enum>> {                                                                                      \
-		static _FORCE_INLINE_ BitField<m_enum> get(const Variant *v) { return BitField<m_enum>(*VariantInternal::get_int(v)); }             \
-		static _FORCE_INLINE_ void set(Variant *v, BitField<m_enum> p_value) { *VariantInternal::get_int(v) = p_value.operator int64_t(); } \
+		static _FORCE_INLINE_ BitField<m_enum> get(const Variant *v) { return BitField<m_enum>((uint64_t) * VariantInternal::get_int(v)); } \
+		static _FORCE_INLINE_ void set(Variant *v, BitField<m_enum> p_value) { *VariantInternal::get_int(v) = (uint64_t)p_value; }          \
 	};
 
 // Object enum casts must go here
@@ -179,29 +179,29 @@ VARIANT_BITFIELD_CAST(KeyModifierMask);
 VARIANT_ENUM_CAST(KeyLocation);
 
 static inline Key &operator|=(Key &a, BitField<KeyModifierMask> b) {
-	a = static_cast<Key>(static_cast<int>(a) | static_cast<int>(b.operator int64_t()));
+	a = static_cast<Key>(static_cast<int>(a) | static_cast<int>(b));
 	return a;
 }
 
 static inline Key &operator&=(Key &a, BitField<KeyModifierMask> b) {
-	a = static_cast<Key>(static_cast<int>(a) & static_cast<int>(b.operator int64_t()));
+	a = static_cast<Key>(static_cast<int>(a) & static_cast<int>(b));
 	return a;
 }
 
 static inline Key operator|(Key a, BitField<KeyModifierMask> b) {
-	return (Key)((int)a | (int)b.operator int64_t());
+	return (Key)((int)a | (int)b);
 }
 
 static inline Key operator&(Key a, BitField<KeyModifierMask> b) {
-	return (Key)((int)a & (int)b.operator int64_t());
+	return (Key)((int)a & (int)b);
 }
 
 static inline Key operator+(BitField<KeyModifierMask> a, Key b) {
-	return (Key)((int)a.operator int64_t() + (int)b);
+	return (Key)((int)a + (int)b);
 }
 
 static inline Key operator|(BitField<KeyModifierMask> a, Key b) {
-	return (Key)((int)a.operator int64_t() | (int)b);
+	return (Key)((int)a | (int)b);
 }
 
 template <>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -248,21 +248,21 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 
 template <typename T>
 class BitField {
-	int64_t value = 0;
+	uint64_t value = 0;
 
 public:
 	_FORCE_INLINE_ BitField<T> &set_flag(T p_flag) {
-		value |= (int64_t)p_flag;
+		value |= (uint64_t)p_flag;
 		return *this;
 	}
-	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & (int64_t)p_flag; }
+	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & (uint64_t)p_flag; }
 	_FORCE_INLINE_ bool is_empty() const { return value == 0; }
-	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~(int64_t)p_flag; }
+	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~(uint64_t)p_flag; }
 	_FORCE_INLINE_ void clear() { value = 0; }
 	_FORCE_INLINE_ constexpr BitField() = default;
-	_FORCE_INLINE_ constexpr BitField(int64_t p_value) { value = p_value; }
-	_FORCE_INLINE_ constexpr BitField(T p_value) { value = (int64_t)p_value; }
-	_FORCE_INLINE_ operator int64_t() const { return value; }
+	_FORCE_INLINE_ constexpr BitField(uint64_t p_value) { value = p_value; }
+	_FORCE_INLINE_ constexpr BitField(T p_value) { value = (uint64_t)p_value; }
+	_FORCE_INLINE_ operator uint64_t() const { return value; }
 	_FORCE_INLINE_ operator Variant() const { return value; }
 	_FORCE_INLINE_ BitField<T> operator^(const BitField<T> &p_b) const { return BitField<T>(value ^ p_b.value); }
 };

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -283,7 +283,7 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 	}
 	ev->set_pressed(p_pressed);
 	ev->set_canceled(p_canceled);
-	BitField<MouseButtonMask> changed_button_mask = BitField<MouseButtonMask>(buttons_state.operator int64_t() ^ event_buttons_mask.operator int64_t());
+	BitField<MouseButtonMask> changed_button_mask = BitField<MouseButtonMask>(uint64_t(buttons_state) ^ uint64_t(event_buttons_mask));
 
 	buttons_state = event_buttons_mask;
 
@@ -395,7 +395,7 @@ void AndroidInputHandler::_wheel_button_click(BitField<MouseButtonMask> event_bu
 	Ref<InputEventMouseButton> evd = ev->duplicate();
 	_set_key_modifier_state(evd, Key::NONE);
 	evd->set_button_index(wheel_button);
-	evd->set_button_mask(BitField<MouseButtonMask>(event_buttons_mask.operator int64_t() ^ int64_t(mouse_button_to_mask(wheel_button))));
+	evd->set_button_mask(BitField<MouseButtonMask>(uint64_t(event_buttons_mask) ^ uint64_t(mouse_button_to_mask(wheel_button))));
 	evd->set_factor(factor);
 	Input::get_singleton()->parse_input_event(evd);
 	Ref<InputEventMouseButton> evdd = evd->duplicate();
@@ -423,7 +423,7 @@ void AndroidInputHandler::process_pan(Point2 p_pos, Vector2 p_delta) {
 }
 
 MouseButton AndroidInputHandler::_button_index_from_mask(BitField<MouseButtonMask> button_mask) {
-	switch (MouseButtonMask(button_mask.operator int64_t())) {
+	switch (MouseButtonMask(uint64_t(button_mask))) {
 		case MouseButtonMask::LEFT:
 			return MouseButton::LEFT;
 		case MouseButtonMask::RIGHT:


### PR DESCRIPTION
Discussed at the GDExtension meeting.

This aims to reduce ambiguity in how bitfields are expected to be handled, without actually altering any existing bindings.