### PR TITLE
Export: Don't export global class list if none is used

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -873,7 +873,10 @@ String EditorExportPlatform::_get_script_encryption_key(const Ref<EditorExportPr
 Vector<String> EditorExportPlatform::get_forced_export_files() {
 	Vector<String> files;
 
-	files.push_back(ProjectSettings::get_singleton()->get_global_class_list_path());
+	const String global_class_list = ProjectSettings::get_singleton()->get_global_class_list_path();
+	if (FileAccess::exists(global_class_list)) {
+		files.push_back(global_class_list);
+	}
 
 	String icon = GLOBAL_GET("application/config/icon");
 	String splash = GLOBAL_GET("application/boot_splash/image");


### PR DESCRIPTION
Draft for now as I need to confirm when this happens exactly.

I noticed this error when exporting the MRP from #94537 to the web (one click deploy), which uses gdextension.

~I don't see the same in a MRP with nothing at all, so more investigation is needed.~

*Edit:* Actually I do, here's a MRP:
[testexportsimple.zip](https://github.com/user-attachments/files/16442205/testexportsimple.zip)