### PR TITLE
Fix typo in Array's `sort()` method description

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -694,7 +694,7 @@
 		<method name="sort">
 			<return type="void" />
 			<description>
-				Sorts the array in ascending order. The final order is dependent on the "less than" ([code]&gt;[/code]) comparison between elements.
+				Sorts the array in ascending order. The final order is dependent on the "less than" ([code]&lt;[/code]) comparison between elements.
 				[codeblocks]
 				[gdscript]
 				var numbers = [10, 5, 2.5, 8]


### PR DESCRIPTION
Reading through the `Array` Godot's help, I noticed a small typo: the intent was to use the `<` (less than) symbol but instead it was the `>` (greater than) symbol. This PR fixes it.