### PR TITLE
Fix LightmapGI not taking environment sky rotation into account when baking

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1072,6 +1072,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 
 					if (env.is_valid()) {
 						environment_image = RS::get_singleton()->environment_bake_panorama(env->get_rid(), true, Size2i(128, 64));
+						environment_transform = Basis::from_euler(env->get_sky_rotation()).inverse();
 					}
 				}
 			} break;


### PR DESCRIPTION
The sky rotation now affects the baked environment lighting as it should, making it match how real-time ambient light rendering works.

Tested on all rendering methods. Thanks @permelin for contributing this fix :slightly_smiling_face:

**Testing project:** [test_lightmap_environment_custom_orientation.zip](https://github.com/user-attachments/files/16500044/test_lightmap_environment_custom_orientation.zip)

- This closes https://github.com/godotengine/godot/issues/56135.

## Preview

*Left = real-time lighting, right = baked lighting.*

### Default sky rotation

*No change (as expected).*

Before | After
-|-
![Before](https://github.com/user-attachments/assets/730d800f-8aad-48c6-979e-e2c967422057) | ![After](https://github.com/user-attachments/assets/402ee419-d46b-46fa-8e8d-d9de328abe75)

### Custom sky rotation

*Previously, the baked environment light did not rotate at all.*

Before | After
-|-
![Before](https://github.com/user-attachments/assets/63f3b7fa-1db3-43db-974c-05e6dc443788) | ![After](https://github.com/user-attachments/assets/f1c8bf70-9e62-4901-8797-2b2c1e1fa5a5)