### PR TITLE
GDScript: Restore support for `Token::UNDERSCORE` in identifiers

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -574,7 +574,9 @@ GDScriptTokenizer::Token GDScriptTokenizerText::potential_identifier() {
 
 	if (len == 1 && _peek(-1) == '_') {
 		// Lone underscore.
-		return make_token(Token::UNDERSCORE);
+		Token token = make_token(Token::UNDERSCORE);
+		token.literal = "_";
+		return token;
 	}
 
 	String name(_start, len);

--- a/modules/gdscript/tests/scripts/runtime/features/single_underscore_node_name.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/single_underscore_node_name.gd
@@ -1,0 +1,15 @@
+extends Node
+
+func test() -> void:
+    var node1 := Node.new()
+    node1.name = "_"
+    var node2 := Node.new()
+    node2.name = "Child"
+    var node3 := Node.new()
+    node3.name = "Child"
+
+    add_child(node1)
+    node1.add_child(node2)
+    add_child(node3)
+
+    assert(get_node("_/Child") == $_/Child)

--- a/modules/gdscript/tests/scripts/runtime/features/single_underscore_node_name.out
+++ b/modules/gdscript/tests/scripts/runtime/features/single_underscore_node_name.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Fixes #94310

`get_identifier` used the token source before. With the introduction of the binary tokenizer this is handled differently, so we need to manually set the identifier on `Token::UNDERSCORE`.
