### PR TITLE
Fix typo in EditorPlugin `_forward_3d_draw_over_viewport(overlay)` method example

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -60,7 +60,7 @@
 				[gdscript]
 				func _forward_3d_draw_over_viewport(overlay):
 				    # Draw a circle at cursor position.
-				    overlay.draw_circle(overlay.get_local_mouse_position(), 64)
+				    overlay.draw_circle(overlay.get_local_mouse_position(), 64, Color.WHITE)
 
 				func _forward_3d_gui_input(camera, event):
 				    if event is InputEventMouseMotion:


### PR DESCRIPTION
The example is now matching the C# example

> Too few arguments for "draw_circle()" call. Expected at least 3 but received 2.