### PR TITLE
Fix custom resources using incorrect icons

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1779,7 +1779,9 @@ String EditorFileSystem::_get_global_script_class(const String &p_type, const St
 
 void EditorFileSystem::_update_file_icon_path(EditorFileSystemDirectory::FileInfo *file_info) {
 	String icon_path;
-	if (file_info->script_class_icon_path.is_empty() && !file_info->deps.is_empty()) {
+	if (file_info->resource_script_class != StringName()) {
+		icon_path = EditorNode::get_editor_data().script_class_get_icon_path(file_info->resource_script_class);
+	} else if (file_info->script_class_icon_path.is_empty() && !file_info->deps.is_empty()) {
 		const String &script_dep = file_info->deps[0]; // Assuming the first dependency is a script.
 		const String &script_path = script_dep.contains("::") ? script_dep.get_slice("::", 2) : script_dep;
 		if (!script_path.is_empty()) {


### PR DESCRIPTION
Fix #93874 
Fix #92942 

Instead of going by the first dependency, go by the icon linked to the resource's script class (if it has one)
I'm unsure if the rest of the function is necessary (or what cases it covers really) but I chose to leave it in for safety's sake. I'm not familiar enough with the code base to make that assumption confidently.
Please let me know if there's anything I missed or failed to consider!