### PR TITLE
Change NavigationMesh to also parse collision shapes by default

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -139,7 +139,7 @@
 			The physics layers to scan for static colliders.
 			Only used when [member geometry_parsed_geometry_type] is [constant PARSED_GEOMETRY_STATIC_COLLIDERS] or [constant PARSED_GEOMETRY_BOTH].
 		</member>
-		<member name="geometry_parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" enum="NavigationMesh.ParsedGeometryType" default="0">
+		<member name="geometry_parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" enum="NavigationMesh.ParsedGeometryType" default="2">
 			Determines which type of nodes will be parsed as geometry. See [enum ParsedGeometryType] for possible values.
 		</member>
 		<member name="geometry_source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" enum="NavigationMesh.SourceGeometryMode" default="0">

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -96,7 +96,7 @@ protected:
 	float detail_sample_max_error = 1.0f;
 
 	SamplePartitionType partition_type = SAMPLE_PARTITION_WATERSHED;
-	ParsedGeometryType parsed_geometry_type = PARSED_GEOMETRY_MESH_INSTANCES;
+	ParsedGeometryType parsed_geometry_type = PARSED_GEOMETRY_BOTH;
 	uint32_t collision_mask = 0xFFFFFFFF;
 
 	SourceGeometryMode source_geometry_mode = SOURCE_GEOMETRY_ROOT_NODE_CHILDREN;


### PR DESCRIPTION
Changes `NavigationMesh` parse geometry types to include collision shapes as well by default.

The NavigationMesh default properties are set to only parse visual meshes but not collision shapes. New users regular stumble and fumble with this and for older users it is an annoyance that the properties need to always be changed when creating a new NavigationMesh.

The properties need to be changed because parsing visual meshes is objectively bad for performance. Recommending users to use only collision shapes for the baking when the defaults ignore those shapes is always very awkward. This is especially irritating for people that switch to Godot from other engines as in basically all other game engines the default is set to parse collision shapes (and often only collision shapes) so they do not even expect a setting for this.

For legacy and compatibility reasons (as Godot does not store defaults) this is hard to fully change now without breaking a lot of older projects so this PR at least changes that by default both are parsed. This already is the case with the newer parsing on the 2D NavigationPolygon.



<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
