### PR TITLE
Fix Android export failing with custom keystores and no JDK setup in the OS environment

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2323,7 +2323,8 @@ static bool has_valid_keystore_credentials(String &r_error_str, const String &p_
 	args.push_back(p_password);
 	args.push_back("-alias");
 	args.push_back(p_username);
-	Error error = OS::get_singleton()->execute("keytool", args, &output, nullptr, true);
+	String keytool_path = EditorExportPlatformAndroid::get_keytool_path();
+	Error error = OS::get_singleton()->execute(keytool_path, args, &output, nullptr, true);
 	String keytool_error = "keytool error:";
 	bool valid = output.substr(0, keytool_error.length()) != keytool_error;
 


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/94815

## Test environment
Godot Engine v4.3.rc1.official
Windows 11 Pro, Version 23H2, Build 22631.3880

## Issue
Export for Android fails on Windows if there is no path to a JDK set in the PATH environment variable and debug and/or release keystores have been set in the options dialg of the export window.  
This issue should also affect other operating systems but i have only tested in windows.
The error message printed in the console looks like this:

```
Could not create child process: keytool -list -keystore ******** -storepass ******** -alias ********
```

## Fix
The reason for this is that the static function **has_valid_keystore_credentials** in ```platform/android/export/export_plugin.cpp``` runs the hardcoded **"keytool"** command instead of using **get_keytool_path** to get the correct path that uses the ```export/android/java_sdk_path``` setting.  
The proposed fix replaces all occurrences of the hardcoded **"keytool"** with a string returned by **get_keytool_path**.