### PR TITLE
Only print physics sync warning on dev builds to avoid warning spam from using `move_and_slide`

### DIFF
--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -45,7 +45,11 @@
 #endif
 
 #ifdef DEBUG_ENABLED
+#ifdef DEV_ENABLED
 #define MAIN_THREAD_SYNC_WARN WARN_PRINT("Call to " + String(__FUNCTION__) + " causing PhysicsServer2D synchronizations on every frame. This significantly affects performance.");
+#else
+#define MAIN_THREAD_SYNC_WARN
+#endif
 #endif
 
 class PhysicsServer2DWrapMT : public PhysicsServer2D {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -44,7 +44,11 @@
 #endif
 
 #ifdef DEBUG_ENABLED
+#ifdef DEV_ENABLED
 #define MAIN_THREAD_SYNC_WARN WARN_PRINT("Call to " + String(__FUNCTION__) + " causing PhysicsServer3D synchronizations on every frame. This significantly affects performance.");
+#else
+#define MAIN_THREAD_SYNC_WARN
+#endif
 #endif
 
 class PhysicsServer3DWrapMT : public PhysicsServer3D {


### PR DESCRIPTION
Works around for the 4.3 release https://github.com/godotengine/godot/issues/94205

The check should be restored once we implement move_and_slide in a way that doesn't sync the physics thread

We can't do a full solution to https://github.com/godotengine/godot/issues/94205 for 4.3 since it will require big changes to `move_and_slide()`. This PR hides the warning from users for now so we can fix `move_and_slide()` and then re-enable the warning in 4.4 (ideally). 

This PR only impacts the physics server, the rendering server continues to have the check enabled. 