### PR TITLE
[4.4] [Core] Fix `FileAccessCompressed.get_buffer` size error on multiples of block size

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -270,6 +270,13 @@ uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) con
 				read_block_size = read_block == read_block_count - 1 ? read_total % block_size : block_size;
 				read_pos = 0;
 
+				if (read_block_size == 0) {
+					at_end = true;
+					if (i + 1 < p_length) {
+						read_eof = true;
+					}
+					return i + 1;
+				}
 			} else {
 				read_block--;
 				at_end = true;


### PR DESCRIPTION
Attempted other approaches involving the module but it didn't work out, might be missing something in those cases but this solves the problem while making sure it works correctly in general

* Fixes: https://github.com/godotengine/godot/issues/95014

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
