### PR TITLE
Add support for default arguments in utility functions

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -588,14 +588,20 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			bool vararg = Variant::is_utility_function_vararg(name);
 			func["is_vararg"] = Variant::is_utility_function_vararg(name);
 			func["hash"] = Variant::get_utility_function_hash(name);
+
 			Array arguments;
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(name);
 			int argcount = Variant::get_utility_function_argument_count(name);
 			for (int i = 0; i < argcount; i++) {
 				Dictionary arg;
 				String argname = vararg ? "arg" + itos(i + 1) : Variant::get_utility_function_argument_name(name, i);
 				arg["name"] = argname;
 				arg["type"] = get_builtin_or_variant_type_name(Variant::get_utility_function_argument_type(name, i));
-				//no default value support in utility functions
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(name, i);
+				if (dargidx >= 0) {
+					arg["default_value"] = def_args[dargidx].get_construct_string();
+				}
 				arguments.push_back(arg);
 			}
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -689,7 +689,7 @@ _ALWAYS_INLINE_ double randd() {
 _ALWAYS_INLINE_ float randf() {
 	return (float)rand() / (float)UINT32_MAX;
 }
-double randfn(double p_mean, double p_deviation);
+double randfn(double p_mean = 0.0, double p_deviation = 1.0);
 
 double random(double p_from, double p_to);
 float random(float p_from, float p_to);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -811,6 +811,8 @@ public:
 	static int get_utility_function_argument_count(const StringName &p_name);
 	static Variant::Type get_utility_function_argument_type(const StringName &p_name, int p_arg);
 	static String get_utility_function_argument_name(const StringName &p_name, int p_arg);
+	static Vector<Variant> get_utility_function_default_arguments(const StringName &p_name);
+	static int get_utility_function_default_argument_index(const StringName &p_name, int p_arg);
 	static bool has_utility_function_return_value(const StringName &p_name);
 	static Variant::Type get_utility_function_return_type(const StringName &p_name);
 	static bool is_utility_function_vararg(const StringName &p_name);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1167,39 +1167,19 @@ String VariantUtilityFunctions::join_string(const Variant **p_args, int p_arg_co
 #define VCALL p_func(VariantCaster<P>::cast(*p_args[Is])...)
 #endif // DEBUG_ENABLED
 
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALLR;
-	(void)p_args; // avoid gcc warning
-	(void)r_error;
-}
-
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, IndexSequence<Is...>) {
-	*ret = p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void ptr_call_helperpr(R (*p_func)(P...), void *ret, const void **p_args, IndexSequence<Is...>) {
-	PtrToArg<R>::encode(p_func(PtrToArg<P>::convert(p_args[Is])...), ret);
-	(void)p_args;
+template <typename R, typename... P>
+static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_ret_dv(p_func, p_args, p_argcount, *r_ret, r_error, p_defvals);
 }
 
 template <typename R, typename... P>
-static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error) {
-	call_helperpr(p_func, ret, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *r_ret, const Variant **p_args) {
+	call_with_validated_variant_args_static_method_ret(p_func, p_args, r_ret);
 }
 
 template <typename R, typename... P>
-static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args) {
-	validated_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
-}
-
-template <typename R, typename... P>
-static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *ret, const void **p_args) {
-	ptr_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *r_ret, const void **p_args) {
+	call_with_ptr_args_static_method_ret<R, P...>(p_func, p_args, r_ret);
 }
 
 template <typename R, typename... P>
