### PR TITLE
Restrict sampler hint validation to only screen texture hints

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1123,6 +1123,7 @@ private:
 
 	bool _validate_function_call(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, DataType *r_ret_type, StringName *r_ret_type_str, bool *r_is_custom_function = nullptr);
 	bool _parse_function_arguments(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, int *r_complete_arg = nullptr);
+	ShaderNode::Uniform::Hint _sanitize_hint(ShaderNode::Uniform::Hint p_hint);
 	bool _propagate_function_call_sampler_uniform_settings(const StringName &p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat, ShaderNode::Uniform::Hint p_hint);
 	bool _propagate_function_call_sampler_builtin_reference(const StringName &p_name, int p_argument, const StringName &p_builtin);
 	bool _validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/94897

This chunk of code was supposed to ban mixing textures with _incompatible_ hints, but in reality what it did was stop the function from accepting any two textures with _different_ hints. Most hints are compatibility with one another. In practice, we only care if the hint is a screen texture type (color, depth, or normal-roughness) as those are the only ones with custom code-gen. 

CC @BastiaanOlij 
