### PR TITLE
Add new rendering settings to `LabelSettings` and in `Label` theme

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -142,7 +142,7 @@
 			The vertical offset of the text's shadow.
 		</theme_item>
 		<theme_item name="draw_shadow_before_outline" data_type="constant" type="int" default="0">
-			Changes the order in which the font [code]shadow[/code] and [code]shadow_outline[/code] is drawn. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default.
+			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
 			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
 			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
 			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -124,6 +124,12 @@
 		<theme_item name="font_shadow_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			[Color] of the shadow outline.
 		</theme_item>
+		<theme_item name="draw_shadow_before_outline" data_type="constant" type="int" default="0">
+			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
+			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
+			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
+			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
+		</theme_item>
 		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
 		</theme_item>
@@ -132,20 +138,14 @@
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 			[b]Note:[/b] Using a value that is larger than half the font size is not recommended, as the font outline may fail to be fully closed in this case.
 		</theme_item>
-		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="0">
-			The size of the shadow outline.
-		</theme_item>
 		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the text's shadow.
 		</theme_item>
 		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the text's shadow.
 		</theme_item>
-		<theme_item name="draw_shadow_before_outline" data_type="constant" type="int" default="0">
-			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
-			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
-			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
-			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
+		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="0">
+			The size of the shadow outline.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the [Label]'s text.

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -121,6 +121,9 @@
 		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			[Color] of the text's shadow effect.
 		</theme_item>
+		<theme_item name="font_shadow_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
+			[Color] of the shadow outline.
+		</theme_item>
 		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
 		</theme_item>
@@ -129,14 +132,20 @@
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 			[b]Note:[/b] Using a value that is larger than half the font size is not recommended, as the font outline may fail to be fully closed in this case.
 		</theme_item>
+		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="0">
+			The size of the shadow outline.
+		</theme_item>
 		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the text's shadow.
 		</theme_item>
 		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the text's shadow.
 		</theme_item>
-		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
-			The size of the shadow outline.
+		<theme_item name="draw_shadow_before_outline" data_type="constant" type="int" default="0">
+			Changes the order in which the [code]shadow[/code] and [code]shadow_outline[/code] is draw. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default
+			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
+			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
+			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the [Label]'s text.

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -142,7 +142,7 @@
 			The vertical offset of the text's shadow.
 		</theme_item>
 		<theme_item name="draw_shadow_before_outline" data_type="constant" type="int" default="0">
-			Changes the order in which the [code]shadow[/code] and [code]shadow_outline[/code] is draw. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default
+			Changes the order in which the font [code]shadow[/code] and [code]shadow_outline[/code] is drawn. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default.
 			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
 			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
 			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -39,7 +39,7 @@
 		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2(1, 1)">
 			Offset of the shadow effect, in pixels.
 		</member>
-		<member name="shadow_outline_color" type="int" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
+		<member name="shadow_outline_color" type="Color" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
 			The color of the shadow outline. If alpha is [code]0[/code], no shadow outline will be drawn.
 		</member>
 		<member name="shadow_outline_size" type="int" setter="set_shadow_outline_size" getter="get_shadow_outline_size" default="0">

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -40,7 +40,7 @@
 			Shadow outline size.
 		</member>
 		<member name="draw_shadow_before_outline" type="int" setter="set_draw_shadow_before_outline" getter="get_draw_shadow_before_outline" default="0">
-			Changes the order in which the [code]shadow[/code] and [code]shadow_outline[/code] is draw. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default
+			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
 			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
 			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
 			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="draw_shadow_before_outline" type="int" setter="set_draw_shadow_before_outline" getter="get_draw_shadow_before_outline" default="0">
+			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
+			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
+			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
+			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
+		</member>
 		<member name="font" type="Font" setter="set_font" getter="get_font">
 			[Font] used for the text.
 		</member>
@@ -21,7 +27,7 @@
 		<member name="line_spacing" type="float" setter="set_line_spacing" getter="get_line_spacing" default="3.0">
 			Vertical space between lines when the text is multiline.
 		</member>
-		<member name="outline_color" type="Color" setter="set_outline_color" getter="get_outline_color" default="Color(1, 1, 1, 1)">
+		<member name="outline_color" type="Color" setter="set_outline_color" getter="get_outline_color" default="Color(0, 0, 0, 1)">
 			The color of the outline.
 		</member>
 		<member name="outline_size" type="int" setter="set_outline_size" getter="get_outline_size" default="0">
