### PR TITLE
Add extra padding to Revert button, to make it easier to hit

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -311,8 +311,9 @@ void EditorProperty::_notification(int p_what) {
 
 			if (can_revert && !is_read_only()) {
 				Ref<Texture2D> reload_icon = get_editor_theme_icon(SNAME("ReloadSmall"));
+				Size2 padding = Size2(4, 4) * EDSCALE;
 				text_limit -= reload_icon->get_width() + get_theme_constant(SNAME("h_separation"), SNAME("Tree"));
-				revert_rect = Rect2(ofs + text_limit, (size.height - reload_icon->get_height()) / 2, reload_icon->get_width(), reload_icon->get_height());
+				revert_rect = Rect2(ofs + text_limit - (padding.width / 2), (size.height - (reload_icon->get_height() + padding.height)) / 2, reload_icon->get_width() + padding.width, reload_icon->get_height() + padding.height);
 
 				Color color2(1, 1, 1);
 				if (revert_hover) {
@@ -321,9 +322,9 @@ void EditorProperty::_notification(int p_what) {
 					color2.b *= 1.2;
 				}
 				if (rtl) {
-					draw_texture(reload_icon, Vector2(size.width - revert_rect.position.x - reload_icon->get_width(), revert_rect.position.y), color2);
+					draw_texture(reload_icon, Vector2(size.width - revert_rect.position.x - (padding.width / 2) - reload_icon->get_width(), revert_rect.position.y + (padding.height / 2)), color2);
 				} else {
-					draw_texture(reload_icon, revert_rect.position, color2);
+					draw_texture(reload_icon, revert_rect.position + padding / 2, color2);
 				}
 			} else {
 				revert_rect = Rect2();


### PR DESCRIPTION
A s discussed here: https://github.com/godotengine/godot-proposals/discussions/10265

This would add extra padding to the Revert button so it makes it easier to click.

You can see the difference here:

[Screencast_20240725_115514.webm](https://github.com/user-attachments/assets/2003a774-f5a1-49cb-8782-22f262e97e95)

With rtl == true the icon is not lining up exactly with previous placement. Is that needed, and if so do you have any recommendation?