### PR TITLE
Bind `Material.get_shader_rid`

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -42,6 +42,12 @@
 				Creates a placeholder version of this resource ([PlaceholderMaterial]).
 			</description>
 		</method>
+		<method name="get_shader_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the RID of the [Material]'s [Shader]. If you inherit from [Material] and create a custom material, you can override the [method _get_shader_rid] method to return the RID of your custom shader.
+			</description>
+		</method>
 		<method name="inspect_native_shader_code">
 			<return type="void" />
 			<description>

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -152,6 +152,8 @@ void Material::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Material::create_placeholder);
 
+	ClassDB::bind_method(D_METHOD("get_shader_rid"), &Material::get_shader_rid);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RENDER_PRIORITY_MIN) + "," + itos(RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next_pass", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_next_pass", "get_next_pass");
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
#### Overview

The `get_shader_rid` function is a virtual method implemented by all subclasses of `Material`. This pull request adds a binding for `get_shader_rid`, enabling developers to directly access the `shader_rid` associated with a `Material` instance.

#### Motivation

In plugin development and custom import scripts, accessing shader information tied to various materials is often required. However, many functions in `RenderingServer` need a `shader_rid` as input to retrieve shader details.

By exposing the `get_shader_rid` method, developers can directly obtain the `shader_rid` from `Material` instances. This simplifies the process of using `RenderingServer` to fetch shader parameter lists, shader code, and other shader-related data.

#### Changes

- Added a binding for the `get_shader_rid` method in the `Material` class, making it accessible to developers.

#### Usage Example

In this example, get_shader_rid is used to obtain the shader rid from a StandardMaterial3D instance. This rid is then used to fetch shader code and parameters, which are used to create and configure a new ShaderMaterial. The material is then applied to the mesh instance, allowing for more flexible material processing during scene import.

```gdscript
@tool
extends EditorScenePostImport

var texture_names := {}

func _init() -> void:
	texture_names["texture_albedo"] = BaseMaterial3D.TextureParam.TEXTURE_ALBEDO;

func _post_import(scene):
	iterate(scene)
	return scene

func iterate(node):
	if node != null:
		if node is MeshInstance3D:
			var instance := node as MeshInstance3D
			var material := instance.mesh.surface_get_material(0) as StandardMaterial3D
			var shader_rid := material.get_shader_rid()

			var code := RenderingServer.shader_get_code(shader_rid)

			var shader := Shader.new()
			shader.code = code
			var smat := ShaderMaterial.new()
			smat.shader = shader

			var params := RenderingServer.get_shader_parameter_list(shader_rid)
			for param in params:
				if param.name in texture_names:
					var texture := material.get_texture(texture_names[param.name])
					if texture != null:
						smat.set_shader_parameter(param.name, texture)
				else:
					var value = RenderingServer.material_get_param(material.get_rid(), param.name)
					smat.set_shader_parameter(param.name, value)
			
			smat.resource_local_to_scene = material.resource_local_to_scene
			smat.setup_local_to_scene()

			instance.set_surface_override_material(0, smat)
		for child in node.get_children():
			iterate(child)

```

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8121.*