### PR TITLE
Windows: Update ANGLE surface size when window is resized

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4686,16 +4686,16 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					rect_changed = true;
 				}
 #if defined(RD_ENABLED)
-				if (rendering_context && window.context_created) {
+				if (window.create_completed && rendering_context && window.context_created) {
 					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
 					rendering_context->window_set_size(window_id, window.width, window.height);
 				}
 #endif
 #if defined(GLES3_ENABLED)
-				if (gl_manager_native) {
+				if (window.create_completed && gl_manager_native) {
 					gl_manager_native->window_resize(window_id, window.width, window.height);
 				}
-				if (gl_manager_angle) {
+				if (window.create_completed && gl_manager_angle) {
 					gl_manager_angle->window_resize(window_id, window.width, window.height);
 				}
 #endif
@@ -5403,6 +5403,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			SetWindowPos(wd.hWnd, HWND_TOP, srect.position.x, srect.position.y, srect.size.width, srect.size.height, SWP_NOZORDER | SWP_NOACTIVATE);
 		}
 
+		wd.create_completed = true;
 		window_id_counter++;
 	}
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -385,6 +385,7 @@ class DisplayServerWindows : public DisplayServer {
 
 		Vector<Vector2> mpath;
 
+		bool create_completed = false;
 		bool pre_fs_valid = false;
 		RECT pre_fs_rect;
 		bool maximized = false;

--- a/platform/windows/gl_manager_windows_angle.cpp
+++ b/platform/windows/gl_manager_windows_angle.cpp
@@ -67,4 +67,9 @@ Vector<EGLint> GLManagerANGLE_Windows::_get_platform_context_attribs() const {
 	return ret;
 }
 
+void GLManagerANGLE_Windows::window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {
+	window_make_current(p_window_id);
+	eglWaitNative(EGL_CORE_NATIVE_ENGINE);
+}
+
 #endif // WINDOWS_ENABLED && GLES3_ENABLED

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -50,7 +50,7 @@ private:
 	virtual Vector<EGLint> _get_platform_context_attribs() const override;
 
 public:
-	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
+	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 
 	GLManagerANGLE_Windows(){};
 	~GLManagerANGLE_Windows(){};


### PR DESCRIPTION
ANGLE needs to be told to resize the DXGI swap chain using `eglWaitNative`. Otherwise the resize will only happen in `eglSwapBuffers`, which causes some janky stretching during window resize.

---

See: https://github.com/google/angle/blob/43ecf2bd98fc9dd135c82d6b153e18bf1fbcaf37/src/libANGLE/renderer/d3d/DisplayD3D.cpp#L401

This only fixes part of the issue because DisplayServerWindows does not currently force update and redraw during resize, which I aim to address separately.

<details>
<summary>Demo (GIF)</summary>

Before:
![before](https://github.com/user-attachments/assets/e4ce33d1-1e6b-4725-9ed7-a23267986bf1)

After: (the slowness is probably from being a debug build)
![after](https://github.com/user-attachments/assets/51f65145-d420-4329-b18b-47eee0e2bf68)
</details>

Fixes https://github.com/godotengine/godot/issues/94951