### PR TITLE
Fix SceneTree Timer to Safely Handle Node Deletion on Timeout

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1620,7 +1620,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
 
-	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always", "process_in_physics", "ignore_time_scale", "owner"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always", "process_in_physics", "ignore_time_scale", "owner"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false), DEFVAL(nullptr));
 
 	ClassDB::bind_method(D_METHOD("create_tween"), &SceneTree::create_tween);
 	ClassDB::bind_method(D_METHOD("get_processed_tweens"), &SceneTree::get_processed_tweens);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -81,9 +81,6 @@ void SceneTreeTimer::_bind_methods() {
 
 void SceneTreeTimer::set_owner(Object *p_owner) {
     owner = Object::cast_to<Node>(p_owner);
-    if (!owner) {
-        owner = nullptr;
-    }
 }
 
 Node *SceneTreeTimer::get_owner() const {
@@ -612,7 +609,7 @@ void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 
 		if (time_left <= 0) {
             if (E->get()->get_owner() && E->get()->get_owner()->is_inside_tree() ) {
-                E->get()->emit_signal("timeout");
+                E->get()->emit_signal(SNAME("timeout"));
             }
 			timers.erase(E);
 		}
@@ -1488,7 +1485,8 @@ void SceneTree::add_current_scene(Node *p_current) {
 	current_scene = p_current;
 	root->add_child(p_current);
 }
-Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, Node *p_owner, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale) {
+
+Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale, Node *p_owner) {
 	_THREAD_SAFE_METHOD_
 	Ref<SceneTreeTimer> stt;
 	stt.instantiate();
@@ -1622,7 +1620,8 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
 
-	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "owner", "process_always", "process_in_physics", "ignore_time_scale"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always", "process_in_physics", "ignore_time_scale", "owner"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
+
 	ClassDB::bind_method(D_METHOD("create_tween"), &SceneTree::create_tween);
 	ClassDB::bind_method(D_METHOD("get_processed_tweens"), &SceneTree::get_processed_tweens);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1622,7 +1622,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
 
-	ClassDB::bind_method(D_METHOD("create_timer", "time_sec","owner", "process_always", "process_in_physics", "ignore_time_scale"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "owner", "process_always", "process_in_physics", "ignore_time_scale"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_tween"), &SceneTree::create_tween);
 	ClassDB::bind_method(D_METHOD("get_processed_tweens"), &SceneTree::get_processed_tweens);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -81,9 +81,6 @@ void SceneTreeTimer::_bind_methods() {
 
 void SceneTreeTimer::set_owner(Object *p_owner) {
     owner = Object::cast_to<Node>(p_owner);
-    if (!owner) {
-        owner = nullptr;
-    }
 }
 
 Node *SceneTreeTimer::get_owner() const {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -612,7 +612,7 @@ void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 
 		if (time_left <= 0) {
             if (E->get()->get_owner() && E->get()->get_owner()->is_inside_tree() ) {
-                E->get()->emit_signal("timeout");
+                E->get()->emit_signal(SNAME("timeout"));
             }
 			timers.erase(E);
 		}

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -56,6 +56,7 @@ class SceneTreeTimer : public RefCounted {
 	bool process_always = true;
 	bool process_in_physics = false;
 	bool ignore_time_scale = false;
+	Node *owner;
 
 protected:
 	static void _bind_methods();
@@ -74,6 +75,9 @@ public:
 	bool is_ignore_time_scale();
 
 	void release_connections();
+
+ 	void set_owner(Object *p_owner);
+    Node *get_owner() const;
 
 	SceneTreeTimer();
 };
@@ -395,7 +399,7 @@ public:
 	Error reload_current_scene();
 	void unload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
+	Ref<SceneTreeTimer> create_timer(double p_delay_sec, Node *p_owner = nullptr, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
 	Ref<Tween> create_tween();
 	TypedArray<Tween> get_processed_tweens();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -56,7 +56,7 @@ class SceneTreeTimer : public RefCounted {
 	bool process_always = true;
 	bool process_in_physics = false;
 	bool ignore_time_scale = false;
-	Node *owner;
+	Node *owner = nullptr;
 
 protected:
 	static void _bind_methods();
@@ -76,7 +76,7 @@ public:
 
 	void release_connections();
 
- 	void set_owner(Object *p_owner);
+ 	void set_owner(Node *p_owner);
     Node *get_owner() const;
 
 	SceneTreeTimer();
@@ -399,7 +399,7 @@ public:
 	Error reload_current_scene();
 	void unload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(double p_delay_sec, Node *p_owner = nullptr, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
+	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false, Node *p_owner = nullptr);
 	Ref<Tween> create_tween();
 	TypedArray<Tween> get_processed_tweens();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -56,7 +56,7 @@ class SceneTreeTimer : public RefCounted {
 	bool process_always = true;
 	bool process_in_physics = false;
 	bool ignore_time_scale = false;
-	Node *owner;
+	Node *owner = nullptr;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This update addresses an issue in the Godot Engine where a SceneTreeTimer would cause an error if its timeout signal was emitted after the node that created it was deleted. The fix ensures that the timer checks whether the owner node still exists and is inside the scene tree before emitting the timeout signal, and it properly handles the timer removal without causing errors.