### PR TITLE
Fix `res://` being selected when a file is deleted from it

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -249,8 +249,8 @@ private:
 	void _reselect_items_selected_on_drag_begin(bool reset = false);
 
 	Ref<Texture2D> _get_tree_item_icon(bool p_is_valid, const String &p_file_type, const String &p_icon_path);
-	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
-	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false);
+	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false, bool p_fs_changed = false);
+	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false, bool p_fs_changed = false);
 	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false);
 
 	void _file_list_gui_input(Ref<InputEvent> p_event);


### PR DESCRIPTION
This prevents the selection from defaulting to parent directory when the tree update is coming from a filesystem change. It's done to avoid defaulting when a file is deleted, which is the problem in #94829.

I'm not sure if this is a good idea, I hope someone can tell me.

Fixes #94829.