### PR TITLE
Add "Snap To Pixel True Center" option

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -604,6 +604,9 @@
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled" default="false">
 			If [code]true[/code], the object draws behind its parent.
 		</member>
+		<member name="snap_to_pixel" type="int" setter="set_snap_to_pixel" getter="get_snap_to_pixel" enum="CanvasItem.SnapToPixel" default="0">
+			The snapping to pixel mode to use on this [CanvasItem].
+		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="CanvasItem.TextureFilter" default="0">
 			The texture filtering mode to use on this [CanvasItem].
 		</member>
@@ -735,6 +738,18 @@
 		</constant>
 		<constant name="CLIP_CHILDREN_MAX" value="3" enum="ClipChildrenMode">
 			Represents the size of the [enum ClipChildrenMode] enum.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_PARENT_NODE" value="0" enum="SnapToPixel">
+			The [CanvasItem] will inherit the snapping mode from its parent.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_DISABLED" value="1" enum="SnapToPixel">
+			The [CanvasItem] will not snap.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_ENABLED" value="2" enum="SnapToPixel">
+			The [CanvasItem] will snap.
+		</constant>
+		<constant name="SNAP_TO_PIXEL_MAX" value="3" enum="SnapToPixel">
+			Represents the size of the [enum SnapToPixel] enum.
 		</constant>
 	</constants>
 </class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -659,6 +659,7 @@ void EditorNode::_notification(int p_what) {
 			get_tree()->get_root()->set_as_audio_listener_3d(false);
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
+			get_tree()->get_root()->set_snap_2d_transforms_to_pixel_true_center(false);
 			get_tree()->get_root()->set_snap_2d_vertices_to_pixel(false);
 			get_tree()->set_auto_accept_quit(false);
 #ifdef ANDROID_ENABLED

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -266,10 +266,6 @@ void AnimatedSprite2D::_notification(int p_what) {
 				ofs -= s / 2;
 			}
 
-			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = (ofs + Point2(0.5, 0.5)).floor();
-			}
-
 			Rect2 dst_rect(ofs, s);
 
 			if (hflip) {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -97,10 +97,6 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 		dest_offset -= frame_size / 2;
 	}
 
-	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = (dest_offset + Point2(0.5, 0.5)).floor();
-	}
-
 	r_dst_rect = Rect2(dest_offset, frame_size);
 
 	if (hflip) {
@@ -397,10 +393,6 @@ Rect2 Sprite2D::get_rect() const {
 	Point2 ofs = offset;
 	if (centered) {
 		ofs -= Size2(s) / 2;
-	}
-
-	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = (ofs + Point2(0.5, 0.5)).floor();
 	}
 
 	if (s == Size2(0, 0)) {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -73,6 +73,13 @@ public:
 		CLIP_CHILDREN_MAX,
 	};
 
+	enum SnapToPixel {
+		SNAP_TO_PIXEL_PARENT_NODE,
+		SNAP_TO_PIXEL_DISABLED,
+		SNAP_TO_PIXEL_ENABLED,
+		SNAP_TO_PIXEL_MAX,
+	};
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -112,8 +119,10 @@ private:
 
 	mutable RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	mutable RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+	mutable RS::CanvasItemSnapToPixel snap_to_pixel_cache = RS::CANVAS_ITEM_SNAP_TO_PIXEL_DISABLED;
 	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
 	TextureRepeat texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
+	SnapToPixel snap_to_pixel = SNAP_TO_PIXEL_PARENT_NODE;
 
 	Ref<Material> material;
 
@@ -148,12 +157,15 @@ private:
 	void _update_texture_repeat_changed(bool p_propagate);
 	void _refresh_texture_filter_cache() const;
 	void _update_texture_filter_changed(bool p_propagate);
+	void _refresh_snap_to_pixel_cache() const;
+	void _update_snap_to_pixel_changed(bool p_propagate);
 
 	void _notify_transform_deferred();
 
 protected:
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat);
 	virtual void _update_self_texture_filter(RS::CanvasItemTextureFilter p_texture_filter);
+	virtual void _update_self_snap_to_pixel(RS::CanvasItemSnapToPixel p_snap);
 
 	_FORCE_INLINE_ void _notify_transform() {
 		_notify_transform(this);
@@ -380,6 +392,9 @@ public:
 	int get_canvas_layer() const;
 	CanvasLayer *get_canvas_layer_node() const;
 
+	virtual void set_snap_to_pixel(SnapToPixel p_snap_to_pixel);
+	SnapToPixel get_snap_to_pixel() const;
+
 	CanvasItem();
 	~CanvasItem();
 };
