### PR TITLE
[RegEx] Add `show_error` parameter to control error printing on compilation fail

### DIFF
--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -48,3 +48,11 @@ GH-93605
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Semaphore/methods/post': arguments
 
 Optional arguments added. Compatibility methods registered.
+
+
+GH-95212
+--------
+Validate extension JSON: Error: Field 'classes/RegEx/methods/compile/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/RegEx/methods/create_from_string/arguments': size changed value in new API, from 1 to 2.
+
+Add optional argument to control error printing on compilation fail. Compatibility methods registered.

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -58,15 +58,17 @@
 		<method name="compile">
 			<return type="int" enum="Error" />
 			<param index="0" name="pattern" type="String" />
+			<param index="1" name="show_error" type="bool" default="true" />
 			<description>
-				Compiles and assign the search pattern to use. Returns [constant OK] if the compilation is successful. If an error is encountered, details are printed to standard output and an error is returned.
+				Compiles and assign the search pattern to use. Returns [constant OK] if the compilation is successful. If compilation fails, returns [constant FAILED] and when [param show_error] is [code]true[/code], details are printed to standard output.
 			</description>
 		</method>
 		<method name="create_from_string" qualifiers="static">
 			<return type="RegEx" />
 			<param index="0" name="pattern" type="String" />
+			<param index="1" name="show_error" type="bool" default="true" />
 			<description>
-				Creates and compiles a new [RegEx] object.
+				Creates and compiles a new [RegEx] object. See also [method compile].
 			</description>
 		</method>
 		<method name="get_group_count" qualifiers="const">

--- a/modules/regex/regex.compat.inc
+++ b/modules/regex/regex.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  regex.h                                                               */
+/*  regex.compat.inc                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,83 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef REGEX_H
-#define REGEX_H
-
-#include "core/object/ref_counted.h"
-#include "core/string/ustring.h"
-#include "core/templates/hash_map.h"
-#include "core/templates/vector.h"
-#include "core/variant/array.h"
-#include "core/variant/dictionary.h"
-#include "core/variant/typed_array.h"
-
-class RegExMatch : public RefCounted {
-	GDCLASS(RegExMatch, RefCounted);
-
-	struct Range {
-		int start = 0;
-		int end = 0;
-	};
-
-	String subject;
-	Vector<Range> data;
-	HashMap<String, int> names;
-
-	friend class RegEx;
-
-protected:
-	static void _bind_methods();
-
-	int _find(const Variant &p_name) const;
-
-public:
-	String get_subject() const;
-	int get_group_count() const;
-	Dictionary get_names() const;
-
-	PackedStringArray get_strings() const;
-	String get_string(const Variant &p_name) const;
-	int get_start(const Variant &p_name) const;
-	int get_end(const Variant &p_name) const;
-};
-
-class RegEx : public RefCounted {
-	GDCLASS(RegEx, RefCounted);
-
-	void *general_ctx = nullptr;
-	void *code = nullptr;
-	String pattern;
-
-	void _pattern_info(uint32_t what, void *where) const;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	static Ref<RegEx> _create_from_string_bind_compat_95212(const String &p_pattern);
-	Error _compile_bind_compat_95212(const String &p_pattern);
-	static void _bind_compatibility_methods();
+
+Ref<RegEx> RegEx::_create_from_string_bind_compat_95212(const String &p_pattern) {
+	return create_from_string(p_pattern, true);
+}
+
+Error RegEx::_compile_bind_compat_95212(const String &p_pattern) {
+	return compile(p_pattern, true);
+}
+
+void RegEx::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_static_method("RegEx", D_METHOD("create_from_string", "pattern"), &RegEx::_create_from_string_bind_compat_95212);
+	ClassDB::bind_compatibility_method(D_METHOD("compile", "pattern"), &RegEx::_compile_bind_compat_95212);
+}
+
 #endif
-
-public:
-	static Ref<RegEx> create_from_string(const String &p_pattern, bool p_show_error = true);
-
-	void clear();
-	Error compile(const String &p_pattern, bool p_show_error = true);
-
-	Ref<RegExMatch> search(const String &p_subject, int p_offset = 0, int p_end = -1) const;
-	TypedArray<RegExMatch> search_all(const String &p_subject, int p_offset = 0, int p_end = -1) const;
-	String sub(const String &p_subject, const String &p_replacement, bool p_all = false, int p_offset = 0, int p_end = -1) const;
-
-	bool is_valid() const;
-	String get_pattern() const;
-	int get_group_count() const;
-	PackedStringArray get_names() const;
-
-	RegEx();
-	RegEx(const String &p_pattern);
-	~RegEx();
-};
-
-#endif // REGEX_H

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "regex.h"
+#include "regex.compat.inc"
 
 #include "core/os/memory.h"
 
@@ -161,10 +162,10 @@ void RegEx::_pattern_info(uint32_t what, void *where) const {
 	pcre2_pattern_info_32((pcre2_code_32 *)code, what, where);
 }
 
-Ref<RegEx> RegEx::create_from_string(const String &p_pattern) {
+Ref<RegEx> RegEx::create_from_string(const String &p_pattern, bool p_show_error) {
 	Ref<RegEx> ret;
 	ret.instantiate();
-	ret->compile(p_pattern);
+	ret->compile(p_pattern, p_show_error);
 	return ret;
 }
 
@@ -175,7 +176,7 @@ void RegEx::clear() {
 	}
 }
 
-Error RegEx::compile(const String &p_pattern) {
+Error RegEx::compile(const String &p_pattern, bool p_show_error) {
 	pattern = p_pattern;
 	clear();
 
@@ -192,10 +193,12 @@ Error RegEx::compile(const String &p_pattern) {
 	pcre2_compile_context_free_32(cctx);
 
 	if (!code) {
-		PCRE2_UCHAR32 buf[256];
-		pcre2_get_error_message_32(err, buf, 256);
-		String message = String::num(offset) + ": " + String((const char32_t *)buf);
-		ERR_PRINT(message.utf8());
+		if (p_show_error) {
+			PCRE2_UCHAR32 buf[256];
+			pcre2_get_error_message_32(err, buf, 256);
+			String message = String::num(offset) + ": " + String((const char32_t *)buf);
+			ERR_PRINT(message.utf8());
+		}
 		return FAILED;
 	}
 	return OK;
@@ -395,10 +398,10 @@ RegEx::~RegEx() {
 }
 
 void RegEx::_bind_methods() {
-	ClassDB::bind_static_method("RegEx", D_METHOD("create_from_string", "pattern"), &RegEx::create_from_string);
+	ClassDB::bind_static_method("RegEx", D_METHOD("create_from_string", "pattern", "show_error"), &RegEx::create_from_string, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("clear"), &RegEx::clear);
-	ClassDB::bind_method(D_METHOD("compile", "pattern"), &RegEx::compile);
+	ClassDB::bind_method(D_METHOD("compile", "pattern", "show_error"), &RegEx::compile, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("search", "subject", "offset", "end"), &RegEx::search, DEFVAL(0), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("search_all", "subject", "offset", "end"), &RegEx::search_all, DEFVAL(0), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("sub", "subject", "replacement", "all", "offset", "end"), &RegEx::sub, DEFVAL(false), DEFVAL(0), DEFVAL(-1));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Implements https://github.com/godotengine/godot-proposals/issues/10381