### PR TITLE
[RFC] Use DXGI to present OpenGL frames on Windows

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -82,6 +82,10 @@
 #define strcpy strcpy_s
 #endif
 
+#ifdef WINDOWS_ENABLED
+bool RasterizerGLES3::screen_flipped_y = false;
+#endif
+
 bool RasterizerGLES3::gles_over_gl = true;
 
 void RasterizerGLES3::begin_frame(double frame_step) {
@@ -380,6 +384,12 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 		flip_y = false;
 	}
 
+#ifdef WINDOWS_ENABLED
+	if (screen_flipped_y) {
+		flip_y = !flip_y;
+	}
+#endif
+
 	GLuint read_fbo = 0;
 	glGenFramebuffers(1, &read_fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
@@ -476,9 +486,14 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 		screenrect.position += ((Size2(win_size.width, win_size.height) - screenrect.size) / 2.0).floor();
 	}
 
-	// Flip Y.
-	screenrect.position.y = win_size.y - screenrect.position.y;
-	screenrect.size.y = -screenrect.size.y;
+#ifdef WINDOWS_ENABLED
+	if (!screen_flipped_y)
+#endif
+	{
+		// Flip Y.
+		screenrect.position.y = win_size.y - screenrect.position.y;
+		screenrect.size.y = -screenrect.size.y;
+	}
 
 	// Normalize texture coordinates to window size.
 	screenrect.position /= win_size;

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -58,6 +58,10 @@ private:
 	double time_total = 0.0;
 	bool flip_xy_workaround = false;
 
+#ifdef WINDOWS_ENABLED
+	static bool screen_flipped_y;
+#endif
+
 	static bool gles_over_gl;
 
 protected:
@@ -116,6 +120,12 @@ public:
 		_create_func = _create_current;
 		low_end = true;
 	}
+
+#ifdef WINDOWS_ENABLED
+	static void set_screen_flipped_y(bool p_flipped) {
+		screen_flipped_y = p_flipped;
+	}
+#endif
 
 	_ALWAYS_INLINE_ uint64_t get_frame_number() const { return frame; }
 	_ALWAYS_INLINE_ double get_frame_delta_time() const { return delta; }

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3003,6 +3003,12 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 void DisplayServerWindows::process_events() {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 
+#if defined(GLES3_ENABLED)
+	if (gl_manager_native) {
+		gl_manager_native->wait_for_present(get_focused_window());
+	}
+#endif
+
 	if (!drop_events) {
 		joypad->process_joypads();
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5477,6 +5477,11 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 				windows.erase(id);
 				ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Failed to create an OpenGL window.");
 			}
+			if (id == MAIN_WINDOW_ID && gl_manager_native->is_using_dxgi_swap_chain()) {
+				// When presenting with DXGI the screen FBO is "upside down"
+				// w.r.t. OpenGL.
+				RasterizerGLES3::set_screen_flipped_y(true);
+			}
 			window_set_vsync_mode(p_vsync_mode, id);
 		}
 
@@ -6024,6 +6029,8 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	if (rendering_driver == "opengl3") {
 		gl_manager_native = memnew(GLManagerNative_Windows);
+
+		gl_manager_native->set_prefer_dxgi_swap_chain(true);
 
 		if (gl_manager_native->initialize() != OK) {
 			memdelete(gl_manager_native);

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -1039,13 +1039,6 @@ GLManagerNative_Windows::DxgiSwapChain *GLManagerNative_Windows::DxgiSwapChain::
 		}
 	}
 
-	ComPtr<IDXGIFactory2> dxgi_factory_2;
-	hr = dxgi_factory.As(&dxgi_factory_2);
-	if (!SUCCEEDED(hr)) {
-		ERR_PRINT(vformat("Failed to get IDXGIFactory2, HRESULT: 0x%08X", (unsigned)hr));
-		return nullptr;
-	}
-
 	DXGI_SWAP_CHAIN_DESC1 swap_chain_desc_1 = {};
 	swap_chain_desc_1.Width = p_width;
 	swap_chain_desc_1.Height = p_height;

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -464,7 +464,7 @@ private:
 #endif
 
 	bool setup_render_target();
-	void release_render_target(bool p_need_unlock);
+	void release_render_target();
 
 	void lock_for_opengl();
 	void unlock_from_opengl();
@@ -1199,7 +1199,8 @@ void GLManagerNative_Windows::DxgiSwapChain::destroy() {
 		GLES3::TextureStorage::system_fbo = 0;
 	}
 
