### PR TITLE
D3D12: Avoid cases of redundant render target clears

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5057,6 +5057,7 @@ void RenderingDeviceDriverD3D12::command_begin_render_pass(CommandBufferID p_cmd
 			if (pass_info->attachments[i].load_op == ATTACHMENT_LOAD_OP_CLEAR) {
 				clear.aspect.set_flag(TEXTURE_ASPECT_COLOR_BIT);
 				clear.color_attachment = i;
+				tex_info->pending_clear.remove_from_list();
 			}
 		} else if ((tex_info->desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) {
 			if (pass_info->attachments[i].stencil_load_op == ATTACHMENT_LOAD_OP_CLEAR) {


### PR DESCRIPTION
There's a mechanism to prevent not-yet-rendered to targets from containing garbage, which is clearing them to black before rendering. However, there's a clear-on-render-pass-start mechanism that, if used, would have already written something to the target.

Before this PR both mechanisms would clear the render target, which seems problematic on certain drivers. This PR unmarks the render target as "pending clear," so only the more explicitly wanted one happens.

The ideal fix would happen in `command_render_clear_attachments()`, which is the function that ultimately performs the additional clears and may be called directly. However, that'd be hard to implement as it only has heap descriptors, no longer bound to the info-rich bookkept resources. While it would be possible to have an inverse map, we can just use this fix for the most common case for now. The other possibilities may not even happen in practice, but it's good to bear them in mind.

Fixes #94749.