### PR TITLE
[X11] Fix mouse events triggered by non-popup or non-focused window

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4968,7 +4968,7 @@ void DisplayServerX11::process_events() {
 				Ref<InputEventMouseMotion> mm;
 				mm.instantiate();
 
-				mm->set_window_id(window_id);
+				mm->set_window_id(focused_window_id);
 				if (xi.pressure_supported) {
 					mm->set_pressure(xi.pressure);
 				} else {
@@ -4989,37 +4989,12 @@ void DisplayServerX11::process_events() {
 
 				last_mouse_pos = pos;
 
-				// printf("rel: %d,%d\n", rel.x, rel.y );
-				// Don't propagate the motion event unless we have focus
-				// this is so that the relative motion doesn't get messed up
-				// after we regain focus.
-				if (focused) {
-					Input::get_singleton()->parse_input_event(mm);
-				} else {
-					// Propagate the event to the focused window,
-					// because it's received only on the topmost window.
-					// Note: This is needed for drag & drop to work between windows,
-					// because the engine expects events to keep being processed
-					// on the same window dragging started.
-					for (const KeyValue<WindowID, WindowData> &E : windows) {
-						const WindowData &wd_other = E.value;
-						if (wd_other.focused) {
-							int x, y;
-							Window child;
-							XTranslateCoordinates(x11_display, wd.x11_window, wd_other.x11_window, event.xmotion.x, event.xmotion.y, &x, &y, &child);
-
-							Point2i pos_focused(x, y);
-
-							mm->set_window_id(E.key);
-							mm->set_position(pos_focused);
-							mm->set_global_position(pos_focused);
-							mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
-							Input::get_singleton()->parse_input_event(mm);
-
-							break;
-						}
-					}
+				if (focused_window_id != window_id) {
+					// Adjust event position relative to window distance when event is sent to a different window.
+					mm->set_position(mm->get_position() - window_get_position(focused_window_id) + window_get_position(window_id));
+					mm->set_global_position(mm->get_position());
 				}
+				Input::get_singleton()->parse_input_event(mm);
 
 			} break;
 			case KeyPress:

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4989,10 +4989,16 @@ void DisplayServerX11::process_events() {
 
 				last_mouse_pos = pos;
 
-				if (focused_window_id != window_id) {
-					// Adjust event position relative to window distance when event is sent to a different window.
-					mm->set_position(mm->get_position() - window_get_position(focused_window_id) + window_get_position(window_id));
-					mm->set_global_position(mm->get_position());
+				if (windows[focused_window_id].mpass || wd.is_popup) {
+					mm->set_window_id(window_id);
+				} else {
+					int x, y;
+					Window child;
+					XTranslateCoordinates(x11_display, wd.x11_window, windows[focused_window_id].x11_window, event.xmotion.x, event.xmotion.y, &x, &y, &child);
+
+					Point2i pos_focused(x, y);
+					mm->set_position(pos_focused);
+					mm->set_global_position(pos_focused);
 				}
 				Input::get_singleton()->parse_input_event(mm);
 


### PR DESCRIPTION
Fix: https://github.com/godotengine/godot/issues/94615
There are several issues here:

1. By default, the focused property of windows created by X11 is set to true: https://github.com/godotengine/godot/blob/8e36f98ea5b5ab4c1fb5249f94b61a7bbfb379a1/platform/linuxbsd/x11/display_server_x11.h#L204
And it is only modified after a focus event occurs:https://github.com/godotengine/godot/blob/8e36f98ea5b5ab4c1fb5249f94b61a7bbfb379a1/platform/linuxbsd/x11/display_server_x11.cpp#L4661-L4669
https://github.com/godotengine/godot/blob/8e36f98ea5b5ab4c1fb5249f94b61a7bbfb379a1/platform/linuxbsd/x11/display_server_x11.cpp#L4708-L4723

2. That leads to a situation where the focued of main window is true, and the newly created popup window also has a focused property of true, resulting in multiple windows with a true focused property.

3. When a mouse movement event occurs, if the event happens on the main window and the main window's focued property is true, even if the popup window's focused property is also true, the event will be handled by the main window, During the main window' event handling process, it will close the popop window.

And I am not sure whether to modify the default focused property.