### PR TITLE
Fix scene not updated when editing animation track key value in AnimationTrackKeyEdit Inspector panel

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4767,6 +4767,11 @@ void AnimationTrackEditor::_animation_changed() {
 		return; // All will be updated, don't bother with anything.
 	}
 
+	AnimationPlayer *player = AnimationPlayerEditor::get_singleton()->get_player();
+	if (player != nullptr) {
+		player->advance(0.0); // Force an update to refresh the view.
+	}
+
 	_check_bezier_exist();
 
 	if (key_edit) {


### PR DESCRIPTION
* Fixes: #78131

## Test environment
Godot Engine v4.3.rc1.official
Windows 11 Pro, Version 23H2, Build 22631.3880

## Issue
Modifications to properties related to ```AnimationTrackKeyEdit``` instances do not request the animation player to update.  

## Fix
This fix modifies the ```AnimationTrackEditor::_animation_changed()``` method to call the ```AnimationPlayer::advance()``` method of the animation player with a zero offset. That forces the animation player to udate and the UI to refresh.