### PR TITLE
Add place_random_tiles method to place tiles randomly across a region

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -185,6 +185,19 @@
 				[b]Note:[/b] This does not trigger a direct update of the [TileMapLayer], the update will be done at the end of the frame as usual (unless you call [method update_internals]).
 			</description>
 		</method>
+		<method name="place_random_tiles">
+			<return type="void" />
+			<param index="0" name="atlas_coords_array" type="Array" />
+			<param index="1" name="region" type="Rect2i" />
+			<param index="2" name="scattering_probability" type="float" />
+			<param index="3" name="replace_tile" type="bool" />
+			<description>
+				Places random tiles within a specified region.
+				The [param atlas_coords_array] is an array of [Vector4i] elements, where the first element is the source ID of the atlas, the second element is the X-index, and the third element is the Y-index for the desired atlas tile, the fourth element is the optional alternative tile to use. If the atlas source ID is a scene collection, the first element is the scene collection source ID, the next element is the scene ID within that collection, and the last two values are ignored.
+				The [param scattering_probability] is a [float] from 0 to 1 that defines the probability of placing a tile in a cell. If set to [code]0[/code], all cells in the region will be filled with a random tile from the [param atlas_coords_array].
+				The [param replace_tile] parameter defines whether to replace existing tiles in the region. If set to [code]true[/code], existing tiles will be replaced with random tiles from the [param atlas_coords_array], otherwise, no existing tiles will be replaced.
+			</description>
+		</method>
 		<method name="set_cell">
 			<return type="void" />
 			<param index="0" name="coords" type="Vector2i" />

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1764,6 +1764,7 @@ void TileMapLayer::_bind_methods() {
 	// --- Cells manipulation ---
 	// Generic cells manipulations and access.
 	ClassDB::bind_method(D_METHOD("set_cell", "coords", "source_id", "atlas_coords", "alternative_tile"), &TileMapLayer::set_cell, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("place_random_tiles", "atlas_coords_array", "region", "scattering_probability", "replace_tile"), &TileMapLayer::place_random_tiles);
 	ClassDB::bind_method(D_METHOD("erase_cell", "coords"), &TileMapLayer::erase_cell);
 	ClassDB::bind_method(D_METHOD("fix_invalid_tiles"), &TileMapLayer::fix_invalid_tiles);
 	ClassDB::bind_method(D_METHOD("clear"), &TileMapLayer::clear);
@@ -2353,6 +2354,110 @@ void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vec
 	_queue_internal_update();
 
 	used_rect_cache_dirty = true;
+}
+
+void TileMapLayer::place_random_tiles(Array atlas_coords_array, Rect2i region, float scattering_probability, bool replace_tile) {
+	// Validate the input
+	if (atlas_coords_array.is_empty()) {
+		return;
+	}
+
+	// Initialize the maximum coordinates for the region
+	int max_x = region.position.x + region.size.x;
+	int max_y = region.position.y + region.size.y;
+
+	// Precompute the sum of probabilities and store them in a vector for quick access
+	Vector<double> probabilities;
+	probabilities.resize(atlas_coords_array.size());
+	double sum = 0.0;
+
+	for (int i = 0; i < atlas_coords_array.size(); ++i) {
+		Vector4i tile_info = atlas_coords_array[i];
+		int source_id = tile_info.x;
+		int scene_id = tile_info.y; // Used for scene collections
+		Vector2i atlas_coords(tile_info.z, tile_info.w); // Used for 2D tile atlases
+
+		Ref<TileSetSource> source = tile_set->get_source(source_id);
+
+		// Check if the source is a TileSetAtlasSource
+		Ref<TileSetAtlasSource> atlas_source = source;
+		if (atlas_source.is_valid()) {
+			if (atlas_source->has_tile(atlas_coords)) {
+				TileData *tile_data = atlas_source->get_tile_data(atlas_coords, 0);
+				if (tile_data) {
+					sum += tile_data->get_probability();
+					probabilities.set(i, sum);
+				}
+			}
+		} else {
+			// Handle scene collections
+			Ref<TileSetScenesCollectionSource> scenes_collection_source = source;
+			if (scenes_collection_source.is_valid()) {
+				if (scenes_collection_source->has_scene_tile_id(scene_id)) {
+					// For scene collections, we don’t need to calculate probability
+					sum += 1.0; // Treat each scene as having equal probability
+					probabilities.set(i, sum);
+				}
+			}
+		}
+	}
+
+	// Loop through each cell in the specified region
+	for (int x = region.position.x; x < max_x; ++x) {
+		for (int y = region.position.y; y < max_y; ++y) {
+			// Use the scattering value to decide whether to place a tile
+			if (Math::randf() > scattering_probability) {
+				continue; // Skip placing a tile in this cell
+			}
+
+			// Check if we should replace existing tiles
+			if (!replace_tile) {
+				int existing_source_id = get_cell_source_id(Vector2i(x, y));
+				if (existing_source_id != -1) {
+					continue; // Skip this cell if it already has a tile and we shouldn't replace it
+				}
+			}
+
+			// Generate a random number to pick a tile based on precomputed probabilities
+			double picked = Math::randf() * sum;
+			for (int i = 0; i < probabilities.size(); ++i) {
+				if (picked <= probabilities[i]) {
+					Vector4i tile_info = atlas_coords_array[i];
+					int source_id = tile_info.x;
+					int scene_id = tile_info.y; // Used for scene collections
+					Vector2i atlas_coords(tile_info.z, tile_info.w); // Used for 2D tile atlases
+
+					Ref<TileSetSource> source = tile_set->get_source(source_id);
+					Ref<TileSetAtlasSource> atlas_source = source;
+
+					if (atlas_source.is_valid()) {
+						if (atlas_source->has_tile(atlas_coords)) {
+							set_cell(Vector2i(x, y), source_id, atlas_coords, 0);
+						}
+					} else {
+						// Handle scene collections
+						Ref<TileSetScenesCollectionSource> scenes_collection_source = source;
+						if (scenes_collection_source.is_valid()) {
+							if (scenes_collection_source->has_scene_tile_id(scene_id)) {
+								Ref<PackedScene> scene = scenes_collection_source->get_scene_tile_scene(scene_id);
+								if (scene.is_valid()) {
+									// Create an instance of the scene
+									Node2D *node = Object::cast_to<Node2D>(scene->instantiate());
+									if (node) {
+										// Set the position of the node
+										Vector2 local_position = map_to_local(Vector2(x, y));
+										node->set_position(local_position);
+										add_child(node);
+									}
+								}
+							}
+						}
+					}
+					break;
+				}
+			}
+		}
+	}
 }
 
 void TileMapLayer::erase_cell(const Vector2i &p_coords) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -425,6 +425,7 @@ public:
 	// --- Cells manipulation ---
 	// Generic cells manipulations and data access.
 	void set_cell(const Vector2i &p_coords, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i &p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);
