### PR TITLE
Expose ClassDB methods `get_property_setter` / `get_property_getter`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1440,6 +1440,14 @@ TypedArray<Dictionary> ClassDB::class_get_property_list(const StringName &p_clas
 	return ret;
 }
 
+StringName ClassDB::class_get_property_getter(const StringName &p_class, const StringName &p_property) {
+	return ::ClassDB::get_property_getter(p_class, p_property);
+}
+
+StringName ClassDB::class_get_property_setter(const StringName &p_class, const StringName &p_property) {
+	return ::ClassDB::get_property_setter(p_class, p_property);
+}
+
 Variant ClassDB::class_get_property(Object *p_object, const StringName &p_property) const {
 	Variant ret;
 	::ClassDB::get_property(p_object, p_property, ret);
@@ -1601,6 +1609,8 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &ClassDB::class_get_signal_list, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &ClassDB::class_get_property_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_property_getter", "class", "property"), &ClassDB::class_get_property_getter);
+	::ClassDB::bind_method(D_METHOD("class_get_property_setter", "class", "property"), &ClassDB::class_get_property_setter);
 	::ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &ClassDB::class_get_property);
 	::ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &ClassDB::class_set_property);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -447,6 +447,8 @@ public:
 	TypedArray<Dictionary> class_get_signal_list(const StringName &p_class, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_property_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	StringName class_get_property_getter(const StringName &p_class, const StringName &p_property);
+	StringName class_get_property_setter(const StringName &p_class, const StringName &p_property);
 	Variant class_get_property(Object *p_object, const StringName &p_property) const;
 	Error class_set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -99,12 +99,28 @@
 				Returns the default value of [param property] of [param class] or its ancestor classes.
 			</description>
 		</method>
+		<method name="class_get_property_getter">
+			<return type="StringName" />
+			<param index="0" name="class" type="StringName" />
+			<param index="1" name="property" type="StringName" />
+			<description>
+				Returns the getter method name of [param property] of [param class].
+			</description>
+		</method>
 		<method name="class_get_property_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the properties of [param class] or its ancestry if [param no_inheritance] is [code]false[/code].
+			</description>
+		</method>
+		<method name="class_get_property_setter">
+			<return type="StringName" />
+			<param index="0" name="class" type="StringName" />
+			<param index="1" name="property" type="StringName" />
+			<description>
+				Returns the setter method name of [param property] of [param class].
 			</description>
 		</method>
 		<method name="class_get_signal" qualifiers="const">


### PR DESCRIPTION
This allows certain `EditorPlugin` implementations to resolve specifically what the developer has defined as the accessor (getter) and the mutator (setter) method for a given property, if any, are defined.  

This information is not currently exposed to scripting, making it difficult for editor tooling. We originally attempted a simple approach using `get_`, `set_`, or `is_` prefixes followed by the property name, but we found that insufficient because there are numerous cases, even in Godot, where the naming of one or both of the methods differed from the name of the property, e.g., `Sprite2D.is_flipped_h()` for the `flip_h` property.
