### PR TITLE
D3D12: Avoid crash on exit

### DIFF
--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -85,6 +85,11 @@ const GUID CLSID_D3D12SDKConfigurationGodot = { 0x7cda6aca, 0xa03e, 0x49c8, { 0x
 RenderingContextDriverD3D12::RenderingContextDriverD3D12() {}
 
 RenderingContextDriverD3D12::~RenderingContextDriverD3D12() {
+	// Let's release manually everything that may still be holding
+	// onto the DLLs before freeing them.
+	device_factory.Reset();
+	dxgi_factory.Reset();
+
 	if (lib_d3d12) {
 		FreeLibrary(lib_d3d12);
 	}


### PR DESCRIPTION
An alternative would be just not to free the DLLs. There's some risk of the bug being reintroduced if new COM smart pointers are added, but for now this should do the trick. Another alternative would be to have a DLL handle wrapper (for RAII), but it's also a bit dirty to have to rely on the order of member destruction, despite being deterministic.