+	void place_random_tiles(Array atlas_coords_array, Rect2i region, float scattering_probability, bool replace_tile);
 	void erase_cell(const Vector2i &p_coords);
 	void fix_invalid_tiles();
 	void clear();


### PR DESCRIPTION
Resolves: https://github.com/godotengine/godot-proposals/issues/9697 

This pull request adds a method to scatter tiles randomly over a region through code, similar to the `scattering` property in the TileMap editor.

This feature is especially useful (and common) for roguelikes, where much of the game's map is procedurally generated, but it can apply to any game that uses procedurally generated maps. Being implemented in C++ makes this feature much faster than the most efficient equivalent in GDScript, and therefore makes sense to implement it as a new feature. I believe this feature makes sense to be core because roguelikes are a common use-case for this type of feature, and they are a popular genre for 2D games. Therefore I think this feature will be used widely for all kinds of projects. 

Just to extrapolate further, this method can also be used to create spawn tables for loot or enemies. It can be used to define an area in which these entities can spawn which is something that could be used in a wide range of projects. That's just one example, I'm sure there are plenty I haven't thought of. I'm sure with scene collections it's possible to implement even more advanced logic.

There are 4 arguments:

- `atlas_coords_array`, an `Array` of `Vector4i`'s. Where, in the case of 2D texture atlases, the first element of the `Vector4i` is the atlas source ID, so it knows which atlas to pick the tiles from, the next element is the x-index of the tile within the tile map, and the next element is the y-index of the tile within the tile-map, and the last element is the alternative tile to use. If the atlas source ID is instead a scene collection, then the first element is the scene collection source ID, the next element is the scene ID within that collection, and the last two values are ignored.
- `region` which is a `Rect2i` representing the region over which to perform the random placement.
- `scattering_probability` is a `float` between `0` and `1` which much like the editor's `scattering` property, determines the likelihood of any tile within the region having a tile placed there. At `0` no tiles will be placed anywhere within the `region`, and at `1` all tiles within the region will have a random tile placed there.
- `replace_tile` is a `bool` which when `true` will allow it to replace existing tiles within the `region` with one of the random tiles. If set to `false` no existing tiles will be replaced.