@@ -387,6 +402,7 @@ public:
 VARIANT_ENUM_CAST(CanvasItem::TextureFilter)
 VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
+VARIANT_ENUM_CAST(CanvasItem::SnapToPixel)
 
 class CanvasTexture : public Texture2D {
 	GDCLASS(CanvasTexture, Texture2D);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -80,6 +80,13 @@ public:
 		SNAP_TO_PIXEL_MAX,
 	};
 
+	enum SnapToPixelTrueCenter {
+		SNAP_TO_PIXEL_TRUE_CENTER_PARENT_NODE,
+		SNAP_TO_PIXEL_TRUE_CENTER_DISABLED,
+		SNAP_TO_PIXEL_TRUE_CENTER_ENABLED,
+		SNAP_TO_PIXEL_TRUE_CENTER_MAX,
+	};
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -120,9 +127,11 @@ private:
 	mutable RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	mutable RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 	mutable RS::CanvasItemSnapToPixel snap_to_pixel_cache = RS::CANVAS_ITEM_SNAP_TO_PIXEL_DISABLED;
+	mutable RS::CanvasItemSnapToPixelTrueCenter snap_to_pixel_true_center_cache = RS::CANVAS_ITEM_SNAP_TO_PIXEL_TRUE_CENTER_DISABLED;
 	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
 	TextureRepeat texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
 	SnapToPixel snap_to_pixel = SNAP_TO_PIXEL_PARENT_NODE;
+	SnapToPixelTrueCenter snap_to_pixel_true_center = SNAP_TO_PIXEL_TRUE_CENTER_PARENT_NODE;
 
 	Ref<Material> material;
 
@@ -159,6 +168,8 @@ private:
 	void _update_texture_filter_changed(bool p_propagate);
 	void _refresh_snap_to_pixel_cache() const;
 	void _update_snap_to_pixel_changed(bool p_propagate);
+	void _refresh_snap_to_pixel_true_center_cache() const;
+	void _update_snap_to_pixel_true_center_changed(bool p_propagate);
 
 	void _notify_transform_deferred();
 
@@ -166,6 +177,7 @@ protected:
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat);
 	virtual void _update_self_texture_filter(RS::CanvasItemTextureFilter p_texture_filter);
 	virtual void _update_self_snap_to_pixel(RS::CanvasItemSnapToPixel p_snap);
+	virtual void _update_self_snap_to_pixel_true_center(RS::CanvasItemSnapToPixelTrueCenter p_snap_true_center);
 
 	_FORCE_INLINE_ void _notify_transform() {
 		_notify_transform(this);
@@ -395,6 +407,9 @@ public:
 	virtual void set_snap_to_pixel(SnapToPixel p_snap_to_pixel);
 	SnapToPixel get_snap_to_pixel() const;
 
+	virtual void set_snap_to_pixel_true_center(SnapToPixelTrueCenter p_snap_to_pixel_true_center);
+	SnapToPixelTrueCenter get_snap_to_pixel_true_center() const;
+
 	CanvasItem();
 	~CanvasItem();
 };
@@ -403,6 +418,7 @@ VARIANT_ENUM_CAST(CanvasItem::TextureFilter)
 VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
 VARIANT_ENUM_CAST(CanvasItem::SnapToPixel)
