### PR TITLE
Update documentation for places to receive InputEventShortcut

### DIFF
--- a/doc/classes/InputEventShortcut.xml
+++ b/doc/classes/InputEventShortcut.xml
@@ -4,7 +4,7 @@
 		Represents a triggered keyboard [Shortcut].
 	</brief_description>
 	<description>
-		InputEventShortcut is a special event that can be received in [method Node._unhandled_key_input]. It is typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_input].
+		InputEventShortcut is a special event that can be received in [method Node._input], [method Node._shortcut_input], and [method Node._unhandled_input]. It is typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_input].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
I didn't test it myself, but https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html#how-does-it-work and https://docs.godotengine.org/en/latest/classes/class_node.html#class-node-private-method-shortcut-input say so.