### PR TITLE
Fix reload of GDExtension libraries in framework package on macOS

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -781,22 +781,13 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 		}
 	}
 
-	String actual_lib_path;
 	OS::GDExtensionData data = {
 		true, // also_set_library_path
-		&actual_lib_path, // r_resolved_path
+		&library_path, // r_resolved_path
 		Engine::get_singleton()->is_editor_hint(), // generate_temp_files
 		&abs_dependencies_paths, // library_dependencies
 	};
 	Error err = OS::get_singleton()->open_dynamic_library(abs_path, library, &data);
-
-	if (actual_lib_path.get_file() != abs_path.get_file()) {
-		// If temporary files are generated, let's change the library path to point at the original,
-		// because that's what we want to check to see if it's changed.
-		library_path = actual_lib_path.get_base_dir().path_join(p_path.get_file());
-	} else {
-		library_path = actual_lib_path;
-	}
 
 	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, "GDExtension dynamic library not found: " + abs_path);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Can't open GDExtension dynamic library: " + abs_path);

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -383,7 +383,7 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	if (!err) {
 		return status.st_mtime;
 	} else {
-		print_verbose("Failed to get modified time for: " + p_file + "");
+		WARN_PRINT("Failed to get modified time for: " + p_file);
 		return 0;
 	}
 }


### PR DESCRIPTION
`GDExtension::open_library` has a check in it to see if the library was loaded from a temp file, and if it was to restore the original name as that is the one we actually care about. This check is breaking extension reloading on Mac when the library path is to a framework folder, as the file inside the framework will not generally be the same name as the folder.

This check also shouldn't be necessary even on Windows, which is the only platform that uses `generate_temp_files`, since disposal of the created temp file is handled within `OS_Windows::open_dynamic_library`, and `GDExtension::open_library` (which is the only function to call `open_dynamic_library` with a `p_data` argument) only cares about the original library file path and has to do extra work to remove the name of the temp file. Instead, I have removed that check and set `OS_Windows::open_dynamic_library` to return the name of the original file and not the name of the copy.

This fixes GDExtension reloading on macOS. I do not have a Windows machine available to test that it still works properly on Windows, so someone should check that before merging this.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
