### PR TITLE
Fix editor settings still displayed when replaced

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -998,6 +998,13 @@ const String EditorSettings::_get_project_metadata_path() const {
 	return EditorPaths::get_singleton()->get_project_settings_dir().path_join("project_metadata.cfg");
 }
 
+#ifndef DISABLE_DEPRECATED
+void EditorSettings::_remove_deprecated_settings() {
+	erase("run/output/always_open_output_on_play");
+	erase("run/output/always_close_output_on_stop");
+}
+#endif
+
 // PUBLIC METHODS
 
 EditorSettings *EditorSettings::get_singleton() {
@@ -1078,6 +1085,9 @@ void EditorSettings::create() {
 		singleton->setup_network();
 		singleton->load_favorites_and_recent_dirs();
 		singleton->list_text_editor_themes();
+#ifndef DISABLE_DEPRECATED
+		singleton->_remove_deprecated_settings();
+#endif
 
 		return;
 	}

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -114,6 +114,9 @@ private:
 	bool _save_text_editor_theme(const String &p_file);
 	bool _is_default_text_editor_theme(const String &p_theme_name);
 	const String _get_project_metadata_path() const;
+#ifndef DISABLE_DEPRECATED
+	void _remove_deprecated_settings();
+#endif
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
- Fixes #94577

Even though no consensus was achieved about what to do with removed or replaced settings in the editor settings, I suggest this PR to fix the problem where old settings `run/output/always_open_output_on_play` and `run/output/always_close_output_on_stop` are displayed in the editor settings if the user migrates from an earlier version of Godot.

This PR adds the `EditorSettings::_remove_deprecated_settings` method and calls it when loading editor settings. It's the easiest way to fix the problem and can be used for future removal or replacement of editor settings.