### PR TITLE
Enable ASTC encoder build when building with ANGLE.

### DIFF
--- a/modules/astcenc/config.py
+++ b/modules/astcenc/config.py
@@ -1,5 +1,7 @@
 def can_build(env, platform):
-    return env.editor_build
+    # Godot only uses it in the editor, but ANGLE depends on it and we had
+    # to remove the copy from prebuilt ANGLE libs to solve symbol clashes.
+    return env.editor_build or env.get("angle_libs")
 
 
 def configure(env):


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot-angle-static/pull/13
Fixes https://github.com/godotengine/godot/issues/94814