### PR TITLE
Restore default clear color after displaying boot splash

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2917,8 +2917,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 		MAIN_PRINT("Main: Clear Color");
 
 		DisplayServer::set_early_window_clear_color_override(false);
-		RenderingServer::get_singleton()->set_default_clear_color(
-				GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 
 		GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/icon", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), String());
 		GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"), String());
@@ -3219,6 +3217,8 @@ void Main::setup_boot_logo() {
 		}
 #endif
 	}
+	RenderingServer::get_singleton()->set_default_clear_color(
+			GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 }
 
 String Main::get_rendering_driver_name() {


### PR DESCRIPTION
On Android the boot splash can be shown at a different time, so the clear color restore needs to happen within the `setup_boot_logo` function

When there is no boot splash logo, we alter the default clear color to `application/boot_splash/bg_color`. It needs to be reset after.

When there is no environment in the scene, the default clear color is used as the ambient light color. Therefore, in the MRP the entire scene became darker because there was no boot splash logo!

Fixes: https://github.com/godotengine/godot/issues/94225

CC @m4gr3d 
