### PR TITLE
Preserve visual layer of meshes in GridMap nodes

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -100,6 +100,13 @@
 				When running in the editor, returns a generated item preview (a 3D rendering in isometric perspective). When used in a running project, returns the manually-defined item preview which can be set using [method set_item_preview]. Returns an empty [Texture2D] if no preview was manually set in a running project.
 			</description>
 		</method>
+		<method name="get_item_render_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns item render layers bitmask.
+			</description>
+		</method>
 		<method name="get_item_shapes" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="id" type="int" />
@@ -184,6 +191,14 @@
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
 				Sets a texture to use as the item's preview icon in the editor.
+			</description>
+		</method>
+		<method name="set_item_render_layers">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="render_layers" type="int" />
+			<description>
+				Sets item render layers bitmask.
 			</description>
 		</method>
 		<method name="set_item_shapes">

--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -107,6 +107,13 @@
 				When running in the editor, returns a generated item preview (a 3D rendering in isometric perspective). When used in a running project, returns the manually-defined item preview which can be set using [method set_item_preview]. Returns an empty [Texture2D] if no preview was manually set in a running project.
 			</description>
 		</method>
+		<method name="get_item_render_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns item render layers bitmask.
+			</description>
+		</method>
 		<method name="get_item_shapes" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="id" type="int" />
@@ -201,6 +208,14 @@
 				Sets a texture to use as the item's preview icon in the editor.
 			</description>
 		</method>
+		<method name="set_item_render_layers">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="render_layers" type="int" />
+			<description>
+				Sets item render layers bitmask.
+			</description>
+		</method>
 		<method name="set_item_shapes">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
@@ -238,6 +253,8 @@
 		</member>
 		<member name="item/{index}/preview" type="Texture2D" setter="" getter="">
 			The texture to use as the item's preview icon in the editor.
+		</member>
+		<member name="item/{index}/render_layers" type="int" setter="" getter="" default="1">
 		</member>
 		<member name="item/{index}/shapes" type="Array" setter="" getter="" default="[]">
 			The item's collision shapes. The array should consist of [Shape3D] objects, each followed by a [Transform3D] that will be applied to it. For shapes that should not have a transform, use [constant Transform3D.IDENTITY].

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -90,6 +90,8 @@ bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Va
 	} else if (p_name == "shapes") {
 		mesh_library->call("set_item_shapes", mesh_id, p_value);
 #endif // PHYSICS_3D_DISABLED
+	} else if (p_name == "render_layers") {
+		mesh_library->set_item_render_layers(mesh_id, p_value);
 	} else if (p_name == "preview") {
 		mesh_library->set_item_preview(mesh_id, p_value);
 	} else if (p_name == "navigation_mesh") {
@@ -128,6 +130,8 @@ bool MeshLibraryEditor::MeshLibraryItem::_get(const StringName &p_name, Variant 
 		r_ret = mesh_library->get_item_navigation_mesh_transform(mesh_id);
 	} else if (p_name == "navigation_layers") {
 		r_ret = mesh_library->get_item_navigation_layers(mesh_id);
+	} else if (p_name == "render_layers") {
+		r_ret = mesh_library->get_item_render_layers(mesh_id);
 	} else if (p_name == "preview") {
 		r_ret = mesh_library->get_item_preview(mesh_id);
 	} else {
@@ -150,6 +154,7 @@ void MeshLibraryEditor::MeshLibraryItem::_get_property_list(List<PropertyInfo> *
 	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static()));
 	p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 	p_list->push_back(PropertyInfo(Variant::INT, PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION));
+	p_list->push_back(PropertyInfo(Variant::INT, PNAME("render_layers"), PROPERTY_HINT_LAYERS_3D_RENDER));
 	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_DEFAULT));
 }
 
@@ -394,6 +399,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			int nav_layers = mesh_library->get_item_navigation_layers(selected_item);
 			Ref<NavigationMesh> nav_mesh = mesh_library->get_item_navigation_mesh(selected_item);
 			Transform3D nav_mesh_transform = mesh_library->get_item_navigation_mesh_transform(selected_item);
