### PR TITLE
Add `advance_on_start` option to `NodeAnimation` to handle `advance(0)` for each `NodeAnimation`

### DIFF
--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -12,6 +12,10 @@
 		<link title="Third Person Shooter (TPS) Demo">https://godotengine.org/asset-library/asset/2710</link>
 	</tutorials>
 	<members>
+		<member name="advance_on_start" type="bool" setter="set_advance_on_start" getter="is_advance_on_start" default="false">
+			If [code]true[/code], on receiving a request to play an animation from the start, the first frame is not drawn, but only processed, and playback starts from the next frame.
+			See also the notes of [method AnimationPlayer.play].
+		</member>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;&quot;">
 			Animation to use as an output. It is one of the animations provided by [member AnimationTree.anim_player].
 		</member>

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -38,6 +38,8 @@ class AnimationNodeAnimation : public AnimationRootNode {
 
 	StringName animation;
 
+	bool advance_on_start = false;
+
 	bool use_custom_timeline = false;
 	double timeline_length = 1.0;
 	Animation::LoopMode loop_mode = Animation::LOOP_NONE;
@@ -71,6 +73,9 @@ public:
 
 	void set_backward(bool p_backward);
 	bool is_backward() const;
+
+	void set_advance_on_start(bool p_advance_on_start);
+	bool is_advance_on_start() const;
 
 	void set_use_custom_timeline(bool p_use_custom_timeline);
 	bool is_using_custom_timeline() const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -371,7 +371,9 @@ AnimationNode::NodeTimeInfo AnimationNode::process(const AnimationMixer::Playbac
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	if (p_playback_info.seeked) {
-		pi.delta = get_node_time_info().position - p_playback_info.time;
+		if (p_playback_info.is_external_seeking) {
+			pi.delta = get_node_time_info().position - p_playback_info.time;
+		}
 	} else {
 		pi.time = get_node_time_info().position + p_playback_info.delta;
 	}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -91,7 +91,7 @@ public:
 			if (Math::is_zero_approx(remain)) {
 				return 0;
 			}
-			return length - position;
+			return remain;
 		}
 	};
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/91215
- Prerequisite https://github.com/godotengine/godot/pull/94304

As described in the AnimationPlayer documentation, the default behavior is for the animation to draw the first frame immediately after playback.

> [b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].

While this may be desirable for managing very different states, this behavior may cause a hitch if you want to handle a sequence of animations.

This PR can be modified to properly pass delta at start time, and an option can be added to apply the same `advance(0)` behavior at start time to each `NodeAnimation`.

This option must be had for each `NodeAnimation`, not for the entire `AnimationTree` since we need to be able to handle many cases, for example, the first state in a StateMachine may want to disable it and the others may want to enable it. Also, this can only be added to the lowest level - `NodeAnimation`, for the same reason as `custom_timeline`, given the possibility of it being broken by nesting.

![image](https://github.com/user-attachments/assets/22a442fc-bf3b-4d8c-99a4-b47e4b7f7159)

~However, the hitch is not yet completely eliminated; there may still be a small amount of error due to a decimal point error when comparing double values. The `get_remain()` function for the remaining time has been improved a little by setting the double value to zero by approximation. But to solve this problem completely, I think it is necessary to change all AnimationNode time comparisons to compare approximate values that take the error into account.~

Most of the problems have been eliminated, but in cases such as 1 animation vs. 3 animation queues, there is a possibility that the animation may not be perfectly synchronized due to a small error in the decimal point from the "animation length". Well, the results seem to be relatively stable as long as CallbackModePhysics is used.

