### PR TITLE
Don't fold resources when child of main inspector exits

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3417,7 +3417,8 @@ void EditorPropertyResource::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			const EditorInspector *ei = get_parent_inspector();
-			if (ei && !ei->is_main_editor_inspector()) {
+			const EditorInspector *main_ei = InspectorDock::get_inspector_singleton();
+			if (ei && main_ei && ei != main_ei && !main_ei->is_ancestor_of(ei)) {
 				fold_resource();
 			}
 		} break;


### PR DESCRIPTION
Fixes #81481

There is some
```
ERROR: Condition "plugins_list.has(p_plugin)" is true.
   at: EditorPluginList::add_plugin (C:\godot_source\editor/editor_node.cpp:7893)
```
error, but it's pre-existing. This change only exposes it a bit more.