### PR TITLE
GDScript: Fix moving scripts leaves some invalid state

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1062,6 +1062,15 @@ void GDScript::set_path(const String &p_path, bool p_take_over) {
 	String old_path = path;
 	path = p_path;
 	path_valid = true;
+
+	if (is_root_script()) {
+		if (local_name == StringName()) {
+			fully_qualified_name = canonicalize_path(p_path);
+		}
+	} else {
+		fully_qualified_name = _owner->fully_qualified_name + "::" + local_name;
+	}
+
 	GDScriptCache::move_script(old_path, p_path);
 
 	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -145,7 +145,7 @@ GDScriptParserRef::~GDScriptParserRef() {
 GDScriptCache *GDScriptCache::singleton = nullptr;
 
 void GDScriptCache::move_script(const String &p_from, const String &p_to) {
-	if (singleton == nullptr || p_from == p_to) {
+	if (singleton == nullptr || p_from == p_to || p_from.is_empty()) {
 		return;
 	}
 
@@ -155,14 +155,23 @@ void GDScriptCache::move_script(const String &p_from, const String &p_to) {
 		return;
 	}
 
+	if (singleton->dependencies.has(p_from)) {
+		singleton->dependencies[p_to] = singleton->dependencies[p_from];
+	}
+	singleton->dependencies.erase(p_from);
+
+	for (KeyValue<String, HashSet<String>> &E : singleton->dependencies) {
+		E.value.erase(p_from);
+	}
+
 	remove_parser(p_from);
 
-	if (singleton->shallow_gdscript_cache.has(p_from) && !p_from.is_empty()) {
+	if (singleton->shallow_gdscript_cache.has(p_from)) {
 		singleton->shallow_gdscript_cache[p_to] = singleton->shallow_gdscript_cache[p_from];
 	}
 	singleton->shallow_gdscript_cache.erase(p_from);
 
-	if (singleton->full_gdscript_cache.has(p_from) && !p_from.is_empty()) {
+	if (singleton->full_gdscript_cache.has(p_from)) {
 		singleton->full_gdscript_cache[p_to] = singleton->full_gdscript_cache[p_from];
 	}
 	singleton->full_gdscript_cache.erase(p_from);


### PR DESCRIPTION
Fix #94590

The state that wasn't fixed properly was in the script's `fully_qualified_name`, and the cache's `dependencies`.