@@ -30,20 +36,14 @@
 		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0)">
 			Color of the shadow effect. If alpha is [code]0[/code], no shadow will be drawn.
 		</member>
-		<member name="shadow_outline_color" type="int" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
-			The color of the shadow outline. If alpha is [code]0[/code], no shadow outline will be drawn.
-		</member>
 		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2(1, 1)">
 			Offset of the shadow effect, in pixels.
 		</member>
+		<member name="shadow_outline_color" type="int" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
+			The color of the shadow outline. If alpha is [code]0[/code], no shadow outline will be drawn.
+		</member>
 		<member name="shadow_outline_size" type="int" setter="set_shadow_outline_size" getter="get_shadow_outline_size" default="0">
 			Shadow outline size.
-		</member>
-		<member name="draw_shadow_before_outline" type="int" setter="set_draw_shadow_before_outline" getter="get_draw_shadow_before_outline" default="0">
-			Changes the order in which the font [b]shadow[/b] and [b]shadow outline[/b] is drawn. If the value is [code]1[/code], the [b]shadow[/b] and the [b]shadow outline[/b] will be [b]between[/b] the [b]text_outline[/b] and the main [b]text[/b], otherwise the shadow will be in the background by default.
-			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
-			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
-			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
 		</member>
 	</members>
 </class>

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -42,7 +42,7 @@
 		<member name="shadow_outline_color" type="Color" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
 			The color of the shadow outline. If alpha is [code]0[/code], no shadow outline will be drawn.
 		</member>
-		<member name="shadow_outline_size" type="int" setter="set_shadow_outline_size" getter="get_shadow_outline_size" default="0">
+		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size" default="0">
 			Shadow outline size.
 		</member>
 	</members>

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -30,11 +30,20 @@
 		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0)">
 			Color of the shadow effect. If alpha is [code]0[/code], no shadow will be drawn.
 		</member>
+		<member name="shadow_outline_color" type="int" setter="set_shadow_outline_color" getter="get_shadow_outline_color" default="Color(0, 0, 0, 0)">
+			The color of the shadow outline. If alpha is [code]0[/code], no shadow outline will be drawn.
+		</member>
 		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2(1, 1)">
 			Offset of the shadow effect, in pixels.
 		</member>
-		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size" default="1">
-			Size of the shadow effect.
+		<member name="shadow_outline_size" type="int" setter="set_shadow_outline_size" getter="get_shadow_outline_size" default="0">
+			Shadow outline size.
+		</member>
+		<member name="draw_shadow_before_outline" type="int" setter="set_draw_shadow_before_outline" getter="get_draw_shadow_before_outline" default="0">
+			Changes the order in which the [code]shadow[/code] and [code]shadow_outline[/code] is draw. If the value is [code]1[/code], the [code]shadow[/code] and the [code]shadow_outline[/code] will be [b]between[/b] the [code]text_outline[/code] and the main [code]text[/code], otherwise the shadow will be in the background by default
+			[b]Note:[/b] If the value is [code]0[/code], the drawing order is: 0 - shadow outline, 1 - shadow, 2 - text outline, 3 - text.
+			If the value is [code]1[/code], the drawing order is: 0 - text outline, 1 - shadow outline, 2 - shadow, 3 - text.
+			[b]Note:[/b] Using any value that does [b]not[/b] equal [code]0[/code] will result in the [b]same[/b] effect as using [code]1[/code].
 		</member>
 	</members>
 </class>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1460,14 +1460,16 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_stylebox(CoreStringName(normal), "Label", p_config.base_empty_style);
 
 		p_theme->set_color(SceneStringName(font_color), "Label", p_config.font_color);
-		p_theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
 		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
+		p_theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+		p_theme->set_color("font_shadow_outline_color", "Label", Color(0, 0, 0, 0));
 
-		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
 		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
 		p_theme->set_constant("outline_size", "Label", 0);
