### PR TITLE
Fix scene node selection problem when no auto expand

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1000,6 +1000,7 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 	TreeItem *item = p_node ? _find(tree->get_root(), p_node->get_path()) : nullptr;
 
 	if (item) {
+		selected = p_node;
 		if (auto_expand_selected) {
 			// Make visible when it's collapsed.
 			TreeItem *node = item->get_parent();
@@ -1009,8 +1010,24 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 			}
 			item->select(0);
 			item->set_as_cursor(0);
-			selected = p_node;
 			tree->ensure_cursor_is_visible();
+		} else {
+			// Ensure the node is selected and visible for the user if the node
+			// is not collapsed.
+			bool collapsed = false;
+			TreeItem *node = item;
+			while (node && node != tree->get_root()) {
+				if (node->is_collapsed()) {
+					collapsed = true;
+					break;
+				}
+				node = node->get_parent();
+			}
+			if (!collapsed) {
+				item->select(0);
+				item->set_as_cursor(0);
+				tree->ensure_cursor_is_visible();
+			}
 		}
 	} else {
 		if (!p_node) {


### PR DESCRIPTION
- Fixes #94467

When the option `Docks > Scene Tree > Auto Expand to Selected` was disabled, the `selected` node was not updated in the method `SceneTreeEditor::set_selected`. Additionally, even if the node was not collapsed, `tree->ensure_cursor_is_visible` was never called, preventing the user from seeing the node after its creation if the tree was long enough. The same problem was present when navigating with the back/forward buttons of the Inspector.

Problem reproduction:

https://github.com/user-attachments/assets/69bf5a63-2f90-428a-8265-492b9d2a2c00

https://github.com/user-attachments/assets/af6b5bbd-9856-48d2-b3ab-187c7fa34e5b


