### PR TITLE
Fix cursor disappearing behind minimap

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -600,7 +600,7 @@ void TextEdit::_notification(int p_what) {
 			RID ci = get_canvas_item();
 			int xmargin_beg = theme_cache.style_normal->get_margin(SIDE_LEFT) + gutters_width + gutter_padding;
 
-			int xmargin_end = size.width - theme_cache.style_normal->get_margin(SIDE_RIGHT);
+			int xmargin_end = size.width - theme_cache.style_normal->get_margin(SIDE_RIGHT) + RIGHT_SIDE_BUFFER;
 			if (draw_minimap) {
 				xmargin_end -= minimap_width;
 			}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -122,6 +122,7 @@ public:
 	};
 
 private:
+	static constexpr int RIGHT_SIDE_BUFFER = 5;
 	struct GutterInfo {
 		GutterType type = GutterType::GUTTER_TYPE_STRING;
 		String name = "";


### PR DESCRIPTION
Added a small space between the last selectable character of the code editor and the right side minimap, now the cursor is never hidden behind the minimap and is always separated from it, which in my opiinion looks better.

<i>Bugsquad edit:</i>
- Fix https://github.com/godotengine/godot/issues/94185