### PR TITLE
Support custom color & data for `GridMap` cells

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -16,6 +16,20 @@
 		<link title="3D Kinematic Character Demo">https://godotengine.org/asset-library/asset/2739</link>
 	</tutorials>
 	<methods>
+		<method name="cell_has_color" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Returns whether or not the specified cell has a [Color] assigned to it. See [method set_cell_color].
+			</description>
+		</method>
+		<method name="cell_has_data" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Returns whether or not the specified cell has custom data assigned to it. See [method set_cell_data].
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -46,6 +60,20 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns one of 24 possible rotations that lie along the vectors (x,y,z) with each component being either -1, 0, or 1. For further details, refer to the Godot source code.
+			</description>
+		</method>
+		<method name="get_cell_color" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Returns the [Color] assigned to the specified cell. If the cell has no [Color] assigned, [code]null[/code] will be returned instead. See [method set_cell_color].
+			</description>
+		</method>
+		<method name="get_cell_data" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Returns the custom data assigned to the specified cell, in the form of a [Color]. If the cell has no custom data assigned, [code]null[/code] will be returned instead. See [method set_cell_data].
 			</description>
 		</method>
 		<method name="get_cell_item" qualifiers="const">
@@ -138,11 +166,43 @@
 				Returns the position of a grid cell in the GridMap's local coordinate space. To convert the returned value into global coordinates, use [method Node3D.to_global]. See also [method local_to_map].
 			</description>
 		</method>
+		<method name="remove_cell_color">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Removes any [Color] assigned to the specified cell. See [method set_cell_color].
+			</description>
+		</method>
+		<method name="remove_cell_data">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Removes any custom data assigned to the specified cell. See [method set_cell_data].
+			</description>
+		</method>
 		<method name="resource_changed" deprecated="Use [signal Resource.changed] instead.">
 			<return type="void" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
 				This method does nothing.
+			</description>
+		</method>
+		<method name="set_cell_color">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3i" />
+			<param index="1" name="color" type="Color" />
+			<description>
+				Assigns a [Color] to the specified cell, which can then be used in the contained item's spatial shader using the [code]COLOR[/code] built-in.
+				This allows for specific shader effects on that individual cell.
+			</description>
+		</method>
+		<method name="set_cell_data">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3i" />
+			<param index="1" name="data" type="Color" />
+			<description>
+				Assigns custom data to the specified cell in the form of a [Color]. This custom data can then be used in the contained item's spatial shader using the [code]INSTANCE_CUSTOM[/code] built-in.
+				This allows for specific shader effects on that individual cell.
 			</description>
 		</method>
 		<method name="set_cell_item">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -350,6 +350,7 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			g.cells.erase(key);
 			g.dirty = true;
 			cell_map.erase(key);
+
 			_queue_octants_dirty();
 		}
 		return;
@@ -498,6 +499,170 @@ int GridMap::get_orthogonal_index_from_basis(const Basis &p_basis) const {
 	}
 
 	return 0;
