### PR TITLE
Use `HashMap` to track touches on web

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -673,7 +673,7 @@ void DisplayServerWeb::_touch_callback(int p_type, int p_count) {
 			ev->set_index(touch_event.identifier[i]);
 			ev->set_position(point);
 
-			Point2 &prev = ds->touches[i];
+			Point2 &prev = ds->touches[touch_event.identifier[i]];
 			ev->set_relative(ev->get_position() - prev);
 			ev->set_relative_screen_position(ev->get_relative());
 			prev = ev->get_position();
@@ -690,7 +690,12 @@ void DisplayServerWeb::_touch_callback(int p_type, int p_count) {
 			ev->set_index(touch_event.identifier[i]);
 			ev->set_position(point);
 			ev->set_pressed(p_type == 0);
-			ds->touches[i] = point;
+
+			if (p_type == 0) {
+				ds->touches[touch_event.identifier[i]] = point;
+			} else {
+				ds->touches.erase(touch_event.identifier[i]);
+			}
 
 			Input::get_singleton()->parse_input_event(ev);
 

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -71,7 +71,7 @@ private:
 	Callable drop_files_callback;
 
 	String clipboard;
-	Point2 touches[32];
+	HashMap<uint32_t, Point2> touches;
 
 	Array voices;
 


### PR DESCRIPTION
## Summary

This PR modified how display_server_web.h stores info about touches to fix bug described by issue https://github.com/godotengine/godot/issues/94346.

## Description

The bug was being caused because the value of `InputEventScreenDrag.relative` was sometimes being calculated with an event with a mismatched identifier/index. This happened because `relative` was being computed without checking if the coordinates of the point stored in the `touches` array in `DisplayServerWeb` had a matching identifier/index.

### Example 
Consider the following example. A user has two fingers dragging on a touch screen. At frame 1, the [`TouchList`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches) of the `touchmove` event fired would contain two items: `[{identifier: 0, clientX: 15, clientY: 110,  ...}, {identifier: 1, clientX: 20, clientY: 110,  ...}]`. Let's say the finger for `identifier: 0` stops moving, but is still touching the screen. The next time `touchmove` fires, the `TouchList` looks like this: `[{identifier: 1, clientX: 5, clientY: 110,  ...}]`. So when `relative` for `identifier: 1` is computed, it uses the `TouchList` from frame 1 to compute the value. As mentioned above, the current implementation assumes that the `TouchList` contains the same touch with the same identifier at the index it was last frame. But, this is not always the case. Therefore, this causes relative to be `(10, 0)` instead of the expected `(15, 0)`.

## Fix 

This PR fixes the issue by using a HashMap to store and retrieve touch points by their identifier, ensuring accurate computation of relative values. *Note that the [documentation of the TouchEvent API](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches) says that the ID of the touch should be used when accessing the `TouchList` .*

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/94346*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
