### PR TITLE
Pass current value to `EditorInterface` node/property popups

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -305,8 +305,9 @@
 			<return type="void" />
 			<param index="0" name="callback" type="Callable" />
 			<param index="1" name="valid_types" type="StringName[]" default="[]" />
+			<param index="2" name="current_value" type="Node" default="null" />
 			<description>
-				Pops up an editor dialog for selecting a [Node] from the edited scene. The [param callback] must take a single argument of type [NodePath]. It is called on the selected [NodePath] or the empty path [code]^""[/code] if the dialog is canceled. If [param valid_types] is provided, the dialog will only show Nodes that match one of the listed Node types.
+				Pops up an editor dialog for selecting a [Node] from the edited scene. The [param callback] must take a single argument of type [NodePath]. It is called on the selected [NodePath] or the empty path [code]^""[/code] if the dialog is canceled. If [param valid_types] is provided, the dialog will only show Nodes that match one of the listed Node types. If [param current_value] is provided, the Node will be automatically selected in the tree, if it exists.
 				[b]Example:[/b] Display the node selection dialog as soon as this node is added to the tree for the first time:
 				[codeblock]
 				func _ready():
@@ -326,8 +327,9 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="callback" type="Callable" />
 			<param index="2" name="type_filter" type="PackedInt32Array" default="PackedInt32Array()" />
+			<param index="3" name="current_value" type="String" default="&quot;&quot;" />
 			<description>
-				Pops up an editor dialog for selecting properties from [param object]. The [param callback] must take a single argument of type [NodePath]. It is called on the selected property path (see [method NodePath.get_as_property_path]) or the empty path [code]^""[/code] if the dialog is canceled. If [param type_filter] is provided, the dialog will only show properties that match one of the listed [enum Variant.Type] values.
+				Pops up an editor dialog for selecting properties from [param object]. The [param callback] must take a single argument of type [NodePath]. It is called on the selected property path (see [method NodePath.get_as_property_path]) or the empty path [code]^""[/code] if the dialog is canceled. If [param type_filter] is provided, the dialog will only show properties that match one of the listed [enum Variant.Type] values. If [param current_value] is provided, the property will be selected automatically in the property list, if it exists.
 				[codeblock]
 				func _ready():
 				    if Engine.is_editor_hint():

--- a/editor/editor_interface.compat.inc
+++ b/editor/editor_interface.compat.inc
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  editor_interface.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_interface.h"
+
+#ifndef DISABLE_DEPRECATED
+
+void EditorInterface::_popup_node_selector_bind_compat_94323(const Callable &p_callback, const TypedArray<StringName> &p_valid_types) {
+	popup_node_selector(p_callback, p_valid_types, nullptr);
+}
+
+void EditorInterface::_popup_property_selector_bind_compat_94323(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter) {
+	popup_property_selector(p_object, p_callback, p_type_filter, String());
+}
+
+void EditorInterface::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("popup_node_selector", "callback", "valid_types"), &EditorInterface::_popup_node_selector_bind_compat_94323, DEFVAL(TypedArray<StringName>()));
+	ClassDB::bind_compatibility_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter"), &EditorInterface::_popup_property_selector_bind_compat_94323, DEFVAL(PackedInt32Array()));
+}
+
+#endif

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "editor_interface.h"
+#include "editor_interface.compat.inc"
 
 #include "editor/editor_command_palette.h"
 #include "editor/editor_feature_profile.h"
@@ -276,7 +277,7 @@ void EditorInterface::set_current_feature_profile(const String &p_profile_name) 
 
 // Editor dialogs.
 
