### PR TITLE
Tweak script editor zoom presets to be more useful

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -798,7 +798,7 @@ FindReplaceBar::FindReplaceBar() {
 
 /*** CODE EDITOR ****/
 
-static constexpr float ZOOM_FACTOR_PRESETS[7] = { 0.25f, 0.5f, 0.75f, 1.0f, 1.5f, 2.0f, 3.0f };
+static constexpr float ZOOM_FACTOR_PRESETS[8] = { 0.5f, 0.75f, 0.9f, 1.0f, 1.1f, 1.25f, 1.5f, 2.0f };
 
 // This function should be used to handle shortcuts that could otherwise
 // be handled too late if they weren't handled here.
@@ -1690,8 +1690,7 @@ void CodeTextEditor::_zoom_to(float p_zoom_factor) {
 }
 
 void CodeTextEditor::set_zoom_factor(float p_zoom_factor) {
-	int preset_count = sizeof(ZOOM_FACTOR_PRESETS) / sizeof(float);
-	zoom_factor = CLAMP(p_zoom_factor, ZOOM_FACTOR_PRESETS[0], ZOOM_FACTOR_PRESETS[preset_count - 1]);
+	zoom_factor = CLAMP(p_zoom_factor, 0.25f, 3.0f);
 	int neutral_font_size = int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE;
 	int new_font_size = Math::round(zoom_factor * neutral_font_size);
 
@@ -1815,7 +1814,8 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar->add_child(zoom_button);
 	zoom_button->set_flat(true);
 	zoom_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
-	zoom_button->set_tooltip_text(TTR("Zoom factor"));
+	zoom_button->set_tooltip_text(
+			TTR("Zoom factor") + "\n" + vformat(TTR("%sMouse wheel, %s/%s: Finetune\n%s: Reset"), keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL), ED_GET_SHORTCUT("script_editor/zoom_in")->get_as_text(), ED_GET_SHORTCUT("script_editor/zoom_out")->get_as_text(), ED_GET_SHORTCUT("script_editor/reset_zoom")->get_as_text()));
 	zoom_button->set_text("100 %");
 
 	PopupMenu *zoom_menu = zoom_button->get_popup();


### PR DESCRIPTION
The presets are now 50%, 75%, 90%, 100%, 110%, 125%, 150%.

This also mentions <kbd>Ctrl + mouse wheel</kbd> and zoom keyboard shortcuts in the tooltip. This method of zooming still allows the same zoom range as before (between 25% and 300%).

- This closes https://github.com/godotengine/godot-proposals/issues/9794.

## Preview

![image](https://github.com/user-attachments/assets/ac6ce0d0-eff0-41bf-8826-d9fec94894c1)

![image](https://github.com/user-attachments/assets/5ce2241d-781d-4f5e-a856-85f2984cdfa4)