### PR TITLE
[MP] Fix relay protocol routing with negative targets

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -321,21 +321,24 @@ void SceneMultiplayer::_process_sys(int p_from, const uint8_t *p_packet, int p_p
 				multiplayer_peer->set_transfer_mode(p_mode);
 				multiplayer_peer->set_transfer_channel(p_channel);
 				if (peer > 0) {
+					// Single destination.
 					multiplayer_peer->set_target_peer(peer);
 					_send(data.ptr(), relay_buffer->get_position());
 				} else {
+					// Multiple destinations.
 					for (const int &P : connected_peers) {
 						// Not to sender, nor excluded.
-						if (P == p_from || (peer < 0 && P != -peer)) {
+						if (P == p_from || P == -peer) {
 							continue;
 						}
 						multiplayer_peer->set_target_peer(P);
 						_send(data.ptr(), relay_buffer->get_position());
 					}
-				}
-				if (peer == 0 || peer == -1) {
-					should_process = true;
-					peer = p_from; // Process as the source.
+					if (peer != -1) {
+						// The server is one of the targets, process the packet with sender as source.
+						should_process = true;
+						peer = p_from;
+					}
 				}
 			} else {
 				ERR_FAIL_COND(p_from != 1); // Bug.


### PR DESCRIPTION
Godot supports sending messages to "all but one peer" by sending a packet with a negative target (the negated ID of the excluded peer).

The relay protocol was incorrectly interpreting the values and relaying the message to the wrong peers.

This issue only affected "send_bytes" since the other subsystem (RPC and replication) "resolves" the correct IDs client-side (to match visibility information).

Tested with the following script:
```gdscript
extends Control

var last_id = 1

# Called when the node enters the scene tree for the first time.
func _ready() -> void:
	multiplayer.connected_to_server.connect(_connected)
	var peer = ENetMultiplayerPeer.new()
	if "--server" in OS.get_cmdline_args():
		peer.create_server(4343)
	else:
		peer.create_client("127.0.0.1", 4343)
	multiplayer.multiplayer_peer = peer
	multiplayer.peer_packet.connect(f1)
	multiplayer.peer_connected.connect(_peer_connected)


func _peer_connected(id):
	if id != 1:
		last_id = id


func _connected():
	await get_tree().create_timer(3).timeout
	(multiplayer as SceneMultiplayer).send_bytes(var_to_bytes(last_id), last_id)
	(multiplayer as SceneMultiplayer).send_bytes(var_to_bytes(-last_id), -last_id)
	(multiplayer as SceneMultiplayer).send_bytes(var_to_bytes(1), 1)
	(multiplayer as SceneMultiplayer).send_bytes(var_to_bytes(0), 0)
	(multiplayer as SceneMultiplayer).send_bytes(var_to_bytes(-1), -1)


func f1(from=0, data=PackedByteArray()):
	print("Called f1 from %d=%d in %d. Data: %d" % [multiplayer.get_remote_sender_id(), from, multiplayer.get_unique_id(), bytes_to_var(data)])
```