### PR TITLE
Apply `prefer_wayland` only if no display driver is set

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2631,10 +2631,12 @@ Error Main::setup2(bool p_show_boot_logo) {
 						}
 					}
 
-					if (prefer_wayland) {
-						display_driver = "wayland";
-					} else {
-						display_driver = "default";
+					if (display_driver.is_empty()) {
+						if (prefer_wayland) {
+							display_driver = "wayland";
+						} else {
+							display_driver = "default";
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #94755.

Before this patch any other display driver preference would be overridden.

---

Regarding the `display_driver = "default"` line, it's there so that if the project uses Wayland and `prefer_wayland` is set to false the editor actually tries X11 first like I think the user would expect and the documentation implies.

I think that this option should probably be improved in the first place but we're on a release candidate :gdsweat: