### PR TITLE
Change default window size to match default project manager size

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -212,7 +212,7 @@ static DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_WINDOW
 static DisplayServer::ScreenOrientation window_orientation = DisplayServer::SCREEN_LANDSCAPE;
 static DisplayServer::VSyncMode window_vsync_mode = DisplayServer::VSYNC_ENABLED;
 static uint32_t window_flags = 0;
-static Size2i window_size = Size2i(1152, 648);
+static Size2i window_size = Size2i(1024, 600);
 
 static int init_screen = DisplayServer::SCREEN_PRIMARY;
 static bool init_fullscreen = false;


### PR DESCRIPTION
Currently the project manager window is created, and then almost immediately resized to be a bit smaller when the project manager loads. Happens since 4.2.

This will make it consistent (at least in editor scale 1).

Edit:
Addresses #93028
Conflicts with #91889

#91889 is probably better. Should have looked for related issues