### PR TITLE
[Tests] Add check for argument name validity

### DIFF
--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -414,6 +414,9 @@ void validate_argument(const Context &p_context, const ExposedClass &p_class, co
 #ifdef DEBUG_METHODS_ENABLED
 	TEST_COND((p_arg.name.is_empty() || p_arg.name.begins_with("_unnamed_arg")),
 			vformat("Unnamed argument in position %d of %s '%s.%s'.", p_arg.position, p_owner_type, p_class.name, p_owner_name));
+
+	TEST_FAIL_COND((p_arg.name != "@varargs@" && !p_arg.name.is_valid_ascii_identifier()),
+			vformat("Invalid argument name '%s' of %s '%s.%s'.", p_arg.name, p_owner_type, p_class.name, p_owner_name));
 #endif // DEBUG_METHODS_ENABLED
 
 	const ExposedClass *arg_class = p_context.find_exposed_class(p_arg.type);


### PR DESCRIPTION
Checks that all method and signal arguments have valid names

See:
* https://github.com/godotengine/godot-cpp/issues/1536

I'd say a check in unit tests should suffice, but we could add checks in the API dump as well but we'd need to add some more for class, method, and signal names etc., which would double with the unit tests so I'd say the unit tests should cover the API
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
