### PR TITLE
[3.x] Fix external images getting embedded on import

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3106,6 +3106,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 				Ref<Texture> texture = ResourceLoader::load(uri);
 				if (texture.is_valid()) {
 					p_state->images.push_back(texture->get_data());
+					p_state->external_images_paths.insert(i, uri);
 					continue;
 				} else if (mimetype == "image/png" || mimetype == "image/jpeg") {
 					// Fallback to loading as byte array.
@@ -3234,17 +3235,25 @@ Error GLTFDocument::_parse_textures(Ref<GLTFState> p_state) {
 		}
 		p_state->textures.push_back(t);
 
+		Ref<Texture> tex;
+
 		// Create and cache the texture used in the engine
-		Ref<ImageTexture> imgTex;
-		imgTex.instance();
-		imgTex->create_from_image(p_state->images[t->get_src_image()]);
+		if (p_state->external_images_paths.has(t->get_src_image())) {
+			tex = ResourceLoader::load(p_state->external_images_paths[t->get_src_image()]);
+		} else {
+			Ref<ImageTexture> img_tex;
+			img_tex.instance();
+			img_tex->create_from_image(p_state->images[t->get_src_image()]);
 
-		// Set texture filter and repeat based on sampler settings
-		const Ref<GLTFTextureSampler> sampler = _get_sampler_for_texture(p_state, i);
-		Texture::Flags flags = sampler->get_texture_flags();
-		imgTex->set_flags(flags);
+			// Set texture filter and repeat based on sampler settings. Only supported for embedded textures
+			const Ref<GLTFTextureSampler> sampler = _get_sampler_for_texture(p_state, i);
+			Texture::Flags flags = sampler->get_texture_flags();
+			img_tex->set_flags(flags);
 
-		p_state->texture_cache.insert(i, imgTex);
+			tex = img_tex;
+		}
+
+		p_state->texture_cache.insert(i, tex);
 	}
 
 	return OK;

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -78,6 +78,7 @@ class GLTFState : public Resource {
 	Vector<Ref<GLTFTextureSampler>> texture_samplers;
 	Ref<GLTFTextureSampler> default_texture_sampler;
 	Vector<Ref<Image>> images;
+	Map<GLTFImageIndex, String> external_images_paths;
 	Map<GLTFTextureIndex, Ref<Texture>> texture_cache;
 	Vector<String> extensions_used;
 	Vector<String> extensions_required;


### PR DESCRIPTION
Fixes #94475

It keeps track of the external images and loads them accordingly as textures, instead of replacing them with generic image textures.

I tried to also take into account the "sampler" flags from the GLTF.

One thing I'm worried though is that maybe the import flags of the external file should override the configuration of the GLTF?

Before merging this it'd be great to think about that. I'm actually thinking that I should probably commit a change to ignore sampler configuration for external images, since those can be configured in the import settings.