### PR TITLE
Fix `add_collision_triangles` will overwrite previously added mesh

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -57,7 +57,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 	bool selected;
 
 	Vector<Vector3> collision_segments;
-	Ref<TriangleMesh> collision_mesh;
+	Vector<Ref<TriangleMesh>> collision_meshs;
 
 	Vector<Vector3> handles;
 	Vector<int> handle_ids;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/94519

But I suppose this pr will break compatibility to some extent.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
