### PR TITLE
Fix LOD generation for meshes with tangents & mirrored UVs

### DIFF
--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -295,6 +295,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 		Vector<Vector3> vertices = surfaces[i].arrays[RS::ARRAY_VERTEX];
 		PackedInt32Array indices = surfaces[i].arrays[RS::ARRAY_INDEX];
 		Vector<Vector3> normals = surfaces[i].arrays[RS::ARRAY_NORMAL];
+		Vector<float> tangents = surfaces[i].arrays[RS::ARRAY_TANGENT];
 		Vector<Vector2> uvs = surfaces[i].arrays[RS::ARRAY_TEX_UV];
 		Vector<Vector2> uv2s = surfaces[i].arrays[RS::ARRAY_TEX_UV2];
 		Vector<int> bones = surfaces[i].arrays[RS::ARRAY_BONES];
@@ -354,6 +355,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 		LocalVector<int> merged_normals_counts;
 		const Vector2 *uvs_ptr = uvs.ptr();
 		const Vector2 *uv2s_ptr = uv2s.ptr();
+		const float *tangents_ptr = tangents.ptr();
 
 		for (unsigned int j = 0; j < vertex_count; j++) {
 			const Vector3 &v = vertices_ptr[j];
@@ -368,9 +370,10 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 				for (const Pair<int, int> &idx : close_verts) {
 					bool is_uvs_close = (!uvs_ptr || uvs_ptr[j].distance_squared_to(uvs_ptr[idx.second]) < CMP_EPSILON2);
 					bool is_uv2s_close = (!uv2s_ptr || uv2s_ptr[j].distance_squared_to(uv2s_ptr[idx.second]) < CMP_EPSILON2);
+					bool is_tang_aligned = !tangents_ptr || (tangents_ptr[j * 4 + 3] < 0) == (tangents_ptr[idx.second * 4 + 3] < 0);
 					ERR_FAIL_INDEX(idx.second, normals.size());
 					bool is_normals_close = normals[idx.second].dot(n) > normal_merge_threshold;
-					if (is_uvs_close && is_uv2s_close && is_normals_close) {
+					if (is_uvs_close && is_uv2s_close && is_normals_close && is_tang_aligned) {
 						vertex_remap.push_back(idx.first);
 						merged_normals[idx.first] += normals[idx.second];
 						merged_normals_counts[idx.first]++;


### PR DESCRIPTION
When UVs are mirrored in a mesh, collapsing vertices across the mirroring seam can significantly reduce quality in a way that is not apparent to the simplifier. Even if simplifier was given access to UV data, the coordinates would need to be weighted very highly to prevent these collapses, which would penalize overall quality of reasonable models.

Normally, well behaved models with mirrored UVs have tangent data that is correctly mirrored, which results in duplicate vertices along the seam. The simplifier automatically recognizes that seam and preserves its structure; typically models have few edge loops where UV winding is flipped so this does not affect simplification quality much.

However, pre-processing for LOD data welds vertices when UVs and normals were close, which welds these seams and breaks simplification, creating triangles with distorted UVs.

We now take tangent frame sign into account when the input model has tangent data, and only weld vertices when the sign is the same.

Fixes #67891.