### PR TITLE
Fix compilation failure in `test_graph_node.h` with `disable_exceptions=false`

### DIFF
--- a/tests/scene/test_graph_node.h
+++ b/tests/scene/test_graph_node.h
@@ -48,8 +48,10 @@ TEST_CASE("[GraphNode][SceneTree]") {
 		test_node->add_child(test_child);
 
 		// Test.
-		CHECK_NOTHROW_MESSAGE(test_node->remove_child(test_child));
+		test_node->remove_child(test_child);
+		CHECK(test_node->get_child_count(false) == 0);
 
+		memdelete(test_child);
 		memdelete(test_node);
 	}
 }


### PR DESCRIPTION
Fix [#94833](https://github.com/godotengine/godot/issues/94833)