### PR TITLE
Fix odd-sized pixel snapping

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -267,7 +267,12 @@ void AnimatedSprite2D::_notification(int p_what) {
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = (ofs + Point2(0.5, 0.5)).floor();
+				if (Math::fmod(s.x, 2.0f) == 0) {
+					ofs.x = Math::floor(ofs.x + 0.5);
+				}
+				if (Math::fmod(s.y, 2.0f) == 0) {
+					ofs.y = Math::floor(ofs.y + 0.5);
+				}
 			}
 
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -98,7 +98,12 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = (dest_offset + Point2(0.5, 0.5)).floor();
+		if (Math::fmod(frame_size.x, 2.0f) == 0.0f) {
+			dest_offset.x = Math::floor(dest_offset.x + 0.5);
+		}
+		if (Math::fmod(frame_size.y, 2.0f) == 0.0f) {
+			dest_offset.y = Math::floor(dest_offset.y + 0.5);
+		}
 	}
 
 	r_dst_rect = Rect2(dest_offset, frame_size);
@@ -400,7 +405,12 @@ Rect2 Sprite2D::get_rect() const {
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = (ofs + Point2(0.5, 0.5)).floor();
+		if (Math::fmod(s.x, 2.0f) == 0.0f) {
+			ofs.x = Math::floor(ofs.x + 0.5);
+		}
+		if (Math::fmod(s.y, 2.0f) == 0.0f) {
+			ofs.y = Math::floor(ofs.y + 0.5);
+		}
 	}
 
 	if (s == Size2(0, 0)) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1249,7 +1249,12 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 					}
 
 					if (is_inside_tree() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-						fx_offset = (fx_offset + Point2(0.5, 0.5)).floor();
+						if (Math::fmod(width, 2.0f) == 0.0f) {
+							fx_offset.x = Math::floor(fx_offset.x + 0.5);
+						}
+						if (Math::fmod(l_height, 2.0) == 0.0f) {
+							fx_offset.y = Math::floor(fx_offset.y + 0.5);
+						}
 					}
 
 					Vector2 char_off = char_xform.get_origin();

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -284,8 +284,14 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	}
 
 	if (snapping_2d_transforms_to_pixel) {
-		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor();
-		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor();
+		if (Math::fmod(p_canvas_item->get_rect().get_size().x, 2.0f) == 0.0f) {
+			final_xform.columns[2].x = Math::floor(final_xform.columns[2].x + 0.5);
+			parent_xform.columns[2].x = Math::floor(parent_xform.columns[2].x + 0.5);
+		}
+		if (Math::fmod(p_canvas_item->get_rect().get_size().y, 2.0f) == 0.0f) {
+			final_xform.columns[2].y = Math::floor(final_xform.columns[2].y + 0.5);
+			parent_xform.columns[2].y = Math::floor(parent_xform.columns[2].y + 0.5);
+		}
 	}
 
 	final_xform = parent_xform * final_xform;


### PR DESCRIPTION
> [!WARNING]
> This PR needs to be thoroughly tested before merging it.

This PR makes it so that it doesn't add 0.5 pixels to odd sized items before snapping them.

Fixes #94298. 

### Tests
- [x] @KeyboardDanni's [PixelPerfectTest.zip](https://github.com/user-attachments/files/16335627/PixelPerfectTest.zip)
- [x] #94298's MRP
- [ ] Test some RichTextLabels FX
