### PR TITLE
Re-add `Skeleton3D::animate_physical_bones` property

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -57,11 +57,6 @@
 				Force updates the bone transform for the bone at [param bone_idx] and all of its children.
 			</description>
 		</method>
-		<method name="get_animate_physical_bones" qualifiers="const" deprecated="">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
 		<method name="get_bone_children" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="bone_idx" type="int" />
@@ -239,14 +234,6 @@
 				Sets all bone poses to rests.
 			</description>
 		</method>
-		<method name="set_animate_physical_bones" deprecated="">
-			<return type="void" />
-			<param index="0" name="enabled" type="bool" />
-			<description>
-				This method exists for compatibility with old structures in which the [Skeleton3D] does not have a [PhysicalBoneSimulator3D] as a child, but directly has [PhysicalBone3D]s as children.
-				In case you need to raycast to it without running [method physical_bones_start_simulation], call this method with [code]enabled == true[/code].
-			</description>
-		</method>
 		<method name="set_bone_enabled">
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
@@ -342,6 +329,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="animate_physical_bones" type="bool" setter="set_animate_physical_bones" getter="get_animate_physical_bones" default="true" deprecated="">
+			If you follow the recommended workflow and explicitly have [PhysicalBoneSimulator3D] as a child of [Skeleton3D], you can control whether it is affected by raycasting without running [method physical_bones_start_simulation], by its [member SkeletonModifier3D.active].
+			However, for old (deprecated) configurations, [Skeleton3D] has an internal virtual [PhysicalBoneSimulator3D] for compatibility. This property controls the internal virtual [PhysicalBoneSimulator3D]'s [member SkeletonModifier3D.active].
+		</member>
 		<member name="modifier_callback_mode_process" type="int" setter="set_modifier_callback_mode_process" getter="get_modifier_callback_mode_process" enum="Skeleton3D.ModifierCallbackModeProcess" default="1">
 			Sets the processing timing for the Modifier.
 		</member>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -254,13 +254,6 @@ Validate extension JSON: API was removed: classes/VisualShaderNodeComment/method
 Validate extension JSON: API was removed: classes/VisualShaderNodeComment/properties/title
 
 
-GH-87888
---------
-Validate extension JSON: API was removed: classes/Skeleton3D/properties/animate_physical_bones
-
-These base class is changed to SkeletonModifier3D which is processed by Skeleton3D with the assumption that it is Skeleton3D's child.
-
-
 GH-90575
 --------
 Validate extension JSON: API was removed: classes/BoneAttachment3D/methods/on_bone_pose_update

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -301,6 +301,7 @@ void Skeleton3D::setup_simulator() {
 	sim->is_compat = true;
 	sim->set_active(false); // Don't run unneeded process.
 	add_child(simulator);
+	set_animate_physical_bones(animate_physical_bones);
 }
 #endif // _DISABLE_DEPRECATED
 
@@ -1097,6 +1098,9 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("physical_bones_start_simulation", "bones"), &Skeleton3D::physical_bones_start_simulation_on, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("physical_bones_add_collision_exception", "exception"), &Skeleton3D::physical_bones_add_collision_exception);
 	ClassDB::bind_method(D_METHOD("physical_bones_remove_collision_exception", "exception"), &Skeleton3D::physical_bones_remove_collision_exception);
+
+	ADD_GROUP("Deprecated", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "animate_physical_bones"), "set_animate_physical_bones", "get_animate_physical_bones");
 #endif // _DISABLE_DEPRECATED
 }
 
@@ -1136,19 +1140,15 @@ Node *Skeleton3D::get_simulator() {
 }
 
 void Skeleton3D::set_animate_physical_bones(bool p_enabled) {
+	animate_physical_bones = p_enabled;
 	PhysicalBoneSimulator3D *sim = cast_to<PhysicalBoneSimulator3D>(simulator);
 	if (!sim) {
 		return;
 	}
-	animate_physical_bones = p_enabled;
 	sim->set_active(animate_physical_bones || sim->is_simulating_physics());
 }
 
 bool Skeleton3D::get_animate_physical_bones() const {
-	PhysicalBoneSimulator3D *sim = cast_to<PhysicalBoneSimulator3D>(simulator);
-	if (!sim) {
-		return false;
-	}
 	return animate_physical_bones;
 }
 

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -67,7 +67,7 @@ class Skeleton3D : public Node3D {
 	GDCLASS(Skeleton3D, Node3D);
 
 #ifndef DISABLE_DEPRECATED
-	bool animate_physical_bones = false;
+	bool animate_physical_bones = true;
 	Node *simulator = nullptr;
 	void setup_simulator();
 #endif // _DISABLE_DEPRECATED


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/90880

~The `bone_pose_updated` signal is very dangerous as described in https://github.com/godotengine/godot/pull/90575, so it is reimplemented as an alias of `skeleton_updated`.~ We cannot re-add a compatible signal that is not hazardous and has no performance problems, so bone_pose_changed signal should be eliminated.

- Follow-up https://github.com/godotengine/godot/pull/93504

The internal PhysicalBoneSimulator3D is set after enter_tree, so that `animate_physical_bones` is updated once there.

However, the old configuration where PhysicalBone is directly a child of Skeleton3D without already having PhysicalBoneSimulator3D is deprecated, so it is placed under the group "Deprecated", to avoid confusion if the user follows the recommended new settings and has PhysicalBoneSimulator3D explicitly.

![image](https://github.com/user-attachments/assets/0d821897-418f-4fb6-9cc4-7924d4954496)

