### PR TITLE
Snap half-px sprite offset the opposite way as canvas items

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -267,7 +267,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = (ofs + Point2(0.5, 0.5)).floor();
+				ofs = (ofs - Point2(0.5, 0.5)).ceil();
 			}
 
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -98,7 +98,7 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = (dest_offset + Point2(0.5, 0.5)).floor();
+		dest_offset = (dest_offset - Point2(0.5, 0.5)).ceil();
 	}
 
 	r_dst_rect = Rect2(dest_offset, frame_size);
@@ -400,7 +400,7 @@ Rect2 Sprite2D::get_rect() const {
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = (ofs + Point2(0.5, 0.5)).floor();
+		ofs = (ofs - Point2(0.5, 0.5)).ceil();
 	}
 
 	if (s == Size2(0, 0)) {


### PR DESCRIPTION
For the sprite offset of `Sprite2D` and `AnimatedSprite2D`, rounding towards positive direction changes the snapping direction of odd-sized sprites with `centered=true` compared to 4.2 or earlier. This is likely an undesirable change, so it should be changed to round halfway values the opposite direction using `ceil(x - 0.5)`.

- Fixes #94298