### PR TITLE
Android Editor: Disable file reimport when .import changes

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -722,12 +722,16 @@ bool EditorFileSystem::_update_scan_actions() {
 				String full_path = ia.dir->get_file_path(idx);
 
 				bool need_reimport = _test_for_reimport(full_path, false);
+				// Workaround GH-94416 for the Android editor for now.
+				// `import_mt` seems to always be 0 and force a reimport on any fs scan.
+#ifndef ANDROID_ENABLED
 				if (!need_reimport && FileAccess::exists(full_path + ".import")) {
 					uint64_t import_mt = ia.dir->get_file_import_modified_time(idx);
 					if (import_mt != FileAccess::get_modified_time(full_path + ".import")) {
 						need_reimport = true;
 					}
 				}
+#endif
 
 				if (need_reimport) {
 					//must reimport


### PR DESCRIPTION
This is disabling (for Android only) the logic added in #84974 which caused #94416. That issue still needs to be debugged further, but this works around the regression and should have minimal usability impact on Android.

- Works around #94416, making it not a release blocker (but keeping it open to look for a proper fix).