### PR TITLE
[Android editor] Fix issue with importing projects

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -351,15 +351,19 @@ void ProjectDialog::_install_path_changed() {
 }
 
 void ProjectDialog::_browse_project_path() {
+	String path = project_path->get_text();
+	if (path.is_empty()) {
+		path = EDITOR_GET("filesystem/directories/default_project_path");
+	}
 	if (mode == MODE_IMPORT && install_path->is_visible_in_tree()) {
 		// Select last ZIP file.
-		fdialog_project->set_current_path(project_path->get_text());
+		fdialog_project->set_current_path(path);
 	} else if ((mode == MODE_NEW || mode == MODE_INSTALL) && create_dir->is_pressed()) {
 		// Select parent directory of project path.
-		fdialog_project->set_current_dir(project_path->get_text().get_base_dir());
+		fdialog_project->set_current_dir(path.get_base_dir());
 	} else {
 		// Select project path.
-		fdialog_project->set_current_dir(project_path->get_text());
+		fdialog_project->set_current_dir(path);
 	}
 
 	if (mode == MODE_IMPORT) {


### PR DESCRIPTION
The [issue](https://github.com/godotengine/godot/issues/94570) was introduced by https://github.com/godotengine/godot/pull/94113:

- Prior to https://github.com/godotengine/godot/pull/94113
  - `show_dialog()` was invoked in `ask_for_path_and_show()` before `_browse_project_path()` and this had the side effect of updating the value of `project_path`  to the default project path.
  - `fdialog_project`'s current directory is then set in `_browse_project_path()` to the current value of `project_path`

- After https://github.com/godotengine/godot/pull/94113
  - `project_path` has a `null` value when used in `_browse_project_path()` to update `fdialog_project`'s current directory, causing the current directory to default to the filesystem root.


The tentative fix checks whether `project_path` is empty, and if so uses to the default project path instead, matching the previous behavior. There are other options available (e.g: initializing `project_path`'s value in the constructor instead) so feedback are welcome.

We could also revert the other PR, but it may be preferable to fix forward instead since reverting would reintroduce the issue it was addressing.

Fixes https://github.com/godotengine/godot/issues/94570

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
