### PR TITLE
GDScript: Fix autocompletion issues with nested types

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1317,7 +1317,10 @@ public:
 		FunctionNode *current_function = nullptr;
 		SuiteNode *current_suite = nullptr;
 		int current_line = -1;
-		int current_argument = -1;
+		union {
+			int current_argument = -1;
+			int type_chain_index;
+		};
 		Variant::Type builtin_type = Variant::VARIANT_MAX;
 		Node *node = nullptr;
 		Object *base = nullptr;

--- a/modules/gdscript/tests/scripts/completion/class_a.notest.gd
+++ b/modules/gdscript/tests/scripts/completion/class_a.notest.gd
@@ -1,5 +1,27 @@
 extends Node
 
+class InnerA:
+	class InnerInnerA:
+		enum EnumOfInnerInnerA {
+		ENUM_VALUE_1,
+		ENUM_VALUE_2,
+	}
+
+	enum EnumOfInnerA {
+		ENUM_VALUE_1,
+		ENUM_VALUE_2,
+	}
+
+	signal signal_of_inner_a
+	var property_of_inner_a
+	func func_of_inner_a():
+		pass
+
+enum EnumOfA {
+	ENUM_VALUE_1,
+	ENUM_VALUE_2,
+}
+
 signal signal_of_a
 
 var property_of_a

--- a/modules/gdscript/tests/scripts/completion/class_b.notest.gd
+++ b/modules/gdscript/tests/scripts/completion/class_b.notest.gd
@@ -1,0 +1,31 @@
+extends Node
+class_name B
+
+class InnerB:
+	class InnerInnerB:
+		enum EnumOfInnerInnerB {
+		ENUM_VALUE_1,
+		ENUM_VALUE_2,
+	}
+
+	enum EnumOfInnerB {
+		ENUM_VALUE_1,
+		ENUM_VALUE_2,
+	}
+
+	signal signal_of_inner_b
+	var property_of_inner_b
+	func func_of_inner_b():
+		pass
+
+enum EnumOfB {
+	ENUM_VALUE_1,
+	ENUM_VALUE_2,
+}
+
+signal signal_of_b
+
+var property_of_b
+
+func func_of_b():
+	pass

--- a/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.gd
+++ b/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.gd
@@ -1,8 +1,8 @@
-class B:
+class TestClass:
 	func to_str(b: int):
 		return str(b)
 
-var a: B
+var a: TestClass
 
 func _ready():
 	a.to_str(10).➡

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.cfg
@@ -1,4 +1,4 @@
 [output]
 exclude=[
-    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+	{"display": "AUTO_TRANSLATE_MODE_INHERIT"},
 ]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
