### PR TITLE
Improve `CowData::insert` performance

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -222,12 +222,15 @@ public:
 	}
 
 	Error insert(Size p_pos, const T &p_val) {
-		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
-		resize(size() + 1);
-		for (Size i = (size() - 1); i > p_pos; i--) {
-			set(i, get(i - 1));
+		Size new_size = size() + 1;
+		ERR_FAIL_INDEX_V(p_pos, new_size, ERR_INVALID_PARAMETER);
+		Error err = resize(new_size);
+		ERR_FAIL_COND_V(err, err);
+		T *p = ptrw();
+		for (Size i = new_size - 1; i > p_pos; i--) {
+			p[i] = p[i - 1];
 		}
-		set(p_pos, p_val);
+		p[p_pos] = p_val;
 
 		return OK;
 	}


### PR DESCRIPTION
Update `CowData::insert` to call `ptrw()` before loop, to avoid calling `_copy_on_write` for each item in the array, as well as repeated index checks in `set` and `get`.  For larger `Vector`s/`Array`s, this makes inserts around 10x faster for ints, 3x faster for `String`s, and 2x faster for `Variant`s.  Less of an impact on smaller `Vector`s/`Array`s, as a larger percentage of the time is spent allocating.

Compared old/new code times with below gdscript:

```
extends Node2D

func _ready():
	test_insert_int()
	test_insert_str()
	test_insert_var()

func test_insert_int():
	var a : PackedInt32Array = []
	var start = Time.get_ticks_msec()
	for i in 10000:
		a.insert(0, i)
	var end = Time.get_ticks_msec()
	print("test_insert_int: %dms" % [end - start])
	
func test_insert_str():
	var a : PackedStringArray = []
	var s := "test"
	var start = Time.get_ticks_msec()
	for i in 10000:
		a.insert(0, s)
	var end = Time.get_ticks_msec()
	print("test_insert_str: %dms" % [end - start])

func test_insert_var():
	var a : Array = []
	var start = Time.get_ticks_msec()
	for i in 10000:
		a.insert(0, i)
	var end = Time.get_ticks_msec()
	print("test_insert_var: %dms" % [end - start])
```

old:
```
test_insert_int: 134ms
test_insert_str: 165ms
test_insert_var: 200ms
```

new:
```
test_insert_int: 12ms
test_insert_str: 50ms
test_insert_var: 91ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
