### PR TITLE
Tweak warning/error formatting in EditorLog to be closer to console output

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -358,14 +358,18 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 			log->push_color(theme_cache.error_color);
 			Ref<Texture2D> icon = theme_cache.error_icon;
 			log->add_image(icon);
-			log->add_text(" ");
+			log->push_bold();
+			log->add_text(" ERROR: ");
+			log->pop(); // bold
 			tool_button->set_button_icon(icon);
 		} break;
 		case MSG_TYPE_WARNING: {
 			log->push_color(theme_cache.warning_color);
 			Ref<Texture2D> icon = theme_cache.warning_icon;
 			log->add_image(icon);
-			log->add_text(" ");
+			log->push_bold();
+			log->add_text(" WARNING: ");
+			log->pop(); // bold
 			tool_button->set_button_icon(icon);
 		} break;
 		case MSG_TYPE_EDITOR: {


### PR DESCRIPTION
This makes the output easier to understand when it's copied to a plain text file (without visible colors).

## Preview

*Software Vulkan warning comes from https://github.com/godotengine/godot/pull/95071.*

*In the `@tool` error message, the backtrace would point to the GDScript file instead of the C++ declaration of `push_error()` with https://github.com/godotengine/godot/pull/93648.*

![image](https://github.com/user-attachments/assets/3e2eaa20-cea6-4763-9439-0145ced8ce12)