### PR TITLE
Fix ScriptEditor scrolling horizontally when reopening script

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5913,6 +5913,11 @@ void TextEdit::adjust_viewport_to_caret(int p_caret) {
 	}
 	visible_width -= 20; // Give it a little more space.
 
+	if (visible_width <= 0) {
+		// Not resized yet.
+		return;
+	}
+
 	Vector2i caret_pos;
 
 	// Get position of the start of caret.


### PR DESCRIPTION
The script must have enough text to be able to scroll horizontally and the caret must not be saved on column 0.
The editor was scrolling horizontally to put the caret at the left edge of the screen when it doesn't need to.

There is another issue that causes it to scroll horizontally when the Editor opens, this only fixes it when a script is reopened.

`adjust_viewport_to_caret` was being called before the TextEdit is resized initially, so the `visible_width` was invalid.

*Bugsquad Edit:* Fixes #33865