### PR TITLE
Fix game window stops responding when debugger pauses

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -39,6 +39,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
+#include "servers/display_server.h"
 
 class RemoteDebugger::PerformanceProfiler : public EngineProfiler {
 	Object *performance = nullptr;
@@ -539,7 +540,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			OS::get_singleton()->delay_usec(10000);
 			if (Thread::get_caller_id() == Thread::get_main_id()) {
 				// If this is a busy loop on the main thread, events still need to be processed.
-				OS::get_singleton()->process_and_drop_events();
+				DisplayServer::get_singleton()->force_process_and_drop_events();
 			}
 		}
 	}

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -328,8 +328,6 @@ public:
 	virtual void benchmark_end_measure(const String &p_context, const String &p_what);
 	virtual void benchmark_dump();
 
-	virtual void process_and_drop_events() {}
-
 	virtual Error setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path);
 
 	enum PreferredTextureFormat {


### PR DESCRIPTION
Fixes #73374
Redo of https://github.com/godotengine/godot/pull/94186

As of godot 4 On windows/osx the game window will be frozen and will not be updated.

In the debugger loop it calls

OS::get_singleton()->process_and_drop_events();
which allows windows/osx to handle system events. If the window doesn't handle these events then both systems will judge the window to be 'not responding' (osx beachball cursor)

When the event processing code was migrated from OS to DisplayServer the process_and_drop_events() logic was moved to DisplayServer, but the call inside the remote debugger pause loop was not updated to call the DisplayServer version, there are currently no implementations of OS::process_and_drop_events() so i removed it and switched to the new DisplayServer::force_process_and_drop_events() method.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
