### PR TITLE
Make static and inline keyword combinations consistent (Code Style)

### DIFF
--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -46,7 +46,7 @@ class CoreStringNames {
 	CoreStringNames();
 
 public:
-	_FORCE_INLINE_ static CoreStringNames *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ CoreStringNames *get_singleton() { return singleton; }
 
 	static CoreStringNames *singleton;
 

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -103,10 +103,10 @@ protected:
 	static void (*allow_focus_steal_fn)();
 
 public:
-	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
-	_FORCE_INLINE_ static bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
+	static _FORCE_INLINE_ EngineDebugger *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
 
-	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; };
+	static _FORCE_INLINE_ ScriptDebugger *get_script_debugger() { return script_debugger; };
 
 	static void initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)());
 	static void deinitialize();

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -218,7 +218,7 @@ IPAddress::IPAddress(const String &p_string) {
 	}
 }
 
-_FORCE_INLINE_ static void _32_to_buf(uint8_t *p_dst, uint32_t p_n) {
+static _FORCE_INLINE_ void _32_to_buf(uint8_t *p_dst, uint32_t p_n) {
 	p_dst[0] = (p_n >> 24) & 0xff;
 	p_dst[1] = (p_n >> 16) & 0xff;
 	p_dst[2] = (p_n >> 8) & 0xff;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -274,7 +274,7 @@ public:
 	static void remove_custom_loaders();
 
 	static void set_create_missing_resources_if_class_unavailable(bool p_enable);
-	_FORCE_INLINE_ static bool is_creating_missing_resources_if_class_unavailable_enabled() { return create_missing_resources_if_class_unavailable; }
+	static _FORCE_INLINE_ bool is_creating_missing_resources_if_class_unavailable_enabled() { return create_missing_resources_if_class_unavailable; }
 
 	static Ref<Resource> ensure_resource_ref_override_for_outer_load(const String &p_path, const String &p_res_type);
 	static Ref<Resource> get_resource_ref_override(const String &p_path);

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -98,14 +98,14 @@ class Delaunay3D {
 	};
 
 	struct TriangleHasher {
-		_FORCE_INLINE_ static uint32_t hash(const Triangle &p_triangle) {
+		static _FORCE_INLINE_ uint32_t hash(const Triangle &p_triangle) {
 			uint32_t h = hash_djb2_one_32(p_triangle.triangle[0]);
 			h = hash_djb2_one_32(p_triangle.triangle[1], h);
 			return hash_fmix32(hash_djb2_one_32(p_triangle.triangle[2], h));
 		}
 	};
 
-	_FORCE_INLINE_ static void circum_sphere_compute(const Vector3 *p_points, Simplex *p_simplex) {
+	static _FORCE_INLINE_ void circum_sphere_compute(const Vector3 *p_points, Simplex *p_simplex) {
 		// The only part in the algorithm where there may be precision errors is this one,
 		// so ensure that we do it with the maximum precision possible.
 
@@ -163,7 +163,7 @@ class Delaunay3D {
 		p_simplex->circum_r2 = radius1;
 	}
 
-	_FORCE_INLINE_ static bool simplex_contains(const Vector3 *p_points, const Simplex &p_simplex, uint32_t p_vertex) {
+	static _FORCE_INLINE_ bool simplex_contains(const Vector3 *p_points, const Simplex &p_simplex, uint32_t p_vertex) {
 		R128 v_x = p_points[p_vertex].x;
 		R128 v_y = p_points[p_vertex].y;
 		R128 v_z = p_points[p_vertex].z;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -594,7 +594,7 @@ public:
 		max = x2;                        \
 	}
 
-	_FORCE_INLINE_ static bool planeBoxOverlap(Vector3 normal, real_t d, Vector3 maxbox) {
+	static _FORCE_INLINE_ bool planeBoxOverlap(Vector3 normal, real_t d, Vector3 maxbox) {
 		int q;
 		Vector3 vmin, vmax;
 		for (q = 0; q <= 2; q++) {
@@ -709,7 +709,7 @@ public:
 		return false;                              \
 	}
 
-	_FORCE_INLINE_ static bool triangle_box_overlap(const Vector3 &boxcenter, const Vector3 boxhalfsize, const Vector3 *triverts) {
+	static _FORCE_INLINE_ bool triangle_box_overlap(const Vector3 &boxcenter, const Vector3 boxhalfsize, const Vector3 *triverts) {
 		/*    use separating axis theorem to test overlap between triangle and box */
 		/*    need to test for overlap in these directions: */
 		/*    1) the {x,y,z}-directions (actually, since we use the AABB of the triangle */
@@ -830,7 +830,7 @@ public:
 #undef STP
 	}
 
-	_FORCE_INLINE_ static Vector3 octahedron_map_decode(const Vector2 &p_uv) {
+	static _FORCE_INLINE_ Vector3 octahedron_map_decode(const Vector2 &p_uv) {
 		// https://twitter.com/Stubbesaurus/status/937994790553227264
 		const Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
 		Vector3 n = Vector3(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -163,8 +163,8 @@ class MessageQueue : public CallQueue {
 	friend class CallQueue;
 
 public:
-	_FORCE_INLINE_ static CallQueue *get_singleton() { return thread_singleton ? thread_singleton : main_singleton; }
-	_FORCE_INLINE_ static CallQueue *get_main_singleton() { return main_singleton; }
+	static _FORCE_INLINE_ CallQueue *get_singleton() { return thread_singleton ? thread_singleton : main_singleton; }
+	static _FORCE_INLINE_ CallQueue *get_main_singleton() { return main_singleton; }
 
 	static void set_thread_singleton_override(CallQueue *p_thread_singleton);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -448,10 +448,10 @@ public:                                                                         
 	}                                                                                                                                            \
                                                                                                                                                  \
 protected:                                                                                                                                       \
-	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                        \
+	static _FORCE_INLINE_ void (*_get_bind_methods())() {                                                                                        \
 		return &m_class::_bind_methods;                                                                                                          \
 	}                                                                                                                                            \
-	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {                                                                          \
+	static _FORCE_INLINE_ void (*_get_bind_compatibility_methods())() {                                                                          \
 		return &m_class::_bind_compatibility_methods;                                                                                            \
 	}                                                                                                                                            \
                                                                                                                                                  \
@@ -719,10 +719,10 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; };
 	void _notification(int p_notification) {}
 
-	_FORCE_INLINE_ static void (*_get_bind_methods())() {
+	static _FORCE_INLINE_ void (*_get_bind_methods())() {
 		return &Object::_bind_methods;
 	}
-	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {
+	static _FORCE_INLINE_ void (*_get_bind_compatibility_methods())() {
 		return &Object::_bind_compatibility_methods;
 	}
 	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &r_ret) const {
@@ -783,7 +783,7 @@ protected:
 
 public: // Should be protected, but bug in clang++.
 	static void initialize_class();
-	_FORCE_INLINE_ static void register_custom_data_to_otdb() {}
+	static _FORCE_INLINE_ void register_custom_data_to_otdb() {}
 
 public:
 	static constexpr bool _class_is_enabled = true;
@@ -1040,7 +1040,7 @@ class ObjectDB {
 public:
 	typedef void (*DebugFunc)(Object *p_obj);
 
-	_ALWAYS_INLINE_ static Object *get_instance(ObjectID p_instance_id) {
+	static _ALWAYS_INLINE_ Object *get_instance(ObjectID p_instance_id) {
 		uint64_t id = p_instance_id;
 		uint32_t slot = id & OBJECTDB_SLOT_MAX_COUNT_MASK;
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -242,7 +242,7 @@ public:
 
 template <typename T>
 struct PtrToArg<Ref<T>> {
-	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ Ref<T> convert(const void *p_ptr) {
 		if (p_ptr == nullptr) {
 			return Ref<T>();
 		}
@@ -252,7 +252,7 @@ struct PtrToArg<Ref<T>> {
 
 	typedef Ref<T> EncodeT;
 
-	_FORCE_INLINE_ static void encode(Ref<T> p_val, const void *p_ptr) {
+	static _FORCE_INLINE_ void encode(Ref<T> p_val, const void *p_ptr) {
 		// p_ptr points to an EncodeT object which is a Ref<T> object.
 		*(const_cast<Ref<RefCounted> *>(reinterpret_cast<const Ref<RefCounted> *>(p_ptr))) = p_val;
 	}
@@ -262,7 +262,7 @@ template <typename T>
 struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
-	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ Ref<T> convert(const void *p_ptr) {
 		if (p_ptr == nullptr) {
 			return Ref<T>();
 		}

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -73,7 +73,7 @@ public:
 
 	static void set_scripting_enabled(bool p_enabled);
 	static bool is_scripting_enabled();
-	_FORCE_INLINE_ static int get_language_count() { return _language_count; }
+	static _FORCE_INLINE_ int get_language_count() { return _language_count; }
 	static ScriptLanguage *get_language(int p_idx);
 	static ScriptLanguage *get_language_for_extension(const String &p_extension);
 	static Error register_language(ScriptLanguage *p_language);

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -69,8 +69,8 @@ public:
 
 class DefaultAllocator {
 public:
-	_FORCE_INLINE_ static void *alloc(size_t p_memory) { return Memory::alloc_static(p_memory, false); }
-	_FORCE_INLINE_ static void free(void *p_ptr) { Memory::free_static(p_ptr, false); }
+	static _FORCE_INLINE_ void *alloc(size_t p_memory) { return Memory::alloc_static(p_memory, false); }
+	static _FORCE_INLINE_ void free(void *p_ptr) { Memory::free_static(p_ptr, false); }
 };
 
 void *operator new(size_t p_size, const char *p_description); ///< operator new that takes a description and uses MemoryStaticPool

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -105,16 +105,16 @@ public:
 
 	_FORCE_INLINE_ ID get_id() const { return id; }
 	// get the ID of the caller thread
-	_FORCE_INLINE_ static ID get_caller_id() {
+	static _FORCE_INLINE_ ID get_caller_id() {
 		if (unlikely(caller_id == UNASSIGNED_ID)) {
 			caller_id = id_counter.increment();
 		}
 		return caller_id;
 	}
 	// get the ID of the main thread
-	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }
+	static _FORCE_INLINE_ ID get_main_id() { return MAIN_ID; }
 
-	_FORCE_INLINE_ static bool is_main_thread() { return caller_id == MAIN_ID; } // Gain a tiny bit of perf here because there is no need to validate caller_id here, because only main thread will be set as 1.
+	static _FORCE_INLINE_ bool is_main_thread() { return caller_id == MAIN_ID; } // Gain a tiny bit of perf here because there is no need to validate caller_id here, because only main thread will be set as 1.
 
 	static Error set_name(const String &p_name);
 
@@ -171,10 +171,10 @@ public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
 
 	_FORCE_INLINE_ ID get_id() const { return 0; }
-	_FORCE_INLINE_ static ID get_caller_id() { return MAIN_ID; }
-	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }
+	static _FORCE_INLINE_ ID get_caller_id() { return MAIN_ID; }
+	static _FORCE_INLINE_ ID get_main_id() { return MAIN_ID; }
 
-	_FORCE_INLINE_ static bool is_main_thread() { return true; }
+	static _FORCE_INLINE_ bool is_main_thread() { return true; }
 
 	static Error set_name(const String &p_name) { return ERR_UNAVAILABLE; }
 

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -137,7 +137,7 @@ class TranslationServer : public Object {
 	void init_locale_info();
 
 public:
-	_FORCE_INLINE_ static TranslationServer *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ TranslationServer *get_singleton() { return singleton; }
 
 	void set_enabled(bool p_enabled) { enabled = p_enabled; }
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -93,11 +93,11 @@ struct VariantCaster<const T &> {
 	};                                                                                                                  \
 	template <>                                                                                                         \
 	struct PtrToArg<m_enum> {                                                                                           \
-		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) {                                                       \
+		static _FORCE_INLINE_ m_enum convert(const void *p_ptr) {                                                       \
 			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr));                                                   \
 		}                                                                                                               \
 		typedef int64_t EncodeT;                                                                                        \
-		_FORCE_INLINE_ static void encode(m_enum p_val, const void *p_ptr) {                                            \
+		static _FORCE_INLINE_ void encode(m_enum p_val, const void *p_ptr) {                                            \
 			*(int64_t *)p_ptr = (int64_t)p_val;                                                                         \
 		}                                                                                                               \
 	};                                                                                                                  \
@@ -121,11 +121,11 @@ struct VariantCaster<const T &> {
 	};                                                                                                                                      \
 	template <>                                                                                                                             \
 	struct PtrToArg<BitField<m_enum>> {                                                                                                     \
-		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {                                                                 \
+		static _FORCE_INLINE_ BitField<m_enum> convert(const void *p_ptr) {                                                                 \
 			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));                                                             \
 		}                                                                                                                                   \
 		typedef int64_t EncodeT;                                                                                                            \
-		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, const void *p_ptr) {                                                      \
+		static _FORCE_INLINE_ void encode(BitField<m_enum> p_val, const void *p_ptr) {                                                      \
 			*(int64_t *)p_ptr = p_val;                                                                                                      \
 		}                                                                                                                                   \
 	};                                                                                                                                      \
@@ -213,11 +213,11 @@ struct VariantCaster<char32_t> {
 
 template <>
 struct PtrToArg<char32_t> {
-	_FORCE_INLINE_ static char32_t convert(const void *p_ptr) {
+	static _FORCE_INLINE_ char32_t convert(const void *p_ptr) {
 		return char32_t(*reinterpret_cast<const int *>(p_ptr));
 	}
 	typedef int64_t EncodeT;
-	_FORCE_INLINE_ static void encode(char32_t p_val, const void *p_ptr) {
+	static _FORCE_INLINE_ void encode(char32_t p_val, const void *p_ptr) {
 		*(int *)p_ptr = p_val;
 	}
 };

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -41,21 +41,21 @@ struct PtrToArg {};
 #define MAKE_PTRARG(m_type)                                              \
 	template <>                                                          \
 	struct PtrToArg<m_type> {                                            \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) { \
+		static _FORCE_INLINE_ const m_type &convert(const void *p_ptr) { \
 			return *reinterpret_cast<const m_type *>(p_ptr);             \
 		}                                                                \
 		typedef m_type EncodeT;                                          \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {   \
+		static _FORCE_INLINE_ void encode(m_type p_val, void *p_ptr) {   \
 			*((m_type *)p_ptr) = p_val;                                  \
 		}                                                                \
 	};                                                                   \
 	template <>                                                          \
 	struct PtrToArg<const m_type &> {                                    \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) { \
+		static _FORCE_INLINE_ const m_type &convert(const void *p_ptr) { \
 			return *reinterpret_cast<const m_type *>(p_ptr);             \
 		}                                                                \
 		typedef m_type EncodeT;                                          \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {   \
+		static _FORCE_INLINE_ void encode(m_type p_val, void *p_ptr) {   \
 			*((m_type *)p_ptr) = p_val;                                  \
 		}                                                                \
 	}
@@ -63,21 +63,21 @@ struct PtrToArg {};
 #define MAKE_PTRARGCONV(m_type, m_conv)                                           \
 	template <>                                                                   \
 	struct PtrToArg<m_type> {                                                     \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+		static _FORCE_INLINE_ m_type convert(const void *p_ptr) {                 \
 			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
 		}                                                                         \
 		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
+		static _FORCE_INLINE_ void encode(m_type p_val, void *p_ptr) {            \
 			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
 		}                                                                         \
 	};                                                                            \
 	template <>                                                                   \
 	struct PtrToArg<const m_type &> {                                             \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+		static _FORCE_INLINE_ m_type convert(const void *p_ptr) {                 \
 			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
 		}                                                                         \
 		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
+		static _FORCE_INLINE_ void encode(m_type p_val, void *p_ptr) {            \
 			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
 		}                                                                         \
 	}
@@ -85,21 +85,21 @@ struct PtrToArg {};
 #define MAKE_PTRARG_BY_REFERENCE(m_type)                                      \
 	template <>                                                               \
 	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) {      \
+		static _FORCE_INLINE_ const m_type &convert(const void *p_ptr) {      \
 			return *reinterpret_cast<const m_type *>(p_ptr);                  \
 		}                                                                     \
 		typedef m_type EncodeT;                                               \
-		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const m_type &p_val, void *p_ptr) { \
 			*((m_type *)p_ptr) = p_val;                                       \
 		}                                                                     \
 	};                                                                        \
 	template <>                                                               \
 	struct PtrToArg<const m_type &> {                                         \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) {      \
+		static _FORCE_INLINE_ const m_type &convert(const void *p_ptr) {      \
 			return *reinterpret_cast<const m_type *>(p_ptr);                  \
 		}                                                                     \
 		typedef m_type EncodeT;                                               \
-		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const m_type &p_val, void *p_ptr) { \
 			*((m_type *)p_ptr) = p_val;                                       \
 		}                                                                     \
 	}
@@ -159,22 +159,22 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 
 template <typename T>
 struct PtrToArg<T *> {
-	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
+	static _FORCE_INLINE_ T *convert(const void *p_ptr) {
 		return likely(p_ptr) ? const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr)) : nullptr;
 	}
 	typedef Object *EncodeT;
-	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(T *p_var, void *p_ptr) {
 		*((T **)p_ptr) = p_var;
 	}
 };
 
 template <typename T>
 struct PtrToArg<const T *> {
-	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
+	static _FORCE_INLINE_ const T *convert(const void *p_ptr) {
 		return likely(p_ptr) ? *reinterpret_cast<T *const *>(p_ptr) : nullptr;
 	}
 	typedef const Object *EncodeT;
-	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(T *p_var, void *p_ptr) {
 		*((T **)p_ptr) = p_var;
 	}
 };
@@ -183,11 +183,11 @@ struct PtrToArg<const T *> {
 
 template <>
 struct PtrToArg<ObjectID> {
-	_FORCE_INLINE_ static const ObjectID convert(const void *p_ptr) {
+	static _FORCE_INLINE_ const ObjectID convert(const void *p_ptr) {
 		return ObjectID(*reinterpret_cast<const uint64_t *>(p_ptr));
 	}
 	typedef uint64_t EncodeT;
-	_FORCE_INLINE_ static void encode(const ObjectID &p_val, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(const ObjectID &p_val, void *p_ptr) {
 		*((uint64_t *)p_ptr) = p_val;
 	}
 };
@@ -198,7 +198,7 @@ struct PtrToArg<ObjectID> {
 #define MAKE_VECARG(m_type)                                                              \
 	template <>                                                                          \
 	struct PtrToArg<Vector<m_type>> {                                                    \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {                \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {                \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
 			Vector<m_type> ret;                                                          \
 			int len = dvs->size();                                                       \
@@ -211,7 +211,7 @@ struct PtrToArg<ObjectID> {
 			}                                                                            \
 			return ret;                                                                  \
 		}                                                                                \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) {    \
+		static _FORCE_INLINE_ void encode(const Vector<m_type> &p_vec, void *p_ptr) {    \
 			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);              \
 			int len = p_vec.size();                                                      \
 			dv->resize(len);                                                             \
@@ -225,7 +225,7 @@ struct PtrToArg<ObjectID> {
 	};                                                                                   \
 	template <>                                                                          \
 	struct PtrToArg<const Vector<m_type> &> {                                            \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {                \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {                \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
 			Vector<m_type> ret;                                                          \
 			int len = dvs->size();                                                       \
@@ -244,7 +244,7 @@ struct PtrToArg<ObjectID> {
 #define MAKE_VECARG_ALT(m_type, m_type_alt)                                               \
 	template <>                                                                           \
 	struct PtrToArg<Vector<m_type_alt>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type_alt> convert(const void *p_ptr) {             \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr);  \
 			Vector<m_type_alt> ret;                                                       \
 			int len = dvs->size();                                                        \
@@ -257,7 +257,7 @@ struct PtrToArg<ObjectID> {
 			}                                                                             \
 			return ret;                                                                   \
 		}                                                                                 \
-		_FORCE_INLINE_ static void encode(const Vector<m_type_alt> &p_vec, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const Vector<m_type_alt> &p_vec, void *p_ptr) { \
 			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);               \
 			int len = p_vec.size();                                                       \
 			dv->resize(len);                                                              \
@@ -271,7 +271,7 @@ struct PtrToArg<ObjectID> {
 	};                                                                                    \
 	template <>                                                                           \
 	struct PtrToArg<const Vector<m_type_alt> &> {                                         \
-		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type_alt> convert(const void *p_ptr) {             \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr);  \
 			Vector<m_type_alt> ret;                                                       \
 			int len = dvs->size();                                                        \
@@ -294,7 +294,7 @@ MAKE_VECARG_ALT(String, StringName);
 #define MAKE_VECARR(m_type)                                                           \
 	template <>                                                                       \
 	struct PtrToArg<Vector<m_type>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {             \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
 			Vector<m_type> ret;                                                       \
 			int len = arr->size();                                                    \
@@ -304,7 +304,7 @@ MAKE_VECARG_ALT(String, StringName);
 			}                                                                         \
 			return ret;                                                               \
 		}                                                                             \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
 			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
 			int len = p_vec.size();                                                   \
 			arr->resize(len);                                                         \
@@ -315,7 +315,7 @@ MAKE_VECARG_ALT(String, StringName);
 	};                                                                                \
 	template <>                                                                       \
 	struct PtrToArg<const Vector<m_type> &> {                                         \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {             \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
 			Vector<m_type> ret;                                                       \
 			int len = arr->size();                                                    \
@@ -335,7 +335,7 @@ MAKE_VECARR(Plane);
 #define MAKE_DVECARR(m_type)                                                          \
 	template <>                                                                       \
 	struct PtrToArg<Vector<m_type>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {             \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
 			Vector<m_type> ret;                                                       \
 			int len = arr->size();                                                    \
@@ -348,7 +348,7 @@ MAKE_VECARR(Plane);
 			}                                                                         \
 			return ret;                                                               \
 		}                                                                             \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
 			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
 			int len = p_vec.size();                                                   \
 			arr->resize(len);                                                         \
@@ -362,7 +362,7 @@ MAKE_VECARR(Plane);
 	};                                                                                \
 	template <>                                                                       \
 	struct PtrToArg<const Vector<m_type> &> {                                         \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ Vector<m_type> convert(const void *p_ptr) {             \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
 			Vector<m_type> ret;                                                       \
 			int len = arr->size();                                                    \
@@ -383,11 +383,11 @@ MAKE_VECARR(Plane);
 #define MAKE_STRINGCONV_BY_REFERENCE(m_type)                                  \
 	template <>                                                               \
 	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ m_type convert(const void *p_ptr) {             \
 			m_type s = *reinterpret_cast<const String *>(p_ptr);              \
 			return s;                                                         \
 		}                                                                     \
-		_FORCE_INLINE_ static void encode(const m_type &p_vec, void *p_ptr) { \
+		static _FORCE_INLINE_ void encode(const m_type &p_vec, void *p_ptr) { \
 			String *arr = reinterpret_cast<String *>(p_ptr);                  \
 			*arr = p_vec;                                                     \
 		}                                                                     \
@@ -395,7 +395,7 @@ MAKE_VECARR(Plane);
                                                                               \
 	template <>                                                               \
 	struct PtrToArg<const m_type &> {                                         \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+		static _FORCE_INLINE_ m_type convert(const void *p_ptr) {             \
 			m_type s = *reinterpret_cast<const String *>(p_ptr);              \
 			return s;                                                         \
 		}                                                                     \
@@ -406,7 +406,7 @@ MAKE_STRINGCONV_BY_REFERENCE(IPAddress);
 // No EncodeT because direct pointer conversion not possible.
 template <>
 struct PtrToArg<Vector<Face3>> {
-	_FORCE_INLINE_ static Vector<Face3> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ Vector<Face3> convert(const void *p_ptr) {
 		const Vector<Vector3> *dvs = reinterpret_cast<const Vector<Vector3> *>(p_ptr);
 		Vector<Face3> ret;
 		int len = dvs->size() / 3;
@@ -422,7 +422,7 @@ struct PtrToArg<Vector<Face3>> {
 		}
 		return ret;
 	}
-	_FORCE_INLINE_ static void encode(const Vector<Face3> &p_vec, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(const Vector<Face3> &p_vec, void *p_ptr) {
 		Vector<Vector3> *arr = reinterpret_cast<Vector<Vector3> *>(p_ptr);
 		int len = p_vec.size();
 		arr->resize(len * 3);
@@ -441,7 +441,7 @@ struct PtrToArg<Vector<Face3>> {
 // No EncodeT because direct pointer conversion not possible.
 template <>
 struct PtrToArg<const Vector<Face3> &> {
-	_FORCE_INLINE_ static Vector<Face3> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ Vector<Face3> convert(const void *p_ptr) {
 		const Vector<Vector3> *dvs = reinterpret_cast<const Vector<Vector3> *>(p_ptr);
 		Vector<Face3> ret;
 		int len = dvs->size() / 3;

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -115,21 +115,21 @@ struct GetTypeInfo<GDExtensionPtr<T>> {
 
 template <typename T>
 struct PtrToArg<GDExtensionConstPtr<T>> {
-	_FORCE_INLINE_ static GDExtensionConstPtr<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ GDExtensionConstPtr<T> convert(const void *p_ptr) {
 		return GDExtensionConstPtr<T>(reinterpret_cast<const T *>(p_ptr));
 	}
 	typedef const T *EncodeT;
-	_FORCE_INLINE_ static void encode(GDExtensionConstPtr<T> p_val, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(GDExtensionConstPtr<T> p_val, void *p_ptr) {
 		*((const T **)p_ptr) = p_val.data;
 	}
 };
 template <typename T>
 struct PtrToArg<GDExtensionPtr<T>> {
-	_FORCE_INLINE_ static GDExtensionPtr<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ GDExtensionPtr<T> convert(const void *p_ptr) {
 		return GDExtensionPtr<T>(reinterpret_cast<const T *>(p_ptr));
 	}
 	typedef T *EncodeT;
-	_FORCE_INLINE_ static void encode(GDExtensionPtr<T> p_val, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(GDExtensionPtr<T> p_val, void *p_ptr) {
 		*((T **)p_ptr) = p_val.data;
 	}
 };

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -149,11 +149,11 @@ MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
 
 template <typename T>
 struct PtrToArg<TypedArray<T>> {
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ TypedArray<T> convert(const void *p_ptr) {
 		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
 	}
 	typedef Array EncodeT;
-	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
+	static _FORCE_INLINE_ void encode(TypedArray<T> p_val, void *p_ptr) {
 		*(Array *)p_ptr = p_val;
 	}
 };
@@ -161,7 +161,7 @@ struct PtrToArg<TypedArray<T>> {
 template <typename T>
 struct PtrToArg<const TypedArray<T> &> {
 	typedef Array EncodeT;
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
+	static _FORCE_INLINE_ TypedArray<T> convert(const void *p_ptr) {
 		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
 	}
 };

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -47,7 +47,7 @@ struct PtrConstruct {};
 #define MAKE_PTRCONSTRUCT(m_type)                                                  \
 	template <>                                                                    \
 	struct PtrConstruct<m_type> {                                                  \
-		_FORCE_INLINE_ static void construct(const m_type &p_value, void *p_ptr) { \
+		static _FORCE_INLINE_ void construct(const m_type &p_value, void *p_ptr) { \
 			memnew_placement(p_ptr, m_type(p_value));                              \
 		}                                                                          \
 	};
@@ -78,7 +78,7 @@ MAKE_PTRCONSTRUCT(RID);
 
 template <>
 struct PtrConstruct<Object *> {
-	_FORCE_INLINE_ static void construct(Object *p_value, void *p_ptr) {
+	static _FORCE_INLINE_ void construct(Object *p_value, void *p_ptr) {
 		*((Object **)p_ptr) = p_value;
 	}
 };

--- a/core/variant/variant_destruct.h
+++ b/core/variant/variant_destruct.h
@@ -41,10 +41,10 @@ struct VariantDestruct {};
 #define MAKE_PTRDESTRUCT(m_type)                               \
 	template <>                                                \
 	struct VariantDestruct<m_type> {                           \
-		_FORCE_INLINE_ static void ptr_destruct(void *p_ptr) { \
+		static _FORCE_INLINE_ void ptr_destruct(void *p_ptr) { \
 			reinterpret_cast<m_type *>(p_ptr)->~m_type();      \
 		}                                                      \
-		_FORCE_INLINE_ static Variant::Type get_base_type() {  \
+		static _FORCE_INLINE_ Variant::Type get_base_type() {  \
 			return GetTypeInfo<m_type>::VARIANT_TYPE;          \
 		}                                                      \
 	}

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -43,7 +43,7 @@ class VariantInternal {
 
 public:
 	// Set type.
-	_FORCE_INLINE_ static void initialize(Variant *v, Variant::Type p_type) {
+	static _FORCE_INLINE_ void initialize(Variant *v, Variant::Type p_type) {
 		v->clear();
 		v->type = p_type;
 
@@ -125,99 +125,99 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ static bool initialize_ref(Object *object) {
+	static _FORCE_INLINE_ bool initialize_ref(Object *object) {
 		return Variant::initialize_ref(object);
 	}
 
 	// Atomic types.
-	_FORCE_INLINE_ static bool *get_bool(Variant *v) { return &v->_data._bool; }
-	_FORCE_INLINE_ static const bool *get_bool(const Variant *v) { return &v->_data._bool; }
-	_FORCE_INLINE_ static int64_t *get_int(Variant *v) { return &v->_data._int; }
-	_FORCE_INLINE_ static const int64_t *get_int(const Variant *v) { return &v->_data._int; }
-	_FORCE_INLINE_ static double *get_float(Variant *v) { return &v->_data._float; }
-	_FORCE_INLINE_ static const double *get_float(const Variant *v) { return &v->_data._float; }
-	_FORCE_INLINE_ static String *get_string(Variant *v) { return reinterpret_cast<String *>(v->_data._mem); }
-	_FORCE_INLINE_ static const String *get_string(const Variant *v) { return reinterpret_cast<const String *>(v->_data._mem); }
+	static _FORCE_INLINE_ bool *get_bool(Variant *v) { return &v->_data._bool; }
+	static _FORCE_INLINE_ const bool *get_bool(const Variant *v) { return &v->_data._bool; }
+	static _FORCE_INLINE_ int64_t *get_int(Variant *v) { return &v->_data._int; }
+	static _FORCE_INLINE_ const int64_t *get_int(const Variant *v) { return &v->_data._int; }
+	static _FORCE_INLINE_ double *get_float(Variant *v) { return &v->_data._float; }
+	static _FORCE_INLINE_ const double *get_float(const Variant *v) { return &v->_data._float; }
+	static _FORCE_INLINE_ String *get_string(Variant *v) { return reinterpret_cast<String *>(v->_data._mem); }
+	static _FORCE_INLINE_ const String *get_string(const Variant *v) { return reinterpret_cast<const String *>(v->_data._mem); }
 
 	// Math types.
-	_FORCE_INLINE_ static Vector2 *get_vector2(Variant *v) { return reinterpret_cast<Vector2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector2 *get_vector2(const Variant *v) { return reinterpret_cast<const Vector2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector2i *get_vector2i(Variant *v) { return reinterpret_cast<Vector2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector2i *get_vector2i(const Variant *v) { return reinterpret_cast<const Vector2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Rect2 *get_rect2(Variant *v) { return reinterpret_cast<Rect2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Rect2 *get_rect2(const Variant *v) { return reinterpret_cast<const Rect2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Rect2i *get_rect2i(Variant *v) { return reinterpret_cast<Rect2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Rect2i *get_rect2i(const Variant *v) { return reinterpret_cast<const Rect2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector3 *get_vector3(Variant *v) { return reinterpret_cast<Vector3 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector3 *get_vector3(const Variant *v) { return reinterpret_cast<const Vector3 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector3i *get_vector3i(Variant *v) { return reinterpret_cast<Vector3i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector3i *get_vector3i(const Variant *v) { return reinterpret_cast<const Vector3i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector4 *get_vector4(Variant *v) { return reinterpret_cast<Vector4 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector4 *get_vector4(const Variant *v) { return reinterpret_cast<const Vector4 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector4i *get_vector4i(Variant *v) { return reinterpret_cast<Vector4i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector4i *get_vector4i(const Variant *v) { return reinterpret_cast<const Vector4i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Transform2D *get_transform2d(Variant *v) { return v->_data._transform2d; }
-	_FORCE_INLINE_ static const Transform2D *get_transform2d(const Variant *v) { return v->_data._transform2d; }
-	_FORCE_INLINE_ static Plane *get_plane(Variant *v) { return reinterpret_cast<Plane *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Plane *get_plane(const Variant *v) { return reinterpret_cast<const Plane *>(v->_data._mem); }
-	_FORCE_INLINE_ static Quaternion *get_quaternion(Variant *v) { return reinterpret_cast<Quaternion *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Quaternion *get_quaternion(const Variant *v) { return reinterpret_cast<const Quaternion *>(v->_data._mem); }
-	_FORCE_INLINE_ static ::AABB *get_aabb(Variant *v) { return v->_data._aabb; }
-	_FORCE_INLINE_ static const ::AABB *get_aabb(const Variant *v) { return v->_data._aabb; }
-	_FORCE_INLINE_ static Basis *get_basis(Variant *v) { return v->_data._basis; }
-	_FORCE_INLINE_ static const Basis *get_basis(const Variant *v) { return v->_data._basis; }
-	_FORCE_INLINE_ static Transform3D *get_transform(Variant *v) { return v->_data._transform3d; }
-	_FORCE_INLINE_ static const Transform3D *get_transform(const Variant *v) { return v->_data._transform3d; }
-	_FORCE_INLINE_ static Projection *get_projection(Variant *v) { return v->_data._projection; }
-	_FORCE_INLINE_ static const Projection *get_projection(const Variant *v) { return v->_data._projection; }
+	static _FORCE_INLINE_ Vector2 *get_vector2(Variant *v) { return reinterpret_cast<Vector2 *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector2 *get_vector2(const Variant *v) { return reinterpret_cast<const Vector2 *>(v->_data._mem); }
+	static _FORCE_INLINE_ Vector2i *get_vector2i(Variant *v) { return reinterpret_cast<Vector2i *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector2i *get_vector2i(const Variant *v) { return reinterpret_cast<const Vector2i *>(v->_data._mem); }
+	static _FORCE_INLINE_ Rect2 *get_rect2(Variant *v) { return reinterpret_cast<Rect2 *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Rect2 *get_rect2(const Variant *v) { return reinterpret_cast<const Rect2 *>(v->_data._mem); }
+	static _FORCE_INLINE_ Rect2i *get_rect2i(Variant *v) { return reinterpret_cast<Rect2i *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Rect2i *get_rect2i(const Variant *v) { return reinterpret_cast<const Rect2i *>(v->_data._mem); }
+	static _FORCE_INLINE_ Vector3 *get_vector3(Variant *v) { return reinterpret_cast<Vector3 *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector3 *get_vector3(const Variant *v) { return reinterpret_cast<const Vector3 *>(v->_data._mem); }
+	static _FORCE_INLINE_ Vector3i *get_vector3i(Variant *v) { return reinterpret_cast<Vector3i *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector3i *get_vector3i(const Variant *v) { return reinterpret_cast<const Vector3i *>(v->_data._mem); }
+	static _FORCE_INLINE_ Vector4 *get_vector4(Variant *v) { return reinterpret_cast<Vector4 *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector4 *get_vector4(const Variant *v) { return reinterpret_cast<const Vector4 *>(v->_data._mem); }
+	static _FORCE_INLINE_ Vector4i *get_vector4i(Variant *v) { return reinterpret_cast<Vector4i *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Vector4i *get_vector4i(const Variant *v) { return reinterpret_cast<const Vector4i *>(v->_data._mem); }
+	static _FORCE_INLINE_ Transform2D *get_transform2d(Variant *v) { return v->_data._transform2d; }
+	static _FORCE_INLINE_ const Transform2D *get_transform2d(const Variant *v) { return v->_data._transform2d; }
+	static _FORCE_INLINE_ Plane *get_plane(Variant *v) { return reinterpret_cast<Plane *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Plane *get_plane(const Variant *v) { return reinterpret_cast<const Plane *>(v->_data._mem); }
+	static _FORCE_INLINE_ Quaternion *get_quaternion(Variant *v) { return reinterpret_cast<Quaternion *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Quaternion *get_quaternion(const Variant *v) { return reinterpret_cast<const Quaternion *>(v->_data._mem); }
+	static _FORCE_INLINE_ ::AABB *get_aabb(Variant *v) { return v->_data._aabb; }
+	static _FORCE_INLINE_ const ::AABB *get_aabb(const Variant *v) { return v->_data._aabb; }
+	static _FORCE_INLINE_ Basis *get_basis(Variant *v) { return v->_data._basis; }
+	static _FORCE_INLINE_ const Basis *get_basis(const Variant *v) { return v->_data._basis; }
+	static _FORCE_INLINE_ Transform3D *get_transform(Variant *v) { return v->_data._transform3d; }
+	static _FORCE_INLINE_ const Transform3D *get_transform(const Variant *v) { return v->_data._transform3d; }
+	static _FORCE_INLINE_ Projection *get_projection(Variant *v) { return v->_data._projection; }
+	static _FORCE_INLINE_ const Projection *get_projection(const Variant *v) { return v->_data._projection; }
 
 	// Misc types.
-	_FORCE_INLINE_ static Color *get_color(Variant *v) { return reinterpret_cast<Color *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Color *get_color(const Variant *v) { return reinterpret_cast<const Color *>(v->_data._mem); }
-	_FORCE_INLINE_ static StringName *get_string_name(Variant *v) { return reinterpret_cast<StringName *>(v->_data._mem); }
-	_FORCE_INLINE_ static const StringName *get_string_name(const Variant *v) { return reinterpret_cast<const StringName *>(v->_data._mem); }
-	_FORCE_INLINE_ static NodePath *get_node_path(Variant *v) { return reinterpret_cast<NodePath *>(v->_data._mem); }
-	_FORCE_INLINE_ static const NodePath *get_node_path(const Variant *v) { return reinterpret_cast<const NodePath *>(v->_data._mem); }
-	_FORCE_INLINE_ static ::RID *get_rid(Variant *v) { return reinterpret_cast<::RID *>(v->_data._mem); }
-	_FORCE_INLINE_ static const ::RID *get_rid(const Variant *v) { return reinterpret_cast<const ::RID *>(v->_data._mem); }
-	_FORCE_INLINE_ static Callable *get_callable(Variant *v) { return reinterpret_cast<Callable *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Callable *get_callable(const Variant *v) { return reinterpret_cast<const Callable *>(v->_data._mem); }
-	_FORCE_INLINE_ static Signal *get_signal(Variant *v) { return reinterpret_cast<Signal *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Signal *get_signal(const Variant *v) { return reinterpret_cast<const Signal *>(v->_data._mem); }
-	_FORCE_INLINE_ static Dictionary *get_dictionary(Variant *v) { return reinterpret_cast<Dictionary *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Dictionary *get_dictionary(const Variant *v) { return reinterpret_cast<const Dictionary *>(v->_data._mem); }
-	_FORCE_INLINE_ static Array *get_array(Variant *v) { return reinterpret_cast<Array *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Array *get_array(const Variant *v) { return reinterpret_cast<const Array *>(v->_data._mem); }
+	static _FORCE_INLINE_ Color *get_color(Variant *v) { return reinterpret_cast<Color *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Color *get_color(const Variant *v) { return reinterpret_cast<const Color *>(v->_data._mem); }
+	static _FORCE_INLINE_ StringName *get_string_name(Variant *v) { return reinterpret_cast<StringName *>(v->_data._mem); }
+	static _FORCE_INLINE_ const StringName *get_string_name(const Variant *v) { return reinterpret_cast<const StringName *>(v->_data._mem); }
+	static _FORCE_INLINE_ NodePath *get_node_path(Variant *v) { return reinterpret_cast<NodePath *>(v->_data._mem); }
+	static _FORCE_INLINE_ const NodePath *get_node_path(const Variant *v) { return reinterpret_cast<const NodePath *>(v->_data._mem); }
+	static _FORCE_INLINE_ ::RID *get_rid(Variant *v) { return reinterpret_cast<::RID *>(v->_data._mem); }
+	static _FORCE_INLINE_ const ::RID *get_rid(const Variant *v) { return reinterpret_cast<const ::RID *>(v->_data._mem); }
+	static _FORCE_INLINE_ Callable *get_callable(Variant *v) { return reinterpret_cast<Callable *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Callable *get_callable(const Variant *v) { return reinterpret_cast<const Callable *>(v->_data._mem); }
+	static _FORCE_INLINE_ Signal *get_signal(Variant *v) { return reinterpret_cast<Signal *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Signal *get_signal(const Variant *v) { return reinterpret_cast<const Signal *>(v->_data._mem); }
+	static _FORCE_INLINE_ Dictionary *get_dictionary(Variant *v) { return reinterpret_cast<Dictionary *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Dictionary *get_dictionary(const Variant *v) { return reinterpret_cast<const Dictionary *>(v->_data._mem); }
+	static _FORCE_INLINE_ Array *get_array(Variant *v) { return reinterpret_cast<Array *>(v->_data._mem); }
+	static _FORCE_INLINE_ const Array *get_array(const Variant *v) { return reinterpret_cast<const Array *>(v->_data._mem); }
 
 	// Typed arrays.
-	_FORCE_INLINE_ static PackedByteArray *get_byte_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedByteArray *get_byte_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt32Array *get_int32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt32Array *get_int32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt64Array *get_int64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt64Array *get_int64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat32Array *get_float32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat32Array *get_float32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat64Array *get_float64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat64Array *get_float64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedStringArray *get_string_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedStringArray *get_string_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector2Array *get_vector2_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector2Array *get_vector2_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector3Array *get_vector3_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedColorArray *get_color_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector4Array *get_vector4_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector4Array *get_vector4_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedByteArray *get_byte_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedByteArray *get_byte_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedInt32Array *get_int32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedInt32Array *get_int32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedInt64Array *get_int64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedInt64Array *get_int64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedFloat32Array *get_float32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedFloat32Array *get_float32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedFloat64Array *get_float64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedFloat64Array *get_float64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedStringArray *get_string_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedStringArray *get_string_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedVector2Array *get_vector2_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedVector2Array *get_vector2_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedVector3Array *get_vector3_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedColorArray *get_color_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ PackedVector4Array *get_vector4_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const PackedVector4Array *get_vector4_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
 
-	_FORCE_INLINE_ static Object **get_object(Variant *v) { return (Object **)&v->_get_obj().obj; }
-	_FORCE_INLINE_ static const Object **get_object(const Variant *v) { return (const Object **)&v->_get_obj().obj; }
+	static _FORCE_INLINE_ Object **get_object(Variant *v) { return (Object **)&v->_get_obj().obj; }
+	static _FORCE_INLINE_ const Object **get_object(const Variant *v) { return (const Object **)&v->_get_obj().obj; }
 
-	_FORCE_INLINE_ static const ObjectID get_object_id(const Variant *v) { return v->_get_obj().id; }
+	static _FORCE_INLINE_ const ObjectID get_object_id(const Variant *v) { return v->_get_obj().id; }
 
 	template <typename T>
-	_FORCE_INLINE_ static void init_generic(Variant *v) {
+	static _FORCE_INLINE_ void init_generic(Variant *v) {
 		v->type = GetTypeInfo<T>::VARIANT_TYPE;
 	}
 
@@ -225,120 +225,120 @@ public:
 	// Those primitive and vector types don't need an `init_` method:
 	// Nil, bool, float, Vector2/i, Rect2/i, Vector3/i, Plane, Quat, RID.
 	// Object is a special case, handled via `object_assign_null`.
-	_FORCE_INLINE_ static void init_string(Variant *v) {
+	static _FORCE_INLINE_ void init_string(Variant *v) {
 		memnew_placement(v->_data._mem, String);
 		v->type = Variant::STRING;
 	}
-	_FORCE_INLINE_ static void init_transform2d(Variant *v) {
+	static _FORCE_INLINE_ void init_transform2d(Variant *v) {
 		v->_data._transform2d = (Transform2D *)Variant::Pools::_bucket_small.alloc();
 		memnew_placement(v->_data._transform2d, Transform2D);
 		v->type = Variant::TRANSFORM2D;
 	}
-	_FORCE_INLINE_ static void init_aabb(Variant *v) {
+	static _FORCE_INLINE_ void init_aabb(Variant *v) {
 		v->_data._aabb = (AABB *)Variant::Pools::_bucket_small.alloc();
 		memnew_placement(v->_data._aabb, AABB);
 		v->type = Variant::AABB;
 	}
-	_FORCE_INLINE_ static void init_basis(Variant *v) {
+	static _FORCE_INLINE_ void init_basis(Variant *v) {
 		v->_data._basis = (Basis *)Variant::Pools::_bucket_medium.alloc();
 		memnew_placement(v->_data._basis, Basis);
 		v->type = Variant::BASIS;
 	}
-	_FORCE_INLINE_ static void init_transform3d(Variant *v) {
+	static _FORCE_INLINE_ void init_transform3d(Variant *v) {
 		v->_data._transform3d = (Transform3D *)Variant::Pools::_bucket_medium.alloc();
 		memnew_placement(v->_data._transform3d, Transform3D);
 		v->type = Variant::TRANSFORM3D;
 	}
-	_FORCE_INLINE_ static void init_projection(Variant *v) {
+	static _FORCE_INLINE_ void init_projection(Variant *v) {
 		v->_data._projection = (Projection *)Variant::Pools::_bucket_large.alloc();
 		memnew_placement(v->_data._projection, Projection);
 		v->type = Variant::PROJECTION;
 	}
-	_FORCE_INLINE_ static void init_color(Variant *v) {
+	static _FORCE_INLINE_ void init_color(Variant *v) {
 		memnew_placement(v->_data._mem, Color);
 		v->type = Variant::COLOR;
 	}
-	_FORCE_INLINE_ static void init_string_name(Variant *v) {
+	static _FORCE_INLINE_ void init_string_name(Variant *v) {
 		memnew_placement(v->_data._mem, StringName);
 		v->type = Variant::STRING_NAME;
 	}
-	_FORCE_INLINE_ static void init_node_path(Variant *v) {
+	static _FORCE_INLINE_ void init_node_path(Variant *v) {
 		memnew_placement(v->_data._mem, NodePath);
 		v->type = Variant::NODE_PATH;
 	}
-	_FORCE_INLINE_ static void init_callable(Variant *v) {
+	static _FORCE_INLINE_ void init_callable(Variant *v) {
 		memnew_placement(v->_data._mem, Callable);
 		v->type = Variant::CALLABLE;
 	}
-	_FORCE_INLINE_ static void init_signal(Variant *v) {
+	static _FORCE_INLINE_ void init_signal(Variant *v) {
 		memnew_placement(v->_data._mem, Signal);
 		v->type = Variant::SIGNAL;
 	}
-	_FORCE_INLINE_ static void init_dictionary(Variant *v) {
+	static _FORCE_INLINE_ void init_dictionary(Variant *v) {
 		memnew_placement(v->_data._mem, Dictionary);
 		v->type = Variant::DICTIONARY;
 	}
-	_FORCE_INLINE_ static void init_array(Variant *v) {
+	static _FORCE_INLINE_ void init_array(Variant *v) {
 		memnew_placement(v->_data._mem, Array);
 		v->type = Variant::ARRAY;
 	}
-	_FORCE_INLINE_ static void init_byte_array(Variant *v) {
+	static _FORCE_INLINE_ void init_byte_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<uint8_t>::create(Vector<uint8_t>());
 		v->type = Variant::PACKED_BYTE_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_int32_array(Variant *v) {
+	static _FORCE_INLINE_ void init_int32_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<int32_t>::create(Vector<int32_t>());
 		v->type = Variant::PACKED_INT32_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_int64_array(Variant *v) {
+	static _FORCE_INLINE_ void init_int64_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<int64_t>::create(Vector<int64_t>());
 		v->type = Variant::PACKED_INT64_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_float32_array(Variant *v) {
+	static _FORCE_INLINE_ void init_float32_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<float>::create(Vector<float>());
 		v->type = Variant::PACKED_FLOAT32_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_float64_array(Variant *v) {
+	static _FORCE_INLINE_ void init_float64_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<double>::create(Vector<double>());
 		v->type = Variant::PACKED_FLOAT64_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_string_array(Variant *v) {
+	static _FORCE_INLINE_ void init_string_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<String>::create(Vector<String>());
 		v->type = Variant::PACKED_STRING_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_vector2_array(Variant *v) {
+	static _FORCE_INLINE_ void init_vector2_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<Vector2>::create(Vector<Vector2>());
 		v->type = Variant::PACKED_VECTOR2_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_vector3_array(Variant *v) {
+	static _FORCE_INLINE_ void init_vector3_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<Vector3>::create(Vector<Vector3>());
 		v->type = Variant::PACKED_VECTOR3_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_color_array(Variant *v) {
+	static _FORCE_INLINE_ void init_color_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<Color>::create(Vector<Color>());
 		v->type = Variant::PACKED_COLOR_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_vector4_array(Variant *v) {
+	static _FORCE_INLINE_ void init_vector4_array(Variant *v) {
 		v->_data.packed_array = Variant::PackedArrayRef<Vector4>::create(Vector<Vector4>());
 		v->type = Variant::PACKED_VECTOR4_ARRAY;
 	}
-	_FORCE_INLINE_ static void init_object(Variant *v) {
+	static _FORCE_INLINE_ void init_object(Variant *v) {
 		object_assign_null(v);
 		v->type = Variant::OBJECT;
 	}
 
-	_FORCE_INLINE_ static void clear(Variant *v) {
+	static _FORCE_INLINE_ void clear(Variant *v) {
 		v->clear();
 	}
 
 	static void object_assign(Variant *v, const Object *o); // Needs RefCounted, so it's implemented elsewhere.
 	static void refcounted_object_assign(Variant *v, const RefCounted *rc);
 
-	_FORCE_INLINE_ static void object_assign(Variant *v, const Variant *o) {
+	static _FORCE_INLINE_ void object_assign(Variant *v, const Variant *o) {
 		object_assign(v, o->_get_obj().obj);
 	}
 
-	_FORCE_INLINE_ static void object_assign_null(Variant *v) {
+	static _FORCE_INLINE_ void object_assign_null(Variant *v) {
 		v->_get_obj().obj = nullptr;
 		v->_get_obj().id = ObjectID();
 	}
@@ -350,7 +350,7 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ static void *get_opaque_pointer(Variant *v) {
+	static _FORCE_INLINE_ void *get_opaque_pointer(Variant *v) {
 		switch (v->type) {
 			case Variant::NIL:
 				return nullptr;
@@ -436,7 +436,7 @@ public:
 		ERR_FAIL_V(nullptr);
 	}
 
-	_FORCE_INLINE_ static const void *get_opaque_pointer(const Variant *v) {
+	static _FORCE_INLINE_ const void *get_opaque_pointer(const Variant *v) {
 		switch (v->type) {
 			case Variant::NIL:
 				return nullptr;
@@ -1545,21 +1545,21 @@ struct VariantTypeChanger {
 
 template <typename T>
 struct VariantTypeAdjust {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+	static _FORCE_INLINE_ void adjust(Variant *r_ret) {
 		VariantTypeChanger<GetSimpleTypeT<T>>::change(r_ret);
 	}
 };
 
 template <>
 struct VariantTypeAdjust<Variant> {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+	static _FORCE_INLINE_ void adjust(Variant *r_ret) {
 		// Do nothing for variant.
 	}
 };
 
 template <>
 struct VariantTypeAdjust<Object *> {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+	static _FORCE_INLINE_ void adjust(Variant *r_ret) {
 		VariantInternal::clear(r_ret);
 		*r_ret = (Object *)nullptr;
 	}
@@ -1569,12 +1569,12 @@ struct VariantTypeAdjust<Object *> {
 
 template <typename T>
 struct VariantTypeConstructor {
-	_FORCE_INLINE_ static void variant_from_type(void *r_variant, void *p_value) {
+	static _FORCE_INLINE_ void variant_from_type(void *r_variant, void *p_value) {
 		// r_variant is provided by caller as uninitialized memory
 		memnew_placement(r_variant, Variant(*((T *)p_value)));
 	}
 
-	_FORCE_INLINE_ static void type_from_variant(void *r_value, void *p_variant) {
+	static _FORCE_INLINE_ void type_from_variant(void *r_value, void *p_variant) {
 		// r_value is provided by caller as uninitialized memory
 		memnew_placement(r_value, T(*reinterpret_cast<Variant *>(p_variant)));
 	}

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -781,7 +781,7 @@ public:
 template <typename A, typename B>
 class OperatorEvaluatorXor {
 public:
-	_FORCE_INLINE_ static bool xor_op(const A &a, const B &b) {
+	static _FORCE_INLINE_ bool xor_op(const A &a, const B &b) {
 		return ((a) || (b)) && !((a) && (b));
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -820,7 +820,7 @@ public:
 
 class OperatorEvaluatorAddArray {
 public:
-	_FORCE_INLINE_ static void _add_arrays(Array &sum, const Array &array_a, const Array &array_b) {
+	static _FORCE_INLINE_ void _add_arrays(Array &sum, const Array &array_a, const Array &array_b) {
 		int asize = array_a.size();
 		int bsize = array_b.size();
 
@@ -907,7 +907,7 @@ class OperatorEvaluatorStringFormat;
 template <typename S>
 class OperatorEvaluatorStringFormat<S, void> {
 public:
-	_FORCE_INLINE_ static String do_mod(const String &s, bool *r_valid) {
+	static _FORCE_INLINE_ String do_mod(const String &s, bool *r_valid) {
 		Array values;
 		values.push_back(Variant());
 
@@ -935,7 +935,7 @@ public:
 template <typename S>
 class OperatorEvaluatorStringFormat<S, Array> {
 public:
-	_FORCE_INLINE_ static String do_mod(const String &s, const Array &p_values, bool *r_valid) {
+	static _FORCE_INLINE_ String do_mod(const String &s, const Array &p_values, bool *r_valid) {
 		String a = s.sprintf(p_values, r_valid);
 		if (r_valid) {
 			*r_valid = !*r_valid;
@@ -960,7 +960,7 @@ public:
 template <typename S>
 class OperatorEvaluatorStringFormat<S, Object> {
 public:
-	_FORCE_INLINE_ static String do_mod(const String &s, const Object *p_object, bool *r_valid) {
+	static _FORCE_INLINE_ String do_mod(const String &s, const Object *p_object, bool *r_valid) {
 		Array values;
 		values.push_back(p_object);
 		String a = s.sprintf(values, r_valid);
@@ -988,7 +988,7 @@ public:
 template <typename S, typename T>
 class OperatorEvaluatorStringFormat {
 public:
-	_FORCE_INLINE_ static String do_mod(const String &s, const T &p_value, bool *r_valid) {
+	static _FORCE_INLINE_ String do_mod(const String &s, const T &p_value, bool *r_valid) {
 		Array values;
 		values.push_back(p_value);
 		String a = s.sprintf(values, r_valid);
@@ -1046,55 +1046,55 @@ public:
 
 ///// OR ///////
 
-_FORCE_INLINE_ static bool _operate_or(bool p_left, bool p_right) {
+static _FORCE_INLINE_ bool _operate_or(bool p_left, bool p_right) {
 	return p_left || p_right;
 }
 
-_FORCE_INLINE_ static bool _operate_and(bool p_left, bool p_right) {
+static _FORCE_INLINE_ bool _operate_and(bool p_left, bool p_right) {
 	return p_left && p_right;
 }
 
-_FORCE_INLINE_ static bool _operate_xor(bool p_left, bool p_right) {
+static _FORCE_INLINE_ bool _operate_xor(bool p_left, bool p_right) {
 	return (p_left || p_right) && !(p_left && p_right);
 }
 
-_FORCE_INLINE_ static bool _operate_get_nil(const Variant *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_nil(const Variant *p_ptr) {
 	return p_ptr->get_validated_object() != nullptr;
 }
 
-_FORCE_INLINE_ static bool _operate_get_bool(const Variant *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_bool(const Variant *p_ptr) {
 	return *VariantGetInternalPtr<bool>::get_ptr(p_ptr);
 }
 
-_FORCE_INLINE_ static bool _operate_get_int(const Variant *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_int(const Variant *p_ptr) {
 	return *VariantGetInternalPtr<int64_t>::get_ptr(p_ptr) != 0;
 }
 
-_FORCE_INLINE_ static bool _operate_get_float(const Variant *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_float(const Variant *p_ptr) {
 	return *VariantGetInternalPtr<double>::get_ptr(p_ptr) != 0.0;
 }
 
-_FORCE_INLINE_ static bool _operate_get_object(const Variant *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_object(const Variant *p_ptr) {
 	return p_ptr->get_validated_object() != nullptr;
 }
 
-_FORCE_INLINE_ static bool _operate_get_ptr_nil(const void *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_ptr_nil(const void *p_ptr) {
 	return false;
 }
 
-_FORCE_INLINE_ static bool _operate_get_ptr_bool(const void *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_ptr_bool(const void *p_ptr) {
 	return PtrToArg<bool>::convert(p_ptr);
 }
 
-_FORCE_INLINE_ static bool _operate_get_ptr_int(const void *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_ptr_int(const void *p_ptr) {
 	return PtrToArg<int64_t>::convert(p_ptr) != 0;
 }
 
-_FORCE_INLINE_ static bool _operate_get_ptr_float(const void *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_ptr_float(const void *p_ptr) {
 	return PtrToArg<double>::convert(p_ptr) != 0.0;
 }
 
-_FORCE_INLINE_ static bool _operate_get_ptr_object(const void *p_ptr) {
+static _FORCE_INLINE_ bool _operate_get_ptr_object(const void *p_ptr) {
 	return PtrToArg<Object *>::convert(p_ptr) != nullptr;
 }
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1274,7 +1274,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 	}
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+static _FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 1 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1211,7 +1211,7 @@ void RasterizerSceneGLES3::voxel_gi_update(RID p_probe, bool p_update_light_inst
 void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality) {
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+static _FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 1 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -348,7 +348,7 @@ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataType type, int p_
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
+static _FORCE_INLINE_ void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
 	switch (type) {
 		case ShaderLanguage::TYPE_BOOL: {
 			uint32_t *gui = (uint32_t *)data;
@@ -500,7 +500,7 @@ _FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type,
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type, int p_array_size, uint8_t *data) {
+static _FORCE_INLINE_ void _fill_std140_ubo_empty(ShaderLanguage::DataType type, int p_array_size, uint8_t *data) {
 	if (p_array_size <= 0) {
 		p_array_size = 1;
 	}

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -122,7 +122,7 @@ private:
 public:
 	friend class DebugAdapterServer;
 
-	_FORCE_INLINE_ static DebugAdapterProtocol *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ DebugAdapterProtocol *get_singleton() { return singleton; }
 	_FORCE_INLINE_ bool is_active() const { return _initialized && clients.size() > 0; }
 
 	bool process_message(const String &p_text);

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -274,11 +274,11 @@ class EditorHelpBit : public VBoxContainer {
 		Vector<ArgumentData> arguments; // For methods and signals.
 	};
 
-	inline static HashMap<StringName, HelpData> doc_class_cache;
-	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_property_cache;
-	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_method_cache;
-	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_signal_cache;
-	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_theme_item_cache;
+	static inline HashMap<StringName, HelpData> doc_class_cache;
+	static inline HashMap<StringName, HashMap<StringName, HelpData>> doc_property_cache;
+	static inline HashMap<StringName, HashMap<StringName, HelpData>> doc_method_cache;
+	static inline HashMap<StringName, HashMap<StringName, HelpData>> doc_signal_cache;
+	static inline HashMap<StringName, HashMap<StringName, HelpData>> doc_theme_item_cache;
 
 	RichTextLabel *title = nullptr;
 	RichTextLabel *content = nullptr;

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -76,8 +76,8 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	inline static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
-	inline static EditorResourcePreview *singleton = nullptr;
+	static inline constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	static inline EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {
 		Ref<Resource> resource;

--- a/editor/editor_string_names.h
+++ b/editor/editor_string_names.h
@@ -45,7 +45,7 @@ public:
 		singleton = nullptr;
 	}
 
-	_FORCE_INLINE_ static EditorStringNames *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ EditorStringNames *get_singleton() { return singleton; }
 
 	StringName Editor;
 	StringName EditorFonts;

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -115,7 +115,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ TileSetEditor *get_singleton() { return singleton; }
 
 	void edit(Ref<TileSet> p_tile_set);
 

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -85,7 +85,7 @@ private:
 	void _thread();
 
 public:
-	_FORCE_INLINE_ static TilesEditorUtils *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ TilesEditorUtils *get_singleton() { return singleton; }
 
 	// Pattern preview API.
 	void queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2528,7 +2528,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_csharp_attributes(Vector<S
 	return found_renames;
 }
 
-_FORCE_INLINE_ static String builtin_escape(const String &p_str, bool p_builtin) {
+static _FORCE_INLINE_ String builtin_escape(const String &p_str, bool p_builtin) {
 	if (p_builtin) {
 		return p_str.replace("\"", "\\\"");
 	} else {

--- a/editor/run_instances_dialog.h
+++ b/editor/run_instances_dialog.h
@@ -59,7 +59,7 @@ class RunInstancesDialog : public AcceptDialog {
 		String get_feature_tags() const;
 	};
 
-	inline static RunInstancesDialog *singleton = nullptr;
+	static inline RunInstancesDialog *singleton = nullptr;
 
 	TypedArray<Dictionary> stored_data;
 	Vector<InstanceData> instances_data;

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -36,11 +36,11 @@
 
 // Static helper functions.
 
-inline static bool is_snapable(const Vector3 &p_point1, const Vector3 &p_point2, real_t p_distance) {
+static inline bool is_snapable(const Vector3 &p_point1, const Vector3 &p_point2, real_t p_distance) {
 	return p_point2.distance_squared_to(p_point1) < p_distance * p_distance;
 }
 
-inline static Vector2 interpolate_segment_uv(const Vector2 p_segment_points[2], const Vector2 p_uvs[2], const Vector2 &p_interpolation_point) {
+static inline Vector2 interpolate_segment_uv(const Vector2 p_segment_points[2], const Vector2 p_uvs[2], const Vector2 &p_interpolation_point) {
 	if (p_segment_points[0].is_equal_approx(p_segment_points[1])) {
 		return p_uvs[0];
 	}
@@ -52,7 +52,7 @@ inline static Vector2 interpolate_segment_uv(const Vector2 p_segment_points[2], 
 	return p_uvs[0].lerp(p_uvs[1], fraction);
 }
 
-inline static Vector2 interpolate_triangle_uv(const Vector2 p_vertices[3], const Vector2 p_uvs[3], const Vector2 &p_interpolation_point) {
+static inline Vector2 interpolate_triangle_uv(const Vector2 p_vertices[3], const Vector2 p_uvs[3], const Vector2 &p_interpolation_point) {
 	if (p_interpolation_point.is_equal_approx(p_vertices[0])) {
 		return p_uvs[0];
 	}
@@ -154,7 +154,7 @@ inline bool is_point_in_triangle(const Vector3 &p_point, const Vector3 p_vertice
 	return true;
 }
 
-inline static bool is_triangle_degenerate(const Vector2 p_vertices[3], real_t p_vertex_snap2) {
+static inline bool is_triangle_degenerate(const Vector2 p_vertices[3], real_t p_vertex_snap2) {
 	real_t det = p_vertices[0].x * p_vertices[1].y - p_vertices[0].x * p_vertices[2].y +
 			p_vertices[0].y * p_vertices[2].x - p_vertices[0].y * p_vertices[1].x +
 			p_vertices[1].x * p_vertices[2].y - p_vertices[1].y * p_vertices[2].x;
@@ -162,7 +162,7 @@ inline static bool is_triangle_degenerate(const Vector2 p_vertices[3], real_t p_
 	return det < p_vertex_snap2;
 }
 
-inline static bool are_segments_parallel(const Vector2 p_segment1_points[2], const Vector2 p_segment2_points[2], float p_vertex_snap2) {
+static inline bool are_segments_parallel(const Vector2 p_segment1_points[2], const Vector2 p_segment2_points[2], float p_vertex_snap2) {
 	Vector2 segment1 = p_segment1_points[1] - p_segment1_points[0];
 	Vector2 segment2 = p_segment2_points[1] - p_segment2_points[0];
 	real_t segment1_length2 = segment1.dot(segment1);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -232,7 +232,7 @@ public:
 #endif
 
 	static String canonicalize_path(const String &p_path);
-	_FORCE_INLINE_ static bool is_canonically_equal_paths(const String &p_path_a, const String &p_path_b) {
+	static _FORCE_INLINE_ bool is_canonically_equal_paths(const String &p_path_a, const String &p_path_b) {
 		return canonicalize_path(p_path_a) == canonicalize_path(p_path_b);
 	}
 
@@ -542,7 +542,7 @@ public:
 	bool has_any_global_constant(const StringName &p_name) { return named_globals.has(p_name) || globals.has(p_name); }
 	Variant get_any_global_constant(const StringName &p_name);
 
-	_FORCE_INLINE_ static GDScriptLanguage *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ GDScriptLanguage *get_singleton() { return singleton; }
 
 	virtual String get_name() const override;
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -150,7 +150,7 @@ public:
 		_FORCE_INLINE_ String to_string_strict() const { return is_hard_type() ? to_string() : "Variant"; }
 		PropertyInfo to_property_info(const String &p_name) const;
 
-		_FORCE_INLINE_ static DataType get_variant_type() { // Default DataType for container elements.
+		static _FORCE_INLINE_ DataType get_variant_type() { // Default DataType for container elements.
 			DataType datatype;
 			datatype.kind = VARIANT;
 			datatype.type_source = INFERRED;

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -100,7 +100,7 @@ protected:
 	void initialized(const Variant &p_params);
 
 public:
-	_FORCE_INLINE_ static GDScriptLanguageProtocol *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ GDScriptLanguageProtocol *get_singleton() { return singleton; }
 	_FORCE_INLINE_ Ref<GDScriptWorkspace> get_workspace() { return workspace; }
 	_FORCE_INLINE_ Ref<GDScriptTextDocument> get_text_document() { return text_document; }
 	_FORCE_INLINE_ bool is_initialized() const { return _initialized; }

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -131,7 +131,7 @@ class LightmapperRD : public Lightmapper {
 	Vector<Probe> probe_positions;
 
 	struct EdgeHash {
-		_FORCE_INLINE_ static uint32_t hash(const Edge &p_edge) {
+		static _FORCE_INLINE_ uint32_t hash(const Edge &p_edge) {
 			uint32_t h = hash_murmur3_one_float(p_edge.a.x);
 			h = hash_murmur3_one_float(p_edge.a.y, h);
 			h = hash_murmur3_one_float(p_edge.a.z, h);
@@ -167,7 +167,7 @@ class LightmapperRD : public Lightmapper {
 	};
 
 	struct VertexHash {
-		_FORCE_INLINE_ static uint32_t hash(const Vertex &p_vtx) {
+		static _FORCE_INLINE_ uint32_t hash(const Vertex &p_vtx) {
 			uint32_t h = hash_murmur3_one_float(p_vtx.position[0]);
 			h = hash_murmur3_one_float(p_vtx.position[1], h);
 			h = hash_murmur3_one_float(p_vtx.position[2], h);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -457,7 +457,7 @@ public:
 	}
 	void set_language_index(int p_idx);
 
-	_FORCE_INLINE_ static CSharpLanguage *get_singleton() {
+	static _FORCE_INLINE_ CSharpLanguage *get_singleton() {
 		return singleton;
 	}
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -110,7 +110,7 @@ public:
 #endif // TOOLS_ENABLED
 #endif // DEBUG_METHODS_ENABLED
 
-	_FORCE_INLINE_ static String get_expected_api_build_config() {
+	static _FORCE_INLINE_ String get_expected_api_build_config() {
 #ifdef TOOLS_ENABLED
 		return "Debug";
 #else

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -416,7 +416,7 @@ public:
 	bool interaction_profile_supports_io_path(const String &p_ip_path, const String &p_io_path);
 
 	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
-	_FORCE_INLINE_ static OpenXRAPI *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ OpenXRAPI *get_singleton() { return singleton; }
 
 	XrResult try_get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr);
 	XrResult get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -622,7 +622,7 @@ class TextServerAdvanced : public TextServerExtension {
 	};
 
 	struct SystemFontKeyHasher {
-		_FORCE_INLINE_ static uint32_t hash(const SystemFontKey &p_a) {
+		static _FORCE_INLINE_ uint32_t hash(const SystemFontKey &p_a) {
 			uint32_t hash = p_a.font_name.hash();
 			hash = hash_murmur3_one_32(p_a.variation_coordinates.hash(), hash);
 			hash = hash_murmur3_one_32(p_a.weight, hash);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -538,7 +538,7 @@ class TextServerFallback : public TextServerExtension {
 	};
 
 	struct SystemFontKeyHasher {
-		_FORCE_INLINE_ static uint32_t hash(const SystemFontKey &p_a) {
+		static _FORCE_INLINE_ uint32_t hash(const SystemFontKey &p_a) {
 			uint32_t hash = p_a.font_name.hash();
 			hash = hash_murmur3_one_32(p_a.variation_coordinates.hash(), hash);
 			hash = hash_murmur3_one_32(p_a.weight, hash);

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -73,7 +73,7 @@ class JavaClass : public RefCounted {
 		jmethodID method;
 	};
 
-	_FORCE_INLINE_ static void _convert_to_variant_type(int p_sig, Variant::Type &r_type, float &likelihood) {
+	static _FORCE_INLINE_ void _convert_to_variant_type(int p_sig, Variant::Type &r_type, float &likelihood) {
 		likelihood = 1.0;
 		r_type = Variant::NIL;
 
@@ -169,7 +169,7 @@ class JavaClass : public RefCounted {
 		}
 	}
 
-	_FORCE_INLINE_ static bool _convert_object_to_variant(JNIEnv *env, jobject obj, Variant &var, uint32_t p_sig);
+	static _FORCE_INLINE_ bool _convert_object_to_variant(JNIEnv *env, jobject obj, Variant &var, uint32_t p_sig);
 
 	bool _call_method(JavaObject *p_instance, const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &ret);
 

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -54,20 +54,20 @@ The `dependencies` section and fields are optional and defined as follow:
  See https://github.com/godotengine/godot/issues/38157#issuecomment-618773871
  */
 struct PluginConfigAndroid {
-	inline static const char *PLUGIN_CONFIG_EXT = ".gdap";
+	static inline const char *PLUGIN_CONFIG_EXT = ".gdap";
 
-	inline static const char *CONFIG_SECTION = "config";
-	inline static const char *CONFIG_NAME_KEY = "name";
-	inline static const char *CONFIG_BINARY_TYPE_KEY = "binary_type";
-	inline static const char *CONFIG_BINARY_KEY = "binary";
+	static inline const char *CONFIG_SECTION = "config";
+	static inline const char *CONFIG_NAME_KEY = "name";
+	static inline const char *CONFIG_BINARY_TYPE_KEY = "binary_type";
+	static inline const char *CONFIG_BINARY_KEY = "binary";
 
-	inline static const char *DEPENDENCIES_SECTION = "dependencies";
-	inline static const char *DEPENDENCIES_LOCAL_KEY = "local";
-	inline static const char *DEPENDENCIES_REMOTE_KEY = "remote";
-	inline static const char *DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY = "custom_maven_repos";
+	static inline const char *DEPENDENCIES_SECTION = "dependencies";
+	static inline const char *DEPENDENCIES_LOCAL_KEY = "local";
+	static inline const char *DEPENDENCIES_REMOTE_KEY = "remote";
+	static inline const char *DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY = "custom_maven_repos";
 
-	inline static const char *BINARY_TYPE_LOCAL = "local";
-	inline static const char *BINARY_TYPE_REMOTE = "remote";
+	static inline const char *BINARY_TYPE_LOCAL = "local";
+	static inline const char *BINARY_TYPE_REMOTE = "remote";
 
 	// Set to true when the config file is properly loaded.
 	bool valid_config = false;

--- a/platform/ios/export/godot_plugin_config.h
+++ b/platform/ios/export/godot_plugin_config.h
@@ -53,24 +53,24 @@ The `plist` section are optional.
  */
 
 struct PluginConfigIOS {
-	inline static const char *PLUGIN_CONFIG_EXT = ".gdip";
+	static inline const char *PLUGIN_CONFIG_EXT = ".gdip";
 
-	inline static const char *CONFIG_SECTION = "config";
-	inline static const char *CONFIG_NAME_KEY = "name";
-	inline static const char *CONFIG_BINARY_KEY = "binary";
-	inline static const char *CONFIG_USE_SWIFT_KEY = "use_swift_runtime";
-	inline static const char *CONFIG_INITIALIZE_KEY = "initialization";
-	inline static const char *CONFIG_DEINITIALIZE_KEY = "deinitialization";
+	static inline const char *CONFIG_SECTION = "config";
+	static inline const char *CONFIG_NAME_KEY = "name";
+	static inline const char *CONFIG_BINARY_KEY = "binary";
+	static inline const char *CONFIG_USE_SWIFT_KEY = "use_swift_runtime";
+	static inline const char *CONFIG_INITIALIZE_KEY = "initialization";
+	static inline const char *CONFIG_DEINITIALIZE_KEY = "deinitialization";
 
-	inline static const char *DEPENDENCIES_SECTION = "dependencies";
-	inline static const char *DEPENDENCIES_LINKED_KEY = "linked";
-	inline static const char *DEPENDENCIES_EMBEDDED_KEY = "embedded";
-	inline static const char *DEPENDENCIES_SYSTEM_KEY = "system";
-	inline static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
-	inline static const char *DEPENDENCIES_FILES_KEY = "files";
-	inline static const char *DEPENDENCIES_LINKER_FLAGS = "linker_flags";
+	static inline const char *DEPENDENCIES_SECTION = "dependencies";
+	static inline const char *DEPENDENCIES_LINKED_KEY = "linked";
+	static inline const char *DEPENDENCIES_EMBEDDED_KEY = "embedded";
+	static inline const char *DEPENDENCIES_SYSTEM_KEY = "system";
+	static inline const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
+	static inline const char *DEPENDENCIES_FILES_KEY = "files";
+	static inline const char *DEPENDENCIES_LINKER_FLAGS = "linker_flags";
 
-	inline static const char *PLIST_SECTION = "plist";
+	static inline const char *PLIST_SECTION = "plist";
 
 	enum PlistItemType {
 		UNKNOWN,

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -482,7 +482,7 @@ private:
 	};
 
 	// FIXME: Is this the right thing to do?
-	inline static const char *proxy_tag = "godot";
+	static inline const char *proxy_tag = "godot";
 
 	Thread events_thread;
 	ThreadData thread_data;

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -98,7 +98,7 @@ private:
 	};
 
 	struct SurfaceKeyHasher {
-		_FORCE_INLINE_ static uint32_t hash(const SurfaceKey &p_a) {
+		static _FORCE_INLINE_ uint32_t hash(const SurfaceKey &p_a) {
 			return hash_murmur3_buffer(&p_a, sizeof(SurfaceKey));
 		}
 	};

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -603,7 +603,7 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ static bool is_group_processing() { return current_process_thread_group; }
+	static _FORCE_INLINE_ bool is_group_processing() { return current_process_thread_group; }
 
 	void set_process_thread_messages(BitField<ProcessThreadMessages> p_flags);
 	BitField<ProcessThreadMessages> get_process_thread_messages() const;

--- a/scene/resources/2d/polygon_path_finder.h
+++ b/scene/resources/2d/polygon_path_finder.h
@@ -53,7 +53,7 @@ class PolygonPathFinder : public Resource {
 		_FORCE_INLINE_ bool operator==(const Edge &p_edge) const {
 			return key == p_edge.key;
 		}
-		_FORCE_INLINE_ static uint32_t hash(const Edge &p_edge) {
+		static _FORCE_INLINE_ uint32_t hash(const Edge &p_edge) {
 			return hash_one_uint64(p_edge.key);
 		}
 

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -568,7 +568,7 @@ private:
 	};
 
 	struct GlyphMeshKeyHasher {
-		_FORCE_INLINE_ static uint32_t hash(const GlyphMeshKey &p_a) {
+		static _FORCE_INLINE_ uint32_t hash(const GlyphMeshKey &p_a) {
 			return hash_murmur3_buffer(&p_a, sizeof(GlyphMeshKey));
 		}
 	};

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -73,7 +73,7 @@ class Font : public Resource {
 	};
 
 	struct ShapedTextKeyHasher {
-		_FORCE_INLINE_ static uint32_t hash(const ShapedTextKey &p_a) {
+		static _FORCE_INLINE_ uint32_t hash(const ShapedTextKey &p_a) {
 			uint32_t hash = p_a.text.hash();
 			hash = hash_murmur3_one_32(p_a.font_size, hash);
 			hash = hash_murmur3_one_float(p_a.width, hash);

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -49,7 +49,7 @@ class SceneStringNames {
 	SceneStringNames();
 
 public:
-	_FORCE_INLINE_ static SceneStringNames *get_singleton() { return singleton; }
+	static _FORCE_INLINE_ SceneStringNames *get_singleton() { return singleton; }
 
 	StringName resized;
 	StringName draw;

--- a/servers/display/native_menu.h
+++ b/servers/display/native_menu.h
@@ -47,7 +47,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ static NativeMenu *get_singleton() {
+	static _FORCE_INLINE_ NativeMenu *get_singleton() {
 		return singleton;
 	}
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -54,7 +54,7 @@ class DisplayServer : public Object {
 #endif
 
 public:
-	_FORCE_INLINE_ static DisplayServer *get_singleton() {
+	static _FORCE_INLINE_ DisplayServer *get_singleton() {
 		return singleton;
 	}
 

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -51,7 +51,7 @@ struct _CollectorCallback2D {
 
 typedef void (*GenerateContactsFunc)(const Vector2 *, int, const Vector2 *, int, _CollectorCallback2D *);
 
-_FORCE_INLINE_ static void _generate_contacts_point_point(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
+static _FORCE_INLINE_ void _generate_contacts_point_point(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND(p_point_count_A != 1);
 	ERR_FAIL_COND(p_point_count_B != 1);
@@ -60,7 +60,7 @@ _FORCE_INLINE_ static void _generate_contacts_point_point(const Vector2 *p_point
 	p_collector->call(*p_points_A, *p_points_B);
 }
 
-_FORCE_INLINE_ static void _generate_contacts_point_edge(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
+static _FORCE_INLINE_ void _generate_contacts_point_edge(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND(p_point_count_A != 1);
 	ERR_FAIL_COND(p_point_count_B != 2);
@@ -77,7 +77,7 @@ struct _generate_contacts_Pair {
 	_FORCE_INLINE_ bool operator<(const _generate_contacts_Pair &l) const { return d < l.d; }
 };
 
-_FORCE_INLINE_ static void _generate_contacts_edge_edge(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
+static _FORCE_INLINE_ void _generate_contacts_edge_edge(const Vector2 *p_points_A, int p_point_count_A, const Vector2 *p_points_B, int p_point_count_B, _CollectorCallback2D *p_collector) {
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND(p_point_count_A != 2);
 	ERR_FAIL_COND(p_point_count_B != 2); // circle is actually a 4x3 matrix

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -39,7 +39,7 @@
 #define TEST_MOTION_MARGIN_MIN_VALUE 0.0001
 #define TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR 0.05
 
-_FORCE_INLINE_ static bool _can_collide_with(GodotCollisionObject2D *p_object, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
+static _FORCE_INLINE_ bool _can_collide_with(GodotCollisionObject2D *p_object, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 	if (!(p_object->get_collision_layer() & p_collision_mask)) {
 		return false;
 	}

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -38,7 +38,7 @@
 #define TEST_MOTION_MARGIN_MIN_VALUE 0.0001
 #define TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR 0.05
 
-_FORCE_INLINE_ static bool _can_collide_with(GodotCollisionObject3D *p_object, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
+static _FORCE_INLINE_ bool _can_collide_with(GodotCollisionObject3D *p_object, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 	if (!(p_object->get_collision_layer() & p_collision_mask)) {
 		return false;
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -797,7 +797,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 	}
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+static _FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 1 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1770,7 +1770,7 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 	}
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+static _FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 1 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -401,7 +401,7 @@ void RendererCanvasRenderRD::_bind_canvas_texture(RD::DrawListID p_draw_list, RI
 	r_last_texture = p_texture;
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+static _FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 1 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -342,7 +342,7 @@ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataType type, int p_
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
+static _FORCE_INLINE_ void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
 	switch (type) {
 		case ShaderLanguage::TYPE_BOOL: {
 			uint32_t *gui = (uint32_t *)data;
@@ -494,7 +494,7 @@ _FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type,
 	}
 }
 
-_FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type, int p_array_size, uint8_t *data) {
+static _FORCE_INLINE_ void _fill_std140_ubo_empty(ShaderLanguage::DataType type, int p_array_size, uint8_t *data) {
 	if (p_array_size <= 0) {
 		p_array_size = 1;
 	}

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -99,13 +99,13 @@ public:
 	//#define DEBUG_CHANGES
 
 #ifdef DEBUG_CHANGES
-	_FORCE_INLINE_ static void redraw_request() {
+	static _FORCE_INLINE_ void redraw_request() {
 		changes++;
 		_changes_changed();
 	}
 
 #else
-	_FORCE_INLINE_ static void redraw_request() {
+	static _FORCE_INLINE_ void redraw_request() {
 		changes++;
 	}
 #endif

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -609,7 +609,7 @@ private:
 	Vector<Ref<TextServer>> interfaces;
 
 public:
-	_FORCE_INLINE_ static TextServerManager *get_singleton() {
+	static _FORCE_INLINE_ TextServerManager *get_singleton() {
 		return singleton;
 	}
 

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -257,7 +257,7 @@ int register_test_command(String p_command, TestFunc p_function);
 
 class SignalWatcher : public Object {
 private:
-	inline static SignalWatcher *singleton;
+	static inline SignalWatcher *singleton;
 
 	/* Equal to: RBMap<String, Vector<Vector<Variant>>> */
 	HashMap<String, Array> _signals;


### PR DESCRIPTION
This aims to address the inconsistency in the usage of static and inline keyword combinations. The current codebase has variations like:

```c++
static _FORCE_INLINE_ ...
static _ALWAYS_INLINE_ ...
```

and

```c++
_FORCE_INLINE_ static ...
_ALWAYS_INLINE_ static ...
```

These variations are a result of different coding styles from multiple contributors. This change will enforce a consistent order for these keyword combinations throughout the codebase.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10189*