### PR TITLE
Add a guard statement to TileSourceInspectorPlugin:can_handle

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -997,7 +997,7 @@ void TileSourceInspectorPlugin::_confirm_change_id() {
 }
 
 bool TileSourceInspectorPlugin::can_handle(Object *p_object) {
-	return p_object->is_class("TileSetAtlasSourceProxyObject") || p_object->is_class("TileSetScenesCollectionProxyObject");
+	return p_object != nullptr  && (p_object->is_class("TileSetAtlasSourceProxyObject") || p_object->is_class("TileSetScenesCollectionProxyObject"));
 }
 
 bool TileSourceInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {


### PR DESCRIPTION
nullptr guard for TileSourceInspectorPlugin:can_handle

i was confused since most can_handle method don't go like  this,but keep it .

Context:
Encounter crashes when using #89324 feature merged into a 4.3 rc build which use`usesEditorInspector::instantiate_property_editor(nullptr, current_type, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE);` 

realize it's caused by the lack of a guard statement.

 