### PR TITLE
[3.x] Fix physics tick count in `Input.action_press` and `Input.action_release`

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -646,7 +646,8 @@ void InputDefault::action_press(const StringName &p_action, float p_strength) {
 	// Create or retrieve existing action.
 	Action &action = action_state[p_action];
 
-	action.pressed_physics_frame = Engine::get_singleton()->get_physics_frames();
+	// As input may come in part way through a physics tick, the earliest we can react to it is the next physics tick.
+	action.pressed_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 	action.pressed_idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = true;
 	action.exact = true;
@@ -658,7 +659,8 @@ void InputDefault::action_release(const StringName &p_action) {
 	// Create or retrieve existing action.
 	Action &action = action_state[p_action];
 
-	action.released_physics_frame = Engine::get_singleton()->get_physics_frames();
+	// As input may come in part way through a physics tick, the earliest we can react to it is the next physics tick.
+	action.released_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 	action.released_idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = false;
 	action.exact = true;


### PR DESCRIPTION
…ase`

The physics tick count was not yet updated there.

3.x version of #94413
Regression from #92941 
Fixes #94409 for 3.x

## Notes
* Didn't spot this, another point where the tick needed adjusting.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
