### PR TITLE
Focus code editor on double click on debugger error instead of single click

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -101,8 +101,8 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("stop_requested", callable_mp(this, &EditorDebuggerNode::_debugger_wants_stop).bind(id));
 	node->connect("stopped", callable_mp(this, &EditorDebuggerNode::_debugger_stopped).bind(id));
 	node->connect("stack_frame_selected", callable_mp(this, &EditorDebuggerNode::_stack_frame_selected).bind(id));
-	node->connect("error_selected", callable_mp(this, &EditorDebuggerNode::_error_selected).bind(id));
-	node->connect("breakpoint_selected", callable_mp(this, &EditorDebuggerNode::_error_selected).bind(id));
+	node->connect("error_activated", callable_mp(this, &EditorDebuggerNode::_error_activated).bind(id));
+	node->connect("breakpoint_selected", callable_mp(this, &EditorDebuggerNode::_breakpoint_selected).bind(id));
 	node->connect("clear_execution", callable_mp(this, &EditorDebuggerNode::_clear_execution));
 	node->connect("breaked", callable_mp(this, &EditorDebuggerNode::_breaked).bind(id));
 	node->connect("remote_tree_updated", callable_mp(this, &EditorDebuggerNode::_remote_tree_updated).bind(id));
@@ -144,7 +144,12 @@ void EditorDebuggerNode::_stack_frame_selected(int p_debugger) {
 	_text_editor_stack_goto(dbg);
 }
 
-void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p_debugger) {
+void EditorDebuggerNode::_breakpoint_selected(const String &p_file, int p_line, int p_debugger) {
+	Ref<Script> s = ResourceLoader::load(p_file);
+	emit_signal(SNAME("goto_script_line"), s, p_line - 1);
+}
+
+void EditorDebuggerNode::_error_activated(const String &p_file, int p_line, int p_debugger) {
 	Ref<Script> s = ResourceLoader::load(p_file);
 	emit_signal(SNAME("goto_script_line"), s, p_line - 1);
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -149,7 +149,8 @@ protected:
 	void _text_editor_stack_goto(const ScriptEditorDebugger *p_debugger);
 	void _text_editor_stack_clear(const ScriptEditorDebugger *p_debugger);
 	void _stack_frame_selected(int p_debugger);
-	void _error_selected(const String &p_file, int p_line, int p_debugger);
+	void _breakpoint_selected(const String &p_file, int p_line, int p_debugger);
+	void _error_activated(const String &p_file, int p_line, int p_debugger);
 	void _breaked(bool p_breaked, bool p_can_debug, const String &p_message, bool p_has_stackdump, int p_debugger);
 	void _paused();
 	void _break_state_changed();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1537,17 +1537,12 @@ void ScriptEditorDebugger::_error_activated() {
 		return;
 	}
 
-	// TreeItem *ci = selected->get_first_child();
-	// if (ci) {
-	// 	selected->set_collapsed(!selected->is_collapsed());
-	// }
-
 	Array meta = selected->get_metadata(0);
-	if (meta.size() == 0) {
+	if (meta.is_empty()) {
 		return;
 	}
 
-	emit_signal(SNAME("error_activated"), String(meta[0]), int(meta[1]));
+	emit_signal(SNAME("error_activated"), int(meta[1]));
 }
 
 void ScriptEditorDebugger::_error_selected() {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1537,10 +1537,17 @@ void ScriptEditorDebugger::_error_activated() {
 		return;
 	}
 
-	TreeItem *ci = selected->get_first_child();
-	if (ci) {
-		selected->set_collapsed(!selected->is_collapsed());
+	// TreeItem *ci = selected->get_first_child();
+	// if (ci) {
+	// 	selected->set_collapsed(!selected->is_collapsed());
+	// }
+
+	Array meta = selected->get_metadata(0);
+	if (meta.size() == 0) {
+		return;
 	}
+
+	emit_signal(SNAME("error_activated"), String(meta[0]), int(meta[1]));
 }
 
 void ScriptEditorDebugger::_error_selected() {
@@ -1749,6 +1756,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("stop_requested"));
 	ADD_SIGNAL(MethodInfo("stack_frame_selected", PropertyInfo(Variant::INT, "frame")));
 	ADD_SIGNAL(MethodInfo("error_selected", PropertyInfo(Variant::INT, "error")));
+	ADD_SIGNAL(MethodInfo("error_activated", PropertyInfo(Variant::INT, "error")));
 	ADD_SIGNAL(MethodInfo("breakpoint_selected", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("set_execution", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("clear_execution", PropertyInfo("script")));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixes #84306

This changes the input for focusing code in the bound IDE to double click (activation) instead of single click (selection). This prevents external IDE windows from popping to the front, or godot from switching to the internal editor everytime an entry is simply selected, expanded or collapsed, which is less distracting.
Toggling expanded & collapsed state is thus no longer done by double clicking, which i personally don't think is an issue as that is what the foldout did and still does.

Note:
Selecting breakpoints and errors previously seemed to use the same logic. But because i don't use the built-in debugger, i can't judge whether the behaviour there is still desired, so i left it in and only changed the error clicking to double clicking.
This also duplicates the signal handler that previously handled both selections, but as these are semantically different actions, i think it's reasonable to have a separate one for each case. I can merge them, if that's not desired.