### PR TITLE
Don't drop `PackedScene` as property

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3331,9 +3331,10 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 
 	const String &res_path = p_files[0];
 	const StringName res_type = EditorFileSystem::get_singleton()->get_file_type(res_path);
+	const bool is_dropping_scene = ClassDB::is_parent_class(res_type, "PackedScene");
 
-	// Dropping as property when possible.
-	if (p_type == 0 && p_files.size() == 1) {
+	// Dropping as property.
+	if (p_type == 0 && p_files.size() == 1 && !is_dropping_scene) {
 		List<String> valid_properties;
 
 		List<PropertyInfo> pinfo;
@@ -3378,7 +3379,7 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 	// Either instantiate scenes or create AudioStreamPlayers.
 	int to_pos = -1;
 	_normalize_drop(node, to_pos, p_type);
-	if (ClassDB::is_parent_class(res_type, "PackedScene")) {
+	if (is_dropping_scene) {
 		_perform_instantiate_scenes(p_files, node, to_pos);
 	} else if (ClassDB::is_parent_class(res_type, "AudioStream")) {
 		_perform_create_audio_stream_players(p_files, node, to_pos);


### PR DESCRIPTION
Closes #94959

This PR reverts the [behavior change](https://github.com/godotengine/godot/pull/92004#issuecomment-2115031374) introduced in #92004.

Treating `PackedScene` the same as other resources is _technically_ more consistent. But it's counterintuitive from the perspective of UX (Users typically do not consider scene files as a type of resource).

I did not bother adding an editor setting for toggling between the behaviors since it's the safe-old behavior of dropping `PackedScene` and we're in the RC stage. I don't want to introduce more moving parts :P