+			uint32_t render_layers = mesh_library->get_item_render_layers(selected_item);
 			Ref<Texture2D> preview = mesh_library->get_item_preview(selected_item);
 			Array shapes = mesh_library->call("get_item_shapes", selected_item);
 
@@ -405,6 +411,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_layers", selected_item, nav_layers);
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_mesh", selected_item, nav_mesh);
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_mesh_transform", selected_item, nav_mesh_transform);
+			undo_redo->add_undo_method(*mesh_library, "set_item_render_layers", selected_item, render_layers);
 			undo_redo->add_undo_method(*mesh_library, "set_item_preview", selected_item, preview);
 			undo_redo->add_undo_method(*mesh_library, "set_item_shapes", selected_item, shapes);
 
@@ -535,6 +542,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		}
 	}
 	p_library->set_item_mesh(item_id, item_mesh);
+	p_library->set_item_render_layers(item_id, mesh_instance_node->get_layer_mask());
 
 	GeometryInstance3D::ShadowCastingSetting gi3d_cast_shadows_setting = mesh_instance_node->get_cast_shadows_setting();
 	switch (gi3d_cast_shadows_setting) {
@@ -560,6 +568,8 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		item_mesh_transform = mesh_instance_node->get_transform();
 	}
 	p_library->set_item_mesh_transform(item_id, item_mesh_transform);
+	uint32_t item_mesh_layer_mask = mesh_instance_node->get_layer_mask();
+	p_library->set_item_render_layers(item_id, item_mesh_layer_mask);
 
 	Vector<MeshLibrary::ShapeData> collisions;
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -93,6 +93,8 @@ bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Va
 	} else if (p_name == "shapes") {
 		mesh_library->_set_item_shapes(mesh_id, p_value);
 #endif // PHYSICS_3D_DISABLED
+	} else if (p_name == "render_layers") {
+		mesh_library->set_item_render_layers(mesh_id, p_value);
 	} else if (p_name == "preview") {
 		mesh_library->set_item_preview(mesh_id, p_value);
 	} else if (p_name == "navigation_mesh") {
@@ -133,6 +135,8 @@ bool MeshLibraryEditor::MeshLibraryItem::_get(const StringName &p_name, Variant 
 		r_ret = mesh_library->get_item_navigation_mesh_transform(mesh_id);
 	} else if (p_name == "navigation_layers") {
 		r_ret = mesh_library->get_item_navigation_layers(mesh_id);
+	} else if (p_name == "render_layers") {
+		r_ret = mesh_library->get_item_render_layers(mesh_id);
 	} else if (p_name == "preview") {
 		r_ret = mesh_library->get_item_preview(mesh_id);
 	} else {
@@ -156,6 +160,7 @@ void MeshLibraryEditor::MeshLibraryItem::_get_property_list(List<PropertyInfo> *
 	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static()));
 	p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 	p_list->push_back(PropertyInfo(Variant::INT, PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION));
+	p_list->push_back(PropertyInfo(Variant::INT, PNAME("render_layers"), PROPERTY_HINT_LAYERS_3D_RENDER));
 	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_DEFAULT));
 }
 
@@ -411,6 +416,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			int nav_layers = mesh_library->get_item_navigation_layers(selected_item);
 			Ref<NavigationMesh> nav_mesh = mesh_library->get_item_navigation_mesh(selected_item);
 			Transform3D nav_mesh_transform = mesh_library->get_item_navigation_mesh_transform(selected_item);
+			uint32_t render_layers = mesh_library->get_item_render_layers(selected_item);
 			Ref<Texture2D> preview = mesh_library->get_item_preview(selected_item);
 			Array shapes = mesh_library->call("get_item_shapes", selected_item);
 
@@ -422,6 +428,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_layers", selected_item, nav_layers);
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_mesh", selected_item, nav_mesh);
 			undo_redo->add_undo_method(*mesh_library, "set_item_navigation_mesh_transform", selected_item, nav_mesh_transform);
+			undo_redo->add_undo_method(*mesh_library, "set_item_render_layers", selected_item, render_layers);
 			undo_redo->add_undo_method(*mesh_library, "set_item_preview", selected_item, preview);
 			undo_redo->add_undo_method(*mesh_library, "set_item_shapes", selected_item, shapes);
 
