### PR TITLE
Fix removing a folder that contains a file is not removed from the FileSystem Dock

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1594,7 +1594,10 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 		}
 
 		if (idx == -1) {
-			//does not exist, create i guess?
+			// Only create a missing directory in memory when it exists on disk.
+			if (!dir->dir_exists(fs->get_path().path_join(path[i]))) {
+				return false;
+			}
 			EditorFileSystemDirectory *efsd = memnew(EditorFileSystemDirectory);
 
 			efsd->name = path[i];


### PR DESCRIPTION
- Fixes #94431
- Fixes #93097

The issue is a side-effect from #92303. To be able to manage correctly the removing of scripts with global class names, I added all removed files in `scan_actions` with the action `ACTION_FILE_REMOVE`. But in `_update_scene_groups` or `_update_script_documentation` the method `find_file` is called, which calls `_find_file`. The method `_find_file` recreates the parent folder of the searched file if it does not exist in `filesystem`.

I added a check to prevent adding a folder in `filesystem` that does not exist on the disk.