### PR TITLE
Combine existing modes when calling SetConsoleMode

### DIFF
--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -65,7 +65,9 @@ int main(int argc, char *argv[]) {
 
 	// Enable virtual terminal sequences processing.
 	HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
-	DWORD out_mode = ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	DWORD out_mode = 0;
+	GetConsoleMode(stdout_handle, &out_mode);
+	out_mode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	SetConsoleMode(stdout_handle, out_mode);
 
 	// Find main executable name and check if it exist.

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1925,7 +1925,9 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	// NOTE: The engine does not use ANSI escape codes to color error/warning messages; it uses Windows API calls instead.
 	// Therefore, error/warning messages are still colored on Windows versions older than 10.
 	HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-	DWORD outMode = ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	DWORD outMode = 0;
+	GetConsoleMode(stdoutHandle, &outMode);
+	outMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	if (!SetConsoleMode(stdoutHandle, outMode)) {
 		// Windows 8.1 or below, or Windows 10 prior to Anniversary Update.
 		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");


### PR DESCRIPTION
Otherwise the default modes will be cleared, which causes long lines to be truncated in some terminals (e.g. Windows Terminal).

(Specifically, the `ENABLE_WRAP_AT_EOL_OUTPUT` mode.)