### PR TITLE
Fix FOG shader issue in Compatibility mode

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1920,11 +1920,7 @@ void main() {
 	fog.xy = unpackHalf2x16(fog_rg);
 	fog.zw = unpackHalf2x16(fog_ba);
 
-#ifndef DISABLE_FOG
-	if (scene_data.fog_enabled) {
-		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
-	}
-#endif // !DISABLE_FOG
+	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
 #endif // !FOG_DISABLED
 
 	// Tonemap before writing as we are writing to an sRGB framebuffer
@@ -2131,11 +2127,7 @@ void main() {
 	fog.xy = unpackHalf2x16(fog_rg);
 	fog.zw = unpackHalf2x16(fog_ba);
 
-#ifndef DISABLE_FOG
-	if (scene_data.fog_enabled) {
-		additive_light_color *= (1.0 - fog.a);
-	}
-#endif // !DISABLE_FOG
+	additive_light_color *= (1.0 - fog.a);
 #endif // !FOG_DISABLED
 
 	// Tonemap before writing as we are writing to an sRGB framebuffer


### PR DESCRIPTION
Removing `#ifndef DISABLE_FOG` from two places to fix shader issues in Compatibility mode. Additionally, removing `if (scene_data.fog_enabled)` from the same, as the shader will not function properly in compatibility mode otherwise. Manually setting `fog_enabled` to `true` breaks the shader in a different way, implying that `fog_enabled` should not need to be `true` for this shader to function in compatibility mode.

- Fixes #94183 