@@ -1219,39 +1199,19 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helperr(R (*p_func)(P...)) {
 
 // WITHOUT RET
 
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperp(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALL;
-	(void)p_args;
-	(void)r_error;
-}
-
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperp(void (*p_func)(P...), const Variant **p_args, IndexSequence<Is...>) {
-	p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void ptr_call_helperp(void (*p_func)(P...), const void **p_args, IndexSequence<Is...>) {
-	p_func(PtrToArg<P>::convert(p_args[Is])...);
-	(void)p_args;
-}
-
 template <typename... P>
-static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error) {
-	call_helperp(p_func, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_dv(p_func, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename... P>
 static _FORCE_INLINE_ void validated_call_helper(void (*p_func)(P...), const Variant **p_args) {
-	validated_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_method(p_func, p_args);
 }
 
 template <typename... P>
 static _FORCE_INLINE_ void ptr_call_helper(void (*p_func)(P...), const void **p_args) {
-	ptr_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_ptr_args_static_method<P...>(p_func, p_args);
 }
 
 template <typename... P>
@@ -1269,117 +1229,150 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
 
-#define FUNCBINDR(m_func, m_args, m_category)                                                                    \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                              \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                      \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                       \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDR(m_func, m_args, m_category)                                                                                                      \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, p_argcount, p_defvals, r_error);                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                                                        \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                                                         \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVR(m_func, m_args, m_category)                                                                          \
-	class Func_##m_func {                                                                                               \
-	public:                                                                                                             \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {        \
-			r_error.error = Callable::CallError::CALL_OK;                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                              \
-		}                                                                                                               \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                            \
-			Callable::CallError ce;                                                                                     \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                   \
-		}                                                                                                               \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                           \
-			Callable::CallError ce;                                                                                     \
-			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret); \
-		}                                                                                                               \
-		static int get_argument_count() {                                                                               \
-			return 1;                                                                                                   \
-		}                                                                                                               \
-		static Variant::Type get_argument_type(int p_arg) {                                                             \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static Variant::Type get_return_type() {                                                                        \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static bool has_return_type() {                                                                                 \
-			return true;                                                                                                \
-		}                                                                                                               \
-		static bool is_vararg() {                                                                                       \
-			return false;                                                                                               \
-		}                                                                                                               \
-		static Variant::UtilityFunctionType get_type() {                                                                \
-			return m_category;                                                                                          \
-		}                                                                                                               \
-	};                                                                                                                  \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDRD(m_func, m_args, m_defvals, m_category)                                                                                          \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, p_argcount, p_defvals, r_error);                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                                                        \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                                                         \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, m_defvals)
 
-#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                    \
-	class Func_##m_func {                                                                                                          \
-	public:                                                                                                                        \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                   \
-			r_error.error = Callable::CallError::CALL_OK;                                                                          \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                             \
-		}                                                                                                                          \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                       \
-			Callable::CallError ce;                                                                                                \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                  \
-		}                                                                                                                          \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                      \
-			Callable::CallError ce;                                                                                                \
-			Variant r;                                                                                                             \
-			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce); \
-			PtrToArg<Variant>::encode(r, ret);                                                                                     \
-		}                                                                                                                          \
-		static int get_argument_count() {                                                                                          \
-			return 2;                                                                                                              \
-		}                                                                                                                          \
-		static Variant::Type get_argument_type(int p_arg) {                                                                        \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static Variant::Type get_return_type() {                                                                                   \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static bool has_return_type() {                                                                                            \
-			return true;                                                                                                           \
-		}                                                                                                                          \
-		static bool is_vararg() {                                                                                                  \
-			return false;                                                                                                          \
-		}                                                                                                                          \
-		static Variant::UtilityFunctionType get_type() {                                                                           \
-			return m_category;                                                                                                     \
-		}                                                                                                                          \
-	};                                                                                                                             \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVR(m_func, m_args, m_category)                                                                                                     \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                                                         \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                                              \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret);                            \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
+
+#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                                    \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                                             \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                                  \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			Variant r;                                                                                                                             \
+			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce);                 \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 #define FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                           \
 	class Func_##m_func {                                                                                                                                                 \
 	public:                                                                                                                                                               \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                                                          \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {                        \
 			r_error.error = Callable::CallError::CALL_OK;                                                                                                                 \
 			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], r_error);                                                                        \
 		}                                                                                                                                                                 \
@@ -1412,181 +1405,182 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 			return m_category;                                                                                                                                            \
 		}                                                                                                                                                                 \
 	};                                                                                                                                                                    \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARG(m_func, m_args, m_category)                                                               \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<Variant>::encode(r, ret);                                                                   \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 2;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARG(m_func, m_args, m_category)                                                                                                 \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                              \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<String>::encode(r.operator String(), ret);                                                  \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::STRING;                                                                              \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                                                                \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<String>::encode(r.operator String(), ret);                                                                                    \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::STRING;                                                                                                                \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                          \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                  \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                        \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                                                            \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                                                    \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                                                          \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 #define FUNCBINDVARARGV(m_func, m_args, m_category) FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category)
 
