### PR TITLE
Make "Remove Item" appear at the top of the list when editing the value of an array or dictionary

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -638,6 +638,8 @@ void EditorPropertyArray::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			change_type->clear();
+			change_type->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Remove Item"), Variant::VARIANT_MAX);
+			change_type->add_separator();
 			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 				if (i == Variant::CALLABLE || i == Variant::SIGNAL || i == Variant::RID) {
 					// These types can't be constructed or serialized properly, so skip them.
@@ -647,8 +649,6 @@ void EditorPropertyArray::_notification(int p_what) {
 				String type = Variant::get_type_name(Variant::Type(i));
 				change_type->add_icon_item(get_editor_theme_icon(type), type, i);
 			}
-			change_type->add_separator();
-			change_type->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Remove Item"), Variant::VARIANT_MAX);
 
 			if (button_add_item) {
 				button_add_item->set_icon(get_editor_theme_icon(SNAME("Add")));
@@ -1107,6 +1107,8 @@ void EditorPropertyDictionary::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			change_type->clear();
+			change_type->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Remove Item"), Variant::VARIANT_MAX);
+			change_type->add_separator();
 			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 				if (i == Variant::CALLABLE || i == Variant::SIGNAL || i == Variant::RID) {
 					// These types can't be constructed or serialized properly, so skip them.
@@ -1116,8 +1118,6 @@ void EditorPropertyDictionary::_notification(int p_what) {
 				String type = Variant::get_type_name(Variant::Type(i));
 				change_type->add_icon_item(get_editor_theme_icon(type), type, i);
 			}
-			change_type->add_separator();
-			change_type->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Remove Item"), Variant::VARIANT_MAX);
 
 			if (button_add_item) {
 				button_add_item->set_icon(get_editor_theme_icon(SNAME("Add")));


### PR DESCRIPTION
This moves the "Remove Item" option to the top of the list when editing an array/dict value, as opposed to the bottom:
![image](https://github.com/user-attachments/assets/a8064f99-66e5-4c51-956e-dd0d686d6924)
![image](https://github.com/user-attachments/assets/e1cc63ab-3b44-4b0c-8d0b-7c8226bf0ff3)

Just a small QOL thing that I think is nice

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
