### PR TITLE
Fix incorrect passing of parameter to visual shader preview

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -7724,7 +7724,7 @@ void VisualShaderNodePortPreview::_shader_changed() {
 			List<PropertyInfo> params;
 			src_mat->get_shader()->get_shader_uniform_list(&params);
 			for (const PropertyInfo &E : params) {
-				mat->set(E.name, src_mat->get(E.name));
+				mat->set_shader_parameter(E.name, src_mat->get_shader_parameter(E.name));
 			}
 		}
 	}


### PR DESCRIPTION
Currently, it doesn't work at all.

Before:

![vs_param_old](https://github.com/user-attachments/assets/0193b147-71e0-4537-abe3-fc9a48509f5c)

After:

![vs_param](https://github.com/user-attachments/assets/7c0da744-4bc7-4d5e-b5ea-016fb1f84035)
