### PR TITLE
Add validation to glTF importer for Blendshape and Animation

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -288,14 +288,8 @@ String FBXDocument::_gen_unique_name(HashSet<String> &unique_names, const String
 }
 
 String FBXDocument::_sanitize_animation_name(const String &p_name) {
-	// Animations disallow the normal node invalid characters as well as  "," and "["
-	// (See animation/animation_player.cpp::add_animation)
-
-	// TODO: Consider adding invalid_characters or a validate_animation_name to animation_player to mirror Node.
 	String anim_name = p_name.validate_node_name();
-	anim_name = anim_name.replace(",", "");
-	anim_name = anim_name.replace("[", "");
-	return anim_name;
+	return AnimationLibrary::validate_library_name(anim_name);
 }
 
 String FBXDocument::_gen_unique_animation_name(Ref<FBXState> p_state, const String &p_name) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -472,14 +472,8 @@ String GLTFDocument::_gen_unique_name(Ref<GLTFState> p_state, const String &p_na
 }
 
 String GLTFDocument::_sanitize_animation_name(const String &p_name) {
-	// Animations disallow the normal node invalid characters as well as  "," and "["
-	// (See animation/animation_player.cpp::add_animation)
-
-	// TODO: Consider adding invalid_characters or a validate_animation_name to animation_player to mirror Node.
 	String anim_name = p_name.validate_node_name();
-	anim_name = anim_name.replace(",", "");
-	anim_name = anim_name.replace("[", "");
-	return anim_name;
+	return AnimationLibrary::validate_library_name(anim_name);
 }
 
 String GLTFDocument::_gen_unique_animation_name(Ref<GLTFState> p_state, const String &p_name) {

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -34,6 +34,7 @@
 #include "core/math/convex_hull.h"
 #include "core/math/random_pcg.h"
 #include "core/math/static_raycaster.h"
+#include "scene/resources/animation_library.h"
 #include "scene/resources/surface_tool.h"
 
 #include <cstdint>
@@ -134,9 +135,18 @@ void ImporterMesh::Surface::_split_normals(Array &r_arrays, const LocalVector<in
 	}
 }
 
+String ImporterMesh::validate_blend_shape_name(const String &p_name) {
+	String name = p_name;
+	const char *characters = ":";
+	for (const char *p = characters; *p; p++) {
+		name = name.replace(String::chr(*p), "_");
+	}
+	return name;
+}
+
 void ImporterMesh::add_blend_shape(const String &p_name) {
 	ERR_FAIL_COND(surfaces.size() > 0);
-	blend_shapes.push_back(p_name);
+	blend_shapes.push_back(validate_blend_shape_name(p_name));
 }
 
 int ImporterMesh::get_blend_shape_count() const {

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -93,6 +93,8 @@ public:
 	int get_blend_shape_count() const;
 	String get_blend_shape_name(int p_blend_shape) const;
 
+	static String validate_blend_shape_name(const String &p_name);
+
 	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint64_t p_flags = 0);
 	int get_surface_count() const;
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/94740

I don't know if there are other places where this is needed, but these related to animation need to be validated as they can break the Track path.

I am not sure if this needs to be punt to 4.4, as it breaks compatibility but is an invalid property name to begin with; `:` is used by type annotation and subpath.