### PR TITLE
Fix regression around OpenGL swapchain optimization for OpenXR

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -107,7 +107,7 @@ void RasterizerGLES3::end_frame(bool p_swap_buffers) {
 	utils->capture_timestamps_end();
 }
 
-void RasterizerGLES3::end_viewport(bool p_swap_buffers) {
+void RasterizerGLES3::gl_end_frame(bool p_swap_buffers) {
 	if (p_swap_buffers) {
 		DisplayServer::get_singleton()->swap_buffers();
 	} else {
@@ -491,7 +491,7 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	copy_effects->copy_to_rect(screenrect);
 	glBindTexture(GL_TEXTURE_2D, 0);
 
-	end_viewport(true);
+	gl_end_frame(true);
 
 	texture_storage->texture_free(texture);
 }

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -99,7 +99,7 @@ public:
 
 	void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
 
-	void end_viewport(bool p_swap_buffers);
+	void gl_end_frame(bool p_swap_buffers);
 	void end_frame(bool p_swap_buffers);
 
 	void finalize();

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -88,7 +88,7 @@ public:
 
 	void blit_render_targets_to_screen(int p_screen, const BlitToScreen *p_render_targets, int p_amount) override {}
 
-	void end_viewport(bool p_swap_buffers) override {}
+	void gl_end_frame(bool p_swap_buffers) override {}
 
 	void end_frame(bool p_swap_buffers) override {
 		if (p_swap_buffers) {

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -98,7 +98,7 @@ public:
 
 	virtual void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount) = 0;
 
-	virtual void end_viewport(bool p_swap_buffers) = 0;
+	virtual void gl_end_frame(bool p_swap_buffers) = 0;
 	virtual void end_frame(bool p_swap_buffers) = 0;
 	virtual void finalize() = 0;
 	virtual uint64_t get_frame_number() const = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -122,7 +122,7 @@ public:
 	void begin_frame(double frame_step);
 	void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
 
-	void end_viewport(bool p_swap_buffers) {}
+	void gl_end_frame(bool p_swap_buffers) {}
 	void end_frame(bool p_swap_buffers);
 	void finalize();
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -786,6 +786,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 					if (OS::get_singleton()->get_current_rendering_driver_name().begins_with("opengl3")) {
 						if (blits.size() > 0) {
 							RSG::rasterizer->blit_render_targets_to_screen(vp->viewport_to_screen, blits.ptr(), blits.size());
+							RSG::rasterizer->gl_end_frame(p_swap_buffers);
 						}
 					} else if (blits.size() > 0) {
 						if (!blit_to_screen_list.has(vp->viewport_to_screen)) {
@@ -796,7 +797,6 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 							blit_to_screen_list[vp->viewport_to_screen].push_back(blits[b]);
 						}
 					}
-					RSG::rasterizer->end_viewport(p_swap_buffers && blits.size() > 0);
 				}
 			}
 		} else
@@ -826,10 +826,10 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 					Vector<BlitToScreen> blit_to_screen_vec;
 					blit_to_screen_vec.push_back(blit);
 					RSG::rasterizer->blit_render_targets_to_screen(vp->viewport_to_screen, blit_to_screen_vec.ptr(), 1);
+					RSG::rasterizer->gl_end_frame(p_swap_buffers);
 				} else {
 					blit_to_screen_list[vp->viewport_to_screen].push_back(blit);
 				}
-				RSG::rasterizer->end_viewport(p_swap_buffers);
 			}
 		}
 


### PR DESCRIPTION
After a long discussion with @clayjohn we came to the conclusion that #84244 was the cause of our performance regression on OpenGL due to a misunderstanding on my part between a crucial difference between Vulkan and OpenGL.
This caused `glFinish` to be called in a scenario that wasn't needed.

Due to the confusion caused by original naming of methods I've kept `end_frame` in its new place, giving us the opportunity to do the proper swapchain swap on Vulkan, and proper timing check in OpenGL instead of the workaround that was in place before.

`end_viewport` has been renamed to `gl_end_frame` to better communicate that this is a call specific to OpenGL and is only called after output has been blitted to our swapchain and it has to be handled.

What we are still unsure of, seeing how things were before #84244 is whether the logic is correct when `p_swap_buffers` is false, which happens when a user called `force_draw`.

It is possible that the correct code in the XR branch should be:
```
if (blits.size() > 0 || !p_swap_buffers) {
	RSG::rasterizer->gl_end_frame(p_swap_buffers);
}
```
However, calling `force_draw` when XR is active is probably fairly dangerous to begin with as this would result in an extra call to `xrWaitFrame` with all sorts of timing things going wrong.

All in all, it would be good to test this PR against a normal application that uses `force_draw` to see if the functionality works as expected. I do not have a valid example project for this.

- Fixes #94870
- Fixes #94856
