### PR TITLE
Fix benchmark key `Startup:Core`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2516,7 +2516,6 @@ error:
 		memdelete(message_queue);
 	}
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Core");
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup");
 
 #if defined(STEAMAPI_ENABLED)


### PR DESCRIPTION
**Begin measure** `("Startup", "Core")` was removed last week. [commit](
https://github.com/godotengine/godot/commit/c6a23a7a7d3f0747ccfdc11a56fc04f57feb867f#diff-18b7c19417a461e4793bb2157831659d96ede991391e10ee5bc51f19453b7685L918)

-----------------------

Command line `--help`

![image](https://github.com/user-attachments/assets/e20cd66f-ed51-447f-9394-f0ef73a15e2d)
