### PR TITLE
GLTF: Propagate owner for root node children

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5658,6 +5658,15 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIn
 	if (p_scene_root == nullptr) {
 		// If the root node argument is null, this is the root node.
 		p_scene_root = current_node;
+		// If multiple nodes were generated under the root node, ensure they have the owner set.
+		if (unlikely(current_node->get_child_count() > 0)) {
+			Array args;
+			args.append(p_scene_root);
+			for (int i = 0; i < current_node->get_child_count(); i++) {
+				Node *child = current_node->get_child(i);
+				child->propagate_call(StringName("set_owner"), args);
+			}
+		}
 	} else {
 		// Add the node we generated and set the owner to the scene root.
 		p_scene_parent->add_child(current_node, true);


### PR DESCRIPTION
I ran into an edge case where this code designed to propagate the owner for all generated nodes:

```cpp
Array args;
args.append(p_scene_root);
current_node->propagate_call(StringName("set_owner"), args);
```

was not being run for the special case of the root node itself. Therefore, if an extension tried to generate multiple nodes for one glTF node, this would fail if that node was the root node.

I used `unlikely` here because this won't be the case for most files, and it will happen at most once per file.

This is a fairly straightforward change, we could merge it before 4.3, but I put it as 4.4+cherrypick because we are very close to release and this bugfix is very non-critical.