### PR TITLE
Bind `PhysicsServer*D::body_set_state_sync_callback`

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -694,6 +694,17 @@
 				[b]Note:[/b] The state change doesn't take effect immediately. The state will change on the next physics frame.
 			</description>
 		</method>
+		<method name="body_set_state_sync_callback">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Sets the body's state synchronization callback function to [param callable]. Use an empty [Callable] ([code skip-lint]Callable()[/code]) to clear the callback.
+				The function [param callable] will be called every physics frame, assuming that the body was active during the previous physics tick, and can be used to fetch the latest state from the physics server.
+				The function [param callable] must take the following parameters:
+				1. [code]state[/code]: a [PhysicsDirectBodyState2D], used to retrieve the body's state.
+			</description>
+		</method>
 		<method name="body_test_motion">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -713,7 +713,7 @@
 			<param index="1" name="callable" type="Callable" />
 			<description>
 				Assigns the [param body] to call the given [param callable] during the synchronization phase of the loop, before [method _step] is called. See also [method _sync].
-				Overridable version of [PhysicsServer2D]'s internal [code]body_set_state_sync_callback[/code] method.
+				Overridable version of [method PhysicsServer2D.body_set_state_sync_callback].
 			</description>
 		</method>
 		<method name="_body_test_motion" qualifiers="virtual const">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -678,6 +678,17 @@
 				Sets a body state (see [enum BodyState] constants).
 			</description>
 		</method>
+		<method name="body_set_state_sync_callback">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Sets the body's state synchronization callback function to [param callable]. Use an empty [Callable] ([code skip-lint]Callable()[/code]) to clear the callback.
+				The function [param callable] will be called every physics frame, assuming that the body was active during the previous physics tick, and can be used to fetch the latest state from the physics server.
+				The function [param callable] must take the following parameters:
+				1. [code]state[/code]: a [PhysicsDirectBodyState3D], used to retrieve the body's state.
+			</description>
+		</method>
 		<method name="body_test_motion">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -754,6 +754,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "enable"), &PhysicsServer2D::body_set_omit_force_integration);
 	ClassDB::bind_method(D_METHOD("body_is_omitting_force_integration", "body"), &PhysicsServer2D::body_is_omitting_force_integration);
 
+	ClassDB::bind_method(D_METHOD("body_set_state_sync_callback", "body", "callable"), &PhysicsServer2D::body_set_state_sync_callback);
+
 	ClassDB::bind_method(D_METHOD("body_set_force_integration_callback", "body", "callable", "userdata"), &PhysicsServer2D::body_set_force_integration_callback, DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("body_test_motion", "body", "parameters", "result"), &PhysicsServer2D::_body_test_motion, DEFVAL(Variant()));

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -829,6 +829,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "enable"), &PhysicsServer3D::body_set_omit_force_integration);
 	ClassDB::bind_method(D_METHOD("body_is_omitting_force_integration", "body"), &PhysicsServer3D::body_is_omitting_force_integration);
 
+	ClassDB::bind_method(D_METHOD("body_set_state_sync_callback", "body", "callable"), &PhysicsServer3D::body_set_state_sync_callback);
+
 	ClassDB::bind_method(D_METHOD("body_set_force_integration_callback", "body", "callable", "userdata"), &PhysicsServer3D::body_set_force_integration_callback, DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("body_set_ray_pickable", "body", "enable"), &PhysicsServer3D::body_set_ray_pickable);


### PR DESCRIPTION
Currently if you want to implement your own `RigidBody*D`-like physics nodes from the script side of things, whether that's GDScript, C#, C++, Rust or any other scripting language, you're forced to hack the state synchronization (i.e. pulling the latest state from the physics server) by using the callback passed to `body_set_force_integration_callback`, which can sort of serve the same purpose as the callback passed to `body_set_state_sync_callback`.

This is a hack though, and `body_set_state_sync_callback` should rightfully be exposed/bound, so this PR does exactly that.