### PR TITLE
[FileDialog] Rework option controls.

### DIFF
--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -35,7 +35,6 @@
 #include "scene/gui/dialogs.h"
 #include "scene/property_list_helper.h"
 
-class GridContainer;
 class DependencyRemoveDialog;
 class HSplitContainer;
 class ItemList;
@@ -89,7 +88,7 @@ private:
 	Button *makedir = nullptr;
 	Access access = ACCESS_RESOURCES;
 
-	GridContainer *grid_options = nullptr;
+	VBoxContainer *vbox_options = nullptr;
 	VBoxContainer *vbox = nullptr;
 	FileMode mode = FILE_MODE_SAVE_FILE;
 	bool can_create_dir = false;
@@ -176,6 +175,8 @@ private:
 		Ref<Texture2D> file_medium_thumbnail;
 		Ref<Texture2D> folder_big_thumbnail;
 		Ref<Texture2D> file_big_thumbnail;
+
+		Ref<StyleBox> check_box_normal;
 
 		Ref<Texture2D> progress[8]{};
 	} theme_cache;

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -39,8 +39,6 @@
 #include "scene/gui/tree.h"
 #include "scene/property_list_helper.h"
 
-class GridContainer;
-
 class FileDialog : public ConfirmationDialog {
 	GDCLASS(FileDialog, ConfirmationDialog);
 
@@ -73,7 +71,7 @@ private:
 	Button *makedir = nullptr;
 	Access access = ACCESS_RESOURCES;
 	VBoxContainer *vbox = nullptr;
-	GridContainer *grid_options = nullptr;
+	VBoxContainer *vbox_options = nullptr;
 	FileMode mode;
 	LineEdit *dir = nullptr;
 	HBoxContainer *drives_container = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95079

- Replaces `GridContainter` with nested `BoxContainer`s.
- Replaces `CheckBox` with `CheckButton` to ensure check element is on the same side as `OptionButton` in multiple choice options.

<img width="763" alt="Screenshot 2024-08-04 at 20 04 22" src="https://github.com/user-attachments/assets/931c7d22-5810-49eb-bb69-86a0352abcc1">