+VARIANT_ENUM_CAST(CanvasItem::SnapToPixelTrueCenter)
 
 class CanvasTexture : public Texture2D {
 	GDCLASS(CanvasTexture, Texture2D);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1797,6 +1797,9 @@ SceneTree::SceneTree() {
 	bool snap_2d_transforms = GLOBAL_DEF_BASIC("rendering/2d/snap/snap_2d_transforms_to_pixel", false);
 	root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
 
+	bool snap_2d_transforms_true_center = GLOBAL_DEF_BASIC("rendering/2d/snap/snap_2d_transforms_to_pixel_true_center", false);
+	root->set_snap_2d_transforms_to_pixel_true_center(snap_2d_transforms_true_center);
+
 	bool snap_2d_vertices = GLOBAL_DEF("rendering/2d/snap/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3576,6 +3576,17 @@ bool Viewport::is_snap_2d_transforms_to_pixel_enabled() const {
 	return snap_2d_transforms_to_pixel;
 }
 
+void Viewport::set_snap_2d_transforms_to_pixel_true_center(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+	snap_2d_transforms_to_pixel_true_center = p_enable;
+	RS::get_singleton()->viewport_set_snap_2d_transforms_to_pixel_true_center(viewport, snap_2d_transforms_to_pixel_true_center);
+}
+
+bool Viewport::is_snap_2d_transforms_to_pixel_true_center_enabled() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return snap_2d_transforms_to_pixel_true_center;
+}
+
 void Viewport::set_snap_2d_vertices_to_pixel(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	snap_2d_vertices_to_pixel = p_enable;
@@ -4729,6 +4740,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_snap_2d_transforms_to_pixel", "enabled"), &Viewport::set_snap_2d_transforms_to_pixel);
 	ClassDB::bind_method(D_METHOD("is_snap_2d_transforms_to_pixel_enabled"), &Viewport::is_snap_2d_transforms_to_pixel_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_snap_2d_transforms_to_pixel_true_center", "enabled"), &Viewport::set_snap_2d_transforms_to_pixel_true_center);
+	ClassDB::bind_method(D_METHOD("is_snap_2d_transforms_to_pixel_true_center_enabled"), &Viewport::is_snap_2d_transforms_to_pixel_true_center_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_snap_2d_vertices_to_pixel", "enabled"), &Viewport::set_snap_2d_vertices_to_pixel);
 	ClassDB::bind_method(D_METHOD("is_snap_2d_vertices_to_pixel_enabled"), &Viewport::is_snap_2d_vertices_to_pixel_enabled);
 
@@ -4820,6 +4834,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent_bg"), "set_transparent_background", "has_transparent_background");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_transforms_to_pixel"), "set_snap_2d_transforms_to_pixel", "is_snap_2d_transforms_to_pixel_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_transforms_to_pixel_true_center"), "set_snap_2d_transforms_to_pixel_true_center", "is_snap_2d_transforms_to_pixel_true_center_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_vertices_to_pixel"), "set_snap_2d_vertices_to_pixel", "is_snap_2d_vertices_to_pixel_enabled");
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msaa_2d", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),2× (Average),4× (Slow),8× (Slowest)")), "set_msaa_2d", "get_msaa_2d");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -255,6 +255,7 @@ private:
 
 	bool snap_controls_to_pixels = true;
 	bool snap_2d_transforms_to_pixel = false;
+	bool snap_2d_transforms_to_pixel_true_center = false;
 	bool snap_2d_vertices_to_pixel = false;
 
 	bool physics_object_picking = false;
@@ -612,6 +613,9 @@ public:
 
 	void set_snap_2d_transforms_to_pixel(bool p_enable);
 	bool is_snap_2d_transforms_to_pixel_enabled() const;
+
+	void set_snap_2d_transforms_to_pixel_true_center(bool p_enable);
+	bool is_snap_2d_transforms_to_pixel_true_center_enabled() const;
 
 	void set_snap_2d_vertices_to_pixel(bool p_enable);
 	bool is_snap_2d_vertices_to_pixel_enabled() const;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -285,7 +285,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		rect.position -= repeat_size / scale * (repeat_times / 2);
 	}
 
