### PR TITLE
Fix for folding "Editable Children" nodes in Scene tree not being saved

### DIFF
--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -93,7 +93,7 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 		if (!p_node->get_owner()) {
 			return; //not owned, bye
 		}
-		if (p_node->get_owner() != p_root && !p_root->is_editable_instance(p_node)) {
+		if (p_node->get_owner() != p_root && !p_root->is_editable_instance(p_node->get_owner())) {
 			return;
 		}
 	}


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/91542

When _fill_folds is called on a child of an instantiated scene with editable children enabled, it will not be parsed correctly on child nodes due to the is_editable_instance check never being true.  

Changed:
```cpp
if (p_node->get_owner() != p_root && !p_root->is_editable_instance(p_node)) {
```
```cpp
if (p_node->get_owner() != p_root && !p_root->is_editable_instance(p_node->get_owner())) {
```

MRP Taken from related issue
[Node.Folding.zip](https://github.com/user-attachments/files/16412795/Node.Folding.zip)

