### PR TITLE
[C#] Change the `VisualShaderNodeCustom` template to use the correct override types and signatures

### DIFF
--- a/modules/mono/editor/script_templates/VisualShaderNodeCustom/basic.cs
+++ b/modules/mono/editor/script_templates/VisualShaderNodeCustom/basic.cs
@@ -3,6 +3,8 @@
 using _BINDINGS_NAMESPACE_;
 using System;
 
+[Tool]
+[GlobalClass]
 public partial class VisualShaderNode_CLASS_ : _BASE_
 {
     public override string _GetName()
@@ -20,37 +22,37 @@ public partial class VisualShaderNode_CLASS_ : _BASE_
         return "";
     }
 
-    public override long _GetReturnIconType()
+    public override VisualShaderNode.PortType _GetReturnIconType()
     {
         return 0;
     }
 
-    public override long _GetInputPortCount()
+    public override int _GetInputPortCount()
     {
         return 0;
     }
 
-    public override string _GetInputPortName(long port)
+    public override string _GetInputPortName(int port)
     {
         return "";
     }
 
-    public override long _GetInputPortType(long port)
+    public override VisualShaderNode.PortType _GetInputPortType(int port)
     {
         return 0;
     }
 
-    public override long _GetOutputPortCount()
+    public override int _GetOutputPortCount()
     {
         return 1;
     }
 
-    public override string _GetOutputPortName(long port)
+    public override string _GetOutputPortName(int port)
     {
         return "result";
     }
 
-    public override long _GetOutputPortType(long port)
+    public override VisualShaderNode.PortType _GetOutputPortType(int port)
     {
         return 0;
     }


### PR DESCRIPTION
While trying to create a custom VisualShader Node, it wouldn't show up any of the custom nodes when implemented in C# (works with GDScript), trying to create one from within the editor using the provided template created a script with compile errors.

I saw somwhere in the source that we should assume 64-bit types, so that might be why long is used instead of int, but since it's a signature / type mismatch with the base class, it won't compile.

I also added the Godot.Tool attribute, since it is required according to the docs:
"... you must use the `@tool` annotation ..."
https://docs.godotengine.org/en/4.2/classes/class_visualshadernodecustom.html#description

I will also submit an issue for the problem related to the C# VisualShaderNodeCustom files not showing up / getting recognized by the editor.

(This is my first PR, so I might have missed something!)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->