### PR TITLE
Automatically enable `doNotStrip` for dev builds

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -95,25 +95,18 @@ if lib_arch_dir != "":
         else:
             gradle_process = ["./gradlew"]
 
-        if env["target"] != "editor" and env["dev_build"]:
-            subprocess.run(
-                gradle_process
-                + [
-                    "generateDevTemplate",
-                    "--quiet",
-                ],
-                cwd="platform/android/java",
-            )
-        else:
-            # Android editor with `dev_build=yes` is handled by the `generateGodotEditor` task.
-            subprocess.run(
-                gradle_process
-                + [
-                    "generateGodotEditor" if env["target"] == "editor" else "generateGodotTemplates",
-                    "--quiet",
-                ],
-                cwd="platform/android/java",
-            )
+        gradle_process += [
+            "generateGodotEditor" if env["target"] == "editor" else "generateGodotTemplates",
+            "--quiet",
+        ]
+
+        if env["debug_symbols"]:
+            gradle_process += ["-PdoNotStrip=true"]
+
+        subprocess.run(
+            gradle_process,
+            cwd="platform/android/java",
+        )
 
     if env["generate_apk"]:
         generate_apk_command = env_android.Command("generate_apk", [], generate_apk)


### PR DESCRIPTION
Fix the `generate_apk` build logic to automatically include `doNotStrip` when `dev_build` or `debug_symbols` are enabled

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
