### PR TITLE
[RFC] D3D12: Use waitable swap chain to reduce input latency

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -512,6 +512,8 @@ private:
 		TightLocalVector<TextureInfo> render_targets_info;
 		TightLocalVector<FramebufferID> framebuffers;
 		RDD::DataFormat data_format = DATA_FORMAT_MAX;
+		HANDLE frame_latency_waitable_obj = nullptr;
+		bool needs_wait = false;
 	};
 
 	void _swap_chain_release(SwapChain *p_swap_chain);
@@ -524,6 +526,7 @@ public:
 	virtual RenderPassID swap_chain_get_render_pass(SwapChainID p_swap_chain) override;
 	virtual DataFormat swap_chain_get_format(SwapChainID p_swap_chain) override;
 	virtual void swap_chain_free(SwapChainID p_swap_chain) override;
+	virtual void wait_for_present(SwapChainID p_swap_chain) override;
 
 	/*********************/
 	/**** FRAMEBUFFER ****/

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3003,6 +3003,12 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 void DisplayServerWindows::process_events() {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_wait_for_present(get_focused_window() == INVALID_WINDOW_ID ? MAIN_WINDOW_ID : get_focused_window());
+	}
+#endif
+
 	if (!drop_events) {
 		joypad->process_joypads();
 	}

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3544,6 +3544,15 @@ Error RenderingDevice::screen_free(DisplayServer::WindowID p_screen) {
 	return OK;
 }
 
+void RenderingDevice::screen_wait_for_present(DisplayServer::WindowID p_screen) {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServer::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
+	ERR_FAIL_COND_MSG(it == screen_swap_chains.end(), "A swap chain was not created for the screen.");
+
+	driver->wait_for_present(it->value);
+}
+
 /*******************/
 /**** DRAW LIST ****/
 /*******************/

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1054,6 +1054,7 @@ public:
 	int screen_get_height(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	FramebufferFormatID screen_get_framebuffer_format(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	Error screen_free(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
+	void screen_wait_for_present(DisplayServer::WindowID p_screen);
 
 	/*************************/
 	/**** DRAW LISTS (II) ****/

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -459,6 +459,9 @@ public:
 	// Wait until all rendering associated to the swap chain is finished before deleting it.
 	virtual void swap_chain_free(SwapChainID p_swap_chain) = 0;
 
+	// Wait for the swap chain to be presented on the screen.
+	virtual void wait_for_present(SwapChainID p_swap_chain){};
+
 	/*********************/
 	/**** FRAMEBUFFER ****/
 	/*********************/


### PR DESCRIPTION
Using a waitable swap chain allows Godot to delay input processing until the swap chain is ready to accept a new frame. This moves the blocking wait that usually happens when trying to present a new frame while the swap chain queue is full, to before starting the process for a new frame, thus reducing input latency

(This is basically a straight port of what I have in #94503 to the D3D12 driver.)

Here is a trace with Intel Graphics Trace Analyzer:
<details>

![trace](https://github.com/user-attachments/assets/4203043f-4c91-4325-bc77-901bef8c7b67)

Zoomed in:

![trace](https://github.com/user-attachments/assets/7e0ea126-ba64-4840-8f3a-1b00dac7b2ac)

</details>

GPUView:
<details>

![GPUView](https://github.com/user-attachments/assets/3bd0c221-f210-456c-8b07-cfd83b41d799)

</details>