-	if (snapping_2d_transforms_to_pixel) {
+	if ((p_canvas_item->snap_to_pixel == RS::CANVAS_ITEM_SNAP_TO_PIXEL_DEFAULT && snapping_2d_transforms_to_pixel) || (p_canvas_item->snap_to_pixel == RS::CANVAS_ITEM_SNAP_TO_PIXEL_ENABLED)) {
 		Size2 scale = final_xform.get_scale().snappedf(0.0001);
 		Point2 abs_scaled_position = (rect.position * scale).abs();
 		Point2 odd_sized_correction = Point2(
@@ -2325,6 +2325,12 @@ void RendererCanvasCull::canvas_item_set_default_texture_repeat(RID p_item, RS::
 	Item *ci = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(ci);
 	ci->texture_repeat = p_repeat;
+}
+
+void RendererCanvasCull::canvas_item_set_snap_to_pixel(RID p_item, RS::CanvasItemSnapToPixel p_snap) {
+	Item *ci = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(ci);
+	ci->snap_to_pixel = p_snap;
 }
 
 void RendererCanvasCull::update_visibility_notifiers() {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -292,8 +292,11 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		Point2 remainder = Point2(
 				Math::fmod(rect_position_scaled.x, 1.0l),
 				Math::fmod(rect_position_scaled.y, 1.0l));
-		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder;
-		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder;
+		Point2 remainder_leftover = Point2(
+				Math::fmod(remainder.x / rect_scale.x, 1.0l),
+				Math::fmod(remainder.y / rect_scale.y, 1.0l));
+		final_xform.columns[2] = (final_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder_leftover;
+		parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor() - remainder_leftover;
 	}
 
 	final_xform = parent_xform * final_xform;

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -339,6 +339,7 @@ public:
 
 	void canvas_item_set_default_texture_filter(RID p_item, RS::CanvasItemTextureFilter p_filter);
 	void canvas_item_set_default_texture_repeat(RID p_item, RS::CanvasItemTextureRepeat p_repeat);
+	void canvas_item_set_snap_to_pixel(RID p_item, RS::CanvasItemSnapToPixel p_snap);
 
 	void update_visibility_notifiers();
 

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -176,6 +176,7 @@ public:
 	bool disable_scale;
 	bool sdf_used = false;
 	bool snapping_2d_transforms_to_pixel = false;
+	bool snapping_2d_transforms_to_pixel_true_center = false;
 
 	bool debug_redraw = false;
 	double debug_redraw_time = 0;
@@ -196,7 +197,7 @@ private:
 	RendererCanvasRender::Item **z_last_list;
 
 public:
-	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
+	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_transforms_to_pixel_true_center, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
 
 	bool was_sdf_used();
 
@@ -340,6 +341,7 @@ public:
 	void canvas_item_set_default_texture_filter(RID p_item, RS::CanvasItemTextureFilter p_filter);
 	void canvas_item_set_default_texture_repeat(RID p_item, RS::CanvasItemTextureRepeat p_repeat);
 	void canvas_item_set_snap_to_pixel(RID p_item, RS::CanvasItemSnapToPixel p_snap);
+	void canvas_item_set_snap_to_pixel_true_center(RID p_item, RS::CanvasItemSnapToPixelTrueCenter p_snap_true_center);
 
 	void update_visibility_notifiers();
 

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -458,6 +458,7 @@ public:
 
 		RS::CanvasItemTextureFilter texture_filter;
 		RS::CanvasItemTextureRepeat texture_repeat;
+		RS::CanvasItemSnapToPixel snap_to_pixel;
 
 		Item() {
 			commands = nullptr;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -459,6 +459,7 @@ public:
 		RS::CanvasItemTextureFilter texture_filter;
 		RS::CanvasItemTextureRepeat texture_repeat;
 		RS::CanvasItemSnapToPixel snap_to_pixel;
+		RS::CanvasItemSnapToPixelTrueCenter snap_to_pixel_true_center;
 
 		Item() {
 			commands = nullptr;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -613,7 +613,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				ptr = ptr->filter_next_ptr;
 			}
 
-			RSG::canvas->render_canvas(p_viewport->render_target, canvas, xform, canvas_lights, canvas_directional_lights, clip_rect, p_viewport->texture_filter, p_viewport->texture_repeat, p_viewport->snap_2d_transforms_to_pixel, p_viewport->snap_2d_vertices_to_pixel, p_viewport->canvas_cull_mask, &p_viewport->render_info);
+			RSG::canvas->render_canvas(p_viewport->render_target, canvas, xform, canvas_lights, canvas_directional_lights, clip_rect, p_viewport->texture_filter, p_viewport->texture_repeat, p_viewport->snap_2d_transforms_to_pixel, p_viewport->snap_2d_transforms_to_pixel_true_center, p_viewport->snap_2d_vertices_to_pixel, p_viewport->canvas_cull_mask, &p_viewport->render_info);
 			if (RSG::canvas->was_sdf_used()) {
 				p_viewport->sdf_active = true;
 			}
@@ -1405,6 +1405,12 @@ void RendererViewport::viewport_set_snap_2d_transforms_to_pixel(RID p_viewport, 
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_NULL(viewport);
 	viewport->snap_2d_transforms_to_pixel = p_enabled;
+}
+
+void RendererViewport::viewport_set_snap_2d_transforms_to_pixel_true_center(RID p_viewport, bool p_enabled) {
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
+	ERR_FAIL_NULL(viewport);
+	viewport->snap_2d_transforms_to_pixel_true_center = p_enabled;
 }
 
 void RendererViewport::viewport_set_snap_2d_vertices_to_pixel(RID p_viewport, bool p_enabled) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -94,6 +94,7 @@ public:
 		bool measure_render_time = false;
 
 		bool snap_2d_transforms_to_pixel = false;
+		bool snap_2d_transforms_to_pixel_true_center = false;
 		bool snap_2d_vertices_to_pixel = false;
 
 		uint64_t time_cpu_begin;
@@ -288,6 +289,7 @@ public:
 	float viewport_get_measured_render_time_gpu(RID p_viewport) const;
 
 	void viewport_set_snap_2d_transforms_to_pixel(RID p_viewport, bool p_enabled);
+	void viewport_set_snap_2d_transforms_to_pixel_true_center(RID p_viewport, bool p_enabled);
 	void viewport_set_snap_2d_vertices_to_pixel(RID p_viewport, bool p_enabled);
 
 	void viewport_set_default_canvas_item_texture_filter(RID p_viewport, RS::CanvasItemTextureFilter p_filter);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -883,6 +883,8 @@ public:
 
 	FUNC2(canvas_item_set_draw_behind_parent, RID, bool)
 
+	FUNC2(canvas_item_set_snap_to_pixel, RID, CanvasItemSnapToPixel)
+
 	FUNC6(canvas_item_add_line, RID, const Point2 &, const Point2 &, const Color &, float, bool)
 	FUNC5(canvas_item_add_polyline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)
 	FUNC5(canvas_item_add_multiline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -640,6 +640,7 @@ public:
 	FUNC2(viewport_set_transparent_background, RID, bool)
 	FUNC2(viewport_set_use_hdr_2d, RID, bool)
 	FUNC2(viewport_set_snap_2d_transforms_to_pixel, RID, bool)
+	FUNC2(viewport_set_snap_2d_transforms_to_pixel_true_center, RID, bool)
 	FUNC2(viewport_set_snap_2d_vertices_to_pixel, RID, bool)
 
 	FUNC2(viewport_set_default_canvas_item_texture_filter, RID, CanvasItemTextureFilter)
@@ -884,6 +885,7 @@ public:
 	FUNC2(canvas_item_set_draw_behind_parent, RID, bool)
 
 	FUNC2(canvas_item_set_snap_to_pixel, RID, CanvasItemSnapToPixel)
+	FUNC2(canvas_item_set_snap_to_pixel_true_center, RID, CanvasItemSnapToPixelTrueCenter)
 
 	FUNC6(canvas_item_add_line, RID, const Point2 &, const Point2 &, const Color &, float, bool)
 	FUNC5(canvas_item_add_polyline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2793,6 +2793,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_attach_canvas", "viewport", "canvas"), &RenderingServer::viewport_attach_canvas);
 	ClassDB::bind_method(D_METHOD("viewport_remove_canvas", "viewport", "canvas"), &RenderingServer::viewport_remove_canvas);
 	ClassDB::bind_method(D_METHOD("viewport_set_snap_2d_transforms_to_pixel", "viewport", "enabled"), &RenderingServer::viewport_set_snap_2d_transforms_to_pixel);
+	ClassDB::bind_method(D_METHOD("viewport_set_snap_2d_transforms_to_pixel_true_center", "viewport", "enabled"), &RenderingServer::viewport_set_snap_2d_transforms_to_pixel_true_center);
 	ClassDB::bind_method(D_METHOD("viewport_set_snap_2d_vertices_to_pixel", "viewport", "enabled"), &RenderingServer::viewport_set_snap_2d_vertices_to_pixel);
 
 	ClassDB::bind_method(D_METHOD("viewport_set_default_canvas_item_texture_filter", "viewport", "filter"), &RenderingServer::viewport_set_default_canvas_item_texture_filter);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -867,6 +867,13 @@ public:
 		CANVAS_ITEM_SNAP_TO_PIXEL_MAX,
 	};
 
+	enum CanvasItemSnapToPixelTrueCenter {
+		CANVAS_ITEM_SNAP_TO_PIXEL_TRUE_CENTER_DEFAULT,
+		CANVAS_ITEM_SNAP_TO_PIXEL_TRUE_CENTER_DISABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_TRUE_CENTER_ENABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_TRUE_CENTER_MAX,
+	};
+
 	virtual RID viewport_create() = 0;
 
 	enum ViewportScaling3DMode {
@@ -932,6 +939,7 @@ public:
 	virtual void viewport_set_transparent_background(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_use_hdr_2d(RID p_viewport, bool p_use_hdr) = 0;
 	virtual void viewport_set_snap_2d_transforms_to_pixel(RID p_viewport, bool p_enabled) = 0;
+	virtual void viewport_set_snap_2d_transforms_to_pixel_true_center(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_snap_2d_vertices_to_pixel(RID p_viewport, bool p_enabled) = 0;
 
 	virtual void viewport_set_default_canvas_item_texture_filter(RID p_viewport, CanvasItemTextureFilter p_filter) = 0;
@@ -1459,6 +1467,7 @@ public:
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_snap_to_pixel(RID p_item, CanvasItemSnapToPixel p_snap) = 0;
+	virtual void canvas_item_set_snap_to_pixel_true_center(RID p_item, CanvasItemSnapToPixelTrueCenter p_snap_to_pixel_true_center) = 0;
 
 	enum NinePatchAxisMode {
 		NINE_PATCH_STRETCH,

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -860,6 +860,13 @@ public:
 		CANVAS_ITEM_TEXTURE_REPEAT_MAX,
 	};
 
+	enum CanvasItemSnapToPixel {
+		CANVAS_ITEM_SNAP_TO_PIXEL_DEFAULT,
+		CANVAS_ITEM_SNAP_TO_PIXEL_DISABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_ENABLED,
+		CANVAS_ITEM_SNAP_TO_PIXEL_MAX,
+	};
+
 	virtual RID viewport_create() = 0;
 
 	enum ViewportScaling3DMode {
@@ -1450,6 +1457,8 @@ public:
 	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_visibility_layer) = 0;
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
+
+	virtual void canvas_item_set_snap_to_pixel(RID p_item, CanvasItemSnapToPixel p_snap) = 0;
 
 	enum NinePatchAxisMode {
 		NINE_PATCH_STRETCH,


### PR DESCRIPTION
Combines #94660 and #94673, and adds the CanvasItem "Snap To Pixel True Center" option. (the name can change)

| New CanvasItem option | New project setting option |
| ---- | ---- |
| <img width="481" alt="Capture d’écran, le 2024-07-26 à 15 37 49" src="https://github.com/user-attachments/assets/022331f8-ec88-47ce-b5e4-e7727a73c8c4"> | <img width="790" alt="Capture d’écran, le 2024-07-26 à 15 38 39" src="https://github.com/user-attachments/assets/afa7400f-4208-43c8-87dd-45f9a8ab6bd3"> |

## Difference between both modes
When the scaled CanvasItem is odd, the result is the same in both modes: the CanvasItem is offsetted to take into account the middle pixel column.

But the difference occurs when the CanvasItem is scaled to be "even sized". Then, if the "true center" option is active, it will snap the resized CanvasItem in the middle, making it compatible other snapped CanvasItems. When disabled, the offset will still be there, making the CanvasItem non compatible with even snapped CanvasItems.

The next example is about a 3x3 square scaled 2x.

| "True Center" Disabled | "True Center" Enabled |
| ---- | ---- |
| <img width="501" alt="Capture d’écran, le 2024-07-27 à 10 27 29" src="https://github.com/user-attachments/assets/3e637d0a-823b-49fa-95c7-ee0079cd8231"> | <img width="502" alt="Capture d’écran, le 2024-07-27 à 10 27 20" src="https://github.com/user-attachments/assets/7292e4e7-2720-42a7-bbd1-c452215e7c67"> |

### CanvasItem snap "non-compatibility"

Here's an example of non-compatible snaps, when one odd-sized CanvasItem is scaled evenly, but without the "true center" option.

[true-center-non-compatible.webm](https://github.com/user-attachments/assets/5b914261-6f9d-4480-8c6e-5361b2c27548)

## Drawback

This mode is super useful to make scaled odd-sized sprites snap correctly with even sprites. This is less useful, though, when animating the scale.

## Demo
In the following demo, all the squares are snapped, but: 
- the left square is centered, but doesn't snap to true center (the sprite is offset even if the sprite is scaled and even)
- the middle square is centered, and snapped to the true center when the size is even (as if the sprite was even).
- the right square is not centered

[scale-3x3.zip](https://github.com/user-attachments/files/16396175/scale-3x3.zip)

### Viewport scale
[true-center-center.webm](https://github.com/user-attachments/assets/f64378c4-d67a-4721-8a76-7fb22354b3e0)

### CanvasItem scale
[true-center-center-non-pixel.webm](https://github.com/user-attachments/assets/21cae0bd-dbcc-49e1-b6bb-b6f4c7c5c73c)

