### PR TITLE
Fix TextEdit placeholder fit content height

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -764,7 +764,7 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 
-			bool draw_placeholder = text.size() == 1 && text[0].is_empty() && ime_text.is_empty();
+			bool draw_placeholder = _using_placeholder();
 
 			// Get the highlighted words.
 			String highlighted_text = get_selected_text(0);
@@ -2847,6 +2847,10 @@ void TextEdit::_update_placeholder() {
 		Vector2i line_range = placeholder_data_buf->get_line_range(i);
 		placeholder_wraped_rows.push_back(placeholder_translated.substr(line_range.x, line_range.y - line_range.x));
 	}
+}
+
+bool TextEdit::_using_placeholder() const {
+	return text.size() == 1 && text[0].is_empty() && ime_text.is_empty();
 }
 
 void TextEdit::_update_theme_item_cache() {
@@ -7840,10 +7844,10 @@ void TextEdit::_update_scrollbars() {
 	h_scroll->set_begin(Point2(0, size.height - hmin.height));
 	h_scroll->set_end(Point2(size.width - vmin.width, size.height));
 
-	bool draw_placeholder = text.size() == 1 && text[0].length() == 0;
+	bool draw_placeholder = _using_placeholder();
 
 	int visible_rows = get_visible_line_count();
-	int total_rows = draw_placeholder ? placeholder_wraped_rows.size() - 1 : get_total_visible_line_count();
+	int total_rows = draw_placeholder ? placeholder_wraped_rows.size() : get_total_visible_line_count();
 	if (scroll_past_end_of_file_enabled && !fit_content_height) {
 		total_rows += visible_rows - 1;
 	}
@@ -7921,7 +7925,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 	}
 	if (v_scroll->is_visible_in_tree()) {
 		// Set line ofs and wrap ofs.
-		bool draw_placeholder = text.size() == 1 && text[0].length() == 0;
+		bool draw_placeholder = _using_placeholder();
 
 		int v_scroll_i = floor(get_v_scroll());
 		int sc = 0;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -297,6 +297,7 @@ private:
 	Vector<String> placeholder_wraped_rows;
 
 	void _update_placeholder();
+	bool _using_placeholder() const;
 
 	/* Initialize to opposite first, so we get past the early-out in set_editable. */
 	bool editable = false;


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/74822

Also makes sure placeholder isn't used for scrollbars when only IME is open.