### PR TITLE
Improve blend tree contrast/margins

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -167,6 +167,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			name->set_text(E);
 			name->set_editable(!read_only);
 			name->set_expand_to_text_length_enabled(true);
+			name->set_custom_minimum_size(Vector2(100, 0) * EDSCALE);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, read_only ? -1 : 0, get_theme_color(SceneStringName(font_color), SNAME("Label")));
 			name->connect("text_submitted", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed).bind(agnode), CONNECT_DEFERRED);
@@ -206,6 +207,14 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 				prop->update_property();
 				prop->set_name_split_ratio(0);
 				prop->connect("property_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_property_changed));
+
+				if (F.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+					// Give the resource editor some more space to make the inside readable.
+					prop->set_custom_minimum_size(Vector2(180, 0) * EDSCALE);
+					// Align the size of the node with the resource editor, its un-expanding does not trigger a resize.
+					prop->connect(SceneStringName(resized), Callable(node, "reset_size"));
+				}
+
 				node->add_child(prop);
 				visible_properties.push_back(prop);
 			}
@@ -267,17 +276,14 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected).bind(options, E), CONNECT_DEFERRED);
 		}
 
-		// TODO: Avoid using strings, expose a method on GraphNode instead.
-		Ref<StyleBoxFlat> sb = node->get_theme_stylebox(SceneStringName(panel));
-		Color c = sb->get_border_color();
-		Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
-		mono_color.a = 0.85;
-		c = mono_color;
+		Ref<StyleBox> sb_panel = node->get_theme_stylebox(SceneStringName(panel), "GraphNode")->duplicate();
+		if (sb_panel.is_valid()) {
+			sb_panel->set_content_margin(SIDE_TOP, 12 * EDSCALE);
+			sb_panel->set_content_margin(SIDE_BOTTOM, 12 * EDSCALE);
+			node->add_theme_style_override(SceneStringName(panel), sb_panel);
+		}
 
-		node->add_theme_color_override("title_color", c);
-		c.a = 0.7;
-		node->add_theme_color_override("close_color", c);
-		node->add_theme_color_override("resizer_color", c);
+		node->add_theme_constant_override("separation", 4 * EDSCALE);
 	}
 
 	List<AnimationNodeBlendTree::NodeConnection> node_connections;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -46,6 +46,7 @@
 #include "editor/plugins/material_editor_plugin.h"
 #include "editor/plugins/shader_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_theme_manager.h"
 #include "scene/animation/tween.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
@@ -572,6 +573,10 @@ void VisualShaderGraphPlugin::update_theme() {
 	Ref<Font> label_bold_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_bold_msdf", EditorStringName(EditorFonts));
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "Label", label_font);
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "GraphNodeTitleLabel", label_bold_font);
+	if (!EditorThemeManager::is_dark_theme()) {
+		// Override the color to white for light themes.
+		vs_msdf_fonts_theme->set_color(SceneStringName(font_color), "GraphNodeTitleLabel", Color(1, 1, 1));
+	}
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "LineEdit", label_font);
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "Button", label_font);
 }

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1681,8 +1681,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			// GraphNode's title Label.
 			p_theme->set_type_variation("GraphNodeTitleLabel", "Label");
 			p_theme->set_stylebox(CoreStringName(normal), "GraphNodeTitleLabel", make_empty_stylebox(0, 0, 0, 0));
-			p_theme->set_color(SceneStringName(font_color), "GraphNodeTitleLabel", p_config.dark_theme ? p_config.font_color : Color(1, 1, 1)); // Also use a bright font color for light themes.
-			p_theme->set_color("font_shadow_color", "GraphNodeTitleLabel", Color(0, 0, 0, 0.35));
+			p_theme->set_color("font_shadow_color", "GraphNodeTitleLabel", p_config.shadow_color);
 			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
 			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
 			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);


### PR DESCRIPTION
Improved light theme contrast and readability by adding some margins and adjusting some theme stuff that I think might be leftovers from previous PRs that made adjustments to this.

~Fixed graph nodes using `get_size()` instead of `get_minimum_size()` when they weren't resizable which could result in the nodes retaining their original size after changes. I could not find what exactly caused this regression since 4.2 but this seems like it should be the intended behavior anyhow, if the user can't resize the graph node, it should just adjust to its contents automatically.~

| 4.2 | 4.3 | This PR |
|---|---|---|
| <video src="https://github.com/user-attachments/assets/ea67125b-0a40-477c-b769-e45ea1664422" /> |  <video src="https://github.com/user-attachments/assets/e4768bb3-43f7-4a42-a797-64025574d434" /> | <video src="https://github.com/user-attachments/assets/8f99338f-a407-4844-b518-872fd666524f" />
