### PR TITLE
Fix to restore `library_path` as absolute path

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -795,7 +795,7 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 		// because that's what we want to check to see if it's changed.
 		library_path = actual_lib_path.get_base_dir().path_join(p_path.get_file());
 	} else {
-		library_path = p_path;
+		library_path = actual_lib_path;
 	}
 
 	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, "GDExtension dynamic library not found: " + abs_path);


### PR DESCRIPTION
Fix for possible issue with `library_path` being set as a local resource path rather than an absolute file system path. May have broken the Python bindings, and possibly any other extension needing an absolute path. Needs a little more investigation, marking as draft for now. @dsnopek, could you look this over too?

Related:
- #84620
- #87117
- #90961

