### PR TITLE
Fix autoload node cannot be accessed by plugin on start-up

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -457,7 +457,9 @@ void EditorAutoloadSettings::init_autoloads() {
 
 	for (const AutoloadInfo &info : autoload_cache) {
 		if (info.node && info.in_editor) {
-			callable_mp((Node *)get_tree()->get_root(), &Node::add_child).call_deferred(info.node, false, Node::INTERNAL_MODE_DISABLED);
+			// It's important to add the node without deferring because code in plugins or tool scripts
+			// could use the autoload node when they are enabled.
+			get_tree()->get_root()->add_child(info.node);
 		}
 	}
 }


### PR DESCRIPTION
- Fixes #77037

I was testing if #92667 fixes the issue #77037. Unfortunately, it does not.

But, I think the issue was caused by that:
- When the editor is already running, calling `add_autoload_singleton` creates and adds the autoload into the scene tree directly. So, the `get_node("/root/" + AUTOLOAD_NAME)` works fine. The autoload is now in the project settings.
- When the editor is restarted, now that the autoload is in the project settings, the autoload is created before the plugin init but the `add_child` to the scene is deferred in `EditorAutoloadSettings::init_autoloads`:
```
callable_mp((Node *)get_tree()->get_root(), &Node::add_child).call_deferred(info.node, false, Node::INTERNAL_MODE_DISABLED);
```
Then, the plugin is initialized and added to the scene and oups, we are in a situation where the plugin `_entre_tree` is executed before the autoload is added the the scene.

So, the solution was to call add_child directly, no deferred in `EditorAutoloadSettings::init_autoloads`. I think that was not possible before #92303 because the autoloads were created way earlier.

This is a simple MRP to reproduce the problem:
[test-godot-plugin-autoload-with-resource.zip](https://github.com/user-attachments/files/16392922/test-godot-plugin-autoload-with-resource.zip)


Note: This is an alternative solution to #86453 that fixes the problem without changing any loading order.
