### PR TITLE
Add emission shape ring for CPUParticles2D

### DIFF
--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -172,6 +172,12 @@
 		<member name="emission_rect_extents" type="Vector2" setter="set_emission_rect_extents" getter="get_emission_rect_extents">
 			The rectangle's extents if [member emission_shape] is set to [constant EMISSION_SHAPE_RECTANGLE].
 		</member>
+		<member name="emission_ring_inner_radius" type="float" setter="set_emission_ring_inner_radius" getter="get_emission_ring_inner_radius">
+			The ring's inner radius if [member emission_shape] is set to [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_radius" type="float" setter="set_emission_ring_radius" getter="get_emission_ring_radius">
+			The ring's outer radius if [member emission_shape] is set to [constant EMISSION_SHAPE_RING].
+		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="CPUParticles2D.EmissionShape" default="0">
 			Particles will be emitted inside this region.
 		</member>
@@ -385,7 +391,10 @@
 		<constant name="EMISSION_SHAPE_DIRECTED_POINTS" value="5" enum="EmissionShape">
 			Particles will be emitted at a position chosen randomly among [member emission_points]. Particle velocity and rotation will be set based on [member emission_normals]. Particle color will be modulated by [member emission_colors].
 		</constant>
-		<constant name="EMISSION_SHAPE_MAX" value="6" enum="EmissionShape">
+		<constant name="EMISSION_SHAPE_RING" value="6" enum="EmissionShape">
+			Particles will be emitted in the area of a ring parameterized by its outer and inner radius.
+		</constant>
+		<constant name="EMISSION_SHAPE_MAX" value="7" enum="EmissionShape">
 			Represents the size of the [enum EmissionShape] enum.
 		</constant>
 	</constants>

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -524,6 +524,14 @@ void CPUParticles2D::set_emission_colors(const Vector<Color> &p_colors) {
 	emission_colors = p_colors;
 }
 
+void CPUParticles2D::set_emission_ring_inner_radius(real_t p_inner_radius) {
+	emission_ring_inner_radius = p_inner_radius;
+}
+
+void CPUParticles2D::set_emission_ring_radius(real_t p_ring_radius) {
+	emission_ring_radius = p_ring_radius;
+}
+
 real_t CPUParticles2D::get_emission_sphere_radius() const {
 	return emission_sphere_radius;
 }
@@ -542,6 +550,14 @@ Vector<Vector2> CPUParticles2D::get_emission_normals() const {
 
 Vector<Color> CPUParticles2D::get_emission_colors() const {
 	return emission_colors;
+}
+
+real_t CPUParticles2D::get_emission_ring_inner_radius() const {
+	return emission_ring_inner_radius;
+}
+
+real_t CPUParticles2D::get_emission_ring_radius() const {
+	return emission_ring_radius;
 }
 
 CPUParticles2D::EmissionShape CPUParticles2D::get_emission_shape() const {
@@ -644,6 +660,13 @@ void CPUParticles2D::_validate_property(PropertyInfo &p_property) const {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 	if (p_property.name.begins_with("scale_curve_") && !split_scale) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+
+	if (p_property.name == "emission_ring_inner_radius" && emission_shape != EMISSION_SHAPE_RING) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	if (p_property.name == "emission_ring_radius" && emission_shape != EMISSION_SHAPE_RING) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
@@ -925,6 +948,13 @@ void CPUParticles2D::_particles_process(double p_delta) {
 					if (emission_colors.size() == pc) {
 						p.base_color = emission_colors.get(random_idx);
 					}
+				} break;
+				case EMISSION_SHAPE_RING: {
+					real_t t = Math::TAU * Math::randf();
+					real_t outer_sq = emission_ring_radius * emission_ring_radius;
+					real_t inner_sq = emission_ring_inner_radius * emission_ring_inner_radius;
+					real_t radius = Math::sqrt(Math::randf() * (outer_sq - inner_sq) + inner_sq);
+					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
 				} break;
 				case EMISSION_SHAPE_MAX: { // Max value for validity check.
 					break;
@@ -1379,6 +1409,9 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	Vector2 rect_extents = Vector2(proc_mat->get_emission_box_extents().x, proc_mat->get_emission_box_extents().y);
 	set_emission_rect_extents(rect_extents);
 
+	set_emission_ring_radius(proc_mat->get_emission_ring_radius());
+	set_emission_ring_inner_radius(proc_mat->get_emission_ring_inner_radius());
+
 	Ref<CurveXYZTexture> scale3D = proc_mat->get_param_texture(ParticleProcessMaterial::PARAM_SCALE);
 	if (scale3D.is_valid()) {
 		split_scale = true;
@@ -1527,6 +1560,12 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emission_colors", "array"), &CPUParticles2D::set_emission_colors);
 	ClassDB::bind_method(D_METHOD("get_emission_colors"), &CPUParticles2D::get_emission_colors);
 
+	ClassDB::bind_method(D_METHOD("set_emission_ring_inner_radius", "inner_radius"), &CPUParticles2D::set_emission_ring_inner_radius);
+	ClassDB::bind_method(D_METHOD("get_emission_ring_inner_radius"), &CPUParticles2D::get_emission_ring_inner_radius);
+
+	ClassDB::bind_method(D_METHOD("set_emission_ring_radius", "radius"), &CPUParticles2D::set_emission_ring_radius);
+	ClassDB::bind_method(D_METHOD("get_emission_ring_radius"), &CPUParticles2D::get_emission_ring_radius);
+
 	ClassDB::bind_method(D_METHOD("get_gravity"), &CPUParticles2D::get_gravity);
 	ClassDB::bind_method(D_METHOD("set_gravity", "accel_vec"), &CPUParticles2D::set_gravity);
 
@@ -1544,12 +1583,14 @@ void CPUParticles2D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("finished"));
 
 	ADD_GROUP("Emission Shape", "emission_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Sphere Surface,Rectangle,Points,Directed Points", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_emission_shape", "get_emission_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Sphere Surface,Rectangle,Points,Directed Points,Ring", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_emission_shape", "get_emission_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_sphere_radius", PROPERTY_HINT_RANGE, "0.01,128,0.01,suffix:px"), "set_emission_sphere_radius", "get_emission_sphere_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "emission_rect_extents", PROPERTY_HINT_NONE, "suffix:px"), "set_emission_rect_extents", "get_emission_rect_extents");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "emission_points"), "set_emission_points", "get_emission_points");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "emission_normals"), "set_emission_normals", "get_emission_normals");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "emission_colors"), "set_emission_colors", "get_emission_colors");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_ring_inner_radius"), "set_emission_ring_inner_radius", "get_emission_ring_inner_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_ring_radius"), "set_emission_ring_radius", "get_emission_ring_radius");
 	ADD_GROUP("Particle Flags", "particle_flag_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_align_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
 	ADD_GROUP("Direction", "");
@@ -1638,6 +1679,7 @@ void CPUParticles2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_RECTANGLE);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_POINTS);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_DIRECTED_POINTS);
+	BIND_ENUM_CONSTANT(EMISSION_SHAPE_RING);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_MAX);
 }
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -74,7 +74,8 @@ public:
 		EMISSION_SHAPE_RECTANGLE,
 		EMISSION_SHAPE_POINTS,
 		EMISSION_SHAPE_DIRECTED_POINTS,
