### PR TITLE
Add scale factor options in texture importer

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -50,13 +50,6 @@
 				If you want to update the image, but don't need to change its parameters (format, size), use [method update] instead for better performance.
 			</description>
 		</method>
-		<method name="set_size_override">
-			<return type="void" />
-			<param index="0" name="size" type="Vector2i" />
-			<description>
-				Resizes the texture to the specified dimensions.
-			</description>
-		</method>
 		<method name="update">
 			<return type="void" />
 			<param index="0" name="image" type="Image" />

--- a/doc/classes/PortableCompressedTexture2D.xml
+++ b/doc/classes/PortableCompressedTexture2D.xml
@@ -59,9 +59,6 @@
 			This flag allows to keep the compressed data in memory if you intend it to persist after loading.
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
-		<member name="size_override" type="Vector2" setter="set_size_override" getter="get_size_override" default="Vector2(0, 0)">
-			Allow overriding the texture size (for 2D only).
-		</member>
 	</members>
 	<constants>
 		<constant name="COMPRESSION_MODE_LOSSLESS" value="0" enum="CompressionMode">

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -14,7 +14,7 @@
 			Resizes the image to the scale factor without affecting the texture size. This can be used to reduce app size and memory usage.
 		</member>
 		<member name="2d/size_override" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
-			Allow overriding the texture size.
+			Overrides the texture size if both dimensions are greater than 0.
 		</member>
 		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
 			Controls how color channels should be used in the imported texture.

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -10,6 +10,12 @@
 		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<members>
+		<member name="2d/display_scale" type="float" setter="" getter="" default="1.0">
+			Resizes the image to the scale factor without affecting the texture size. This can be used to reduce app size and memory usage.
+		</member>
+		<member name="2d/size_override" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
+			Allow overriding the texture size.
+		</member>
 		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
 			Controls how color channels should be used in the imported texture.
 			[b]sRGB Friendly:[/b] Prevents the RG color format from being used, as it does not support sRGB color.
@@ -88,7 +94,7 @@
 			- In 3D, there is no support for premultiplied alpha blend mode yet, so this option is only suited for 2D.
 		</member>
 		<member name="process/size_limit" type="int" setter="" getter="" default="0">
-			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using cubic interpolation.
+			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using Lanczos interpolation.
 			This can be used to reduce memory usage without affecting the source images, or avoid issues with textures not displaying on mobile/web platforms (as these usually can't display textures larger than 4096×4096).
 		</member>
 		<member name="roughness/mode" type="int" setter="" getter="" default="0">

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -146,4 +146,9 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="size_override" type="Vector2i" setter="set_size_override" getter="get_size_override" default="Vector2i(0, 0)">
+			Allow overriding the texture size.
+		</member>
+	</members>
 </class>

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -242,6 +242,8 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_as_srgb"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_clamp_exposure"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/size_limit", PROPERTY_HINT_RANGE, "0,4096,1"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "2d/display_scale", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::VECTOR2I, "2d/size_override"), Vector2i(0, 0)));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "detect_3d/compress_to", PROPERTY_HINT_ENUM, "Disabled,VRAM Compressed,Basis Universal"), (p_preset == PRESET_DETECT) ? 1 : 0));
 
 	// Do path based customization only if a path was passed.
@@ -342,7 +344,14 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 	}
 }
 
-void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, float p_display_scale, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+	// Apply the display scale.
+	int original_width = p_image->get_width();
+	int original_height = p_image->get_height();
+	int scaled_width = p_display_scale * p_image->get_width();
+	int scaled_height = p_display_scale * p_image->get_height();
+	p_image->resize(scaled_width, scaled_height, Image::INTERPOLATE_LANCZOS);
+
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 	f->store_8('G');
@@ -353,8 +362,8 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	//format version
 	f->store_32(CompressedTexture2D::FORMAT_VERSION);
 	//texture may be resized later, so original size must be saved first