+		p_theme->set_constant("shadow_outline_size", "Label", 0);
+		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
+		p_theme->set_constant("draw_shadow_before_outline", "Label", 0);
 	}
 
 	// SpinBox.

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -549,7 +549,6 @@ void Label::_notification(int p_what) {
 				const Glyph *ellipsis_glyphs = TS->shaped_text_get_ellipsis_glyphs(lines_rid[i]);
 				int ellipsis_gl_size = TS->shaped_text_get_ellipsis_glyph_count(lines_rid[i]);
 
-
 				LabelDrawStep draw_steps[DRAW_STEP_MAX];
 
 				if (shadow_before_outline) {
@@ -1234,7 +1233,6 @@ void Label::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Label, font_outline_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Label, font_shadow_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Label, font_shadow_outline_color);
-
 }
 
 Label::Label(const String &p_text) {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -440,7 +440,7 @@ void Label::_notification(int p_what) {
 			Color font_outline_color = has_settings ? settings->get_outline_color() : theme_cache.font_outline_color;
 			Color font_shadow_outline_color = has_settings ? settings->get_shadow_outline_color() : theme_cache.font_shadow_outline_color;
 			int outline_size = has_settings ? settings->get_outline_size() : theme_cache.font_outline_size;
-			int shadow_outline_size = has_settings ? settings->get_shadow_outline_size() : theme_cache.font_shadow_outline_size;
+			int shadow_outline_size = has_settings ? settings->get_shadow_size() : theme_cache.font_shadow_outline_size;
 			bool shadow_before_outline = has_settings ? settings->get_draw_shadow_before_outline() : theme_cache.draw_shadow_before_outline;
 			bool rtl = (TS->shaped_text_get_inferred_direction(text_rid) == TextServer::DIRECTION_RTL);
 			bool rtl_layout = is_layout_rtl();

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -39,6 +39,7 @@ class Label : public Control {
 
 private:
 	enum LabelDrawStep {
+		DRAW_STEP_SHADOW_OUTLINE,
 		DRAW_STEP_SHADOW,
 		DRAW_STEP_OUTLINE,
 		DRAW_STEP_TEXT,
@@ -87,8 +88,10 @@ private:
 		Color font_shadow_color;
 		Point2 font_shadow_offset;
 		Color font_outline_color;
+		Color font_shadow_outline_color;
 		int font_outline_size;
 		int font_shadow_outline_size;
+		int draw_shadow_before_outline;
 	} theme_cache;
 
 	void _update_visible();

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -53,8 +53,8 @@ void LabelSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_outline_color", "color"), &LabelSettings::set_outline_color);
 	ClassDB::bind_method(D_METHOD("get_outline_color"), &LabelSettings::get_outline_color);
 
-	ClassDB::bind_method(D_METHOD("set_shadow_outline_size", "size"), &LabelSettings::set_shadow_outline_size);
-	ClassDB::bind_method(D_METHOD("get_shadow_outline_size"), &LabelSettings::get_shadow_outline_size);
+	ClassDB::bind_method(D_METHOD("set_shadow_size", "size"), &LabelSettings::set_shadow_size);
+	ClassDB::bind_method(D_METHOD("get_shadow_size"), &LabelSettings::get_shadow_size);
 
 	ClassDB::bind_method(D_METHOD("set_shadow_color", "color"), &LabelSettings::set_shadow_color);
 	ClassDB::bind_method(D_METHOD("get_shadow_color"), &LabelSettings::get_shadow_color);
@@ -80,7 +80,7 @@ void LabelSettings::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "outline_color"), "set_outline_color", "get_outline_color");
 
 	ADD_GROUP("Shadow", "shadow_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_outline_size", PROPERTY_HINT_RANGE, "0,127,1,or_greater,suffix:px"), "set_shadow_outline_size", "get_shadow_outline_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_size", PROPERTY_HINT_RANGE, "0,127,1,or_greater,suffix:px"), "set_shadow_size", "get_shadow_size");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color"), "set_shadow_color", "get_shadow_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_outline_color"), "set_shadow_outline_color", "get_shadow_outline_color");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "shadow_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_shadow_offset", "get_shadow_offset");
@@ -159,15 +159,15 @@ Color LabelSettings::get_outline_color() const {
 	return outline_color;
 }
 
