### PR TITLE
[macOS] Fix `is_process_running` and  `kill` for bundled apps.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -422,6 +422,7 @@
 			<description>
 				Returns the exit code of a spawned process once it has finished running (see [method is_process_running]).
 				Returns [code]-1[/code] if the [param pid] is not a PID of a spawned child process, the process is still running, or the method is not implemented for the current platform.
+				[b]Note:[/b] Returns [code]-1[/code] if the [param pid] is a macOS bundled app process.
 				[b]Note:[/b] This method is implemented on Android, Linux, macOS and Windows.
 			</description>
 		</method>

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -109,6 +109,8 @@ public:
 	virtual String get_executable_path() const override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
+	virtual Error kill(const ProcessID &p_pid) override;
+	virtual bool is_process_running(const ProcessID &p_pid) const override;
 
 	virtual String get_unique_id() const override;
 	virtual String get_processor_name() const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -666,6 +666,24 @@ Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_ch
 	}
 }
 
+bool OS_MacOS::is_process_running(const ProcessID &p_pid) const {
+	NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)p_pid];
+	if (!app) {
+		return OS_Unix::is_process_running(p_pid);
+	}
+
+	return ![app isTerminated];
+}
+
+Error OS_MacOS::kill(const ProcessID &p_pid) {
+	NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)p_pid];
+	if (!app) {
+		return OS_Unix::kill(p_pid);
+	}
+
+	return [app forceTerminate] ? OK : ERR_INVALID_PARAMETER;
+}
+
 String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/94974

Note: there's no exit code for bundled apps, so it's not overridden, but I have added a note to the docs.