### PR TITLE
Emit `normal_roughness` compatibility code in custom functions

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1286,6 +1286,13 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 													break;
 												}
 												if (function->arguments[j].tex_argument_check) {
+													if (function->arguments[j].tex_hint == ShaderLanguage::ShaderNode::Uniform::HINT_SCREEN_TEXTURE) {
+														is_screen_texture = true;
+													} else if (function->arguments[j].tex_hint == ShaderLanguage::ShaderNode::Uniform::HINT_DEPTH_TEXTURE) {
+														is_depth_texture = true;
+													} else if (function->arguments[j].tex_hint == ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL_ROUGHNESS_TEXTURE) {
+														is_normal_roughness_texture = true;
+													}
 													sampler_name = _get_sampler_name(function->arguments[j].tex_argument_filter, function->arguments[j].tex_argument_repeat);
 													found = true;
 													break;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4761,7 +4761,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_functi
 	return false;
 }
 
-bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(const StringName &p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat) {
+bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(const StringName &p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat, ShaderNode::Uniform::Hint p_hint) {
 	for (int i = 0; i < shader->vfunctions.size(); i++) {
 		if (shader->vfunctions[i].name == p_name) {
 			ERR_FAIL_INDEX_V(p_argument, shader->vfunctions[i].function->arguments.size(), false);
@@ -4770,20 +4770,21 @@ bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(const Str
 				_set_error(vformat(RTR("Sampler argument %d of function '%s' called more than once using both built-ins and uniform textures, this is not supported (use either one or the other)."), p_argument, String(p_name)));
 				return false;
 			} else if (arg->tex_argument_check) {
-				//was checked, verify that filter and repeat are the same
-				if (arg->tex_argument_filter == p_filter && arg->tex_argument_repeat == p_repeat) {
+				// Was checked, verify that filter, repeat, and hint are the same.
+				if (arg->tex_argument_filter == p_filter && arg->tex_argument_repeat == p_repeat && arg->tex_hint == p_hint) {
 					return true;
 				} else {
-					_set_error(vformat(RTR("Sampler argument %d of function '%s' called more than once using textures that differ in either filter or repeat setting."), p_argument, String(p_name)));
+					_set_error(vformat(RTR("Sampler argument %d of function '%s' called more than once using textures that differ in either filter, repeat, or texture hint setting."), p_argument, String(p_name)));
 					return false;
 				}
 			} else {
 				arg->tex_argument_check = true;
 				arg->tex_argument_filter = p_filter;
 				arg->tex_argument_repeat = p_repeat;
+				arg->tex_hint = p_hint;
 				for (KeyValue<StringName, HashSet<int>> &E : arg->tex_argument_connect) {
 					for (const int &F : E.value) {
-						if (!_propagate_function_call_sampler_uniform_settings(E.key, F, p_filter, p_repeat)) {
+						if (!_propagate_function_call_sampler_uniform_settings(E.key, F, p_filter, p_repeat, p_hint)) {
 							return false;
 						}
 					}
@@ -5583,7 +5584,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 											}
 
 											//propagate
-											if (!_propagate_function_call_sampler_uniform_settings(name, i, u->filter, u->repeat)) {
+											if (!_propagate_function_call_sampler_uniform_settings(name, i, u->filter, u->repeat, u->hint)) {
 												return nullptr;
 											}
 										} else if (p_function_info.built_ins.has(varname)) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -578,42 +578,6 @@ public:
 				Node(NODE_TYPE_STRUCT) {}
 	};
 
-	struct FunctionNode : public Node {
-		struct Argument {
-			ArgumentQualifier qualifier;
-			StringName name;
-			DataType type;
-			StringName struct_name;
-			DataPrecision precision;
-			//for passing textures as arguments
-			bool tex_argument_check;
-			TextureFilter tex_argument_filter;
-			TextureRepeat tex_argument_repeat;
-			bool tex_builtin_check;
-			StringName tex_builtin;
-			bool is_const;
-			int array_size;
-
-			HashMap<StringName, HashSet<int>> tex_argument_connect;
-		};
-
-		StringName name;
-		DataType return_type = TYPE_VOID;
-		StringName return_struct_name;
-		DataPrecision return_precision = PRECISION_DEFAULT;
-		int return_array_size = 0;
-		Vector<Argument> arguments;
-		BlockNode *body = nullptr;
-		bool can_discard = false;
-
-		virtual DataType get_datatype() const override { return return_type; }
-		virtual String get_datatype_name() const override { return String(return_struct_name); }
-		virtual int get_array_size() const override { return return_array_size; }
-
-		FunctionNode() :
-				Node(NODE_TYPE_FUNCTION) {}
-	};
-
 	struct ShaderNode : public Node {
 		struct Constant {
 			StringName name;
@@ -720,6 +684,43 @@ public:
 
 		ShaderNode() :
 				Node(NODE_TYPE_SHADER) {}
+	};
+
+	struct FunctionNode : public Node {
+		struct Argument {
+			ArgumentQualifier qualifier;
+			StringName name;
+			DataType type;
+			StringName struct_name;
+			DataPrecision precision;
+			//for passing textures as arguments
+			bool tex_argument_check;
+			TextureFilter tex_argument_filter;
+			TextureRepeat tex_argument_repeat;
+			bool tex_builtin_check;
+			StringName tex_builtin;
+			ShaderNode::Uniform::Hint tex_hint;
+			bool is_const;
+			int array_size;
+
+			HashMap<StringName, HashSet<int>> tex_argument_connect;
+		};
+
+		StringName name;
+		DataType return_type = TYPE_VOID;
+		StringName return_struct_name;
+		DataPrecision return_precision = PRECISION_DEFAULT;
+		int return_array_size = 0;
+		Vector<Argument> arguments;
+		BlockNode *body = nullptr;
+		bool can_discard = false;
+
+		virtual DataType get_datatype() const override { return return_type; }
+		virtual String get_datatype_name() const override { return String(return_struct_name); }
+		virtual int get_array_size() const override { return return_array_size; }
+
+		FunctionNode() :
+				Node(NODE_TYPE_FUNCTION) {}
 	};
 
 	struct UniformOrderComparator {
@@ -1122,7 +1123,7 @@ private:
 
 	bool _validate_function_call(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, DataType *r_ret_type, StringName *r_ret_type_str, bool *r_is_custom_function = nullptr);
 	bool _parse_function_arguments(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, int *r_complete_arg = nullptr);
-	bool _propagate_function_call_sampler_uniform_settings(const StringName &p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat);
+	bool _propagate_function_call_sampler_uniform_settings(const StringName &p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat, ShaderNode::Uniform::Hint p_hint);
 	bool _propagate_function_call_sampler_builtin_reference(const StringName &p_name, int p_argument, const StringName &p_builtin);
 	bool _validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message);
 	bool _check_node_constness(const Node *p_node) const;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/94777

When reading from the normal_roughness buffer we need to emit compatibility code to ensure that the user gets proper normals even though the texture is stored in a custom format. 

In master the compatibility code is only added when the normal_roughness uniform is used directly. When the normal_roughness uniform is passed as an argument to a custom function the compatibility code is not used. 

This PR does two things:
1. It checks if the source of the argument is a a screen_texture and emits the compatibility code if it is
2. It bans passing a screen texture to custom function if the custom function is already used with a non-screen texture (we already had this logic in place for when two uniforms were used with different filter or roughness settings)

As a bonus, we can now undo the restriction added in https://github.com/godotengine/godot/pull/72300 which forbid passing screen textures to custom functions when using XR shaders. 