### PR TITLE
Fix editor crash when editor settings resource is invalid

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1063,13 +1063,13 @@ void EditorSettings::create() {
 		}
 
 		singleton = ResourceLoader::load(config_file_path, "EditorSettings");
-		singleton->set_path(get_newest_settings_path()); // Settings can be loaded from older version file, so make sure it's newest.
-
 		if (singleton.is_null()) {
 			ERR_PRINT("Could not load editor settings from path: " + config_file_path);
+			config_file_path = get_newest_settings_path();
 			goto fail;
 		}
 
+		singleton->set_path(get_newest_settings_path()); // Settings can be loaded from older version file, so make sure it's newest.
 		singleton->save_changed_setting = true;
 
 		print_verbose("EditorSettings: Load OK!");


### PR DESCRIPTION
- Fixes #93826

This fixes a regression from #90875 where an invalid editor-settings resource causes a editor crash on startup instead of using default settings.

That does not fix the source problem where the editor-settings.tres get corrupted when launching a project from the Project Manager. I think it should be another PR because this issue is probably more complicated to fix and I don't have the Android expertise to do it.