### PR TITLE
Make EditorSpinSlider display a slider for floats with a step of 1.0

### DIFF
--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -10,6 +10,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="editing_integer" type="bool" setter="set_editing_integer" getter="is_editing_integer" default="false">
+			If [code]true[/code], the [EditorSpinSlider] is considered to be editing an integer value. If [code]false[/code], the [EditorSpinSlider] is considered to be editing a floating-point value. This is used to determine whether a slider should be drawn. The slider is only drawn for floats; integers use up-down arrows similar to [SpinBox] instead.
+		</member>
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 			If [code]true[/code], the slider will not draw background.
 		</member>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1343,6 +1343,7 @@ void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, 
 EditorPropertyInteger::EditorPropertyInteger() {
 	spin = memnew(EditorSpinSlider);
 	spin->set_flat(true);
+	spin->set_editing_integer(true);
 	add_child(spin);
 	add_focusable(spin);
 	spin->connect(SceneStringName(value_changed), callable_mp(this, &EditorPropertyInteger::_value_changed));

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -376,7 +376,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 	TS->free_rid(num_rid);
 
 	if (!hide_slider) {
-		if (get_step() == 1) {
+		if (editing_integer) {
 			Ref<Texture2D> updown2 = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
 			int updown_vofs = (size.height - updown2->get_height()) / 2;
 			if (rtl) {
@@ -528,6 +528,19 @@ void EditorSpinSlider::set_hide_slider(bool p_hide) {
 
 bool EditorSpinSlider::is_hiding_slider() const {
 	return hide_slider;
+}
+
+void EditorSpinSlider::set_editing_integer(bool p_editing_integer) {
+	if (p_editing_integer == editing_integer) {
+		return;
+	}
+
+	editing_integer = p_editing_integer;
+	queue_redraw();
+}
+
+bool EditorSpinSlider::is_editing_integer() const {
+	return editing_integer;
 }
 
 void EditorSpinSlider::set_label(const String &p_label) {
@@ -689,11 +702,15 @@ void EditorSpinSlider::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hide_slider", "hide_slider"), &EditorSpinSlider::set_hide_slider);
 	ClassDB::bind_method(D_METHOD("is_hiding_slider"), &EditorSpinSlider::is_hiding_slider);
 
+	ClassDB::bind_method(D_METHOD("set_editing_integer", "editing_integer"), &EditorSpinSlider::set_editing_integer);
+	ClassDB::bind_method(D_METHOD("is_editing_integer"), &EditorSpinSlider::is_editing_integer);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_slider"), "set_hide_slider", "is_hiding_slider");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editing_integer"), "set_editing_integer", "is_editing_integer");
 
 	ADD_SIGNAL(MethodInfo("grabbed"));
 	ADD_SIGNAL(MethodInfo("ungrabbed"));

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -71,6 +71,7 @@ class EditorSpinSlider : public Range {
 
 	bool hide_slider = false;
 	bool flat = false;
+	bool editing_integer = false;
 
 	void _grab_start();
 	void _grab_end();
@@ -112,6 +113,9 @@ public:
 
 	void set_hide_slider(bool p_hide);
 	bool is_hiding_slider() const;
+
+	void set_editing_integer(bool p_editing_integer);
+	bool is_editing_integer() const;
 
 	void set_read_only(bool p_enable);
 	bool is_read_only() const;


### PR DESCRIPTION
Integers still don't display a slider (and use up/down arrows instead), so that they can be quickly distinguished from floats in the inspector. The [original issue](https://github.com/godotengine/godot/issues/42809) mentioned that integers could be made to look like floats in the inspector, but it means we'd be losing this particular UX affordance, so I didn't go as far as making all integers have a slider for now.

However, this now makes floats with a step of 1.0 look different from integers in the inspector. This complements https://github.com/godotengine/godot/pull/47502 in that sense.

- This partially addresses https://github.com/godotengine/godot/issues/42809.

## Preview

```gdscript
@export_range(0, 10, 1) var integer_step_1 := 1
@export_range(0.0, 10.0, 1.0) var float_step_1 := 1.0
@export_range(0.0, 10.0, 0.1) var float_step_0_1 := 1.0
```

### Before

![Screenshot_20240805_190042](https://github.com/user-attachments/assets/7ccff49a-f490-4667-89e7-419958bee047)

### After

![Screenshot_20240805_191712](https://github.com/user-attachments/assets/f2e996ce-7f2d-4623-9e1a-9e2f801e916f)