### PR TITLE
AnimationMixer: Fix `processed_hashes` type to `Animation::TypeHash` instead of `int`

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1081,7 +1081,7 @@ void AnimationMixer::_blend_calc_total_weight() {
 		Ref<Animation> a = ai.animation_data.animation;
 		real_t weight = ai.playback_info.weight;
 		Vector<real_t> track_weights = ai.playback_info.track_weights;
-		Vector<int> processed_hashes;
+		Vector<Animation::TypeHash> processed_hashes;
 		for (int i = 0; i < a->get_track_count(); i++) {
 			if (!a->track_is_enabled(i)) {
 				continue;


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/94716

It should be strictly typed for safety.