@@ -552,6 +559,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		}
 	}
 	p_library->set_item_mesh(item_id, item_mesh);
+	p_library->set_item_render_layers(item_id, mesh_instance_node->get_layer_mask());
 
 	GeometryInstance3D::ShadowCastingSetting gi3d_cast_shadows_setting = mesh_instance_node->get_cast_shadows_setting();
 	switch (gi3d_cast_shadows_setting) {
@@ -577,6 +585,8 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		item_mesh_transform = mesh_instance_node->get_transform();
 	}
 	p_library->set_item_mesh_transform(item_id, item_mesh_transform);
+	uint32_t item_mesh_layer_mask = mesh_instance_node->get_layer_mask();
+	p_library->set_item_render_layers(item_id, item_mesh_layer_mask);
 
 	Vector<MeshLibrary::ShapeData> collisions;
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1449,6 +1449,7 @@ void GridMapEditor::_update_cursor_instance() {
 				cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
 				RSE::ShadowCastingSetting cast_shadows = (RSE::ShadowCastingSetting)node->get_mesh_library()->get_item_mesh_cast_shadow(selected_palette);
 				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, cast_shadows);
+				RS::get_singleton()->instance_set_layer_mask(cursor_instance, node->get_mesh_library()->get_item_render_layers(selected_palette));
 			}
 		}
 	} else if (mode_buttons_group->get_pressed_button() == select_mode_button) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1659,6 +1659,7 @@ void GridMapEditor::_update_cursor_instance() {
 					cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
 					RSE::ShadowCastingSetting cast_shadows = (RSE::ShadowCastingSetting)node->get_mesh_library()->get_item_mesh_cast_shadow(selected_palette);
 					RS::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, cast_shadows);
+					RS::get_singleton()->instance_set_layer_mask(cursor_instance, node->get_mesh_library()->get_item_render_layers(selected_palette));
 				}
 			}
 		} else if (mode_buttons_group->get_pressed_button() == select_mode_button) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -97,6 +97,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 		for (int i = 0; i < meshes.size(); i++) {
 			BakedMesh bm;
 			bm.mesh = meshes[i];
+			bm.item = -1;
 			ERR_CONTINUE(bm.mesh.is_null());
 			bm.instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
@@ -110,6 +111,18 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 
 		_recreate_octant_data();
 
+	} else if (name == "baked_meshes_library_items") {
+		Array bmli = p_value;
+
+		if (bmli.size() != baked_meshes.size() || !mesh_library.is_valid()) {
+			return false;
+		}
+
+		int i = 0;
+		for (auto &bm : baked_meshes) {
+			bm.item = bmli[i++];
+			RS::get_singleton()->instance_set_layer_mask(bm.instance, mesh_library->get_item_render_layers(bm.item));
+		}
 	} else {
 		return false;
 	}
@@ -146,6 +159,17 @@ bool GridMap::_get(const StringName &p_name, Variant &r_ret) const {
 		}
 		r_ret = ret;
 
+	} else if (name == "baked_meshes_library_items") {
+		Array ret;
+		ret.resize(baked_meshes.size());
+		for (int i = 0; i < baked_meshes.size(); i++) {
+			if (baked_meshes[i].item < 0) {
+				// Invalid meshlib index, so assume (and keep) old format
+				return false;
+			}
+			ret[i] = baked_meshes[i].item;
+		}
+		r_ret = ret;
 	} else {
 		return false;
 	}