-	release_render_target(true);
+	unlock_from_opengl();
+	release_render_target();
 #if defined(OPENGL_DXGI_USE_D3D11_DEPTH_BUFFER) || defined(OPENGL_DXGI_ADD_DEPTH_RENDERBUFFER)
 	release_depth_buffer();
 #endif
@@ -1388,11 +1389,7 @@ bool GLManagerNative_Windows::DxgiSwapChain::setup_render_target() {
 	return true;
 }
 
-void GLManagerNative_Windows::DxgiSwapChain::release_render_target(bool p_need_unlock) {
-	if (p_need_unlock) {
-		unlock_from_opengl();
-	}
-
+void GLManagerNative_Windows::DxgiSwapChain::release_render_target() {
 	// Release the back buffer.
 #ifdef OPENGL_DXGI_USE_RENDERBUFFER
 	BOOL res = gd_wglDXUnregisterObjectNV(gldx_device, gldx_color_buffer_rb);
@@ -1483,7 +1480,8 @@ void GLManagerNative_Windows::DxgiSwapChain::unlock_from_opengl() {
 }
 
 void GLManagerNative_Windows::DxgiSwapChain::present(bool p_use_vsync) {
-	release_render_target(true);
+	unlock_from_opengl();
+	release_render_target();
 
 #ifdef OPENGL_DXGI_USE_FLIP_MODEL
 	HRESULT hr;
@@ -1514,7 +1512,8 @@ void GLManagerNative_Windows::DxgiSwapChain::present(bool p_use_vsync) {
 }
 
 void GLManagerNative_Windows::DxgiSwapChain::resize_swap_chain(int p_width, int p_height) {
-	release_render_target(true);
+	unlock_from_opengl();
+	release_render_target();
 #if defined(OPENGL_DXGI_USE_D3D11_DEPTH_BUFFER) || defined(OPENGL_DXGI_ADD_DEPTH_RENDERBUFFER)
 	release_depth_buffer();
 #endif

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -1489,17 +1489,17 @@ void GLManagerNative_Windows::DxgiSwapChain::present(bool p_use_vsync) {
 	HRESULT hr;
 	if (p_use_vsync) {
 		hr = swap_chain->Present(1, 0);
-		DWORD wait = WaitForSingleObject(frame_latency_waitable_obj, 1000);
-		if (wait != WAIT_OBJECT_0) {
-			if (wait == WAIT_FAILED) {
-				DWORD error = GetLastError();
-				ERR_PRINT(vformat("Wait for frame latency waitable failed with error: 0x%08X", (unsigned)error));
-			} else {
-				ERR_PRINT(vformat("Wait for frame latency waitable failed, WaitForSingleObject returned 0x%08X", (unsigned)wait));
-			}
-		}
 	} else {
 		hr = swap_chain->Present(0, supports_tearing ? DXGI_PRESENT_ALLOW_TEARING : 0);
+	}
+	DWORD wait = WaitForSingleObject(frame_latency_waitable_obj, 1000);
+	if (wait != WAIT_OBJECT_0) {
+		if (wait == WAIT_FAILED) {
+			DWORD error = GetLastError();
+			ERR_PRINT(vformat("Wait for frame latency waitable failed with error: 0x%08X", (unsigned)error));
+		} else {
+			ERR_PRINT(vformat("Wait for frame latency waitable failed, WaitForSingleObject returned 0x%08X", (unsigned)wait));
+		}
 	}
 #else
 	// TODO: vsync???

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -1455,7 +1455,7 @@ void GLManagerNative_Windows::DxgiSwapChain::unlock_from_opengl() {
 }
 
 void GLManagerNative_Windows::DxgiSwapChain::present(bool p_use_vsync) {
-	unlock_from_opengl();
+	release_render_target(true);
 
 #ifdef OPENGL_DXGI_USE_FLIP_MODEL
 	HRESULT hr;
@@ -1481,7 +1481,6 @@ void GLManagerNative_Windows::DxgiSwapChain::present(bool p_use_vsync) {
 		ERR_PRINT(vformat("Present failed, HRESULT: 0x%08X", (unsigned)hr));
 	}
 
-	release_render_target(false);
 	setup_render_target();
 	lock_for_opengl();
 }

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -43,6 +43,9 @@
 typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);
 typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);
 
+class ID3D11Device;
+class ID3D11DeviceContext;
+
 class GLManagerNative_Windows {
 private:
 	class DxgiSwapChain;
@@ -71,6 +74,9 @@ private:
 	GLWindow *_current_window = nullptr;
 
 	PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = nullptr;
+
+	ID3D11Device *d3d11_device = nullptr;
+	ID3D11DeviceContext *d3d11_device_context = nullptr;
 
 	GLWindow &get_window(unsigned int id) { return _windows[id]; }
 	const GLWindow &get_window(unsigned int id) const { return _windows[id]; }

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -100,6 +100,7 @@ public:
 
 	void release_current();
 	void swap_buffers();
+	void wait_for_present(DisplayServer::WindowID p_window_id);
 
 	void window_make_current(DisplayServer::WindowID p_window_id);
 

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -45,6 +45,8 @@ typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);
 
 class GLManagerNative_Windows {
 private:
+	class DxgiSwapChain;
+
 	// any data specific to the window
 	struct GLWindow {
 		bool use_vsync = false;
@@ -54,6 +56,8 @@ private:
 		HWND hwnd;
 
 		int gldisplay_id = 0;
+
+		DxgiSwapChain *dxgi = nullptr;
 	};
 
 	struct GLDisplay {
@@ -75,6 +79,7 @@ private:
 	const GLDisplay &get_display(unsigned int id) { return _displays[id]; }
 
 	bool direct_render;
+	bool prefer_dxgi = false;
 	int glx_minor, glx_major;
 
 private:
@@ -85,7 +90,7 @@ private:
 public:
 	Error window_create(DisplayServer::WindowID p_window_id, HWND p_hwnd, HINSTANCE p_hinstance, int p_width, int p_height);
 	void window_destroy(DisplayServer::WindowID p_window_id);
-	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
+	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 
 	void release_current();
 	void swap_buffers();
@@ -99,6 +104,10 @@ public:
 
 	HDC get_hdc(DisplayServer::WindowID p_window_id);
 	HGLRC get_hglrc(DisplayServer::WindowID p_window_id);
+
+	void set_prefer_dxgi_swap_chain(bool p_prefer);
+	// Only valid after creating the first window.
+	bool is_using_dxgi_swap_chain();
 
 	GLManagerNative_Windows();
 	~GLManagerNative_Windows();

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -43,8 +43,8 @@
 typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);
 typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);
 
-class ID3D11Device;
-class ID3D11DeviceContext;
+struct ID3D11Device;
+struct ID3D11DeviceContext;
 
 class GLManagerNative_Windows {
 private:


### PR DESCRIPTION
https://github.com/godotengine/godot-proposals/issues/10242

This is an experiment using the `WGL_NV_DX_INTEROP2` extension to present frames rendered by the native OpenGL renderer. There are some compile-time options near the top of `gl_manager_windows_native.cpp` to change the behaviour of the code. The default tries to aim for the least latency, but this needs proper testing.

Notes:

- The way it works is: We first create a D3D11 device and a DXGI swap chain. Then for each frame we get the DXGI back buffer, pass it to OpenGL, then bind it to an FBO, and set `GLES3::TextureStorage::system_fbo` so that `RasterizerGLES3` blits the render targets onto it. On swap buffers, we present the frame with DXGI and, if vsync is enabled, wait for the frame latency waitable object.
- Because D3D11 has the screen origin on the top-left as opposed to bottom-left in OpenGL, I am using a hack to flip the screen Y in `RasterizerGLES3`. Thankfully render targets are already rendered on their own FBOs so this introduces no additional overhead compared to presenting with native OpenGL.
- This does not use `DirectComposition`. I've read that it may have some benefits, and is supposedly the only way we can get smooth resize with flip model swap chains, so perhaps it will be worth trying.

On Windows 10, when independent flip is engaged (according to PresentMon), I seem to be able to get ~~2 frames~~ 1 frame latency with v-sync on, less than 2 ms latency with v-sync off. (No variable refresh rate.)

Please test this if you are able to. To verify that it is using DXGI, pass `--verbose` and you should see "GLManagerNative_Windows: Presenting with D3D11 DXGI swap chain." on the output.

I like testing with this project: [spinning-cube_multiwindow.zip](https://github.com/user-attachments/files/16363090/spinning-cube_multiwindow.zip)

_bugsquad edit: fixes https://github.com/godotengine/godot/issues/98453_