Here I've set up a basic `TileMapLayer` with a grid of sprites in the top left:

<img width="917" alt="Screenshot 2024-07-28 213256" src="https://github.com/user-attachments/assets/2854725b-c41c-44f6-992e-ca3772c51622">

I've created an array that has `Vector4i`'s specifying that it should get tiles from tile atlas 0, and then I've specified the exact tiles I want. I've attached a script that has the `place_random_tiles` method within the `_ready` method, giving us a random layout every time the scene is loaded:

<img width="1157" alt="screenshot8" src="https://github.com/user-attachments/assets/1fd8565e-13b2-41d0-b780-d65a1a3ea851">

Randomized tile layout from the specified array of tiles:
<img width="575" alt="Screenshot 2024-07-28 213506" src="https://github.com/user-attachments/assets/cbafd03e-5689-479b-b2e9-d7d4149947da">

With `scattering_probability` set to `0.25`:
<img width="572" alt="Screenshot 2024-07-28 213818" src="https://github.com/user-attachments/assets/419754f6-5a8a-46ab-9245-5863208237f5">

With `scattering_probability` set to `0.75`:
<img width="572" alt="Screenshot 2024-07-28 213842" src="https://github.com/user-attachments/assets/48b3c569-05f8-495b-a444-60d9bd249ac0">

With `scattering_probability` set to `1.0`:

<img width="574" alt="Screenshot 2024-07-28 213908" src="https://github.com/user-attachments/assets/a6241fc6-ba93-4cb4-b3a7-855ba656896d">

With `replace_tile` set to `true`, existing tiles can be replaced:
<img width="575" alt="Screenshot 2024-07-28 213933" src="https://github.com/user-attachments/assets/63f5705e-3990-4f4c-92c1-9ea88b110dfa">

Atlas source IDs are specified in the `atlas_coords_array` so you can select tiles from different tile atlases:
<img width="1340" alt="Screenshot 2024-07-28 213333" src="https://github.com/user-attachments/assets/5630de34-4b63-4a66-a389-54b4f0fc9b7a">

<img width="1340" alt="Screenshot 2024-07-28 213356" src="https://github.com/user-attachments/assets/b8c08991-8110-41d7-bb3d-281f0cf8e816">

Here's the breakdown of how each element works in the `atlas_coords_array` argument:
![Screenshot9](https://github.com/user-attachments/assets/c38c59ac-ae6d-49ba-a122-77250bbb02d1)

The above `Vector4i` element will include this tile in the randomization:
<img width="1342" alt="Screenshot 2024-07-28 220923" src="https://github.com/user-attachments/assets/4cd8c2ef-f8c6-467c-8e04-c649049eb040">

Here's the project so you can test it yourself:
[TileMapDev.zip](https://github.com/user-attachments/files/16409648/TileMapDev.zip)
The project includes testing for _**scene collections**_ as well.
