### PR TITLE
Make sure that selected tile source is remembered

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -163,7 +163,10 @@ void TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list() {
 	int old_source = -1;
 	if (old_current > -1) {
 		old_source = sources_list->get_item_metadata(old_current);
+	} else {
+		old_source = sources_list->get_meta("old_source", -1);
 	}
+	sources_list->set_meta("old_source", old_source);
 	sources_list->clear();
 
 	TileMapLayer *edited_layer = _get_edited_layer();


### PR DESCRIPTION
Fixes #73536
Source list was updated twice in a row, with the first time happening without layer, so the selected source was lost.