### PR TITLE
Use `windowBackgroundColor` instead of `controlColor` for macOS system base color

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -903,7 +903,7 @@ Color DisplayServerMacOS::get_base_color() const {
 		__block NSColor *color = nullptr;
 		if (@available(macOS 11.0, *)) {
 			[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
-				color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+				color = [[NSColor windowBackgroundColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 			}];
 		} else {
 			NSAppearance *saved_appearance = [NSAppearance currentAppearance];


### PR DESCRIPTION
Per Apple Developer Documentation:
windowBackgroundColor: "The color to use for the window background."
controlColor: "The color to use for the flat surfaces of a control."

Godot's base_color more closely corresponds to windowBackgroundColor.
In some cases, controlColor may even return values that are not appropriate for use as a base color (see the referenced issue).

Fixes #95047