### PR TITLE
Fix crash when division by zero/modulo by zero happen on vectors

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/errors/division_by_zero.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/division_by_zero.gd
@@ -1,0 +1,3 @@
+func test():
+	var integer: int = 1
+	integer /= 0

--- a/modules/gdscript/tests/scripts/runtime/errors/division_by_zero.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/division_by_zero.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/division_by_zero.gd
+>> 3
+>> Division by zero error in operator '/'.

--- a/modules/gdscript/tests/scripts/runtime/errors/modulo_by_zero.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/modulo_by_zero.gd
@@ -1,0 +1,3 @@
+func test():
+	var integer: int = 1
+	integer %= 0

--- a/modules/gdscript/tests/scripts/runtime/errors/modulo_by_zero.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/modulo_by_zero.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/modulo_by_zero.gd
+>> 3
+>> Modulo by zero error in operator '%'.


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/95168

```gdscript
func test_vector():
	var v1 := Vector2i(1, 1)
	var v2 := Vector2i(0, 0)
	print(v1 / v2)

# or

func test_vector2():
	var v1 := Vector2i(1, 1)
	var v2 := 0
	print(v1 / v2)
```

Will now correctly finish with error, instead of silent crash.