### PR TITLE
Fixed AnimationPlayer crashing Godot when its made the Scene Root

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -323,7 +323,10 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 			track_editor->set_animation(anim, animation_library_is_foreign);
 			Node *root = player->get_node_or_null(player->get_root_node());
 			if (root) {
+				cached_player_root_node = root; // caching as track_editor can lose track of player's root node
 				track_editor->set_root(root);
+			} else {
+				player->set_root_node(player->get_path_to(cached_player_root_node));
 			}
 		}
 		frame->set_max((double)anim->get_length());

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -322,11 +322,17 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 			track_editor->set_animation(anim, animation_library_is_foreign);
 			Node *root = player->get_node_or_null(player->get_root_node());
-			if (root) {
-				cached_player_root_node = root; // caching as track_editor can lose track of player's root node
-				track_editor->set_root(root);
+
+			// Player shouldn't access parent if its scene root
+			if (!root || (player == get_tree()->get_edited_scene_root() && player->get_root_node() == SceneStringNames::get_singleton()->path_pp)) {
+				if (cached_player_root_node) {
+					player->set_root_node(player->get_path_to(cached_player_root_node));
+				} else {
+					player->set_root_node(SceneStringNames::get_singleton()->path_pp); // No other choice, preventing crash
+				}
 			} else {
-				player->set_root_node(player->get_path_to(cached_player_root_node));
+				cached_player_root_node = root; // Caching as track_editor can lose track of player's root node
+				track_editor->set_root(root);
 			}
 		}
 		frame->set_max((double)anim->get_length());

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -52,6 +52,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	AnimationPlayerEditorPlugin *plugin = nullptr;
 	AnimationMixer *original_node = nullptr; // For pinned mark in SceneTree.
 	AnimationPlayer *player = nullptr; // For AnimationPlayerEditor, could be dummy.
+	Node *cached_player_root_node = nullptr;
 	bool is_dummy = false;
 
 	enum {


### PR DESCRIPTION
When an AnimationPlayer node is made the root of a scene, the node links on the animation track are broken and clicking on them will crash Godot. This happens because when it is made the scene root, the editor loses track of the AnimationPlayer's `root_node`, as the path to the root node gets broken.

By keeping a cached pointer to the AnimationPlayer's `root_node`, and using this copy when the editor can't find it, the track links can remain functional and avoid a crash.

Fixes #91043
Works in 4.2.2-stable.