### PR TITLE
Fix update mouse cursor state wrong mouse position

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -810,7 +810,7 @@ void Window::update_mouse_cursor_state() {
 	mm->set_position(pos);
 	mm->set_global_position(xform.xform(pos));
 	mm->set_device(InputEvent::DEVICE_ID_INTERNAL);
-	push_input(mm);
+	push_input(mm, true);
 }
 
 void Window::show() {


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/93131

`mouse_default_cursor_shape` called `update_mouse_cursor_state()` which was sending the wrong position when updating the mouse, since it wasn't marked as local and gets transformed.

Also the behavior is buggy even before https://github.com/godotengine/godot/pull/85313, so its not the root cause. The wrong mouse position being sent can be seen in v4.0.4.stable.official [fc0b241c9] as well.