### PR TITLE
[X11] Fix popup window cannot get mouse information when running in WSLg

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5698,22 +5698,6 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 			}
 		}
 
-		if (wd.is_popup || wd.no_focus) {
-			// Set Utility type to disable fade animations.
-			Atom type_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE_UTILITY", False);
-			Atom wt_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE", False);
-			if (wt_atom != None && type_atom != None) {
-				XChangeProperty(x11_display, wd.x11_window, wt_atom, XA_ATOM, 32, PropModeReplace, (unsigned char *)&type_atom, 1);
-			}
-		} else {
-			Atom type_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE_NORMAL", False);
-			Atom wt_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE", False);
-
-			if (wt_atom != None && type_atom != None) {
-				XChangeProperty(x11_display, wd.x11_window, wt_atom, XA_ATOM, 32, PropModeReplace, (unsigned char *)&type_atom, 1);
-			}
-		}
-
 		_update_size_hints(id);
 
 #if defined(RD_ENABLED)


### PR DESCRIPTION
Fixes: #82204 
There are two solutions:

1. Add override_redirect for popup window
2. Remove _NET_WM_WINDOW_TYPE_UTILITY for popup window

The reason for choosing the second solution is that a previous commit 9f426498231816ccb9d686b3944373f61312aa24 removed the override_redirect to fix IME can not get input focus