### PR TITLE
Fix position from vertex shader partially uninitialized

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -352,7 +352,7 @@ void vertex_shader(vec3 vertex_input,
 	}
 
 #ifdef OVERRIDE_POSITION
-	vec4 position;
+	vec4 position = vec4(1.0);
 #endif
 
 #ifdef USE_MULTIVIEW

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -352,7 +352,7 @@ void main() {
 	}
 
 #ifdef OVERRIDE_POSITION
-	vec4 position;
+	vec4 position = vec4(1.0);
 #endif
 
 #ifdef USE_MULTIVIEW


### PR DESCRIPTION
A vertex shader in Godot can write to a subset of the fileds of `POSITION`, which would lead to the `vec4 position` being partially unitialized. The DirectX Shader Compiler will reject that. This PR initializes the variable to the most sensible value so the user can re-override whatever members they want. Shader optimization is expected to remove the redundant assignments.

A different fix may be put in place: that the Godot shader compiler rejects the shader unless it writes to the whole vector. This PR shouldn't be an obstacle to doing that later anyway.