### PR TITLE
Use GDExtension's `to_string` in C# `ToString` implementation

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -694,6 +694,9 @@ protected:
 	}
 
 	friend class GDExtensionMethodBind;
+#ifdef MODULE_MONO_ENABLED
+	friend class CSharpInstance;
+#endif
 	_ALWAYS_INLINE_ const ObjectGDExtension *_get_extension() const { return _extension; }
 	_ALWAYS_INLINE_ GDExtensionClassInstancePtr _get_extension_instance() const { return _extension_instance; }
 	virtual void _initialize_classv() { initialize_class(); }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1922,6 +1922,22 @@ String CSharpInstance::to_string(bool *r_valid) {
 	return res;
 }
 
+// Default implementation of `Object::to_string` that avoids calling the script's to_string method
+// to prevent an endless circular loop. It is used by the `GodotObject.ToString` implementation
+// which is used when the user C# class does not override `ToString`.
+String CSharpInstance::object_to_string(const Object *p_self) {
+	// Keep this method in sync with `Object::to_string`.
+	const ObjectGDExtension *extension = p_self->_get_extension();
+	if (extension && extension->to_string) {
+		String ret;
+		GDExtensionBool is_valid;
+		extension->to_string(p_self->_get_extension_instance(), &is_valid, &ret);
+		return ret;
+	}
+
+	return "<" + p_self->get_class() + "#" + itos(p_self->get_instance_id()) + ">";
+}
+
 Ref<Script> CSharpInstance::get_script() const {
 	return script;
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -371,6 +371,8 @@ public:
 
 	String to_string(bool *r_valid) override;
 
+	static String object_to_string(const Object *p_self);
+
 	Ref<Script> get_script() const override;
 
 	ScriptLanguage *get_language() override;

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1431,9 +1431,9 @@ void godotsharp_object_to_string(Object *p_ptr, godot_string *r_str) {
 	// Cannot happen in C#; would get an ObjectDisposedException instead.
 	CRASH_COND(p_ptr == nullptr);
 #endif
-	// Can't call 'Object::to_string()' here, as that can end up calling 'ToString' again resulting in an endless circular loop.
-	memnew_placement(r_str,
-			String("<" + p_ptr->get_class() + "#" + itos(p_ptr->get_instance_id()) + ">"));
+	// Can't call 'Object::to_string()' here, as that can end up calling 'ToString' again
+	// resulting in an endless circular loop.
+	memnew_placement(r_str, String(CSharpInstance::object_to_string(p_ptr)));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This makes the C# `ToString` implementation match the `Object::to_string` implementation, while still avoiding an endless circular loop.

- Fixes https://github.com/godotengine/godot/issues/94213
