### PR TITLE
Add note about `Script.has_source_code` and GDScript binary tokenization

### DIFF
--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -93,6 +93,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the script contains non-empty source code.
+				[b]Note:[/b] If a script does not have source code, this does not mean that it is invalid or unusable. For example, a [GDScript] that was exported with binary tokenization has no source code, but still behaves as expected and could be instantiated. This can be checked with [method can_instantiate].
 			</description>
 		</method>
 		<method name="instance_has" qualifiers="const">


### PR DESCRIPTION
Documents #94150
A real fix needs to happen on the addon side.
