### PR TITLE
Fix NavigationPolygon not updating consistently on rebakes

### DIFF
--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -193,6 +193,10 @@ void NavigationPolygon::set_data(const Vector<Vector2> &p_vertices, const Vector
 	for (int i = 0; i < p_polygons.size(); i++) {
 		polygons.write[i].indices = p_polygons[i];
 	}
+	{
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
+	}
 }
 
 void NavigationPolygon::get_data(Vector<Vector2> &r_vertices, Vector<Vector<int>> &r_polygons) {


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/94358

Fixes that NavigationPolygon did not update in all cases because the internal NavigationMesh was not always unref and freed which blocked creating a new mesh later if nothing else freed it.

regression from https://github.com/godotengine/godot/pull/93426 that added the new `set_data()` function.

That new function was missing the `unref()` for the old internal NavigationMesh. Without the unref, if nothing else would trigger it, when the NavigationServer would later request the internal NavigationMesh the NavigationPolygon would not build a new version of its internal NavigationMesh and just return the old.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
