### PR TITLE
[3.x] Fix invalid string to numeric type cast yields 0.

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -170,6 +170,7 @@ public:
 	static String get_type_name(Variant::Type p_type);
 	static bool can_convert(Type p_type_from, Type p_type_to);
 	static bool can_convert_strict(Type p_type_from, Type p_type_to);
+	bool can_convert(Type p_type_to) const;
 
 	bool is_ref() const;
 	_FORCE_INLINE_ bool is_num() const { return type == INT || type == REAL; };

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -70,7 +70,7 @@ struct _VariantCall {
 				if (tptr[i] == Variant::NIL || tptr[i] == p_args[i]->type) {
 					continue; // all good
 				}
-				if (!Variant::can_convert(p_args[i]->type, tptr[i])) {
+				if (!p_args[i]->can_convert(tptr[i])) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
 					r_error.argument = i;
 					r_error.expected = tptr[i];
@@ -1335,7 +1335,7 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 
 	} else if (p_argcount == 1 && p_args[0]->type == p_type) {
 		return *p_args[0]; //copy construct
-	} else if (p_argcount == 1 && (!p_strict || Variant::can_convert(p_args[0]->type, p_type))) {
+	} else if (p_argcount == 1 && (!p_strict || p_args[0]->can_convert(p_type))) {
 		//near match construct
 
 		switch (p_type) {
@@ -1418,7 +1418,7 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 
 			//validate parameters
 			for (int i = 0; i < cd.arg_count; i++) {
-				if (!Variant::can_convert(p_args[i]->type, cd.arg_types[i])) {
+				if (!p_args[i]->can_convert(cd.arg_types[i])) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT; //no such constructor
 					r_error.argument = i;
 					r_error.expected = cd.arg_types[i];

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -225,7 +225,7 @@ public:
 
 						if (t != args[idx].get_type()) {
 							Variant::CallError err;
-							if (Variant::can_convert(args[idx].get_type(), t)) {
+							if (args[idx].can_convert(t)) {
 								Variant old = args[idx];
 								Variant *ptrs[1] = { &old };
 								args.write[idx] = Variant::construct(t, (const Variant **)ptrs, 1, err);
@@ -844,7 +844,7 @@ public:
 
 								if (t != args[idx].get_type()) {
 									Variant::CallError err;
-									if (Variant::can_convert(args[idx].get_type(), t)) {
+									if (args[idx].can_convert(t)) {
 										Variant old = args[idx];
 										Variant *ptrs[1] = { &old };
 										args.write[idx] = Variant::construct(t, (const Variant **)ptrs, 1, err);
@@ -2423,7 +2423,7 @@ bool AnimationTrackEdit::_is_value_key_valid(const Variant &p_key_value, Variant
 		r_valid_type = obj->get_static_property_type_indexed(leftover_path, &prop_exists);
 	}
 
-	return (!prop_exists || Variant::can_convert(p_key_value.get_type(), r_valid_type));
+	return (!prop_exists || p_key_value.can_convert(r_valid_type));
 }
 
 Ref<Texture> AnimationTrackEdit::_get_key_type_icon() const {
@@ -5681,7 +5681,7 @@ void AnimationTrackEditor::_cleanup_animation(Ref<Animation> p_animation) {
 		for (int j = 0; j < p_animation->track_get_key_count(i); j++) {
 			Variant v = p_animation->track_get_key_value(i, j);
 
-			if (!Variant::can_convert(v.get_type(), valid_type)) {
+			if (!v.can_convert(valid_type)) {
 				p_animation->track_remove_key(i, j);
 				j--;
 			}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5127,7 +5127,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						ConstantNode *cn = static_cast<ConstantNode *>(subexpr);
 						if (cn->value.get_type() != Variant::NIL) {
 							if (member._export.type != Variant::NIL && cn->value.get_type() != member._export.type) {
-								if (!Variant::can_convert(cn->value.get_type(), member._export.type)) {
+								if (!cn->value.can_convert(member._export.type)) {
 									_set_error("Can't convert the provided value to the export type.");
 									return;
 								} else if (!member.data_type.has_type) {

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -61,7 +61,7 @@ public:
 		bool call_error = !E || E->get().argtypes.size() != p_argcount;
 		if (!call_error) {
 			for (int i = 0; i < p_argcount; i++) {
-				if (!Variant::can_convert(p_args[i]->get_type(), E->get().argtypes[i])) {
+				if (!p_args[i]->can_convert(E->get().argtypes[i])) {
 					call_error = true;
 					break;
 				}


### PR DESCRIPTION
This PR fixes a bug where casting a string variant to an integer results in 0. This bug is most noticable when passing a string as a parameter to a function that accepts an integer as a parameter such as `Array.remove`.

_Bugsquad edit: fixes #93113_