### PR TITLE
[3.x] Revert "Fix parsing inner class declaration"

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -599,9 +599,6 @@ private:
 
 	bool _parse_arguments(Node *p_parent, Vector<Node *> &p_args, bool p_static, bool p_can_codecomplete = false, bool p_parsing_constant = false);
 	bool _enter_indent_block(BlockNode *p_block = nullptr);
-	bool _enter_inner_class_indent_block();
-	bool _parse_colon();
-	bool _parse_indent_block_newlines(BlockNode *p_block = nullptr);
 	bool _parse_newline();
 	Node *_parse_expression(Node *p_parent, bool p_static, bool p_allow_assign = false, bool p_parsing_constant = false);
 	Node *_reduce_expression(Node *p_node, bool p_to_const = false);


### PR DESCRIPTION
This reverts commit 5bcc3d476cd06c9e9edd00e63a221d77d9ff7c0b.

Fixes #94152

## Notes
* As I understand, the PR fixes a minor bug but has proven prone to regressions.
* With the author we figured it may be better to revert for the release candidates and fix in a point release with more time to track down regressions.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
