### PR TITLE
Improve time to close scene with many 3D gizmos

### DIFF
--- a/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
@@ -293,9 +293,15 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 
 void Joint3DGizmoPlugin::incremental_update_gizmos() {
 	if (!current_gizmos.is_empty()) {
-		update_idx++;
-		update_idx = update_idx % current_gizmos.size();
-		redraw(current_gizmos.get(update_idx));
+		HashSet<EditorNode3DGizmo *>::Iterator E = current_gizmos.find(last_drawn);
+		if (E) {
+			++E;
+		}
+		if (!E) {
+			E = current_gizmos.begin();
+		}
+		redraw(*E);
+		last_drawn = *E;
 	}
 }
 

--- a/editor/plugins/gizmos/joint_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/joint_3d_gizmo_plugin.h
@@ -37,7 +37,7 @@ class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Joint3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 	Timer *update_timer = nullptr;
-	uint64_t update_idx = 0;
+	EditorNode3DGizmo *last_drawn = nullptr;
 
 	void incremental_update_gizmos();
 

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1023,7 +1023,7 @@ Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_spatial) {
 	ref->set_node_3d(p_spatial);
 	ref->set_hidden(current_state == HIDDEN);
 
-	current_gizmos.push_back(ref.ptr());
+	current_gizmos.insert(ref.ptr());
 	return ref;
 }
 

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -152,7 +152,7 @@ public:
 
 protected:
 	int current_state;
-	List<EditorNode3DGizmo *> current_gizmos;
+	HashSet<EditorNode3DGizmo *> current_gizmos;
 	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
 
 	static void _bind_methods();


### PR DESCRIPTION
Changed `EditorNode3DGizmoPlugin::current_gizmos` from `List` to `HashSet`, to avoid having to iterate through all gizmos when `~EditorNode3DGizmo` unregisters itself.  Fixes the scene closing slowness in #94648

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
