### PR TITLE
Fix several typos in the documentation

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The [AudioStreamPlayer] node plays an audio stream non-positionally. It is ideal for user interfaces, menus, or background music.
-		To use this node, [member stream] needs to be set to a valid [AudioStream] resource. Playing more than one sound at the time is also supported, see [member max_polyphony].
+		To use this node, [member stream] needs to be set to a valid [AudioStream] resource. Playing more than one sound at the same time is also supported, see [member max_polyphony].
 		If you need to play audio at a specific position, use [AudioStreamPlayer2D] or [AudioStreamPlayer3D] instead.
 	</description>
 	<tutorials>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -355,7 +355,6 @@
 				# Prints { "fruit": "apple", "vegetable": "potato", "dressing": "vinegar" }
 				print(extra.merged(base, true))
 				[/codeblock]
-				See also [method merge].
 			</description>
 		</method>
 		<method name="recursive_equal" qualifiers="const">

--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		[SkeletonModifier3D] retrieves a target [Skeleton3D] by having a [Skeleton3D] parent.
 		If there is [AnimationMixer], modification always performs after playback process of the [AnimationMixer].
-		This node should be used to implement custom IK solvers, constraints, or skeleton physics
+		This node should be used to implement custom IK solvers, constraints, or skeleton physics.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
@@ -47,7 +47,7 @@
 	</members>
 	<constants>
 		<constant name="MAX_STREAMS" value="32">
-			Maximum amount of streams that can be synchrohized.
+			Maximum amount of streams that can be synchronized.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -176,7 +176,7 @@
 			<param index="0" name="refresh_rate" type="float" />
 			<description>
 				Informs the user the HMD refresh rate has changed.
-				[b]Node:[/b] Only emitted if XR runtime supports the refresh rate extension.
+				[b]Note:[/b] Only emitted if XR runtime supports the refresh rate extension.
 			</description>
 		</signal>
 		<signal name="session_begun">

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -151,16 +151,16 @@
 			Indicates whether your app uses advertising data for tracking.
 		</member>
 		<member name="privacy/collected_data/audio_data/collected" type="bool" setter="" getter="">
-			Indicates whether your app collects audio data data.
+			Indicates whether your app collects audio data.
 		</member>
 		<member name="privacy/collected_data/audio_data/collection_purposes" type="int" setter="" getter="">
 			The reasons your app collects audio data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
 		</member>
 		<member name="privacy/collected_data/audio_data/linked_to_user" type="bool" setter="" getter="">
-			Indicates whether your app links audio data data to the user's identity.
+			Indicates whether your app links audio data to the user's identity.
 		</member>
 		<member name="privacy/collected_data/audio_data/used_for_tracking" type="bool" setter="" getter="">
-			Indicates whether your app uses audio data data for tracking.
+			Indicates whether your app uses audio data for tracking.
 		</member>
 		<member name="privacy/collected_data/browsing_history/collected" type="bool" setter="" getter="">
 			Indicates whether your app collects browsing history.

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -224,16 +224,16 @@
 			Indicates whether your app uses advertising data for tracking.
 		</member>
 		<member name="privacy/collected_data/audio_data/collected" type="bool" setter="" getter="">
-			Indicates whether your app collects audio data data.
+			Indicates whether your app collects audio data.
 		</member>
 		<member name="privacy/collected_data/audio_data/collection_purposes" type="int" setter="" getter="">
 			The reasons your app collects audio data. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
 		</member>
 		<member name="privacy/collected_data/audio_data/linked_to_user" type="bool" setter="" getter="">
-			Indicates whether your app links audio data data to the user's identity.
+			Indicates whether your app links audio data to the user's identity.
 		</member>
 		<member name="privacy/collected_data/audio_data/used_for_tracking" type="bool" setter="" getter="">
-			Indicates whether your app uses audio data data for tracking.
+			Indicates whether your app uses audio data for tracking.
 		</member>
 		<member name="privacy/collected_data/browsing_history/collected" type="bool" setter="" getter="">
 			Indicates whether your app collects browsing history.


### PR DESCRIPTION
Typos and copy-paste erros found when translating the class reference.

Note: The reason for deleting `See also [method merge]` is that this sentence has already appeared in the first paragraph.