### PR TITLE
[CI] Upload build cache before running tests

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -1,5 +1,5 @@
-name: Setup Godot build cache
-description: Setup Godot build cache.
+name: Restore Godot build cache
+description: Restore Godot build cache.
 inputs:
   cache-name:
     description: The cache base name (job name by default).
@@ -10,9 +10,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Upload cache on completion and check it out now.
-    - name: Load SCons cache directory
-      uses: actions/cache@v4
+    - name: Restore SCons cache directory
+      uses: actions/cache/restore@v4
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -1,0 +1,17 @@
+name: Save Godot build cache
+description: Save Godot build cache.
+inputs:
+  cache-name:
+    description: The cache base name (job name by default).
+    default: "${{github.job}}"
+  scons-cache:
+    description: The SCons cache path.
+    default: "${{github.workspace}}/.scons-cache/"
+runs:
+  using: "composite"
+  steps:
+    - name: Save SCons cache directory
+      uses: actions/cache/save@v4
+      with:
+        path: ${{inputs.scons-cache}}
+        key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -49,8 +49,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
@@ -65,6 +65,12 @@ jobs:
           platform: android
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
       - name: Generate Godot templates
         if: matrix.target == 'template_release'

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         continue-on-error: true
 
       - name: Setup Python and SCons
@@ -36,6 +36,10 @@ jobs:
           platform: ios
           target: template_release
           tests: false
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        continue-on-error: true
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -111,8 +111,8 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           echo "Disk usage after:" && df -h
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
@@ -139,6 +139,12 @@ jobs:
           platform: linuxbsd
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
       - name: Generate C# glue
         if: ${{ matrix.build-mono }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
@@ -65,6 +65,12 @@ jobs:
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
       - name: Prepare artifact
         run: |

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -52,8 +52,8 @@ jobs:
         run: |
           emcc -v
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
@@ -68,6 +68,12 @@ jobs:
           platform: web
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Godot build cache
-        uses: ./.github/actions/godot-cache
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
@@ -75,6 +75,12 @@ jobs:
           platform: windows
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
       - name: Prepare artifact
         run: |


### PR DESCRIPTION
This improves turnaround time on large PRs where compilation is successful but unit testing or similar fails, forcing recompilation of unchanged code

Unsure what exactly should be part of the upload but placed the save step after the artifact prepare step and before the upload step to hopefully upload as identically as possible, assuming the artifact preparation might make for a better artifact with striping down, unsure what exactly is uploaded (it seems only the `.scons-cache` is uploaded, so might be able to move it earlier as the cache isn't touched by other steps)

This was a source of friction for me making some PRs where the compilation worked fine, but the changes were relatively substantial and unit tests kept failing on Linux builds due to sanitizer errors, being unable to run those locally I ended up having to run a few CI builds to try and fix it and since they had to be recompiled from scratch (or rather from `master`) it took longer than it could have, hence this PR

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
