### PR TITLE
Fix animation library copy-paste not preserving resource reference

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -561,7 +561,9 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 					return;
 				}
 
-				anim = anim->duplicate(); // Users simply dont care about referencing, so making a copy works better here.
+				if (!anim->get_path().is_resource_file()) {
+					anim = anim->duplicate(); // Users simply dont care about referencing, so making a copy works better here.
+				}
 
 				String base_name;
 				if (anim->get_name() != "") {


### PR DESCRIPTION
Currently when using the copy-paste functionality in the animation library editor (found under the "Manage Animations..." button in the Animation dock) you're not able to copy an animation while also preserving any resource file reference that it might have.

Here's how it looks currently:

https://github.com/user-attachments/assets/407179d3-893e-4b1c-b60f-1ffa912a1bf3

Here's what it looks like with this change applied:

https://github.com/user-attachments/assets/a89c053c-d539-4377-9b87-6b95a72fc35f

I've talked to @reduz who wrote the affected line, and it seems that the current behavior was not the original intention, so this is likely a bug.

(Note that copying an animation which doesn't reference an external resource file will still copy by-value rather than by-reference.)