-void EditorInterface::popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types) {
+void EditorInterface::popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types, Node *p_current_value) {
 	// TODO: Should reuse dialog instance instead of creating a fresh one, but need to rework set_valid_types first.
 	if (node_selector) {
 		node_selector->disconnect(SNAME("selected"), callable_mp(this, &EditorInterface::_node_selected).bind(p_callback));
@@ -296,7 +297,7 @@ void EditorInterface::popup_node_selector(const Callable &p_callback, const Type
 
 	get_base_control()->add_child(node_selector);
 
-	node_selector->popup_scenetree_dialog();
+	node_selector->popup_scenetree_dialog(p_current_value);
 
 	const Callable selected_callback = callable_mp(this, &EditorInterface::_node_selected).bind(p_callback);
 	node_selector->connect(SNAME("selected"), selected_callback, CONNECT_DEFERRED);
@@ -305,7 +306,7 @@ void EditorInterface::popup_node_selector(const Callable &p_callback, const Type
 	node_selector->connect(SNAME("canceled"), canceled_callback, CONNECT_DEFERRED);
 }
 
-void EditorInterface::popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter) {
+void EditorInterface::popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter, const String &p_current_value) {
 	// TODO: Should reuse dialog instance instead of creating a fresh one, but need to rework set_type_filter first.
 	if (property_selector) {
 		property_selector->disconnect(SNAME("selected"), callable_mp(this, &EditorInterface::_property_selected).bind(p_callback));
@@ -325,7 +326,7 @@ void EditorInterface::popup_property_selector(Object *p_object, const Callable &
 
 	get_base_control()->add_child(property_selector);
 
-	property_selector->select_property_from_instance(p_object);
+	property_selector->select_property_from_instance(p_object, p_current_value);
 
 	const Callable selected_callback = callable_mp(this, &EditorInterface::_property_selected).bind(p_callback);
 	property_selector->connect(SNAME("selected"), selected_callback, CONNECT_DEFERRED);
@@ -564,8 +565,8 @@ void EditorInterface::_bind_methods() {
 
 	// Editor dialogs.
 
-	ClassDB::bind_method(D_METHOD("popup_node_selector", "callback", "valid_types"), &EditorInterface::popup_node_selector, DEFVAL(TypedArray<StringName>()));
-	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()));
+	ClassDB::bind_method(D_METHOD("popup_node_selector", "callback", "valid_types", "current_value"), &EditorInterface::popup_node_selector, DEFVAL(TypedArray<StringName>()), DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter", "current_value"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()), DEFVAL(String()));
 
 	// Editor docks.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -81,6 +81,13 @@ class EditorInterface : public Object {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _popup_node_selector_bind_compat_94323(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>());
+	void _popup_property_selector_bind_compat_94323(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array());
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	static EditorInterface *get_singleton() { return singleton; }
 
@@ -128,9 +135,9 @@ public:
 
 	// Editor dialogs.
 
-	void popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>());
+	void popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>(), Node *p_current_value = nullptr);
 	// Must use Vector<int> because exposing Vector<Variant::Type> is not supported.
-	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array());
+	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array(), const String &p_current_value = String());
 
 	// Editor docks.
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -162,6 +162,9 @@ void PropertySelector::_update_search() {
 			if (!found && !search_box->get_text().is_empty() && E.name.containsn(search_text)) {
 				item->select(0);
 				found = true;
+			} else if (!found && search_box->get_text().is_empty() && E.name == selected) {
+				item->select(0);
+				found = true;
 			}
 
 			item->set_selectable(0, true);
@@ -173,6 +176,12 @@ void PropertySelector::_update_search() {
 		if (category && category->get_first_child() == nullptr) {
 			memdelete(category); //old category was unused
 		}
+
+		if (found) {
+			// As we call this while adding items, defer until list is completely populated.
+			callable_mp(search_options, &Tree::scroll_to_item).call_deferred(search_options->get_selected(), true);
+		}
+
 	} else {
 		List<MethodInfo> methods;
 
@@ -305,11 +314,19 @@ void PropertySelector::_update_search() {
 			if (!found && !search_box->get_text().is_empty() && name.containsn(search_text)) {
 				item->select(0);
 				found = true;
+			} else if (!found && search_box->get_text().is_empty() && name == selected) {
+				item->select(0);
+				found = true;
 			}
 		}
 
 		if (category && category->get_first_child() == nullptr) {
 			memdelete(category); //old category was unused
+		}
+
+		if (found) {
+			// As we call this while adding items, defer until list is completely populated.
+			callable_mp(search_options, &Tree::scroll_to_item).call_deferred(search_options->get_selected(), true);
 		}
 	}
 

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -65,3 +65,11 @@ Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/properties/pl
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
 
 These setters have been renamed to expose them. GDExtension language bindings couldn't have exposed these properties before.
+
+
+GH-94322
+--------
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_node_selector/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_property_selector/arguments': size changed value in new API, from 3 to 4.
+
+Added optional argument to popup_property_selector and popup_node_selector to specify the current value.


### PR DESCRIPTION
Fixes #94322 

As outlined in the issue, while these new methods are nice in Godot 4.3, they don't seem to hit the mark in terms of being fully user friendly without being able to specify a current value, should these be used in cases where the addon already has an existing value and would prefer to highlight that in the dialog when its shown.