+}
+
+bool GridMap::cell_has_color(const Vector3i &p_position) const {
+	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, false);
+	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, false);
+	ERR_FAIL_INDEX_V(ABS(p_position.z), 1 << 20, false);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	if (color_map.has(key)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void GridMap::set_cell_color(const Vector3i &p_position, const Color p_color) {
+	ERR_FAIL_INDEX(ABS(p_position.x), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.y), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.z), 1 << 20);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	OctantKey ok;
+	ok.x = p_position.x / octant_size;
+	ok.y = p_position.y / octant_size;
+	ok.z = p_position.z / octant_size;
+
+	color_map[key] = p_color;
+
+	if (cell_map.has(key)) {
+		Octant &g = *octant_map[ok];
+		g.dirty = true;
+		_queue_octants_dirty();
+	}
+}
+
+Variant GridMap::get_cell_color(const Vector3i &p_position) const {
+	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, Variant());
+	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, Variant());
+	ERR_FAIL_INDEX_V(ABS(p_position.z), 1 << 20, Variant());
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	if (cell_has_color(p_position)) {
+		return color_map[key];
+	} else {
+		return Variant(); //Returns null if no color was set
+	}
+}
+
+void GridMap::remove_cell_color(const Vector3i &p_position) {
+	ERR_FAIL_INDEX(ABS(p_position.x), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.y), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.z), 1 << 20);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	OctantKey ok;
+	ok.x = p_position.x / octant_size;
+	ok.y = p_position.y / octant_size;
+	ok.z = p_position.z / octant_size;
+
+	if (cell_has_color(p_position)) {
+		color_map.erase(key);
+
+		Octant &g = *octant_map[ok];
+		g.dirty = true;
+		_queue_octants_dirty();
+	}
+}
+
+bool GridMap::cell_has_data(const Vector3i &p_position) const {
+	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, false);
+	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, false);
+	ERR_FAIL_INDEX_V(ABS(p_position.z), 1 << 20, false);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	if (data_map.has(key)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void GridMap::set_cell_data(const Vector3i &p_position, const Color p_data) {
+	ERR_FAIL_INDEX(ABS(p_position.x), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.y), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.z), 1 << 20);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	OctantKey ok;
+	ok.x = p_position.x / octant_size;
+	ok.y = p_position.y / octant_size;
+	ok.z = p_position.z / octant_size;
+
+	data_map[key] = p_data;
+
+	if (cell_map.has(key)) {
+		Octant &g = *octant_map[ok];
+		g.dirty = true;
+		_queue_octants_dirty();
+	}
+}
+
+Variant GridMap::get_cell_data(const Vector3i &p_position) const {
+	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, Variant());
+	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, Variant());
+	ERR_FAIL_INDEX_V(ABS(p_position.z), 1 << 20, Variant());
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	if (cell_has_data(p_position)) {
+		return data_map[key];
+	} else {
+		return Variant(); //Returns null if no data was set
+	}
+}
+
+void GridMap::remove_cell_data(const Vector3i &p_position) {
+	ERR_FAIL_INDEX(ABS(p_position.x), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.y), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.z), 1 << 20);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	OctantKey ok;
+	ok.x = p_position.x / octant_size;
+	ok.y = p_position.y / octant_size;
+	ok.z = p_position.z / octant_size;
+
+	if (cell_has_data(p_position)) {
+		data_map.erase(key);
+
+		Octant &g = *octant_map[ok];
+		g.dirty = true;
+		_queue_octants_dirty();
+	}
 }
 
 Vector3i GridMap::local_to_map(const Vector3 &p_world_position) const {
@@ -687,13 +852,36 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		for (const KeyValue<int, List<Pair<Transform3D, IndexKey>>> &E : multimesh_items) {
 			Octant::MultimeshInstance mmi;
 
+			//Only enable color/data feature on multimesh if any cell in the octant uses it
+			bool use_colors = false;
+			bool use_data = false;
+			for (const Pair<Transform3D, IndexKey> &CD : E.value) {
+				if (color_map.has(CD.second)) {
+					use_colors = true;
+				}
+				if (data_map.has(CD.second)) {
+					use_data = true;
+				}
+			}
+
 			RID mm = RS::get_singleton()->multimesh_create();
-			RS::get_singleton()->multimesh_allocate_data(mm, E.value.size(), RS::MULTIMESH_TRANSFORM_3D);
+			RS::get_singleton()->multimesh_allocate_data(mm, E.value.size(), RS::MULTIMESH_TRANSFORM_3D, use_colors, use_data);
 			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E.key)->get_rid());
 
 			int idx = 0;
 			for (const Pair<Transform3D, IndexKey> &F : E.value) {
 				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F.first);
+
+				if (color_map.has(F.second)) {
+					Color col = color_map[F.second];
+					RS::get_singleton()->multimesh_instance_set_color(mm, idx, col);
+				}
+
+				if (data_map.has(F.second)) {
+					Color dat = data_map[F.second];
+					RS::get_singleton()->multimesh_instance_set_custom_data(mm, idx, dat);
+				}
+
 #ifdef TOOLS_ENABLED
 
 				Octant::MultimeshInstance::Item it;
