### PR TITLE
Fix new stream types `mix()` not returning 0 when inactive

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -858,10 +858,7 @@ int AudioStreamPlaybackInteractive::mix(AudioFrame *p_buffer, float p_rate_scale
 	}
 
 	if (!active) {
-		for (int i = 0; i < p_frames; i++) {
-			p_buffer[i] = AudioFrame(0.0, 0.0);
-		}
-		return p_frames;
+		return 0;
 	}
 
 	int todo = p_frames;

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -259,10 +259,7 @@ void AudioStreamPlaybackPlaylist::seek(double p_time) {
 
 int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 	if (!active) {
-		for (int i = 0; i < p_frames; i++) {
-			p_buffer[i] = AudioFrame(0.0, 0.0);
-		}
-		return p_frames;
+		return 0;
 	}
 
 	double time_dec = (1.0 / AudioServer::get_singleton()->get_mix_rate());

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -204,11 +204,8 @@ void AudioStreamPlaybackSynchronized::seek(double p_time) {
 }
 
 int AudioStreamPlaybackSynchronized::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
-	if (active != true) {
-		for (int i = 0; i < p_frames; i++) {
-			p_buffer[i] = AudioFrame(0.0, 0.0);
-		}
-		return p_frames;
+	if (!active) {
+		return 0;
 	}
 
 	int todo = p_frames;


### PR DESCRIPTION
Fixes #94229