### PR TITLE
Change default centering of sprite offset to act like in 4.2

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -100,7 +100,7 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 
 	Point2 ofs = offset;
 	if (centered) {
-		ofs -= s / 2;
+		ofs += (-s / 2).floor();
 	}
 
 	if (s == Size2(0, 0)) {
@@ -263,7 +263,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			Size2 s = texture->get_size();
 			Point2 ofs = offset;
 			if (centered) {
-				ofs -= s / 2;
+				ofs += (-s / 2).floor();
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -94,7 +94,7 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 
 	Point2 dest_offset = offset;
 	if (centered) {
-		dest_offset -= frame_size / 2;
+		dest_offset += (-frame_size / 2).floor();
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
@@ -396,7 +396,7 @@ Rect2 Sprite2D::get_rect() const {
 
 	Point2 ofs = offset;
 	if (centered) {
-		ofs -= Size2(s) / 2;
+		ofs += (-Size2(s) / 2).floor();
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {


### PR DESCRIPTION
Make it so that centering odd-sized sprites does not subtract 0.5 from the user-specified offset, but instead explicitly rounded down (effectively rounding up the sprite "anchor" with respect to the sprite's top-left corner).

---

- Fixes #94298

This is perhaps a less controversial change than #94305. This only changes how the `centered` property work. The offset property is rounded the same way as the transform position (unchanged).

This does affect how the offset property gets rounded when the sprite has odd dimensions compared to before, but it's now more consistent.