### PR TITLE
CI: Bump GHA Python/SCons to latest versions

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -3,13 +3,13 @@ description: Setup Python, install the pip version of SCons.
 inputs:
   python-version:
     description: The Python version to use.
-    default: "3.12.3"
+    default: "3.12.4"
   python-arch:
     description: The Python architecture.
     default: "x64"
   scons-version:
     description: The SCons version to use.
-    default: "4.7.0"
+    default: "4.8.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Bumps the GHA versions for Python (3.12.3→3.12.4) and SCons (4.7.0→4.8.0). The former can be safely incremented now that the initial MacOS issue was fixed by actions/python-versions#286.