### PR TITLE
Avoid potential crash on signal disconnection

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2097,7 +2097,11 @@ Object::~Object() {
 	// Disconnect signals that connect to this object.
 	while (connections.size()) {
 		Connection c = connections.front()->get();
-		bool disconnected = c.signal.get_object()->_disconnect(c.signal.get_name(), c.callable, true);
+		Object *obj = c.callable.get_object();
+		bool disconnected = false;
+		if (likely(obj)) {
+			disconnected = c.signal.get_object()->_disconnect(c.signal.get_name(), c.callable, true);
+		}
 		if (unlikely(!disconnected)) {
 			// If the disconnect has failed, abandon the connection to avoid getting trapped in an infinite loop here.
 			connections.pop_front();


### PR DESCRIPTION
I have not been able to come up with an MRP. It seems that on very complex resource dependency graphs, with signal connections among them, there's the possibility of hitting a pathological case where a signal connection is no longer in the map, which causes as segfault.