### PR TITLE
Speed up `GDScriptLanguage::finish`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1537,10 +1537,14 @@ void GDScript::clear(ClearData *p_clear_data) {
 		}
 	}
 
-	RBSet<GDScript *> must_clear_dependencies = get_must_clear_dependencies();
-	for (GDScript *E : must_clear_dependencies) {
-		clear_data->scripts.insert(E);
-		E->clear(clear_data);
+	// If we're in the process of shutting things down then every single script will be cleared
+	// anyway, so we can safely skip this very costly operation.
+	if (!GDScriptLanguage::singleton->finishing) {
+		RBSet<GDScript *> must_clear_dependencies = get_must_clear_dependencies();
+		for (GDScript *E : must_clear_dependencies) {
+			clear_data->scripts.insert(E);
+			E->clear(clear_data);
+		}
 	}
 
 	for (const KeyValue<StringName, GDScriptFunction *> &E : member_functions) {
@@ -2246,6 +2250,11 @@ String GDScriptLanguage::get_extension() const {
 }
 
 void GDScriptLanguage::finish() {
+	if (finishing) {
+		return;
+	}
+	finishing = true;
+
 	_call_stack.free();
 
 	// Clear the cache before parsing the script_list
@@ -2281,6 +2290,8 @@ void GDScriptLanguage::finish() {
 	}
 	script_list.clear();
 	function_list.clear();
+
+	finishing = false;
 }
 
 void GDScriptLanguage::profiling_start() {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -411,6 +411,8 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	static GDScriptLanguage *singleton;
 
+	bool finishing = false;
+
 	Variant *_global_array = nullptr;
 	Vector<Variant> global_array;
 	HashMap<StringName, int> globals;


### PR DESCRIPTION
(The issue here is more or less a duplicate of #85435, but with the number of scripts cranked up, as well as more complex dependencies.)

Despite the optimizations introduced in #85603 to lessen the exponentially slower shutdown time in `GDScriptLanguage::finish`, this exponential slowdown still very much remains an issue when the number of scripts in your project goes into the hundreds, with complex (potentially circular) dependencies, which is not unreasonable to find in larger projects.

Here is an MRP to illustrate the problem, with an accompanying Python script to generate the scripts: [slow-gdscript-shutdown.zip](https://github.com/user-attachments/files/16282770/slow-gdscript-shutdown.zip)

On my machine this MRP spends 12 seconds in `GDScriptLanguage::finish` when quitting the editor.

This slowdown is seemingly caused by every script having `GDScript::clear` called on it in `GDScriptLanguage::finish`, which in turn causes it to go looking for every dependency that it itself must `clear`, thereby calling `GDScript::get_all_dependencies`, which itself ends up calling `GDScript::get_dependencies` for every single script in the project, which is fairly costly on top of the obvious exponential complexity of this whole thing.

As far as I can tell this work (in the context of `GDScriptLanguage::finish` specifically) is entirely redundant. The whole point of the `must_clear_dependencies` stuff in `GDScript::clear` is, as mentioned above, to call `clear` on any of its `must_clear_dependencies`, but seeing as how every `GDScript` instance currently alive will have `clear` called on it in `GDScriptLanguage::finish` anyway, this work seems to be entirely redundant (again, in the context of `GDScriptLanguage::finish` specifically).

This PR speeds things up by simply checking in `GDScript::clear` if we're currently in `GDScriptLanguage::finish` and skips the transitive/recursive `clear` for its dependencies if that's the case, which brings the time of `GDScriptLanguage::finish` in the MRP down from 12 seconds to 6 milliseconds on my machine.