### PR TITLE
[3.x] Support adding custom items to editor right-click context menus

### DIFF
--- a/editor/editor_context_menu_plugin.cpp
+++ b/editor/editor_context_menu_plugin.cpp
@@ -1,0 +1,189 @@
+/**************************************************************************/
+/*  editor_context_menu_plugin.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_context_menu_plugin.h"
+
+#include "scene/gui/popup_menu.h"
+
+bool EditorContextMenuPlugin::can_handle(Array &p_paths) {
+	if (get_script_instance()) {
+		Variant arg = p_paths;
+		Variant *argptr = &arg;
+		Variant::CallError ce;
+		return get_script_instance()->call("can_handle", (const Variant **)&argptr, 1, ce);
+	}
+	return false;
+}
+
+void EditorContextMenuPlugin::add_context_menu_item(const Ref<Texture> &p_texture, const String &p_name, Object *p_handler, const String &p_callback) {
+	Array parameters;
+	parameters.push_back(p_texture);
+	parameters.push_back(p_name);
+	parameters.push_back(p_handler->get_instance_id());
+	parameters.push_back(p_callback);
+	set_meta("parameters", parameters);
+}
+
+Ref<EditorContextMenuPlugin> EditorContextMenu::scene_tree_plugins[MAX_PLUGINS];
+Ref<EditorContextMenuPlugin> EditorContextMenu::filesystem_plugins[MAX_PLUGINS];
+Ref<EditorContextMenuPlugin> EditorContextMenu::script_editor_plugins[MAX_PLUGINS];
+
+void EditorContextMenu::add_context_menu_plugin(ContextMenuSlot slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
+	Ref<EditorContextMenuPlugin> *plugin_list = get_plugin_array(slot);
+	ERR_FAIL_COND(plugin_list[MAX_PLUGINS - 1].is_valid());
+	Ref<EditorContextMenuPlugin> plugin = p_plugin;
+
+	for (int i = 0; i < MAX_PLUGINS; ++i) {
+		if (plugin_list[i].is_null()) {
+			plugin_list[i] = p_plugin;
+			plugin->set_meta("idx", CONTEXT_ITEM_ID_BASE + i + 1);
+			break;
+		}
+	}
+}
+
+void EditorContextMenu::remove_context_menu_plugin(ContextMenuSlot slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
+	Ref<EditorContextMenuPlugin> *plugin_list = get_plugin_array(slot);
+	for (int i = 0; i < MAX_PLUGINS; ++i) {
+		if (plugin_list[i] == p_plugin) {
+			plugin_list[i].unref();
+			break;
+		}
+	}
+}
+
+void EditorContextMenu::_bind_methods() {
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_SCENE_TREE);
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_FILESYSTEM);
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_SCRIPT_EDITOR);
+}
+
+void EditorContextMenu::handle_plugins(ContextMenuSlot p_slot, Vector<String> &p_paths, PopupMenu *p_popup) {
+	Ref<EditorContextMenuPlugin> *plugin_list = get_plugin_array(p_slot);
+	bool add_separator = false;
+
+	Array paths;
+	for (int i = 0; i < p_paths.size(); i++) {
+		paths.push_back(p_paths.get(i));
+	}
+
+	for (int i = 0; i < MAX_PLUGINS; i++) {
+		Ref<EditorContextMenuPlugin> plugin = plugin_list[i];
+		if (plugin.is_null()) {
+			break;
+		}
+		if (!plugin->can_handle(paths)) {
+			continue;
+		}
+		if (!add_separator) {
+			add_separator = true;
+			p_popup->add_separator();
+		}
+		Array params = plugin->get_meta("parameters");
+		Variant icon = params[0];
+		int idx = plugin->get_meta("idx");
+		if (icon.get_type() != Variant::NIL) {
+			p_popup->add_icon_item(icon, params[1], idx);
+		} else {
+			p_popup->add_item(params[1], idx);
+		}
+	}
+}
+
+template <typename T>
+void EditorContextMenu::invoke_plugin_callback(ContextMenuSlot p_slot, int p_option, const T &p_arg) {
+	Ref<EditorContextMenuPlugin> *plugin_list = get_plugin_array(p_slot);
+	Variant arg = p_arg;
+	Variant *argptr = &arg;
+	Variant::CallError ce;
+
+	for (int i = 0; i < MAX_PLUGINS; i++) {
+		Ref<EditorContextMenuPlugin> plugin = plugin_list[i];
+		if (plugin.is_null()) {
+			break;
+		}
+		int idx = plugin->get_meta("idx");
+		if (p_option != idx) {
+			continue;
+		}
+		Array params = plugin->get_meta("parameters");
+		Object *handler = ObjectDB::get_instance(params[2]);
+		String callback = params[3];
+
+		handler->call(callback, (const Variant **)&argptr, 1, ce);
+		if (ce.error != Variant::CallError::CALL_OK) {
+			String err = Variant::get_call_error_text(handler, callback, (const Variant **)&argptr, 1, ce);
+			ERR_PRINT("Error calling function from context menu: " + err);
+		}
+	}
+}
+
+void EditorContextMenu::options_pressed(ContextMenuSlot p_slot, int p_option, const List<Node *> &p_selected) {
+	Array nodes;
+	for (int i = 0; i < p_selected.size(); i++) {
+		nodes.append(p_selected[i]);
+	}
+	invoke_plugin_callback(p_slot, p_option, nodes);
+}
+
+void EditorContextMenu::options_pressed(ContextMenuSlot p_slot, int p_option, const RES &p_script) {
+	invoke_plugin_callback(p_slot, p_option, p_script);
+}
+
+void EditorContextMenu::options_pressed(ContextMenuSlot p_slot, int p_option, const Vector<String> &p_selected) {
+	Array paths;
+	for (int i = 0; i < p_selected.size(); i++) {
+		paths.push_back(p_selected[i]);
+	}
+	invoke_plugin_callback(p_slot, p_option, paths);
+}
+
+Ref<EditorContextMenuPlugin> *EditorContextMenu::get_plugin_array(ContextMenuSlot p_slot) {
+	switch (p_slot) {
+		case CONTEXT_SLOT_SCENE_TREE:
+			return scene_tree_plugins;
+		case CONTEXT_SLOT_FILESYSTEM:
+			return filesystem_plugins;
+		case CONTEXT_SLOT_SCRIPT_EDITOR:
+			return script_editor_plugins;
+		default:
+			return nullptr;
+	}
+}
+
+void EditorContextMenuPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_context_menu_item", "icon", "name", "handler", "callback"), &EditorContextMenuPlugin::add_context_menu_item);
+
+	MethodInfo vm;
+	vm.name = "can_handle";
+	vm.return_val.type = Variant::BOOL;
+	vm.arguments.push_back(PropertyInfo(Variant::ARRAY, "paths"));
+	BIND_VMETHOD(vm);
+}

--- a/editor/editor_context_menu_plugin.h
+++ b/editor/editor_context_menu_plugin.h
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  editor_context_menu_plugin.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_CONTEXT_MENU_H
+#define EDITOR_CONTEXT_MENU_H
+
+#include "core/reference.h"
+#include "core/resource.h"
+
+class Node;
+class PopupMenu;
+class Texture;
+
+class EditorContextMenuPlugin : public Reference {
+	GDCLASS(EditorContextMenuPlugin, Reference);
+
+	friend class EditorContextMenu;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual bool can_handle(Array &p_paths);
+
+	void add_context_menu_item(const Ref<Texture> &p_texture, const String &p_name, Object *p_handler, const String &p_callback);
+};
+
+class EditorContextMenu : public Reference {
+	GDCLASS(EditorContextMenu, Reference);
+
+	friend class EditorContextMenuPlugin;
+
+	enum {
+		MAX_PLUGINS = 32
+	};
+
+	static Ref<EditorContextMenuPlugin> scene_tree_plugins[MAX_PLUGINS];
+	static Ref<EditorContextMenuPlugin> filesystem_plugins[MAX_PLUGINS];
+	static Ref<EditorContextMenuPlugin> script_editor_plugins[MAX_PLUGINS];
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum ContextMenuSlot {
+		CONTEXT_SLOT_SCENE_TREE,
+		CONTEXT_SLOT_FILESYSTEM,
+		CONTEXT_SLOT_SCRIPT_EDITOR,
+	};
+
+	enum {
+		CONTEXT_ITEM_ID_BASE = 200
+	};
+
+	static void add_context_menu_plugin(ContextMenuSlot slot, const Ref<EditorContextMenuPlugin> &p_plugin);
+
+	static void remove_context_menu_plugin(ContextMenuSlot slot, const Ref<EditorContextMenuPlugin> &p_plugin);
+
+	static void handle_plugins(ContextMenuSlot p_slot, Vector<String> &p_paths, PopupMenu *p_popup);
+
+	static void options_pressed(ContextMenuSlot p_slot, int p_option, const Vector<String> &p_selected);
+	//For scene dock
+	static void options_pressed(ContextMenuSlot p_slot, int p_option, const List<Node *> &p_selected);
+	//For script editor
+	static void options_pressed(ContextMenuSlot p_slot, int p_option, const RES &p_script);
+
+	static Ref<EditorContextMenuPlugin> *get_plugin_array(ContextMenuSlot p_slot);
+	template <typename T>
+	static void invoke_plugin_callback(ContextMenuSlot p_slot, int p_option, const T &p_arg);
+};
+
+VARIANT_ENUM_CAST(EditorContextMenu::ContextMenuSlot);
+
+#endif //EDITOR_CONTEXT_MENU_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3947,6 +3947,8 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorResourcePicker>();
 	ClassDB::register_class<EditorScriptPicker>();
 	ClassDB::register_virtual_class<FileSystemDock>();
+	ClassDB::register_class<EditorContextMenuPlugin>();
+	ClassDB::register_class<EditorContextMenu>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	ClassDB::register_class<EditorScenePostImport>();

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -759,6 +759,16 @@ int find(const PoolStringArray &a, const String &v) {
 	return -1;
 }
 
+void EditorPlugin::add_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
+	ERR_FAIL_COND(!p_plugin.is_valid());
+	EditorContextMenu::add_context_menu_plugin(EditorContextMenu::ContextMenuSlot(p_slot), p_plugin);
+}
+
+void EditorPlugin::remove_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
+	ERR_FAIL_COND(!p_plugin.is_valid());
+	EditorContextMenu::remove_context_menu_plugin(EditorContextMenu::ContextMenuSlot(p_slot), p_plugin);
+}
+
 void EditorPlugin::enable_plugin() {
 	// Called when the plugin gets enabled in project settings, after it's added to the tree.
 	// You can implement it to register autoloads.
@@ -852,6 +862,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
+	ClassDB::bind_method(D_METHOD("add_context_menu_plugin", "slot", "plugin"), &EditorPlugin::add_context_menu_plugin);
+	ClassDB::bind_method(D_METHOD("remove_context_menu_plugin", "slot", "plugin"), &EditorPlugin::remove_context_menu_plugin);
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
@@ -907,6 +919,10 @@ void EditorPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UR);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BR);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
+
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_SCENE_TREE);
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_FILESYSTEM);
+	BIND_ENUM_CONSTANT(CONTEXT_SLOT_SCRIPT_EDITOR);
 }
 
 EditorPlugin::EditorPlugin() :

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "core/io/config_file.h"
 #include "core/undo_redo.h"
+#include "editor/editor_context_menu_plugin.h"
 #include "editor/editor_inspector.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_scene.h"
@@ -167,6 +168,12 @@ public:
 		DOCK_SLOT_MAX
 	};
 
+	enum ContextMenuSlot {
+		CONTEXT_SLOT_SCENE_TREE,
+		CONTEXT_SLOT_FILESYSTEM,
+		CONTEXT_SLOT_SCRIPT_EDITOR
+	};
+
 	//TODO: send a resource for editing to the editor node?
 
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
@@ -249,6 +256,9 @@ public:
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);
 
+	void add_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin);
+	void remove_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin);
+
 	void enable_plugin();
 	void disable_plugin();
 
@@ -258,6 +268,7 @@ public:
 
 VARIANT_ENUM_CAST(EditorPlugin::CustomControlContainer);
 VARIANT_ENUM_CAST(EditorPlugin::DockSlot);
+VARIANT_ENUM_CAST(EditorPlugin::ContextMenuSlot);
 
 typedef EditorPlugin *(*EditorPluginCreateFunc)(EditorNode *);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1888,6 +1888,11 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_NEW_RESOURCE: {
 			new_resource_dialog->popup_create(true);
 		} break;
+
+		default:
+			// context menu plugins option selected.
+			EditorContextMenu::options_pressed(EditorContextMenu::CONTEXT_SLOT_FILESYSTEM, p_option, p_selected);
+			break;
 	}
 }
 
@@ -2419,6 +2424,8 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 		p_popup->add_icon_item(get_icon("Filesystem", "EditorIcons"), item_text, FILE_SHOW_IN_EXPLORER);
 		path = fpath;
 	}
+
+	EditorContextMenu::handle_plugins(EditorContextMenu::CONTEXT_SLOT_FILESYSTEM, p_paths, p_popup);
 }
 
 void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1112,7 +1112,15 @@ void ScriptEditor::_menu_option(int p_option) {
 			}
 		}
 	}
-
+	// Context menu options.
+	if (p_option >= EditorContextMenu::CONTEXT_ITEM_ID_BASE) {
+		RES resource;
+		if (current) {
+			resource = current->get_edited_resource();
+		}
+		EditorContextMenu::options_pressed(EditorContextMenu::CONTEXT_SLOT_SCRIPT_EDITOR, p_option, resource);
+		return;
+	}
 	if (current) {
 		switch (p_option) {
 			case FILE_SAVE: {
@@ -2746,6 +2754,17 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_UP), tab_container->get_current_tab() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_DOWN), tab_container->get_current_tab() >= tab_container->get_child_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_SORT), tab_container->get_child_count() <= 1);
+
+	// Context menu plugin.
+	Vector<String> selected_paths;
+	if (se) {
+		Ref<Script> scr = se->get_edited_resource();
+		if (scr.is_valid()) {
+			String path = scr->get_path();
+			selected_paths.push_back(path);
+		}
+	}
+	EditorContextMenu::handle_plugins(EditorContextMenu::CONTEXT_SLOT_SCRIPT_EDITOR, selected_paths, context_menu);
 
 	context_menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 	context_menu->set_size(Vector2(1, 1));

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1249,6 +1249,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 
 		default: {
+			// Context menu options.
+			if (p_tool >= EditorContextMenu::CONTEXT_ITEM_ID_BASE) {
+				List<Node *> selection = editor_selection->get_selected_node_list();
+				EditorContextMenu::options_pressed(EditorContextMenu::CONTEXT_SLOT_SCENE_TREE, p_tool, selection);
+				break;
+			}
+
 			_filter_option_selected(p_tool);
 
 			if (p_tool >= EDIT_SUBRESOURCE_BASE) {
@@ -2993,6 +3000,15 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	menu->set_size(Size2(1, 1));
 	menu->set_position(p_menu_pos);
 	menu->popup();
+
+	// Add context menu plugins.
+	Vector<String> paths;
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
+		String node_path = root->get_path().rel_path_to(E->get()->get_path());
+		paths.push_back(node_path);
+	}
+	EditorContextMenu::handle_plugins(EditorContextMenu::CONTEXT_SLOT_SCENE_TREE, paths, menu);
 }
 
 void SceneTreeDock::_update_filter_menu() {


### PR DESCRIPTION
### Add right-click menu plugin functionality to implement this [proposal](https://github.com/godotengine/godot-proposals/issues/2401)

> plugin.gd


```gdscript
tool
extends EditorPlugin
var FileSystemPlugin = preload("res://addons/csv-update-plugin/file_context_menu.gd")
func _enter_tree():
	filesystem_plugin = FileSystemPlugin.new()
	add_context_menu_plugin(EditorPlugin.CONTEXT_SLOT_FILESYSTEM, filesystem_plugin)

func _exit_tree():
	remove_context_menu_plugin(EditorPlugin.CONTEXT_SLOT_FILESYSTEM, filesystem_plugin)
```

> file_context_menu.gd

```gdscript
extends EditorContextMenuPlugin
var icon = preload("res://addons/csv-update-plugin/context-icon.svg")
func _init():
	add_context_menu_item(icon, "Update csv", self, "handle_csv_update")


func can_handle(paths:Array):
	var has_cvs = false
	for path in paths:
		if path.get_extension()=="csv":
			has_cvs = true
	return has_cvs


func handle_csv_update(files):
	## files arg is Array<String>
	print("update csv files:",files)

```

### In popMenu event handling, the parameter types for 3 different areas are different.

**CONTEXT_SLOT_SCENE_TREE** -> *Array\<Node\>*
**CONTEXT_SLOT_FILESYSTEM** -> *Array\<String\>*
**CONTEXT_SLOT_SCRIPT_EDITOR** -> *Resource\<GDScript\>*

Finally, I will explain the motivation behind this pull request. It mainly stems from my desire to create a plugin. 
The general functionality is as follows: we use GoogleDocs as a place for game configuration (collaboration among multiple remote users). 
In order to use this configuration in the game, I have developed a plugin that converts GoogleDocs to CSV (I also used another plugin of mine for configuration).
 Each update from GoogleDocs involves updating the entire file. When the number of configuration files and data increases, our workflow slows down. 
Therefore, I wondered if it would be possible to implement the operation of updating a single configuration file in the file browser area's right-click menu. 
After searching around, I came across this proposal which had the same requirement, so I decided to attempt to implement it. 
This is my first time contributing a pull request to the Godot Engine source code, and I'm not particularly skilled in C++. There may be areas in the code of this pull request that are not perfect. Thank you for pointing them out. 🤚~