### PR TITLE
Unlock Resource Loader before calling `copy_from`

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -357,7 +357,9 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 				Ref<Resource> old_res = ResourceCache::get_ref(load_task.local_path);
 				if (old_res.is_valid() && old_res != load_task.resource) {
 					// If resource is already loaded, only replace its data, to avoid existing invalidating instances.
+					thread_load_mutex.unlock();
 					old_res->copy_from(load_task.resource);
+					thread_load_mutex.lock();
 					load_task.resource = old_res;
 				}
 			}


### PR DESCRIPTION
Unlock the resource loader before calling copy_from as copy_from can trigger resource change emissions leading to further resource loads, for example when calling copy_from on a shader resource, it will trigger a change emission leading to the shader preprocessor resource loading any shader includes in the .gdshader.