### PR TITLE
RenderingDevice: Fix getting cubemap layer data

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1585,9 +1585,6 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 			"Texture requires the `RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT` to be set to be retrieved.");
 
 	uint32_t layer_count = tex->layers;
-	if (tex->type == TEXTURE_TYPE_CUBE || tex->type == TEXTURE_TYPE_CUBE_ARRAY) {
-		layer_count *= 6;
-	}
 	ERR_FAIL_COND_V(p_layer >= layer_count, Vector<uint8_t>());
 
 	if ((tex->usage_flags & TEXTURE_USAGE_CPU_READ_BIT)) {


### PR DESCRIPTION
I've noticed this while working on #94600.

The code for retrieving cubemap layer data would multiply the layer count by 6, even though each cube face was already considered a separate layer. Due to this, the DEV_ASSERT below would get triggered due to mismatched data sizes.