### PR TITLE
StringName: Use inline static field definitions

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -39,18 +39,9 @@ StaticCString StaticCString::create(const char *p_ptr) {
 	return scs;
 }
 
-StringName::_Data *StringName::_table[STRING_TABLE_LEN];
-
 StringName _scs_create(const char *p_chr, bool p_static) {
 	return (p_chr[0] ? StringName(StaticCString::create(p_chr), p_static) : StringName());
 }
-
-bool StringName::configured = false;
-Mutex StringName::mutex;
-
-#ifdef DEBUG_ENABLED
-bool StringName::debug_stringname = false;
-#endif
 
 void StringName::setup() {
 	ERR_FAIL_COND(configured);

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -67,7 +67,7 @@ class StringName {
 		_Data() {}
 	};
 
-	static _Data *_table[STRING_TABLE_LEN];
+	static inline _Data *_table[STRING_TABLE_LEN];
 
 	_Data *_data = nullptr;
 
@@ -75,10 +75,10 @@ class StringName {
 	friend void register_core_types();
 	friend void unregister_core_types();
 	friend class Main;
-	static Mutex mutex;
+	static inline Mutex mutex;
 	static void setup();
 	static void cleanup();
-	static bool configured;
+	static inline bool configured = false;
 #ifdef DEBUG_ENABLED
 	struct DebugSortReferences {
 		bool operator()(const _Data *p_left, const _Data *p_right) const {
@@ -86,7 +86,7 @@ class StringName {
 		}
 	};
 
-	static bool debug_stringname;
+	static inline bool debug_stringname = false;
 #endif
 
 	StringName(_Data *p_data) { _data = p_data; }


### PR DESCRIPTION
Before this change StringName used regular static field definitions for its mutex, _table, configured and debug_stringname fields.

Since in the general case the ordering of the static variable and field initialization and destruction is undefined, it was possible that the destruction of StringName's static fields happened prior to the destruction of statically allocated StringName instances.

By changing the static field definitions to inline in string_name.h, the C++17 standard guarantees the correct initialization and destruction ordering.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
