### PR TITLE
[RTL] Add method to generate BBCode from tag stack.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -65,6 +65,11 @@
 				Clears the current selection.
 			</description>
 		</method>
+		<method name="get_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="get_character_line">
 			<return type="int" />
 			<param index="0" name="character" type="int" />

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -190,6 +190,7 @@ private:
 
 	struct ItemFrame : public Item {
 		bool cell = false;
+		int col = -1;
 
 		LocalVector<Line> lines;
 		std::atomic<int> first_invalid_line;
@@ -609,6 +610,8 @@ private:
 	Ref<RichTextEffect> _get_custom_effect_by_code(String p_bbcode_identifier);
 	virtual Dictionary parse_expressions_for_values(Vector<String> p_expressions);
 
+	static HashMap<String, String> special_chars;
+
 	Size2 _get_image_size(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Rect2 &p_region = Rect2());
 
 	String _get_prefix(Item *p_item, const Vector<int> &p_list_index, const Vector<ItemList *> &p_list_items);
@@ -668,6 +671,7 @@ private:
 
 public:
 	String get_parsed_text() const;
+	String get_bbcode() const;
 	void add_text(const String &p_text);
 	void add_image(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false);
 	void update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false);


### PR DESCRIPTION
Adds `get_bbcode` to generate BBCode from tag stack created by `push_` calls.

TODO:
- [ ] Integrate it with `text` property (currently BBCode tags are a bit ambiguous, and some additional info should be stored to restore BBCode one-to-one).
- [ ] Ensure that both BBCode and `push_` calls have access to all features.