### PR TITLE
Revert "CI: Pin Python 3.12.3 to workaround GHA issue"

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -3,7 +3,7 @@ description: Setup Python, install the pip version of SCons.
 inputs:
   python-version:
     description: The Python version to use.
-    default: "3.12.3"
+    default: "3.x"
   python-arch:
     description: The Python architecture.
     default: "x64"


### PR DESCRIPTION
- Reverts #92967
- Supersedes #94271

The pinned version is no longer needed, as the issue in question was fixed via actions/python-versions#286. In the future, this kind of change shouldn't be necessary, as runners requiring different builds can simply supply a pinned python version instead. If the issue was still present, the preferred implementation would be:
```yml
# macos_builds.yml
...
      - name: Setup Python and SCons
        uses: ./.github/actions/godot-deps
        with:
          # Workaround GHA unable to extract 3.12.4 tarball
          python-version: 3.12.3
...
```