### PR TITLE
Fix Object encoded as id in dictionaries to be represented as int in the inspector.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -124,6 +124,16 @@ bool EditorPropertyDictionaryObject::_set(const StringName &p_name, const Varian
 }
 
 bool EditorPropertyDictionaryObject::_get(const StringName &p_name, Variant &r_ret) const {
+	if (!get_by_property_name(p_name, r_ret)) {
+		return false;
+	}
+	if (r_ret.get_type() == Variant::OBJECT && Object::cast_to<EncodedObjectAsID>(r_ret)) {
+		r_ret = Object::cast_to<EncodedObjectAsID>(r_ret)->get_object_id();
+	}
+	return true;
+}
+
+bool EditorPropertyDictionaryObject::get_by_property_name(const String &p_name, Variant &r_ret) const {
 	String name = p_name;
 
 	if (name == "new_item_key") {
@@ -140,10 +150,6 @@ bool EditorPropertyDictionaryObject::_get(const StringName &p_name, Variant &r_r
 		int index = name.get_slicec('/', 1).to_int();
 		Variant key = dict.get_key_at_index(index);
 		r_ret = dict[key];
-		if (r_ret.get_type() == Variant::OBJECT && Object::cast_to<EncodedObjectAsID>(r_ret)) {
-			r_ret = Object::cast_to<EncodedObjectAsID>(r_ret)->get_object_id();
-		}
-
 		return true;
 	}
 
@@ -1050,7 +1056,8 @@ void EditorPropertyDictionary::update_property() {
 			if (!slot_visible) {
 				continue;
 			}
-			Variant value = object->get(slot.prop_name);
+			Variant value;
+			object->get_by_property_name(slot.prop_name, value);
 			Variant::Type value_type = value.get_type();
 
 			// Check if the editor property needs to be updated.

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -77,6 +77,7 @@ public:
 		NEW_VALUE_INDEX,
 	};
 
+	bool get_by_property_name(const String &p_name, Variant &r_ret) const;
 	void set_dict(const Dictionary &p_dict);
 	Dictionary get_dict();
 


### PR DESCRIPTION
Fix #92533

So I add some time to check this morning and here is the full explanation of what is happening. First getting the value is something hard on a Dictionary since you have values but also two new values and in addition we wish to add keys wich would even more complicate the thing. So Instead of having two places that would do the logic I put in one place. This is the difference with Array. 
Now for why this make it fails. This linked to the code @KoBeWi pointed to. This piece of code seems to be needed as `EditorPropertyObjectID` seems to need an `int` and not an `Object`. Keeping it will make dictionnary handle it as an int and removing it will cause inconsistency as Kobewi showed but also more hard errors such as this one when clicking to edit the button.
<img width="725" alt="Capture d’écran 2024-07-22 à 09 30 00" src="https://github.com/user-attachments/assets/d0e2f7c4-c5ef-4e91-bba0-c4bbeedf1779">
Hence we need to separate the two while keeping it as coupled as possible (for easier maintenance and easier addition of key editing) this is why I created a new function keeping it without the bit of code that causes problem and `_get` just calls the new function and then do the code that is needed only there.

An alternative solution would be to outright remove the problematic code and just make `EditorPropertyObjectID` handle `Object` directly instead of `int`. This seems like a cleaner solution and what I would have preferred to be done but this has more potential to have unexpected consequences which wouldn't be possible for 4.3.