### PR TITLE
OpenXR: Fix enabling passthrough via environment blend mode in project settings

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -707,13 +707,6 @@ bool OpenXRAPI::load_supported_environmental_blend_modes() {
 		print_verbose(String("OpenXR: Found environmental blend mode ") + OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_modes[i]));
 	}
 
-	// Check value we loaded at startup...
-	if (!is_environment_blend_mode_supported(environment_blend_mode)) {
-		print_verbose(String("OpenXR: ") + OpenXRUtil::get_environment_blend_mode_name(environment_blend_mode) + String(" isn't supported, defaulting to ") + OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_modes[0]));
-
-		environment_blend_mode = supported_environment_blend_modes[0];
-	}
-
 	return true;
 }
 
@@ -835,6 +828,13 @@ bool OpenXRAPI::create_session() {
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_session_created(session);
+	}
+
+	// Check our environment blend mode. This needs to happen after we call `on_session_created()`
+	// on the extension wrappers, so they can emulate alpha blend mode.
+	if (!set_environment_blend_mode(environment_blend_mode)) {
+		print_verbose(String("OpenXR: ") + OpenXRUtil::get_environment_blend_mode_name(environment_blend_mode) + String(" isn't supported, defaulting to ") + OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_modes[0]));
+		set_environment_blend_mode(supported_environment_blend_modes[0]);
 	}
 
 	return true;


### PR DESCRIPTION
PR https://github.com/godotengine/godot/pull/87630 made it possible to enable passthrough by setting the environment blend mode to "alpha blend", even on headsets that need to use a special passthrough extension - in that case it works by emulating alpha blend mode.

Currently, this is working great if you set the environment blend mode via code!

However, it you set it in project settings, you'll get this error:

```
OpenXR: XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND isn't supported, defaulting to XR_ENVIRONMENT_BLEND_MODE_OPAQUE
```

This is because we're checking the blend mode before OpenXR extension wrappers have had the opportunity to enable emulation of alpha blend mode.

This PR basically moves these checks to later, after `on_session_created()` is run on all the extension wrappers.