### PR TITLE
Support 64-bit image sizes for VRAM compression

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2560,7 +2560,7 @@ Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_qua
 	return save_webp_buffer_func(Ref<Image>((Image *)this), p_lossy, p_quality);
 }
 
-int Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps) {
+int64_t Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps) {
 	int mm;
 	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmaps ? -1 : 0);
 }

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -353,7 +353,7 @@ public:
 	static int get_format_block_size(Format p_format);
 	static void get_format_min_pixel_size(Format p_format, int &r_w, int &r_h);
 
-	static int get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false);
+	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false);
 	static int get_image_required_mipmaps(int p_width, int p_height, Format p_format);
 	static Size2i get_image_mipmap_size(int p_width, int p_height, Format p_format, int p_mipmap);
 	static int64_t get_image_mipmap_offset(int p_width, int p_height, Format p_format, int p_mipmap);

--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -97,7 +97,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 
 	// Initialize astcenc.
 
-	int dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
+	int64_t dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
 	Vector<uint8_t> dest_data;
 	dest_data.resize(dest_size);
 	uint8_t *dest_write = dest_data.ptrw();
@@ -125,12 +125,12 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	int mip_count = mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	for (int i = 0; i < mip_count + 1; i++) {
 		int src_mip_w, src_mip_h;
-		int src_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, r_img->get_format(), i, src_mip_w, src_mip_h);
+		int64_t src_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, r_img->get_format(), i, src_mip_w, src_mip_h);
 
 		const uint8_t *slices = &image_data.ptr()[src_ofs];
 
 		int dst_mip_w, dst_mip_h;
