### PR TITLE
Windows: Fix window pos when shown on monitor with diff. dpi scale

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1751,6 +1751,10 @@ void DisplayServerWindows::window_set_exclusive(WindowID p_window, bool p_exclus
 			if (wd.exclusive) {
 				WindowData &wd_parent = windows[wd.transient_parent];
 				SetWindowLongPtr(wd.hWnd, GWLP_HWNDPARENT, (LONG_PTR)wd_parent.hWnd);
+				// HACK: Windows becomes confused if we change GWLP_HWNDPARENT
+				// when the window is on a screen with different DPI scale.
+				// Calling SetParent somehow fixes it.
+				SetParent(wd.hWnd, nullptr);
 			} else {
 				SetWindowLongPtr(wd.hWnd, GWLP_HWNDPARENT, (LONG_PTR) nullptr);
 			}
@@ -1793,6 +1797,10 @@ void DisplayServerWindows::window_set_transient(WindowID p_window, WindowID p_pa
 
 		if (wd_window.exclusive) {
 			SetWindowLongPtr(wd_window.hWnd, GWLP_HWNDPARENT, (LONG_PTR)wd_parent.hWnd);
+			// HACK: Windows becomes confused if we change GWLP_HWNDPARENT
+			// when the window is on a screen with different DPI scale.
+			// Calling SetParent somehow fixes it.
+			SetParent(wd_window.hWnd, nullptr);
 		}
 	}
 }


### PR DESCRIPTION
This works around an issue of exclusive transient windows jumping position and scale when they are being shown on a different monitor with different high-DPI scaling. This affected some windows in the Editor, for example the Project Settings window.

---

- Fixes #74261
- Related: #79187 (does not completely fix it - help window is no longer offset but is centred around the main window instead of the script editor)

I can reproduce this on Windows 10. It seems this behaviour is specific to the DPI virtualization (i.e. will only happen if multiple monitors have different scale factors, and that Godot is not per-monitor DPI aware).

When the window is created with the initial position on the other monitor, it is positioned correctly and is properly DPI-virtualized. The window is then set as exclusive and transient, which causes DisplayServerWindows to call `SetWindowLongPtr` with `GWLP_HWNDPARENT` to change the owner of the window.. It is exactly after this call that the DPI virtualization suddenly breaks and causes the window to shift and appear be rendered as the same DPI as the main window.

Here is the thing, calling `SetWindowLongPtr` with `GWLP_HWNDPARENT` is really an undocumented thing, but like everybody does it and is literally the only way to change the owner of a window (the alternative is to destroy and recreate the window). Despite this, I cannot find any references about it causing this kind of DPI virtualization bug on the Internet. (I'm sure I've seen this kind of issues in other programs, but nothing documented.)

So I had to look for random hacks. One way is to move the window to the position of the owner then move it back, but this can cause all sort of issues when we finally support per-monitor DPI, which is why I decided against it. After some experimenting, I found that calling `SetParent(hwnd, nullptr)` somehow fixes it (despite the window not having a parent to begin with), which is probably the least intrusive fix. Though the window may still flicker once.

CC @bruvzg