### PR TITLE
Fix issue preventing enabling the remote button for Android/iOS

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -58,12 +58,12 @@ void EditorRunNative::_notification(int p_what) {
 					for (int j = 0; j < EditorExport::get_singleton()->get_export_platform_count(); j++) {
 						if (eep->get_name() == EditorExport::get_singleton()->get_export_platform(j)->get_name()) {
 							platform_idx = j;
+							break;
 						}
 					}
 					int dc = MIN(eep->get_options_count(), 9000);
-					bool needs_templates;
 					String error;
-					if (dc > 0 && preset->is_runnable() && eep->can_export(preset, error, needs_templates)) {
+					if (dc > 0 && preset->is_runnable()) {
 						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
 						popup->set_item_disabled(-1, true);
 						for (int j = 0; j < dc; j++) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -441,6 +441,7 @@ void EditorExportPlatformAndroid::_update_preset_status() {
 	} else {
 		has_runnable_preset.clear();
 	}
+	devices_changed.set();
 }
 #endif
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -2971,6 +2971,7 @@ void EditorExportPlatformIOS::_update_preset_status() {
 	} else {
 		has_runnable_preset.clear();
 	}
+	devices_changed.set();
 }
 #endif
 


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/92032 updated the logic to enable / disable the remote debug button, and in doing so added a `can_export` check.

However, no events / notifications are dispatched when the value of the `can_export` check changes, which in turn prevents the logic used to enable / disable the remote debug button from running again.

The fix consists then in removing the `can_export` check, so that the remote debug button shows as `enabled` when a preset is present and is runnable.

Fixes https://github.com/godotengine/godot/issues/93531

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
