### PR TITLE
Fix some non-gamepad devices opened as gamepads on Linux

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -361,7 +361,9 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		// Check if the device supports basic gamepad events
 		bool has_abs_left = (test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit));
 		bool has_abs_right = (test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit));
-		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right))) {
+		bool is_gamepad = test_bit(BTN_GAMEPAD, keybit);
+
+		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right)) || !is_gamepad) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
Fixes #94775 where some non-gamepad devices pass as gamepad devices. This commit brings an additional check to prevent this from happening