### PR TITLE
Optimize ANGLE on D3D11 to remove an extra blit

### DIFF
--- a/drivers/egl/egl_manager.h
+++ b/drivers/egl/egl_manager.h
@@ -53,11 +53,18 @@ private:
 		EGLDisplay egl_display = EGL_NO_DISPLAY;
 		EGLContext egl_context = EGL_NO_CONTEXT;
 		EGLConfig egl_config = nullptr;
+
+#ifdef WINDOWS_ENABLED
+		bool has_EGL_ANGLE_surface_orientation = false;
+#endif
 	};
 
 	// EGL specific window data.
 	struct GLWindow {
 		bool initialized = false;
+#ifdef WINDOWS_ENABLED
+		bool flipped_y = false;
+#endif
 
 		// An handle to the GLDisplay associated with this window.
 		int gldisplay_id = -1;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -82,6 +82,10 @@
 #define strcpy strcpy_s
 #endif
 
+#ifdef WINDOWS_ENABLED
+bool RasterizerGLES3::screen_flipped_y = false;
+#endif
+
 bool RasterizerGLES3::gles_over_gl = true;
 
 void RasterizerGLES3::begin_frame(double frame_step) {
@@ -380,6 +384,12 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 		flip_y = false;
 	}
 
+#ifdef WINDOWS_ENABLED
+	if (screen_flipped_y) {
+		flip_y = !flip_y;
+	}
+#endif
+
 	GLuint read_fbo = 0;
 	glGenFramebuffers(1, &read_fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
@@ -476,9 +486,14 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 		screenrect.position += ((Size2(win_size.width, win_size.height) - screenrect.size) / 2.0).floor();
 	}
 
-	// Flip Y.
-	screenrect.position.y = win_size.y - screenrect.position.y;
-	screenrect.size.y = -screenrect.size.y;
+#ifdef WINDOWS_ENABLED
+	if (!screen_flipped_y)
+#endif
+	{
+		// Flip Y.
+		screenrect.position.y = win_size.y - screenrect.position.y;
+		screenrect.size.y = -screenrect.size.y;
+	}
 
 	// Normalize texture coordinates to window size.
 	screenrect.position /= win_size;

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -58,6 +58,10 @@ private:
 	double time_total = 0.0;
 	bool flip_xy_workaround = false;
 
+#ifdef WINDOWS_ENABLED
+	static bool screen_flipped_y;
+#endif
+
 	static bool gles_over_gl;
 
 protected:
@@ -116,6 +120,12 @@ public:
 		_create_func = _create_current;
 		low_end = true;
 	}
+
+#ifdef WINDOWS_ENABLED
+	static void set_screen_flipped_y(bool p_flipped) {
+		screen_flipped_y = p_flipped;
+	}
+#endif
 
 	_ALWAYS_INLINE_ uint64_t get_frame_number() const { return frame; }
 	_ALWAYS_INLINE_ double get_frame_delta_time() const { return delta; }


### PR DESCRIPTION
Support the extension EGL_ANGLE_surface_orientation, which allows ANGLE to skip an extra blit from an intermediate buffer to the D3D11 swap chain back buffer for inverting the Y axis due to the difference in coordinate systems. Instead we do our inverting in RasterizerGLES3.

---
When running with `--rendering-driver opengl3_angle --verbose` you should see these in the output:

```
EGL: EGL_ANGLE_surface_orientation is supported.
EGL: Using optimal surface orientation: Invert Y
```

I have verified with RenderDoc that this replaces two `Draw` calls (one for `glBlitFramebuffer` from the render target FBO to the "screen" which is ANGLE's intermediate buffer with inverted Y, another for drawing ANGLE's intermediate buffer to the swap chain's back buffer) with one `CopySubresourceRegion` call (`glBlitFramebuffer` from the render target FBO to the swap chain's back buffer).