### PR TITLE
Fix global class cache file not present when no class name

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -491,10 +491,6 @@ void ScriptServer::save_global_classes() {
 	ProjectSettings::get_singleton()->store_global_class_list(gcarr);
 }
 
-String ScriptServer::get_global_class_cache_file_path() {
-	return ProjectSettings::get_singleton()->get_global_class_list_path();
-}
-
 ////////////////////
 
 ScriptCodeCompletionCache *ScriptCodeCompletionCache::singleton = nullptr;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -97,7 +97,6 @@ public:
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void save_global_classes();
-	static String get_global_class_cache_file_path();
 
 	static void init_languages();
 	static void finish_languages();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1353,11 +1353,16 @@ void EditorFileSystem::_thread_func_sources(void *_userdata) {
 
 void EditorFileSystem::_remove_invalid_global_class_names(const HashSet<String> &p_existing_class_names) {
 	List<StringName> global_classes;
+	bool must_save = false;
 	ScriptServer::get_global_class_list(&global_classes);
 	for (const StringName &class_name : global_classes) {
 		if (!p_existing_class_names.has(class_name)) {
 			ScriptServer::remove_global_class(class_name);
+			must_save = true;
 		}
+	}
+	if (must_save) {
+		ScriptServer::save_global_classes();
 	}
 }
 
@@ -1812,6 +1817,10 @@ void EditorFileSystem::_update_files_icon_path(EditorFileSystemDirectory *edp) {
 
 void EditorFileSystem::_update_script_classes() {
 	if (update_script_paths.is_empty()) {
+		// Ensure the global class file is always present; it's essential for exports to work.
+		if (!FileAccess::exists(ProjectSettings::get_singleton()->get_global_class_list_path())) {
+			ScriptServer::save_global_classes();
+		}
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes an issue where the `global_script_class_cache.cfg` could be missing on disk when the project contains no scripts.

The original draft was #94540

I added save_global_classes at 2 places:
- In `EditorFileSystem::_update_script_classes` when no scripts and the file does not exists on file.
- In `EditorFileSystem::_remove_invalid_global_class_names` when global class names are removed at startup.

Also removed `ScriptServer::get_global_class_cache_file_path()` which is unused.