### PR TITLE
Add method for getting packet flags from ENetPacketPeer

### DIFF
--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -18,6 +18,12 @@
 				Returns the number of channels allocated for communication with peer.
 			</description>
 		</method>
+		<method name="get_packet_flags" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the ENet flags of the next packet in the received queue. See [code]FLAG_*[/code] constants for available packet flags. Note that not all flags are replicated from the sending peer to the receiving peer.
+			</description>
+		</method>
 		<method name="get_remote_address" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -175,6 +175,11 @@ int ENetPacketPeer::get_channels() const {
 	return peer->channelCount;
 }
 
+int ENetPacketPeer::get_packet_flags() const {
+	ERR_FAIL_COND_V(packet_queue.is_empty(), 0);
+	return packet_queue.front()->get()->flags;
+}
+
 void ENetPacketPeer::_on_disconnect() {
 	if (peer) {
 		peer->data = nullptr;
@@ -206,6 +211,7 @@ void ENetPacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("send", "channel", "packet", "flags"), &ENetPacketPeer::_send);
 	ClassDB::bind_method(D_METHOD("throttle_configure", "interval", "acceleration", "deceleration"), &ENetPacketPeer::throttle_configure);
 	ClassDB::bind_method(D_METHOD("set_timeout", "timeout", "timeout_min", "timeout_max"), &ENetPacketPeer::set_timeout);
+	ClassDB::bind_method(D_METHOD("get_packet_flags"), &ENetPacketPeer::get_packet_flags);
 	ClassDB::bind_method(D_METHOD("get_remote_address"), &ENetPacketPeer::get_remote_address);
 	ClassDB::bind_method(D_METHOD("get_remote_port"), &ENetPacketPeer::get_remote_port);
 	ClassDB::bind_method(D_METHOD("get_statistic", "statistic"), &ENetPacketPeer::get_statistic);

--- a/modules/enet/enet_packet_peer.h
+++ b/modules/enet/enet_packet_peer.h
@@ -113,6 +113,7 @@ public:
 	double get_statistic(PeerStatistic p_stat);
 	PeerState get_state() const;
 	int get_channels() const;
+	int get_packet_flags() const;
 
 	// Extras
 	IPAddress get_remote_address() const;


### PR DESCRIPTION
Fixes proposal 10240: https://github.com/godotengine/godot-proposals/issues/10240

This PR adds the `get_packet_flags` method to `ENetPacketPeer` which can be used to obtain the flags sent with the packet. In my experimentation, it appears that not all flags are replicated from peer to peer, but it's unclear which are and which aren't (the ENet documentation does not specify), so I opted not to include this info explicitly in Godot's documentation.

This is my first PR, so let me know if I have missed anything.

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/10240