### PR TITLE
Remove linearization of canvas modulate in GLES3 backend

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -341,15 +341,10 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		normal_transform.columns[2] = Vector2();
 		_update_transform_2d_to_mat4(normal_transform, state_buffer.canvas_normal_transform);
 
-		bool use_linear_colors = texture_storage->render_target_is_using_hdr(p_to_render_target);
-		Color modulate = p_modulate;
-		if (use_linear_colors) {
-			modulate = p_modulate.srgb_to_linear();
-		}
-		state_buffer.canvas_modulate[0] = modulate.r;
-		state_buffer.canvas_modulate[1] = modulate.g;
-		state_buffer.canvas_modulate[2] = modulate.b;
-		state_buffer.canvas_modulate[3] = modulate.a;
+		state_buffer.canvas_modulate[0] = p_modulate.r;
+		state_buffer.canvas_modulate[1] = p_modulate.g;
+		state_buffer.canvas_modulate[2] = p_modulate.b;
+		state_buffer.canvas_modulate[3] = p_modulate.a;
 
 		Size2 render_target_size = texture_storage->render_target_get_size(p_to_render_target);
 		state_buffer.screen_pixel_size[0] = 1.0 / render_target_size.x;


### PR DESCRIPTION
Follow up to: https://github.com/godotengine/godot/pull/93802

I was unclear in my review comment and requested that some new changed be reverted. I meant that only the changes to the RD backend should be reverted, but I was unclear in my message. Previous changes to the GLES3 backend were also reverted and then merged when they should not have been.

The GLES3 renderer is always in sRGB space, even when using an HDR format, so we should never linearize the inputs

