### PR TITLE
[3.x] Fix SSR warp when using orthogonal camera

### DIFF
--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -67,7 +67,11 @@ void main() {
 	vec4 world_pos = inverse_projection * vec4(uv_interp * 2.0 - 1.0, depth_tex * 2.0 - 1.0, 1.0);
 	vec3 vertex = world_pos.xyz / world_pos.w;
 
+#ifdef USE_ORTHOGONAL_PROJECTION
+	vec3 view_dir = vec3(0.0, 0.0, -1.0);
+#else
 	vec3 view_dir = normalize(vertex);
+#endif
 	vec3 ray_dir = normalize(reflect(view_dir, normal));
 
 	if (dot(ray_dir, normal) < 0.001) {


### PR DESCRIPTION
- Fixes: #49204 
- Backported from: https://github.com/godotengine/godot/pull/94184

SSR shader were using a view direction value calculated from the view space when raymarching, which produces perspective on the reflection with lower camera z-depths. Using a constant -z view direction solves this issue. Tested the fix with different camera/object positions and rotations. All seems okay. Perspective camera isn't affected.