### PR TITLE
Android Editor: Make progress dialog visible again

### DIFF
--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -130,9 +130,7 @@ void ProgressDialog::_update_ui() {
 	// Run main loop for two frames.
 	if (is_inside_tree()) {
 		DisplayServer::get_singleton()->process_events();
-#ifndef ANDROID_ENABLED
 		Main::iteration();
-#endif
 	}
 }
 


### PR DESCRIPTION
While debugging #94416, I noticed that the long hang was indeed a reimport, but there was no visible sign of it. Turns out that we prevented ProgressDialog from rendering anything, so it was stuck on the previous frame showing a FileSystem dock rescan at around 98% or 99%.

@m4gr3d suggested that this was disabled due to an input bug that has since been fixed, so it might be fine to re-enable. I've tested briefly on a Google Pixel 7a (with the TPS demo) and it seems to work ok.