### PR TITLE
Improve mesh/material thumbnail quality in the editor by using 4× MSAA

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -111,6 +111,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ALWAYS);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, size, size);
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RS::VIEWPORT_MSAA_4X);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -332,6 +332,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RS::VIEWPORT_MSAA_4X);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
@@ -756,6 +757,7 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RS::VIEWPORT_MSAA_4X);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);


### PR DESCRIPTION
4× MSAA is already used in the mesh/material inspector previews.

Note that the previews are rendered once and then cached, so this has no continuous performance impact when the editor is running.

## Preview

### Before

![Screenshot_20240721_070053](https://github.com/user-attachments/assets/fba10e92-d647-48a2-87c0-550a61f396f9)

<details>
<summary>400% zoom</summary>

![image](https://github.com/user-attachments/assets/8d8b8123-7251-416c-8533-ed99daec0095)
</details>

### After

![Screenshot_20240721_070042](https://github.com/user-attachments/assets/a47451fb-9c32-404b-a110-1b0db65d9879)

<details>
<summary>400% zoom</summary>

![image](https://github.com/user-attachments/assets/0cde8e66-356c-475e-b7c1-3c6b1509c008)
</details>
