### PR TITLE
Fix warning printing for `VisualShaderNodeTextureParameter`

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -6498,6 +6498,8 @@ bool VisualShaderNodeTextureParameter::is_show_prop_names() const {
 }
 
 String VisualShaderNodeTextureParameter::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
+	String warning = VisualShaderNodeParameter::get_warning(p_mode, p_type);
+
 	if (texture_source != SOURCE_NONE) {
 		String texture_source_str;
 
@@ -6528,7 +6530,10 @@ String VisualShaderNodeTextureParameter::get_warning(Shader::Mode p_mode, Visual
 				default:
 					break;
 			}
-			return vformat(RTR("'%s' type is incompatible with '%s' source."), texture_type_str, texture_source_str);
+			if (!warning.is_empty()) {
+				warning += "\n";
+			}
+			warning += vformat(RTR("'%s' type is incompatible with '%s' source."), texture_type_str, texture_source_str);
 		} else if (color_default != COLOR_DEFAULT_WHITE) {
 			String color_default_str;
 
@@ -6542,11 +6547,14 @@ String VisualShaderNodeTextureParameter::get_warning(Shader::Mode p_mode, Visual
 				default:
 					break;
 			}
-			return vformat(RTR("'%s' default color is incompatible with '%s' source."), color_default_str, texture_source_str);
+			if (!warning.is_empty()) {
+				warning += "\n";
+			}
+			warning += vformat(RTR("'%s' default color is incompatible with '%s' source."), color_default_str, texture_source_str);
 		}
 	}
 
-	return "";
+	return warning;
 }
 
 HashMap<StringName, String> VisualShaderNodeTextureParameter::get_editable_properties_names() const {


### PR DESCRIPTION
This will fix the warning printing for that node.

![vs_warning](https://github.com/user-attachments/assets/847ff359-c820-432d-9e80-902e84d058c7)

- Closes https://github.com/godotengine/godot/issues/94508
