### PR TITLE
Fix AddressSanitizer: heap-buffer-overflow from embree buffer check

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -349,9 +349,11 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	}
 
 	int vertices_size = occ->vertices.size();
-
+	occ_inst->xformed_vertices.resize(vertices_size);
 	// Embree requires the last element to be readable by a 16-byte SSE load instruction, so we add padding to be safe.
-	occ_inst->xformed_vertices.resize(vertices_size + 1);
+	const size_t byte_padding = sizeof(int) * 3;
+	const size_t vertices_padding = ceil((float)byte_padding / (float)sizeof(Vector3));
+	occ_inst->xformed_vertices.reserve(vertices_size + vertices_padding);
 
 	const Vector3 *read_ptr = occ->vertices.ptr();
 	Vector3 *write_ptr = occ_inst->xformed_vertices.ptr();


### PR DESCRIPTION
Fixes #94548

Embree code seems to do some ~~incorrect~~ confusing pointer math when checking the padding, This evaluates to extra 12 bytes dereferencing an additional 4 byte int.

When the address sanitizer is enabled it triggers an assertion
```
    /*! checks padding to 16 byte check, fails hard */
    __forceinline void checkPadding16() const
    {
      if (ptr_ofs && num)
volatile int MAYBE_UNUSED w = *((int*)getPtr(size()-1)+3); // FIXME: is failing hard avoidable?
    }
```
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