-	f->store_32(p_image->get_width());
-	f->store_32(p_image->get_height());
+	f->store_32(scaled_width);
+	f->store_32(scaled_height);
 
 	uint32_t flags = 0;
 	if (p_streamable) {
@@ -375,9 +384,9 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 
 	f->store_32(flags);
 	f->store_32(p_limit_mipmap);
-	//reserved for future use
-	f->store_32(0);
-	f->store_32(0);
+	f->store_32(original_width);
+	f->store_32(original_height);
+	// Reserved for future use.
 	f->store_32(0);
 
 	if ((p_compress_mode == COMPRESS_LOSSLESS || p_compress_mode == COMPRESS_LOSSY) && p_image->get_format() > Image::FORMAT_RGBA8) {
@@ -455,6 +464,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 	// Support for texture streaming is not implemented yet.
 	const bool stream = false;
 	const int size_limit = p_options["process/size_limit"];
+	const Vector2i size_override = p_options["2d/size_override"];
 	const bool hdr_as_srgb = p_options["process/hdr_as_srgb"];
 	if (hdr_as_srgb) {
 		loader_flags |= ImageFormatLoader::FLAG_FORCE_LINEAR;
@@ -523,14 +533,22 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 				int new_width = size_limit;
 				int new_height = target_image->get_height() * new_width / target_image->get_width();
 
-				target_image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+				target_image->resize(new_width, new_height, Image::INTERPOLATE_LANCZOS);
 			} else {
 				int new_height = size_limit;
 				int new_width = target_image->get_width() * new_height / target_image->get_height();
 
-				target_image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+				target_image->resize(new_width, new_height, Image::INTERPOLATE_LANCZOS);
 			}
 
+			if (normal == 1) {
+				target_image->normalize();
+			}
+		}
+
+		// Apply the size override.
+		if (size_override.width > 0 && size_override.height > 0) {
+			target_image->resize(size_override.width, size_override.height, Image::INTERPOLATE_LANCZOS);
 			if (normal == 1) {
 				target_image->normalize();
 			}
@@ -598,6 +616,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 		compress_mode = COMPRESS_VRAM_COMPRESSED;
 	}
 
+	const float display_scale = p_options["2d/display_scale"];
 	bool detect_3d = int(p_options["detect_3d/compress_to"]) > 0;
 	bool detect_roughness = roughness == 0;
 	bool detect_normal = normal == 0;
@@ -651,7 +670,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 		}
 
 		if (use_uncompressed) {
-			_save_ctex(image, p_save_path + ".ctex", COMPRESS_VRAM_UNCOMPRESSED, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+			_save_ctex(image, p_save_path + ".ctex", COMPRESS_VRAM_UNCOMPRESSED, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, display_scale, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
 		} else {
 			if (can_s3tc_bptc) {
 				Image::CompressMode image_compress_mode;
@@ -663,7 +682,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 					image_compress_mode = Image::COMPRESS_S3TC;
 					image_compress_format = "s3tc";
 				}
-				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, display_scale, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
 				r_platform_variants->push_back(image_compress_format);
 			}
 
@@ -677,17 +696,17 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 					image_compress_mode = Image::COMPRESS_ETC2;
 					image_compress_format = "etc2";
 				}
-				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, display_scale, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
 				r_platform_variants->push_back(image_compress_format);
 			}
 		}
 	} else {
 		// Import normally.
-		_save_ctex(image, p_save_path + ".ctex", compress_mode, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+		_save_ctex(image, p_save_path + ".ctex", compress_mode, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, display_scale, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
 	}
 
 	if (editor_image.is_valid()) {
-		_save_ctex(editor_image, p_save_path + ".editor.ctex", compress_mode, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+		_save_ctex(editor_image, p_save_path + ".editor.ctex", compress_mode, lossy, Image::COMPRESS_S3TC /*this is ignored */, mipmaps, stream, display_scale, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
 
 		// Generate and save editor-specific metadata, which we cannot save to the .import file.
 		Dictionary editor_meta;

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -74,7 +74,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, float p_display_scale, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -171,6 +171,11 @@ void Sprite2DEditor::_update_mesh_data() {
 		image->decompress();
 	}
 
+	Vector2i size_override = texture->get_size_override();
+	if (size_override.width > 0 && size_override.height > 0) {
+		image->resize(size_override.width, size_override.height);
+	}
+
 	Rect2 rect = node->is_region_enabled() ? node->get_region_rect() : Rect2(Point2(), image->get_size());
 	rect.size /= Vector2(node->get_hframes(), node->get_vframes());
 	rect.position += node->get_frame_coords() * rect.size;

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -556,7 +556,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "set_scancode", "set_keycode" }, // InputEventKey
 	{ "set_shader_param", "set_shader_parameter" }, // ShaderMaterial
 	{ "set_shift", "set_shift_pressed" }, // InputEventWithModifiers
-	{ "set_size_override", "set_size_2d_override" }, // SubViewport -- Breaks ImageTexture.
+	{ "set_size_override", "set_size_2d_override" }, // SubViewport -- Breaks Texture2D.
 	{ "set_size_override_stretch", "set_size_2d_override_stretch" }, // SubViewport
 	{ "set_slips_on_slope", "set_slide_on_slope" }, // SeparationRayShape2D, SeparationRayShape3D
 	{ "set_sort_enabled", "set_y_sort_enabled" }, // Node2D

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/resources/bit_map.h"
 
-Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {
+Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &r_mipmap_limit, int &r_override_width, int &r_override_height, int p_size_limit) {
 	alpha_cache.unref();
 
 	ERR_FAIL_COND_V(image.is_null(), ERR_INVALID_PARAMETER);
@@ -55,11 +55,12 @@ Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r
 	r_height = f->get_32();
 	uint32_t df = f->get_32(); //data format
 
-	//skip reserved
-	mipmap_limit = int(f->get_32());
-	//reserved
-	f->get_32();
-	f->get_32();
+	r_mipmap_limit = int(f->get_32());
+
+	r_override_width = f->get_32();
+	r_override_height = f->get_32();
+
+	// Skip reserved fields.
 	f->get_32();
 
 #ifdef TOOLS_ENABLED
@@ -134,8 +135,10 @@ Error CompressedTexture2D::load(const String &p_path) {
 	bool request_normal;
 	bool request_roughness;
 	int mipmap_limit;
+	int override_width;
+	int override_height;
 
-	Error err = _load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit);
+	Error err = _load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit, override_width, override_height);
 	if (err) {
 		return err;
 	}
@@ -146,9 +149,8 @@ Error CompressedTexture2D::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
-	if (lw || lh) {
-		RS::get_singleton()->texture_set_size_override(texture, lw, lh);
-	}
+
+	set_size_override(Size2i(override_width, override_height));
 
 	w = lw;
 	h = lh;
@@ -197,11 +199,19 @@ String CompressedTexture2D::get_load_path() const {
 }
 
 int CompressedTexture2D::get_width() const {
-	return w;
+	int ret = w;
+	if (get_size_override().width != 0) {
+		ret = get_size_override().width;
+	}
+	return ret;
 }
 
 int CompressedTexture2D::get_height() const {
-	return h;
+	int ret = h;
+	if (get_size_override().height != 0) {
+		ret = get_size_override().height;
+	}
+	return ret;
 }
 
 RID CompressedTexture2D::get_rid() const {
@@ -269,8 +279,8 @@ bool CompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 		int x = p_x * aw / w;
 		int y = p_y * ah / h;
 
-		x = CLAMP(x, 0, aw);
-		y = CLAMP(y, 0, ah);
+		x = CLAMP(x, 0, aw - 1);
+		y = CLAMP(y, 0, ah - 1);
 
 		return alpha_cache->get_bit(x, y);
 	}

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -150,10 +150,11 @@ Error CompressedTexture2D::load(const String &p_path) {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
 
-	set_size_override(Size2i(override_width, override_height));
-
 	w = lw;
 	h = lh;
+
+	set_size_override(Size2i(override_width, override_height));
+
 	path_to_file = p_path;
 	format = image->get_format();
 
@@ -199,19 +200,19 @@ String CompressedTexture2D::get_load_path() const {
 }
 
 int CompressedTexture2D::get_width() const {
-	int ret = w;
-	if (get_size_override().width != 0) {
-		ret = get_size_override().width;
-	}
-	return ret;
+	return w;
 }
 
 int CompressedTexture2D::get_height() const {
-	int ret = h;
-	if (get_size_override().height != 0) {
-		ret = get_size_override().height;
+	return h;
+}
+
+void CompressedTexture2D::set_size_override(const Vector2i &p_size) {
+	if (p_size.width > 0 && p_size.height > 0) {
+		w = p_size.width;
+		h = p_size.height;
+		Texture2D::set_size_override(p_size);
 	}
-	return ret;
 }
 
 RID CompressedTexture2D::get_rid() const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -94,6 +94,9 @@ public:
 
 	int get_width() const override;
 	int get_height() const override;
+
+	void set_size_override(const Vector2i &p_size) override;
+
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -67,7 +67,7 @@ private:
 	int h = 0;
 	mutable Ref<BitMap> alpha_cache;
 
-	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit = 0);
+	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &r_mipmap_limit, int &r_override_width, int &r_override_height, int p_size_limit = 0);
 	virtual void reload_from_file() override;
 
 	static void _requested_3d(void *p_ud);

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -140,6 +140,14 @@ int ImageTexture::get_height() const {
 	return h;
 }
 
+void ImageTexture::set_size_override(const Size2i &p_size) {
+	if (p_size.width > 0 && p_size.height > 0) {
+		w = p_size.width;
+		h = p_size.height;
+		Texture2D::set_size_override(p_size);
+	}
+}
+
 RID ImageTexture::get_rid() const {
 	if (texture.is_null()) {
 		// We are in trouble, create something temporary.
@@ -206,17 +214,6 @@ bool ImageTexture::is_pixel_opaque(int p_x, int p_y) const {
 	return true;
 }
 
-void ImageTexture::set_size_override(const Size2i &p_size) {
-	Size2i s = p_size;
-	if (s.x != 0) {
-		w = s.x;
-	}
-	if (s.y != 0) {
-		h = s.y;
-	}
-	RenderingServer::get_singleton()->texture_set_size_override(texture, w, h);
-}
-
 void ImageTexture::set_path(const String &p_path, bool p_take_over) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
@@ -231,7 +228,6 @@ void ImageTexture::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_image", "image"), &ImageTexture::set_image);
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);
-	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
 }
 
 ImageTexture::ImageTexture() {}

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -69,7 +69,7 @@ public:
 	int get_width() const override;
 	int get_height() const override;
 
-	virtual void set_size_override(const Size2i &p_size) override;
+	void set_size_override(const Size2i &p_size) override;
 
 	virtual RID get_rid() const override;
 

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -69,6 +69,8 @@ public:
 	int get_width() const override;
 	int get_height() const override;
 
+	virtual void set_size_override(const Size2i &p_size) override;
+
 	virtual RID get_rid() const override;
 
 	bool has_alpha() const override;
@@ -77,8 +79,6 @@ public:
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;
 
 	bool is_pixel_opaque(int p_x, int p_y) const override;
-
-	void set_size_override(const Size2i &p_size);
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -223,6 +223,13 @@ int PortableCompressedTexture2D::get_height() const {
 	return size.height;
 }
 
+void PortableCompressedTexture2D::set_size_override(const Vector2i &p_size) {
+	if (p_size.width > 0 && p_size.height > 0) {
+		size = p_size;
+		Texture2D::set_size_override(p_size);
+	}
+}
+
 RID PortableCompressedTexture2D::get_rid() const {
 	if (texture.is_null()) {
 		// We are in trouble, create something temporary.

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -113,8 +113,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 	}
 
 	image_stored = true;
-	size_override = size;
-	RenderingServer::get_singleton()->texture_set_size_override(texture, size_override.width, size_override.height);
+	set_size_override(size);
 	alpha_cache.unref();
 
 	if (keep_all_compressed_buffers || keep_compressed_buffer) {
@@ -290,15 +289,6 @@ bool PortableCompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 	return true;
 }
 
-void PortableCompressedTexture2D::set_size_override(const Size2 &p_size) {
-	size_override = p_size;
-	RenderingServer::get_singleton()->texture_set_size_override(texture, size_override.width, size_override.height);
-}
-
-Size2 PortableCompressedTexture2D::get_size_override() const {
-	return size_override;
-}
-
 void PortableCompressedTexture2D::set_path(const String &p_path, bool p_take_over) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
@@ -333,9 +323,6 @@ void PortableCompressedTexture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_format"), &PortableCompressedTexture2D::get_format);
 	ClassDB::bind_method(D_METHOD("get_compression_mode"), &PortableCompressedTexture2D::get_compression_mode);
 
-	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &PortableCompressedTexture2D::set_size_override);
-	ClassDB::bind_method(D_METHOD("get_size_override"), &PortableCompressedTexture2D::get_size_override);
-
 	ClassDB::bind_method(D_METHOD("set_keep_compressed_buffer", "keep"), &PortableCompressedTexture2D::set_keep_compressed_buffer);
 	ClassDB::bind_method(D_METHOD("is_keeping_compressed_buffer"), &PortableCompressedTexture2D::is_keeping_compressed_buffer);
 
@@ -346,7 +333,6 @@ void PortableCompressedTexture2D::_bind_methods() {
 	ClassDB::bind_static_method("PortableCompressedTexture2D", D_METHOD("is_keeping_all_compressed_buffers"), &PortableCompressedTexture2D::is_keeping_all_compressed_buffers);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "_set_data", "_get_data");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size_override", PROPERTY_HINT_NONE, "suffix:px"), "set_size_override", "get_size_override");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_compressed_buffer"), "set_keep_compressed_buffer", "is_keeping_compressed_buffer");
 
 	BIND_ENUM_CONSTANT(COMPRESSION_MODE_LOSSLESS);

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -88,6 +88,8 @@ public:
 	int get_width() const override;
 	int get_height() const override;
 
+	void set_size_override(const Vector2i &p_size) override;
+
 	virtual RID get_rid() const override;
 
 	bool has_alpha() const override;

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -62,7 +62,6 @@ private:
 	bool keep_compressed_buffer = false;
 	Vector<uint8_t> compressed_buffer;
 	Size2 size;
-	Size2 size_override;
 	bool mipmaps = false;
 	Image::Format format = Image::FORMAT_L8;
 
@@ -99,9 +98,6 @@ public:
 	bool is_pixel_opaque(int p_x, int p_y) const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
-
-	void set_size_override(const Size2 &p_size);
-	Size2 get_size_override() const;
 
 	void set_keep_compressed_buffer(bool p_keep);
 	bool is_keeping_compressed_buffer() const;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -94,16 +94,44 @@ Ref<Resource> Texture2D::create_placeholder() const {
 	return placeholder;
 }
 
+void Texture2D::set_size_override(const Size2i &p_size) {
+	if (size_override == p_size) {
+		return;
+	}
+
+	size_override = p_size;
+
+	int width = get_width();
+	int height = get_height();
+	if (p_size.x != 0) {
+		width = p_size.x;
+	}
+	if (p_size.y != 0) {
+		height = p_size.y;
+	}
+	RenderingServer::get_singleton()->texture_set_size_override(get_rid(), width, height);
+}
+
+Size2i Texture2D::get_size_override() const {
+	return size_override;
+}
+
 void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_width"), &Texture2D::get_width);
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture2D::get_height);
 	ClassDB::bind_method(D_METHOD("get_size"), &Texture2D::get_size);
 	ClassDB::bind_method(D_METHOD("has_alpha"), &Texture2D::has_alpha);
+
+	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &Texture2D::set_size_override);
+	ClassDB::bind_method(D_METHOD("get_size_override"), &Texture2D::get_size_override);
+
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "position", "modulate", "transpose"), &Texture2D::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect", "canvas_item", "rect", "tile", "modulate", "transpose"), &Texture2D::draw_rect, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect_region", "canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &Texture2D::draw_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_image"), &Texture2D::get_image);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture2D::create_placeholder);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size_override", PROPERTY_HINT_RANGE, "1,16384,1"), "set_size_override", "get_size_override");
 
 	ADD_GROUP("", "");
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -54,6 +54,8 @@ class Texture2D : public Texture {
 	GDCLASS(Texture2D, Texture);
 	OBJ_SAVE_TYPE(Texture2D); // Saves derived classes with common type so they can be interchanged.
 
+	Size2i size_override;
+
 protected:
 	static void _bind_methods();
 
@@ -70,6 +72,9 @@ public:
 	virtual int get_width() const;
 	virtual int get_height() const;
 	virtual Size2 get_size() const;
+
+	virtual Vector2i get_size_override() const;
+	virtual void set_size_override(const Vector2i &p_size);
 
 	virtual bool is_pixel_opaque(int p_x, int p_y) const;
 


### PR DESCRIPTION
Partially completes proposal: 
- https://github.com/godotengine/godot-proposals/issues/10034

Also changes cubic interpolation to Lanczos interpolation for better quality when applying `process/size_limit`.