### PR TITLE
[Web] Gracefully handle non-finite audio volumes

### DIFF
--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -858,7 +858,10 @@ class Bus {
 	 * @returns {void}
 	 */
 	setVolumeDb(val) {
-		this._gainNode.gain.value = GodotAudio.db_to_linear(val);
+		const linear = GodotAudio.db_to_linear(val);
+		if (isFinite(linear)) {
+			this._gainNode.gain.value = linear;
+		}
 	}
 
 	/**


### PR DESCRIPTION
These values aren't valid but they should be handled gracefully, ~could handle with a `isFinite()` instead (though that would involve checking after converting, so bit more complex code), with or without a message, but I think this is the most straight forward way to handle it~

This shouldn't happen with properly handled input, but in case of user error entering invalid values we should handle this gracefully instead of failing to load

* Closes: https://github.com/godotengine/godot/issues/94806
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
