### PR TITLE
Increase threshold for displaying scene group update progress

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1888,7 +1888,7 @@ void EditorFileSystem::_update_scene_groups() {
 	}
 
 	EditorProgress *ep = nullptr;
-	if (update_scene_paths.size() > 1) {
+	if (update_scene_paths.size() > 20) {
 		ep = memnew(EditorProgress("update_scene_groups", TTR("Update Scene Groups"), update_scene_paths.size()));
 	}
 	int step_count = 0;


### PR DESCRIPTION
Fixes #94563
This makes the progress bar appear only when there is more than 20 updated scenes, which realistically can only happen when the cache is re-generated for the whole project.