### PR TITLE
Fix handling of missing bin file in gltf separate

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -789,8 +789,9 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 					ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
 					uri = uri.uri_decode();
 					uri = p_base_path.path_join(uri).replace("\\", "/"); // Fix for Windows.
+					ERR_FAIL_COND_V_MSG(!FileAccess::exists(uri), ERR_FILE_NOT_FOUND, "glTF: Binary file not found: " + uri);
 					buffer_data = FileAccess::get_file_as_bytes(uri);
-					ERR_FAIL_COND_V_MSG(buffer.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
+					ERR_FAIL_COND_V_MSG(buffer_data.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
 				}
 
 				ERR_FAIL_COND_V(!buffer.has("byteLength"), ERR_PARSE_ERROR);


### PR DESCRIPTION
Fix #85177

The missing `.bin` file case was not handled very well, because the error check after attempting to load it checked the wrong variable, so the function returned `OK` and errors popped up elsewhere.

Since it's very possible for the user to miss moving the `.bin` when moving gltf separate in the editor filesystem (because it isn't visible), adding another check to more explicitly complain that the file is missing.

Errors before:

```
  Can't open file from path 'res://untitled.bin'.
  modules/gltf/gltf_document.cpp:1323 - Condition "(int)(offset + buffer_end) > buffer.size()" is true. Returning: ERR_PARSE_ERROR
  modules/gltf/gltf_document.cpp:1323 - Condition "(int)(offset + buffer_end) > buffer.size()" is true. Returning: ERR_PARSE_ERROR
  modules/gltf/gltf_document.cpp:2868 - Condition "vertex_num <= 0" is true. Returning: ERR_INVALID_DECLARATION
  modules/gltf/gltf_document.cpp:7251 - Condition "err != OK" is true. Returning: ERR_PARSE_ERROR
  modules/gltf/gltf_document.cpp:6895 - Condition "err != OK" is true. Returning: err
  modules/gltf/gltf_document.cpp:7426 - Condition "err != OK" is true. Returning: err
  Error importing 'res://untitled.gltf'.
```

Errors after:

```
  glTF: Binary file not found: res://untitled.bin
  modules\gltf\gltf_document.cpp:7207 - Condition "err != OK" is true. Returning: ERR_PARSE_ERROR
  modules\gltf\gltf_document.cpp:6896 - Condition "err != OK" is true. Returning: err
  modules\gltf\gltf_document.cpp:7427 - Condition "err != OK" is true. Returning: err
  Error importing 'res://untitled.gltf'.
```