### PR TITLE
Fix type-o in `MobileVRInterface` sample code in docs: `xr` -> `use_xr`

### DIFF
--- a/modules/mobile_vr/doc_classes/MobileVRInterface.xml
+++ b/modules/mobile_vr/doc_classes/MobileVRInterface.xml
@@ -10,7 +10,7 @@
 		[codeblock]
 		var interface = XRServer.find_interface("Native mobile")
 		if interface and interface.initialize():
-		    get_viewport().xr = true
+		    get_viewport().use_xr = true
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
A tiny type-o that I noticed in the documentation page for `MobileVRInterface`:

https://docs.godotengine.org/en/latest/classes/class_mobilevrinterface.html

It has `get_viewport().xr = true` which should be `get_viewport.use_xr = true` (so, `xr` to `use_xr`).