### PR TITLE
Add missing null check before disconnecting source

### DIFF
--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -630,7 +630,9 @@ class SampleNode {
 	 * @returns {void}
 	 */
 	_restart() {
-		this._source.disconnect();
+		if (this._source != null) {
+			this._source.disconnect();
+		}
 		this._source = GodotAudio.ctx.createBufferSource();
 		this._source.buffer = this.getSample().getAudioBuffer();
 


### PR DESCRIPTION
It seems that `this._source` can be null. I added a null check just to be sure that `restart()` runs properly.

![image](https://github.com/user-attachments/assets/5c478e78-3444-4e4f-adcc-573f4e38d3d6)