### PR TITLE
Get `Node3D.global_rotation` from orthonormalized global basis

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -357,7 +357,7 @@ void Node3D::set_global_basis(const Basis &p_basis) {
 
 Vector3 Node3D::get_global_rotation() const {
 	ERR_READ_THREAD_GUARD_V(Vector3());
-	return get_global_transform().get_basis().get_euler();
+	return get_global_transform().get_basis().get_euler_normalized();
 }
 
 Vector3 Node3D::get_global_rotation_degrees() const {


### PR DESCRIPTION
Fixes #95051.

The previously used `Basis::get_euler` assumes the given Basis is orthonormal, the article linked in there is about decomposing rotation matrix (so not scaled):
https://github.com/godotengine/godot/blob/3978628c6cc1227250fc6ed45c8d854d24c30c30/core/math/basis.cpp#L457-L461

(not sure about the milestone)