### PR TITLE
Some improvements for MinGW and LLVM build on Windows

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -495,6 +495,8 @@ def use_windows_spawn_fix(self, platform=None):
         rv = proc.wait()
         if rv:
             print_error(err)
+        elif len(err) > 0 and not err.isspace():
+            print(err)
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -20,7 +20,7 @@ def get_name():
     return "Windows"
 
 
-def try_cmd(test, prefix, arch):
+def try_cmd(test, prefix, arch, check_clang=False):
     archs = ["x86_64", "x86_32", "arm64", "arm32"]
     if arch:
         archs = [arch]
@@ -33,8 +33,10 @@ def try_cmd(test, prefix, arch):
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
             )
-            out.communicate()
+            outs, errs = out.communicate()
             if out.returncode == 0:
+                if check_clang and not outs.startswith(b"clang"):
+                    return False
                 return True
         except Exception:
             pass
@@ -640,6 +642,10 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = False
+
+    if not env["use_llvm"] and try_cmd("gcc --version", env["mingw_prefix"], env["arch"], True):
+        print("Detected GCC to be a wrapper for Clang.")
+        env["use_llvm"] = True
 
     # TODO: Re-evaluate the need for this / streamline with common config.
     if env["target"] == "template_release":

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -21,10 +21,14 @@ def get_name():
 
 
 def try_cmd(test, prefix, arch):
+    archs = ["x86_64", "x86_32", "arm64", "arm32"]
     if arch:
+        archs = [arch]
+
+    for a in archs:
         try:
             out = subprocess.Popen(
-                get_mingw_bin_prefix(prefix, arch) + test,
+                get_mingw_bin_prefix(prefix, a) + test,
                 shell=True,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
@@ -34,20 +38,6 @@ def try_cmd(test, prefix, arch):
                 return True
         except Exception:
             pass
-    else:
-        for a in ["x86_64", "x86_32", "arm64", "arm32"]:
-            try:
-                out = subprocess.Popen(
-                    get_mingw_bin_prefix(prefix, a) + test,
-                    shell=True,
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                )
-                out.communicate()
-                if out.returncode == 0:
-                    return True
-            except Exception:
-                pass
 
     return False
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -762,6 +762,8 @@ def configure_mingw(env: "SConsEnvironment"):
     if env["use_llvm"] and os.name == "nt" and methods._colorize:
         env.Append(CCFLAGS=["$(-fansi-escape-codes$)", "$(-fcolor-diagnostics$)"])
 
+    env.Append(ARFLAGS=["--thin"])
+
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(
         CPPDEFINES=[

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -759,6 +759,9 @@ def configure_mingw(env: "SConsEnvironment"):
         env.Append(CCFLAGS=san_flags)
         env.Append(LINKFLAGS=san_flags)
 
+    if env["use_llvm"] and os.name == "nt" and methods._colorize:
+        env.Append(CCFLAGS=["$(-fansi-escape-codes$)", "$(-fcolor-diagnostics$)"])
+
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(
         CPPDEFINES=[


### PR DESCRIPTION
This PR aims to improve the MinGW developer experience, especially for [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) on Windows:

- Detect llvm-mingw - this toolchain provides GCC-like wrappers (e.g. `x86_64-w64-mingw-gcc.exe`) that helps using the toolchain as a drop-in replacement of GCC, but because the Godot build has some special logic for LLVM based on the `use_llvm` option, it will be better if the build script detects this situation and automatically set `use_llvm=True`.
- Enable Clang colour output if supported on terminal (self explanatory)
- Use thin archives - full archive files take a lot of space (1.3 GB total) compared to thin archives (57 MB total). (This is with llvm-mingw doing an editor dev build, other builds may vary.)
    - Something to note is that the `--thin` flag is only supported for `llvm-ar` since LLVM 14 from 2022 (binutils `ar` has had it for ages). Do we need to support older LLVM versions? Adding a check for this would be annoying though.
- Print compiler warnings when building on Windows
- ...and some minor changes.
