### PR TITLE
Fix snapping for odd sized canvas items (mk. 2)

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -266,10 +266,6 @@ void AnimatedSprite2D::_notification(int p_what) {
 				ofs -= s / 2;
 			}
 
-			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = (ofs + Point2(0.5, 0.5)).floor();
-			}
-
 			Rect2 dst_rect(ofs, s);
 
 			if (hflip) {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -97,10 +97,6 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 		dest_offset -= frame_size / 2;
 	}
 
-	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = (dest_offset + Point2(0.5, 0.5)).floor();
-	}
-
 	r_dst_rect = Rect2(dest_offset, frame_size);
 
 	if (hflip) {
@@ -397,10 +393,6 @@ Rect2 Sprite2D::get_rect() const {
 	Point2 ofs = offset;
 	if (centered) {
 		ofs -= Size2(s) / 2;
-	}
-
-	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = (ofs + Point2(0.5, 0.5)).floor();
 	}
 
 	if (s == Size2(0, 0)) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -292,8 +292,11 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		Point2 remainder = Point2(
 				Math::fmod(rect_position_scaled.x, 1.0l),
 				Math::fmod(rect_position_scaled.y, 1.0l));
-		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder;
-		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder;
+		Point2 remainder_leftover = Point2(
+				Math::fmod(remainder.x / rect_scale.x, 1.0l),
+				Math::fmod(remainder.y / rect_scale.y, 1.0l));
+		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder_leftover;
+		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder_leftover;
 	}
 
 	final_xform = parent_xform * final_xform;


### PR DESCRIPTION
> [!WARNING]
> Must be tested thoroughly before merging.

Supersedes #94625.
Not compatible with #94660.

Only affects canvas items when using 2D transform snapping.

This PR:
- Removes offset snapping
- Fixes snapping for odd-sized canvas items
- Fixes rotation for odd-sized canvas items


[rotate-before.webm](https://github.com/user-attachments/assets/7472bcf4-6531-4ee5-b18e-093579628920)

[rotate-after.webm](https://github.com/user-attachments/assets/ecd007f9-b235-4787-ab29-28b7a269420c)

### Screenshots

| Description | Before | After |
| --- | --- | --- |
| Centered odd-sized 3x3 | <img width="844" alt="Capture d’écran, le 2024-07-23 à 11 02 49" src="https://github.com/user-attachments/assets/7d60bd3f-c3ee-4279-9092-71f22f63e18a"> | <img width="751" alt="Capture d’écran, le 2024-07-23 à 10 28 57" src="https://github.com/user-attachments/assets/70708728-fafa-4dea-b605-1b730aabb5ac"> |
| Non centered odd-sized 3x3 | <img width="796" alt="Capture d’écran, le 2024-07-23 à 11 03 01" src="https://github.com/user-attachments/assets/ae5b17a1-a455-4af3-8701-b8888f96a676"> | <img width="726" alt="Capture d’écran, le 2024-07-23 à 10 29 04" src="https://github.com/user-attachments/assets/3ba7418f-7e26-4f79-8b87-06c103685b00"> |
| 45° rotated and centered odd-sized 3x3 | <img width="841" alt="Capture d’écran, le 2024-07-23 à 11 03 19" src="https://github.com/user-attachments/assets/410466f6-d27f-4e41-ab2d-c68c28013821"> | <img width="833" alt="Capture d’écran, le 2024-07-23 à 10 56 59" src="https://github.com/user-attachments/assets/6eeaf998-705a-47b7-b329-df67ebae1468"> |
| 90° rotated and centered odd-sized 3x3 | <img width="832" alt="Capture d’écran, le 2024-07-23 à 11 06 31" src="https://github.com/user-attachments/assets/d1dd3373-b604-40ef-a9e5-1db322d79a3e"> | <img width="745" alt="Capture d’écran, le 2024-07-23 à 11 07 32" src="https://github.com/user-attachments/assets/db98b8c0-8791-4279-9e8f-313587ff75fa"> |
| 2x centered odd-sized 3x3 | <img width="856" alt="Capture d’écran, le 2024-07-23 à 11 03 38" src="https://github.com/user-attachments/assets/dc8e7fbc-f762-4982-8758-50959daf1f86"> | <img width="881" alt="Capture d’écran, le 2024-07-23 à 10 29 16" src="https://github.com/user-attachments/assets/277f7888-0429-4fc0-8cae-f9b0363999e8"> |

### Tested on
- [x] @KeyboardDanni's [PixelPerfectTest.zip](https://github.com/user-attachments/files/16335627/PixelPerfectTest.zip)
- [x] Rotating 3x3 [rotate-3x3.zip](https://github.com/user-attachments/files/16350258/rotate-3x3.zip)
- [ ] Scaling 3x3 [scale-3x3.zip](https://github.com/user-attachments/files/16353858/scale-3x3.zip)
