### PR TITLE
Change  .gitignore to only exclude root android template folder

### DIFF
--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -367,7 +367,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		} else {
 			f->store_line("# Godot 4+ specific ignores");
 			f->store_line(".godot/");
-			f->store_line("android/");
+			f->store_line("/android/");
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);
 		if (f.is_null()) {


### PR DESCRIPTION
This PR fixes https://github.com/godotengine/godot/issues/94595 by changing the .gitignore generated by Godot to only ignore the top-level `/android/` folder, rather than all android folders recursively.