### PR TITLE
[macOS] Add option to emit signal when opening files/urls with the app, instead of starting new instance.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1445,6 +1445,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 	GLOBAL_DEF("application/config/auto_accept_quit", true);
 	GLOBAL_DEF("application/config/quit_on_go_back", true);
+	GLOBAL_DEF_BASIC("application/config/emit_on_file_open", false);
 
 	// The default window size is tuned to:
 	// - Have a 16:9 aspect ratio,

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -45,6 +45,7 @@ void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_TEXT_SERVER_CHANGED);
 
 	ADD_SIGNAL(MethodInfo("on_request_permissions_result", PropertyInfo(Variant::STRING, "permission"), PropertyInfo(Variant::BOOL, "granted")));
+	ADD_SIGNAL(MethodInfo("on_file_open", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
 
 	GDVIRTUAL_BIND(_initialize);
 	GDVIRTUAL_BIND(_physics_process, "delta");

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -90,6 +90,13 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="on_file_open">
+			<param index="0" name="files" type="PackedStringArray" />
+			<description>
+				Emitted when a user opens file with the application. Signal is emitted only is [member ProjectSettings.application/config/emit_on_file_open] is [code]true[/code] or application is running in the macOS sandbox.
+				[b]Note:[/b] This signal is implemented only on macOS.
+			</description>
+		</signal>
 		<signal name="on_request_permissions_result">
 			<param index="0" name="permission" type="String" />
 			<param index="1" name="granted" type="bool" />

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -271,6 +271,10 @@
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
+		<member name="application/config/emit_on_file_open" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], application will emit [signal MainLoop.on_file_open] signal instead of starting new application instance.
+			[b]Note:[/b] This setting is implemented only on macOS.
+		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon as a fallback if necessary.
 		</member>

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -179,8 +179,16 @@
 
 	if (!args.is_empty()) {
 		if (os->get_main_loop()) {
-			// Application is already running, open a new instance with the URL/files as command line arguments.
-			os->create_instance(args);
+			// Application is already running, open a new instance with the URL/files as command line arguments, or emit signal.
+			if ((OS::get_singleton()->is_sandboxed() || GLOBAL_GET("application/config/emit_on_file_open").operator bool()) && !Engine::get_singleton()->is_editor_hint()) {
+				Vector<String> args_vector;
+				for (List<String>::Element *E = args.front(); E; E = E->next()) {
+					args_vector.push_back(E->get());
+				}
+				os->get_main_loop()->emit_signal(SNAME("on_file_open"), args_vector);
+			} else {
+				os->create_instance(args);
+			}
 		} else {
 			// Application is just started, add to the list of command line arguments and continue.
 			os->set_cmdline_platform_args(args);


### PR DESCRIPTION
Adds `application/config/emit_on_file_open` setting to emit `MainLoop::on_file_open` signal instead of starting new app instance. Always enabled for sandboxed apps, since these can't open instance with command line arguments. When launching the first instance, the opened file names are sent via command line arguments as before.

```gdscript
func _ready() -> void:
	get_tree().on_file_open.connect(_on_file_open) # connect signal


func _on_file_open(files: PackedStringArray) -> void:
	$TextEdit.text = "\n".join(files) # process newely opened file
```

Fixes https://github.com/godotengine/godot/issues/94788