### PR TITLE
[macOS] Attempt to terminate process normally before using `forceTerminate`.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -680,8 +680,11 @@ Error OS_MacOS::kill(const ProcessID &p_pid) {
 	if (!app) {
 		return OS_Unix::kill(p_pid);
 	}
-
-	return [app forceTerminate] ? OK : ERR_INVALID_PARAMETER;
+	bool terminated = [app terminate];
+	if (!terminated) {
+		terminated = [app forceTerminate];
+	}
+	return terminated ? OK : ERR_INVALID_PARAMETER;
 }
 
 String OS_MacOS::get_unique_id() const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95167

We probably should add an extra `force` flag to `kill` method, and change the editor logic. Killing running project processes unconditionally seems like a bad idea, it probably should try killing it normally and only kill on a timer if a child process is still running.