### PR TITLE
Remove unused Bitstream Vera license

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -581,48 +581,6 @@ License: Apache-2.0
  See the License for the specific language governing permissions and
  limitations under the License.
 
-License: Bitstream Vera Fonts Copyright
- Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a
- trademark of Bitstream, Inc.
- .
- Permission is hereby granted, free of charge, to any person obtaining a copy of
- the fonts accompanying this license ("Fonts") and associated documentation
- files (the "Font Software"), to reproduce and distribute the Font Software,
- including without limitation the rights to use, copy, merge, publish,
- distribute, and/or sell copies of the Font Software, and to permit persons to
- whom the Font Software is furnished to do so, subject to the following
- conditions:
- .
- The above copyright and trademark notices and this permission notice shall be
- included in all copies of one or more of the Font Software typefaces.
- .
- The Font Software may be modified, altered, or added to, and in particular the
- designs of glyphs or characters in the Fonts may be modified and additional
- glyphs or characters may be added to the Fonts, only if the fonts are renamed
- to names not containing either the words "Bitstream" or the word "Vera".
- .
- This License becomes null and void to the extent applicable to Fonts or Font
- Software that has been modified and is distributed under the "Bitstream Vera"
- names.
- .
- The Font Software may be sold as part of a larger software package but no copy
- of one or more of the Font Software typefaces may be sold by itself.
- .
- THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
- TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION
- BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL,
- SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION
- OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO
- USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
- .
- Except as contained in this notice, the names of GNOME, the GNOME Foundation,
- and Bitstream Inc., shall not be used in advertising or otherwise to promote
- the sale, use or other dealings in this Font Software without prior written
- authorization from the GNOME Foundation or Bitstream Inc., respectively. For
- further information, contact: fonts at gnome dot org.
-
 License: BSD-2-clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
After the default code font was changed from Hack to Jetbrains Mono, Godot was left without any third-party content under that license, so it's unnecessary to keep it.

Leftover of #36198.