### PR TITLE
[X11 WSLg] Fix stuck on the main page when launching in fullscreen mode

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2650,6 +2650,7 @@ void DisplayServerX11::_set_wm_fullscreen(WindowID p_window, bool p_enabled, boo
 	if (p_enabled) {
 		// Set the window as resizable to prevent window managers to ignore the fullscreen state flag.
 		_update_size_hints(p_window);
+		XMoveWindow(x11_display, wd.x11_window, 1, 1);
 	}
 
 	// Using EWMH -- Extended Window Manager Hints
@@ -2687,6 +2688,7 @@ void DisplayServerX11::_set_wm_fullscreen(WindowID p_window, bool p_enabled, boo
 	if (!p_enabled) {
 		// Reset the non-resizable flags if we un-set these before.
 		_update_size_hints(p_window);
+		XMoveWindow(x11_display, wd.x11_window, wd.position.x, wd.position.y);
 
 		// put back or remove decorations according to the last set borderless state
 		Hints hints;


### PR DESCRIPTION
Fix: https://github.com/godotengine/godot/issues/94596
On WSLg, setting a window to fullscreen mode with its position at (0, 0), will cause a position value error, making the window unable to receive input events
![fullscreen godot](https://github.com/user-attachments/assets/1264362e-8c27-4832-81e3-9dbe7fbecf07)
