### PR TITLE
Fix checkbox alignment when using compact theme spacing

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -865,7 +865,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		// CheckBox.
 		{
 			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
-			checkbox_style->set_content_margin_all(p_config.base_margin * EDSCALE);
+			checkbox_style->set_content_margin_individual((p_config.increased_margin + 2) * EDSCALE, p_config.base_margin * EDSCALE, (p_config.increased_margin + 2) * EDSCALE, p_config.base_margin * EDSCALE);
 
 			p_theme->set_stylebox(CoreStringName(normal), "CheckBox", checkbox_style);
 			p_theme->set_stylebox(SceneStringName(pressed), "CheckBox", checkbox_style);


### PR DESCRIPTION
Believe this should fix https://github.com/godotengine/godot/issues/88696

Before:
![image](https://github.com/user-attachments/assets/f03e7be5-5f12-4377-88fa-5cb96b7e4076)

After:
![image](https://github.com/user-attachments/assets/d5db31ea-9cf6-45f7-bbf6-3bbc5f6d5cec)
