### PR TITLE
Hide Initial Clip property if not relevant in AudioStreamInteractive editor

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -431,6 +431,10 @@ void AudioStreamInteractive::_validate_property(PropertyInfo &r_property) const 
 
 	if (prop == "initial_clip") {
 #ifdef TOOLS_ENABLED
+		if (get_clip_count() == 0) {
+			// Hide property since there's no clip to choose from.
+			r_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
 		r_property.hint_string = _get_streams_hint();
 #endif
 	} else if (prop.begins_with("clip_") && prop != "clip_count") {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/95134 (can be merged independently).

If no clips have been created yet, there's no clip to choose from for the Initial Clip property.

PS: Is there a way to force the parameter list to be updated? This would allow **Switch to Clip** to be hidden if there are no clips as well:

https://github.com/godotengine/godot/blob/3978628c6cc1227250fc6ed45c8d854d24c30c30/modules/interactive_music/audio_stream_interactive.cpp#L458

The following code works, but it doesn't update when you add/remove a clip until you reselect the node:

```cpp
r_parameters->push_back(Parameter(PropertyInfo(Variant::STRING, "switch_to_clip", PROPERTY_HINT_ENUM, clip_names, get_clip_count() == 0 ? PROPERTY_USAGE_NO_EDITOR : PROPERTY_USAGE_EDITOR), ""));
```

Fixing this would allow fully closing https://github.com/godotengine/godot/issues/94140 when coupled with https://github.com/godotengine/godot/pull/95134.

- This partially addresses https://github.com/godotengine/godot/issues/94140.

## Preview

https://github.com/user-attachments/assets/fa2ca8ba-c75d-4d19-ba2a-e73ab83d90bd

