### PR TITLE
Some improvements to TileSetScenesCollectionSource docs

### DIFF
--- a/doc/classes/TileSetScenesCollectionSource.xml
+++ b/doc/classes/TileSetScenesCollectionSource.xml
@@ -6,6 +6,32 @@
 	<description>
 		When placed on a [TileMap], tiles from [TileSetScenesCollectionSource] will automatically instantiate an associated scene at the cell's position in the TileMap.
 		Scenes are instantiated as children of the [TileMap] when it enters the tree. If you add/remove a scene tile in the [TileMap] that is already inside the tree, the [TileMap] will automatically instantiate/free the scene accordingly.
+		[b]Note:[/b] Scene tiles all occupy one tile slot and instead use alternate tile ID to identify scene index. [method TileSetSource.get_tiles_count] will always return [code]1[/code]. Use [method get_scene_tiles_count] to get a number of scenes in a [TileSetScenesCollectionSource].
+		Use this code if you want to find the scene path at a given tile in [TileMapLayer]:
+		[codeblocks]
+		[gdscript]
+		var source_id = tile_map_layer.get_cell_source_id(Vector2i(x, y))
+		if source_id &gt; -1:
+		    var scene_source = tile_map_layer.tile_set.get_source(source_id)
+		    if scene_source is TileSetScenesCollectionSource:
+		        var alt_id = tile_map_layer.get_cell_alternative_tile(Vector2i(x, y))
+		        # The assigned PackedScene.
+		        var scene = scene_source.get_scene_tile_scene(alt_id)
+		[/gdscript]
+		[csharp]
+		int sourceId = tileMapLayer.GetCellSourceId(new Vector2I(x, y));
+		if (sourceId &gt; -1)
+		{
+		    TileSetSource source = tileMapLayer.TileSet.GetSource(sourceId);
+		    if (source is TileSetScenesCollectionSource sceneSource)
+		    {
+		        int altId = tileMapLayer.GetCellAlternativeTile(new Vector2I(x, y));
+		        // The assigned PackedScene.
+		        PackedScene scene = sceneSource.GetSceneTileScene(altId);
+		    }
+		}
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Adds some clarifications to TileSetScenesCollectionSource description regarding how scenes are indexed. Also adds a code example how to get scene ID from a tile, because it's not obvious.

Closes #73645