### PR TITLE
Fix no validation on Blender path on import

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -115,8 +115,15 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		List<String> *r_missing_deps, Error *r_err) {
 	String blender_path = EDITOR_GET("filesystem/import/blender/blender_path");
 
-	if (blender_major_version == -1 || blender_minor_version == -1) {
-		_get_blender_version(blender_path, blender_major_version, blender_minor_version, nullptr);
+	ERR_FAIL_COND_V_MSG(blender_path.is_empty(), nullptr, "Blender path is empty, check your Editor Settings.");
+	ERR_FAIL_COND_V_MSG(!FileAccess::exists(blender_path), nullptr, vformat("Invalid Blender path: %s, check your Editor Settings.", blender_path));
+
+	if (blender_major_version == -1 || blender_minor_version == -1 || last_tested_blender_path != blender_path) {
+		String error;
+		if (!_get_blender_version(blender_path, blender_major_version, blender_minor_version, &error)) {
+			ERR_FAIL_V_MSG(nullptr, error);
+		}
+		last_tested_blender_path = blender_path;
 	}
 
 	// Get global paths for source and sink.

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -45,6 +45,7 @@ class EditorSceneFormatImporterBlend : public EditorSceneFormatImporter {
 
 	int blender_major_version = -1;
 	int blender_minor_version = -1;
+	String last_tested_blender_path;
 
 public:
 	enum {


### PR DESCRIPTION
- Fixes #94914

This PR adds a validation of the Blender path just before executing the Blender import.

My first attempt was to show a popup asking the user to set the Blender path, but it was more complicated than I expected. First, the popup would hang when called in a signal (e.g., when the Reimport button was pressed in the Import Dock). My guess is that the loop in `EditorFileSystemImportFormatSupportQueryBlend::query` on `Main::Iteration()` caused this. I was able to make it work by executing the import and opening the popup from the `NOTIFICATION_PROCESS`. However, there are multiple places from where the advanced options can be called, and refactoring each place to use the `NOTIFICATION_PROCESS` would require a lot of changes, and I'm not sure it's necessary for an issue that should not happen often. Maybe there is another way to prevent this hang that could avoid extensive refactoring, but I don't know??

Note: This bug is marked as a regression for 4.3, but I'm pretty sure it was present before 4.3.

Examples of the new validation errors:
![image](https://github.com/user-attachments/assets/0d7cc224-89bd-4d28-bbb9-458b7d0ebcc3)

