### PR TITLE
Always render when XR is enabled, even if no OS windows can draw

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -879,6 +879,12 @@
 				Registers callables to emit when the menu is respectively about to show or closed. Callback methods should have zero arguments.
 			</description>
 		</method>
+		<method name="has_additional_outputs" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if any additional outputs have been registered via [method register_additional_output].
+			</description>
+		</method>
 		<method name="has_feature" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="DisplayServer.Feature" />
@@ -1020,6 +1026,14 @@
 			<return type="void" />
 			<description>
 				Perform window manager processing, including input flushing. See also [method force_process_and_drop_events], [method Input.flush_buffered_events] and [member Input.use_accumulated_input].
+			</description>
+		</method>
+		<method name="register_additional_output">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<description>
+				Registers an [Object] which represents an additional output that will be rendered too, beyond normal windows. The [Object] is only used as an identifier, which can be later passed to [method unregister_additional_output].
+				This can be used to prevent Godot from skipping rendering when no normal windows are visible.
 			</description>
 		</method>
 		<method name="screen_get_dpi" qualifiers="const">
@@ -1350,6 +1364,13 @@
 				Stops synthesis in progress and removes all utterances from the queue.
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux (X11/Linux), macOS, and Windows.
 				[b]Note:[/b] [member ProjectSettings.audio/general/text_to_speech] should be [code]true[/code] to use text-to-speech.
+			</description>
+		</method>
+		<method name="unregister_additional_output">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<description>
+				Unregisters an [Object] representing an additional output, that was registered via [method register_additional_output].
 			</description>
 		</method>
 		<method name="virtual_keyboard_get_height" qualifiers="const">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4108,7 +4108,7 @@ bool Main::iteration() {
 
 	RenderingServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 
-	if (DisplayServer::get_singleton()->can_any_window_draw() &&
+	if ((DisplayServer::get_singleton()->can_any_window_draw() || DisplayServer::get_singleton()->has_additional_outputs()) &&
 			RenderingServer::get_singleton()->is_render_loop_enabled()) {
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (RenderingServer::get_singleton()->has_changed()) {

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -651,6 +651,10 @@ bool OpenXRInterface::initialize() {
 	// make this our primary interface
 	xr_server->set_primary_interface(this);
 
+	// Register an additional output with the display server, so rendering won't
+	// be skipped if no windows are visible.
+	DisplayServer::get_singleton()->register_additional_output(this);
+
 	initialized = true;
 
 	return initialized;
@@ -673,6 +677,8 @@ void OpenXRInterface::uninitialize() {
 			head.unref();
 		}
 	}
+
+	DisplayServer::get_singleton()->unregister_additional_output(this);
 
 	initialized = false;
 }

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -759,6 +759,17 @@ DisplayServer::WindowID DisplayServer::get_focused_window() const {
 void DisplayServer::set_context(Context p_context) {
 }
 
+void DisplayServer::register_additional_output(Object *p_object) {
+	ObjectID id = p_object->get_instance_id();
+	if (!additional_outputs.has(id)) {
+		additional_outputs.push_back(id);
+	}
+}
+
+void DisplayServer::unregister_additional_output(Object *p_object) {
+	additional_outputs.erase(p_object->get_instance_id());
+}
+
 void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &DisplayServer::has_feature);
 	ClassDB::bind_method(D_METHOD("get_name"), &DisplayServer::get_name);
@@ -996,6 +1007,10 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tablet_set_current_driver", "name"), &DisplayServer::tablet_set_current_driver);
 
 	ClassDB::bind_method(D_METHOD("is_window_transparency_available"), &DisplayServer::is_window_transparency_available);
+
+	ClassDB::bind_method(D_METHOD("register_additional_output", "object"), &DisplayServer::register_additional_output);
+	ClassDB::bind_method(D_METHOD("unregister_additional_output", "object"), &DisplayServer::unregister_additional_output);
+	ClassDB::bind_method(D_METHOD("has_additional_outputs"), &DisplayServer::has_additional_outputs);
 
 #ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(FEATURE_GLOBAL_MENU);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -53,6 +53,8 @@ class DisplayServer : public Object {
 	RID _get_rid_from_name(NativeMenu *p_nmenu, const String &p_menu_root) const;
 #endif
 
+	LocalVector<ObjectID> additional_outputs;
+
 public:
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
 		return singleton;
@@ -581,6 +583,10 @@ public:
 	virtual void set_context(Context p_context);
 
 	virtual bool is_window_transparency_available() const { return false; }
+
+	void register_additional_output(Object *p_output);
+	void unregister_additional_output(Object *p_output);
+	bool has_additional_outputs() const { return additional_outputs.size() > 0; }
 
 	static void register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers);
 	static int get_create_function_count();


### PR DESCRIPTION
**The short explanation:**

Currently, in `Main::iteration()`, it will skip rendering for a particular frame if `DisplayServer::get_singleton()->can_any_window_draw()` returns `false`.

For all current `DisplayServer`s, they either:

1. Always return `true`, or
2. Return `true` if at least one of Godot's windows is visible

However, when using an XR device, we need to keep rendering, even if all OS windows aren't visible. For example, if you have a VR headset connected to your desktop, you don't want it to stop rendering to the headset if the Godot window on your desktop is minimized.

So, this PR will cause rendering to happen if the primary `XRInterface` is initialized, even if `DisplayServer::get_singleton()->can_any_window_draw()` returns `false`.

**The longer explanation:**

I started looking into this because there is a case when using the Meta XR Simulator on MacOS, where we would sometimes call `xrWaitFrame()` twice without calling  `xrBeginFrame()` in between, which leads to the application getting "stuck" forever (spinning beach ball and everything).

According the OpenXR specification ([in Section 10.3](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#frame-synchronization)):

> A subsequent [xrWaitFrame](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrWaitFrame) call must block until the previous frame has been begun with [xrBeginFrame](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrBeginFrame) and must unblock independently of the corresponding call to [xrEndFrame](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrEndFrame).

So, the Meta XR Simulator is acting exactly as specified, and is blocking until the next `xrBeginFrame()` (which will never come when Godot is using single-threaded rendering).

The reason the `xrBeginFrame()` sometimes doesn't happen, is that we're calling it at the beginning of rendering (as we should, per the spec!), and, per the "short explanation" above, Godot may skip rendering if all windows are momentarily not visible.

While I originally dug into this for this very specific OpenXR related bug, I think it logically makes sense that when using XR, we shouldn't make rendering conditional on if OS windows are visible.