### PR TITLE
[Android editor] Enable the display scale option in the Project manager's quick settings

### DIFF
--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -43,7 +43,9 @@
 #include "scene/gui/panel_container.h"
 
 void QuickSettingsDialog::_fetch_setting_values() {
+#ifndef ANDROID_ENABLED
 	editor_languages.clear();
+#endif
 	editor_themes.clear();
 	editor_scales.clear();
 	editor_network_modes.clear();
@@ -55,7 +57,9 @@ void QuickSettingsDialog::_fetch_setting_values() {
 
 		for (const PropertyInfo &pi : editor_settings_properties) {
 			if (pi.name == "interface/editor/editor_language") {
+#ifndef ANDROID_ENABLED
 				editor_languages = pi.hint_string.split(",");
+#endif
 			} else if (pi.name == "interface/theme/preset") {
 				editor_themes = pi.hint_string.split(",");
 			} else if (pi.name == "interface/editor/display_scale") {
@@ -70,6 +74,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 }
 
 void QuickSettingsDialog::_update_current_values() {
+#ifndef ANDROID_ENABLED
 	// Language options.
 	{
 		const String current_lang = EDITOR_GET("interface/editor/editor_language");
@@ -82,6 +87,7 @@ void QuickSettingsDialog::_update_current_values() {
 			}
 		}
 	}
+#endif
 
 	// Theme options.
 	{
@@ -151,10 +157,12 @@ void QuickSettingsDialog::_add_setting_control(const String &p_text, Control *p_
 	container->add_child(p_control);
 }
 
+#ifndef ANDROID_ENABLED
 void QuickSettingsDialog::_language_selected(int p_id) {
 	const String selected_language = language_option_button->get_item_metadata(p_id);
 	_set_setting_value("interface/editor/editor_language", selected_language, true);
 }
+#endif
 
 void QuickSettingsDialog::_theme_selected(int p_id) {
 	const String selected_theme = theme_option_button->get_item_text(p_id);
@@ -195,7 +203,9 @@ void QuickSettingsDialog::_request_restart() {
 }
 
 void QuickSettingsDialog::update_size_limits(const Size2 &p_max_popup_size) {
+#ifndef ANDROID_ENABLED
 	language_option_button->get_popup()->set_max_size(p_max_popup_size);
+#endif
 }
 
 void QuickSettingsDialog::_notification(int p_what) {
@@ -237,6 +247,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		settings_list = memnew(VBoxContainer);
 		settings_list_panel->add_child(settings_list);
 
+#ifndef ANDROID_ENABLED
 		// Language options.
 		{
 			language_option_button = memnew(OptionButton);
@@ -252,6 +263,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 
 			_add_setting_control(TTR("Language"), language_option_button);
 		}
+#endif
 
 		// Theme options.
 		{
@@ -319,13 +331,6 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		}
 
 		_update_current_values();
-
-#ifdef ANDROID_ENABLED
-		// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.
-		// Also, the dropdown it spawns is very tall and can't be scrolled without a hardware mouse.
-		language_option_button->hide();
-		scale_option_button->hide();
-#endif
 	}
 
 	// Restart required panel.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -43,7 +43,9 @@ class VBoxContainer;
 class QuickSettingsDialog : public AcceptDialog {
 	GDCLASS(QuickSettingsDialog, AcceptDialog);
 
+#ifndef ANDROID_ENABLED
 	Vector<String> editor_languages;
+#endif
 	Vector<String> editor_themes;
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
@@ -57,7 +59,11 @@ class QuickSettingsDialog : public AcceptDialog {
 
 	void _add_setting_control(const String &p_text, Control *p_control);
 
+#ifndef ANDROID_ENABLED
+	// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.
+	// Also, the dropdown it spawns is very tall and can't be scrolled without a hardware mouse.
 	OptionButton *language_option_button = nullptr;
+#endif
 	OptionButton *theme_option_button = nullptr;
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
@@ -65,7 +71,9 @@ class QuickSettingsDialog : public AcceptDialog {
 
 	Label *custom_theme_label = nullptr;
 
+#ifndef ANDROID_ENABLED
 	void _language_selected(int p_id);
+#endif
 	void _theme_selected(int p_id);
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/95037
- Removes the `languages` option: it was previously disabled but its label was still visible in the quick settings dialog

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
