### PR TITLE
Add `CanvasItem::toggle_visibility`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -583,6 +583,12 @@
 				Show the [CanvasItem] if it's currently hidden. This is equivalent to setting [member visible] to [code]true[/code]. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
 			</description>
 		</method>
+		<method name="toggle_visibility">
+			<return type="void" />
+			<description>
+			Show the [CanvasItem] if it's currently hidden or hide the [CanvasItem] if it's currently visible.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -586,7 +586,7 @@
 		<method name="toggle_visibility">
 			<return type="void" />
 			<description>
-			Show the [CanvasItem] if it's currently hidden or hide the [CanvasItem] if it's currently visible.
+				Show the [CanvasItem] if it's currently hidden or hide the [CanvasItem] if it's currently visible.
 			</description>
 		</method>
 	</methods>

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -88,6 +88,10 @@ void CanvasItem::set_visible(bool p_visible) {
 	_handle_visibility_change(p_visible);
 }
 
+void CanvasItem::toggle_visibility() {
+	set_visible(!visible);
+}
+
 void CanvasItem::_handle_visibility_change(bool p_visible) {
 	RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, p_visible);
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
@@ -1163,6 +1167,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &CanvasItem::get_canvas_item);
 
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &CanvasItem::set_visible);
+	ClassDB::bind_method(D_METHOD("toggle_visibility"), &CanvasItem::toggle_visibility);
 	ClassDB::bind_method(D_METHOD("is_visible"), &CanvasItem::is_visible);
 	ClassDB::bind_method(D_METHOD("is_visible_in_tree"), &CanvasItem::is_visible_in_tree);
 	ClassDB::bind_method(D_METHOD("show"), &CanvasItem::show);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -234,6 +234,7 @@ public:
 	/* VISIBILITY */
 
 	void set_visible(bool p_visible);
+	void toggle_visibility();
 	bool is_visible() const;
 	bool is_visible_in_tree() const;
 	void show();


### PR DESCRIPTION
Currently if you are only using signals in the inspector, there is no way to simply toggle the visibility of a UI element without writing a small function in a script every time you want to do this.
![image](https://github.com/user-attachments/assets/20cd2575-8be4-46bf-b0aa-9159d5ecb087)

I am using this on a button (with shortcut key) to open and close a menu without knowing the current state of the menu.

resolves godotengine/godot-proposals#10302