### PR TITLE
C#: Fix Vector3 `Slerp` normalization error

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -692,10 +692,18 @@ namespace Godot
                 // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
                 return Lerp(to, weight);
             }
+            Vector3 axis = Cross(to);
+            real_t axisLengthSquared = axis.LengthSquared();
+            if (axisLengthSquared == 0.0)
+            {
+                // Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
+                return Lerp(to, weight);
+            }
+            axis /= Mathf.Sqrt(axisLengthSquared);
             real_t startLength = Mathf.Sqrt(startLengthSquared);
             real_t resultLength = Mathf.Lerp(startLength, Mathf.Sqrt(endLengthSquared), weight);
             real_t angle = AngleTo(to);
-            return Rotated(Cross(to).Normalized(), angle * weight) * (resultLength / startLength);
+            return Rotated(axis, angle * weight) * (resultLength / startLength);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #94049 by adding a check of the rotation axis being the zero vector, and linearly interpolating if so.
The check already exists in the C++ implementation of Slerp, so this PR ports it to C#: https://github.com/godotengine/godot/blob/e343dbbcc1030f04dc5833f1c19d267a17332ca9/core/math/vector3.h#L238-L257

Sample problematic C# code I used for testing:
```
public override void _Ready()
{
  Vector3 vecA = new Vector3(0.12f, 0.12f, 0.12f);
  Vector3 vecB = new Vector3(0.512f, 0.512f, 0.512f);
  Vector3 vecC = new Vector3(-0.512f, -0.512f, -0.512f);
  GD.Print(vecA.Slerp(vecB, 0.5f));
  GD.Print(vecA.Slerp(vecC, 0.5f));
  Vector3 v1 = new Vector3(1,2,3);
  Vector3 v2 = new Vector3(2,4,6);
  Vector3 v3 = new Vector3(-3,-6,-9);
  GD.Print(v1.Slerp(v2, 0.5f));
  GD.Print(v1.Slerp(v3, 0.5f));
}
```
Console output (previously, it would crash on any of the print statements): 
```
(0.316, 0.316, 0.316)
(-0.19600001, -0.19600001, -0.19600001)
(1.5, 3, 4.5)
(-1, -2, -3)
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