-#define FUNCBIND(m_func, m_args, m_category)                                                                     \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helper(VariantUtilityFunctions::m_func, p_args, r_error);                                       \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                      \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                            \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                  \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                         \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBIND(m_func, m_args, m_category)                                                                                                       \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helper(VariantUtilityFunctions::m_func, p_args, p_argcount, p_defvals, r_error);                                                  \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                        \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                              \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                                                    \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                                                           \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 struct VariantUtilityFunctionInfo {
-	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = nullptr;
+	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
 	Variant::ValidatedUtilityFunction validated_call_utility = nullptr;
 	Variant::PTRUtilityFunction ptr_call_utility = nullptr;
+	Vector<Variant> default_arguments;
 	Vector<String> argnames;
 	bool is_vararg = false;
 	bool returns_value = false;
@@ -1600,7 +1594,7 @@ static AHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
 
 template <typename T>
-static void register_utility_function(const String &p_name, const Vector<String> &argnames) {
+static void register_utility_function(const String &p_name, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
 	String name = p_name;
 	if (name.begins_with("_")) {
 		name = name.substr(1);
@@ -1613,10 +1607,11 @@ static void register_utility_function(const String &p_name, const Vector<String>
 	bfi.validated_call_utility = T::validated_call;
 	bfi.ptr_call_utility = T::ptrcall;
 	bfi.is_vararg = T::is_vararg();
-	bfi.argnames = argnames;
+	bfi.default_arguments = p_def_args;
+	bfi.argnames = p_argnames;
 	bfi.argcount = T::get_argument_count();
 	if (!bfi.is_vararg) {
-		ERR_FAIL_COND_MSG(argnames.size() != bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", name));
+		ERR_FAIL_COND_MSG(p_argnames.size() != bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", name));
 	}
 	bfi.get_arg_type = T::get_argument_type;
 	bfi.return_type = T::get_return_type();
@@ -1739,7 +1734,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(randf, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randi_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randf_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDRD(randfn, sarray("mean", "deviation"), varray(0.0, 1.0), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 
@@ -1796,9 +1791,9 @@ void Variant::call_utility_function(const StringName &p_name, Variant *r_ret, co
 		return;
 	}
 
-	if (unlikely(!bfi->is_vararg && p_argcount < bfi->argcount)) {
+	if (unlikely(!bfi->is_vararg && p_argcount < bfi->argcount - bfi->default_arguments.size())) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = bfi->argcount;
+		r_error.expected = bfi->argcount - bfi->default_arguments.size();
 		return;
 	}
 
@@ -1808,7 +1803,7 @@ void Variant::call_utility_function(const StringName &p_name, Variant *r_ret, co
 		return;
 	}
 
-	bfi->call_utility(r_ret, p_args, p_argcount, r_error);
+	bfi->call_utility(r_ret, p_args, p_argcount, bfi->default_arguments, r_error);
 }
 
 bool Variant::has_utility_function(const StringName &p_name) {
@@ -1860,6 +1855,7 @@ MethodInfo Variant::get_utility_function_info(const StringName &p_name) {
 			arg.name = bfi->argnames[i];
 			info.arguments.push_back(arg);
 		}
+		info.default_arguments = bfi->default_arguments;
 	}
 	return info;
 }
@@ -1880,6 +1876,24 @@ Variant::Type Variant::get_utility_function_argument_type(const StringName &p_na
 	}
 
 	return bfi->get_arg_type(p_arg);
+}
+
+Vector<Variant> Variant::get_utility_function_default_arguments(const StringName &p_name) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
+	if (!bfi) {
+		return varray();
+	}
+
+	return bfi->default_arguments;
+}
+
+int Variant::get_utility_function_default_argument_index(const StringName &p_name, int p_arg) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
+	if (!bfi) {
+		return -1;
+	}
+
+	return p_arg - (bfi->argcount - bfi->default_arguments.size());
 }
 
 String Variant::get_utility_function_argument_name(const StringName &p_name, int p_arg) {

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -118,7 +118,7 @@ struct VariantUtilityFunctions {
 	static void randomize();
 	static int64_t randi();
 	static double randf();
-	static double randfn(double mean, double deviation);
+	static double randfn(double mean = 0.0, double deviation = 1.0);
 	static int64_t randi_range(int64_t from, int64_t to);
 	static double randf_range(double from, double to);
 	static void seed(int64_t s);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1037,8 +1037,8 @@
 		</method>
 		<method name="randfn">
 			<return type="float" />
-			<param index="0" name="mean" type="float" />
-			<param index="1" name="deviation" type="float" />
+			<param index="0" name="mean" type="float" default="0.0" />
+			<param index="1" name="deviation" type="float" default="1.0" />
 			<description>
 				Returns a [url=https://en.wikipedia.org/wiki/Normal_distribution]normally-distributed[/url], pseudo-random floating-point value from the specified [param mean] and a standard [param deviation]. This is also known as a Gaussian distribution.
 				[b]Note:[/b] This method uses the [url=https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform]Box-Muller transform[/url] algorithm.

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1007,6 +1007,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			if (Variant::is_utility_function_vararg(E)) {
 				md.qualifiers = "vararg";
 			} else {
+				const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 				for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 					PropertyInfo pi;
 					pi.type = Variant::get_utility_function_argument_type(E, i);
@@ -1016,6 +1017,12 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					}
 					DocData::ArgumentDoc ad;
 					DocData::argument_doc_from_arginfo(ad, pi);
+
+					const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+					if (dargidx >= 0) {
+						ad.default_value = DocData::get_default_value_string(def_args[dargidx]);
+					}
+
 					md.arguments.push_back(ad);
 				}
 			}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -77,6 +77,7 @@ static MethodInfo info_from_utility_func(const StringName &p_function) {
 			pi.type = Variant::get_utility_function_argument_type(p_function, i);
 			info.arguments.push_back(pi);
 		}
+		info.default_arguments = Variant::get_utility_function_default_arguments(p_function);
 	}
 
 	return info;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -623,6 +623,20 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(call->function_name) < Variant::VARIANT_MAX) {
 				gen->write_construct(result, GDScriptParser::get_builtin_type(call->function_name), arguments);
 			} else if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && Variant::has_utility_function(call->function_name)) {
+				const int arg_count = Variant::get_utility_function_argument_count(call->function_name);
+
+				if (call->arguments.size() < arg_count) {
+					const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(call->function_name);
+
+					for (int i = call->arguments.size(); i < arg_count; i++) {
+						const int dargidx = Variant::get_utility_function_default_argument_index(call->function_name, i);
+
+						if (dargidx >= 0) {
+							arguments.push_back(codegen.add_constant(def_args[dargidx]));
+						}
+					}
+				}
+
 				// Variant utility function.
 				gen->write_call_utility(result, call->function_name, arguments);
 			} else if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptUtilityFunctions::function_exists(call->function_name)) {

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -2204,11 +2204,18 @@ TEST_CASE("[Variant] Utility functions") {
 		if (Variant::is_utility_function_vararg(E)) {
 			md.is_vararg = true;
 		} else {
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 			for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 				ArgumentData arg;
 				arg.type = Variant::get_utility_function_argument_type(E, i);
 				arg.name = Variant::get_utility_function_argument_name(E, i);
 				arg.position = i;
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+				if (dargidx >= 0) {
+					arg.has_defval = true;
+					arg.defval = def_args[dargidx];
+				}
 
 				md.arguments.push_back(arg);
 			}
@@ -2224,6 +2231,13 @@ TEST_CASE("[Variant] Utility functions") {
 
 				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
 						vformat("Unnamed argument in position %d of function '%s'.", arg.position, E.name));
+
+				if (arg.has_defval) {
+					const bool arg_defval_assignable_to_type = arg.type == arg.defval.get_type();
+
+					TEST_COND(!arg_defval_assignable_to_type,
+							vformat("Invalid default value for parameter '%s' of function '%s'.", arg.name, E.name));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a rebased version of https://github.com/godotengine/godot/pull/87275 (author seems abandoned it), with some fixes (including adding an actual default argument to ~`is_equal_approx`/`is_zero_approx`~/`randfn`), updating documentation etc.

