### PR TITLE
Fix crash when adding scenes with a group to the level scene

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -275,6 +275,11 @@ void GroupsEditor::_queue_update_groups_and_tree() {
 
 void GroupsEditor::_update_groups_and_tree() {
 	update_groups_and_tree_queued = false;
+	// The scene_root_node could be unset before we actually run this code because this is queued with call_deferred().
+	// In that case NOTIFICATION_VISIBILITY_CHANGED will call this function again soon.
+	if (!scene_root_node) {
+		return;
+	}
 	_update_groups();
 	_update_tree();
 }


### PR DESCRIPTION
Fixes #94274

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
