### PR TITLE
CI: Bump SCons version (4.7.0→4.8.0)

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: "x64"
   scons-version:
     description: The SCons version to use.
-    default: "4.7.0"
+    default: "4.8.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
- Supersedes #94271

Bumps the SCons version to the latest production release at time of writing: 4.8.0.