### PR TITLE
Fix custom resource icons sometimes using icon from incorrect dependency

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1764,7 +1764,10 @@ String EditorFileSystem::_get_global_script_class(const String &p_type, const St
 
 void EditorFileSystem::_update_file_icon_path(EditorFileSystemDirectory::FileInfo *file_info) {
 	String icon_path;
-	if (file_info->script_class_icon_path.is_empty() && !file_info->deps.is_empty()) {
+	if (file_info->resource_script_class != StringName()) {
+		file_info->icon_path = EditorNode::get_editor_data().script_class_get_icon_path(file_info->resource_script_class);
+	}
+	else if (file_info->script_class_icon_path.is_empty() && !file_info->deps.is_empty()) {
 		const String &script_dep = file_info->deps[0]; // Assuming the first dependency is a script.
 		const String &script_path = script_dep.contains("::") ? script_dep.get_slice("::", 2) : script_dep;
 		if (!script_path.is_empty()) {


### PR DESCRIPTION
Fix #93874 #92942

Instead of going by the first dependency, go by the icon linked to the resource's script class (if it has one)
Replacing the entire function with my bit seems to work, I'm unsure what case the rest of the function covers but I chose to leave it just to be safe
I'm still fairly new to the code base, please let me know if there's something I haven't considered!