### PR TITLE
Android Editor: Add immersive mode option

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -94,6 +94,13 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back("--debug-canvas-item-redraw");
 	}
 
+#ifdef ANDROID_ENABLED
+	bool game_immersive_mode = EditorSettings::get_singleton()->get_setting("interface/editor/android/game_immersive_mode");
+	if (game_immersive_mode) {
+		args.push_back("--use_immersive");
+	}
+#endif
+
 	if (p_write_movie != "") {
 		args.push_back("--write-movie");
 		args.push_back(p_write_movie);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -477,7 +477,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #ifdef ANDROID_ENABLED
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_accumulated_input", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_input_buffering", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/immersive_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/editor_immersive_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/game_immersive_mode", false, "", PROPERTY_USAGE_DEFAULT)
 #endif
 
 	// Inspector

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -477,6 +477,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #ifdef ANDROID_ENABLED
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_accumulated_input", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/use_input_buffering", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/android/immersive_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 #endif
 
 	// Inspector

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -130,6 +130,10 @@ open class GodotEditor : GodotActivity() {
 				enablePanningAndScalingGestures(panScaleEnabled)
 				enableInputDispatchToRenderThread(!useInputBuffering && !useAccumulatedInput)
 			}
+
+			if (enableImmersive()) {
+				godotFragment?.godot?.enableImmersive()
+			}
 		}
 	}
 
@@ -285,6 +289,11 @@ open class GodotEditor : GodotActivity() {
 	protected open fun useInputBuffering() = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/use_input_buffering"))
 
 	protected open fun useAccumulatedInput() = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/use_accumulated_input"))
+
+	/**
+	 * Enable immersive mode for the {@link Godot} engine activity.
+	 */
+	protected open fun enableImmersive() = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/editor_immersive_mode"))
 
 	/**
 	 * Whether we should launch the new godot instance in an adjacent window

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -121,6 +121,8 @@ open class GodotEditor : GodotActivity() {
 		val useAccumulatedInput = useAccumulatedInput()
 		GodotLib.updateInputDispatchSettings(useAccumulatedInput, useInputBuffering)
 
+		val enableImmersive = enableImmersive()
+
 		checkForProjectPermissionsToEnable()
 
 		runOnUiThread {
@@ -131,7 +133,7 @@ open class GodotEditor : GodotActivity() {
 				enableInputDispatchToRenderThread(!useInputBuffering && !useAccumulatedInput)
 			}
 
-			if (enableImmersive()) {
+			if (enableImmersive) {
 				godotFragment?.godot?.enableImmersive()
 			}
 		}

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
@@ -49,6 +49,11 @@ class GodotGame : GodotEditor() {
 
 	override fun useAccumulatedInput() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/buffering/android/use_accumulated_input"))
 
+	/**
+	 * Game doesn't read editor settings anyway. Immersive mode flag will be passed by editor.
+	 */
+	override fun enableImmersive() = false
+
 	override fun checkForProjectPermissionsToEnable() {
 		// Nothing to do.. by the time we get here, the project permissions will have already
 		// been requested by the Editor window.

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -224,7 +224,7 @@ class Godot(private val context: Context) : SensorEventListener {
 				} else if (commandLine[i] == "--debug_opengl") {
 					useDebugOpengl = true
 				} else if (commandLine[i] == "--use_immersive") {
-					goImmersive();
+					enableImmersive()
 				} else if (commandLine[i] == "--use_apk_expansion") {
 					useApkExpansion = true
 				} else if (hasExtra && commandLine[i] == "--apk_expansion_md5") {
@@ -302,9 +302,10 @@ class Godot(private val context: Context) : SensorEventListener {
 	 * For now, once you go immersive, you can't go back.
 	 * Call only from UI thread.
 	 */
-	fun goImmersive() {
-		if (useImmersive)
+	fun enableImmersive() {
+		if (useImmersive) {
 			return
+		}
 		val activity = requireActivity()
 		val window = activity.window
 		useImmersive = true
@@ -662,13 +663,6 @@ class Godot(private val context: Context) : SensorEventListener {
 						Log.w(TAG, e)
 					}
 				}
-			}
-		} else {
-			val shouldGoImmersive = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/immersive_mode"))
-
-			runOnUiThread {
-				if (shouldGoImmersive)
-					goImmersive()
 			}
 		}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -224,14 +224,7 @@ class Godot(private val context: Context) : SensorEventListener {
 				} else if (commandLine[i] == "--debug_opengl") {
 					useDebugOpengl = true
 				} else if (commandLine[i] == "--use_immersive") {
-					useImmersive = true
-					window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-							View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
-							View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
-							View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or  // hide nav bar
-							View.SYSTEM_UI_FLAG_FULLSCREEN or  // hide status bar
-							View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-					registerUiChangeListener()
+					goImmersive();
 				} else if (commandLine[i] == "--use_apk_expansion") {
 					useApkExpansion = true
 				} else if (hasExtra && commandLine[i] == "--apk_expansion_md5") {
@@ -302,6 +295,26 @@ class Godot(private val context: Context) : SensorEventListener {
 		} finally {
 			endBenchmarkMeasure("Startup", "Godot::onCreate")
 		}
+	}
+
+	/**
+	 * Goes into immersive mode.
+	 * For now, once you go immersive, you can't go back.
+	 * Call only from UI thread.
+	 */
+	fun goImmersive() {
+		if (useImmersive)
+			return
+		val activity = requireActivity()
+		val window = activity.window
+		useImmersive = true
+		window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+			View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+			View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+			View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or  // hide nav bar
+			View.SYSTEM_UI_FLAG_FULLSCREEN or  // hide status bar
+			View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+		registerUiChangeListener()
 	}
 
 	/**
@@ -649,6 +662,13 @@ class Godot(private val context: Context) : SensorEventListener {
 						Log.w(TAG, e)
 					}
 				}
+			}
+		} else {
+			val shouldGoImmersive = java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/editor/android/immersive_mode"))
+
+			runOnUiThread {
+				if (shouldGoImmersive)
+					goImmersive()
 			}
 		}
 


### PR DESCRIPTION
This allows using the Android Godot Editor in immersive mode, making the most of available screen space.

When this setting is enabled, Godot will change into immersive mode mid-startup, as the editor settings are not available until then. (A marker file was considered, but this seemed neater, all things considered. If it works well enough, it also implies that dynamically switching to immersive mode might be a future feature.)

Pre-commit hooks were skipped due to errors in the class reference that, to my knowledge, are outside of the scope of this PR. See the commit message for details. No code formatting errors were detected by the stages that did succeed.
