### PR TITLE
RenderingDevice: Wait for present if supported (Vulkan Windows/X11/Wayland - needs testing)

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -512,6 +512,8 @@ private:
 		TightLocalVector<TextureInfo> render_targets_info;
 		TightLocalVector<FramebufferID> framebuffers;
 		RDD::DataFormat data_format = DATA_FORMAT_MAX;
+		HANDLE frame_latency_waitable_obj = nullptr;
+		bool needs_wait = false;
 	};
 
 	void _swap_chain_release(SwapChain *p_swap_chain);
@@ -524,6 +526,7 @@ public:
 	virtual RenderPassID swap_chain_get_render_pass(SwapChainID p_swap_chain) override;
 	virtual DataFormat swap_chain_get_format(SwapChainID p_swap_chain) override;
 	virtual void swap_chain_free(SwapChainID p_swap_chain) override;
+	virtual void wait_for_present(SwapChainID p_swap_chain) override;
 
 	/*********************/
 	/**** FRAMEBUFFER ****/

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1401,7 +1401,7 @@ void RenderingDeviceDriverVulkan::wait_for_present(SwapChainID p_swap_chain) {
 		return;
 	}
 
-	int latency = swap_chain->images.size() - 1;
+	int latency = swap_chain->images.size() - 2;
 	if (latency < 0 || swap_chain->present_id <= static_cast<unsigned>(latency)) {
 		return;
 	}
