### PR TITLE
SCons: Load optional ninja tool before setting its options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1025,13 +1025,12 @@ if env["ninja"]:
         Exit(255)
 
     SetOption("experimental", "ninja")
+    env.Tool("ninja")
 
     # By setting this we allow the user to run ninja by themselves with all
     # the flags they need, as apparently automatically running from scons
     # is way slower.
     SetOption("disable_execute_ninja", True)
-
-    env.Tool("ninja")
 
 # Threads
 if env["threads"]:


### PR DESCRIPTION
SCons 4.8.0 made this stricter, as we were advised in #94805.
Thanks @mwichmann for the headsup.

- Fixes #94805.