### PR TITLE
Wayland: Check for suspended flag when unsuspending

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1238,7 +1238,7 @@ void DisplayServerWayland::process_events() {
 		} else {
 			try_suspend();
 		}
-	} else if (wayland_thread.get_reset_frame()) {
+	} else if (!wayland_thread.is_suspended() || wayland_thread.get_reset_frame()) {
 		// At last, a sign of life! We're no longer suspended.
 		suspended = false;
 	}


### PR DESCRIPTION
Should fix #94228.

Before, we would only check for the frame flag, which is unreliable on newer suspension-aware compositors.

Untested, as I don't have yet a setup with the affected compositors (I'm looking into one).