### PR TITLE
Fix ResourceLoader is not printing a resource path on loading when `verbose_stdout` is enabled

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -343,10 +343,17 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 
 	bool xl_remapped = false;
 	const String &remapped_path = _path_remap(load_task.local_path, &xl_remapped);
+
+	print_verbose("Loading resource: " + remapped_path);
+
 	Error load_err = OK;
 	Ref<Resource> res = _load(remapped_path, remapped_path != load_task.local_path ? load_task.local_path : String(), load_task.type_hint, load_task.cache_mode, &load_err, load_task.use_sub_threads, &load_task.progress);
 	if (MessageQueue::get_singleton() != MessageQueue::get_main_singleton()) {
 		MessageQueue::get_singleton()->flush();
+	}
+
+	if (res.is_null()) {
+		print_verbose("Failed loading resource: " + remapped_path);
 	}
 
 	thread_load_mutex.lock();


### PR DESCRIPTION
Fixes the issue from [this post](https://forum.godotengine.org/t/how-to-enable-output-messages-for-resources-that-are-being-loaded-verbose-stdout/70150).

When any resource is going to be loaded and has the `verbose_stdout` setting enabled, the resource loader prints `Loading resource: <resource path>` (and `Failed loading resource` if failed). But after 4.1, this resource loader doesn't print it anymore.

The current version of the `ProjectSettings` document page confirmed that the `verbose_stdout` does this.
"*Print more information to standard output when running. It displays information such as memory leaks, **which scenes and resources are being loaded**, etc* . . ."

This feature was working until #74405 merged. So, This may be a regression.