### PR TITLE
Fix crash when interacting with appended nodes not part of the edited scene

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1065,6 +1065,12 @@ void Node3DEditorViewport::_select_region() {
 		found_nodes.insert(sp);
 
 		Node *node = Object::cast_to<Node>(sp);
+
+		// Prevent selection of nodes that exist outside the current edited scene.
+		if (!edited_scene->is_ancestor_of(node)) {
+			continue;
+		}
+
 		if (node != edited_scene) {
 			node = edited_scene->get_deepest_editable_node(node);
 		}


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/94844

The crash is an issue with how the engine handles the selection of nodes that have been appended to the main screen.  It gets the deepest editable node and then climbs up until it reaches the parent of the edited scene, but for nodes appended to the main scene through plugins, this results in node becoming NULL, which is then checked for a specific class, causing a hard crash. 

added:
```cpp
// Prevent selection of nodes that exist outside the current edited scene.
if (!edited_scene->is_ancestor_of(node)) {
	continue;
}
```

related code:
```cpp
if (node != edited_scene) {
	node = edited_scene->get_deepest_editable_node(node);
}

// Prevent selection of nodes not owned by the edited scene.
while (node && node != edited_scene->get_parent()) {
	Node *node_owner = node->get_owner();
	if (node_owner == edited_scene || node == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
		break;
	}
	node = node->get_parent();
}

// Replace the node by the group if grouped
if (node->is_class("Node3D")) {
```

This change also prevents the pointless spam of  bad ancestor checks prior to the crash:
```cpp
ERROR: Condition "!is_ancestor_of(p_start_node)" is true. Returning: p_start_node
   at: get_deepest_editable_node (scene/main/node.cpp:2525)
ERROR: Condition "!is_ancestor_of(p_node)" is true. Returning: false
   at: is_editable_instance (scene/main/node.cpp:2518)
ERROR: Condition "!is_ancestor_of(p_node)" is true. Returning: false
   at: is_editable_instance (scene/main/node.cpp:2518)
ERROR: Condition "!is_ancestor_of(p_node)" is true. Returning: false
   at: is_editable_instance (scene/main/node.cpp:2518)


================================================================
handle_crash: Program crashed with signal 11
```
