### PR TITLE
Unify Scene and Script tabs

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -683,6 +683,9 @@
 			The amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU/GPU usage, which can improve battery life on laptops. However, higher values will result in a less responsive editor. The default value is set to allow for maximum smoothness on monitors up to 144 Hz. See also [member interface/editor/unfocused_low_processor_mode_sleep_usec].
 			[b]Note:[/b] This setting is ignored if [member interface/editor/update_continuously] is [code]true[/code], as enabling that setting disables low-processor mode.
 		</member>
+		<member name="interface/editor/main_editor_tab_content" type="int" setter="" getter="">
+			Editor main tab content.
+		</member>
 		<member name="interface/editor/main_font" type="String" setter="" getter="">
 			The font to use for the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 		</member>

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -638,7 +638,6 @@ void EditorData::remove_scene(int p_idx) {
 		memdelete(edited_scene[p_idx].root);
 		edited_scene.write[p_idx].root = nullptr;
 	}
-
 	if (current_edited_scene > p_idx) {
 		current_edited_scene--;
 	} else if (current_edited_scene == p_idx && current_edited_scene > 0) {
@@ -813,6 +812,27 @@ String EditorData::get_scene_type(int p_idx) const {
 	return edited_scene[p_idx].root->get_class();
 }
 
+int EditorData::get_scene_by_editor_tab(const EditorTab *p_tab) const {
+	int idx = 0;
+	for (const EditedScene &scene : edited_scene) {
+		if (scene.editor_tab == p_tab) {
+			return idx;
+		}
+		idx++;
+	}
+	return -1;
+}
+
+EditorTab *EditorData::get_scene_editor_tab(int p_idx) {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), nullptr);
+	return edited_scene[p_idx].editor_tab;
+}
+
+void EditorData::set_scene_editor_tab(int p_idx, EditorTab *p_tab) {
+	ERR_FAIL_INDEX(p_idx, edited_scene.size());
+	edited_scene.write[p_idx].editor_tab = p_tab;
+}
+
 void EditorData::move_edited_scene_to_index(int p_idx) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
@@ -933,6 +953,18 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 	set_editor_plugin_states(es.editor_states);
 
 	return es.custom_state;
+}
+
+int EditorData::get_edited_scene_last_editor() {
+	ERR_FAIL_INDEX_V(current_edited_scene, edited_scene.size(), -1);
+
+	return edited_scene[current_edited_scene].last_editor;
+}
+
+void EditorData::set_edited_scene_last_editor(int p_editor) {
+	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
+
+	edited_scene.write[current_edited_scene].last_editor = p_editor;
 }
 
 void EditorData::clear_edited_scenes() {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -32,6 +32,7 @@
 #define EDITOR_DATA_H
 
 #include "core/templates/list.h"
+#include "editor/gui/editor_scene_tabs.h"
 #include "scene/resources/texture.h"
 
 class ConfigFile;
@@ -120,6 +121,8 @@ public:
 		NodePath live_edit_root;
 		int history_id = 0;
 		uint64_t last_checked_version = 0;
+		EditorTab *editor_tab;
+		int last_editor = -1;
 	};
 
 private:
@@ -210,6 +213,9 @@ public:
 	String get_scene_title(int p_idx, bool p_always_strip_extension = false) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;
+	int get_scene_by_editor_tab(const EditorTab *p_tab) const;
+	EditorTab *get_scene_editor_tab(int p_idx);
+	void set_scene_editor_tab(int p_idx, EditorTab *p_tab);
 	void set_scene_path(int p_idx, const String &p_path);
 	Ref<Script> get_scene_root_script(int p_idx) const;
 	void set_scene_modified_time(int p_idx, uint64_t p_time);
@@ -234,6 +240,8 @@ public:
 
 	void save_edited_scene_state(EditorSelection *p_selection, EditorSelectionHistory *p_history, const Dictionary &p_custom);
 	Dictionary restore_edited_scene_state(EditorSelection *p_selection, EditorSelectionHistory *p_history);
+	int get_edited_scene_last_editor();
+	void set_edited_scene_last_editor(int p_editor);
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 	void notify_scene_saved(const String &p_path);

