### PR TITLE
Split editor documentation cache by minor version

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2856,7 +2856,7 @@ void EditorHelp::_compute_doc_version_hash() {
 }
 
 String EditorHelp::get_cache_full_path() {
-	return EditorPaths::get_singleton()->get_cache_dir().path_join("editor_doc_cache.res");
+	return EditorPaths::get_singleton()->get_cache_dir().path_join(vformat("editor_doc_cache-%d.%d.res", VERSION_MAJOR, VERSION_MINOR));
 }
 
 void EditorHelp::load_xml_buffer(const uint8_t *p_buffer, int p_size) {


### PR DESCRIPTION
This avoids conflicts with other editor versions and ensures the cache remains valid if you regularly switch between editor versions.

Considering this kind of change needs to happen sooner than later, we should try to get this in 4.3 if possible (and perhaps cherry-pick to 4.2).

- This closes #93806 and closes https://github.com/godotengine/godot-proposals/issues/10326.

## Preview

*New file at the top, previous file at the bottom.*

![image](https://github.com/user-attachments/assets/1e644f13-c321-416c-8a75-8c7cfadffc6d)
