### PR TITLE
Windows: Update and redraw during window resize

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4719,6 +4719,16 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					ClientToScreen(window.hWnd, (POINT *)&crect.right);
 					ClipCursor(&crect);
 				}
+
+				if (window.create_completed && OS::get_singleton()->get_main_loop()) {
+					_THREAD_SAFE_UNLOCK_
+					_process_key_events();
+					Main::force_redraw();
+					if (!Main::is_iterating()) { // Avoid cyclic loop.
+						Main::iteration();
+					}
+					_THREAD_SAFE_LOCK_
+				}
 			}
 
 			// Return here to prevent WM_MOVE and WM_SIZE from being sent


### PR DESCRIPTION
This makes the window content more synchronized with the window frame during window resize.

---
<details>
<summary>Demo videos:</summary>

Using the MRP from #79446.

Before (OpenGL native):

[before_opengl_native.webm](https://github.com/user-attachments/assets/e523adbb-cbbd-40f4-97d3-a4df7e51dea9)

Before (OpenGL ANGLE):

[before_opengl_angle.webm](https://github.com/user-attachments/assets/a3598e25-0245-496d-8a60-a201365d8c8f)

Before (Vulkan):

[before_vulkan.webm](https://github.com/user-attachments/assets/fc951bf3-feab-43aa-9807-d9e362fd3cc0)

Before (D3D12):

[before_d3d12.webm](https://github.com/user-attachments/assets/e2787af6-166d-4771-b2b0-c3b283b7a1bb)

After (OpenGL native):

[after_opengl_native.webm](https://github.com/user-attachments/assets/8c6ba9c7-d65f-415b-af49-5a82500a93a4)

After (OpenGL ANGLE, when combined with #94428):

[after_opengl_angle.webm](https://github.com/user-attachments/assets/974f9d73-352c-400b-8801-4acd075e1212)

After (Vulkan):

[after_vulkan.webm](https://github.com/user-attachments/assets/0b6edc21-ff88-43bd-b9e9-4ebd2de001ce)

After (D3D12):

[after_d3d12.webm](https://github.com/user-attachments/assets/b6116900-2944-4c40-a073-70d1e24bcef7)

</details>

D3D12 appears to still have some sort of window size desync.

- Fixes #79446
- Fixes #84565