### PR TITLE
Silence warnings about DisplayServer icons on iOS and visionOS

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -230,4 +230,7 @@ public:
 
 	void resize_window(CGSize size);
 	virtual void swap_buffers() override {}
+
+	virtual void set_native_icon(const String &p_filename) override;
+	virtual void set_icon(const Ref<Image> &p_icon) override;
 };

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -817,3 +817,11 @@ DisplayServer::VSyncMode DisplayServerAppleEmbedded::window_get_vsync_mode(Windo
 #endif
 	return DisplayServer::VSYNC_ENABLED;
 }
+
+void DisplayServerAppleEmbedded::set_native_icon(const String &p_filename) {
+	// Not supported on Apple embedded platforms.
+}
+
+void DisplayServerAppleEmbedded::set_icon(const Ref<Image> &p_icon) {
+	// Not supported on Apple embedded platforms.
+}


### PR DESCRIPTION
Setting window icons is not supported on iOS, but there is no concept of window icons on iOS anyway.

- See https://github.com/godotengine/godot/issues/87567.
