### PR TITLE
Fix GraphEdit port snapping in certain edge cases

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -912,7 +912,7 @@ bool GraphEdit::_filter_input(const Point2 &p_point) {
 
 		// This prevents interactions with a port hotzone that is behind another node.
 		Rect2 graph_node_rect = Rect2(graph_node->get_position(), graph_node->get_size() * zoom);
-		if (graph_node_rect.has_point(click_pos * zoom)) {
+		if (graph_node_rect.has_point(p_point)) {
 			break;
 		}
 	}
@@ -1044,12 +1044,6 @@ void GraphEdit::_top_connection_layer_input(const Ref<InputEvent> &p_ev) {
 					return;
 				}
 			}
-
-			// This prevents interactions with a port hotzone that is behind another node.
-			Rect2 graph_node_rect = Rect2(graph_node->get_position(), graph_node->get_size() * zoom);
-			if (graph_node_rect.has_point(click_pos * zoom)) {
-				break;
-			}
 		}
 	}
 
@@ -1120,6 +1114,12 @@ void GraphEdit::_top_connection_layer_input(const Ref<InputEvent> &p_ev) {
 						}
 					}
 					connecting_target_valid = false;
+				}
+
+				// This prevents interactions with a port hotzone that is behind another node.
+				Rect2 graph_node_rect = Rect2(graph_node->get_position(), graph_node->get_size() * zoom);
+				if (graph_node_rect.has_point(mm->get_position())) {
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
- Fixes #34457 (fully).
- Aims to fix a bug where connections couldn't be dragged from a port sporadically (instead the box selection was triggered).

@Naros Can you confirm that this fixes the issue?