### PR TITLE
Fix the behavior of after selecting animation on AnimationPlayerEditor to reset position to `0`

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -345,6 +345,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 		}
 		frame->set_max((double)anim->get_length());
 		autoplay->set_pressed(current == player->get_autoplay());
+		player->stop();
 	} else {
 		track_editor->set_animation(Ref<Animation>(), true);
 		track_editor->set_root(nullptr);


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/93980

I found that when an animation is changed, the timeline position is maintained as long as the animation is not playing, but this is an unintended change and should be fixed to be the same as the original behavior.