### PR TITLE
Add `auto_redraw` property to CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -585,6 +585,11 @@
 		</method>
 	</methods>
 	<members>
+		<member name="auto_redraw" type="int" setter="set_auto_redraw" getter="get_auto_redraw" enum="CanvasItem.AutoRedrawFlags" is_bitfield="true" default="15">
+			Determines whether the [CanvasItem] is redrawn automatically (by calling [method queue_redraw]) on events like visibility change or size change. Disabling this property can improve performance when using complex custom drawing, by avoiding unnecessary redraws. Calling [method queue_redraw] manually will always redraw the item.
+			You can set this property to [constant AUTO_REDRAW_NEVER] to disable it or set it to a specific flag. You can combine flags using boolean or operator (e.g. [code]AUTO_REDRAW_CANVAS_ENTER | AUTO_REDRAW_VISIBILITY_CHANGED[/code]), or use [constant AUTO_REDRAW_ALL] to always redraw.
+			Check descriptions of [enum AutoRedrawFlags] for more details.
+		</member>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
 			Allows the current node to clip child nodes, essentially acting as a mask.
 		</member>
@@ -673,7 +678,7 @@
 			The [CanvasItem]'s visibility has changed.
 		</constant>
 		<constant name="NOTIFICATION_ENTER_CANVAS" value="32">
-			The [CanvasItem] has entered the canvas.
+			The [CanvasItem] has entered the canvas. This notification can be received when entering scene tree, changing [member top_level], or when [World2D] changes.
 		</constant>
 		<constant name="NOTIFICATION_EXIT_CANVAS" value="33">
 			The [CanvasItem] has exited the canvas.
@@ -735,6 +740,24 @@
 		</constant>
 		<constant name="CLIP_CHILDREN_MAX" value="3" enum="ClipChildrenMode">
 			Represents the size of the [enum ClipChildrenMode] enum.
+		</constant>
+		<constant name="AUTO_REDRAW_NEVER" value="0" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will never redraw automatically. Note that some advanced nodes, like [Control], don't use redraw flags in their logic and may still redraw.
+		</constant>
+		<constant name="AUTO_REDRAW_CANVAS_ENTER" value="1" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will redraw when [constant NOTIFICATION_ENTER_CANVAS] is received.
+		</constant>
+		<constant name="AUTO_REDRAW_VISIBILITY_CHANGED" value="2" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will redraw when [constant NOTIFICATION_VISIBILITY_CHANGED] is received.
+		</constant>
+		<constant name="AUTO_REDRAW_SIZE_CHANGED" value="4" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will redraw when its rect size is changed (accompanied by [signal item_rect_changed]). [Control] nodes may redraw on size change regardless of this flag, due to having their own sizing logic.
+		</constant>
+		<constant name="AUTO_REDRAW_TEXTURE_FILTER_REPEAT_CHANGED" value="8" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will redraw when [member texture_filter] or [member texture_repeat] is changed.
+		</constant>
+		<constant name="AUTO_REDRAW_ALL" value="15" enum="AutoRedrawFlags" is_bitfield="true">
+			The [CanvasItem] will redraw in all above cases.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -655,6 +655,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="auto_redraw" type="bool" setter="set_auto_redraw" getter="is_auto_redraw" default="true">
+			Determines whether the [CanvasItem] is redrawn automatically on events like visibility change or size change. Disabling this property can improve performance when using complex custom drawing, by avoiding unnecessary redraws. Calling [method queue_redraw] manually will always redraw the item.
+			[b]Note:[/b] Disabling auto-redraw works best for [Node2D]. More advanced [CanvasItem] nodes, like [Control], don't check this property in their logic and may still redraw.
+		</member>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
 			The mode in which this node clips its children, acting as a mask.
 			[b]Note:[/b] Clipping nodes cannot be nested or placed within a [CanvasGroup]. If an ancestor of this node clips its children or is a [CanvasGroup], then this node's clip mode should be set to [constant CLIP_CHILDREN_DISABLED] to avoid unexpected behavior.
@@ -756,7 +760,7 @@
 			This notification is received [i]before[/i] the related [signal visibility_changed] signal.
 		</constant>
 		<constant name="NOTIFICATION_ENTER_CANVAS" value="32">
-			The [CanvasItem] has entered the canvas.
+			The [CanvasItem] has entered the canvas. This notification can be received when entering scene tree, changing [member top_level], or when [World2D] changes.
 		</constant>
 		<constant name="NOTIFICATION_EXIT_CANVAS" value="33">
 			The [CanvasItem] has exited the canvas.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -105,7 +105,7 @@ void CanvasItem::_handle_visibility_change(bool p_visible) {
 	RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, p_visible);
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 
-	if (p_visible) {
+	if (p_visible && auto_redraw) {
 		queue_redraw();
 	} else {
 		emit_signal(SceneStringName(hidden));
@@ -305,7 +305,9 @@ void CanvasItem::_enter_canvas() {
 		}
 	}
 
-	queue_redraw();
+	if (auto_redraw) {
+		queue_redraw();
+	}
 
 	notification(NOTIFICATION_ENTER_CANVAS);
 }
