### PR TITLE
Expose `EditorInspector.edit` to scripting

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -14,6 +14,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="edit">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<description>
+				Shows the properties of the given [param object] in this inspector for editing. To clear the inspector, call this method with [code]null[/code].
+				[b]Note:[/b] If you want to edit an object in the editor's main inspector, use the [code]edit_*[/code] methods in [EditorInterface] instead.
+			</description>
+		</method>
 		<method name="get_edited_object">
 			<return type="Object" />
 			<description>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4648,6 +4648,7 @@ void EditorInspector::_handle_menu_option(int p_option) {
 }
 
 void EditorInspector::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("edit", "object"), &EditorInspector::edit);
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
 	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);


### PR DESCRIPTION
Context: I tried to add export settings to [a custom format](https://github.com/aaronfranke/godot-gltfx-reference-format) defined in a GDScript plugin, like https://github.com/godotengine/godot/pull/79316, but I found that the `edit` function of EditorInspector was not exposed, so it was not possible. This PR exposes it. I have tested that this works correctly.