### PR TITLE
Make primitive meshes react to texel size change

### DIFF
--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -67,6 +67,9 @@ protected:
 	// assume primitive triangles as the type, correct for all but one and it will change this :)
 	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;
 
+	// Copy of our texel_size project setting.
+	float texel_size = 0.2;
+
 	static void _bind_methods();
 
 	virtual void _create_mesh_array(Array &p_arr) const {}
@@ -75,6 +78,8 @@ protected:
 	Vector2 get_uv2_scale(Vector2 p_margin_scale = Vector2(1.0, 1.0)) const;
 	float get_lightmap_texel_size() const;
 	virtual void _update_lightmap_size(){};
+
+	void _on_settings_changed();
 
 public:
 	virtual int get_surface_count() const override;


### PR DESCRIPTION
Makes primitive meshes subscribe to project settings changes so that we rebuild the mesh if the texel size changes.

Fixes #94637