### PR TITLE
Fix unintended frustum culling

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1781,7 +1781,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 
 	{
 		mesh_preview = memnew(MeshInstance3D);
-		mesh_preview->set_custom_aabb(AABB(Vector3(-10000, -10000, -10000), Vector3(20000, 20000, 20000)));
+		RenderingServer::get_singleton()->instance_set_ignore_culling(mesh_preview->get_instance(), true);
 		base_viewport->add_child(mesh_preview);
 		mesh_preview->hide();
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1781,6 +1781,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 
 	{
 		mesh_preview = memnew(MeshInstance3D);
+		mesh_preview->set_custom_aabb(AABB(Vector3(-10000, -10000, -10000), Vector3(20000, 20000, 20000)));
 		base_viewport->add_child(mesh_preview);
 		mesh_preview->hide();
 


### PR DESCRIPTION
When view some models in scene import settings dialog, the subviewport will have some unintended frustum culling.
<img width="749" alt="image" src="https://github.com/user-attachments/assets/b367ad73-4fbc-4908-850b-b940cb0ed3cd">


Adding a custom aabb for the preview fix this bug.

<img width="749" alt="image" src="https://github.com/user-attachments/assets/0b9978b9-2c1e-4732-ac11-1562d3319437">


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
