### PR TITLE
Assign return value on `Variant` operator failure

### DIFF
--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -923,7 +923,10 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
 		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), &valid);
-		ERR_FAIL_COND_MSG(!valid, result);
+		if (unlikely(!valid)) {
+			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
+		}
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
@@ -948,7 +951,10 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
 		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right), &valid);
-		ERR_FAIL_COND_MSG(!valid, result);
+		if (unlikely(!valid)) {
+			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
+		}
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
@@ -976,7 +982,10 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
 		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), right->get_validated_object(), &valid);
-		ERR_FAIL_COND_MSG(!valid, result);
+		if (unlikely(!valid)) {
+			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
+		}
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
@@ -1003,7 +1012,10 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
 		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), *VariantGetInternalPtr<T>::get_ptr(right), &valid);
-		ERR_FAIL_COND_MSG(!valid, result);
+		if (unlikely(!valid)) {
+			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
+		}
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
@@ -1492,7 +1504,10 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
-		ERR_FAIL_NULL(l);
+		if (unlikely(!l)) {
+			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
+			ERR_FAIL_MSG("Invalid base object for 'in'.");
+		}
 		const String &a = *VariantGetInternalPtr<String>::get_ptr(left);
 
 		bool valid;
@@ -1526,7 +1541,10 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
-		ERR_FAIL_NULL(l);
+		if (unlikely(!l)) {
+			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
+			ERR_FAIL_MSG("Invalid base object for 'in'.");
+		}
 		const StringName &a = *VariantGetInternalPtr<StringName>::get_ptr(left);
 
 		bool valid;


### PR DESCRIPTION
`Variant` operators for `String` formatting and `in` could result in errors, which would return from `validated_evaluate` without assigning `r_ret`.  This would cause scripts using the return value from these operators to get results from previously run code.  Updated to return the original `String` value in the `String` formatting case, and false for `in` when an error occurs.

Fixes #95152

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
