### PR TITLE
[Shader Cache] Include engine version and architecture when calculating hash.

### DIFF
--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -30,6 +30,9 @@
 
 #include "egl_manager.h"
 
+#include "core/string/string_builder.h"
+#include "core/version.h"
+
 #ifdef EGL_ENABLED
 
 #if defined(EGL_STATIC)
@@ -411,15 +414,24 @@ Error EGLManager::initialize(void *p_native_display) {
 		ERR_PRINT("EGL: Can't create shader cache folder, no shader caching will happen: " + shader_cache_dir);
 		shader_cache_dir = String();
 	} else {
-		err = da->change_dir(String("shader_cache").path_join("EGL"));
+		StringBuilder tohash;
+		tohash.append("[GodotVersionNumber]");
+		tohash.append(VERSION_NUMBER);
+		tohash.append("[GodotVersionHash]");
+		tohash.append(VERSION_HASH);
+		tohash.append("[GodotArchitecture]");
+		tohash.append(Engine::get_singleton()->get_architecture_name());
+		String base_sha256 = tohash.as_string().sha256_text();
+
+		err = da->change_dir(String("shader_cache").path_join("EGL").path_join(base_sha256));
 		if (err != OK) {
-			err = da->make_dir_recursive(String("shader_cache").path_join("EGL"));
+			err = da->make_dir_recursive(String("shader_cache").path_join("EGL").path_join(base_sha256));
 		}
 		if (err != OK) {
 			ERR_PRINT("EGL: Can't create shader cache folder, no shader caching will happen: " + shader_cache_dir);
 			shader_cache_dir = String();
 		} else {
-			shader_cache_dir = shader_cache_dir.path_join(String("shader_cache").path_join("EGL"));
+			shader_cache_dir = shader_cache_dir.path_join(String("shader_cache").path_join("EGL").path_join(base_sha256));
 		}
 	}
 #endif

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -35,6 +35,7 @@
 #include "core/io/compression.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/version.h"
 
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "drivers/gles3/storage/config.h"
@@ -130,12 +131,13 @@ void ShaderGLES3::_setup(const char *p_vertex_code, const char *p_fragment_code,
 	feedback_count = p_feedback_count;
 
 	StringBuilder tohash;
-	/*
-	tohash.append("[SpirvCacheKey]");
-	tohash.append(RenderingDevice::get_singleton()->shader_get_spirv_cache_key());
-	tohash.append("[BinaryCacheKey]");
-	tohash.append(RenderingDevice::get_singleton()->shader_get_binary_cache_key());
-	*/
+	tohash.append("[GodotVersionNumber]");
+	tohash.append(VERSION_NUMBER);
+	tohash.append("[GodotVersionHash]");
+	tohash.append(VERSION_HASH);
+	tohash.append("[GodotArchitecture]");
+	tohash.append(Engine::get_singleton()->get_architecture_name());
+
 	tohash.append("[Vertex]");
 	tohash.append(p_vertex_code ? p_vertex_code : "");
 	tohash.append("[Fragment]");

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -122,6 +122,8 @@ void ShaderRD::setup(const char *p_vertex_code, const char *p_fragment_code, con
 	tohash.append(VERSION_NUMBER);
 	tohash.append("[GodotVersionHash]");
 	tohash.append(VERSION_HASH);
+	tohash.append("[GodotArchitecture]");
+	tohash.append(Engine::get_singleton()->get_architecture_name());
 	tohash.append("[SpirvCacheKey]");
 	tohash.append(RenderingDevice::get_singleton()->shader_get_spirv_cache_key());
 	tohash.append("[BinaryCacheKey]");


### PR DESCRIPTION
Might fix https://github.com/godotengine/godot/issues/95142

I can't reproduce the crash (on NVidia, might be Intel specific), but at least for OpenGL, shaders generated by 32-bit and 64-bit binaries built from the same source are definitely different (seems to have a bunch of `size_t` sized elements).