### PR TITLE
[Windows] Add `libSynchronization` to link flags.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -582,7 +582,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
                 "libEGL.windows." + env["arch"] + prebuilt_lib_extra_suffix,
                 "libGLES.windows." + env["arch"] + prebuilt_lib_extra_suffix,
             ]
-            LIBS += ["dxgi", "d3d9", "d3d11"]
+            LIBS += ["dxgi", "d3d9", "d3d11", "synchronization"]
         env.Prepend(CPPPATH=["#thirdparty/angle/include"])
 
     if env["target"] in ["editor", "template_debug"]:
@@ -807,7 +807,7 @@ def configure_mingw(env: "SConsEnvironment"):
                     "ANGLE.windows." + env["arch"],
                 ]
             )
-            env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
+            env.Append(LIBS=["dxgi", "d3d9", "d3d11", "synchronization"])
         env.Prepend(CPPPATH=["#thirdparty/angle/include"])
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-angle-static/pull/7, library required by new versions of ANGLE.