-		int dst_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, dst_mip_w, dst_mip_h);
+		int64_t dst_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, dst_mip_w, dst_mip_h);
 		// Ensure that mip offset is a multiple of 8 (etcpak expects uint64_t pointer).
 		if (unlikely(dst_ofs % 8 != 0)) {
 			astcenc_context_free(context);
@@ -231,7 +231,7 @@ void _decompress_astc(Image *r_img) {
 	const bool mipmaps = r_img->has_mipmaps();
 	int width = r_img->get_width();
 	int height = r_img->get_height();
-	int dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
+	int64_t dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
 	Vector<uint8_t> dest_data;
 	dest_data.resize(dest_size);
 	uint8_t *dest_write = dest_data.ptrw();
@@ -244,9 +244,9 @@ void _decompress_astc(Image *r_img) {
 	for (int i = 0; i < mip_count + 1; i++) {
 		int src_mip_w, src_mip_h;
 
-		int src_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, r_img->get_format(), i, src_mip_w, src_mip_h);
+		int64_t src_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, r_img->get_format(), i, src_mip_w, src_mip_h);
 		const uint8_t *src_data = &image_data.ptr()[src_ofs];
-		int src_size;
+		int64_t src_size;
 		if (i == mip_count) {
 			src_size = image_data.size() - src_ofs;
 		} else {
@@ -255,7 +255,7 @@ void _decompress_astc(Image *r_img) {
 		}
 
 		int dst_mip_w, dst_mip_h;
-		int dst_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, dst_mip_w, dst_mip_h);
+		int64_t dst_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, dst_mip_w, dst_mip_h);
 		// Ensure that mip offset is a multiple of 8 (etcpak expects uint64_t pointer).
 		ERR_FAIL_COND(dst_ofs % 8 != 0);
 		uint8_t *dest_mip_write = (uint8_t *)&dest_write[dst_ofs];

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -307,7 +307,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 		transcoder.get_image_level_info(src_ptr, src_size, basisu_level, 0, i);
 
 		uint32_t mip_block_or_pixel_count = Image::is_format_compressed(image_format) ? basisu_level.m_total_blocks : basisu_level.m_orig_width * basisu_level.m_orig_height;
-		int ofs = Image::get_image_mipmap_offset(basisu_info.m_width, basisu_info.m_height, image_format, i);
+		int64_t ofs = Image::get_image_mipmap_offset(basisu_info.m_width, basisu_info.m_height, image_format, i);
 
 		bool result = transcoder.transcode_image_level(src_ptr, src_size, 0, i, dst + ofs, mip_block_or_pixel_count, basisu_format);
 

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -190,14 +190,14 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 	const uint8_t *rb = p_image->get_data().ptr();
 
 	Vector<uint8_t> data;
-	int target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
 	int mm_count = p_image->has_mipmaps() ? Image::get_image_required_mipmaps(w, h, target_format) : 0;
 	data.resize(target_size);
 	int shift = Image::get_format_pixel_rshift(target_format);
 
 	uint8_t *wb = data.ptrw();
 
-	int dst_ofs = 0;
+	int64_t dst_ofs = 0;
 
 	CVTTCompressionJobQueue job_queue;
 	job_queue.job_params.is_hdr = is_hdr;
@@ -219,7 +219,7 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 		int bw = w % 4 != 0 ? w + (4 - w % 4) : w;
 		int bh = h % 4 != 0 ? h + (4 - h % 4) : h;
 
-		int src_ofs = p_image->get_mipmap_offset(i);
+		int64_t src_ofs = p_image->get_mipmap_offset(i);
 
 		const uint8_t *in_bytes = &rb[src_ofs];
 		uint8_t *out_bytes = &wb[dst_ofs];
@@ -279,7 +279,7 @@ void image_decompress_cvtt(Image *p_image) {
 	const uint8_t *rb = p_image->get_data().ptr();
 
 	Vector<uint8_t> data;
-	int target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
 	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 
@@ -287,10 +287,10 @@ void image_decompress_cvtt(Image *p_image) {
 
 	int bytes_per_pixel = is_hdr ? 6 : 4;
 
-	int dst_ofs = 0;
+	int64_t dst_ofs = 0;
 
 	for (int i = 0; i <= mm_count; i++) {
-		int src_ofs = p_image->get_mipmap_offset(i);
+		int64_t src_ofs = p_image->get_mipmap_offset(i);
 
 		const uint8_t *in_bytes = &rb[src_ofs];
 		uint8_t *out_bytes = &wb[dst_ofs];

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -181,7 +181,7 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img) {
 
 	print_verbose(vformat("etcpak: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), mipmaps ? ", with mipmaps" : ""));
 
-	int dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
+	int64_t dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
 	Vector<uint8_t> dest_data;
 	dest_data.resize(dest_size);
 	uint8_t *dest_write = dest_data.ptrw();
@@ -192,7 +192,7 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img) {
 	for (int i = 0; i < mip_count + 1; i++) {
 		// Get write mip metrics for target image.
 		int orig_mip_w, orig_mip_h;
-		int mip_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, orig_mip_w, orig_mip_h);
+		int64_t mip_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, orig_mip_w, orig_mip_h);
 		// Ensure that mip offset is a multiple of 8 (etcpak expects uint64_t pointer).
 		ERR_FAIL_COND(mip_ofs % 8 != 0);
 		uint64_t *dest_mip_write = (uint64_t *)&dest_write[mip_ofs];
@@ -203,7 +203,7 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img) {
 		const uint32_t blocks = mip_w * mip_h / 16;
 
 		// Get mip data from source image for reading.
-		int src_mip_ofs = r_img->get_mipmap_offset(i);
+		int64_t src_mip_ofs = r_img->get_mipmap_offset(i);
 		const uint32_t *src_mip_read = (const uint32_t *)&src_read[src_mip_ofs];
 
 		// Pad textures to nearest block by smearing.

--- a/modules/squish/image_decompress_squish.cpp
+++ b/modules/squish/image_decompress_squish.cpp
@@ -40,7 +40,7 @@ void image_decompress_squish(Image *p_image) {
 	Image::Format target_format = Image::FORMAT_RGBA8;
 
 	Vector<uint8_t> data;
-	int target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
 	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 


### PR DESCRIPTION
Follow-up to #94243

Allows VRAM compression/decompression of images whose sizes exceed the int32 limit.