-		EMISSION_SHAPE_MAX
+		EMISSION_SHAPE_RING,
+		EMISSION_SHAPE_MAX,
 	};
 
 private:
@@ -177,6 +178,8 @@ private:
 	Vector<Vector2> emission_normals;
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
+	real_t emission_ring_inner_radius = 0.8;
+	real_t emission_ring_radius = 1.0;
 
 	Ref<Curve> scale_curve_x;
 	Ref<Curve> scale_curve_y;
@@ -306,6 +309,8 @@ public:
 	void set_emission_points(const Vector<Vector2> &p_points);
 	void set_emission_normals(const Vector<Vector2> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);
+	void set_emission_ring_inner_radius(real_t p_inner_radius);
+	void set_emission_ring_radius(real_t p_ring_radius);
 	void set_scale_curve_x(Ref<Curve> p_scale_curve);
 	void set_scale_curve_y(Ref<Curve> p_scale_curve);
 	void set_split_scale(bool p_split_scale);
@@ -316,6 +321,8 @@ public:
 	Vector<Vector2> get_emission_points() const;
 	Vector<Vector2> get_emission_normals() const;
 	Vector<Color> get_emission_colors() const;
+	real_t get_emission_ring_inner_radius() const;
+	real_t get_emission_ring_radius() const;
 	Ref<Curve> get_scale_curve_x() const;
 	Ref<Curve> get_scale_curve_y() const;
 	bool get_split_scale();

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -557,6 +557,9 @@ void GPUParticles2D::convert_from_particles(Node *p_particles) {
 	proc_mat->set_emission_shape(ParticleProcessMaterial::EmissionShape(cpu_particles->get_emission_shape()));
 	proc_mat->set_emission_sphere_radius(cpu_particles->get_emission_sphere_radius());
 
+	proc_mat->set_emission_ring_radius(cpu_particles->get_emission_ring_radius());
+	proc_mat->set_emission_ring_inner_radius(cpu_particles->get_emission_ring_inner_radius());
+
 	Vector2 rect_extents = cpu_particles->get_emission_rect_extents();
 	proc_mat->set_emission_box_extents(Vector3(rect_extents.x, rect_extents.y, 0));
 


### PR DESCRIPTION
Particles will be emitted in the area of a ring parameterized by its outer and inner radius. The distribution is uniform across the area.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/10303.*