### PR TITLE
Fix `CSGShape3D`'s collision hint visibility

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -489,7 +489,7 @@ void CSGShape3D::_update_collision_faces() {
 }
 
 bool CSGShape3D::_is_debug_collision_shape_visible() {
-	return is_inside_tree() && (get_tree()->is_debugging_collisions_hint() || Engine::get_singleton()->is_editor_hint());
+	return is_inside_tree() && get_tree()->is_debugging_collisions_hint();
 }
 
 void CSGShape3D::_update_debug_collision_shape() {


### PR DESCRIPTION
Fix CSG collision hint toggle in the editor.

`CSGShape3D`'s collision hint now behavior is the same as `CollisionShape3D`. It will display when not selected but can be hidden by toggling view gizmos or the csg specific gizmo and will appear on the running game if `Debug > Visible Collision Shapes` is enabled.

* Fixes: https://github.com/godotengine/godot/issues/87919