@@ -749,7 +751,7 @@ bool CanvasItem::_property_get_revert(const StringName &p_name, Variant &r_prope
 
 void CanvasItem::item_rect_changed(bool p_size_changed) {
 	ERR_MAIN_THREAD_GUARD;
-	if (p_size_changed) {
+	if (p_size_changed && auto_redraw) {
 		queue_redraw();
 	}
 	emit_signal(SceneStringName(item_rect_changed));
@@ -1462,6 +1464,9 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_as_top_level", "enable"), &CanvasItem::set_as_top_level);
 	ClassDB::bind_method(D_METHOD("is_set_as_top_level"), &CanvasItem::is_set_as_top_level);
 
+	ClassDB::bind_method(D_METHOD("set_auto_redraw", "enable"), &CanvasItem::set_auto_redraw);
+	ClassDB::bind_method(D_METHOD("is_auto_redraw"), &CanvasItem::is_auto_redraw);
+
 	ClassDB::bind_method(D_METHOD("set_light_mask", "light_mask"), &CanvasItem::set_light_mask);
 	ClassDB::bind_method(D_METHOD("get_light_mask"), &CanvasItem::get_light_mask);
 
@@ -1574,6 +1579,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "self_modulate"), "set_self_modulate", "get_self_modulate");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_behind_parent"), "set_draw_behind_parent", "is_draw_behind_parent_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_redraw"), "set_auto_redraw", "is_auto_redraw");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "clip_children", PROPERTY_HINT_ENUM, "Disabled,Clip Only,Clip + Draw"), "set_clip_children_mode", "get_clip_children_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "oversampling_with_scale", PROPERTY_HINT_ENUM, "Inherit,Disabled,Enabled"), "set_oversampling_with_scale", "get_oversampling_with_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
@@ -1748,7 +1754,10 @@ void CanvasItem::_refresh_texture_filter_cache() const {
 
 void CanvasItem::_update_self_texture_filter(RSE::CanvasItemTextureFilter p_texture_filter) {
 	RS::get_singleton()->canvas_item_set_default_texture_filter(get_canvas_item(), p_texture_filter);
-	queue_redraw();
+
+	if (auto_redraw) {
+		queue_redraw();
+	}
 }
 
 void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
@@ -1810,7 +1819,10 @@ void CanvasItem::_refresh_texture_repeat_cache() const {
 
 void CanvasItem::_update_self_texture_repeat(RSE::CanvasItemTextureRepeat p_texture_repeat) {
 	RS::get_singleton()->canvas_item_set_default_texture_repeat(get_canvas_item(), p_texture_repeat);
-	queue_redraw();
+
+	if (auto_redraw) {
+		queue_redraw();
+	}
 }
 
 void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -73,6 +73,19 @@ public:
 		CLIP_CHILDREN_MAX,
 	};
 
+	enum AutoRedrawFlags {
+		AUTO_REDRAW_NEVER = 0,
+		AUTO_REDRAW_CANVAS_ENTER = 1 << 0,
+		AUTO_REDRAW_VISIBILITY_CHANGED = 1 << 1,
+		AUTO_REDRAW_SIZE_CHANGED = 1 << 2,
+		AUTO_REDRAW_TEXTURE_FILTER_REPEAT_CHANGED = 1 << 3,
+		AUTO_REDRAW_ALL =
+				AUTO_REDRAW_CANVAS_ENTER |
+				AUTO_REDRAW_VISIBILITY_CHANGED |
+				AUTO_REDRAW_SIZE_CHANGED |
+				AUTO_REDRAW_TEXTURE_FILTER_REPEAT_CHANGED,
+	};
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -100,6 +113,7 @@ private:
 	bool parent_visible_in_tree = false;
 	bool pending_update = false;
 	bool top_level = false;
+	BitField<AutoRedrawFlags> auto_redraw = AUTO_REDRAW_ALL;
 	bool drawing = false;
 	bool block_transform_notify = false;
 	bool behind = false;
@@ -321,6 +335,9 @@ public:
 	void set_draw_behind_parent(bool p_enable);
 	bool is_draw_behind_parent_enabled() const;
 
+	void set_auto_redraw(BitField<AutoRedrawFlags> p_auto);
+	BitField<AutoRedrawFlags> get_auto_redraw() const;
+
 	CanvasItem *get_parent_item() const;
 
 	virtual Transform2D get_transform() const = 0;
@@ -387,6 +404,7 @@ public:
 VARIANT_ENUM_CAST(CanvasItem::TextureFilter)
 VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
+VARIANT_BITFIELD_CAST(CanvasItem::AutoRedrawFlags)
 
 class CanvasTexture : public Texture2D {
 	GDCLASS(CanvasTexture, Texture2D);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -119,6 +119,7 @@ private:
 	bool pending_update = false;
 	bool draw_commands_dirty = false;
 	bool top_level = false;
+	bool auto_redraw = true;
 	bool drawing = false;
 	bool block_transform_notify = false;
 	bool behind = false;
@@ -377,6 +378,9 @@ public:
 
 	void set_draw_behind_parent(bool p_enable);
 	bool is_draw_behind_parent_enabled() const;
+
+	void set_auto_redraw(bool p_auto) { auto_redraw = p_auto; }
+	bool is_auto_redraw() const { return auto_redraw; }
 
 	CanvasItem *get_parent_item() const;
 


### PR DESCRIPTION
Adds a new `auto_redraw` property that, if disabled, prevents redrawing the CanvasItem automatically on events like visibility change or rect change.

Simple example, with a rectangle that draws with random color:

https://github.com/user-attachments/assets/b973058d-56c0-4ca4-8977-ffca906c1a80

A real-life example with custom screen that draws a map.
This is in official build:

https://github.com/user-attachments/assets/bb3dc8a8-bf1f-4584-8252-4343b858694e

This is dev build with `auto_redraw` disabled:

https://github.com/user-attachments/assets/27cc2230-aecb-4a48-805d-145500838140

Closes https://github.com/godotengine/godot-proposals/issues/9753