@@ -2365,7 +2365,7 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 
 			bool skip_present = false;
 			if (present_wait_support && swap_chain->needs_wait) {
-				int latency = swap_chain->images.size() - 1;
+				int latency = swap_chain->images.size() - 2;
 				if (latency < 0 || swap_chain->present_id <= static_cast<unsigned>(latency)) {
 					// No-op.
 				} else {
@@ -2904,6 +2904,10 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::swap_chain_acquire_framebuffer(C
 		// The surface does not have a valid swap chain or it indicates it requires a resize.
 		r_resize_required = true;
 		return FramebufferID();
+	}
+
+	if (swap_chain->image_index < swap_chain->images.size()) {
+		return swap_chain->framebuffers[swap_chain->image_index];
 	}
 
 	VkResult err;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1402,7 +1402,7 @@ void RenderingDeviceDriverVulkan::wait_for_present(SwapChainID p_swap_chain) {
 	}
 
 	int latency = swap_chain->images.size() - 1;
-	if (latency < 0 || swap_chain->present_id <= latency) {
+	if (latency < 0 || swap_chain->present_id <= static_cast<unsigned>(latency)) {
 		return;
 	}
 
@@ -2366,11 +2366,11 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 			bool skip_present = false;
 			if (present_wait_support && swap_chain->needs_wait) {
 				int latency = swap_chain->images.size() - 1;
-				if (latency < 0 || swap_chain->present_id <= latency) {
+				if (latency < 0 || swap_chain->present_id <= static_cast<unsigned>(latency)) {
 					// No-op.
 				} else {
 					uint64_t wait_present_id = swap_chain->present_id - latency;
-					VkResult err = device_functions.WaitForPresentKHR(vk_device, swap_chain->vk_swapchain, wait_present_id, 0);
+					err = device_functions.WaitForPresentKHR(vk_device, swap_chain->vk_swapchain, wait_present_id, 0);
 					if (err != VK_SUCCESS) {
 						if (err == VK_TIMEOUT) {
 							skip_present = true;

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -111,6 +111,7 @@ class RenderingDeviceDriverVulkan : public RenderingDeviceDriver {
 		PFN_vkAcquireNextImageKHR AcquireNextImageKHR = nullptr;
 		PFN_vkQueuePresentKHR QueuePresentKHR = nullptr;
 		PFN_vkCreateRenderPass2KHR CreateRenderPass2KHR = nullptr;
+		PFN_vkWaitForPresentKHR WaitForPresentKHR = nullptr;
 	};
 
 	VkDevice vk_device = VK_NULL_HANDLE;
@@ -132,6 +133,7 @@ class RenderingDeviceDriverVulkan : public RenderingDeviceDriver {
 	ShaderCapabilities shader_capabilities;
 	StorageBufferCapabilities storage_buffer_capabilities;
 	bool pipeline_cache_control_support = false;
+	bool present_wait_support = false;
 	DeviceFunctions device_functions;
 
 	void _register_requested_device_extension(const CharString &p_extension_name, bool p_required);
@@ -181,6 +183,7 @@ public:
 	virtual uint64_t buffer_get_allocation_size(BufferID p_buffer) override final;
 	virtual uint8_t *buffer_map(BufferID p_buffer) override final;
 	virtual void buffer_unmap(BufferID p_buffer) override final;
+	virtual void wait_for_present(SwapChainID p_swap_chain) override;
 
 	/*****************/
 	/**** TEXTURE ****/
@@ -333,6 +336,8 @@ private:
 		LocalVector<uint32_t> command_queues_acquired_semaphores;
 		RenderPassID render_pass;
 		uint32_t image_index = 0;
+		uint64_t present_id = 0;
+		bool needs_wait = true;
 	};
 
 	void _swap_chain_release(SwapChain *p_swap_chain);

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1134,6 +1134,12 @@ void DisplayServerWayland::try_suspend() {
 }
 
 void DisplayServerWayland::process_events() {
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_wait_for_present(get_focused_window() == INVALID_WINDOW_ID ? MAIN_WINDOW_ID : get_focused_window());
+	}
+#endif
+
 	wayland_thread.mutex.lock();
 
 	while (wayland_thread.has_message()) {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4327,6 +4327,12 @@ bool DisplayServerX11::_window_focus_check() {
 void DisplayServerX11::process_events() {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_wait_for_present(get_focused_window() == INVALID_WINDOW_ID ? MAIN_WINDOW_ID : get_focused_window());
+	}
+#endif
+
 	_THREAD_SAFE_LOCK_
 
 #ifdef DISPLAY_SERVER_X11_DEBUG_LOGS_ENABLED

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3003,6 +3003,12 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 void DisplayServerWindows::process_events() {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_wait_for_present(get_focused_window() == INVALID_WINDOW_ID ? MAIN_WINDOW_ID : get_focused_window());
+	}
+#endif
+
 	if (!drop_events) {
 		joypad->process_joypads();
 	}

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3544,6 +3544,15 @@ Error RenderingDevice::screen_free(DisplayServer::WindowID p_screen) {
 	return OK;
 }
 
+void RenderingDevice::screen_wait_for_present(DisplayServer::WindowID p_screen) {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServer::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
+	ERR_FAIL_COND_MSG(it == screen_swap_chains.end(), "A swap chain was not created for the screen.");
+
+	driver->wait_for_present(it->value);
+}
+
 /*******************/
 /**** DRAW LIST ****/
 /*******************/

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1054,6 +1054,7 @@ public:
 	int screen_get_height(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	FramebufferFormatID screen_get_framebuffer_format(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	Error screen_free(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
+	void screen_wait_for_present(DisplayServer::WindowID p_screen);
 
 	/*************************/
 	/**** DRAW LISTS (II) ****/

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -459,6 +459,9 @@ public:
 	// Wait until all rendering associated to the swap chain is finished before deleting it.
 	virtual void swap_chain_free(SwapChainID p_swap_chain) = 0;
 
+	// Wait for the swap chain to be presented on the screen.
+	virtual void wait_for_present(SwapChainID p_swap_chain){};
+
 	/*********************/
 	/**** FRAMEBUFFER ****/
 	/*********************/

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -460,7 +460,7 @@ public:
 	virtual void swap_chain_free(SwapChainID p_swap_chain) = 0;
 
 	// Wait for the swap chain to be presented on the screen.
-	virtual void wait_for_present(SwapChainID p_swap_chain){};
+	virtual void wait_for_present(SwapChainID p_swap_chain) = 0;
 
 	/*********************/
 	/**** FRAMEBUFFER ****/


### PR DESCRIPTION
Naive attempt to extend #94960 to support Vulkan using the `VK_KHR_present_wait` extension. I have no idea how functional this is since I cannot test it correctly. (The only environment I can test this on is Windows + NVIDIA Optimus, which doesn't show any real improvements.)

It needs to be especially tested with multiple windows on separate monitors, with different refresh rates.

To verify that present wait is in use, run with `--verbose` and check for `VK_KHR_present_wait`.