### PR TITLE
Fix embedded popup connection errors

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -71,14 +71,14 @@ void Popup::_deinitialize_visible_parents() {
 	if (is_embedded()) {
 		for (Window *parent_window : visible_parents) {
 			Callable focus_entered_callable = callable_mp(this, &Popup::_parent_focused);
-                        Callable tree_exited_callable = callable_mp(this, &Popup::_deinitialize_visible_parents);
+			Callable tree_exited_callable = callable_mp(this, &Popup::_deinitialize_visible_parents);
 
-                        if (parent_window->is_connected(SceneStringName(focus_entered), focus_entered_callable)) {
-                                parent_window->disconnect(SceneStringName(focus_entered), focus_entered_callable);
-                        }
-                        if (parent_window->is_connected(SceneStringName(tree_exited), tree_exited_callable)) {
-                                parent_window->disconnect(SceneStringName(tree_exited), tree_exited_callable);
-                        }
+			if (parent_window->is_connected(SceneStringName(focus_entered), focus_entered_callable)) {
+				parent_window->disconnect(SceneStringName(focus_entered), focus_entered_callable);
+			}
+			if (parent_window->is_connected(SceneStringName(tree_exited), tree_exited_callable)) {
+				parent_window->disconnect(SceneStringName(tree_exited), tree_exited_callable);
+			}
 		}
 
 		visible_parents.clear();

--- a/tests/scene/test_popup.h
+++ b/tests/scene/test_popup.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  test_viewport.h                                                       */
+/*  test_popup.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -31,14 +31,12 @@
 #ifndef TEST_POPUP_H
 #define TEST_POPUP_H
 
-#include "scene/gui/popup.h"
 #include "scene/gui/control.h"
+#include "scene/gui/popup.h"
 #include "scene/main/window.h"
-#include "core/object/worker_thread_pool.h"
 
 #include "tests/test_macros.h"
 #include "tests/test_tools.h"
-
 
 namespace TestPopup {
 
@@ -67,7 +65,6 @@ TEST_CASE("[SceneTree][Popup]") {
 		CHECK_FALSE(ed.has_error);
 		ed.clear();
 	}
-
 }
 
 } // namespace TestPopup

--- a/tests/scene/test_popup.h
+++ b/tests/scene/test_popup.h
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  test_viewport.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_POPUP_H
+#define TEST_POPUP_H
+
+#include "scene/gui/popup.h"
+#include "scene/gui/control.h"
+#include "scene/main/window.h"
+#include "core/object/worker_thread_pool.h"
+
+#include "tests/test_macros.h"
+#include "tests/test_tools.h"
+
+
+namespace TestPopup {
+
+TEST_CASE("[SceneTree][Popup]") {
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->set_embedding_subwindows(true);
+	Control *parent = memnew(Control);
+	Popup *popup = memnew(Popup);
+
+	// Scene tree:
+	// - root (Window) (Default visible: true)
+	//   - parent (Control) (Default visible: true)
+	//     - popup (Popup) (Default visible: false)
+
+	root->add_child(parent);
+	parent->add_child(popup);
+	ErrorDetector ed;
+
+	SUBCASE("[_initialize_visiable_parents] Calling twice without deinitializing should first disconnect current connections (fix #87626).") {
+		popup->set_visible(true);
+		CHECK_FALSE(ed.has_error);
+		ed.clear();
+		ERR_PRINT_OFF;
+		popup->notification(popup->NOTIFICATION_VISIBILITY_CHANGED);
+		ERR_PRINT_ON;
+		CHECK_FALSE(ed.has_error);
+		ed.clear();
+	}
+
+}
+
+} // namespace TestPopup
+
+#endif // TEST_POPUP_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -118,6 +118,7 @@
 #include "tests/scene/test_packed_scene.h"
 #include "tests/scene/test_path_2d.h"
 #include "tests/scene/test_path_follow_2d.h"
+#include "tests/scene/test_popup.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"


### PR DESCRIPTION
On release builds of Godot with `display/window/subwindows/embed_subwindows` enabled, errors are thrown when any Popup tries to connect/disconnect the `focus_entered` and `tree_exited` signals to its visible parent(s) (see #87626 for more information). This PR adds checks in the `_initialize_visible_parents` and `_deinitialize_visible_parents` functions to ensure the signals are handled properly. It also adds a unit test to prevent regressions, however it only checks the errors in `_initialize_visible_parents` because I cannot figure out how to reliably induce the disconnect errors in the test environment.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/87626*