### PR TITLE
Handle internal seek on AnimationPlayer to process discrete correctly

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -248,7 +248,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 			player->clear_caches(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->seek(time, true, true);
+		player->seek_internal(time, true, true, true);
 		player->play(current);
 	}
 
@@ -286,7 +286,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 			player->clear_caches(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->seek(time, true, true);
+		player->seek_internal(time, true, true, true);
 		player->play_backwards(current);
 	}
 
@@ -1295,7 +1295,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 	pos = CLAMP(pos, 0, (double)anim->get_length() - CMP_EPSILON2); // Hack: Avoid fposmod with LOOP_LINEAR.
 
 	if (!p_timeline_only && anim.is_valid()) {
-		player->seek(pos, true, true);
+		player->seek_internal(pos, true, true, false);
 	}
 
 	track_editor->set_anim_pos(pos);
@@ -1706,7 +1706,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_step_prepare(int p_step_offs
 		bool valid = anim->get_loop_mode() != Animation::LOOP_NONE || (pos >= 0 && pos <= anim->get_length());
 		onion.captures_valid[p_capture_idx] = valid;
 		if (valid) {
-			player->seek(pos, true, true);
+			player->seek_internal(pos, true, true, false);
 			OS::get_singleton()->get_main_loop()->process(0);
 			// This is the key: process the frame and let all callbacks/updates/notifications happen
 			// so everything (transforms, skeletons, etc.) is up-to-date visually.
@@ -1763,7 +1763,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_epilog() {
 	//        backed by a proper reset animation will work correctly with onion
 	//        skinning and the possibility to restore the values mentioned in the
 	//        first point above is gone. Still good enough.
-	player->seek(onion.temp.anim_player_position, true, true);
+	player->seek_internal(onion.temp.anim_player_position, true, true, false);
 	player->restore(onion.temp.anim_values_backup);
 
 	// Restore state of main editors.

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -80,6 +80,7 @@ private:
 		PlaybackData current;
 		StringName assigned;
 		bool seeked = false;
+		bool internal_seeked = false;
 		bool started = false;
 		List<Blend> blend;
 	} playback;
@@ -116,7 +117,7 @@ private:
 
 	void _play(const StringName &p_name, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void _capture(const StringName &p_name, bool p_from_end = false, double p_duration = -1.0, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
-	void _process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_started, bool p_is_current = false);
+	void _process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current = false);
 	void _blend_playback_data(double p_delta, bool p_started);
 	void _stop_internal(bool p_reset, bool p_keep_state);
 	void _check_immediately_after_start();
@@ -200,6 +201,7 @@ public:
 	void set_movie_quit_on_finish_enabled(bool p_enabled);
 	bool is_movie_quit_on_finish_enabled() const;
 
+	void seek_internal(double p_time, bool p_update = false, bool p_update_only = false, bool p_is_internal_seek = false);
 	void seek(double p_time, bool p_update = false, bool p_update_only = false);
 
 	double get_current_animation_position() const;


### PR DESCRIPTION
Discrete mode gets the previous key during seek, but when it is playing backwards, it gets the next key in time. This could cause a problem since time is going backwards when stopping, and that is being treated as a reverse playback seek

As for stopping, restarting, the key must be obtained in Exact mode not Nearest mode, just as start playback. It should be treated as an internal seek.

I cannot determine if it is correct behavior of retrieving the previous key when seeking. I believe this has been the old behavior. And I expect it is a hack to process the last key after crossing a key, because in the past it was not possible to get the delta correctly when seeking (I remember I have fixed that at early 4.0). So it may be a behavior that should be fixed now that we are able to get the delta. I will send another PR for about it later if needed.