### PR TITLE
[3.x] Fix `PopupMenu` size calculations not taking into account control/canvas scale

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -327,9 +327,11 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	// Make an area which does not include v scrollbar, so that items are not activated when dragging scrollbar.
-	Rect2 item_clickable_area = control->get_global_rect();
+	Transform2D xform = get_global_transform_with_canvas();
+	Point2 item_origin = xform.get_origin();
 	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_size().width : 0;
-	item_clickable_area.set_size(Size2(item_clickable_area.size.width - scroll_width, item_clickable_area.size.height));
+	Size2 item_size = (control->get_global_rect().get_size() - Vector2(scroll_width, 0)) * xform.get_scale();
+	Rect2 item_clickable_area = Rect2(item_origin, item_size);
 
 	Ref<InputEventMouseButton> b = p_event;
 


### PR DESCRIPTION
Closes #94247

Calculation of the `item_clickable_area` now takes into account scale both from the node itself and from parent nodes, such as in a CanvasLayer.

https://github.com/user-attachments/assets/6869b25b-1251-4fdd-a985-970473337cd6

Updated MRP to test: [ViewportBugTest.zip](https://github.com/user-attachments/files/16319987/ViewportBugTest.zip)
