### PR TITLE
Add reset_rotation_smoothing method to Camera2D; Rename reset_smoothing method to reset_position_smoothing

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -66,7 +66,7 @@
 				Forces this [Camera2D] to become the current active one. [member enabled] must be [code]true[/code].
 			</description>
 		</method>
-		<method name="reset_smoothing">
+		<method name="reset_position_smoothing">
 			<return type="void" />
 			<description>
 				Sets the camera's position immediately to its current smoothing destination.
@@ -78,6 +78,12 @@
 			<description>
 				Sets the camera's rotation immediately to its current smoothing destination.
 				This method has no effect if [member rotation_smoothing_enabled] is [code]false[/code].
+			</description>
+		</method>
+		<method name="reset_smoothing" deprecated="Use [method reset_position_smoothing] instead.">
+			<return type="void" />
+			<description>
+				Has the same functionality as [method reset_position_smoothing].
 			</description>
 		</method>
 		<method name="set_drag_margin">
@@ -158,7 +164,7 @@
 		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly stops when reaches its limits.
 			This property has no effect if [member position_smoothing_enabled] is [code]false[/code].
-			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
+			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_position_smoothing].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
 			Top scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -73,6 +73,13 @@
 				This method has no effect if [member position_smoothing_enabled] is [code]false[/code].
 			</description>
 		</method>
+		<method name="reset_rotation_smoothing">
+			<return type="void" />
+			<description>
+				Sets the camera's rotation immediately to its current smoothing destination.
+				This method has no effect if [member rotation_smoothing_enabled] is [code]false[/code].
+			</description>
+		</method>
 		<method name="set_drag_margin">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -615,7 +615,7 @@ void Camera2D::force_update_scroll() {
 	_update_scroll();
 }
 
-void Camera2D::reset_smoothing() {
+void Camera2D::reset_position_smoothing() {
 	_update_scroll();
 	smoothed_camera_pos = camera_pos;
 }
@@ -885,7 +885,10 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rotation_smoothing_speed"), &Camera2D::get_rotation_smoothing_speed);
 
 	ClassDB::bind_method(D_METHOD("force_update_scroll"), &Camera2D::force_update_scroll);
-	ClassDB::bind_method(D_METHOD("reset_smoothing"), &Camera2D::reset_smoothing);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("reset_smoothing"), &Camera2D::reset_position_smoothing);
+#endif // DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("reset_position_smoothing"), &Camera2D::reset_position_smoothing);
 	ClassDB::bind_method(D_METHOD("reset_rotation_smoothing"), &Camera2D::reset_rotation_smoothing);
 	ClassDB::bind_method(D_METHOD("align"), &Camera2D::align);
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -620,6 +620,11 @@ void Camera2D::reset_smoothing() {
 	smoothed_camera_pos = camera_pos;
 }
 
+void Camera2D::reset_rotation_smoothing() {
+	_update_scroll();
+	camera_angle = get_global_rotation();
+}
+
 void Camera2D::align() {
 	ERR_FAIL_COND(custom_viewport && !ObjectDB::get_instance(custom_viewport_id));
 
@@ -881,6 +886,7 @@ void Camera2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_update_scroll"), &Camera2D::force_update_scroll);
 	ClassDB::bind_method(D_METHOD("reset_smoothing"), &Camera2D::reset_smoothing);
+	ClassDB::bind_method(D_METHOD("reset_rotation_smoothing"), &Camera2D::reset_rotation_smoothing);
 	ClassDB::bind_method(D_METHOD("align"), &Camera2D::align);
 
 	ClassDB::bind_method(D_METHOD("_set_old_smoothing", "follow_smoothing"), &Camera2D::_set_old_smoothing);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -186,6 +186,7 @@ public:
 	Vector2 get_camera_position() const;
 	void force_update_scroll();
 	void reset_smoothing();
+	void reset_rotation_smoothing();
 	void align();
 
 	void set_screen_drawing_enabled(bool enable);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -185,7 +185,7 @@ public:
 
 	Vector2 get_camera_position() const;
 	void force_update_scroll();
-	void reset_smoothing();
+	void reset_position_smoothing();
 	void reset_rotation_smoothing();
 	void align();
 


### PR DESCRIPTION
this PR adds the reset_rotation_smoothing method to Camera2D and renames the reset_smoothing method to reset_position_smoothing, deprecating previous name, so there will be a simple way to reset camera rotation smoothing.

See [this](https://github.com/godotengine/godot-proposals/discussions/10056) discussion for more details.

And I don't know whether I need use `_update_scroll()` before `camera_angle = get_global_rotation()` or not, but I did it in analogy with `reset_smoothing` implementation.