### PR TITLE
Improve Curve preview colors for consistency

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -1077,10 +1077,8 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 	Image &im = **img_ref;
 	im.initialize_data(thumbnail_size.x, thumbnail_size.y, false, Image::FORMAT_RGBA8);
 
-	Color bg_color(0.1, 0.1, 0.1, 1.0);
-	Color line_color(0.8, 0.8, 0.8, 1.0);
+	Color line_color = EditorInterface::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor));
 
-	im.fill(bg_color);
 	// Set the first pixel of the thumbnail.
 	float v = (curve->sample_baked(0) - curve->get_min_value()) / curve->get_range();
 	int y = CLAMP(im.get_height() - v * im.get_height(), 0, im.get_height() - 1);


### PR DESCRIPTION
Similar treatment as #92504, avoid drawing a background and instead use theme colors.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/7964c4f6-1a3c-49c6-a452-d1b0992be01f) | ![image](https://github.com/user-attachments/assets/f84052d6-1a22-42aa-8064-5a8fc1deee68)
