### PR TITLE
Fix `AnimationPlayer` crash when it's made the scene root

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -52,6 +52,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	AnimationPlayerEditorPlugin *plugin = nullptr;
 	AnimationMixer *original_node = nullptr; // For pinned mark in SceneTree.
 	AnimationPlayer *player = nullptr; // For AnimationPlayerEditor, could be dummy.
+	ObjectID cached_root_node_id;
 	bool is_dummy = false;
 
 	enum {
@@ -253,6 +254,7 @@ public:
 	AnimationMixer *get_editing_node() const;
 	AnimationPlayer *get_player() const;
 	AnimationMixer *fetch_mixer_for_library() const;
+	Node *get_cached_root_node() const;
 
 	static AnimationPlayerEditor *get_singleton() { return singleton; }
 


### PR DESCRIPTION
When an AnimationPlayer node is made the root of a scene, the node links on the Animation Track can become broken and clicking on them will crash Godot 4.2.2-stable. The current master branch also breaks the node links when AnimationPlayer is made scene root, and can also crash the engine if another node was made the scene root prior to the AnimationPlayer (See Issue #91043)

This happens because when made root, the editor loses track of AnimationPlayer's `root_node`. By keeping a cached pointer to the `root_node`, the track links can remain functional.

Fixes Crash in 4.2.2-stable and Fixes Broken Node Links and Potential Crash in current master branch.

* *Bugsquad edit, fixes: #91043*
