### PR TITLE
[Windows] Reject `WM_POINTER(UP/DOWN)` messages for non pen pointer type.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4250,6 +4250,16 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
+			uint32_t pointer_id = LOWORD(wParam);
+			POINTER_INPUT_TYPE pointer_type = PT_POINTER;
+			if (!win8p_GetPointerType(pointer_id, &pointer_type)) {
+				break;
+			}
+
+			if (pointer_type != PT_PEN) {
+				break;
+			}
+
 			Ref<InputEventMouseButton> mb;
 			mb.instantiate();
 			mb->set_window_id(window_id);


### PR DESCRIPTION
Fixes #95135
Fixes #95106

Process only pen up/down messages directly (same is already done for move and enter/exit) and skip touchscreen messages to allow default window procedure to generate `WM_TOUCH` events.