### PR TITLE
Fix input lock issue when drag scrolling on a `Tree` element on touchscreen devices

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5440,6 +5440,24 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 	return -100;
 }
 
+bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+	if (drag_touching) {
+		// Disable data drag & drop when touch dragging.
+		return false;
+	}
+
+	return Control::can_drop_data(p_point, p_data);
+}
+
+Variant Tree::get_drag_data(const Point2 &p_point) {
+	if (drag_touching) {
+		// Disable data drag & drop when touch dragging.
+		return Variant();
+	}
+
+	return Control::get_drag_data(p_point);
+}
+
 TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -698,6 +698,8 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
+	virtual Variant get_drag_data(const Point2 &p_point) override;
 	TreeItem *get_item_at_position(const Point2 &p_pos) const;
 	int get_column_at_position(const Point2 &p_pos) const;
 	int get_drop_section_at_position(const Point2 &p_pos) const;


### PR DESCRIPTION
Prior to this fix, scrolling via mouse drag on touchscreen devices, and drag&drop operation of a `TreeItem` element would conflict with each other preventing the drag scroll from being released when the mouse button is released.

The issue is addressed by disabling drag&drop operations when drag scrolling is ongoing.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
