### PR TITLE
Add note to `shadow_mesh` docs to warn about improper usage

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -206,7 +206,8 @@
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="shadow_mesh" type="ArrayMesh" setter="set_shadow_mesh" getter="get_shadow_mesh">
-			An optional mesh which is used for rendering shadows and can be used for the depth prepass. Can be used to increase performance of shadow rendering by using a mesh that only contains vertex position data (without normals, UVs, colors, etc.).
+			An optional mesh which can be used for rendering shadows and the depth prepass. Can be used to increase performance by supplying a mesh with fused vertices and only vertex position data (without normals, UVs, colors, etc.).
+			[b]Note:[/b] This mesh must have exactly the same vertex positions as the source mesh (including the source mesh's LODs, if present). If vertex positions differ, then the mesh will not draw correctly.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72071

Using a different mesh for shadow_mesh breaks rendering right now because the shadow mesh is used for the depth prepass. 

If we don't use it for the depth prepass, we will hurt performance. Further, the rendering will still appear broken as we will get all kinds of self-shadowing artifacts. Therefore, we just shouldn't support using a different shaped mesh for shadows. Users should use the old workflow which is to have a child MeshInstance3D with `SHADOW_CASTING_SETTING_SHADOWS_ONLY` and have the source mesh use `SHADOW_CASTING_SETTING_OFF`. Doing so has no additional cost over using `shadow_mesh`, but gives the user full control over how the shadow is drawn. 