### PR TITLE
[MP] Partially revert cache cleanup, track paths as fallback

### DIFF
--- a/modules/multiplayer/scene_cache_interface.h
+++ b/modules/multiplayer/scene_cache_interface.h
@@ -49,8 +49,18 @@ private:
 		HashMap<int, bool> confirmed_peers; // peer id, confirmed
 	};
 
+	struct RecvNode {
+		ObjectID oid;
+		NodePath path;
+
+		RecvNode(const ObjectID &p_oid, const NodePath &p_path) {
+			oid = p_oid;
+			path = p_path;
+		}
+	};
+
 	struct PeerInfo {
-		HashMap<int, ObjectID> recv_nodes; // remote cache id, ObjectID
+		HashMap<int, RecvNode> recv_nodes; // remote cache id, (ObjectID, NodePath)
 		HashSet<ObjectID> sent_nodes;
 	};
 


### PR DESCRIPTION
Cleaning up remote NodePath cache is not trivial since the visibility API allows for certain nodes to be despawned (and re-spawned) on some peers while being retained in the authority.

This means that from the server point of view, the node has not changed, and the path simplification protocol won't be run again after respawning.

While we can track this information for synchronizers via the replication API, we can't easily track this information for potential child nodes that use RPCs (I'm convinced it is doable, but we need to track the whole dependency tree which would require some more complex refactoring).

This commit partially reverts some of the cache cleanup logic to always retain remote IDs, and adds a NodePath lookup fallback when the ObjectID is invalid.

Fixes #90908 (regression from #87190). For 4.2, we might instead want to playing safe card of just reverting #87190 (I greatly underestimated the side effects it could have).