### PR TITLE
Avoid `const_cast` in `mesh_storage.h`

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1768,14 +1768,14 @@ AABB MeshStorage::_multimesh_get_custom_aabb(RID p_multimesh) const {
 	return multimesh->custom_aabb;
 }
 
-AABB MeshStorage::_multimesh_get_aabb(RID p_multimesh) const {
+AABB MeshStorage::_multimesh_get_aabb(RID p_multimesh) {
 	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
 	ERR_FAIL_NULL_V(multimesh, AABB());
 	if (multimesh->custom_aabb != AABB()) {
 		return multimesh->custom_aabb;
 	}
 	if (multimesh->aabb_dirty) {
-		const_cast<MeshStorage *>(this)->_update_dirty_multimeshes();
+		_update_dirty_multimeshes();
 	}
 	return multimesh->aabb;
 }

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -510,7 +510,7 @@ public:
 	virtual RID _multimesh_get_mesh(RID p_multimesh) const override;
 	virtual void _multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) override;
 	virtual AABB _multimesh_get_custom_aabb(RID p_multimesh) const override;
-	virtual AABB _multimesh_get_aabb(RID p_multimesh) const override;
+	virtual AABB _multimesh_get_aabb(RID p_multimesh) override;
 
 	virtual Transform3D _multimesh_instance_get_transform(RID p_multimesh, int p_index) const override;
 	virtual Transform2D _multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const override;

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -163,7 +163,7 @@ public:
 	virtual AABB _multimesh_get_custom_aabb(RID p_multimesh) const override { return AABB(); }
 
 	virtual RID _multimesh_get_mesh(RID p_multimesh) const override { return RID(); }
-	virtual AABB _multimesh_get_aabb(RID p_multimesh) const override { return AABB(); }
+	virtual AABB _multimesh_get_aabb(RID p_multimesh) override { return AABB(); }
 
 	virtual Transform3D _multimesh_instance_get_transform(RID p_multimesh, int p_index) const override { return Transform3D(); }
 	virtual Transform2D _multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const override { return Transform2D(); }

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -2040,7 +2040,7 @@ AABB MeshStorage::_multimesh_get_custom_aabb(RID p_multimesh) const {
 	return multimesh->custom_aabb;
 }
 
-AABB MeshStorage::_multimesh_get_aabb(RID p_multimesh) const {
+AABB MeshStorage::_multimesh_get_aabb(RID p_multimesh) {
 	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
 	ERR_FAIL_NULL_V(multimesh, AABB());
 	if (multimesh->custom_aabb != AABB()) {
@@ -2048,7 +2048,7 @@ AABB MeshStorage::_multimesh_get_aabb(RID p_multimesh) const {
 	}
 
 	if (multimesh->aabb_dirty) {
-		const_cast<MeshStorage *>(this)->_update_dirty_multimeshes();
+		_update_dirty_multimeshes();
 	}
 	return multimesh->aabb;
 }

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -652,7 +652,7 @@ public:
 	virtual void _multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) override;
 	virtual AABB _multimesh_get_custom_aabb(RID p_multimesh) const override;
 
-	virtual AABB _multimesh_get_aabb(RID p_multimesh) const override;
+	virtual AABB _multimesh_get_aabb(RID p_multimesh) override;
 
 	virtual MultiMeshInterpolator *_multimesh_get_interpolator(RID p_multimesh) const override;
 

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -285,7 +285,7 @@ int RendererMeshStorage::multimesh_get_visible_instances(RID p_multimesh) const 
 	return _multimesh_get_visible_instances(p_multimesh);
 }
 
-AABB RendererMeshStorage::multimesh_get_aabb(RID p_multimesh) const {
+AABB RendererMeshStorage::multimesh_get_aabb(RID p_multimesh) {
 	return _multimesh_get_aabb(p_multimesh);
 }
 

--- a/servers/rendering/storage/mesh_storage.h
+++ b/servers/rendering/storage/mesh_storage.h
@@ -151,7 +151,7 @@ public:
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible);
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const;
 
-	virtual AABB multimesh_get_aabb(RID p_multimesh) const;
+	virtual AABB multimesh_get_aabb(RID p_multimesh);
 
 	virtual RID _multimesh_allocate() = 0;
 	virtual void _multimesh_initialize(RID p_rid) = 0;
@@ -183,7 +183,7 @@ public:
 	virtual void _multimesh_set_visible_instances(RID p_multimesh, int p_visible) = 0;
 	virtual int _multimesh_get_visible_instances(RID p_multimesh) const = 0;
 
-	virtual AABB _multimesh_get_aabb(RID p_multimesh) const = 0;
+	virtual AABB _multimesh_get_aabb(RID p_multimesh) = 0;
 
 	// Multimesh is responsible for allocating / destroying a MultiMeshInterpolator object.
 	// This allows shared functionality for interpolation across backends.


### PR DESCRIPTION
Avoids const_cast in mesh_storage.h by changing the virtual method `RendererMeshStorage::multimesh_get_aabb` to match the constness of `RendererMeshStorage::mesh_get_aabb`, which has to do similar dirty checks

this kind of const_cast can be very nasty as the compiler might be able to choose to return `aabb` before its changed by `_update_dirty_multimeshes` (like in https://github.com/godotengine/godot/issues/93759)