### PR TITLE
Fix double writing without check inside ``VisualShader::connect_nodes``

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1287,6 +1287,8 @@ Error VisualShader::connect_nodes(Type p_type, int p_from_node, int p_from_port,
 	VisualShaderNode::PortType to_port_type = g->nodes[p_to_node].node->get_input_port_type(p_to_port);
 	bool port_types_are_compatible = is_port_types_compatible(from_port_type, to_port_type);
 
+	ERR_FAIL_COND_V_MSG(!port_types_are_compatible, ERR_INVALID_PARAMETER, "Incompatible port types.");
+
 	if (to_node_reroute.is_valid()) {
 		List<int> visited_reroute_nodes;
 		port_types_are_compatible = _check_reroute_subgraph(p_type, from_port_type, p_to_node, &visited_reroute_nodes);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The value coming from ``is_port_types_compatible`` in https://github.com/godotengine/godot/blob/97b8ad1af0f2b4a216f6f1263bef4fbc69e56c7b/scene/resources/visual_shader.cpp#L1288 is garbaged in the following if conditions without checks, so maybe the calling to ``is_port_types_compatible`` is unnecessary or we have to add another check before writing again however, I think the second one applies.
