### PR TITLE
Bypass PagedAllocator/PagedArrayPool  by default for ASan build

### DIFF
--- a/core/core_globals.cpp
+++ b/core/core_globals.cpp
@@ -30,6 +30,38 @@
 
 #include "core_globals.h"
 
+#ifdef SANITIZERS_ENABLED
+#ifdef __has_feature
+#if __has_feature(address_sanitizer)
+#define ASAN_ENABLED
+#endif
+#elif defined(__SANITIZE_ADDRESS__)
+#define ASAN_ENABLED
+#endif
+#endif
+
+#ifdef ASAN_ENABLED
+#include "core/string/print_string.h"
+#include "os/os.h"
+#endif
+
 bool CoreGlobals::leak_reporting_enabled = true;
 bool CoreGlobals::print_line_enabled = true;
 bool CoreGlobals::print_error_enabled = true;
+
+#ifdef ASAN_ENABLED
+static bool init_allocators_use_asan_malloc() {
+	bool use_malloc = !OS::get_singleton()->has_environment("ALLOCATORS_DO_NOT_USE_ASAN_MALLOC");
+	if (use_malloc) {
+		print_line("Allocators: Using ASan malloc. (Set env ALLOCATORS_DO_NOT_USE_ASAN_MALLOC=1 to disable)");
+	} else {
+		print_line("Allocators: Not using ASan malloc. (Unset env ALLOCATORS_DO_NOT_USE_ASAN_MALLOC to enable)");
+	}
+	return use_malloc;
+}
+
+bool CoreGlobals::allocators_use_asan_malloc() {
+	static bool use_malloc = init_allocators_use_asan_malloc();
+	return use_malloc;
+}
+#endif

--- a/core/core_globals.h
+++ b/core/core_globals.h
@@ -39,6 +39,10 @@ public:
 	static bool leak_reporting_enabled;
 	static bool print_line_enabled;
 	static bool print_error_enabled;
+
+#ifdef SANITIZERS_ENABLED
+	static bool allocators_use_asan_malloc();
+#endif
 };
 
 #endif // CORE_GLOBALS_H


### PR DESCRIPTION
Forward allocations to ASan malloc directly so that they can be more effectively tested by ASan. This can be disabled by setting the environment variable `ALLOCATORS_DO_NOT_USE_ASAN_MALLOC=1`.

When disabled, PagedAllocator will manually poison unallocated chunks instead. Though this is not very effective in detecting memory errors.

---
This change only affects building with ASan enabled.

`PagedAllocator` keeps its own memory pool and hand allocations out by pieces. This prevents ASan from working effectively for allocations handled by `PagedAllocator`. Even if it poisons the unallocated chunks, it hinders these checks:

- Heap buffer overflow/underflow checks: ASan works by having redzones before and after allocations. `PagedAllocator` hands out pieces from contiguous pages without redzones in between pieces, so there is a high chance any overflow or underflow will end up accessing memory of neighbouring pieces which does not trip ASan. (Though there is little reason for code to index into the these allocations, so overflow/underflow normally should not happen for them.)
- Use-after-free: ASan quarantines freed memory for some time to allow use-after-free errors to be caught. `PagedAllocator` does not have a quarantine &ndash; in fact it prefers handing out pieces that was most recently freed. 
- Double free: `PagedAllocator` will have to check this manually.

In addition, ASan poisoning/unpoisoning does not keep the stack traces, so if the code does hit an error that poisoning is able to catch, you can only see the backtrace of where the whole page was allocated (which can be anywhere), instead of the more helpful backtraces of where the memory was allocated and freed that ASan can provide.

This had managed to catch a use-after-free: #94832.