### PR TITLE
Fix crash on powerVR GPUs when a cached shader wasn't loaded in properly

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -698,7 +698,8 @@ void ShaderGLES3::_clear_version(Version *p_version) {
 
 void ShaderGLES3::_initialize_version(Version *p_version) {
 	ERR_FAIL_COND(p_version->variants.size() > 0);
-	if (shader_cache_dir_valid && _load_from_cache(p_version)) {
+	bool use_cache = shader_cache_dir_valid && !(feedback_count > 0 && GLES3::Config::get_singleton()->disable_transform_feedback_shader_cache);
+	if (use_cache && _load_from_cache(p_version)) {
 		return;
 	}
 	p_version->variants.reserve(variant_count);
@@ -709,7 +710,7 @@ void ShaderGLES3::_initialize_version(Version *p_version) {
 		_compile_specialization(spec, i, p_version, specialization_default_mask);
 		p_version->variants[i].insert(specialization_default_mask, spec);
 	}
-	if (shader_cache_dir_valid) {
+	if (use_cache) {
 		_save_to_cache(p_version);
 	}
 }

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -218,6 +218,8 @@ Config::Config() {
 			//https://github.com/godotengine/godot/issues/92662#issuecomment-2161199477
 			//disable_particles_workaround = false;
 		}
+	} else if (rendering_device_name == "PowerVR Rogue GE8320") {
+		disable_transform_feedback_shader_cache = true;
 	}
 }
 

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -96,6 +96,9 @@ public:
 	bool disable_particles_workaround = false; // set to 'true' to disable 'GPUParticles'
 	bool flip_xy_workaround = false;
 
+	// PowerVR GE 8320 workaround
+	bool disable_transform_feedback_shader_cache = false;
+
 #ifdef ANDROID_ENABLED
 	PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC eglFramebufferTextureMultiviewOVR = nullptr;
 	PFNGLTEXSTORAGE3DMULTISAMPLEPROC eglTexStorage3DMultisample = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

fixes #93406

The root cause was a faulty shader cache on some very specific and low end GPUs, for me this was on my Oppo a57s with a PowerVR Rogue GE8320 GPU. This only seemed to occur when you had any Skeleton3D mesh on-screen and only on the second launch as then it would use the shader cache.

The fix is to simply call `glLinkProgram()` right after loading in the shader from the binary cache to force it to re-link everything and make `glGetProgramiv` be able to retrieve the actual linking status. This now catches the error before the shader is used and thus tells Godot to re-compile it rather than move forward and crash.

<i>Bugsquad edit:</i>
- Fix https://github.com/godotengine/godot/issues/93406