### PR TITLE
GDScript: Remove unused values from `Token`

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -359,7 +359,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 	token.end_line = line;
 	token.start_column = start_column;
 	token.end_column = column;
-	token.source = String::utf32(Span(_start, _current - _start));
 
 	if (p_type != Token::ERROR && cursor_line > -1) {
 		// Also count whitespace after token.
@@ -372,7 +371,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 		if (start_line == line) {
 			// Single line token.
 			if (cursor_line == start_line && cursor_column >= start_column && cursor_column <= last_column) {
-				token.cursor_position = cursor_column - start_column;
 				if (cursor_column == start_column) {
 					token.cursor_place = CURSOR_BEGINNING;
 				} else if (cursor_column < column) {
@@ -385,7 +383,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 			// Multi line token.
 			if (cursor_line == start_line && cursor_column >= start_column) {
 				// Is in first line.
-				token.cursor_position = cursor_column - start_column;
 				if (cursor_column == start_column) {
 					token.cursor_place = CURSOR_BEGINNING;
 				} else {
@@ -393,7 +390,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 				}
 			} else if (cursor_line == line && cursor_column <= last_column) {
 				// Is in last line.
-				token.cursor_position = cursor_column - start_column;
 				if (cursor_column < column) {
 					token.cursor_place = CURSOR_MIDDLE;
 				} else {
@@ -401,7 +397,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 				}
 			} else if (cursor_line > start_line && cursor_line < line) {
 				// Is in middle line.
-				token.cursor_position = CURSOR_MIDDLE;
+				token.cursor_place = CURSOR_MIDDLE;
 			}
 		}
 	}
@@ -482,7 +478,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 		_advance();
 	}
 	Token annotation = make_token(Token::ANNOTATION);
-	annotation.literal = StringName(annotation.source);
+	annotation.literal = StringName(String(_start, _current - _start));
 	return annotation;
 }
 

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -164,11 +164,9 @@ public:
 		};
 
 		Type type = EMPTY;
-		Variant literal;
 		int start_line = 0, end_line = 0, start_column = 0, end_column = 0;
-		int cursor_position = -1;
 		CursorPlace cursor_place = CURSOR_NONE;
-		String source;
+		Variant literal;
 
 		const char *get_name() const;
 		String get_debug_name() const;


### PR DESCRIPTION
- `Token.source` only usage was to initialize `Token.identifier` which we can do directly.
- We only use `Token.cursor_place` but not `Token.cursor_position`.

Size of `Token` on my PC:
- before: 72 bytes
- after removing the unused values: 64 bytes
- when placing the `Variant` at the end: 56 bytes (in my setup `Variant` has an alignment of 8 requiring additional padding when the values before it don't add to a multiple of 8)
