### PR TITLE
EGLManager: Track per-window v-sync state

### DIFF
--- a/drivers/egl/egl_manager.h
+++ b/drivers/egl/egl_manager.h
@@ -58,6 +58,8 @@ private:
 	// EGL specific window data.
 	struct GLWindow {
 		bool initialized = false;
+		// On EGL the default swap interval is 1 and thus vsync is on by default.
+		bool use_vsync = true;
 
 		// An handle to the GLDisplay associated with this window.
 		int gldisplay_id = -1;
@@ -69,9 +71,6 @@ private:
 	LocalVector<GLWindow> windows;
 
 	GLWindow *current_window = nullptr;
-
-	// On EGL the default swap interval is 1 and thus vsync is on by default.
-	bool use_vsync = true;
 
 	virtual const char *_get_platform_extension_name() const = 0;
 	virtual EGLenum _get_platform_extension_enum() const = 0;
@@ -102,8 +101,8 @@ public:
 
 	void window_make_current(DisplayServer::WindowID p_window_id);
 
-	void set_use_vsync(bool p_use);
-	bool is_using_vsync() const;
+	void set_use_vsync(DisplayServer::WindowID p_window_id, bool p_use);
+	bool is_using_vsync(DisplayServer::WindowID p_window_id) const;
 
 	EGLContext get_context(DisplayServer::WindowID p_window_id);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -945,13 +945,13 @@ void DisplayServerWayland::window_set_vsync_mode(DisplayServer::VSyncMode p_vsyn
 
 #ifdef GLES3_ENABLED
 	if (egl_manager) {
-		egl_manager->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
+		egl_manager->set_use_vsync(p_window_id, p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 
-		emulate_vsync = egl_manager->is_using_vsync();
+		emulate_vsync = egl_manager->is_using_vsync(p_window_id);
 
 		if (emulate_vsync) {
 			print_verbose("VSYNC: manually throttling frames with swap delay 0.");
-			egl_manager->set_use_vsync(false);
+			egl_manager->set_use_vsync(p_window_id, false);
 		}
 	}
 #endif // GLES3_ENABLED
@@ -970,7 +970,7 @@ DisplayServer::VSyncMode DisplayServerWayland::window_get_vsync_mode(DisplayServ
 
 #ifdef GLES3_ENABLED
 	if (egl_manager) {
-		return egl_manager->is_using_vsync() ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
+		return egl_manager->is_using_vsync(p_window_id) ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
 	}
 #endif // GLES3_ENABLED
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5367,7 +5367,7 @@ void DisplayServerX11::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mo
 		gl_manager->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 	}
 	if (gl_manager_egl) {
-		gl_manager_egl->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
+		gl_manager_egl->set_use_vsync(p_window, p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 	}
 #endif
 }
@@ -5384,7 +5384,7 @@ DisplayServer::VSyncMode DisplayServerX11::window_get_vsync_mode(WindowID p_wind
 		return gl_manager->is_using_vsync() ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
 	}
 	if (gl_manager_egl) {
-		return gl_manager_egl->is_using_vsync() ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
+		return gl_manager_egl->is_using_vsync(p_window) ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
 	}
 #endif
 	return DisplayServer::VSYNC_ENABLED;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2688,7 +2688,7 @@ void DisplayServerMacOS::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_
 	_THREAD_SAFE_METHOD_
 #if defined(GLES3_ENABLED)
 	if (gl_manager_angle) {
-		gl_manager_angle->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
+		gl_manager_angle->set_use_vsync(p_window, p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 	}
 	if (gl_manager_legacy) {
 		gl_manager_legacy->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
@@ -2705,7 +2705,7 @@ DisplayServer::VSyncMode DisplayServerMacOS::window_get_vsync_mode(WindowID p_wi
 	_THREAD_SAFE_METHOD_
 #if defined(GLES3_ENABLED)
 	if (gl_manager_angle) {
-		return (gl_manager_angle->is_using_vsync() ? DisplayServer::VSyncMode::VSYNC_ENABLED : DisplayServer::VSyncMode::VSYNC_DISABLED);
+		return (gl_manager_angle->is_using_vsync(p_window) ? DisplayServer::VSyncMode::VSYNC_ENABLED : DisplayServer::VSyncMode::VSYNC_DISABLED);
 	}
 	if (gl_manager_legacy) {
 		return (gl_manager_legacy->is_using_vsync() ? DisplayServer::VSyncMode::VSYNC_ENABLED : DisplayServer::VSyncMode::VSYNC_DISABLED);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3419,7 +3419,7 @@ void DisplayServerWindows::window_set_vsync_mode(DisplayServer::VSyncMode p_vsyn
 		gl_manager_native->set_use_vsync(p_window, p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 	}
 	if (gl_manager_angle) {
-		gl_manager_angle->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
+		gl_manager_angle->set_use_vsync(p_window, p_vsync_mode != DisplayServer::VSYNC_DISABLED);
 	}
 #endif
 }
@@ -3437,7 +3437,7 @@ DisplayServer::VSyncMode DisplayServerWindows::window_get_vsync_mode(WindowID p_
 		return gl_manager_native->is_using_vsync(p_window) ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
 	}
 	if (gl_manager_angle) {
-		return gl_manager_angle->is_using_vsync() ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
+		return gl_manager_angle->is_using_vsync(p_window) ? DisplayServer::VSYNC_ENABLED : DisplayServer::VSYNC_DISABLED;
 	}
 #endif
 	return DisplayServer::VSYNC_ENABLED;


### PR DESCRIPTION
Before this change, `EGLManager` only tracks a global v-sync state. When setting v-sync state, it only sets it for the "current" window, whichever it is at the time.

This change teaches `EGLManager` to track the v-sync state for each window and set the state for the requested window. This makes it in line with `GLManagerNative_Windows`. (In practice this is still limited by DWM composition forcing one v-sync rate, unless we do some tricks to enable DXGI flip model in ANGLE, but that is something for the future.)

Tested with the following project on Windows (using `--rendering-driver opengl3_angle`) and on Linux X11 (using `--rendering-driver opengl3_es`):
[spinning-cube_multiwindow.zip](https://github.com/user-attachments/files/16363090/spinning-cube_multiwindow.zip)
1. Check that the project with two native windows open is v-syncing.
2. Uncheck v-sync on one window and check that the project is v-syncing.
3. Uncheck v-sync on all windows and check that the project is **not** v-syncing.
4. Close the second window, then press the button to add a new window. Check that the project is **not** v-syncing.
5. Check v-sync on the second window and check that the project is v-syncing.
6. Close the second window and check that the project is **not** v-syncing.

Note: Untested on Wayland and macOS ANGLE>