-void LabelSettings::set_shadow_outline_size(int p_size) {
-	if (shadow_outline_size != p_size) {
-		shadow_outline_size = p_size;
+void LabelSettings::set_shadow_size(int p_size) {
+	if (shadow_size != p_size) {
+		shadow_size = p_size;
 		emit_changed();
 	}
 }
 
-int LabelSettings::get_shadow_outline_size() const {
-	return shadow_outline_size;
+int LabelSettings::get_shadow_size() const {
+	return shadow_size;
 }
 
 void LabelSettings::set_shadow_color(const Color &p_color) {

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -53,14 +53,22 @@ void LabelSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_outline_color", "color"), &LabelSettings::set_outline_color);
 	ClassDB::bind_method(D_METHOD("get_outline_color"), &LabelSettings::get_outline_color);
 
-	ClassDB::bind_method(D_METHOD("set_shadow_size", "size"), &LabelSettings::set_shadow_size);
-	ClassDB::bind_method(D_METHOD("get_shadow_size"), &LabelSettings::get_shadow_size);
+	ClassDB::bind_method(D_METHOD("set_shadow_outline_size", "size"), &LabelSettings::set_shadow_outline_size);
+	ClassDB::bind_method(D_METHOD("get_shadow_outline_size"), &LabelSettings::get_shadow_outline_size);
 
 	ClassDB::bind_method(D_METHOD("set_shadow_color", "color"), &LabelSettings::set_shadow_color);
 	ClassDB::bind_method(D_METHOD("get_shadow_color"), &LabelSettings::get_shadow_color);
+	
+	ClassDB::bind_method(D_METHOD("set_shadow_outline_color", "color"), &LabelSettings::set_shadow_outline_color);
+	ClassDB::bind_method(D_METHOD("get_shadow_outline_color"), &LabelSettings::get_shadow_outline_color);
 
 	ClassDB::bind_method(D_METHOD("set_shadow_offset", "offset"), &LabelSettings::set_shadow_offset);
 	ClassDB::bind_method(D_METHOD("get_shadow_offset"), &LabelSettings::get_shadow_offset);
+
+	ClassDB::bind_method(D_METHOD("set_draw_shadow_before_outline", "state"), &LabelSettings::set_draw_shadow_before_outline);
+	ClassDB::bind_method(D_METHOD("get_draw_shadow_before_outline"), &LabelSettings::get_draw_shadow_before_outline);
+
+
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "line_spacing", PROPERTY_HINT_NONE, "suffix:px"), "set_line_spacing", "get_line_spacing");
 
@@ -74,9 +82,11 @@ void LabelSettings::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "outline_color"), "set_outline_color", "get_outline_color");
 
 	ADD_GROUP("Shadow", "shadow_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_size", PROPERTY_HINT_RANGE, "0,127,1,or_greater,suffix:px"), "set_shadow_size", "get_shadow_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_outline_size", PROPERTY_HINT_RANGE, "0,127,1,or_greater,suffix:px"), "set_shadow_outline_size", "get_shadow_outline_size");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color"), "set_shadow_color", "get_shadow_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_outline_color"), "set_shadow_outline_color", "get_shadow_outline_color");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "shadow_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_shadow_offset", "get_shadow_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "draw_shadow_before_outline", PROPERTY_HINT_RANGE, "0,1,1,or_greater,suffix:px"), "set_draw_shadow_before_outline", "get_draw_shadow_before_outline");
 }
 
 void LabelSettings::set_line_spacing(real_t p_spacing) {
@@ -151,15 +161,15 @@ Color LabelSettings::get_outline_color() const {
 	return outline_color;
 }
 
-void LabelSettings::set_shadow_size(int p_size) {
-	if (shadow_size != p_size) {
-		shadow_size = p_size;
+void LabelSettings::set_shadow_outline_size(int p_size) {
+	if (shadow_outline_size != p_size) {
+		shadow_outline_size = p_size;
 		emit_changed();
 	}
 }
 
-int LabelSettings::get_shadow_size() const {
-	return shadow_size;
+int LabelSettings::get_shadow_outline_size() const {
+	return shadow_outline_size;
 }
 
 void LabelSettings::set_shadow_color(const Color &p_color) {
@@ -173,6 +183,18 @@ Color LabelSettings::get_shadow_color() const {
 	return shadow_color;
 }
 
+void LabelSettings::set_shadow_outline_color(const Color &p_color) {
+	if (shadow_outline_color != p_color) {
+		shadow_outline_color = p_color;
+		emit_changed();
+	}
+}
+
+Color LabelSettings::get_shadow_outline_color() const {
+	return shadow_outline_color;
+}
+
+
 void LabelSettings::set_shadow_offset(const Vector2 &p_offset) {
 	if (shadow_offset != p_offset) {
 		shadow_offset = p_offset;
@@ -182,4 +204,15 @@ void LabelSettings::set_shadow_offset(const Vector2 &p_offset) {
 
 Vector2 LabelSettings::get_shadow_offset() const {
 	return shadow_offset;
+}
+
+void LabelSettings::set_draw_shadow_before_outline(int p_state) {
+	if (draw_shadow_before_outline != p_state) {
+		draw_shadow_before_outline = p_state;
+		emit_changed();
+	}
+}
+
+int LabelSettings::get_draw_shadow_before_outline() const {
+	return draw_shadow_before_outline;
 }

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -58,7 +58,7 @@ void LabelSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_shadow_color", "color"), &LabelSettings::set_shadow_color);
 	ClassDB::bind_method(D_METHOD("get_shadow_color"), &LabelSettings::get_shadow_color);
-	
+
 	ClassDB::bind_method(D_METHOD("set_shadow_outline_color", "color"), &LabelSettings::set_shadow_outline_color);
 	ClassDB::bind_method(D_METHOD("get_shadow_outline_color"), &LabelSettings::get_shadow_outline_color);
 
@@ -67,8 +67,6 @@ void LabelSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_draw_shadow_before_outline", "state"), &LabelSettings::set_draw_shadow_before_outline);
 	ClassDB::bind_method(D_METHOD("get_draw_shadow_before_outline"), &LabelSettings::get_draw_shadow_before_outline);
-
-
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "line_spacing", PROPERTY_HINT_NONE, "suffix:px"), "set_line_spacing", "get_line_spacing");
 
@@ -193,7 +191,6 @@ void LabelSettings::set_shadow_outline_color(const Color &p_color) {
 Color LabelSettings::get_shadow_outline_color() const {
 	return shadow_outline_color;
 }
-
 
 void LabelSettings::set_shadow_offset(const Vector2 &p_offset) {
 	if (shadow_offset != p_offset) {

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -83,7 +83,7 @@ public:
 
 	void set_shadow_color(const Color &p_color);
 	Color get_shadow_color() const;
-	
+
 	void set_shadow_outline_color(const Color &p_color);
 	Color get_shadow_outline_color() const;
 
@@ -92,7 +92,6 @@ public:
 
 	void set_draw_shadow_before_outline(int p_state);
 	int get_draw_shadow_before_outline() const;
-
 };
 
 #endif // LABEL_SETTINGS_H

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -48,7 +48,7 @@ class LabelSettings : public Resource {
 	int outline_size = 0;
 	Color outline_color = Color(0, 0, 0, 1);
 
-	int shadow_outline_size = 0;
+	int shadow_size = 0;
 	Color shadow_color = Color(0, 0, 0, 0);
 	Color shadow_outline_color = Color(0, 0, 0, 0);
 	Vector2 shadow_offset = Vector2(1, 1);
@@ -78,8 +78,8 @@ public:
 	void set_outline_color(const Color &p_color);
 	Color get_outline_color() const;
 
-	void set_shadow_outline_size(int p_size);
-	int get_shadow_outline_size() const;
+	void set_shadow_size(int p_size);
+	int get_shadow_size() const;
 
 	void set_shadow_color(const Color &p_color);
 	Color get_shadow_color() const;

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -43,14 +43,16 @@ class LabelSettings : public Resource {
 
 	Ref<Font> font;
 	int font_size = Font::DEFAULT_FONT_SIZE;
-	Color font_color = Color(1, 1, 1);
+	Color font_color = Color(1, 1, 1, 1);
 
 	int outline_size = 0;
-	Color outline_color = Color(1, 1, 1);
+	Color outline_color = Color(0, 0, 0, 1);
 
-	int shadow_size = 1;
+	int shadow_outline_size = 0;
 	Color shadow_color = Color(0, 0, 0, 0);
+	Color shadow_outline_color = Color(0, 0, 0, 0);
 	Vector2 shadow_offset = Vector2(1, 1);
+	int draw_shadow_before_outline = 0;
 
 	void _font_changed();
 
@@ -76,14 +78,21 @@ public:
 	void set_outline_color(const Color &p_color);
 	Color get_outline_color() const;
 
-	void set_shadow_size(int p_size);
-	int get_shadow_size() const;
+	void set_shadow_outline_size(int p_size);
+	int get_shadow_outline_size() const;
 
 	void set_shadow_color(const Color &p_color);
 	Color get_shadow_color() const;
+	
+	void set_shadow_outline_color(const Color &p_color);
+	Color get_shadow_outline_color() const;
 
 	void set_shadow_offset(const Vector2 &p_offset);
 	Vector2 get_shadow_offset() const;
+
+	void set_draw_shadow_before_outline(int p_state);
+	int get_draw_shadow_before_outline() const;
+
 };
 
 #endif // LABEL_SETTINGS_H

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -391,14 +391,16 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size(SceneStringName(font_size), "Label", -1);
 
 	theme->set_color(SceneStringName(font_color), "Label", Color(1, 1, 1));
+	theme->set_color("font_outline_color", "Label", Color(0, 0, 0, 1));
 	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
-	theme->set_color("font_outline_color", "Label", Color(0, 0, 0));
+	theme->set_color("font_shadow_outline_color", "Label", Color(0, 0, 0, 0));
 
+	theme->set_constant("line_spacing", "Label", Math::round(3 * scale));
+	theme->set_constant("outline_size", "Label", 0);
+	theme->set_constant("shadow_outline_size", "Label", 0);
 	theme->set_constant("shadow_offset_x", "Label", Math::round(1 * scale));
 	theme->set_constant("shadow_offset_y", "Label", Math::round(1 * scale));
-	theme->set_constant("outline_size", "Label", 0);
-	theme->set_constant("shadow_outline_size", "Label", Math::round(1 * scale));
-	theme->set_constant("line_spacing", "Label", Math::round(3 * scale));
+	theme->set_constant("draw_shadow_before_outline", "Label", 0);
 
 	theme->set_type_variation("HeaderSmall", "Label");
 	theme->set_font_size(SceneStringName(font_size), "HeaderSmall", default_font_size + 4);


### PR DESCRIPTION
This PR adds to `Label` Theme and `LabelSettings `advanced text rendering settings and the ability to change the order in which shadows are rendered.
I think this PR is quite important in terms of visual label display, as it eliminates the need in some cases to use shaders that are costly on weak or medium mobile devices. This PR does not affect optimization in any way, but only increases functionality and usability.  The purpose of this PR is to add a toolkit for the ability to create even more variant and colorful fonts out of the box. The changes that have been made are not coordinate  and are therefore stable. It is important to note that it was possible to create an alternative to this function using 2 labels with the same text but different colors, which is very uncomfortable and less optimized than this implementation and moreover thanks to the implementation within the engine you can easily and conveniently use pre-prepared themes for text styling.

**Further changes to this PR include:**
- corrections in shadow outline rendering
- implementation of functionality for adjusting the shadow outline color
- the ability to change the order in which the shadow is rendered.
- the editor visually changed the order of constants and colors in the theme
- changed `shadow_outline_size `parameter in `default_theme.cpp`: `1` -> `0`


Overview of changes:
- theme overrides
![image](https://github.com/user-attachments/assets/b893c1ec-0707-4e6d-8a66-05e92000c87f)


- shadow outline color
https://github.com/user-attachments/assets/bd7df539-1981-445c-a689-821fc9f0069d





- draw shadow before text outline
https://github.com/user-attachments/assets/f204a5c3-aae3-4422-a8fc-c8a41b715ea9





- a clear example of the difference `draw_shadow_before_outline `mode
https://github.com/user-attachments/assets/c1dd7991-5b11-4373-9721-ddca7fc834e2





Results using this functional:
![image](https://github.com/user-attachments/assets/4772a5d9-3035-4604-89c7-38f89086b57a)
![image](https://github.com/user-attachments/assets/5c881b8b-b16d-4c5d-bf0d-456db740ec02)



Built version of the engine (from Godot 4.3-rc2) with implementation of the demonstrated functionality:
- Build parameters: `scons platform=windows dev_mode=yes tests=yes`
[Google drive](https://drive.google.com/file/d/1P9wQGT9-uqWvfBoJmmnd0DveBlwmenRb/view?usp=sharing)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10383*