### PR TITLE
Clarify `is_visible_in_tree()` in CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -525,6 +525,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all its ancestors are also visible. If any ancestor is hidden, this node will not be visible in the scene tree, and is therefore not drawn (see [method _draw]).
+				Visibility is checked only in parent nodes that inherit from [CanvasItem], [CanvasLayer], and [Window]. If the parent is of any other type (such as [Node], [AnimationPlayer], or [Node3D]), it is assumed to be visible.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">


### PR DESCRIPTION
Improves description of `is_visible_in_tree()`. The doc says that "all its ancestors are also visible", but does not mention what ancestors are considered.