### PR TITLE
Call `restart_editor()` in `RUN_PROJECT_MANAGER`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1961,7 +1961,7 @@ void EditorNode::try_autosave() {
 	editor_data.save_editor_external_data();
 }
 
-void EditorNode::restart_editor() {
+void EditorNode::restart_editor(bool p_goto_project_manager) {
 	exiting = true;
 
 	if (project_run_bar->is_playing()) {
@@ -1969,22 +1969,25 @@ void EditorNode::restart_editor() {
 	}
 
 	String to_reopen;
-	if (get_tree()->get_edited_scene_root()) {
+	if (!p_goto_project_manager && get_tree()->get_edited_scene_root()) {
 		to_reopen = get_tree()->get_edited_scene_root()->get_scene_file_path();
 	}
 
 	_exit_editor(EXIT_SUCCESS);
 
 	List<String> args;
-
 	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
 		args.push_back(a);
 	}
 
-	args.push_back("--path");
-	args.push_back(ProjectSettings::get_singleton()->get_resource_path());
+	if (p_goto_project_manager) {
+		args.push_back("--project-manager");
+	} else {
+		args.push_back("--path");
+		args.push_back(ProjectSettings::get_singleton()->get_resource_path());
 
-	args.push_back("-e");
+		args.push_back("-e");
+	}
 
 	if (!to_reopen.is_empty()) {
 		args.push_back(to_reopen);
@@ -3391,23 +3394,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 
 		} break;
 		case RUN_PROJECT_MANAGER: {
-			project_run_bar->stop_playing();
-			_exit_editor(EXIT_SUCCESS);
-			String exec = OS::get_singleton()->get_executable_path();
-
-			List<String> args;
-			for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
-				args.push_back(a);
-			}
-
-			String exec_base_dir = exec.get_base_dir();
-			if (!exec_base_dir.is_empty()) {
-				args.push_back("--path");
-				args.push_back(exec_base_dir);
-			}
-			args.push_back("--project-manager");
-
-			OS::get_singleton()->set_restart_on_exit(true, args);
+			restart_editor(true);
 		} break;
 		case RELOAD_CURRENT_PROJECT: {
 			restart_editor();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -917,7 +917,7 @@ public:
 	void save_scene_list(const HashSet<String> &p_scene_paths);
 	void save_before_run();
 	void try_autosave();
-	void restart_editor();
+	void restart_editor(bool p_goto_project_manager = false);
 	void unload_editor_addons();
 
 	void dim_editor(bool p_dimming);


### PR DESCRIPTION
Follow-up to #85654
The duplicate code in `RUN_PROJECT_MANAGER` branch is replaced with a modified `restart_editor()`.

Seems like the code did not set `exiting` previously, so this might also fix some bugs.