### PR TITLE
[C#] Allow using the Signal attribute on events

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
@@ -20,16 +20,18 @@ namespace Godot.SourceGenerators
         public (MarshalType MarshalType, ITypeSymbol TypeSymbol)? RetType { get; }
     }
 
-    public readonly struct GodotSignalDelegateData
+    public readonly struct GodotSignalData
     {
-        public GodotSignalDelegateData(string name, INamedTypeSymbol delegateSymbol, GodotMethodData invokeMethodData)
+        public GodotSignalData(string name, bool isDelegate, INamedTypeSymbol delegateSymbol, GodotMethodData invokeMethodData)
         {
             Name = name;
+            IsDelegate = isDelegate;
             DelegateSymbol = delegateSymbol;
             InvokeMethodData = invokeMethodData;
         }
 
         public string Name { get; }
+        public bool IsDelegate { get; }
         public INamedTypeSymbol DelegateSymbol { get; }
         public GodotMethodData InvokeMethodData { get; }
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -2,6 +2,6 @@ using System;
 
 namespace Godot
 {
-    [AttributeUsage(AttributeTargets.Delegate)]
+    [AttributeUsage(AttributeTargets.Delegate | AttributeTargets.Event)]
     public sealed class SignalAttribute : Attribute { }
 }


### PR DESCRIPTION
## Motivation

The current method to declare a signal in a C# class requires declaring an inner delegate type. This prevents polymorphism using interfaces since unrelated classes cannot declare a signal of the same type.
Closes #80033, closes godotengine/godot-proposals#9373

## Usage

This PR enables using the `Signal` attribute on events of existing delegate types (such as `Action`):

```cs
[Signal]
public event Action MySignal;
```

Emitting the signal is still done using `EmitSignal(SignalName.MySignal)`, but now the event can be declared in an interface.

## Potential Drawbacks

- This exposes the `Invoke` method on signals declared using an event, which shouldn't be used.