### PR TITLE
Fix SceneTree Timer to Safely Handle Node Deletion on Timeout

### DIFF
--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -56,6 +56,7 @@ class SceneTreeTimer : public RefCounted {
 	bool process_always = true;
 	bool process_in_physics = false;
 	bool ignore_time_scale = false;
+	Node *owner;
 
 protected:
 	static void _bind_methods();
@@ -74,6 +75,9 @@ public:
 	bool is_ignore_time_scale();
 
 	void release_connections();
+
+ 	void set_owner(Object *p_owner);
+    Node *get_owner() const;
 
 	SceneTreeTimer();
 };
@@ -395,7 +399,7 @@ public:
 	Error reload_current_scene();
 	void unload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
+	Ref<SceneTreeTimer> create_timer(double p_delay_sec, Node *p_owner = nullptr, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
 	Ref<Tween> create_tween();
 	TypedArray<Tween> get_processed_tweens();
 


### PR DESCRIPTION
This update addresses an issue in the Godot Engine where a SceneTreeTimer would cause an error if its timeout signal was emitted after the node that created it was deleted. The fix ensures that the timer checks whether the owner node still exists and is inside the scene tree before emitting the timeout signal, and it properly handles the timer removal without causing errors.