--- a/editor/editor_nav_tabs.cpp
+++ b/editor/editor_nav_tabs.cpp
@@ -1,0 +1,204 @@
+/**************************************************************************/
+/*  editor_nav_tabs.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_nav_tabs.h"
+
+#include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
+#include "editor/themes/editor_scale.h"
+
+Rect2i EditorNavTabs::prev_rect = Rect2i();
+bool EditorNavTabs::was_showed = false;
+
+void EditorNavTabs::popup_dialog(Vector<EditorTab *> p_tabs, bool p_next_tab) {
+	if (was_showed) {
+		popup(prev_rect);
+	} else {
+		popup_centered_clamped(Size2(600, 440) * EDSCALE, 0.8f);
+	}
+
+	Vector<EditorTab *> sort_list;
+	sort_list.append_array(p_tabs);
+	sort_list.sort_custom<EditorTab::EditorTabComparator>();
+	_tabs = sort_list;
+
+	_update_tab_list();
+
+	if (tab_list->get_item_count() == 0) {
+		tab_list->select(0);
+	} else if (tab_list->get_item_count() > 1) {
+		if (p_next_tab) {
+			// Select the second to pass directly to the previous tab.
+			tab_list->select(1);
+		} else {
+			tab_list->select(tab_list->get_item_count() - 1);
+		}
+	}
+
+	// Always recroll at the beginning to see the first tabs on top.
+	if (p_next_tab) {
+		tab_list->get_v_scroll_bar()->scroll_to(0);
+	} else {
+		tab_list->get_v_scroll_bar()->scroll_to(tab_list->get_v_scroll_bar()->get_max());
+	}
+	tab_list->grab_focus();
+}
+
+void EditorNavTabs::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible()) {
+				prev_rect = Rect2i(get_position(), get_size());
+				was_showed = true;
+			}
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+			tab_list->set_fixed_icon_size(Size2(icon_size, icon_size));
+		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			_close();
+		} break;
+	}
+}
+
+void EditorNavTabs::_update_tab_list() {
+	tab_list->clear();
+
+	int index = 0;
+	for (const EditorTab *tab : _tabs) {
+		tab_list->add_item(vformat("%s (%s)", tab->get_name(), tab->get_last_used()), tab->get_icon());
+		tab_list->set_item_tooltip(index, tab->get_resource_path());
+		tab_list->set_item_selectable(index, true);
+		index++;
+	}
+}
+
+void EditorNavTabs::_tab_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index) {
+	_select_tab(p_item);
+}
+
+void EditorNavTabs::_select_tab(int p_item) {
+	EditorTab *tab = nullptr;
+	if (p_item >= 0 && p_item < _tabs.size()) {
+		tab = _tabs[p_item];
+	}
+
+	_close();
+
+	if (tab) {
+		this->emit_signal("selected", tab);
+	}
+}
+
+void EditorNavTabs::_close() {
+	tab_list->clear();
+	_tabs.clear();
+	hide();
+}
+
+void EditorNavTabs::shortcut_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventKey> event_key = p_event;
+	if (event_key.is_valid()) {
+		if ((event_key->is_pressed() && !event_key->is_echo()) || Object::cast_to<InputEventShortcut>(*p_event)) {
+			if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
+				_select_next();
+				get_tree()->get_root()->set_input_as_handled();
+			}
+			if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
+				_select_prev();
+				get_tree()->get_root()->set_input_as_handled();
+			}
+		}
+
+		if (p_event->is_released() && !event_key->is_command_or_control_pressed()) {
+			_select_tab(tab_list->get_current());
+		}
+	}
+}
+
+void EditorNavTabs::_select_next() {
+	if (tab_list->get_item_count() > 0) {
+		int next_tab = tab_list->get_current() + 1;
+		next_tab %= _tabs.size();
+		tab_list->select(next_tab, true);
+	}
+}
+
+void EditorNavTabs::_select_prev() {
+	if (tab_list->get_item_count() > 0) {
+		int next_tab = tab_list->get_current() - 1;
+		next_tab = next_tab >= 0 ? next_tab : _tabs.size() - 1;
+		tab_list->select(next_tab, true);
+	}
+}
+
+void EditorNavTabs::_list_gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed()) {
+		// Mouse wheel is grabbed by the EditorSceneTabs or by the ViewPort 2D/3D and not the ItemList
+		// for un unknown reason. Need to manage the mouse wheel here.
+		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed()) {
+			tab_list->get_v_scroll_bar()->set_value(tab_list->get_v_scroll_bar()->get_value() - tab_list->get_v_scroll_bar()->get_page() * mb->get_factor() / 8);
+			set_input_as_handled();
+		}
+		if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_pressed()) {
+			tab_list->get_v_scroll_bar()->set_value(tab_list->get_v_scroll_bar()->get_value() + tab_list->get_v_scroll_bar()->get_page() * mb->get_factor() / 8);
+			set_input_as_handled();
+		}
+	}
+}
+
+void EditorNavTabs::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab")));
+}
+
+EditorNavTabs::EditorNavTabs() {
+	set_process_shortcut_input(true);
+
+	this->get_ok_button()->hide();
+	this->get_cancel_button()->hide();
+	this->set_flag(FLAG_BORDERLESS, true);
+
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(vbc);
+
+	tab_list = memnew(ItemList);
+	tab_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tab_list->set_custom_minimum_size(Size2(150, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	tab_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tab_list->connect("item_clicked", callable_mp(this, &EditorNavTabs::_tab_list_clicked), CONNECT_DEFERRED);
+	tab_list->connect(SceneStringName(gui_input), callable_mp(this, &EditorNavTabs::_list_gui_input));
+	vbc->add_child(tab_list);
+}

--- a/editor/editor_nav_tabs.h
+++ b/editor/editor_nav_tabs.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  editor_nav_tabs.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_NAV_TABS_H
+#define EDITOR_NAV_TABS_H
+
+#include "editor/editor_tab.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
+
+class EditorNavTabs : public ConfirmationDialog {
+	GDCLASS(EditorNavTabs, ConfirmationDialog);
+
+	static Rect2i prev_rect;
+	static bool was_showed;
+
+	Vector<EditorTab *> _tabs;
+
+	ItemList *tab_list = nullptr;
+
+	void _update_tab_list();
+	void _tab_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
+	void _select_tab(int p_item);
+	void _close();
+	void _select_next();
+	void _select_prev();
+
+	void _list_gui_input(const Ref<InputEvent> &p_event);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
+public:
+	void popup_dialog(Vector<EditorTab *> p_tabs, bool p_next_tab);
+
+	EditorNavTabs();
+};
+
+#endif // EDITOR_NAV_TABS_H

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -176,6 +176,7 @@ private:
 		FILE_SAVE_AND_RUN,
 		FILE_SAVE_AND_RUN_MAIN_SCENE,
 		FILE_RUN_SCENE,
+		FILE_COPY_PATH,
 		FILE_SHOW_IN_FILESYSTEM,
 		FILE_EXPORT_PROJECT,
 		FILE_EXPORT_MESH_LIBRARY,
@@ -453,6 +454,7 @@ private:
 
 	bool requested_first_scan = false;
 	bool waiting_for_first_scan = true;
+	bool first_load_config_done = false;
 
 	int current_menu_option = 0;
 
@@ -615,8 +617,10 @@ private:
 
 	bool has_main_screen() const { return true; }
 
+	int _add_edited_scene(int p_at_pos);
 	void _remove_edited_scene(bool p_change_tab = true);
-	void _remove_scene(int index, bool p_change_tab = true);
+	void _remove_scene(int p_index, bool p_change_tab = true);
+	void _remove_scene_internal(int p_index);
 	bool _find_and_save_resource(Ref<Resource> p_res, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	bool _find_and_save_edited_subresources(Object *obj, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
@@ -677,6 +681,14 @@ private:
 	void _notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes);
 
 	void _remove_all_not_owned_children(Node *p_node, Node *p_owner);
+	void _editor_tab_update_needed(EditorTab *p_tab);
+	void _editor_tab_selected(EditorTab *p_tab);
+	void _editor_tab_closing(EditorTab *p_tab);
+	void _editor_tab_button_pressed(EditorTab *p_tab);
+	void _editor_tab_context_menu_needed(EditorTab *p_tab, PopupMenu *p_context_menu);
+	void _editor_tab_context_menu_pressed(EditorTab *p_tab, int p_option);
+
+	void _editor_button_pressed(int p_which);
 
 protected:
 	friend class FileSystemDock;
@@ -691,6 +703,7 @@ public:
 
 	void editor_select(int p_which);
 	void set_visible_editor(EditorTable p_table) { editor_select(p_table); }
+	int get_editor_index_plugin(const EditorPlugin *p_plugin);
 
 	bool call_build();
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -400,6 +400,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Editor
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localize_settings", true, "")
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/main_editor_tab_content", 0, "Only Scenes,Scenes; Scripts and Plugins", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/ui_layout_direction", 0, "Based on Application Locale,Left-to-Right,Right-to-Left,Based on System Locale", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 

--- a/editor/editor_tab.cpp
+++ b/editor/editor_tab.cpp
@@ -1,0 +1,108 @@
+/**************************************************************************/
+/*  editor_tab.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_tab.h"
+
+String EditorTab::get_name() const {
+	return _name;
+}
+
+void EditorTab::set_name(String p_name) {
+	_name = p_name;
+}
+
+String EditorTab::get_resource_path() const {
+	return _resource_path;
+}
+
+void EditorTab::set_resource_path(String p_resource_path) {
+	_resource_path = p_resource_path;
+}
+
+Ref<Texture2D> EditorTab::get_icon() const {
+	return _icon;
+}
+
+void EditorTab::set_icon(Ref<Texture2D> p_icon) {
+	_icon = p_icon;
+}
+
+Ref<Texture2D> EditorTab::get_tab_button_icon() const {
+	return _tab_button_icon;
+}
+
+void EditorTab::set_tab_button_icon(Ref<Texture2D> p_tab_button_icon) {
+	_tab_button_icon = p_tab_button_icon;
+}
+
+Variant EditorTab::get_state() const {
+	return _state;
+}
+
+void EditorTab::set_state(Variant p_state) {
+	_state = p_state;
+}
+
+bool EditorTab::get_closing() const {
+	return _closing;
+}
+
+void EditorTab::set_closing(bool p_closing) {
+	_closing = p_closing;
+}
+
+bool EditorTab::get_cancel() const {
+	return _cancel;
+}
+
+void EditorTab::set_cancel(bool p_cancel) {
+	_cancel = p_cancel;
+}
+
+uint64_t EditorTab::get_last_used() const {
+	return _last_used;
+}
+
+void EditorTab::set_last_used(uint64_t p_last_used) {
+	_last_used = p_last_used;
+}
+
+void EditorTab::update_last_used() {
+	_last_used = OS::get_singleton()->get_ticks_msec();
+}
+
+void EditorTab::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("update_needed", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab")));
+	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab")));
+	ADD_SIGNAL(MethodInfo("closing", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab")));
+	ADD_SIGNAL(MethodInfo("tab_button_pressed", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab")));
+	ADD_SIGNAL(MethodInfo("context_menu_needed", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab"), PropertyInfo(Variant::OBJECT, "context_menu", PROPERTY_HINT_RESOURCE_TYPE, "PopupMenu")));
+	ADD_SIGNAL(MethodInfo("context_menu_pressed", PropertyInfo(Variant::OBJECT, "tab", PROPERTY_HINT_RESOURCE_TYPE, "EditorTab"), PropertyInfo(Variant::INT, "option")));
+}

--- a/editor/editor_tab.h
+++ b/editor/editor_tab.h
@@ -1,0 +1,81 @@
+/**************************************************************************/
+/*  editor_tab.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_TAB_H
+#define EDITOR_TAB_H
+
+#include "core/variant/variant.h"
+#include "scene/resources/image_texture.h"
+
+class EditorTab : public Object {
+	GDCLASS(EditorTab, Object);
+
+	friend class EditorSceneTabs;
+
+private:
+	String _name;
+	String _resource_path;
+	Ref<Texture2D> _icon;
+	Ref<Texture2D> _tab_button_icon;
+	Variant _state;
+	bool _closing = false;
+	bool _cancel = false;
+	uint64_t _last_used = 0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	struct EditorTabComparator {
+		_FORCE_INLINE_ bool operator()(const EditorTab *a, const EditorTab *b) const {
+			return a->get_last_used() > b->get_last_used();
+		}
+	};
+
+	String get_name() const;
+	void set_name(String p_name);
+	String get_resource_path() const;
+	void set_resource_path(String p_resource_path);
+	Ref<Texture2D> get_icon() const;
+	void set_icon(Ref<Texture2D> p_icon);
+	Ref<Texture2D> get_tab_button_icon() const;
+	void set_tab_button_icon(Ref<Texture2D> p_tab_button_icon);
+	Variant get_state() const;
+	void set_state(Variant p_state);
+	bool get_closing() const;
+	void set_closing(bool p_closing);
+	bool get_cancel() const;
+	void set_cancel(bool p_cancel);
+	uint64_t get_last_used() const;
+	void set_last_used(uint64_t p_last_used);
+	void update_last_used();
+};
+
+#endif // EDITOR_TAB_H

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1832,13 +1832,13 @@ void FileSystemDock::_rename_operation_confirm() {
 	HashMap<String, String> folder_renames;
 	_try_move_item(to_rename, new_path, file_renames, folder_renames);
 
-	int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
+	EditorTab *current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 	_update_resource_paths_after_move(file_renames, uids);
 	_update_dependencies_after_move(file_renames, file_owners);
 	_update_project_settings_after_move(file_renames, folder_renames);
 	_update_favorites_list_after_move(file_renames, folder_renames);
 
-	EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
+	EditorSceneTabs::get_singleton()->select_tab(current_tab);
 
 	if (ti) {
 		current_path = new_path;
@@ -1968,13 +1968,13 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 		}
 
 		if (is_moved) {
-			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
+			EditorTab *current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_update_resource_paths_after_move(file_renames, uids);
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_list_after_move(file_renames, folder_renames);
 
-			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
+			EditorSceneTabs::get_singleton()->select_tab(current_tab);
 
 			print_verbose("FileSystem: calling rescan.");
 			_rescan();

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -339,6 +339,11 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 
 	EditorAssetLibrary *addon_library = nullptr;
 
+private:
+	void _editor_tab_selected(EditorTab *p_tab);
+	void _editor_tab_closing(EditorTab *p_tab);
+	EditorTab *_create_editor_tab();
+
 public:
 	static bool is_available();
 
@@ -347,9 +352,8 @@ public:
 	virtual void edit(Object *p_object) override {}
 	virtual bool handles(Object *p_object) const override { return false; }
 	virtual void make_visible(bool p_visible) override;
-	//virtual bool get_remove_list(List<Node*> *p_list) { return canvas_item_editor->get_remove_list(p_list); }
-	//virtual Dictionary get_state() const;
-	//virtual void set_state(const Dictionary& p_state);
+	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
+	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
 
 	AssetLibraryEditorPlugin();
 	~AssetLibraryEditorPlugin();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -32,6 +32,7 @@
 #define SCRIPT_EDITOR_PLUGIN_H
 
 #include "core/object/script_language.h"
+#include "editor/gui/editor_scene_tabs.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/panel_container.h"
@@ -377,6 +378,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _close_current_tab(bool p_save = true, bool p_history_back = true);
 	void _close_discard_current_tab(const String &p_str);
+	void _close_canceled();
+
 	void _close_docs_tab();
 	void _close_other_tabs();
 	void _close_all_tabs();
@@ -514,6 +517,14 @@ class ScriptEditor : public PanelContainer {
 	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
+	EditorTab *_add_new_scene_tab(Node *p_node);
+	void _editor_tab_update_needed(EditorTab *p_tab);
+	void _editor_tab_selected(EditorTab *p_tab);
+	void _editor_tab_closing(EditorTab *p_tab);
+	void _editor_tab_context_menu_needed(EditorTab *p_tab, PopupMenu *p_context_menu);
+	void _editor_tab_context_menu_pressed(EditorTab *p_tab, int p_option);
+	int _get_tab_index_by_node(Node *p_node);
+
 	static ScriptEditor *script_editor;
 
 protected:
@@ -549,6 +560,7 @@ public:
 
 	void set_scene_root_script(Ref<Script> p_script);
 	Vector<Ref<Script>> get_open_scripts() const;
+	void plugin_button_pressed();
 
 	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 


### PR DESCRIPTION
This PR is a work in progress to implement a unification of tabs between scenes and scripts.

Implements a version of the proposal https://github.com/godotengine/godot-proposals/issues/966
I also based these modifications from the discussion on this proposal: https://github.com/godotengine/godot-proposals/issues/4081
There are others proposals on that subject with different approach and suggestion.

The idea was to standardize the Script Editor with what you see in other IDEs by using tabs for Scenes and Scripts. After using Godot for a while, I still struggle every day with the built-in Script Editor. Having a tab over the script that does not correspond to what is under it is too confusing for me after more than 20 years of using tabbed IDEs. Additionally, the navigation between scenes and scripts was always difficult because the Ctrl-Tab and Ctrl-Shift-Tab functionality did not work like other IDEs. It was only working for scenes and did not use the order of the last used scene. I standardized this by adding a popup when using Ctrl-Tab and Ctrl-Shift-Tab, displaying the opened scenes and scripts in one list ordered by last usage.

At the same time, it was important to me to be backward compatible because a lot of users use Godot and like it that way and it's perfect like that! So almost all these modifications are behind a new option in the Editor Settings.

### What’s New
- New option in Editor settings: “Main Editor Tab Content”:
  - Scenes Only: Current/old behavior.
  - Scenes; Scripts and Plugins: New behavior.
- When 'Scenes; Scripts and Plugins' is enabled:
  - When opening a Script, a Help Doc, or the Asset Lib, a tab is created in the same tab container as the scenes.
  - When clicking on a scene tab, the scene is displayed in the 2D/3D view depending on the last view used.
  - When clicking on a script, the script is opened in the script editor.
- **2D/3D button on top**: 
  - When already in 2D/3D view, it only switch to the selected view to allow 2D and 3D on same scene.
  - Otherwise, shows the last edited/selected scene in the selected view.
- **Script button on top**: Opens the last edited script. If no script is edited, it tries to open the script of the edited scene; otherwise, it creates a new script.
- **Script Editor**:
  - The Script list is hidden.
  - **Context menu on a script**:
    - These options from the Script menu are available in the context menu for scripts: Save, Save All, Copy Script Path, Show in File System, Run.
  - **Context menu on a scene**:
    - Added “Copy Scene Path” to standardize with the Script context menu.
- **Changes in both modes**:
  - Tabs navigation: editor/next_tab (Ctrl-Tab) and editor/prev_tab (Ctrl-Shift-Tab) now opens a window to see all your tabs ordered by last usage like VSCode, Visual Studio, or other IDEs.

### Todo

- [x] Keep the order of the tabs on editor restart.
- [ ] Unification of the Main menu and the Script Editor menu. It’s not that bad, but it could be nice to prevent having 2 menus on the screen.
- [ ] Test and manage multi-screen/script editor floating.
- [ ] Test with external script editor.
- [ ] Improve the “empty” scene that is created when all scenes are closed. It’s not natural to have an empty scene created when a scene is closed.
- [ ] Add tooltips on tabs to see the full path. I did not port the setting to show the full path of scripts in tabs.
- [ ] Rename the option ‘Toggle script panel’ in the File menu of the Script Editor when scripts are in tabs.
- [ ] Test plugin with the main screen that handles some type of object or resource.
- [ ] Update `EditorSettings.xml` for the new or updated parameters.
- [ ] Test in distraction-free mode.
- [ ] Test with the parameter `stay_in_script_editor_on_node_selected` inactive.
- [ ] Reopen the Asset Lib on editor restart if it was opened.
- [x] Rename the EditorSetting to be more specific: Updated to `Main Editor Tab Content`

### Questions
- Rename `EditorSceneTabs` to something like `EditorSceneManager`?
- Provide the possibility for plugins to create tabs via `EditorInterface`?
- Port the Script color from the Script list to the tabs?
- Currently, the + button in the tab bar creates a new scene, same as before. Should it create a new scene or script depending on the current editor?


### Some demo

https://github.com/user-attachments/assets/0828c7c1-c832-46c2-b8f3-4325e3b63b2e



Feel free to give me comments and suggestions to improve what was already done.
