### PR TITLE
[MP] Avoid error spam in relay protocol when clients disconnect

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -307,8 +307,10 @@ void SceneMultiplayer::_process_sys(int p_from, const uint8_t *p_packet, int p_p
 			int len = p_packet_len - SYS_CMD_SIZE;
 			bool should_process = false;
 			if (get_unique_id() == 1) { // I am the server.
-				// Direct messages to server should not go through relay.
-				ERR_FAIL_COND(peer > 0 && !connected_peers.has(peer));
+				// The requested target might have disconnected while the packet was in transit.
+				if (unlikely(peer > 0 && !connected_peers.has(peer))) {
+					return;
+				}
 				// Send relay packet.
 				relay_buffer->seek(0);
 				relay_buffer->put_u8(NETWORK_COMMAND_SYS);


### PR DESCRIPTION
When multiple clients are connected, and the server is using the relay sub-protocol, it might happen that a client disconnects while a packet sent to it from another peer is still in transit.

In that case, when the packet reaches the server for relaying, it used to generate an error (as the destination client did no longer exists).

This commit changes check to suppress the error message while still skipping the packet.

Fixes #70505
