### PR TITLE
Automatically enable newly-installed plugins

### DIFF
--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -92,6 +92,7 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	bool _is_item_checked(const String &p_source_path) const;
 
 	void _install_asset();
+	static void _script_classes_updated(Vector<String> plugins);
 	virtual void ok_pressed() override;
 
 protected:


### PR DESCRIPTION
While installing an asset, check whether it installs any files matching the target pattern `res://addons/*/plugin.cfg`. If so, and providing that no errors are encountered while unpacking the asset, enable each plugin plugin once the new files have been scanned and scripts within added to the class database.

Inspired by https://github.com/godotengine/godot/pull/35234.

Fixes https://github.com/godotengine/godot-proposals/issues/324.

----

We at Endless are developing [a block coding plugin](https://github.com/endlessm/godot-block-coding) and other learning tools targeting young people who are new to Godot. We keep seeing people (including our colleagues, in one case twice in a single playtesting session) forget to enable the plugin after installing it, and then wondering why the plugin isn't working.

Unlike #35234 I have not included a way to add an asset without enabling any included plugins, on the basis that there is a clear intent to use the plugin – otherwise, why would one be installing it? I guess the counterargument is that someone may wish to review the code before executing it – but the asset library review process is presumably intended in part to catch malicious plugins, and in reality I think it's unlikely that people are reviewing every plugin they use in detail before enabling it. I feel strongly that the default should be to enable the plugin, even if there were a way to download without enabling.

I am very new to this codebase so I'm sure there are shortcomings in the implementation here! It seems to work in testing so far but this is perhaps more of a proof-of-concept/request-for-comment.