### PR TITLE
Fix "selectable nodes at position clicked" feature in 3D editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1575,7 +1575,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			} else {
 				Node *node_owner = node->get_owner();
 				if (node == edited_scene || node_owner == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
-					if (selection_results.has(node)) {
+					if (!selection_results.has(node)) {
 						selection_results.append(node);
 					}
 					break;


### PR DESCRIPTION
I just stumbled upon this one, so forgive the issue and PR rolled into one.

The viewport toolbar button titled "Show list of selectable nodes at position clicked", also triggered by Alt+RMB on Windows, is apparently broken (in 3D specifically) as of 97b8ad1af0f2b4a216f6f1263bef4fbc69e56c7b, and as far as I can tell was broken by #92188.

The issue is hopefully apparent from looking at the change. The `potential_selection_results` could inherently never be incorporated into `selection_results` as its `node` would only be added to `selection_results` if `selection_results.has(node)`, which doesn't make much sense.

This PR fixes that by inverting that if-check.

CC @SaracenOne.