### PR TITLE
Clarify documentation for `AnimationPlayer.queue`

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -135,7 +135,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Queues an animation for playback once the current one is done.
+				Queues an animation for playback once the current animation and all previously queued animations are done.
 				[b]Note:[/b] If a looped animation is currently playing, the queued animation will never play unless the looped animation is stopped somehow.
 			</description>
 		</method>


### PR DESCRIPTION
Existing `queue` documentation indicates the new animation is queued after the current animation, which reads ambiguously as either replacing any previously queued animation or inserting the new animation at the head of the queue, neither of which is true. This PR updates the documentation to be explicit about the fact the animation is added to the end of the queue.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
