### PR TITLE
Font: Fix typo in `get_supported_variation_list` example

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -279,7 +279,7 @@
 				To print available variation axes of a variable font:
 				[codeblock]
 				var fv = FontVariation.new()
-				fv.set_base_font = load("res://RobotoFlex.ttf")
+				fv.base_font = load("res://RobotoFlex.ttf")
 				var variation_list = fv.get_supported_variation_list()
 				for tag in variation_list:
 				    var name = TextServerManager.get_primary_interface().tag_to_name(tag)

--- a/doc/classes/FontVariation.xml
+++ b/doc/classes/FontVariation.xml
@@ -9,8 +9,8 @@
 		[codeblocks]
 		[gdscript]
 		var fv = FontVariation.new()
-		fv.set_base_font(load("res://BarlowCondensed-Regular.ttf"))
-		fv.set_variation_embolden(1.2)
+		fv.base_font = load("res://BarlowCondensed-Regular.ttf")
+		fv.variation_embolden = 1.2
 		$Label.add_theme_font_override("font", fv)
 		$Label.add_theme_font_size_override("font_size", 64)
 		[/gdscript]


### PR DESCRIPTION
FontVariation.set_base_font is a function, not a property.
