### PR TITLE
Add new `CanvasItem` snapping option

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -604,6 +604,9 @@
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled" default="false">
 			If [code]true[/code], the object draws behind its parent.
 		</member>
+		<member name="snap_to_pixel" type="int" setter="set_snap_to_pixel" getter="get_snap_to_pixel" enum="CanvasItem.SnapToPixel" default="0">
+			The snapping to pixel mode to use on this [CanvasItem].
+		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="CanvasItem.TextureFilter" default="0">
 			The texture filtering mode to use on this [CanvasItem].
 		</member>
@@ -735,6 +738,18 @@
 		</constant>
 		<constant name="CLIP_CHILDREN_MAX" value="3" enum="ClipChildrenMode">
 			Represents the size of the [enum ClipChildrenMode] enum.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_PARENT_NODE" value="0" enum="SnapToPixel">
+			The [CanvasItem] will inherit the snapping mode from its parent.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_DISABLED" value="1" enum="SnapToPixel">
+			The [CanvasItem] will not snap.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_ENABLED" value="2" enum="SnapToPixel">
+			The [CanvasItem] will snap.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_MAX" value="3" enum="SnapToPixel">
+			Represents the size of the [enum SnapToPixel] enum.
 		</constant>
 	</constants>
 </class>

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -73,6 +73,13 @@ public:
 		CLIP_CHILDREN_MAX,
 	};
 
+	enum SnapToPixel {
+		SNAP_TO_PIXEL_PARENT_NODE,
+		SNAP_TO_PIXEL_DISABLED,
+		SNAP_TO_PIXEL_ENABLED,
+		SNAP_TO_PIXEL_MAX,
+	};
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -112,8 +119,10 @@ private:
 
 	mutable RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	mutable RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+	mutable RS::CanvasItemSnapToPixel snap_to_pixel_cache = RS::CANVAS_ITEM_SNAP_TO_PIXEL_DISABLED;
 	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
 	TextureRepeat texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
+	SnapToPixel snap_to_pixel = SNAP_TO_PIXEL_PARENT_NODE;
 
 	Ref<Material> material;
 
@@ -148,12 +157,15 @@ private:
 	void _update_texture_repeat_changed(bool p_propagate);
 	void _refresh_texture_filter_cache() const;
 	void _update_texture_filter_changed(bool p_propagate);
+	void _refresh_snap_to_pixel_cache() const;
+	void _update_snap_to_pixel_changed(bool p_propagate);
 
 	void _notify_transform_deferred();
 
 protected:
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat);
 	virtual void _update_self_texture_filter(RS::CanvasItemTextureFilter p_texture_filter);
+	virtual void _update_self_snap_to_pixel(RS::CanvasItemSnapToPixel p_snap);
 
 	_FORCE_INLINE_ void _notify_transform() {
 		_notify_transform(this);
@@ -380,6 +392,9 @@ public:
 	int get_canvas_layer() const;
 	CanvasLayer *get_canvas_layer_node() const;
 
+	virtual void set_snap_to_pixel(SnapToPixel p_snap_to_pixel);
+	SnapToPixel get_snap_to_pixel() const;
+
 	CanvasItem();
 	~CanvasItem();
 };
@@ -387,6 +402,7 @@ public:
 VARIANT_ENUM_CAST(CanvasItem::TextureFilter)
 VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
+VARIANT_ENUM_CAST(CanvasItem::SnapToPixel)
 
 class CanvasTexture : public Texture2D {
 	GDCLASS(CanvasTexture, Texture2D);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -283,7 +283,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		rect.position -= repeat_size / scale * (repeat_times / 2);
 	}
 
-	if (snapping_2d_transforms_to_pixel) {
+	if ((p_canvas_item->snap_to_pixel == RS::CANVAS_ITEM_SNAP_TO_PIXEL_DEFAULT && snapping_2d_transforms_to_pixel) || (p_canvas_item->snap_to_pixel == RS::CANVAS_ITEM_SNAP_TO_PIXEL_ENABLED)) {
 		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor();
 		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor();
 	}
@@ -2309,6 +2309,12 @@ void RendererCanvasCull::canvas_item_set_default_texture_repeat(RID p_item, RS::
 	Item *ci = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(ci);
 	ci->texture_repeat = p_repeat;
+}
+
+void RendererCanvasCull::canvas_item_set_snap_to_pixel(RID p_item, RS::CanvasItemSnapToPixel p_snap) {
+	Item *ci = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(ci);
+	ci->snap_to_pixel = p_snap;
 }
 
 void RendererCanvasCull::update_visibility_notifiers() {

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -339,6 +339,7 @@ public:
 
 	void canvas_item_set_default_texture_filter(RID p_item, RS::CanvasItemTextureFilter p_filter);
 	void canvas_item_set_default_texture_repeat(RID p_item, RS::CanvasItemTextureRepeat p_repeat);
+	void canvas_item_set_snap_to_pixel(RID p_item, RS::CanvasItemSnapToPixel p_snap);
 
 	void update_visibility_notifiers();
 

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -458,6 +458,7 @@ public:
 
 		RS::CanvasItemTextureFilter texture_filter;
 		RS::CanvasItemTextureRepeat texture_repeat;
+		RS::CanvasItemSnapToPixel snap_to_pixel;
 
 		Item() {
 			commands = nullptr;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -883,6 +883,8 @@ public:
 
 	FUNC2(canvas_item_set_draw_behind_parent, RID, bool)
 
+	FUNC2(canvas_item_set_snap_to_pixel, RID, CanvasItemSnapToPixel)
+
 	FUNC6(canvas_item_add_line, RID, const Point2 &, const Point2 &, const Color &, float, bool)
 	FUNC5(canvas_item_add_polyline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)
 	FUNC5(canvas_item_add_multiline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -860,6 +860,13 @@ public:
 		CANVAS_ITEM_TEXTURE_REPEAT_MAX,
 	};
 
+	enum CanvasItemSnapToPixel {
+		CANVAS_ITEM_SNAP_TO_PIXEL_DEFAULT,
+		CANVAS_ITEM_SNAP_TO_PIXEL_DISABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_ENABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_MAX,
+	};
+
 	virtual RID viewport_create() = 0;
 
 	enum ViewportScaling3DMode {
@@ -1450,6 +1457,8 @@ public:
 	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_visibility_layer) = 0;
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
+
+	virtual void canvas_item_set_snap_to_pixel(RID p_item, CanvasItemSnapToPixel p_snap) = 0;
 
 	enum NinePatchAxisMode {
 		NINE_PATCH_STRETCH,


### PR DESCRIPTION
This PR adds a new `CanvasItem` snapping option in order to override the `rendering/2d/snap/snap_2d_transforms_to_pixel` project setting.

<img width="307" alt="Capture d’écran, le 2024-07-23 à 15 16 27" src="https://github.com/user-attachments/assets/a1012020-21cf-43ef-a911-3a3e4f44118a">

You can test this PR with this project: 
[canvas-item-snap-test.zip](https://github.com/user-attachments/files/16353459/canvas-item-snap-test.zip)