### PR TITLE
Expose RenderingDevice::get_device_api_name() method to script.

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -505,6 +505,12 @@
 				Returns the vendor of the video adapter (e.g. "NVIDIA Corporation"). Equivalent to [method RenderingServer.get_video_adapter_vendor]. See also [method get_device_name].
 			</description>
 		</method>
+		<method name="get_device_api_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the api name of the video adapter (e.g. "Vulkan").
+			</description>
+		</method>
 		<method name="get_driver_resource">
 			<return type="int" />
 			<param index="0" name="resource" type="int" enum="RenderingDevice.DriverResource" />

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6022,6 +6022,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device_vendor_name"), &RenderingDevice::get_device_vendor_name);
 	ClassDB::bind_method(D_METHOD("get_device_name"), &RenderingDevice::get_device_name);
 	ClassDB::bind_method(D_METHOD("get_device_pipeline_cache_uuid"), &RenderingDevice::get_device_pipeline_cache_uuid);
+	ClassDB::bind_method(D_METHOD("get_device_api_name"), &RenderingDevice::get_device_api_name);
 
 	ClassDB::bind_method(D_METHOD("get_memory_usage", "type"), &RenderingDevice::get_memory_usage);
 


### PR DESCRIPTION
There's seems no direct way to get the current rendering api name. 
For example in some cases running game with cmdargs `--rendering-driver` overrided, `ProjectSettings.get_setting_with_override("rendering/rendering_device/driver")` won't return the actual api using.
