### PR TITLE
Improve local debugger quitting

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -267,8 +267,23 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				print_line("Added breakpoint at " + source + ":" + itos(linenr));
 			}
 
-		} else if (line == "q" || line == "quit" ||
+		} else if (line.begins_with("q") || line.begins_with("quit") ||
 				(line.is_empty() && feof(stdin))) {
+			int exit_code = EXIT_FAILURE;
+			if (line.get_slice_count(" ") > 1) {
+				String value = line.get_slicec(' ', 1);
+				if (!value.is_numeric()) {
+					print_line("Error: Invalid exit code '" + value + "'.");
+					continue;
+				}
+
+				exit_code = value.to_int();
+				if (exit_code < 0) {
+					print_line("Error: Invalid exit code " + itos(exit_code) + ".");
+					continue;
+				}
+			}
+
 			// Do not stop again on quit
 			script_debugger->clear_breakpoints();
 			script_debugger->set_depth(-1);
@@ -276,7 +291,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			MainLoop *main_loop = OS::get_singleton()->get_main_loop();
 			if (main_loop->get_class() == "SceneTree") {
-				main_loop->call("quit", EXIT_FAILURE);
+				main_loop->call("quit", exit_code);
 			}
 			break;
 		} else if (line.begins_with("delete")) {
@@ -312,7 +327,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			print_line("\tbr,break [source:line]\t List all breakpoints or place a breakpoint.");
 			print_line("\tdelete [source:line]:\t Delete one/all breakpoints.");
 			print_line("\tset [key=value]:\t List all options, or set one.");
-			print_line("\tq,quit\t\t\t Quit application.");
+			print_line("\tq,quit [exit_code]\t\t Quit application.");
 		} else {
 			print_line("Error: Invalid command, enter \"help\" for assistance.");
 		}

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -276,7 +276,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			MainLoop *main_loop = OS::get_singleton()->get_main_loop();
 			if (main_loop->get_class() == "SceneTree") {
-				main_loop->call("quit");
+				main_loop->call("quit", EXIT_FAILURE);
 			}
 			break;
 		} else if (line.begins_with("delete")) {

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -292,6 +292,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			MainLoop *main_loop = OS::get_singleton()->get_main_loop();
 			if (main_loop->get_class() == "SceneTree") {
 				main_loop->call("quit", exit_code);
+				ScriptServer::set_scripting_enabled(false);
 			}
 			break;
 		} else if (line.begins_with("delete")) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -686,6 +686,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #else
 	OPCODE_WHILE(true) {
 #endif
+		if (!ScriptServer::is_scripting_enabled()) {
+#ifdef DEBUG_ENABLED
+			exit_ok = true;
+#endif
+			OPCODE_BREAK;
+		}
 
 		OPCODE_SWITCH(_code_ptr[ip]) {
 			OPCODE(OPCODE_OPERATOR) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Currently if you `quit` from the debugger, it shuts down the `SceneTree` main loop. That may not stop the program since the GDScript engine is still processing operations. To prevent that, also disable scripting and have GDScript check if scripting is enabled in each iteration of the VM.

A related issue is that Godot exits successfully when quitting from the debugger. Since `--debug` is the only way to get Godot to stop on script errors, it's quite useful for testing your game. Unfortunately, with a successful exit code, there's no way to detect failures besides inspecting the output. Instead, have `quit` exit with a failure by default but allow the caller to specify their desired exit code. This allows running tests from CI like `godot --debug --path . --headless --script myscript.gd </dev/null` and knowing that the process will fail on any script errors.

Fixes: #51387