@@ -156,6 +180,7 @@ bool GridMap::_get(const StringName &p_name, Variant &r_ret) const {
 void GridMap::_get_property_list(List<PropertyInfo> *p_list) const {
 	if (baked_meshes.size()) {
 		p_list->push_back(PropertyInfo(Variant::ARRAY, "baked_meshes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+		p_list->push_back(PropertyInfo(Variant::ARRAY, "baked_meshes_library_items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	}
 
 	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -553,17 +578,17 @@ int GridMap::get_orthogonal_index_from_basis(const Basis &p_basis) const {
 	return 0;
 }
 
-GridMap::OctantKey GridMap::get_octant_key_from_index_key(const IndexKey &p_index_key) const {
+GridMap::SurfaceMapKey GridMap::get_surface_map_key_from_index_key(const IndexKey &p_index_key, int mesh_lib_item) const {
 	const int x = p_index_key.x > 0 ? p_index_key.x / octant_size : (p_index_key.x - (octant_size - 1)) / octant_size;
 	const int y = p_index_key.y > 0 ? p_index_key.y / octant_size : (p_index_key.y - (octant_size - 1)) / octant_size;
 	const int z = p_index_key.z > 0 ? p_index_key.z / octant_size : (p_index_key.z - (octant_size - 1)) / octant_size;
 
-	OctantKey ok;
-	ok.key = 0;
-	ok.x = x;
-	ok.y = y;
-	ok.z = z;
-	return ok;
+	SurfaceMapKey smk;
+	smk.octant_x = x;
+	smk.octant_y = y;
+	smk.octant_z = z;
+	smk.render_layer = mesh_library->get_item_render_layers(mesh_lib_item);
+	return smk;
 }
 
 GridMap::OctantKey GridMap::get_octant_key_from_cell_coords(const Vector3i &p_cell_coords) const {
@@ -816,6 +841,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			RID instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(instance, mm);
+			RS::get_singleton()->instance_set_layer_mask(instance, mesh_library->get_item_render_layers(E.key));
 
 			if (is_inside_tree()) {
 				RS::get_singleton()->instance_set_scenario(instance, scenario);
@@ -1396,7 +1422,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 	}
 
 	//generate
-	HashMap<OctantKey, HashMap<Ref<Material>, Ref<SurfaceTool>>, OctantKey> surface_map;
+	HashMap<SurfaceMapKey, Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>, SurfaceMapKey> surface_map;
 
 	for (KeyValue<IndexKey, Cell> &E : cell_map) {
 		IndexKey key = E.key;
@@ -1420,13 +1446,13 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 
-		const OctantKey ok = get_octant_key_from_index_key(key);
+		const SurfaceMapKey smk = get_surface_map_key_from_index_key(key, item);
 
-		if (!surface_map.has(ok)) {
-			surface_map[ok] = HashMap<Ref<Material>, Ref<SurfaceTool>>();
+		if (!surface_map.has(smk)) {
+			surface_map[smk] = Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>(item, HashMap<Ref<Material>, Ref<SurfaceTool>>());
 		}
 
-		HashMap<Ref<Material>, Ref<SurfaceTool>> &mat_map = surface_map[ok];
+		HashMap<Ref<Material>, Ref<SurfaceTool>> &mat_map = surface_map[smk].second;
 
 		for (int i = 0; i < mesh->get_surface_count(); i++) {
 			if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
@@ -1446,18 +1472,20 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		}
 	}
 
-	for (KeyValue<OctantKey, HashMap<Ref<Material>, Ref<SurfaceTool>>> &E : surface_map) {
+	for (KeyValue<SurfaceMapKey, Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>> &E : surface_map) {
 		Ref<ArrayMesh> mesh;
 		mesh.instantiate();
-		for (KeyValue<Ref<Material>, Ref<SurfaceTool>> &F : E.value) {
+		for (KeyValue<Ref<Material>, Ref<SurfaceTool>> &F : E.value.second) {
 			F.value->commit(mesh);
 		}
 
 		BakedMesh bm;
 		bm.mesh = mesh;
 		bm.instance = RS::get_singleton()->instance_create();
+		bm.item = E.value.first;
 		RS::get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 		RS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
+		RS::get_singleton()->instance_set_layer_mask(bm.instance, mesh_library->get_item_render_layers(bm.item));
 		if (is_inside_tree()) {
 			RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 			RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -98,6 +98,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 		for (int i = 0; i < meshes.size(); i++) {
 			BakedMesh bm;
 			bm.mesh = meshes[i];
+			bm.item = -1;
 			ERR_CONTINUE(bm.mesh.is_null());
 			bm.instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
@@ -111,6 +112,18 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 
 		_recreate_octant_data();
 
+	} else if (name == "baked_meshes_library_items") {
+		Array bmli = p_value;
+
+		if (bmli.size() != baked_meshes.size() || !mesh_library.is_valid()) {
+			return false;
+		}
+
+		int i = 0;
+		for (auto &bm : baked_meshes) {
+			bm.item = bmli[i++];
+			RS::get_singleton()->instance_set_layer_mask(bm.instance, mesh_library->get_item_render_layers(bm.item));
+		}
 	} else {
 		return false;
 	}
@@ -147,6 +160,17 @@ bool GridMap::_get(const StringName &p_name, Variant &r_ret) const {
 		}
 		r_ret = ret;
 
+	} else if (name == "baked_meshes_library_items") {
+		Array ret;
+		ret.resize(baked_meshes.size());
+		for (int i = 0; i < baked_meshes.size(); i++) {
+			if (baked_meshes[i].item < 0) {
+				// Invalid meshlib index, so assume (and keep) old format
+				return false;
+			}
+			ret[i] = baked_meshes[i].item;
+		}
+		r_ret = ret;
 	} else {
 		return false;
 	}
@@ -157,6 +181,7 @@ bool GridMap::_get(const StringName &p_name, Variant &r_ret) const {
 void GridMap::_get_property_list(List<PropertyInfo> *p_list) const {
 	if (baked_meshes.size()) {
 		p_list->push_back(PropertyInfo(Variant::ARRAY, "baked_meshes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+		p_list->push_back(PropertyInfo(Variant::ARRAY, "baked_meshes_library_items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	}
 
 	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -701,17 +726,17 @@ int GridMap::get_orthogonal_index_from_basis(const Basis &p_basis) const {
 	return 0;
 }
 
-GridMap::OctantKey GridMap::get_octant_key_from_index_key(const IndexKey &p_index_key) const {
+GridMap::SurfaceMapKey GridMap::get_surface_map_key_from_index_key(const IndexKey &p_index_key, int mesh_lib_item) const {
 	const int x = p_index_key.x > 0 ? p_index_key.x / octant_size : (p_index_key.x - (octant_size - 1)) / octant_size;
 	const int y = p_index_key.y > 0 ? p_index_key.y / octant_size : (p_index_key.y - (octant_size - 1)) / octant_size;
 	const int z = p_index_key.z > 0 ? p_index_key.z / octant_size : (p_index_key.z - (octant_size - 1)) / octant_size;
 
-	OctantKey ok;
-	ok.key = 0;
-	ok.x = x;
-	ok.y = y;
-	ok.z = z;
-	return ok;
+	SurfaceMapKey smk;
+	smk.octant_x = x;
+	smk.octant_y = y;
+	smk.octant_z = z;
+	smk.render_layer = mesh_library->get_item_render_layers(mesh_lib_item);
+	return smk;
 }
 
 GridMap::OctantKey GridMap::get_octant_key_from_cell_coords(const Vector3i &p_cell_coords) const {
@@ -964,6 +989,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			RID instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(instance, mm);
+			RS::get_singleton()->instance_set_layer_mask(instance, mesh_library->get_item_render_layers(E.key));
 
 			if (is_inside_tree()) {
 				RS::get_singleton()->instance_set_scenario(instance, scenario);
@@ -1801,7 +1827,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 	}
 
 	//generate
-	HashMap<OctantKey, HashMap<Ref<Material>, Ref<SurfaceTool>>, OctantKey> surface_map;
+	HashMap<SurfaceMapKey, Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>, SurfaceMapKey> surface_map;
 
 	for (KeyValue<IndexKey, Cell> &E : cell_map) {
 		IndexKey key = E.key;
@@ -1825,13 +1851,13 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 
-		const OctantKey ok = get_octant_key_from_index_key(key);
+		const SurfaceMapKey smk = get_surface_map_key_from_index_key(key, item);
 
-		if (!surface_map.has(ok)) {
-			surface_map[ok] = HashMap<Ref<Material>, Ref<SurfaceTool>>();
+		if (!surface_map.has(smk)) {
+			surface_map[smk] = Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>(item, HashMap<Ref<Material>, Ref<SurfaceTool>>());
 		}
 
-		HashMap<Ref<Material>, Ref<SurfaceTool>> &mat_map = surface_map[ok];
+		HashMap<Ref<Material>, Ref<SurfaceTool>> &mat_map = surface_map[smk].second;
 
 		for (int i = 0; i < mesh->get_surface_count(); i++) {
 			if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
@@ -1851,18 +1877,20 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		}
 	}
 
-	for (KeyValue<OctantKey, HashMap<Ref<Material>, Ref<SurfaceTool>>> &E : surface_map) {
+	for (KeyValue<SurfaceMapKey, Pair<int, HashMap<Ref<Material>, Ref<SurfaceTool>>>> &E : surface_map) {
 		Ref<ArrayMesh> mesh;
 		mesh.instantiate();
-		for (KeyValue<Ref<Material>, Ref<SurfaceTool>> &F : E.value) {
+		for (KeyValue<Ref<Material>, Ref<SurfaceTool>> &F : E.value.second) {
 			F.value->commit(mesh);
 		}
 
 		BakedMesh bm;
 		bm.mesh = mesh;
 		bm.instance = RS::get_singleton()->instance_create();
+		bm.item = E.value.first;
 		RS::get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 		RS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
+		RS::get_singleton()->instance_set_layer_mask(bm.instance, mesh_library->get_item_render_layers(bm.item));
 		if (is_inside_tree()) {
 			RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 			RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -156,8 +156,33 @@ class GridMap : public Node3D {
 		OctantKey() {}
 	};
 
-	OctantKey get_octant_key_from_index_key(const IndexKey &p_index_key) const;
 	OctantKey get_octant_key_from_cell_coords(const Vector3i &p_cell_coords) const;
+
+	//Octant key merged with other mesh render parameters forcing baked meshes separation
+	union SurfaceMapKey {
+		struct {
+			int16_t octant_x;
+			int16_t octant_y;
+			int16_t octant_z;
+			int16_t octant_empty;
+			uint32_t render_layer;
+		};
+
+		uint8_t data[12];
+
+		static uint32_t hash(const SurfaceMapKey &p_key) {
+			return hash_djb2_buffer(p_key.data, 12);
+		}
+		_FORCE_INLINE_ bool operator==(const SurfaceMapKey &p_key) const {
+			return memcmp((void *)data, (void *)p_key.data, 12) == 0;
+		}
+
+		SurfaceMapKey() {
+			memset((void *)data, 0, 12);
+		}
+	};
+
+	SurfaceMapKey get_surface_map_key_from_index_key(const IndexKey &p_index_key, int mesh_lib_item) const;
 
 #ifndef PHYSICS_3D_DISABLED
 	uint32_t collision_layer = 1;
@@ -229,6 +254,7 @@ class GridMap : public Node3D {
 	struct BakedMesh {
 		Ref<Mesh> mesh;
 		RID instance;
+		int item;
 	};
 
 	Vector<BakedMesh> baked_meshes;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -95,6 +95,8 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // DISABLE_DEPRECATED
 		} else if (what == "navigation_layers") {
 			set_item_navigation_layers(idx, p_value);
+		} else if (what == "render_layers") {
+			set_item_render_layers(idx, p_value);
 		} else {
 			return false;
 		}
@@ -135,6 +137,8 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 	} else if (what == "navigation_layers") {
 		r_ret = get_item_navigation_layers(idx);
+	} else if (what == "render_layers") {
+		r_ret = get_item_render_layers(idx);
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -155,6 +159,7 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION, "", PROPERTY_USAGE_NO_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("render_layers"), PROPERTY_HINT_LAYERS_3D_RENDER, "", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
 	}
 }
@@ -218,6 +223,12 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 	emit_changed();
 }
 
+void MeshLibrary::set_item_render_layers(int p_item, uint32_t p_render_layers) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].render_layers = p_render_layers;
+	emit_changed();
+}
+
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].preview = p_preview;
@@ -264,6 +275,11 @@ Transform3D MeshLibrary::get_item_navigation_mesh_transform(int p_item) const {
 uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_layers;
+}
+
+uint32_t MeshLibrary::get_item_render_layers(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].render_layers;
 }
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
@@ -380,6 +396,7 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
+	ClassDB::bind_method(D_METHOD("set_item_render_layers", "id", "render_layers"), &MeshLibrary::set_item_render_layers);
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 #endif // PHYSICS_3D_DISABLED
@@ -391,6 +408,7 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_item_render_layers", "id"), &MeshLibrary::get_item_render_layers);
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 #endif // PHYSICS_3D_DISABLED

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -195,6 +195,13 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 }
 #endif // NAVIGATION_3D_DISABLED
 
+void MeshLibrary::set_item_render_layers(int p_item, uint32_t p_render_layers) {
+	if (_validate_index(p_item)) {
+		item_map[p_item].render_layers = p_render_layers;
+		emit_changed();
+	}
+}
+
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	if (_validate_index(p_item)) {
 		item_map[p_item].preview = p_preview;
@@ -250,6 +257,11 @@ uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 	return item_map[p_item].navigation_layers;
 }
 #endif // NAVIGATION_3D_DISABLED
+
+uint32_t MeshLibrary::get_item_render_layers(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].render_layers;
+}
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -371,6 +383,8 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
 #endif // NAVIGATION_3D_DISABLED
 
+	ClassDB::bind_method(D_METHOD("set_item_render_layers", "id", "render_layers"), &MeshLibrary::set_item_render_layers);
+
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 #endif // PHYSICS_3D_DISABLED
@@ -387,6 +401,8 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
 #endif // NAVIGATION_3D_DISABLED
+
+	ClassDB::bind_method(D_METHOD("get_item_render_layers", "id"), &MeshLibrary::get_item_render_layers);
 
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
@@ -414,6 +430,8 @@ void MeshLibrary::_bind_methods() {
 #ifndef PHYSICS_3D_DISABLED
 	base_property_helper.register_property(PropertyInfo(Variant::ARRAY, PNAME("shapes"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Array(), &MeshLibrary::_set_item_shapes, &MeshLibrary::_get_item_shapes);
 #endif // PHYSICS_3D_DISABLED
+
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("render_layers"), PROPERTY_HINT_LAYERS_3D_RENDER, "", PROPERTY_USAGE_NO_EDITOR), defaults.mesh_cast_shadow, &MeshLibrary::set_item_render_layers, &MeshLibrary::get_item_render_layers);
 
 #ifndef NAVIGATION_3D_DISABLED
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.navigation_mesh, &MeshLibrary::set_item_navigation_mesh, &MeshLibrary::get_item_navigation_mesh);

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -63,6 +63,7 @@ public:
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+		uint32_t render_layers = 1;
 	};
 
 	RBMap<int, Item> item_map;
@@ -89,6 +90,7 @@ public:
 	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
+	void set_item_render_layers(int p_item, uint32_t p_render_layers);
 #ifndef PHYSICS_3D_DISABLED
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
@@ -100,6 +102,7 @@ public:
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;
+	uint32_t get_item_render_layers(int p_item) const;
 #ifndef PHYSICS_3D_DISABLED
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -72,6 +72,7 @@ public:
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+		uint32_t render_layers = 1;
 	};
 
 // Version used by scripts.
@@ -105,6 +106,7 @@ public:
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
 #endif // NAVIGATION_3D_DISABLED
+	void set_item_render_layers(int p_item, uint32_t p_render_layers);
 
 #ifndef PHYSICS_3D_DISABLED
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
@@ -119,6 +121,7 @@ public:
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;
+	uint32_t get_item_render_layers(int p_item) const;
 #ifndef PHYSICS_3D_DISABLED
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED


### PR DESCRIPTION
### Description
This PR adds visual layer property to `MeshLibrary` items allowing to preserve `MeshInstance` nodes visual layer when used in `GridMap` nodes.

That is long missing feature for `GridMap` node requested even since Godot 3 (see #40245) and possibility for setting different render layers may be required to achieve some rendering effects.

This change should work also for `GridMap`s using baked meshes.

#### Note 1:
To use this new feature you need to recreate your `MeshLibrary` resource (export your tileset source scene as `MeshLibrary` again) or update your old `MeshLibrary` items visual layer by hand.

#### Note 2:
If you are already using baked meshes in your project to use new feature you need to invalidate old baked meshes (for example by modifying `GridMap` cells) and re-bake.

### Example
As an example usage now it is possible to use `Decal` cull property to draw some "selection area" only on floors and avoid texture being mapped also on walls (impossible before when using `GridMap` for floors & walls).

![GridmapRenderLayers](https://github.com/user-attachments/assets/cd2eb0d8-a0a0-44bd-b97f-14b50f869ff8)