### PR TITLE
Replace `arguments` keyword with rest parameter

### DIFF
--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -194,8 +194,8 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 * @ignore
 		 * @type {?function(...*)}
 		 */
-		onPrint: function () {
-			console.log.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+		onPrint: function (...args) {
+			console.log.apply(console, ...args); // eslint-disable-line no-console
 		},
 		/**
 		 * A callback function for handling the standard error stream. This method should usually only be used in debug pages.
@@ -209,8 +209,8 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 * @ignore
 		 * @type {?function(...*)}
 		 */
-		onPrintError: function (var_args) {
-			console.error.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+		onPrintError: function (...args) {
+			console.error.apply(console, ...args); // eslint-disable-line no-console
 		},
 	};
 

--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -215,7 +215,7 @@ const GodotJSWrapper = {
 	godot_js_wrapper_create_cb: function (p_ref, p_func) {
 		const func = GodotRuntime.get_func(p_func);
 		let id = 0;
-		const cb = function () {
+		const cb = function (...args) {
 			if (!GodotJSWrapper.get_proxied_value(id)) {
 				return undefined;
 			}
@@ -223,7 +223,6 @@ const GodotJSWrapper = {
 			// "godot_js_wrapper_object_set_cb_ret" upon calling the user function.
 			// This is safe! JavaScript is single threaded (and using it in threads is not a good idea anyway).
 			GodotJSWrapper.cb_ret = null;
-			const args = Array.from(arguments);
 			const argsProxy = new GodotJSWrapper.MyProxy(args);
 			func(p_ref, argsProxy.get_id(), args.length);
 			argsProxy.unref();

--- a/platform/web/js/libs/library_godot_runtime.js
+++ b/platform/web/js/libs/library_godot_runtime.js
@@ -40,12 +40,12 @@ const GodotRuntime = {
 		/*
 		 * Prints
 		 */
-		error: function () {
-			err.apply(null, Array.from(arguments)); // eslint-disable-line no-undef
+		error: function (...args) {
+			err.apply(null, ...args); // eslint-disable-line no-undef
 		},
 
-		print: function () {
-			out.apply(null, Array.from(arguments)); // eslint-disable-line no-undef
+		print: function (...args) {
+			out.apply(null, ...args); // eslint-disable-line no-undef
 		},
 
 		/*


### PR DESCRIPTION
As noted in the [MDN documentation of `arguments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments#description):

<img width="796" alt="Capture d’écran, le 2024-07-29 à 15 12 13" src="https://github.com/user-attachments/assets/733bfb10-9d39-44c7-aeb8-b8e147bc1097">
