### PR TITLE
Update FileDialog.xml for configuration dependency clarity. 

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -148,7 +148,8 @@
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Save a File&quot;" />
 		<member name="use_native_dialog" type="bool" setter="set_use_native_dialog" getter="get_use_native_dialog" default="false">
-			If [code]true[/code], [member access] is set to [constant ACCESS_FILESYSTEM], and it is supported by the current [DisplayServer], OS native dialog will be used instead of custom one.
+			If true, **and** `access` is **also** set to `ACCESS_FILESYSTEM`, **and** it is **also** supported by the current `DisplayServer`
+			If [code]true[/code], [b]and[/b] [member access] is [b]also[/b] set to [constant ACCESS_FILESYSTEM], [b]and[/b] the current [DisplayServer] support this, OS native dialog will be used instead of custom one.
 			[b]Note:[/b] On macOS, sandboxed apps always use native dialogs to access host filesystem.
 		</member>
 	</members>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -148,7 +148,7 @@
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Save a File&quot;" />
 		<member name="use_native_dialog" type="bool" setter="set_use_native_dialog" getter="get_use_native_dialog" default="false">
-			If [code]true[/code], [b]and[/b] [member access] is [b]also[/b] set to [constant ACCESS_FILESYSTEM], [b]and[/b] the current [DisplayServer] support this, OS native dialog will be used instead of custom one.
+			If [code]true[/code], [b]and[/b] [member access] is [b]also[/b] set to [constant ACCESS_FILESYSTEM], [b]and[/b] the current [DisplayServer] supports it, OS native dialog will be used instead of custom one.
 			[b]Note:[/b] On macOS, sandboxed apps always use native dialogs to access host filesystem.
 		</member>
 	</members>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -148,7 +148,6 @@
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Save a File&quot;" />
 		<member name="use_native_dialog" type="bool" setter="set_use_native_dialog" getter="get_use_native_dialog" default="false">
-			If true, **and** `access` is **also** set to `ACCESS_FILESYSTEM`, **and** it is **also** supported by the current `DisplayServer`
 			If [code]true[/code], [b]and[/b] [member access] is [b]also[/b] set to [constant ACCESS_FILESYSTEM], [b]and[/b] the current [DisplayServer] support this, OS native dialog will be used instead of custom one.
 			[b]Note:[/b] On macOS, sandboxed apps always use native dialogs to access host filesystem.
 		</member>


### PR DESCRIPTION
The changes of this PR are an update for the `FileDialog` class reference.

I have used `FileDialog` in my project with the `use_native_dialog` set to true, but it's not working. The issue is that the `access` property **needs** to be set to `ACCESS_FILESYSTEM` instead of **will** automatically set to true. 

The dependency of this property which in the documentation is described as :

"If true, `access` is set to `ACCESS_FILESYSTEM`, and it is supported by the current `DisplayServer`"

This sentence is too long to read which easily causes misunderstanding like I did, so I modified it to:

"If true, **and** `access` is **also** set to `ACCESS_FILESYSTEM`, **and** the current `DisplayServer` supports it"

Personally, this is clearer for its **dependency**, and it doesn't repeat "and" and "also" too many times. This is my idea, I'd like to talk with you about any better ideas to help clarify things.

> [!NOTE]
> This PR is moved here from <https://github.com/godotengine/godot-docs/pull/9601> with some changes.