@@ -992,9 +1180,17 @@ void GridMap::_queue_octants_dirty() {
 void GridMap::_recreate_octant_data() {
 	recreating_octants = true;
 	HashMap<IndexKey, Cell, IndexKey> cell_copy = cell_map;
+	HashMap<IndexKey, Color> color_copy = color_map;
+	HashMap<IndexKey, Color> data_copy = data_map;
 	_clear_internal();
 	for (const KeyValue<IndexKey, Cell> &E : cell_copy) {
 		set_cell_item(Vector3i(E.key), E.value.item, E.value.rot);
+	}
+	for (const KeyValue<IndexKey, Color> &C : color_copy) {
+		set_cell_color(Vector3i(C.key), C.value);
+	}
+	for (const KeyValue<IndexKey, Color> &D : data_copy) {
+		set_cell_data(Vector3i(D.key), D.value);
 	}
 	recreating_octants = false;
 }
@@ -1011,6 +1207,8 @@ void GridMap::_clear_internal() {
 
 	octant_map.clear();
 	cell_map.clear();
+	color_map.clear();
+	data_map.clear();
 }
 
 void GridMap::clear() {
@@ -1089,6 +1287,16 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_basis_with_orthogonal_index", "index"), &GridMap::get_basis_with_orthogonal_index);
 	ClassDB::bind_method(D_METHOD("get_orthogonal_index_from_basis", "basis"), &GridMap::get_orthogonal_index_from_basis);
 
+	ClassDB::bind_method(D_METHOD("cell_has_color", "position"), &GridMap::cell_has_color);
+	ClassDB::bind_method(D_METHOD("set_cell_color", "position", "color"), &GridMap::set_cell_color);
+	ClassDB::bind_method(D_METHOD("get_cell_color", "position"), &GridMap::get_cell_color);
+	ClassDB::bind_method(D_METHOD("remove_cell_color", "position"), &GridMap::remove_cell_color);
+
+	ClassDB::bind_method(D_METHOD("cell_has_data", "position"), &GridMap::cell_has_data);
+	ClassDB::bind_method(D_METHOD("set_cell_data", "position", "data"), &GridMap::set_cell_data);
+	ClassDB::bind_method(D_METHOD("get_cell_data", "position"), &GridMap::get_cell_data);
+	ClassDB::bind_method(D_METHOD("remove_cell_data", "position"), &GridMap::remove_cell_data);
+
 	ClassDB::bind_method(D_METHOD("local_to_map", "local_position"), &GridMap::local_to_map);
 	ClassDB::bind_method(D_METHOD("map_to_local", "map_position"), &GridMap::map_to_local);
 
@@ -1124,6 +1332,7 @@ void GridMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cell_center_y"), "set_center_y", "get_center_y");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cell_center_z"), "set_center_z", "get_center_z");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_scale"), "set_cell_scale", "get_cell_scale");
+
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -172,6 +172,8 @@ class GridMap : public Node3D {
 
 	HashMap<OctantKey, Octant *, OctantKey> octant_map;
 	HashMap<IndexKey, Cell, IndexKey> cell_map;
+	HashMap<IndexKey, Color> color_map;
+	HashMap<IndexKey, Color> data_map;
 
 	void _recreate_octant_data();
 
@@ -280,6 +282,16 @@ public:
 	Basis get_cell_item_basis(const Vector3i &p_position) const;
 	Basis get_basis_with_orthogonal_index(int p_index) const;
 	int get_orthogonal_index_from_basis(const Basis &p_basis) const;
+
+	bool cell_has_color(const Vector3i &p_position) const;
+	void set_cell_color(const Vector3i &p_position, Color color);
+	Variant get_cell_color(const Vector3i &p_position) const;
+	void remove_cell_color(const Vector3i &p_position);
+
+	bool cell_has_data(const Vector3i &p_position) const;
+	void set_cell_data(const Vector3i &p_position, Color data);
+	Variant get_cell_data(const Vector3i &p_position) const;
+	void remove_cell_data(const Vector3i &p_position);
 
 	Vector3i local_to_map(const Vector3 &p_local_position) const;
 	Vector3 map_to_local(const Vector3i &p_map_position) const;


### PR DESCRIPTION
Fixes godotengine/godot-proposals#8723
Added a color & custom data property on cells in Gridmaps, and assorted methods.
Custom colors and data can now be set on cells through the set_cell_item method.
Passed color/data can then be accessed in the item's spatial shader, allowing for rendering effects on specific cell items.