### PR TITLE
Fix LSP not respecting indentation when connecting a signal

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -88,7 +88,7 @@ void GDScriptWorkspace::apply_new_signal(Object *obj, String function, PackedStr
 		function_body += " -> void";
 	}
 
-	String function_indentation = "";
+	String function_indentation;
 	if (Engine::get_singleton()->is_editor_hint()) {
 		bool use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
 

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -87,7 +87,22 @@ void GDScriptWorkspace::apply_new_signal(Object *obj, String function, PackedStr
 	if (EditorSettings::get_singleton()->get_setting("text_editor/completion/add_type_hints")) {
 		function_body += " -> void";
 	}
-	function_body += ":\n\tpass # Replace with function body.\n";
+
+	String function_indentation = "";
+	if (Engine::get_singleton()->is_editor_hint()) {
+		bool use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
+
+		if (use_space_indentation) {
+			int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
+			function_indentation += String(" ").repeat(indent_size);
+		} else {
+			function_indentation += "\t";
+		}
+	} else {
+		function_indentation += "\t";
+	}
+
+	function_body += ":\n" + function_indentation + "pass # Replace with function body.\n";
 
 	lsp::TextEdit text_edit;
 


### PR DESCRIPTION
When using an external editor with lsp the indentation for a new method when connecting a signal is always "\t", even when the settings in "text_editor/behavior/indent" say otherwise.

This code adds a fix so that the indentation rules set in the editor settings are used.

There is probably a better way to fix this, because my fix duplicates code from modules/gdscript/gdscript_editor.cpp" and it is probably better to implement the virtual function _get_indentation() from gdscript.h, but I am not that versed in C++ and I did not want to muck about with the imports.