### PR TITLE
Fix crash that occurs on termination of the Godot engine on Android

### DIFF
--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -83,6 +83,10 @@ static Vector3 magnetometer;
 static Vector3 gyroscope;
 
 static void _terminate(JNIEnv *env, bool p_restart = false) {
+	if (step.get() == STEP_TERMINATED) {
+		return;
+	}
+
 	step.set(STEP_TERMINATED); // Ensure no further steps are attempted and no further events are sent
 
 	// lets cleanup


### PR DESCRIPTION
This PR + https://github.com/godotengine/godot/pull/85955 should address the last of the crashes visible in the logs when the Godot engine is destroyed on Android.

```
09:30:58.768 libc                     A  FORTIFY: pthread_mutex_destroy called on a destroyed mutex (0xb4000078f6a41bc4)
09:30:58.768 libc                     A  Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 13049 (GLThread 524), pid 13006 (e.editor.v4.dev)
09:30:59.018 DEBUG                    A  Cmdline: org.godotengine.editor.v4.dev
09:30:59.018 DEBUG                    A  pid: 13006, tid: 13049, name: GLThread 524  >>> org.godotengine.editor.v4.dev <<<
09:30:59.018 DEBUG                    A        #04 pc 00000000000c339c  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libc++_shared.so (std::__ndk1::mutex::~mutex()+12) (BuildId: d7ce478d849eba1d3e692ae740f6c04a08fb8fab)
09:30:59.018 DEBUG                    A        #05 pc 00000000046c70f4  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libgodot_android.so (MutexImpl<std::__ndk1::mutex>::~MutexImpl()+20)
09:30:59.018 DEBUG                    A        #06 pc 00000000082d8a9c  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libgodot_android.so (Object::~Object()+1252)
09:30:59.018 DEBUG                    A        #07 pc 0000000002f952f4  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libgodot_android.so (void memdelete<JavaClassWrapper>(JavaClassWrapper*)+44)
09:30:59.018 DEBUG                    A        #08 pc 0000000002f92b6c  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libgodot_android.so (_terminate(_JNIEnv*, bool)+84)
09:30:59.018 DEBUG                    A        #09 pc 0000000002f92b08  /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/lib/arm64/libgodot_android.so (Java_org_godotengine_godot_GodotLib_ondestroy+32)
09:30:59.018 DEBUG                    A        #15 pc 0000000000004ef4  [anon:dalvik-classes12.dex extracted in memory from /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/base.apk!classes12.dex] (org.godotengine.godot.gl.GodotRenderer.onRenderThreadExiting+0)
09:30:59.018 DEBUG                    A        #24 pc 0000000000003c94  [anon:dalvik-classes12.dex extracted in memory from /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/base.apk!classes12.dex] (org.godotengine.godot.gl.GLSurfaceView$GLThread.guardedRun+0)
09:30:59.018 DEBUG                    A        #29 pc 00000000000045a8  [anon:dalvik-classes12.dex extracted in memory from /data/app/~~Ec9iAIQ5fzLqEPPNImdlBQ==/org.godotengine.editor.v4.dev-SqKR3gzRh7N7i790JSQ_Zg==/base.apk!classes12.dex] (org.godotengine.godot.gl.GLSurfaceView$GLThread.run+0)

```

Those crashes have been ongoing for some time but were made more visible by https://github.com/godotengine/godot/pull/94661.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
