### PR TITLE
Close expanded tile editor when inspector updates

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -859,6 +859,11 @@ void GenericTilePolygonEditor::_notification(int p_what) {
 				button_expand->set_pressed_no_signal(false);
 			}
 		} break;
+
+		case NOTIFICATION_READY: {
+			get_parent()->connect(SceneStringName(tree_exited), callable_mp(TileSetEditor::get_singleton(), &TileSetEditor::remove_expanded_editor));
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			button_expand->set_icon(get_editor_theme_icon(SNAME("DistractionFree")));
 			button_create->set_icon(get_editor_theme_icon(SNAME("CurveCreate")));


### PR DESCRIPTION
TileSet editor has an internal inspector that really likes getting refreshed. One instance is when you select another tile, another is when a polygon is added or removed:
https://github.com/godotengine/godot/blob/3978628c6cc1227250fc6ed45c8d854d24c30c30/scene/resources/2d/tile_set.cpp#L6271
This causes all property editors to get destroyed and re-created.

There is one special editor though - the expanded editor. When you expand polygon editor (see #79512), it's moved to a different parent that isn't inside the inspector. So when inspector is cleared, the expanded editor survives it and holds outdated information.

I don't have a good solution for that yet. Perfectly, when inspector is refreshed, the previous editor should be automatically expanded again. However the "previous" editor no longer exists and there can be multiple polygon editors, so it has to be somehow remembered per-property, idk.

For now I just force-close the editor when it's going to become invalid.

https://github.com/user-attachments/assets/1389469d-56f1-4171-8195-5ddf8d1dd0a3

It's a safe fix that could be applied for now.

Closes #84321
Closes #86720
Opens #95XXX (the new behavior is disrupting, so an issue should be opened if this is merged)