### PR TITLE
GDScript: Fix: update member cache of subclasses

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -451,11 +451,18 @@ void GDScript::set_source_code(const String &p_code) {
 	}
 	source = p_code;
 #ifdef TOOLS_ENABLED
-	source_changed_cache = true;
+	mark_source_changed();
 #endif
 }
 
 #ifdef TOOLS_ENABLED
+void GDScript::mark_source_changed() {
+	_source_changed_cache = true;
+	for (KeyValue<StringName, Ref<GDScript>> &inner : subclasses) {
+		inner.value->mark_source_changed();
+	}
+}
+
 void GDScript::_update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames) {
 	for (const KeyValue<StringName, Variant> &E : member_default_values_cache) {
 		values[E.key] = E.value;
@@ -505,8 +512,9 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 	bool changed = p_base_exports_changed;
 
-	if (source_changed_cache) {
-		source_changed_cache = false;
+	if (_source_changed_cache) {
+		// Only set to false for this instance: subclasses have to update themselves
+		_source_changed_cache = false;
 		changed = true;
 
 		String basedir = path;
@@ -521,17 +529,27 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 		GDScriptParser parser;
 		GDScriptAnalyzer analyzer(&parser);
-		Error err = parser.parse(source, path, false);
+
+		const String *s = &source;
+		if (!is_root_script()) {
+			// Subclasses are contained in their root script's source
+			s = &get_root_script()->source;
+		}
+		Error err = parser.parse(*s, path, false);
 
 		if (err == OK && analyzer.analyze() == OK) {
 			const GDScriptParser::ClassNode *c = parser.get_tree();
+			if (!is_root_script()) {
+				// get_tree() would return outer class. We are in that tree somewhere!
+				c = c->find_class(fully_qualified_name);
+			}
 
 			if (base_cache.is_valid()) {
 				base_cache->inheriters_cache.erase(get_instance_id());
 				base_cache = Ref<GDScript>();
 			}
 
-			GDScriptParser::DataType base_type = parser.get_tree()->base_type;
+			GDScriptParser::DataType base_type = c->base_type;
 			if (base_type.kind == GDScriptParser::DataType::CLASS) {
 				Ref<GDScript> bf = GDScriptCache::get_full_script(base_type.script_path, err, path);
 				if (err == OK) {
@@ -1110,7 +1128,7 @@ Error GDScript::load_source_code(const String &p_path) {
 	path = p_path;
 	path_valid = true;
 #ifdef TOOLS_ENABLED
-	source_changed_cache = true;
+	mark_source_changed();
 	set_edited(false);
 	set_last_modified_time(FileAccess::get_modified_time(path));
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -153,7 +153,8 @@ private:
 	HashMap<StringName, Variant> member_default_values_cache;
 	Ref<GDScript> base_cache;
 	HashSet<ObjectID> inheriters_cache;
-	bool source_changed_cache = false;
+	bool _source_changed_cache = false;
+	void mark_source_changed();
 	bool placeholder_fallback_enabled = false;
 	void _update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames);
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -3086,6 +3086,11 @@ void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::Cl
 
 		make_scripts(subclass.ptr(), inner_class, p_keep_state);
 	}
+
+#ifdef TOOLS_ENABLED
+	// Mark all newly created subclasses as having changed source
+	p_script->mark_source_changed();
+#endif // TOOLS_ENABLED
 }
 
 GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement_info(GDScriptFunction *p_func, int p_index, int p_depth, GDScriptFunction *p_parent_func) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -757,6 +757,23 @@ public:
 			ERR_FAIL_INDEX(members_indices[p_name], members.size());
 			members.write[members_indices[p_name]].enum_value.doc_data = p_doc_data;
 		}
+
+		const ClassNode *find_class(const String &p_fqcn) const {
+			if (fqcn == p_fqcn) {
+				return this;
+			}
+
+			for (const Member &member : members) {
+				if (member.type == Member::CLASS) {
+					const ClassNode *c = member.m_class->find_class(p_fqcn);
+					if (c != nullptr) {
+						return c;
+					}
+				}
+			}
+
+			return nullptr;
+		}
 #endif // TOOLS_ENABLED
 
 		bool resolved_interface = false;


### PR DESCRIPTION
This PR fixes a related issue to #23316. The original issue in that ticket could not be reproduced by me, but while attempting to reproduce, I found a related issue, that is detailed in the comments I made on that ticket (https://github.com/godotengine/godot/issues/23316#issuecomment-2241768666). It is also briefly outlined below.

I think we should not explicitly close above issue as fixed, however, as the originally described bug could not be reproduced.

# The Issue

When the editor analyzes a GDScript to find exported properties for display in the editor, it does populate a `member_cache`. Right now, this does not happen correctly for inner classes defined inside a script file with the `class` keyword. This leads to the bug that you cannot see inherited exported properties when they are inherited from an inner class.

`Foo.gd`
```gdscript
class_name Foo
extends Control

@export
var secret = 123

class Inner extends Control:
	@export
	var top_secret = 456
```

`Root.gd`
```gdscript
extends Foo

func _ready():
	for prop in get_property_list():
		if "secret" in prop.name:
			print(prop)
```

`RootInner.gd`
```gdscript
extends Foo.Inner

func _ready():
	for prop in get_property_list():
		if "secret" in prop.name:
			print(prop)
```

The two `Root*.gd` scripts are attached to scenes of analogous name. Running the scenes prints the respective property of the base class correctly.

The following screenshots show excerpts from the inspector pane.

`Root.tscn`
![Screenshot_2024-07-25_19-37-33](https://github.com/user-attachments/assets/9dc3d30c-9d39-4806-afd4-a14e3a788e08)

`RootInner.tscn`
![Screenshot_2024-07-25_19-38-21](https://github.com/user-attachments/assets/c2179751-eaaa-4ce6-acc6-55f91b2e7773)

# The Fix

The following changes have been made to fix the issue outlined above.

* `source_changed_cache` has been renamed to `_source_changed_cache`, and external access has been delegated to `mark_source_changed()`, which recursively marks the class and its inner classes (which share the same source file) as having changed source.
* In `_update_exports` we parse the containing script (in the case of inner classes, `get_root_script()`) and pick the relevant `ClassNode` from the resulting AST.
* `make_scripts` in the GDScript compiler marks sources changed if inner classes are detected. The other points that marked sources as changed before (most notably `GDScript::load_source_code`) are invoked too early to be able to modify not-yet-existing inner classes.
* I added a `find_class` helper to `ClassNode`, for looking up a descendant `ClassNode` with a given FQCN. I am aware of `find_class` on the parser class, but using this with the string obtained from `GDScript#fully_qualified_name` only ever yielded a `nullptr`. I assume this method uses a different format of qualified class name, but I did not investigate this any further so far.

The fix results in the following observable behavior in the case of `RootInner.tscn`:
![Screenshot_2024-07-25_19-46-51](https://github.com/user-attachments/assets/f689bc28-fc9d-44a6-afbe-1c61c1b007da)

No other observable behavior is produced.

Note how this view differs from the one in `Root.tscn` – This seems to be another issue with inner classes not being treated equally to file-scope classes. However, as this is only a cosmetic issue, only visible in this very specific setup, I think it is acceptable for now as a fix. Future work might deem it worthy to reconsider treatment of inner classes in general, but this is out of scope here.

# Considerations

All changes affect only `TOOLS_ENABLED` builds, and there were no discernible performance degradations.

I thought about testing this behavior, but I am not really deep in godot engine development, so I'm unsure how this behavior concerning the editor UI could be tested. If someone has an idea, I'm eager to implement that.