@@ -1,6 +1,0 @@
-extends Node
-
-var test = {
-    t = 1,
-    AutoTranslateMode.➡
-}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.notest.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.notest.gd
@@ -1,0 +1,7 @@
+# Disabled due to GH-105421
+extends Node
+
+var test = {
+	t = 1,
+	AutoTranslateMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_0.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_0.cfg
@@ -1,0 +1,21 @@
+[output]
+include=[
+    {"display": "A"},
+    {"display": "B"},
+    {"display": "LocalInnerClass"},
+    {"display": "LocalInnerEnum"},
+    {"display": "ConnectFlags"},
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "float"},
+    {"display": "Vector2"},
+    {"display": "Vector3"},
+    {"display": "Vector4"},
+    {"display": "Node"},
+    {"display": "Node2D"},
+]
+exclude=[
+    {"display": "AInner"},
+    {"display": "LocalInnerInnerEnum"},
+    {"display": "LocalInnerInnerClass"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_0.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_0.gd
@@ -1,0 +1,11 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+class LocalInnerClass:
+    const AInner = preload("res://completion/class_a.notest.gd")
+    enum LocalInnerInnerEnum {}
+    class LocalInnerInnerClass:
+        pass
+
+enum LocalInnerEnum {}
+
+var test_var: A➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_0_inner_class.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_0_inner_class.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "A"},
+    {"display": "AInner"},
+    {"display": "B"},
+    {"display": "LocalInnerClass"},
+    {"display": "LocalInnerInnerClass"},
+    {"display": "LocalInnerEnum"},
+    {"display": "LocalInnerInnerEnum"},
+    {"display": "ConnectFlags"},
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "float"},
+    {"display": "Vector2"},
+    {"display": "Vector3"},
+    {"display": "Vector4"},
+    {"display": "Node"},
+    {"display": "Node2D"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_0_inner_class.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_0_inner_class.gd
@@ -1,0 +1,10 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+class LocalInnerClass:
+    const AInner = preload("res://completion/class_a.notest.gd")
+    enum LocalInnerInnerEnum {}
+    class LocalInnerInnerClass:
+        pass
+    var test_var: A➡
+
+enum LocalInnerEnum {}

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_global_class.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_global_class.cfg
@@ -1,0 +1,12 @@
+[output]
+include=[
+    {"display": "InnerB"},
+    {"display": "EnumOfB"},
+    {"display": "ConnectFlags"},
+]
+exclude=[
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "Node2D"},
+    {"display": "B"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_global_class.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_global_class.gd
@@ -1,0 +1,1 @@
+var test_var: B.➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_class.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_class.cfg
@@ -1,0 +1,12 @@
+[output]
+include=[
+    {"display": "InnerInnerClass"},
+    {"display": "InnerInnerEnum"},
+    {"display": "ConnectFlags"},
+]
+exclude=[
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "Node2D"},
+    {"display": "B"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_class.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_class.gd
@@ -1,0 +1,8 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+class LocalInnerClass:
+    class InnerInnerClass:
+        pass
+    enum InnerInnerEnum {}
+
+var test_var: LocalInnerClass.➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_enum.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_enum.cfg
@@ -1,0 +1,11 @@
+[output]
+exclude=[
+    {"display": "TEST_LOCAL_VAL"},
+    {"display": "ConnectFlags"},
+]
+exclude=[
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "Node2D"},
+    {"display": "B"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_enum.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_local_enum.gd
@@ -1,0 +1,7 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+enum LocalInnerEnum {
+    TEST_LOCAL_VAL,
+}
+
+var test_var: LocalInnerEnum.➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_preload.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_preload.cfg
@@ -1,0 +1,12 @@
+[output]
+include=[
+    {"display": "InnerA"},
+    {"display": "EnumOfA"},
+    {"display": "ConnectFlags"},
+]
+exclude=[
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "Node2D"},
+    {"display": "B"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_1_preload.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_1_preload.gd
@@ -1,0 +1,3 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+var test_var: A.➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_2.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "AInnerInner"},
+    {"display": "InnerInnerInnerEnum"},
+    {"display": "InnerInnerInnerClass"},
+    {"display": "ConnectFlags"},
+]
+exclude=[
+    {"display": "A"},
+    {"display": "AInner"},
+    {"display": "TestEnum"},
+    {"display": "InnerInnerEnum"},
+    {"display": "InnerInnerClass"},
+    {"display": "LocalInnerClass"},
+    {"display": "int"},
+    {"display": "String"},
+    {"display": "Node2D"},
+    {"display": "B"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/index_2.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/index_2.gd
@@ -1,0 +1,14 @@
+const A = preload("res://completion/class_a.notest.gd")
+
+class LocalInnerClass:
+    const AInner = preload("res://completion/class_a.notest.gd")
+    class InnerInnerClass:
+        const AInnerInner = preload("res://completion/class_a.notest.gd")
+        enum InnerInnerInnerEnum {}
+        class InnerInnerInnerClass:
+            pass
+    enum InnerInnerEnum {}
+
+enum TestEnum {}
+
+var test_var: LocalInnerClass.InnerInnerClass.➡


### PR DESCRIPTION
Fixes #71734
Fixes https://github.com/godotengine/godot/issues/108045
Closes https://github.com/godotengine/godot-proposals/issues/11430
Salvaged from #71842

Also improves/fixes some smaller issues that I stumbled upon when writing tests for the original issue:
- preloaded types are now correctly suggested in type hints
- ordering of types in inner classes shows types from the inner class first
...

Adds support for global classes to the completion test runner and turns of error printing for the tests.

~Marked as draft for now, since I still want to finish the test cases.~