### PR TITLE
Fix incorrect Curve editor preview thumbnail scaling

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -1071,11 +1071,10 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 		return Ref<Texture2D>();
 	}
 
-	Size2 thumbnail_size = p_size * EDSCALE;
 	Ref<Image> img_ref;
 	img_ref.instantiate();
 	Image &im = **img_ref;
-	im.initialize_data(thumbnail_size.x, thumbnail_size.y, false, Image::FORMAT_RGBA8);
+	im.initialize_data(p_size.x, p_size.y, false, Image::FORMAT_RGBA8);
 
 	Color line_color = EditorInterface::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor));
 


### PR DESCRIPTION
`EDSCALE` scaling was applied even though it shouldn't be, which led to pixelated thumbnails due to double scaling. For reference, AudioStream previews don't use `EDSCALE` and look fine at any editor scale (the editor itself already scales the thumbnail requests).

cc @Geometror - I noticed other preview generators such as the [Gradient one](https://github.com/godotengine/godot/pull/60395) also use `EDSCALE`. It should probably be removed there as well but I haven't done extensive testing yet.

## Preview

*Disregard the different background colors (I was using a slightly older commit than https://github.com/godotengine/godot/pull/94494 for the Before screenshots).*

### 75% editor scale

Before | After
-|-
![Screenshot_20240721_055807](https://github.com/user-attachments/assets/471de899-3602-49b6-b68d-200d83089e85) | ![Screenshot_20240721_055752](https://github.com/user-attachments/assets/c38ee0ef-58dc-4d7c-88d9-8e7c743ddcca)


### 175% editor scale

Before | After
-|-
![Screenshot_20240721_055830](https://github.com/user-attachments/assets/83e35c67-7c86-4287-8504-8cb9ec6788ad) | ![Screenshot_20240721_055725](https://github.com/user-attachments/assets/159518ce-d171-4493-adc1-8b2efcf216b2)
