### PR TITLE
Disable FP contraction.

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -190,6 +190,8 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-mfix-cortex-a53-835769"])
         env.Append(CPPDEFINES=["__ARM_ARCH_8A__"])
 
+    env.Append(CCFLAGS=["-ffp-contract=off"])
+
     # Link flags
 
     env.Append(LINKFLAGS="-Wl,--gc-sections -Wl,--no-undefined -Wl,-z,now".split())

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -179,6 +179,8 @@ def configure(env: "SConsEnvironment"):
             env.Append(CCFLAGS=["-fsanitize-recover=memory"])
             env.Append(LINKFLAGS=["-fsanitize=memory"])
 
+    env.Append(CCFLAGS=["-ffp-contract=off"])
+
     # LTO
 
     if env["lto"] == "auto":  # Full LTO for production.

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -96,6 +96,8 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
+    env.Append(CCFLAGS=["-ffp-contract=off"])
+
     cc_version = get_compiler_version(env)
     cc_version_major = cc_version["apple_major"]
     cc_version_minor = cc_version["apple_minor"]

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -467,6 +467,8 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
     if env["arch"] == "x86_32":
         env["x86_libtheora_opt_vc"] = True
 
+    env.Append(CCFLAGS=["/fp:strict"])
+
     env.AppendUnique(CCFLAGS=["/Gd", "/GR", "/nologo"])
     env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
     env.AppendUnique(CXXFLAGS=["/TP"])  # assume all sources are C++
@@ -674,6 +676,8 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["arch"] in ["x86_32", "x86_64"]:
         env["x86_libtheora_opt_gcc"] = True
+
+    env.Append(CCFLAGS=["-ffp-contract=off"])
 
     mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
 

--- a/thirdparty/libwebp/patches/godot-msvc-arm64-fpstrict-fix.patch
+++ b/thirdparty/libwebp/patches/godot-msvc-arm64-fpstrict-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c b/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c
+index 09028428ac..3184e2b80f 100644
+--- a/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c
++++ b/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c
+@@ -26,7 +26,13 @@ static uint32_t kGammaToLinearTabS[GAMMA_TO_LINEAR_TAB_SIZE + 2];
+ #define LINEAR_TO_GAMMA_TAB_SIZE (1 << LINEAR_TO_GAMMA_TAB_BITS)
+ static uint32_t kLinearToGammaTabS[LINEAR_TO_GAMMA_TAB_SIZE + 2];
+ 
++// -- GODOT start --
++#if defined(_MSC_VER)
++static const double kGammaF = 2.222222222222222;
++#else
+ static const double kGammaF = 1. / 0.45;
++#endif
++// -- GODOT end --
+ #define GAMMA_TO_LINEAR_BITS 16
+ 
+ static volatile int kGammaTablesSOk = 0;

--- a/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c
+++ b/thirdparty/libwebp/sharpyuv/sharpyuv_gamma.c
@@ -26,7 +26,13 @@ static uint32_t kGammaToLinearTabS[GAMMA_TO_LINEAR_TAB_SIZE + 2];
 #define LINEAR_TO_GAMMA_TAB_SIZE (1 << LINEAR_TO_GAMMA_TAB_BITS)
 static uint32_t kLinearToGammaTabS[LINEAR_TO_GAMMA_TAB_SIZE + 2];
 
+// -- GODOT start --
+#if defined(_MSC_VER)
+static const double kGammaF = 2.222222222222222;
+#else
 static const double kGammaF = 1. / 0.45;
+#endif
+// -- GODOT end --
 #define GAMMA_TO_LINEAR_BITS 16
 
 static volatile int kGammaTablesSOk = 0;


### PR DESCRIPTION
A more aggressive version of https://github.com/godotengine/godot/pull/94650, disables contractions on all architectures.

Fixes https://github.com/godotengine/godot/issues/91631.