### PR TITLE
Add a diagnostic to Godot.NET.Sdk to prevent tools from exporting members of non-tool types

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@ GD0003  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](ht
 GD0108  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0108.html)
 GD0109  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0109.html)
 GD0110  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0110.html)
+GD0111  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0111.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -137,6 +137,16 @@ namespace Godot.SourceGenerators
                 "The exported tool button is not a Callable. The '[ExportToolButton]' attribute is only supported on members of type Callable.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0110"));
 
+        public static readonly DiagnosticDescriptor ToolsCanOnlyExportToolsRule =
+            new DiagnosticDescriptor(id: "GD0111",
+                title: "Tools can only export tools or native types",
+                messageFormat: "Tools can only export tools or native types",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "Types with the '[Tool]' attribute should not export members of script types that do not have the '[Tool]' attribute.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0111"));
+
         public static readonly DiagnosticDescriptor SignalDelegateMissingSuffixRule =
             new DiagnosticDescriptor(id: "GD0201",
                 title: "The name of the delegate must end with 'EventHandler'",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -296,6 +296,17 @@ namespace Godot.SourceGenerators
         public static bool IsSystemFlagsAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SystemFlagsAttr;
 
+        public static bool SelfOrContainerHasToolAttribute(this ITypeSymbol symbol)
+        {
+            bool isTool = symbol.GetAttributes()
+                .Any(a => a.AttributeClass?.IsGodotToolAttribute() ?? false);
+            if (!isTool && symbol.ContainingType != null)
+            {
+                isTool = symbol.ContainingType.SelfOrContainerHasToolAttribute();
+            }
+            return isTool;
+        }
+
         public static GodotMethodData? HasGodotCompatibleSignature(
             this IMethodSymbol method,
             MarshalUtils.TypeCache typeCache


### PR DESCRIPTION
Fixes godotengine/godot-proposals#9377.

Documentation at [juanjp600/godot-docs@dotnet-tool-export-diagnostic](https://github.com/juanjp600/godot-docs/blob/dotnet-tool-export-diagnostic/tutorials/scripting/c_sharp/diagnostics/GD0111.rst).

MRP: [Tool export mismatch.zip](https://github.com/user-attachments/files/16325134/Tool.export.mismatch.zip)
The MRP also illustrates a mismatch with GDScript that might be worth addressing, see [this comment on a related issue](https://github.com/godotengine/godot/issues/36592#issuecomment-2241692103).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
