### PR TITLE
Blender import: Correct exit code on Python exception

### DIFF
--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -163,14 +163,18 @@ Error EditorImportBlendRunner::start_blender(const String &p_python_script, bool
 
 	List<String> args;
 	args.push_back("--background");
+	args.push_back("--python-exit-code");
+	args.push_back("1");
 	args.push_back("--python-expr");
 	args.push_back(p_python_script);
 
 	Error err;
+	String str;
 	if (p_blocking) {
 		int exitcode = 0;
-		err = OS::get_singleton()->execute(blender_path, args, nullptr, &exitcode);
+		err = OS::get_singleton()->execute(blender_path, args, &str, &exitcode, true);
 		if (exitcode != 0) {
+			print_error(vformat("Blender import failed: %s.", str));
 			return FAILED;
 		}
 	} else {


### PR DESCRIPTION
When running Blender direct import, it executes some Python but does not check if it succeeded.

https://github.com/godotengine/godot/blob/607b230ffe120b2757c56bd3d52a7a0d4e502cfe/modules/gltf/editor/editor_import_blend_runner.cpp#L84-L93

Which goes to `start_blender(...)` and exitcode is checked to determine failure.

https://github.com/godotengine/godot/blob/607b230ffe120b2757c56bd3d52a7a0d4e502cfe/modules/gltf/editor/editor_import_blend_runner.cpp#L161-L175

However, Blender does not return exitcode 1 when the Python script fails: [blender/issues/82494](https://projects.blender.org/blender/blender/issues/82494)

There is `--python-exit-code` which returns the exitcode in the given value whenever the script fails:

```bash
$ blender --help
--python-exit-code <code>
        Set the exit-code in [0..255] to exit if a Python exception is raised
        (only for scripts executed from the command line), zero disables.
```

This PR adds the flag, as well as print the stderr of the Blender process for more clarity.