### PR TITLE
[Windows] Use default aggregate initialization for NVAPI settings

### DIFF
--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -243,7 +243,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		}
 	}
 
-	NVDRS_SETTING ogl_thread_control_setting = { 0 };
+	NVDRS_SETTING ogl_thread_control_setting = {};
 	ogl_thread_control_setting.version = NVDRS_SETTING_VER;
 	ogl_thread_control_setting.settingId = OGL_THREAD_CONTROL_ID;
 	ogl_thread_control_setting.settingType = NVDRS_DWORD_TYPE;
@@ -259,7 +259,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		return;
 	}
 
-	NVDRS_SETTING vrr_mode_setting = { 0 };
+	NVDRS_SETTING vrr_mode_setting = {};
 	vrr_mode_setting.version = NVDRS_SETTING_VER;
 	vrr_mode_setting.settingId = VRR_MODE_ID;
 	vrr_mode_setting.settingType = NVDRS_DWORD_TYPE;


### PR DESCRIPTION
Using the member initialization encouraged in NVAPI documentation for NVDRS_SETTING results in builds enabling `dev_mode` breaking:

```
platform/windows/gl_manager_windows_native.cpp: In member function 'void GLManagerNative_Windows::_nvapi_setup_profile()':
platform/windows/gl_manager_windows_native.cpp:246:56: error: missing initializer for member '_NVDRS_SETTING_V1::settingName' [-Werror=missing-field-initializers]
  246 |         NVDRS_SETTING ogl_thread_control_setting = { 0 };
      |                                                        ^
```
Default aggregate initialization results in a clean build though.

Initialy reported by @patwork in https://github.com/godotengine/godot/pull/93737#issuecomment-2248884048.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
