### PR TITLE
Update OpenXR thirdparty library to 1.1.38

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -525,7 +525,7 @@ bool OpenXRAPI::create_instance() {
 		1, // applicationVersion, we don't currently have this
 		"Godot Game Engine", // engineName
 		VERSION_MAJOR * 10000 + VERSION_MINOR * 100 + VERSION_PATCH, // engineVersion 4.0 -> 40000, 4.0.1 -> 40001, 4.1 -> 40100, etc.
-		XR_CURRENT_API_VERSION // apiVersion
+		XR_API_VERSION_1_0 // apiVersion
 	};
 
 	void *next_pointer = nullptr;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -748,7 +748,7 @@ with the provided patch.
 ## openxr
 
 - Upstream: https://github.com/KhronosGroup/OpenXR-SDK
-- Version: 1.0.34 (288d3a7ebc1ad959f62d51da75baa3d27438c499, 2024)
+- Version: 1.1.38 (f90488c4fb1537f4256d09d4a4d3ad5543ebaf24, 2024)
 - License: Apache 2.0
 
 Files extracted from upstream source:

--- a/thirdparty/openxr/include/openxr/openxr.h
+++ b/thirdparty/openxr/include/openxr/openxr.h
@@ -19,13 +19,17 @@ extern "C" {
 
 
 
+// XR_VERSION_1_0 is a preprocessor guard. Do not pass it to API calls.
 #define XR_VERSION_1_0 1
 #include "openxr_platform_defines.h"
 #define XR_MAKE_VERSION(major, minor, patch) \
     ((((major) & 0xffffULL) << 48) | (((minor) & 0xffffULL) << 32) | ((patch) & 0xffffffffULL))
 
 // OpenXR current version number.
-#define XR_CURRENT_API_VERSION XR_MAKE_VERSION(1, 0, 34)
+#define XR_CURRENT_API_VERSION XR_MAKE_VERSION(1, 1, 38)
+
+// OpenXR 1.0 version number
+#define XR_API_VERSION_1_0 XR_MAKE_VERSION(1, 0, XR_VERSION_PATCH(XR_CURRENT_API_VERSION))
 
 #define XR_VERSION_MAJOR(version) (uint16_t)(((uint64_t)(version) >> 48)& 0xffffULL)
 #define XR_VERSION_MINOR(version) (uint16_t)(((uint64_t)(version) >> 32) & 0xffffULL)
@@ -41,7 +45,6 @@ extern "C" {
     #define XR_NULL_HANDLE 0
 #endif
 #endif
-        
 
 
 #define XR_NULL_SYSTEM_ID 0
@@ -96,13 +99,20 @@ extern "C" {
     #define XR_DEFINE_HANDLE(object) typedef uint64_t object;
 #endif
 #endif
-        
+
+
+#if !defined(XR_DEFINE_OPAQUE_64)
+    #if (XR_PTR_SIZE == 8)
+        #define XR_DEFINE_OPAQUE_64(object) typedef struct object##_T* object;
+    #else
+        #define XR_DEFINE_OPAQUE_64(object) typedef uint64_t object;
+    #endif
+#endif
 
 
 #if !defined(XR_DEFINE_ATOM)
     #define XR_DEFINE_ATOM(object) typedef uint64_t object;
 #endif
-        
 
 typedef uint64_t XrVersion;
 typedef uint64_t XrFlags64;
@@ -190,6 +200,8 @@ typedef enum XrResult {
     XR_ERROR_LOCALIZED_NAME_INVALID = -49,
     XR_ERROR_GRAPHICS_REQUIREMENTS_CALL_MISSING = -50,
     XR_ERROR_RUNTIME_UNAVAILABLE = -51,
+    XR_ERROR_EXTENSION_DEPENDENCY_NOT_ENABLED = -1000710001,
+    XR_ERROR_PERMISSION_INSUFFICIENT = -1000710000,
     XR_ERROR_ANDROID_THREAD_SETTINGS_ID_INVALID_KHR = -1000003000,
     XR_ERROR_ANDROID_THREAD_SETTINGS_FAILURE_KHR = -1000003001,
     XR_ERROR_CREATE_SPATIAL_ANCHOR_FAILED_MSFT = -1000039001,
@@ -239,10 +251,15 @@ typedef enum XrResult {
     XR_ERROR_SPACE_NETWORK_REQUEST_FAILED_FB = -1000169003,
     XR_ERROR_SPACE_CLOUD_STORAGE_DISABLED_FB = -1000169004,
     XR_ERROR_PASSTHROUGH_COLOR_LUT_BUFFER_SIZE_MISMATCH_META = -1000266000,
+    XR_ENVIRONMENT_DEPTH_NOT_AVAILABLE_META = 1000291000,
     XR_ERROR_HINT_ALREADY_SET_QCOM = -1000306000,
     XR_ERROR_NOT_AN_ANCHOR_HTC = -1000319000,
     XR_ERROR_SPACE_NOT_LOCATABLE_EXT = -1000429000,
     XR_ERROR_PLANE_DETECTION_PERMISSION_DENIED_EXT = -1000429001,
+    XR_ERROR_FUTURE_PENDING_EXT = -1000469001,
+    XR_ERROR_FUTURE_INVALID_EXT = -1000469002,
+    XR_ERROR_EXTENSION_DEPENDENCY_NOT_ENABLED_KHR = XR_ERROR_EXTENSION_DEPENDENCY_NOT_ENABLED,
+    XR_ERROR_PERMISSION_INSUFFICIENT_KHR = XR_ERROR_PERMISSION_INSUFFICIENT,
     XR_RESULT_MAX_ENUM = 0x7FFFFFFF
 } XrResult;
 
@@ -297,6 +314,9 @@ typedef enum XrStructureType {
     XR_TYPE_ACTIONS_SYNC_INFO = 61,
     XR_TYPE_BOUND_SOURCES_FOR_ACTION_ENUMERATE_INFO = 62,
     XR_TYPE_INPUT_SOURCE_LOCALIZED_NAME_GET_INFO = 63,
+    XR_TYPE_SPACES_LOCATE_INFO = 1000471000,
+    XR_TYPE_SPACE_LOCATIONS = 1000471001,
+    XR_TYPE_SPACE_VELOCITIES = 1000471002,
     XR_TYPE_COMPOSITION_LAYER_CUBE_KHR = 1000006000,
     XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR = 1000008000,
     XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR = 1000010000,
@@ -562,6 +582,14 @@ typedef enum XrStructureType {
     XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB = 1000287014,
     XR_TYPE_FACE_EXPRESSION_INFO2_FB = 1000287015,
     XR_TYPE_FACE_EXPRESSION_WEIGHTS2_FB = 1000287016,
+    XR_TYPE_ENVIRONMENT_DEPTH_PROVIDER_CREATE_INFO_META = 1000291000,
+    XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_CREATE_INFO_META = 1000291001,
+    XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_STATE_META = 1000291002,
+    XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_ACQUIRE_INFO_META = 1000291003,
+    XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META = 1000291004,
+    XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_META = 1000291005,
+    XR_TYPE_ENVIRONMENT_DEPTH_HAND_REMOVAL_SET_INFO_META = 1000291006,
+    XR_TYPE_SYSTEM_ENVIRONMENT_DEPTH_PROPERTIES_META = 1000291007,
     XR_TYPE_PASSTHROUGH_CREATE_INFO_HTC = 1000317001,
     XR_TYPE_PASSTHROUGH_COLOR_HTC = 1000317002,
     XR_TYPE_PASSTHROUGH_MESH_TRANSFORM_INFO_HTC = 1000317003,
@@ -583,12 +611,19 @@ typedef enum XrStructureType {
     XR_TYPE_PLANE_DETECTOR_LOCATION_EXT = 1000429005,
     XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT = 1000429006,
     XR_TYPE_SYSTEM_PLANE_DETECTION_PROPERTIES_EXT = 1000429007,
+    XR_TYPE_FUTURE_CANCEL_INFO_EXT = 1000469000,
+    XR_TYPE_FUTURE_POLL_INFO_EXT = 1000469001,
+    XR_TYPE_FUTURE_COMPLETION_EXT = 1000469002,
+    XR_TYPE_FUTURE_POLL_RESULT_EXT = 1000469003,
     XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT = 1000470000,
     XR_TYPE_SYSTEM_USER_PRESENCE_PROPERTIES_EXT = 1000470001,
     XR_TYPE_GRAPHICS_BINDING_VULKAN2_KHR = XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR,
     XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR = XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR,
     XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN2_KHR = XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR,
     XR_TYPE_DEVICE_PCM_SAMPLE_RATE_GET_INFO_FB = XR_TYPE_DEVICE_PCM_SAMPLE_RATE_STATE_FB,
+    XR_TYPE_SPACES_LOCATE_INFO_KHR = XR_TYPE_SPACES_LOCATE_INFO,
+    XR_TYPE_SPACE_LOCATIONS_KHR = XR_TYPE_SPACE_LOCATIONS,
+    XR_TYPE_SPACE_VELOCITIES_KHR = XR_TYPE_SPACE_VELOCITIES,
     XR_STRUCTURE_TYPE_MAX_ENUM = 0x7FFFFFFF
 } XrStructureType;
 
@@ -601,8 +636,9 @@ typedef enum XrFormFactor {
 typedef enum XrViewConfigurationType {
     XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO = 1,
     XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO = 2,
-    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO = 1000037000,
+    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET = 1000037000,
     XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT = 1000054000,
+    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET,
     XR_VIEW_CONFIGURATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 } XrViewConfigurationType;
 
@@ -617,10 +653,11 @@ typedef enum XrReferenceSpaceType {
     XR_REFERENCE_SPACE_TYPE_VIEW = 1,
     XR_REFERENCE_SPACE_TYPE_LOCAL = 2,
     XR_REFERENCE_SPACE_TYPE_STAGE = 3,
+    XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR = 1000426000,
     XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT = 1000038000,
     XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO = 1000121000,
     XR_REFERENCE_SPACE_TYPE_LOCALIZATION_MAP_ML = 1000139000,
-    XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT = 1000426000,
+    XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT = XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR,
     XR_REFERENCE_SPACE_TYPE_MAX_ENUM = 0x7FFFFFFF
 } XrReferenceSpaceType;
 
@@ -683,6 +720,8 @@ typedef enum XrObjectType {
     XR_OBJECT_TYPE_SPACE_USER_FB = 1000241000,
     XR_OBJECT_TYPE_PASSTHROUGH_COLOR_LUT_META = 1000266000,
     XR_OBJECT_TYPE_FACE_TRACKER2_FB = 1000287012,
+    XR_OBJECT_TYPE_ENVIRONMENT_DEPTH_PROVIDER_META = 1000291000,
+    XR_OBJECT_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_META = 1000291001,
     XR_OBJECT_TYPE_PASSTHROUGH_HTC = 1000317000,
     XR_OBJECT_TYPE_PLANE_DETECTOR_EXT = 1000429000,
     XR_OBJECT_TYPE_MAX_ENUM = 0x7FFFFFFF
@@ -734,6 +773,7 @@ typedef XrFlags64 XrCompositionLayerFlags;
 static const XrCompositionLayerFlags XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT = 0x00000001;
 static const XrCompositionLayerFlags XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT = 0x00000002;
 static const XrCompositionLayerFlags XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT = 0x00000004;
+static const XrCompositionLayerFlags XR_COMPOSITION_LAYER_INVERTED_ALPHA_BIT_EXT = 0x00000008;
 
 typedef XrFlags64 XrViewStateFlags;
 
@@ -1595,6 +1635,91 @@ XRAPI_ATTR XrResult XRAPI_CALL xrStopHapticFeedback(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_VERSION_1_1 is a preprocessor guard. Do not pass it to API calls.
+#define XR_VERSION_1_1 1
+// OpenXR 1.1 version number
+#define XR_API_VERSION_1_1 XR_MAKE_VERSION(1, 1, XR_VERSION_PATCH(XR_CURRENT_API_VERSION))
+
+#define XR_UUID_SIZE                      16
+typedef struct XrColor3f {
+    float    r;
+    float    g;
+    float    b;
+} XrColor3f;
+
+typedef struct XrExtent3Df {
+    float    width;
+    float    height;
+    float    depth;
+} XrExtent3Df;
+
+typedef struct XrSpheref {
+    XrPosef    center;
+    float      radius;
+} XrSpheref;
+
+typedef struct XrBoxf {
+    XrPosef        center;
+    XrExtent3Df    extents;
+} XrBoxf;
+
+typedef struct XrFrustumf {
+    XrPosef    pose;
+    XrFovf     fov;
+    float      nearZ;
+    float      farZ;
+} XrFrustumf;
+
+typedef struct XrUuid {
+    uint8_t    data[XR_UUID_SIZE];
+} XrUuid;
+
+typedef struct XrSpacesLocateInfo {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpace                     baseSpace;
+    XrTime                      time;
+    uint32_t                    spaceCount;
+    const XrSpace*              spaces;
+} XrSpacesLocateInfo;
+
+typedef struct XrSpaceLocationData {
+    XrSpaceLocationFlags    locationFlags;
+    XrPosef                 pose;
+} XrSpaceLocationData;
+
+typedef struct XrSpaceLocations {
+    XrStructureType         type;
+    void* XR_MAY_ALIAS      next;
+    uint32_t                locationCount;
+    XrSpaceLocationData*    locations;
+} XrSpaceLocations;
+
+typedef struct XrSpaceVelocityData {
+    XrSpaceVelocityFlags    velocityFlags;
+    XrVector3f              linearVelocity;
+    XrVector3f              angularVelocity;
+} XrSpaceVelocityData;
+
+// XrSpaceVelocities extends XrSpaceLocations
+typedef struct XrSpaceVelocities {
+    XrStructureType         type;
+    void* XR_MAY_ALIAS      next;
+    uint32_t                velocityCount;
+    XrSpaceVelocityData*    velocities;
+} XrSpaceVelocities;
+
+typedef XrResult (XRAPI_PTR *PFN_xrLocateSpaces)(XrSession session, const XrSpacesLocateInfo* locateInfo, XrSpaceLocations* spaceLocations);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrLocateSpaces(
+    XrSession                                   session,
+    const XrSpacesLocateInfo*                   locateInfo,
+    XrSpaceLocations*                           spaceLocations);
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_KHR_composition_layer_cube is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_cube 1
 #define XR_KHR_composition_layer_cube_SPEC_VERSION 8
 #define XR_KHR_COMPOSITION_LAYER_CUBE_EXTENSION_NAME "XR_KHR_composition_layer_cube"
@@ -1611,6 +1736,7 @@ typedef struct XrCompositionLayerCubeKHR {
 
 
 
+// XR_KHR_composition_layer_depth is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_depth 1
 #define XR_KHR_composition_layer_depth_SPEC_VERSION 6
 #define XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME "XR_KHR_composition_layer_depth"
@@ -1627,6 +1753,7 @@ typedef struct XrCompositionLayerDepthInfoKHR {
 
 
 
+// XR_KHR_composition_layer_cylinder is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_cylinder 1
 #define XR_KHR_composition_layer_cylinder_SPEC_VERSION 4
 #define XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME "XR_KHR_composition_layer_cylinder"
@@ -1645,6 +1772,7 @@ typedef struct XrCompositionLayerCylinderKHR {
 
 
 
+// XR_KHR_composition_layer_equirect is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_equirect 1
 #define XR_KHR_composition_layer_equirect_SPEC_VERSION 3
 #define XR_KHR_COMPOSITION_LAYER_EQUIRECT_EXTENSION_NAME "XR_KHR_composition_layer_equirect"
@@ -1663,6 +1791,7 @@ typedef struct XrCompositionLayerEquirectKHR {
 
 
 
+// XR_KHR_visibility_mask is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_visibility_mask 1
 #define XR_KHR_visibility_mask_SPEC_VERSION 2
 #define XR_KHR_VISIBILITY_MASK_EXTENSION_NAME "XR_KHR_visibility_mask"
@@ -1706,6 +1835,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetVisibilityMaskKHR(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_KHR_composition_layer_color_scale_bias is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_color_scale_bias 1
 #define XR_KHR_composition_layer_color_scale_bias_SPEC_VERSION 5
 #define XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME "XR_KHR_composition_layer_color_scale_bias"
@@ -1719,6 +1849,7 @@ typedef struct XrCompositionLayerColorScaleBiasKHR {
 
 
 
+// XR_KHR_loader_init is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_loader_init 1
 #define XR_KHR_loader_init_SPEC_VERSION   2
 #define XR_KHR_LOADER_INIT_EXTENSION_NAME "XR_KHR_loader_init"
@@ -1737,6 +1868,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrInitializeLoaderKHR(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_KHR_composition_layer_equirect2 is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_composition_layer_equirect2 1
 #define XR_KHR_composition_layer_equirect2_SPEC_VERSION 1
 #define XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME "XR_KHR_composition_layer_equirect2"
@@ -1756,6 +1888,7 @@ typedef struct XrCompositionLayerEquirect2KHR {
 
 
 
+// XR_KHR_binding_modification is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_binding_modification 1
 #define XR_KHR_binding_modification_SPEC_VERSION 1
 #define XR_KHR_BINDING_MODIFICATION_EXTENSION_NAME "XR_KHR_binding_modification"
@@ -1774,11 +1907,55 @@ typedef struct XrBindingModificationsKHR {
 
 
 
+// XR_KHR_swapchain_usage_input_attachment_bit is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_swapchain_usage_input_attachment_bit 1
 #define XR_KHR_swapchain_usage_input_attachment_bit_SPEC_VERSION 3
 #define XR_KHR_SWAPCHAIN_USAGE_INPUT_ATTACHMENT_BIT_EXTENSION_NAME "XR_KHR_swapchain_usage_input_attachment_bit"
 
 
+// XR_KHR_locate_spaces is a preprocessor guard. Do not pass it to API calls.
+#define XR_KHR_locate_spaces 1
+#define XR_KHR_locate_spaces_SPEC_VERSION 1
+#define XR_KHR_LOCATE_SPACES_EXTENSION_NAME "XR_KHR_locate_spaces"
+typedef XrSpacesLocateInfo XrSpacesLocateInfoKHR;
+
+typedef XrSpaceLocationData XrSpaceLocationDataKHR;
+
+typedef XrSpaceLocations XrSpaceLocationsKHR;
+
+typedef XrSpaceVelocityData XrSpaceVelocityDataKHR;
+
+typedef XrSpaceVelocities XrSpaceVelocitiesKHR;
+
+typedef XrResult (XRAPI_PTR *PFN_xrLocateSpacesKHR)(XrSession session, const XrSpacesLocateInfo* locateInfo, XrSpaceLocations* spaceLocations);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrLocateSpacesKHR(
+    XrSession                                   session,
+    const XrSpacesLocateInfo*                   locateInfo,
+    XrSpaceLocations*                           spaceLocations);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_KHR_maintenance1 is a preprocessor guard. Do not pass it to API calls.
+#define XR_KHR_maintenance1 1
+#define XR_KHR_maintenance1_SPEC_VERSION  1
+#define XR_KHR_MAINTENANCE1_EXTENSION_NAME "XR_KHR_maintenance1"
+typedef XrColor3f XrColor3fKHR;
+
+typedef XrExtent3Df XrExtent3DfKHR;
+
+typedef XrSpheref XrSpherefKHR;
+
+typedef XrBoxf XrBoxfKHR;
+
+typedef XrFrustumf XrFrustumfKHR;
+
+
+
+// XR_EXT_performance_settings is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_performance_settings 1
 #define XR_EXT_performance_settings_SPEC_VERSION 4
 #define XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME "XR_EXT_performance_settings"
@@ -1831,6 +2008,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrPerfSettingsSetPerformanceLevelEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_thermal_query is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_thermal_query 1
 #define XR_EXT_thermal_query_SPEC_VERSION 2
 #define XR_EXT_THERMAL_QUERY_EXTENSION_NAME "XR_EXT_thermal_query"
@@ -1848,6 +2026,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrThermalGetTemperatureTrendEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_debug_utils is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_debug_utils 1
 XR_DEFINE_HANDLE(XrDebugUtilsMessengerEXT)
 #define XR_EXT_debug_utils_SPEC_VERSION   5
@@ -1953,6 +2132,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_eye_gaze_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_eye_gaze_interaction 1
 #define XR_EXT_eye_gaze_interaction_SPEC_VERSION 2
 #define XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME "XR_EXT_eye_gaze_interaction"
@@ -1972,6 +2152,7 @@ typedef struct XrEyeGazeSampleTimeEXT {
 
 
 
+// XR_EXTX_overlay is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXTX_overlay 1
 #define XR_EXTX_overlay_SPEC_VERSION      5
 #define XR_EXTX_OVERLAY_EXTENSION_NAME    "XR_EXTX_overlay"
@@ -2001,16 +2182,19 @@ typedef struct XrEventDataMainSessionVisibilityChangedEXTX {
 
 
 
+// XR_VARJO_quad_views is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_quad_views 1
 #define XR_VARJO_quad_views_SPEC_VERSION  1
 #define XR_VARJO_QUAD_VIEWS_EXTENSION_NAME "XR_VARJO_quad_views"
 
 
+// XR_MSFT_unbounded_reference_space is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_unbounded_reference_space 1
 #define XR_MSFT_unbounded_reference_space_SPEC_VERSION 1
 #define XR_MSFT_UNBOUNDED_REFERENCE_SPACE_EXTENSION_NAME "XR_MSFT_unbounded_reference_space"
 
 
+// XR_MSFT_spatial_anchor is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_spatial_anchor 1
 XR_DEFINE_HANDLE(XrSpatialAnchorMSFT)
 #define XR_MSFT_spatial_anchor_SPEC_VERSION 2
@@ -2052,6 +2236,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroySpatialAnchorMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_composition_layer_image_layout is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_composition_layer_image_layout 1
 #define XR_FB_composition_layer_image_layout_SPEC_VERSION 1
 #define XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME "XR_FB_composition_layer_image_layout"
@@ -2069,8 +2254,9 @@ typedef struct XrCompositionLayerImageLayoutFB {
 
 
 
+// XR_FB_composition_layer_alpha_blend is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_composition_layer_alpha_blend 1
-#define XR_FB_composition_layer_alpha_blend_SPEC_VERSION 2
+#define XR_FB_composition_layer_alpha_blend_SPEC_VERSION 3
 #define XR_FB_COMPOSITION_LAYER_ALPHA_BLEND_EXTENSION_NAME "XR_FB_composition_layer_alpha_blend"
 
 typedef enum XrBlendFactorFB {
@@ -2094,16 +2280,19 @@ typedef struct XrCompositionLayerAlphaBlendFB {
 
 
 
+// XR_MND_headless is a preprocessor guard. Do not pass it to API calls.
 #define XR_MND_headless 1
 #define XR_MND_headless_SPEC_VERSION      2
 #define XR_MND_HEADLESS_EXTENSION_NAME    "XR_MND_headless"
 
 
+// XR_OCULUS_android_session_state_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_OCULUS_android_session_state_enable 1
 #define XR_OCULUS_android_session_state_enable_SPEC_VERSION 1
 #define XR_OCULUS_ANDROID_SESSION_STATE_ENABLE_EXTENSION_NAME "XR_OCULUS_android_session_state_enable"
 
 
+// XR_EXT_view_configuration_depth_range is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_view_configuration_depth_range 1
 #define XR_EXT_view_configuration_depth_range_SPEC_VERSION 1
 #define XR_EXT_VIEW_CONFIGURATION_DEPTH_RANGE_EXTENSION_NAME "XR_EXT_view_configuration_depth_range"
@@ -2119,6 +2308,7 @@ typedef struct XrViewConfigurationDepthRangeEXT {
 
 
 
+// XR_EXT_conformance_automation is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_conformance_automation 1
 #define XR_EXT_conformance_automation_SPEC_VERSION 3
 #define XR_EXT_CONFORMANCE_AUTOMATION_EXTENSION_NAME "XR_EXT_conformance_automation"
@@ -2164,6 +2354,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetInputDeviceLocationEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_spatial_graph_bridge is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_spatial_graph_bridge 1
 XR_DEFINE_HANDLE(XrSpatialGraphNodeBindingMSFT)
 #define XR_GUID_SIZE_MSFT                 16
@@ -2231,11 +2422,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpatialGraphNodeBindingPropertiesMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_hand_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_hand_interaction 1
 #define XR_MSFT_hand_interaction_SPEC_VERSION 1
 #define XR_MSFT_HAND_INTERACTION_EXTENSION_NAME "XR_MSFT_hand_interaction"
 
 
+// XR_EXT_hand_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hand_tracking 1
 
 #define XR_HAND_JOINT_COUNT_EXT 26
@@ -2356,6 +2549,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrLocateHandJointsEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_hand_tracking_mesh is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_hand_tracking_mesh 1
 #define XR_MSFT_hand_tracking_mesh_SPEC_VERSION 4
 #define XR_MSFT_HAND_TRACKING_MESH_EXTENSION_NAME "XR_MSFT_hand_tracking_mesh"
@@ -2442,6 +2636,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrUpdateHandMeshMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_secondary_view_configuration is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_secondary_view_configuration 1
 #define XR_MSFT_secondary_view_configuration_SPEC_VERSION 1
 #define XR_MSFT_SECONDARY_VIEW_CONFIGURATION_EXTENSION_NAME "XR_MSFT_secondary_view_configuration"
@@ -2494,11 +2689,13 @@ typedef struct XrSecondaryViewConfigurationSwapchainCreateInfoMSFT {
 
 
 
+// XR_MSFT_first_person_observer is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_first_person_observer 1
 #define XR_MSFT_first_person_observer_SPEC_VERSION 1
 #define XR_MSFT_FIRST_PERSON_OBSERVER_EXTENSION_NAME "XR_MSFT_first_person_observer"
 
 
+// XR_MSFT_controller_model is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_controller_model 1
 
 #define XR_NULL_CONTROLLER_MODEL_KEY_MSFT 0
@@ -2574,11 +2771,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetControllerModelStateMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_win32_appcontainer_compatible is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_win32_appcontainer_compatible 1
 #define XR_EXT_win32_appcontainer_compatible_SPEC_VERSION 1
 #define XR_EXT_WIN32_APPCONTAINER_COMPATIBLE_EXTENSION_NAME "XR_EXT_win32_appcontainer_compatible"
 
 
+// XR_EPIC_view_configuration_fov is a preprocessor guard. Do not pass it to API calls.
 #define XR_EPIC_view_configuration_fov 1
 #define XR_EPIC_view_configuration_fov_SPEC_VERSION 2
 #define XR_EPIC_VIEW_CONFIGURATION_FOV_EXTENSION_NAME "XR_EPIC_view_configuration_fov"
@@ -2592,6 +2791,7 @@ typedef struct XrViewConfigurationViewFovEPIC {
 
 
 
+// XR_MSFT_composition_layer_reprojection is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_composition_layer_reprojection 1
 #define XR_MSFT_composition_layer_reprojection_SPEC_VERSION 1
 #define XR_MSFT_COMPOSITION_LAYER_REPROJECTION_EXTENSION_NAME "XR_MSFT_composition_layer_reprojection"
@@ -2634,11 +2834,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateReprojectionModesMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HUAWEI_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HUAWEI_controller_interaction 1
 #define XR_HUAWEI_controller_interaction_SPEC_VERSION 1
 #define XR_HUAWEI_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_HUAWEI_controller_interaction"
 
 
+// XR_FB_swapchain_update_state is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_swapchain_update_state 1
 #define XR_FB_swapchain_update_state_SPEC_VERSION 3
 #define XR_FB_SWAPCHAIN_UPDATE_STATE_EXTENSION_NAME "XR_FB_swapchain_update_state"
@@ -2663,6 +2865,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSwapchainStateFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_composition_layer_secure_content is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_composition_layer_secure_content 1
 #define XR_FB_composition_layer_secure_content_SPEC_VERSION 1
 #define XR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_NAME "XR_FB_composition_layer_secure_content"
@@ -2681,6 +2884,7 @@ typedef struct XrCompositionLayerSecureContentFB {
 
 
 
+// XR_FB_body_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_body_tracking 1
 XR_DEFINE_HANDLE(XrBodyTrackerFB)
 #define XR_FB_body_tracking_SPEC_VERSION  1
@@ -2842,6 +3046,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetBodySkeletonFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_dpad_binding is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_dpad_binding 1
 #define XR_EXT_dpad_binding_SPEC_VERSION  1
 #define XR_EXT_DPAD_BINDING_EXTENSION_NAME "XR_EXT_dpad_binding"
@@ -2861,6 +3066,7 @@ typedef struct XrInteractionProfileDpadBindingEXT {
 
 
 
+// XR_VALVE_analog_threshold is a preprocessor guard. Do not pass it to API calls.
 #define XR_VALVE_analog_threshold 1
 #define XR_VALVE_analog_threshold_SPEC_VERSION 2
 #define XR_VALVE_ANALOG_THRESHOLD_EXTENSION_NAME "XR_VALVE_analog_threshold"
@@ -2877,6 +3083,7 @@ typedef struct XrInteractionProfileAnalogThresholdVALVE {
 
 
 
+// XR_EXT_hand_joints_motion_range is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hand_joints_motion_range 1
 #define XR_EXT_hand_joints_motion_range_SPEC_VERSION 1
 #define XR_EXT_HAND_JOINTS_MOTION_RANGE_EXTENSION_NAME "XR_EXT_hand_joints_motion_range"
@@ -2895,21 +3102,25 @@ typedef struct XrHandJointsMotionRangeInfoEXT {
 
 
 
+// XR_EXT_samsung_odyssey_controller is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_samsung_odyssey_controller 1
 #define XR_EXT_samsung_odyssey_controller_SPEC_VERSION 1
 #define XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME "XR_EXT_samsung_odyssey_controller"
 
 
+// XR_EXT_hp_mixed_reality_controller is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hp_mixed_reality_controller 1
 #define XR_EXT_hp_mixed_reality_controller_SPEC_VERSION 1
 #define XR_EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME "XR_EXT_hp_mixed_reality_controller"
 
 
+// XR_MND_swapchain_usage_input_attachment_bit is a preprocessor guard. Do not pass it to API calls.
 #define XR_MND_swapchain_usage_input_attachment_bit 1
 #define XR_MND_swapchain_usage_input_attachment_bit_SPEC_VERSION 2
 #define XR_MND_SWAPCHAIN_USAGE_INPUT_ATTACHMENT_BIT_EXTENSION_NAME "XR_MND_swapchain_usage_input_attachment_bit"
 
 
+// XR_MSFT_scene_understanding is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_scene_understanding 1
 
             XR_DEFINE_HANDLE(XrSceneObserverMSFT)
@@ -3240,6 +3451,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSceneMeshBuffersMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_scene_understanding_serialization is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_scene_understanding_serialization 1
 #define XR_MSFT_scene_understanding_serialization_SPEC_VERSION 2
 #define XR_MSFT_SCENE_UNDERSTANDING_SERIALIZATION_EXTENSION_NAME "XR_MSFT_scene_understanding_serialization"
@@ -3280,6 +3492,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSerializedSceneFragmentDataMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_display_refresh_rate is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_display_refresh_rate 1
 #define XR_FB_display_refresh_rate_SPEC_VERSION 1
 #define XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME "XR_FB_display_refresh_rate"
@@ -3313,11 +3526,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrRequestDisplayRefreshRateFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_vive_cosmos_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_vive_cosmos_controller_interaction 1
 #define XR_HTC_vive_cosmos_controller_interaction_SPEC_VERSION 1
 #define XR_HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_HTC_vive_cosmos_controller_interaction"
 
 
+// XR_HTCX_vive_tracker_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTCX_vive_tracker_interaction 1
 #define XR_HTCX_vive_tracker_interaction_SPEC_VERSION 3
 #define XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME "XR_HTCX_vive_tracker_interaction"
@@ -3347,6 +3562,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateViveTrackerPathsHTCX(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_facial_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_facial_tracking 1
 
 #define XR_FACIAL_EXPRESSION_EYE_COUNT_HTC 14
@@ -3466,21 +3682,25 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetFacialExpressionsHTC(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_vive_focus3_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_vive_focus3_controller_interaction 1
 #define XR_HTC_vive_focus3_controller_interaction_SPEC_VERSION 2
 #define XR_HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_HTC_vive_focus3_controller_interaction"
 
 
+// XR_HTC_hand_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_hand_interaction 1
 #define XR_HTC_hand_interaction_SPEC_VERSION 1
 #define XR_HTC_HAND_INTERACTION_EXTENSION_NAME "XR_HTC_hand_interaction"
 
 
+// XR_HTC_vive_wrist_tracker_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_vive_wrist_tracker_interaction 1
 #define XR_HTC_vive_wrist_tracker_interaction_SPEC_VERSION 1
 #define XR_HTC_VIVE_WRIST_TRACKER_INTERACTION_EXTENSION_NAME "XR_HTC_vive_wrist_tracker_interaction"
 
 
+// XR_FB_color_space is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_color_space 1
 #define XR_FB_color_space_SPEC_VERSION    3
 #define XR_FB_COLOR_SPACE_EXTENSION_NAME  "XR_FB_color_space"
@@ -3521,6 +3741,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetColorSpaceFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_hand_tracking_mesh is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_hand_tracking_mesh 1
 #define XR_FB_hand_tracking_mesh_SPEC_VERSION 3
 #define XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME "XR_FB_hand_tracking_mesh"
@@ -3572,6 +3793,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetHandMeshFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_hand_tracking_aim is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_hand_tracking_aim 1
 #define XR_FB_hand_tracking_aim_SPEC_VERSION 2
 #define XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME "XR_FB_hand_tracking_aim"
@@ -3602,6 +3824,7 @@ typedef struct XrHandTrackingAimStateFB {
 
 
 
+// XR_FB_hand_tracking_capsules is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_hand_tracking_capsules 1
 #define XR_HAND_TRACKING_CAPSULE_POINT_COUNT_FB 2
 #define XR_HAND_TRACKING_CAPSULE_COUNT_FB 19
@@ -3624,9 +3847,9 @@ typedef struct XrHandTrackingCapsulesStateFB {
 
 
 
+// XR_FB_spatial_entity is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity 1
 XR_DEFINE_ATOM(XrAsyncRequestIdFB)
-#define XR_UUID_SIZE_EXT                  16
 #define XR_FB_spatial_entity_SPEC_VERSION 3
 #define XR_FB_SPATIAL_ENTITY_EXTENSION_NAME "XR_FB_spatial_entity"
 
@@ -3672,9 +3895,7 @@ typedef struct XrSpaceComponentStatusFB {
     XrBool32              changePending;
 } XrSpaceComponentStatusFB;
 
-typedef struct XrUuidEXT {
-    uint8_t    data[XR_UUID_SIZE_EXT];
-} XrUuidEXT;
+typedef XrUuid XrUuidEXT;
 
 typedef struct XrEventDataSpatialAnchorCreateCompleteFB {
     XrStructureType             type;
@@ -3732,6 +3953,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpaceComponentStatusFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_foveation is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_foveation 1
 XR_DEFINE_HANDLE(XrFoveationProfileFB)
 #define XR_FB_foveation_SPEC_VERSION      1
@@ -3781,6 +4003,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyFoveationProfileFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_foveation_configuration is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_foveation_configuration 1
 #define XR_FB_foveation_configuration_SPEC_VERSION 1
 #define XR_FB_FOVEATION_CONFIGURATION_EXTENSION_NAME "XR_FB_foveation_configuration"
@@ -3809,6 +4032,7 @@ typedef struct XrFoveationLevelProfileCreateInfoFB {
 
 
 
+// XR_FB_keyboard_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_keyboard_tracking 1
 #define XR_MAX_KEYBOARD_TRACKING_NAME_SIZE_FB 128
 #define XR_FB_keyboard_tracking_SPEC_VERSION 1
@@ -3871,6 +4095,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateKeyboardSpaceFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_triangle_mesh is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_triangle_mesh 1
 XR_DEFINE_HANDLE(XrTriangleMeshFB)
 #define XR_FB_triangle_mesh_SPEC_VERSION  2
@@ -3943,12 +4168,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrTriangleMeshEndVertexBufferUpdateFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_passthrough is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_passthrough 1
 XR_DEFINE_HANDLE(XrPassthroughFB)
 XR_DEFINE_HANDLE(XrPassthroughLayerFB)
 XR_DEFINE_HANDLE(XrGeometryInstanceFB)
 #define XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB 256
-#define XR_FB_passthrough_SPEC_VERSION    3
+#define XR_FB_passthrough_SPEC_VERSION    4
 #define XR_FB_PASSTHROUGH_EXTENSION_NAME  "XR_FB_passthrough"
 
 typedef enum XrPassthroughLayerPurposeFB {
@@ -4007,7 +4233,6 @@ typedef struct XrPassthroughLayerCreateInfoFB {
     XrPassthroughLayerPurposeFB    purpose;
 } XrPassthroughLayerCreateInfoFB;
 
-// XrCompositionLayerPassthroughFB extends XrCompositionLayerBaseHeader
 typedef struct XrCompositionLayerPassthroughFB {
     XrStructureType             type;
     const void* XR_MAY_ALIAS    next;
@@ -4133,6 +4358,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGeometryInstanceSetTransformFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_render_model is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_render_model 1
 
 #define XR_NULL_RENDER_MODEL_KEY_FB 0
@@ -4216,6 +4442,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrLoadRenderModelFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_VARJO_foveated_rendering is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_foveated_rendering 1
 #define XR_VARJO_foveated_rendering_SPEC_VERSION 3
 #define XR_VARJO_FOVEATED_RENDERING_EXTENSION_NAME "XR_VARJO_foveated_rendering"
@@ -4242,6 +4469,7 @@ typedef struct XrSystemFoveatedRenderingPropertiesVARJO {
 
 
 
+// XR_VARJO_composition_layer_depth_test is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_composition_layer_depth_test 1
 #define XR_VARJO_composition_layer_depth_test_SPEC_VERSION 2
 #define XR_VARJO_COMPOSITION_LAYER_DEPTH_TEST_EXTENSION_NAME "XR_VARJO_composition_layer_depth_test"
@@ -4255,6 +4483,7 @@ typedef struct XrCompositionLayerDepthTestVARJO {
 
 
 
+// XR_VARJO_environment_depth_estimation is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_environment_depth_estimation 1
 #define XR_VARJO_environment_depth_estimation_SPEC_VERSION 1
 #define XR_VARJO_ENVIRONMENT_DEPTH_ESTIMATION_EXTENSION_NAME "XR_VARJO_environment_depth_estimation"
@@ -4269,6 +4498,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetEnvironmentDepthEstimationVARJO(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_VARJO_marker_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_marker_tracking 1
 #define XR_VARJO_marker_tracking_SPEC_VERSION 1
 #define XR_VARJO_MARKER_TRACKING_EXTENSION_NAME "XR_VARJO_marker_tracking"
@@ -4330,6 +4560,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateMarkerSpaceVARJO(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_VARJO_view_offset is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_view_offset 1
 #define XR_VARJO_view_offset_SPEC_VERSION 1
 #define XR_VARJO_VIEW_OFFSET_EXTENSION_NAME "XR_VARJO_view_offset"
@@ -4344,16 +4575,19 @@ XRAPI_ATTR XrResult  XRAPI_CALL xrSetViewOffsetVARJO(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_VARJO_xr4_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_VARJO_xr4_controller_interaction 1
 #define XR_VARJO_xr4_controller_interaction_SPEC_VERSION 1
 #define XR_VARJO_XR4_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_VARJO_xr4_controller_interaction"
 
 
+// XR_ML_ml2_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_ml2_controller_interaction 1
 #define XR_ML_ml2_controller_interaction_SPEC_VERSION 1
 #define XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_ML_ml2_controller_interaction"
 
 
+// XR_ML_frame_end_info is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_frame_end_info 1
 #define XR_ML_frame_end_info_SPEC_VERSION 1
 #define XR_ML_FRAME_END_INFO_EXTENSION_NAME "XR_ML_frame_end_info"
@@ -4373,6 +4607,7 @@ typedef struct XrFrameEndInfoML {
 
 
 
+// XR_ML_global_dimmer is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_global_dimmer 1
 #define XR_ML_global_dimmer_SPEC_VERSION  1
 #define XR_ML_GLOBAL_DIMMER_EXTENSION_NAME "XR_ML_global_dimmer"
@@ -4391,6 +4626,7 @@ typedef struct XrGlobalDimmerFrameEndInfoML {
 
 
 
+// XR_ML_marker_understanding is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_marker_understanding 1
 XR_DEFINE_ATOM(XrMarkerML)
 XR_DEFINE_HANDLE(XrMarkerDetectorML)
@@ -4619,6 +4855,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateMarkerSpaceML(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_ML_localization_map is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_localization_map 1
 XR_DEFINE_HANDLE(XrExportedLocalizationMapML)
 #define XR_MAX_LOCALIZATION_MAP_NAME_LENGTH_ML 64
@@ -4745,6 +4982,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetExportedLocalizationMapDataML(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_spatial_anchor_persistence is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_spatial_anchor_persistence 1
 XR_DEFINE_HANDLE(XrSpatialAnchorStoreConnectionMSFT)
 #define XR_MAX_SPATIAL_ANCHOR_NAME_SIZE_MSFT 256
@@ -4810,6 +5048,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrClearSpatialAnchorStoreMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_MSFT_scene_marker is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_scene_marker 1
 #define XR_MSFT_scene_marker_SPEC_VERSION 1
 #define XR_MSFT_SCENE_MARKER_EXTENSION_NAME "XR_MSFT_scene_marker"
@@ -4882,6 +5121,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSceneMarkerDecodedStringMSFT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_ULTRALEAP_hand_tracking_forearm is a preprocessor guard. Do not pass it to API calls.
 #define XR_ULTRALEAP_hand_tracking_forearm 1
 
 #define XR_HAND_FOREARM_JOINT_COUNT_ULTRALEAP 27
@@ -4921,6 +5161,7 @@ typedef enum XrHandForearmJointULTRALEAP {
 } XrHandForearmJointULTRALEAP;
 
 
+// XR_FB_spatial_entity_query is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_query 1
 #define XR_FB_spatial_entity_query_SPEC_VERSION 1
 #define XR_FB_SPATIAL_ENTITY_QUERY_EXTENSION_NAME "XR_FB_spatial_entity_query"
@@ -5020,6 +5261,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrRetrieveSpaceQueryResultsFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_spatial_entity_storage is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_storage 1
 #define XR_FB_spatial_entity_storage_SPEC_VERSION 1
 #define XR_FB_SPATIAL_ENTITY_STORAGE_EXTENSION_NAME "XR_FB_spatial_entity_storage"
@@ -5082,11 +5324,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrEraseSpaceFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_touch_controller_pro is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_touch_controller_pro 1
 #define XR_FB_touch_controller_pro_SPEC_VERSION 1
 #define XR_FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME "XR_FB_touch_controller_pro"
 
 
+// XR_FB_spatial_entity_sharing is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_sharing 1
 XR_DEFINE_HANDLE(XrSpaceUserFB)
 #define XR_FB_spatial_entity_sharing_SPEC_VERSION 1
@@ -5119,6 +5363,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrShareSpacesFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_space_warp is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_space_warp 1
 #define XR_FB_space_warp_SPEC_VERSION     2
 #define XR_FB_SPACE_WARP_EXTENSION_NAME   "XR_FB_space_warp"
@@ -5151,6 +5396,7 @@ typedef struct XrSystemSpaceWarpPropertiesFB {
 
 
 
+// XR_FB_haptic_amplitude_envelope is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_haptic_amplitude_envelope 1
 
 #define XR_MAX_HAPTIC_AMPLITUDE_ENVELOPE_SAMPLES_FB 4000u
@@ -5167,6 +5413,7 @@ typedef struct XrHapticAmplitudeEnvelopeVibrationFB {
 
 
 
+// XR_FB_scene is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_scene 1
 #define XR_FB_scene_SPEC_VERSION          4
 #define XR_FB_SCENE_EXTENSION_NAME        "XR_FB_scene"
@@ -5177,11 +5424,7 @@ static const XrSemanticLabelsSupportFlagsFB XR_SEMANTIC_LABELS_SUPPORT_MULTIPLE_
 static const XrSemanticLabelsSupportFlagsFB XR_SEMANTIC_LABELS_SUPPORT_ACCEPT_DESK_TO_TABLE_MIGRATION_BIT_FB = 0x00000002;
 static const XrSemanticLabelsSupportFlagsFB XR_SEMANTIC_LABELS_SUPPORT_ACCEPT_INVISIBLE_WALL_FACE_BIT_FB = 0x00000004;
 
-typedef struct XrExtent3DfFB {
-    float    width;
-    float    height;
-    float    depth;
-} XrExtent3DfFB;
+typedef XrExtent3Df XrExtent3DfFB;
 
 typedef struct XrOffset3DfFB {
     float    x;
@@ -5263,11 +5506,13 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpaceRoomLayoutFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_palm_pose is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_palm_pose 1
-#define XR_EXT_palm_pose_SPEC_VERSION     2
+#define XR_EXT_palm_pose_SPEC_VERSION     3
 #define XR_EXT_PALM_POSE_EXTENSION_NAME   "XR_EXT_palm_pose"
 
 
+// XR_ALMALENCE_digital_lens_control is a preprocessor guard. Do not pass it to API calls.
 #define XR_ALMALENCE_digital_lens_control 1
 #define XR_ALMALENCE_digital_lens_control_SPEC_VERSION 1
 #define XR_ALMALENCE_DIGITAL_LENS_CONTROL_EXTENSION_NAME "XR_ALMALENCE_digital_lens_control"
@@ -5293,6 +5538,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetDigitalLensControlALMALENCE(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_scene_capture is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_scene_capture 1
 #define XR_FB_scene_capture_SPEC_VERSION  1
 #define XR_FB_SCENE_CAPTURE_EXTENSION_NAME "XR_FB_scene_capture"
@@ -5322,6 +5568,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrRequestSceneCaptureFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_spatial_entity_container is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_container 1
 #define XR_FB_spatial_entity_container_SPEC_VERSION 2
 #define XR_FB_SPATIAL_ENTITY_CONTAINER_EXTENSION_NAME "XR_FB_spatial_entity_container"
@@ -5345,6 +5592,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpaceContainerFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_foveation_eye_tracked is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_foveation_eye_tracked 1
 #define XR_FOVEATION_CENTER_SIZE_META     2
 #define XR_META_foveation_eye_tracked_SPEC_VERSION 1
@@ -5390,6 +5638,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetFoveationEyeTrackedStateMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_face_tracking is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_face_tracking 1
 
 #define XR_FACE_EXPRESSSION_SET_DEFAULT_FB XR_FACE_EXPRESSION_SET_DEFAULT_FB
@@ -5534,6 +5783,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetFaceExpressionWeightsFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_eye_tracking_social is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_eye_tracking_social 1
 XR_DEFINE_HANDLE(XrEyeTrackerFB)
 #define XR_FB_eye_tracking_social_SPEC_VERSION 1
@@ -5599,6 +5849,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetEyeGazesFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_passthrough_keyboard_hands is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_passthrough_keyboard_hands 1
 #define XR_FB_passthrough_keyboard_hands_SPEC_VERSION 2
 #define XR_FB_PASSTHROUGH_KEYBOARD_HANDS_EXTENSION_NAME "XR_FB_passthrough_keyboard_hands"
@@ -5620,6 +5871,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrPassthroughLayerSetKeyboardHandsIntensityFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_composition_layer_settings is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_composition_layer_settings 1
 #define XR_FB_composition_layer_settings_SPEC_VERSION 1
 #define XR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_NAME "XR_FB_composition_layer_settings"
@@ -5641,11 +5893,13 @@ typedef struct XrCompositionLayerSettingsFB {
 
 
 
+// XR_FB_touch_controller_proximity is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_touch_controller_proximity 1
 #define XR_FB_touch_controller_proximity_SPEC_VERSION 1
 #define XR_FB_TOUCH_CONTROLLER_PROXIMITY_EXTENSION_NAME "XR_FB_touch_controller_proximity"
 
 
+// XR_FB_haptic_pcm is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_haptic_pcm 1
 
 #define XR_MAX_HAPTIC_PCM_BUFFER_SIZE_FB 4000
@@ -5682,6 +5936,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetDeviceSampleRateFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_composition_layer_depth_test is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_composition_layer_depth_test 1
 #define XR_FB_composition_layer_depth_test_SPEC_VERSION 1
 #define XR_FB_COMPOSITION_LAYER_DEPTH_TEST_EXTENSION_NAME "XR_FB_composition_layer_depth_test"
@@ -5707,6 +5962,7 @@ typedef struct XrCompositionLayerDepthTestFB {
 
 
 
+// XR_META_local_dimming is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_local_dimming 1
 #define XR_META_local_dimming_SPEC_VERSION 1
 #define XR_META_LOCAL_DIMMING_EXTENSION_NAME "XR_META_local_dimming"
@@ -5725,6 +5981,7 @@ typedef struct XrLocalDimmingFrameEndInfoMETA {
 
 
 
+// XR_META_passthrough_preferences is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_passthrough_preferences 1
 #define XR_META_passthrough_preferences_SPEC_VERSION 1
 #define XR_META_PASSTHROUGH_PREFERENCES_EXTENSION_NAME "XR_META_passthrough_preferences"
@@ -5750,6 +6007,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetPassthroughPreferencesMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_virtual_keyboard is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_virtual_keyboard 1
 XR_DEFINE_HANDLE(XrVirtualKeyboardMETA)
 #define XR_MAX_VIRTUAL_KEYBOARD_COMMIT_TEXT_SIZE_META 3992
@@ -5952,6 +6210,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrChangeVirtualKeyboardTextContextMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_OCULUS_external_camera is a preprocessor guard. Do not pass it to API calls.
 #define XR_OCULUS_external_camera 1
 #define XR_MAX_EXTERNAL_CAMERA_NAME_SIZE_OCULUS 32
 #define XR_OCULUS_external_camera_SPEC_VERSION 1
@@ -6009,6 +6268,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateExternalCamerasOCULUS(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_performance_metrics is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_performance_metrics 1
 #define XR_META_performance_metrics_SPEC_VERSION 2
 #define XR_META_PERFORMANCE_METRICS_EXTENSION_NAME "XR_META_performance_metrics"
@@ -6072,6 +6332,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrQueryPerformanceMetricsCounterMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_spatial_entity_storage_batch is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_storage_batch 1
 #define XR_FB_spatial_entity_storage_batch_SPEC_VERSION 1
 #define XR_FB_SPATIAL_ENTITY_STORAGE_BATCH_EXTENSION_NAME "XR_FB_spatial_entity_storage_batch"
@@ -6102,6 +6363,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSaveSpaceListFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_FB_spatial_entity_user is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_spatial_entity_user 1
 typedef uint64_t XrSpaceUserIdFB;
 #define XR_FB_spatial_entity_user_SPEC_VERSION 1
@@ -6133,6 +6395,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroySpaceUserFB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_headset_id is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_headset_id 1
 #define XR_META_headset_id_SPEC_VERSION   2
 #define XR_META_HEADSET_ID_EXTENSION_NAME "XR_META_headset_id"
@@ -6145,6 +6408,7 @@ typedef struct XrSystemHeadsetIdPropertiesMETA {
 
 
 
+// XR_META_recommended_layer_resolution is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_recommended_layer_resolution 1
 #define XR_META_recommended_layer_resolution_SPEC_VERSION 1
 #define XR_META_RECOMMENDED_LAYER_RESOLUTION_EXTENSION_NAME "XR_META_recommended_layer_resolution"
@@ -6174,6 +6438,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetRecommendedLayerResolutionMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_passthrough_color_lut is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_passthrough_color_lut 1
 XR_DEFINE_HANDLE(XrPassthroughColorLutMETA)
 #define XR_META_passthrough_color_lut_SPEC_VERSION 1
@@ -6248,6 +6513,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrUpdatePassthroughColorLutMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_spatial_entity_mesh is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_spatial_entity_mesh 1
 #define XR_META_spatial_entity_mesh_SPEC_VERSION 1
 #define XR_META_SPATIAL_ENTITY_MESH_EXTENSION_NAME "XR_META_spatial_entity_mesh"
@@ -6279,16 +6545,19 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpaceTriangleMeshMETA(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_automatic_layer_filter is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_automatic_layer_filter 1
 #define XR_META_automatic_layer_filter_SPEC_VERSION 1
 #define XR_META_AUTOMATIC_LAYER_FILTER_EXTENSION_NAME "XR_META_automatic_layer_filter"
 
 
+// XR_META_touch_controller_plus is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_touch_controller_plus 1
 #define XR_META_touch_controller_plus_SPEC_VERSION 1
 #define XR_META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME "XR_META_touch_controller_plus"
 
 
+// XR_FB_face_tracking2 is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_face_tracking2 1
 XR_DEFINE_HANDLE(XrFaceTracker2FB)
 #define XR_FB_face_tracking2_SPEC_VERSION 1
@@ -6443,16 +6712,147 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetFaceExpressionWeights2FB(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_META_environment_depth is a preprocessor guard. Do not pass it to API calls.
+#define XR_META_environment_depth 1
+XR_DEFINE_HANDLE(XrEnvironmentDepthProviderMETA)
+XR_DEFINE_HANDLE(XrEnvironmentDepthSwapchainMETA)
+#define XR_META_environment_depth_SPEC_VERSION 1
+#define XR_META_ENVIRONMENT_DEPTH_EXTENSION_NAME "XR_META_environment_depth"
+typedef XrFlags64 XrEnvironmentDepthProviderCreateFlagsMETA;
+
+// Flag bits for XrEnvironmentDepthProviderCreateFlagsMETA
+
+typedef XrFlags64 XrEnvironmentDepthSwapchainCreateFlagsMETA;
+
+// Flag bits for XrEnvironmentDepthSwapchainCreateFlagsMETA
+
+typedef struct XrEnvironmentDepthProviderCreateInfoMETA {
+    XrStructureType                              type;
+    const void* XR_MAY_ALIAS                     next;
+    XrEnvironmentDepthProviderCreateFlagsMETA    createFlags;
+} XrEnvironmentDepthProviderCreateInfoMETA;
+
+typedef struct XrEnvironmentDepthSwapchainCreateInfoMETA {
+    XrStructureType                               type;
+    const void* XR_MAY_ALIAS                      next;
+    XrEnvironmentDepthSwapchainCreateFlagsMETA    createFlags;
+} XrEnvironmentDepthSwapchainCreateInfoMETA;
+
+typedef struct XrEnvironmentDepthSwapchainStateMETA {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    uint32_t              width;
+    uint32_t              height;
+} XrEnvironmentDepthSwapchainStateMETA;
+
+typedef struct XrEnvironmentDepthImageAcquireInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpace                     space;
+    XrTime                      displayTime;
+} XrEnvironmentDepthImageAcquireInfoMETA;
+
+typedef struct XrEnvironmentDepthImageViewMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrFovf                      fov;
+    XrPosef                     pose;
+} XrEnvironmentDepthImageViewMETA;
+
+typedef struct XrEnvironmentDepthImageMETA {
+    XrStructureType                    type;
+    const void* XR_MAY_ALIAS           next;
+    uint32_t                           swapchainIndex;
+    float                              nearZ;
+    float                              farZ;
+    XrEnvironmentDepthImageViewMETA    views[2];
+} XrEnvironmentDepthImageMETA;
+
+typedef struct XrEnvironmentDepthHandRemovalSetInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrBool32                    enabled;
+} XrEnvironmentDepthHandRemovalSetInfoMETA;
+
+// XrSystemEnvironmentDepthPropertiesMETA extends XrSystemProperties
+typedef struct XrSystemEnvironmentDepthPropertiesMETA {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsEnvironmentDepth;
+    XrBool32              supportsHandRemoval;
+} XrSystemEnvironmentDepthPropertiesMETA;
+
+typedef XrResult (XRAPI_PTR *PFN_xrCreateEnvironmentDepthProviderMETA)(XrSession session, const XrEnvironmentDepthProviderCreateInfoMETA* createInfo, XrEnvironmentDepthProviderMETA* environmentDepthProvider);
+typedef XrResult (XRAPI_PTR *PFN_xrDestroyEnvironmentDepthProviderMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider);
+typedef XrResult (XRAPI_PTR *PFN_xrStartEnvironmentDepthProviderMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider);
+typedef XrResult (XRAPI_PTR *PFN_xrStopEnvironmentDepthProviderMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider);
+typedef XrResult (XRAPI_PTR *PFN_xrCreateEnvironmentDepthSwapchainMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider, const XrEnvironmentDepthSwapchainCreateInfoMETA* createInfo, XrEnvironmentDepthSwapchainMETA* swapchain);
+typedef XrResult (XRAPI_PTR *PFN_xrDestroyEnvironmentDepthSwapchainMETA)(XrEnvironmentDepthSwapchainMETA swapchain);
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateEnvironmentDepthSwapchainImagesMETA)(XrEnvironmentDepthSwapchainMETA swapchain, uint32_t imageCapacityInput, uint32_t* imageCountOutput, XrSwapchainImageBaseHeader* images);
+typedef XrResult (XRAPI_PTR *PFN_xrGetEnvironmentDepthSwapchainStateMETA)(XrEnvironmentDepthSwapchainMETA swapchain, XrEnvironmentDepthSwapchainStateMETA* state);
+typedef XrResult (XRAPI_PTR *PFN_xrAcquireEnvironmentDepthImageMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider, const XrEnvironmentDepthImageAcquireInfoMETA* acquireInfo, XrEnvironmentDepthImageMETA* environmentDepthImage);
+typedef XrResult (XRAPI_PTR *PFN_xrSetEnvironmentDepthHandRemovalMETA)(XrEnvironmentDepthProviderMETA environmentDepthProvider, const XrEnvironmentDepthHandRemovalSetInfoMETA* setInfo);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateEnvironmentDepthProviderMETA(
+    XrSession                                   session,
+    const XrEnvironmentDepthProviderCreateInfoMETA* createInfo,
+    XrEnvironmentDepthProviderMETA*             environmentDepthProvider);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyEnvironmentDepthProviderMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrStartEnvironmentDepthProviderMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrStopEnvironmentDepthProviderMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateEnvironmentDepthSwapchainMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider,
+    const XrEnvironmentDepthSwapchainCreateInfoMETA* createInfo,
+    XrEnvironmentDepthSwapchainMETA*            swapchain);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyEnvironmentDepthSwapchainMETA(
+    XrEnvironmentDepthSwapchainMETA             swapchain);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateEnvironmentDepthSwapchainImagesMETA(
+    XrEnvironmentDepthSwapchainMETA             swapchain,
+    uint32_t                                    imageCapacityInput,
+    uint32_t*                                   imageCountOutput,
+    XrSwapchainImageBaseHeader*                 images);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetEnvironmentDepthSwapchainStateMETA(
+    XrEnvironmentDepthSwapchainMETA             swapchain,
+    XrEnvironmentDepthSwapchainStateMETA*       state);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrAcquireEnvironmentDepthImageMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider,
+    const XrEnvironmentDepthImageAcquireInfoMETA* acquireInfo,
+    XrEnvironmentDepthImageMETA*                environmentDepthImage);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrSetEnvironmentDepthHandRemovalMETA(
+    XrEnvironmentDepthProviderMETA              environmentDepthProvider,
+    const XrEnvironmentDepthHandRemovalSetInfoMETA* setInfo);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_EXT_uuid is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_uuid 1
 #define XR_EXT_uuid_SPEC_VERSION          1
 #define XR_EXT_UUID_EXTENSION_NAME        "XR_EXT_uuid"
+#define XR_UUID_SIZE_EXT                  16
 
 
+// XR_EXT_hand_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hand_interaction 1
 #define XR_EXT_hand_interaction_SPEC_VERSION 1
 #define XR_EXT_HAND_INTERACTION_EXTENSION_NAME "XR_EXT_hand_interaction"
 
 
+// XR_QCOM_tracking_optimization_settings is a preprocessor guard. Do not pass it to API calls.
 #define XR_QCOM_tracking_optimization_settings 1
 #define XR_QCOM_tracking_optimization_settings_SPEC_VERSION 1
 #define XR_QCOM_TRACKING_OPTIMIZATION_SETTINGS_EXTENSION_NAME "XR_QCOM_tracking_optimization_settings"
@@ -6482,6 +6882,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetTrackingOptimizationSettingsHintQCOM(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_passthrough is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_passthrough 1
 XR_DEFINE_HANDLE(XrPassthroughHTC)
 #define XR_HTC_passthrough_SPEC_VERSION   1
@@ -6543,6 +6944,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyPassthroughHTC(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_foveation is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_foveation 1
 #define XR_HTC_foveation_SPEC_VERSION     1
 #define XR_HTC_FOVEATION_EXTENSION_NAME   "XR_HTC_foveation"
@@ -6609,6 +7011,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrApplyFoveationHTC(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_HTC_anchor is a preprocessor guard. Do not pass it to API calls.
 #define XR_HTC_anchor 1
 #define XR_MAX_SPATIAL_ANCHOR_NAME_SIZE_HTC 256
 #define XR_HTC_anchor_SPEC_VERSION        1
@@ -6649,6 +7052,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetSpatialAnchorNameHTC(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_EXT_active_action_set_priority is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_active_action_set_priority 1
 #define XR_EXT_active_action_set_priority_SPEC_VERSION 1
 #define XR_EXT_ACTIVE_ACTION_SET_PRIORITY_EXTENSION_NAME "XR_EXT_active_action_set_priority"
@@ -6667,6 +7071,7 @@ typedef struct XrActiveActionSetPrioritiesEXT {
 
 
 
+// XR_MNDX_force_feedback_curl is a preprocessor guard. Do not pass it to API calls.
 #define XR_MNDX_force_feedback_curl 1
 #define XR_MNDX_force_feedback_curl_SPEC_VERSION 1
 #define XR_MNDX_FORCE_FEEDBACK_CURL_EXTENSION_NAME "XR_MNDX_force_feedback_curl"
@@ -6709,16 +7114,19 @@ XRAPI_ATTR XrResult XRAPI_CALL xrApplyForceFeedbackCurlMNDX(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_BD_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_BD_controller_interaction 1
 #define XR_BD_controller_interaction_SPEC_VERSION 2
 #define XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_BD_controller_interaction"
 
 
+// XR_EXT_local_floor is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_local_floor 1
 #define XR_EXT_local_floor_SPEC_VERSION   1
 #define XR_EXT_LOCAL_FLOOR_EXTENSION_NAME "XR_EXT_local_floor"
 
 
+// XR_EXT_hand_tracking_data_source is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hand_tracking_data_source 1
 #define XR_EXT_hand_tracking_data_source_SPEC_VERSION 1
 #define XR_EXT_HAND_TRACKING_DATA_SOURCE_EXTENSION_NAME "XR_EXT_hand_tracking_data_source"
@@ -6746,9 +7154,10 @@ typedef struct XrHandTrackingDataSourceStateEXT {
 
 
 
+// XR_EXT_plane_detection is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_plane_detection 1
 XR_DEFINE_HANDLE(XrPlaneDetectorEXT)
-#define XR_EXT_plane_detection_SPEC_VERSION 1
+#define XR_EXT_plane_detection_SPEC_VERSION 2
 #define XR_EXT_PLANE_DETECTION_EXTENSION_NAME "XR_EXT_plane_detection"
 
 typedef enum XrPlaneDetectorOrientationEXT {
@@ -6805,11 +7214,7 @@ typedef struct XrPlaneDetectorCreateInfoEXT {
     XrPlaneDetectorFlagsEXT     flags;
 } XrPlaneDetectorCreateInfoEXT;
 
-typedef struct XrExtent3DfEXT {
-    float    width;
-    float    height;
-    float    depth;
-} XrExtent3DfEXT;
+typedef XrExtent3Df XrExtent3DfEXT;
 
 typedef struct XrPlaneDetectorBeginInfoEXT {
     XrStructureType                          type;
@@ -6900,11 +7305,72 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetPlanePolygonBufferEXT(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_OPPO_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_OPPO_controller_interaction 1
 #define XR_OPPO_controller_interaction_SPEC_VERSION 1
 #define XR_OPPO_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_OPPO_controller_interaction"
 
 
+// XR_EXT_future is a preprocessor guard. Do not pass it to API calls.
+#define XR_EXT_future 1
+XR_DEFINE_OPAQUE_64(XrFutureEXT)
+#define XR_EXT_future_SPEC_VERSION        1
+#define XR_EXT_FUTURE_EXTENSION_NAME      "XR_EXT_future"
+#define XR_NULL_FUTURE_EXT                0
+
+typedef enum XrFutureStateEXT {
+    XR_FUTURE_STATE_PENDING_EXT = 1,
+    XR_FUTURE_STATE_READY_EXT = 2,
+    XR_FUTURE_STATE_MAX_ENUM_EXT = 0x7FFFFFFF
+} XrFutureStateEXT;
+typedef struct XrFutureCancelInfoEXT {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrFutureEXT                 future;
+} XrFutureCancelInfoEXT;
+
+typedef struct XrFuturePollInfoEXT {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrFutureEXT                 future;
+} XrFuturePollInfoEXT;
+
+typedef struct XR_MAY_ALIAS XrFutureCompletionBaseHeaderEXT {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrResult              futureResult;
+} XrFutureCompletionBaseHeaderEXT;
+
+typedef struct XrFutureCompletionEXT {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrResult              futureResult;
+} XrFutureCompletionEXT;
+
+typedef struct XrFuturePollResultEXT {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrFutureStateEXT      state;
+} XrFuturePollResultEXT;
+
+typedef XrResult (XRAPI_PTR *PFN_xrPollFutureEXT)(XrInstance instance, const XrFuturePollInfoEXT* pollInfo, XrFuturePollResultEXT* pollResult);
+typedef XrResult (XRAPI_PTR *PFN_xrCancelFutureEXT)(XrInstance instance, const XrFutureCancelInfoEXT* cancelInfo);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrPollFutureEXT(
+    XrInstance                                  instance,
+    const XrFuturePollInfoEXT*                  pollInfo,
+    XrFuturePollResultEXT*                      pollResult);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCancelFutureEXT(
+    XrInstance                                  instance,
+    const XrFutureCancelInfoEXT*                cancelInfo);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_EXT_user_presence is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_user_presence 1
 #define XR_EXT_user_presence_SPEC_VERSION 1
 #define XR_EXT_USER_PRESENCE_EXTENSION_NAME "XR_EXT_user_presence"
@@ -6924,6 +7390,7 @@ typedef struct XrSystemUserPresencePropertiesEXT {
 
 
 
+// XR_ML_user_calibration is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_user_calibration 1
 #define XR_ML_user_calibration_SPEC_VERSION 1
 #define XR_ML_USER_CALIBRATION_EXTENSION_NAME "XR_ML_user_calibration"
@@ -6973,9 +7440,16 @@ XRAPI_ATTR XrResult XRAPI_CALL xrEnableUserCalibrationEventsML(
 #endif /* !XR_NO_PROTOTYPES */
 
 
+// XR_YVR_controller_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_YVR_controller_interaction 1
 #define XR_YVR_controller_interaction_SPEC_VERSION 1
 #define XR_YVR_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_YVR_controller_interaction"
+
+
+// XR_EXT_composition_layer_inverted_alpha is a preprocessor guard. Do not pass it to API calls.
+#define XR_EXT_composition_layer_inverted_alpha 1
+#define XR_EXT_composition_layer_inverted_alpha_SPEC_VERSION 1
+#define XR_EXT_COMPOSITION_LAYER_INVERTED_ALPHA_EXTENSION_NAME "XR_EXT_composition_layer_inverted_alpha"
 
 #ifdef __cplusplus
 }

--- a/thirdparty/openxr/include/openxr/openxr_loader_negotiation.h
+++ b/thirdparty/openxr/include/openxr/openxr_loader_negotiation.h
@@ -20,6 +20,7 @@ extern "C" {
 
 
 
+// XR_LOADER_VERSION_1_0 is a preprocessor guard. Do not pass it to API calls.
 #define XR_LOADER_VERSION_1_0 1
 
 #define XR_CURRENT_LOADER_API_LAYER_VERSION 1

--- a/thirdparty/openxr/include/openxr/openxr_platform.h
+++ b/thirdparty/openxr/include/openxr/openxr_platform.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_KHR_android_thread_settings is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_android_thread_settings 1
 #define XR_KHR_android_thread_settings_SPEC_VERSION 6
 #define XR_KHR_ANDROID_THREAD_SETTINGS_EXTENSION_NAME "XR_KHR_android_thread_settings"
@@ -46,6 +47,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSetAndroidApplicationThreadKHR(
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_KHR_android_surface_swapchain is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_android_surface_swapchain 1
 #define XR_KHR_android_surface_swapchain_SPEC_VERSION 4
 #define XR_KHR_ANDROID_SURFACE_SWAPCHAIN_EXTENSION_NAME "XR_KHR_android_surface_swapchain"
@@ -64,6 +66,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateSwapchainAndroidSurfaceKHR(
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_KHR_android_create_instance is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_android_create_instance 1
 #define XR_KHR_android_create_instance_SPEC_VERSION 3
 #define XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME "XR_KHR_android_create_instance"
@@ -79,6 +82,7 @@ typedef struct XrInstanceCreateInfoAndroidKHR {
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_KHR_vulkan_swapchain_format_list is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_vulkan_swapchain_format_list 1
 #define XR_KHR_vulkan_swapchain_format_list_SPEC_VERSION 4
 #define XR_KHR_VULKAN_SWAPCHAIN_FORMAT_LIST_EXTENSION_NAME "XR_KHR_vulkan_swapchain_format_list"
@@ -93,6 +97,7 @@ typedef struct XrVulkanSwapchainFormatListCreateInfoKHR {
 
 #ifdef XR_USE_GRAPHICS_API_OPENGL
 
+// XR_KHR_opengl_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_opengl_enable 1
 #define XR_KHR_opengl_enable_SPEC_VERSION 10
 #define XR_KHR_OPENGL_ENABLE_EXTENSION_NAME "XR_KHR_opengl_enable"
@@ -169,6 +174,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetOpenGLGraphicsRequirementsKHR(
 
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 
+// XR_KHR_opengl_es_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_opengl_es_enable 1
 #define XR_KHR_opengl_es_enable_SPEC_VERSION 8
 #define XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME "XR_KHR_opengl_es_enable"
@@ -210,6 +216,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetOpenGLESGraphicsRequirementsKHR(
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_KHR_vulkan_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_vulkan_enable 1
 #define XR_KHR_vulkan_enable_SPEC_VERSION 8
 #define XR_KHR_VULKAN_ENABLE_EXTENSION_NAME "XR_KHR_vulkan_enable"
@@ -274,6 +281,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetVulkanGraphicsRequirementsKHR(
 
 #ifdef XR_USE_GRAPHICS_API_D3D11
 
+// XR_KHR_D3D11_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_D3D11_enable 1
 #define XR_KHR_D3D11_enable_SPEC_VERSION  9
 #define XR_KHR_D3D11_ENABLE_EXTENSION_NAME "XR_KHR_D3D11_enable"
@@ -311,6 +319,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetD3D11GraphicsRequirementsKHR(
 
 #ifdef XR_USE_GRAPHICS_API_D3D12
 
+// XR_KHR_D3D12_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_D3D12_enable 1
 #define XR_KHR_D3D12_enable_SPEC_VERSION  9
 #define XR_KHR_D3D12_ENABLE_EXTENSION_NAME "XR_KHR_D3D12_enable"
@@ -349,6 +358,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetD3D12GraphicsRequirementsKHR(
 
 #ifdef XR_USE_PLATFORM_WIN32
 
+// XR_KHR_win32_convert_performance_counter_time is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_win32_convert_performance_counter_time 1
 #define XR_KHR_win32_convert_performance_counter_time_SPEC_VERSION 1
 #define XR_KHR_WIN32_CONVERT_PERFORMANCE_COUNTER_TIME_EXTENSION_NAME "XR_KHR_win32_convert_performance_counter_time"
@@ -372,6 +382,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrConvertTimeToWin32PerformanceCounterKHR(
 
 #ifdef XR_USE_TIMESPEC
 
+// XR_KHR_convert_timespec_time is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_convert_timespec_time 1
 #define XR_KHR_convert_timespec_time_SPEC_VERSION 1
 #define XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME "XR_KHR_convert_timespec_time"
@@ -395,6 +406,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrConvertTimeToTimespecTimeKHR(
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_KHR_loader_init_android is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_loader_init_android 1
 #define XR_KHR_loader_init_android_SPEC_VERSION 1
 #define XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME "XR_KHR_loader_init_android"
@@ -409,6 +421,7 @@ typedef struct XrLoaderInitInfoAndroidKHR {
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_KHR_vulkan_enable2 is a preprocessor guard. Do not pass it to API calls.
 #define XR_KHR_vulkan_enable2 1
 #define XR_KHR_vulkan_enable2_SPEC_VERSION 2
 #define XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME "XR_KHR_vulkan_enable2"
@@ -488,6 +501,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetVulkanGraphicsRequirements2KHR(
 
 #ifdef XR_USE_PLATFORM_EGL
 
+// XR_MNDX_egl_enable is a preprocessor guard. Do not pass it to API calls.
 #define XR_MNDX_egl_enable 1
 #define XR_MNDX_egl_enable_SPEC_VERSION   2
 #define XR_MNDX_EGL_ENABLE_EXTENSION_NAME "XR_MNDX_egl_enable"
@@ -506,6 +520,7 @@ typedef struct XrGraphicsBindingEGLMNDX {
 
 #ifdef XR_USE_PLATFORM_WIN32
 
+// XR_MSFT_perception_anchor_interop is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_perception_anchor_interop 1
 #define XR_MSFT_perception_anchor_interop_SPEC_VERSION 1
 #define XR_MSFT_PERCEPTION_ANCHOR_INTEROP_EXTENSION_NAME "XR_MSFT_perception_anchor_interop"
@@ -529,6 +544,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrTryGetPerceptionAnchorFromSpatialAnchorMSFT(
 
 #ifdef XR_USE_PLATFORM_WIN32
 
+// XR_MSFT_holographic_window_attachment is a preprocessor guard. Do not pass it to API calls.
 #define XR_MSFT_holographic_window_attachment 1
 #define XR_MSFT_holographic_window_attachment_SPEC_VERSION 1
 #define XR_MSFT_HOLOGRAPHIC_WINDOW_ATTACHMENT_EXTENSION_NAME "XR_MSFT_holographic_window_attachment"
@@ -546,6 +562,7 @@ typedef struct XrHolographicWindowAttachmentMSFT {
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_FB_android_surface_swapchain_create is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_android_surface_swapchain_create 1
 #define XR_FB_android_surface_swapchain_create_SPEC_VERSION 1
 #define XR_FB_ANDROID_SURFACE_SWAPCHAIN_CREATE_EXTENSION_NAME "XR_FB_android_surface_swapchain_create"
@@ -568,6 +585,7 @@ typedef struct XrAndroidSurfaceSwapchainCreateInfoFB {
 
 #ifdef XR_USE_PLATFORM_ML
 
+// XR_ML_compat is a preprocessor guard. Do not pass it to API calls.
 #define XR_ML_compat 1
 #define XR_ML_compat_SPEC_VERSION         1
 #define XR_ML_COMPAT_EXTENSION_NAME       "XR_ML_compat"
@@ -592,6 +610,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateSpaceFromCoordinateFrameUIDML(
 
 #ifdef XR_USE_PLATFORM_WIN32
 
+// XR_OCULUS_audio_device_guid is a preprocessor guard. Do not pass it to API calls.
 #define XR_OCULUS_audio_device_guid 1
 #define XR_OCULUS_audio_device_guid_SPEC_VERSION 1
 #define XR_OCULUS_AUDIO_DEVICE_GUID_EXTENSION_NAME "XR_OCULUS_audio_device_guid"
@@ -614,6 +633,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetAudioInputDeviceGuidOculus(
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_FB_foveation_vulkan is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_foveation_vulkan 1
 #define XR_FB_foveation_vulkan_SPEC_VERSION 1
 #define XR_FB_FOVEATION_VULKAN_EXTENSION_NAME "XR_FB_foveation_vulkan"
@@ -630,6 +650,7 @@ typedef struct XrSwapchainImageFoveationVulkanFB {
 
 #ifdef XR_USE_PLATFORM_ANDROID
 
+// XR_FB_swapchain_update_state_android_surface is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_swapchain_update_state_android_surface 1
 #define XR_FB_swapchain_update_state_android_surface_SPEC_VERSION 1
 #define XR_FB_SWAPCHAIN_UPDATE_STATE_ANDROID_SURFACE_EXTENSION_NAME "XR_FB_swapchain_update_state_android_surface"
@@ -646,6 +667,7 @@ typedef struct XrSwapchainStateAndroidSurfaceDimensionsFB {
 
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 
+// XR_FB_swapchain_update_state_opengl_es is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_swapchain_update_state_opengl_es 1
 #define XR_FB_swapchain_update_state_opengl_es_SPEC_VERSION 1
 #define XR_FB_SWAPCHAIN_UPDATE_STATE_OPENGL_ES_EXTENSION_NAME "XR_FB_swapchain_update_state_opengl_es"
@@ -670,6 +692,7 @@ typedef struct XrSwapchainStateSamplerOpenGLESFB {
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_FB_swapchain_update_state_vulkan is a preprocessor guard. Do not pass it to API calls.
 #define XR_FB_swapchain_update_state_vulkan 1
 #define XR_FB_swapchain_update_state_vulkan_SPEC_VERSION 1
 #define XR_FB_SWAPCHAIN_UPDATE_STATE_VULKAN_EXTENSION_NAME "XR_FB_swapchain_update_state_vulkan"
@@ -695,6 +718,7 @@ typedef struct XrSwapchainStateSamplerVulkanFB {
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 
+// XR_META_vulkan_swapchain_create_info is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_vulkan_swapchain_create_info 1
 #define XR_META_vulkan_swapchain_create_info_SPEC_VERSION 1
 #define XR_META_VULKAN_SWAPCHAIN_CREATE_INFO_EXTENSION_NAME "XR_META_vulkan_swapchain_create_info"

--- a/thirdparty/openxr/include/openxr/openxr_reflection.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection.h
@@ -86,6 +86,8 @@ XR_ENUM_STR(XrResult);
     _(XR_ERROR_LOCALIZED_NAME_INVALID, -49) \
     _(XR_ERROR_GRAPHICS_REQUIREMENTS_CALL_MISSING, -50) \
     _(XR_ERROR_RUNTIME_UNAVAILABLE, -51) \
+    _(XR_ERROR_EXTENSION_DEPENDENCY_NOT_ENABLED, -1000710001) \
+    _(XR_ERROR_PERMISSION_INSUFFICIENT, -1000710000) \
     _(XR_ERROR_ANDROID_THREAD_SETTINGS_ID_INVALID_KHR, -1000003000) \
     _(XR_ERROR_ANDROID_THREAD_SETTINGS_FAILURE_KHR, -1000003001) \
     _(XR_ERROR_CREATE_SPATIAL_ANCHOR_FAILED_MSFT, -1000039001) \
@@ -135,10 +137,13 @@ XR_ENUM_STR(XrResult);
     _(XR_ERROR_SPACE_NETWORK_REQUEST_FAILED_FB, -1000169003) \
     _(XR_ERROR_SPACE_CLOUD_STORAGE_DISABLED_FB, -1000169004) \
     _(XR_ERROR_PASSTHROUGH_COLOR_LUT_BUFFER_SIZE_MISMATCH_META, -1000266000) \
+    _(XR_ENVIRONMENT_DEPTH_NOT_AVAILABLE_META, 1000291000) \
     _(XR_ERROR_HINT_ALREADY_SET_QCOM, -1000306000) \
     _(XR_ERROR_NOT_AN_ANCHOR_HTC, -1000319000) \
     _(XR_ERROR_SPACE_NOT_LOCATABLE_EXT, -1000429000) \
     _(XR_ERROR_PLANE_DETECTION_PERMISSION_DENIED_EXT, -1000429001) \
+    _(XR_ERROR_FUTURE_PENDING_EXT, -1000469001) \
+    _(XR_ERROR_FUTURE_INVALID_EXT, -1000469002) \
     _(XR_RESULT_MAX_ENUM, 0x7FFFFFFF)
 
 #define XR_LIST_ENUM_XrStructureType(_) \
@@ -192,6 +197,9 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_ACTIONS_SYNC_INFO, 61) \
     _(XR_TYPE_BOUND_SOURCES_FOR_ACTION_ENUMERATE_INFO, 62) \
     _(XR_TYPE_INPUT_SOURCE_LOCALIZED_NAME_GET_INFO, 63) \
+    _(XR_TYPE_SPACES_LOCATE_INFO, 1000471000) \
+    _(XR_TYPE_SPACE_LOCATIONS, 1000471001) \
+    _(XR_TYPE_SPACE_VELOCITIES, 1000471002) \
     _(XR_TYPE_COMPOSITION_LAYER_CUBE_KHR, 1000006000) \
     _(XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR, 1000008000) \
     _(XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR, 1000010000) \
@@ -457,6 +465,14 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB, 1000287014) \
     _(XR_TYPE_FACE_EXPRESSION_INFO2_FB, 1000287015) \
     _(XR_TYPE_FACE_EXPRESSION_WEIGHTS2_FB, 1000287016) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_PROVIDER_CREATE_INFO_META, 1000291000) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_CREATE_INFO_META, 1000291001) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_STATE_META, 1000291002) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_ACQUIRE_INFO_META, 1000291003) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META, 1000291004) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_META, 1000291005) \
+    _(XR_TYPE_ENVIRONMENT_DEPTH_HAND_REMOVAL_SET_INFO_META, 1000291006) \
+    _(XR_TYPE_SYSTEM_ENVIRONMENT_DEPTH_PROPERTIES_META, 1000291007) \
     _(XR_TYPE_PASSTHROUGH_CREATE_INFO_HTC, 1000317001) \
     _(XR_TYPE_PASSTHROUGH_COLOR_HTC, 1000317002) \
     _(XR_TYPE_PASSTHROUGH_MESH_TRANSFORM_INFO_HTC, 1000317003) \
@@ -478,6 +494,10 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_PLANE_DETECTOR_LOCATION_EXT, 1000429005) \
     _(XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT, 1000429006) \
     _(XR_TYPE_SYSTEM_PLANE_DETECTION_PROPERTIES_EXT, 1000429007) \
+    _(XR_TYPE_FUTURE_CANCEL_INFO_EXT, 1000469000) \
+    _(XR_TYPE_FUTURE_POLL_INFO_EXT, 1000469001) \
+    _(XR_TYPE_FUTURE_COMPLETION_EXT, 1000469002) \
+    _(XR_TYPE_FUTURE_POLL_RESULT_EXT, 1000469003) \
     _(XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT, 1000470000) \
     _(XR_TYPE_SYSTEM_USER_PRESENCE_PROPERTIES_EXT, 1000470001) \
     _(XR_STRUCTURE_TYPE_MAX_ENUM, 0x7FFFFFFF)
@@ -490,7 +510,7 @@ XR_ENUM_STR(XrResult);
 #define XR_LIST_ENUM_XrViewConfigurationType(_) \
     _(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO, 1) \
     _(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO, 2) \
-    _(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO, 1000037000) \
+    _(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET, 1000037000) \
     _(XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT, 1000054000) \
     _(XR_VIEW_CONFIGURATION_TYPE_MAX_ENUM, 0x7FFFFFFF)
 
@@ -504,10 +524,10 @@ XR_ENUM_STR(XrResult);
     _(XR_REFERENCE_SPACE_TYPE_VIEW, 1) \
     _(XR_REFERENCE_SPACE_TYPE_LOCAL, 2) \
     _(XR_REFERENCE_SPACE_TYPE_STAGE, 3) \
+    _(XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR, 1000426000) \
     _(XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT, 1000038000) \
     _(XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO, 1000121000) \
     _(XR_REFERENCE_SPACE_TYPE_LOCALIZATION_MAP_ML, 1000139000) \
-    _(XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT, 1000426000) \
     _(XR_REFERENCE_SPACE_TYPE_MAX_ENUM, 0x7FFFFFFF)
 
 #define XR_LIST_ENUM_XrActionType(_) \
@@ -566,6 +586,8 @@ XR_ENUM_STR(XrResult);
     _(XR_OBJECT_TYPE_SPACE_USER_FB, 1000241000) \
     _(XR_OBJECT_TYPE_PASSTHROUGH_COLOR_LUT_META, 1000266000) \
     _(XR_OBJECT_TYPE_FACE_TRACKER2_FB, 1000287012) \
+    _(XR_OBJECT_TYPE_ENVIRONMENT_DEPTH_PROVIDER_META, 1000291000) \
+    _(XR_OBJECT_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_META, 1000291001) \
     _(XR_OBJECT_TYPE_PASSTHROUGH_HTC, 1000317000) \
     _(XR_OBJECT_TYPE_PLANE_DETECTOR_EXT, 1000429000) \
     _(XR_OBJECT_TYPE_MAX_ENUM, 0x7FFFFFFF)
@@ -1377,6 +1399,11 @@ XR_ENUM_STR(XrResult);
     _(XR_PLANE_DETECTION_STATE_FATAL_EXT, 4) \
     _(XR_PLANE_DETECTION_STATE_MAX_ENUM_EXT, 0x7FFFFFFF)
 
+#define XR_LIST_ENUM_XrFutureStateEXT(_) \
+    _(XR_FUTURE_STATE_PENDING_EXT, 1) \
+    _(XR_FUTURE_STATE_READY_EXT, 2) \
+    _(XR_FUTURE_STATE_MAX_ENUM_EXT, 0x7FFFFFFF)
+
 #define XR_LIST_ENUM_XrHeadsetFitStatusML(_) \
     _(XR_HEADSET_FIT_STATUS_UNKNOWN_ML, 0) \
     _(XR_HEADSET_FIT_STATUS_NOT_WORN_ML, 1) \
@@ -1424,6 +1451,7 @@ XR_ENUM_STR(XrResult);
     _(XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT, 0x00000001) \
     _(XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT, 0x00000002) \
     _(XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT, 0x00000004) \
+    _(XR_COMPOSITION_LAYER_INVERTED_ALPHA_BIT_EXT, 0x00000008) \
 
 #define XR_LIST_BITS_XrViewStateFlags(_) \
     _(XR_VIEW_STATE_ORIENTATION_VALID_BIT, 0x00000001) \
@@ -1572,6 +1600,10 @@ XR_ENUM_STR(XrResult);
     _(XR_PERFORMANCE_METRICS_COUNTER_ANY_VALUE_VALID_BIT_META, 0x00000001) \
     _(XR_PERFORMANCE_METRICS_COUNTER_UINT_VALUE_VALID_BIT_META, 0x00000002) \
     _(XR_PERFORMANCE_METRICS_COUNTER_FLOAT_VALUE_VALID_BIT_META, 0x00000004) \
+
+#define XR_LIST_BITS_XrEnvironmentDepthProviderCreateFlagsMETA(_)
+
+#define XR_LIST_BITS_XrEnvironmentDepthSwapchainCreateFlagsMETA(_)
 
 #define XR_LIST_BITS_XrFoveationDynamicFlagsHTC(_) \
     _(XR_FOVEATION_DYNAMIC_LEVEL_ENABLED_BIT_HTC, 0x00000001) \
@@ -2151,6 +2183,73 @@ XR_ENUM_STR(XrResult);
     _(layerApiVersion) \
     _(getInstanceProcAddr) \
     _(createApiLayerInstance) \
+
+/// Calls your macro with the name of each member of XrColor3f, in order.
+#define XR_LIST_STRUCT_XrColor3f(_) \
+    _(r) \
+    _(g) \
+    _(b) \
+
+/// Calls your macro with the name of each member of XrExtent3Df, in order.
+#define XR_LIST_STRUCT_XrExtent3Df(_) \
+    _(width) \
+    _(height) \
+    _(depth) \
+
+/// Calls your macro with the name of each member of XrSpheref, in order.
+#define XR_LIST_STRUCT_XrSpheref(_) \
+    _(center) \
+    _(radius) \
+
+/// Calls your macro with the name of each member of XrBoxf, in order.
+#define XR_LIST_STRUCT_XrBoxf(_) \
+    _(center) \
+    _(extents) \
+
+/// Calls your macro with the name of each member of XrFrustumf, in order.
+#define XR_LIST_STRUCT_XrFrustumf(_) \
+    _(pose) \
+    _(fov) \
+    _(nearZ) \
+    _(farZ) \
+
+/// Calls your macro with the name of each member of XrUuid, in order.
+#define XR_LIST_STRUCT_XrUuid(_) \
+    _(data) \
+
+/// Calls your macro with the name of each member of XrSpacesLocateInfo, in order.
+#define XR_LIST_STRUCT_XrSpacesLocateInfo(_) \
+    _(type) \
+    _(next) \
+    _(baseSpace) \
+    _(time) \
+    _(spaceCount) \
+    _(spaces) \
+
+/// Calls your macro with the name of each member of XrSpaceLocationData, in order.
+#define XR_LIST_STRUCT_XrSpaceLocationData(_) \
+    _(locationFlags) \
+    _(pose) \
+
+/// Calls your macro with the name of each member of XrSpaceLocations, in order.
+#define XR_LIST_STRUCT_XrSpaceLocations(_) \
+    _(type) \
+    _(next) \
+    _(locationCount) \
+    _(locations) \
+
+/// Calls your macro with the name of each member of XrSpaceVelocityData, in order.
+#define XR_LIST_STRUCT_XrSpaceVelocityData(_) \
+    _(velocityFlags) \
+    _(linearVelocity) \
+    _(angularVelocity) \
+
+/// Calls your macro with the name of each member of XrSpaceVelocities, in order.
+#define XR_LIST_STRUCT_XrSpaceVelocities(_) \
+    _(type) \
+    _(next) \
+    _(velocityCount) \
+    _(velocities) \
 
 /// Calls your macro with the name of each member of XrCompositionLayerCubeKHR, in order.
 #define XR_LIST_STRUCT_XrCompositionLayerCubeKHR(_) \
@@ -3231,10 +3330,6 @@ XR_ENUM_STR(XrResult);
     _(enabled) \
     _(changePending) \
 
-/// Calls your macro with the name of each member of XrUuidEXT, in order.
-#define XR_LIST_STRUCT_XrUuidEXT(_) \
-    _(data) \
-
 /// Calls your macro with the name of each member of XrEventDataSpatialAnchorCreateCompleteFB, in order.
 #define XR_LIST_STRUCT_XrEventDataSpatialAnchorCreateCompleteFB(_) \
     _(type) \
@@ -3857,12 +3952,6 @@ XR_ENUM_STR(XrResult);
     _(amplitudeCount) \
     _(amplitudes) \
 
-/// Calls your macro with the name of each member of XrExtent3DfFB, in order.
-#define XR_LIST_STRUCT_XrExtent3DfFB(_) \
-    _(width) \
-    _(height) \
-    _(depth) \
-
 /// Calls your macro with the name of each member of XrOffset3DfFB, in order.
 #define XR_LIST_STRUCT_XrOffset3DfFB(_) \
     _(x) \
@@ -4348,6 +4437,61 @@ XR_ENUM_STR(XrResult);
     _(dataSource) \
     _(time) \
 
+/// Calls your macro with the name of each member of XrEnvironmentDepthProviderCreateInfoMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthProviderCreateInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(createFlags) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthSwapchainCreateInfoMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthSwapchainCreateInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(createFlags) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthSwapchainStateMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthSwapchainStateMETA(_) \
+    _(type) \
+    _(next) \
+    _(width) \
+    _(height) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthImageAcquireInfoMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthImageAcquireInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(space) \
+    _(displayTime) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthImageViewMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthImageViewMETA(_) \
+    _(type) \
+    _(next) \
+    _(fov) \
+    _(pose) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthImageMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthImageMETA(_) \
+    _(type) \
+    _(next) \
+    _(swapchainIndex) \
+    _(nearZ) \
+    _(farZ) \
+    _(views) \
+
+/// Calls your macro with the name of each member of XrEnvironmentDepthHandRemovalSetInfoMETA, in order.
+#define XR_LIST_STRUCT_XrEnvironmentDepthHandRemovalSetInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(enabled) \
+
+/// Calls your macro with the name of each member of XrSystemEnvironmentDepthPropertiesMETA, in order.
+#define XR_LIST_STRUCT_XrSystemEnvironmentDepthPropertiesMETA(_) \
+    _(type) \
+    _(next) \
+    _(supportsEnvironmentDepth) \
+    _(supportsHandRemoval) \
+
 /// Calls your macro with the name of each member of XrPassthroughCreateInfoHTC, in order.
 #define XR_LIST_STRUCT_XrPassthroughCreateInfoHTC(_) \
     _(type) \
@@ -4483,12 +4627,6 @@ XR_ENUM_STR(XrResult);
     _(next) \
     _(flags) \
 
-/// Calls your macro with the name of each member of XrExtent3DfEXT, in order.
-#define XR_LIST_STRUCT_XrExtent3DfEXT(_) \
-    _(width) \
-    _(height) \
-    _(depth) \
-
 /// Calls your macro with the name of each member of XrPlaneDetectorBeginInfoEXT, in order.
 #define XR_LIST_STRUCT_XrPlaneDetectorBeginInfoEXT(_) \
     _(type) \
@@ -4538,6 +4676,36 @@ XR_ENUM_STR(XrResult);
     _(vertexCapacityInput) \
     _(vertexCountOutput) \
     _(vertices) \
+
+/// Calls your macro with the name of each member of XrFutureCancelInfoEXT, in order.
+#define XR_LIST_STRUCT_XrFutureCancelInfoEXT(_) \
+    _(type) \
+    _(next) \
+    _(future) \
+
+/// Calls your macro with the name of each member of XrFuturePollInfoEXT, in order.
+#define XR_LIST_STRUCT_XrFuturePollInfoEXT(_) \
+    _(type) \
+    _(next) \
+    _(future) \
+
+/// Calls your macro with the name of each member of XrFutureCompletionBaseHeaderEXT, in order.
+#define XR_LIST_STRUCT_XrFutureCompletionBaseHeaderEXT(_) \
+    _(type) \
+    _(next) \
+    _(futureResult) \
+
+/// Calls your macro with the name of each member of XrFutureCompletionEXT, in order.
+#define XR_LIST_STRUCT_XrFutureCompletionEXT(_) \
+    _(type) \
+    _(next) \
+    _(futureResult) \
+
+/// Calls your macro with the name of each member of XrFuturePollResultEXT, in order.
+#define XR_LIST_STRUCT_XrFuturePollResultEXT(_) \
+    _(type) \
+    _(next) \
+    _(state) \
 
 /// Calls your macro with the name of each member of XrEventDataUserPresenceChangedEXT, in order.
 #define XR_LIST_STRUCT_XrEventDataUserPresenceChangedEXT(_) \
@@ -4644,6 +4812,9 @@ XR_ENUM_STR(XrResult);
     _(XrEventDataReferenceSpaceChangePending, XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) \
     _(XrEventDataInteractionProfileChanged, XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED) \
     _(XrHapticVibration, XR_TYPE_HAPTIC_VIBRATION) \
+    _(XrSpacesLocateInfo, XR_TYPE_SPACES_LOCATE_INFO) \
+    _(XrSpaceLocations, XR_TYPE_SPACE_LOCATIONS) \
+    _(XrSpaceVelocities, XR_TYPE_SPACE_VELOCITIES) \
     _(XrCompositionLayerCubeKHR, XR_TYPE_COMPOSITION_LAYER_CUBE_KHR) \
     _(XrCompositionLayerDepthInfoKHR, XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR) \
     _(XrCompositionLayerCylinderKHR, XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR) \
@@ -4873,6 +5044,14 @@ XR_ENUM_STR(XrResult);
     _(XrFaceTrackerCreateInfo2FB, XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB) \
     _(XrFaceExpressionInfo2FB, XR_TYPE_FACE_EXPRESSION_INFO2_FB) \
     _(XrFaceExpressionWeights2FB, XR_TYPE_FACE_EXPRESSION_WEIGHTS2_FB) \
+    _(XrEnvironmentDepthProviderCreateInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_PROVIDER_CREATE_INFO_META) \
+    _(XrEnvironmentDepthSwapchainCreateInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_CREATE_INFO_META) \
+    _(XrEnvironmentDepthSwapchainStateMETA, XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_STATE_META) \
+    _(XrEnvironmentDepthImageAcquireInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_ACQUIRE_INFO_META) \
+    _(XrEnvironmentDepthImageViewMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META) \
+    _(XrEnvironmentDepthImageMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_META) \
+    _(XrEnvironmentDepthHandRemovalSetInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_HAND_REMOVAL_SET_INFO_META) \
+    _(XrSystemEnvironmentDepthPropertiesMETA, XR_TYPE_SYSTEM_ENVIRONMENT_DEPTH_PROPERTIES_META) \
     _(XrPassthroughCreateInfoHTC, XR_TYPE_PASSTHROUGH_CREATE_INFO_HTC) \
     _(XrPassthroughColorHTC, XR_TYPE_PASSTHROUGH_COLOR_HTC) \
     _(XrPassthroughMeshTransformInfoHTC, XR_TYPE_PASSTHROUGH_MESH_TRANSFORM_INFO_HTC) \
@@ -4894,6 +5073,10 @@ XR_ENUM_STR(XrResult);
     _(XrPlaneDetectorLocationEXT, XR_TYPE_PLANE_DETECTOR_LOCATION_EXT) \
     _(XrPlaneDetectorLocationsEXT, XR_TYPE_PLANE_DETECTOR_LOCATIONS_EXT) \
     _(XrPlaneDetectorPolygonBufferEXT, XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT) \
+    _(XrFutureCancelInfoEXT, XR_TYPE_FUTURE_CANCEL_INFO_EXT) \
+    _(XrFuturePollInfoEXT, XR_TYPE_FUTURE_POLL_INFO_EXT) \
+    _(XrFutureCompletionEXT, XR_TYPE_FUTURE_COMPLETION_EXT) \
+    _(XrFuturePollResultEXT, XR_TYPE_FUTURE_POLL_RESULT_EXT) \
     _(XrEventDataUserPresenceChangedEXT, XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT) \
     _(XrSystemUserPresencePropertiesEXT, XR_TYPE_SYSTEM_USER_PRESENCE_PROPERTIES_EXT) \
     _(XrEventDataHeadsetFitChangedML, XR_TYPE_EVENT_DATA_HEADSET_FIT_CHANGED_ML) \
@@ -5200,6 +5383,7 @@ XR_ENUM_STR(XrResult);
     _(XR_META_automatic_layer_filter, 272) \
     _(XR_META_touch_controller_plus, 280) \
     _(XR_FB_face_tracking2, 288) \
+    _(XR_META_environment_depth, 292) \
     _(XR_EXT_uuid, 300) \
     _(XR_EXT_hand_interaction, 303) \
     _(XR_QCOM_tracking_optimization_settings, 307) \
@@ -5213,9 +5397,13 @@ XR_ENUM_STR(XrResult);
     _(XR_EXT_hand_tracking_data_source, 429) \
     _(XR_EXT_plane_detection, 430) \
     _(XR_OPPO_controller_interaction, 454) \
+    _(XR_EXT_future, 470) \
     _(XR_EXT_user_presence, 471) \
+    _(XR_KHR_locate_spaces, 472) \
     _(XR_ML_user_calibration, 473) \
     _(XR_YVR_controller_interaction, 498) \
+    _(XR_EXT_composition_layer_inverted_alpha, 555) \
+    _(XR_KHR_maintenance1, 711) \
 
 
 
@@ -5289,6 +5477,14 @@ XR_ENUM_STR(XrResult);
     _(CreateApiLayerInstance, LOADER_VERSION_1_0) \
     _(NegotiateLoaderRuntimeInterface, LOADER_VERSION_1_0) \
     _(NegotiateLoaderApiLayerInterface, LOADER_VERSION_1_0) \
+
+
+/// For every function defined by XR_VERSION_1_1 in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_VERSION_1_1(_) \
+    _(LocateSpaces, VERSION_1_1) \
 
 
 /// For every function defined by XR_KHR_android_thread_settings in this version of the spec,
@@ -5973,6 +6169,23 @@ XR_ENUM_STR(XrResult);
     _(GetFaceExpressionWeights2FB, FB_face_tracking2) \
 
 
+/// For every function defined by XR_META_environment_depth in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_META_environment_depth(_) \
+    _(CreateEnvironmentDepthProviderMETA, META_environment_depth) \
+    _(DestroyEnvironmentDepthProviderMETA, META_environment_depth) \
+    _(StartEnvironmentDepthProviderMETA, META_environment_depth) \
+    _(StopEnvironmentDepthProviderMETA, META_environment_depth) \
+    _(CreateEnvironmentDepthSwapchainMETA, META_environment_depth) \
+    _(DestroyEnvironmentDepthSwapchainMETA, META_environment_depth) \
+    _(EnumerateEnvironmentDepthSwapchainImagesMETA, META_environment_depth) \
+    _(GetEnvironmentDepthSwapchainStateMETA, META_environment_depth) \
+    _(AcquireEnvironmentDepthImageMETA, META_environment_depth) \
+    _(SetEnvironmentDepthHandRemovalMETA, META_environment_depth) \
+
+
 /// For every function defined by XR_QCOM_tracking_optimization_settings in this version of the spec,
 /// calls your macro with the function name and extension name.
 /// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
@@ -6026,6 +6239,15 @@ XR_ENUM_STR(XrResult);
     _(GetPlaneDetectionStateEXT, EXT_plane_detection) \
     _(GetPlaneDetectionsEXT, EXT_plane_detection) \
     _(GetPlanePolygonBufferEXT, EXT_plane_detection) \
+
+
+/// For every function defined by XR_EXT_future in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_EXT_future(_) \
+    _(PollFutureEXT, EXT_future) \
+    _(CancelFutureEXT, EXT_future) \
 
 
 /// For every function defined by XR_ML_user_calibration in this version of the spec,

--- a/thirdparty/openxr/include/openxr/openxr_reflection_parent_structs.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection_parent_structs.h
@@ -32,6 +32,7 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
     _avail(XrCompositionLayerCylinderKHR, XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR) \
     _avail(XrCompositionLayerEquirectKHR, XR_TYPE_COMPOSITION_LAYER_EQUIRECT_KHR) \
     _avail(XrCompositionLayerEquirect2KHR, XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR) \
+    _avail(XrCompositionLayerPassthroughFB, XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB) \
     _avail(XrCompositionLayerPassthroughHTC, XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_HTC) \
 
 
@@ -259,6 +260,19 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
 #define _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrSpaceFilterInfoBaseHeaderFB_CORE(_avail, _unavail) \
     _avail(XrSpaceUuidFilterInfoFB, XR_TYPE_SPACE_UUID_FILTER_INFO_FB) \
     _avail(XrSpaceComponentFilterInfoFB, XR_TYPE_SPACE_COMPONENT_FILTER_INFO_FB) \
+
+
+
+
+
+/// Like XR_LIST_ALL_STRUCTURE_TYPES, but only includes types whose parent struct type is XrFutureCompletionBaseHeaderEXT
+#define XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrFutureCompletionBaseHeaderEXT(_avail, _unavail) \
+    _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrFutureCompletionBaseHeaderEXT_CORE(_avail, _unavail) \
+
+
+// Implementation detail of XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrFutureCompletionBaseHeaderEXT()
+#define _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrFutureCompletionBaseHeaderEXT_CORE(_avail, _unavail) \
+    _avail(XrFutureCompletionEXT, XR_TYPE_FUTURE_COMPLETION_EXT) \
 
 
 

--- a/thirdparty/openxr/include/openxr/openxr_reflection_structs.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection_structs.h
@@ -92,6 +92,9 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrEventDataReferenceSpaceChangePending, XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) \
     _avail(XrEventDataInteractionProfileChanged, XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED) \
     _avail(XrHapticVibration, XR_TYPE_HAPTIC_VIBRATION) \
+    _avail(XrSpacesLocateInfo, XR_TYPE_SPACES_LOCATE_INFO) \
+    _avail(XrSpaceLocations, XR_TYPE_SPACE_LOCATIONS) \
+    _avail(XrSpaceVelocities, XR_TYPE_SPACE_VELOCITIES) \
     _avail(XrCompositionLayerCubeKHR, XR_TYPE_COMPOSITION_LAYER_CUBE_KHR) \
     _avail(XrCompositionLayerDepthInfoKHR, XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR) \
     _avail(XrCompositionLayerCylinderKHR, XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR) \
@@ -321,6 +324,14 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrFaceTrackerCreateInfo2FB, XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB) \
     _avail(XrFaceExpressionInfo2FB, XR_TYPE_FACE_EXPRESSION_INFO2_FB) \
     _avail(XrFaceExpressionWeights2FB, XR_TYPE_FACE_EXPRESSION_WEIGHTS2_FB) \
+    _avail(XrEnvironmentDepthProviderCreateInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_PROVIDER_CREATE_INFO_META) \
+    _avail(XrEnvironmentDepthSwapchainCreateInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_CREATE_INFO_META) \
+    _avail(XrEnvironmentDepthSwapchainStateMETA, XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_STATE_META) \
+    _avail(XrEnvironmentDepthImageAcquireInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_ACQUIRE_INFO_META) \
+    _avail(XrEnvironmentDepthImageViewMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META) \
+    _avail(XrEnvironmentDepthImageMETA, XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_META) \
+    _avail(XrEnvironmentDepthHandRemovalSetInfoMETA, XR_TYPE_ENVIRONMENT_DEPTH_HAND_REMOVAL_SET_INFO_META) \
+    _avail(XrSystemEnvironmentDepthPropertiesMETA, XR_TYPE_SYSTEM_ENVIRONMENT_DEPTH_PROPERTIES_META) \
     _avail(XrPassthroughCreateInfoHTC, XR_TYPE_PASSTHROUGH_CREATE_INFO_HTC) \
     _avail(XrPassthroughColorHTC, XR_TYPE_PASSTHROUGH_COLOR_HTC) \
     _avail(XrPassthroughMeshTransformInfoHTC, XR_TYPE_PASSTHROUGH_MESH_TRANSFORM_INFO_HTC) \
@@ -342,6 +353,10 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrPlaneDetectorLocationEXT, XR_TYPE_PLANE_DETECTOR_LOCATION_EXT) \
     _avail(XrPlaneDetectorLocationsEXT, XR_TYPE_PLANE_DETECTOR_LOCATIONS_EXT) \
     _avail(XrPlaneDetectorPolygonBufferEXT, XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT) \
+    _avail(XrFutureCancelInfoEXT, XR_TYPE_FUTURE_CANCEL_INFO_EXT) \
+    _avail(XrFuturePollInfoEXT, XR_TYPE_FUTURE_POLL_INFO_EXT) \
+    _avail(XrFutureCompletionEXT, XR_TYPE_FUTURE_COMPLETION_EXT) \
+    _avail(XrFuturePollResultEXT, XR_TYPE_FUTURE_POLL_RESULT_EXT) \
     _avail(XrEventDataUserPresenceChangedEXT, XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT) \
     _avail(XrSystemUserPresencePropertiesEXT, XR_TYPE_SYSTEM_USER_PRESENCE_PROPERTIES_EXT) \
     _avail(XrEventDataHeadsetFitChangedML, XR_TYPE_EVENT_DATA_HEADSET_FIT_CHANGED_ML) \

--- a/thirdparty/openxr/src/common/platform_utils.hpp
+++ b/thirdparty/openxr/src/common/platform_utils.hpp
@@ -47,7 +47,7 @@
 #define XR_ARCH_ABI "aarch64"
 #elif (defined(__ARM_ARCH) && __ARM_ARCH >= 7 && (defined(__ARM_PCS_VFP) || defined(__ANDROID__))) || defined(_M_ARM)
 #define XR_ARCH_ABI "armv7a-vfp"
-#elif defined(__ARM_ARCH_5TE__)
+#elif defined(__ARM_ARCH_5TE__) || (defined(__ARM_ARCH) && __ARM_ARCH > 5)
 #define XR_ARCH_ABI "armv5te"
 #elif defined(__mips64)
 #define XR_ARCH_ABI "mips64"
@@ -90,8 +90,6 @@ void LogPlatformUtilsError(const std::string& message);
 namespace detail {
 
 static inline char* ImplGetEnv(const char* name) { return getenv(name); }
-
-static inline int ImplSetEnv(const char* name, const char* value, int overwrite) { return setenv(name, value, overwrite); }
 
 static inline char* ImplGetSecureEnv(const char* name) {
 #ifdef HAVE_SECURE_GETENV
@@ -162,12 +160,6 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
 
 static inline bool PlatformUtilsGetEnvSet(const char* name) { return detail::ImplGetEnv(name) != nullptr; }
 
-static inline bool PlatformUtilsSetEnv(const char* name, const char* value) {
-    const int shouldOverwrite = 1;
-    int result = detail::ImplSetEnv(name, value, shouldOverwrite);
-    return (result == 0);
-}
-
 #elif defined(XR_OS_APPLE)
 
 static inline std::string PlatformUtilsGetEnv(const char* name) {
@@ -187,12 +179,6 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
 }
 
 static inline bool PlatformUtilsGetEnvSet(const char* name) { return detail::ImplGetEnv(name) != nullptr; }
-
-static inline bool PlatformUtilsSetEnv(const char* name, const char* value) {
-    const int shouldOverwrite = 1;
-    int result = detail::ImplSetEnv(name, value, shouldOverwrite);
-    return (result == 0);
-}
 
 static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std::string& file_name) {
     return detail::ImplTryRuntimeFilename("/usr/local/share/openxr/", major_version, file_name);
@@ -337,18 +323,9 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     return envValue;
 }
 
-// Sets an environment variable via UTF8 strings.
-// The name is case-sensitive.
-// Overwrites the variable if it already exists.
-// Returns true if it could be set.
-static inline bool PlatformUtilsSetEnv(const char* name, const char* value) {
-    const std::wstring wname = utf8_to_wide(name);
-    const std::wstring wvalue = utf8_to_wide(value);
-    BOOL result = ::SetEnvironmentVariableW(wname.c_str(), wvalue.c_str());
-    return (result != 0);
-}
-
 #elif defined(XR_OS_ANDROID)
+
+#include <sys/system_properties.h>
 
 static inline bool PlatformUtilsGetEnvSet(const char* /* name */) {
     // Stub func
@@ -363,11 +340,6 @@ static inline std::string PlatformUtilsGetEnv(const char* /* name */) {
 static inline std::string PlatformUtilsGetSecureEnv(const char* /* name */) {
     // Stub func
     return {};
-}
-
-static inline bool PlatformUtilsSetEnv(const char* /* name */, const char* /* value */) {
-    // Stub func
-    return false;
 }
 
 // Intended to be only used as a fallback on Android, with a more open, "native" technique used in most cases
@@ -385,6 +357,37 @@ static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std:
 
     return false;
 }
+
+// Android system properties are sufficiently different from environment variables that we are not re-using
+// PlatformUtilsGetEnv for this purpose
+static inline std::string PlatformUtilsGetAndroidSystemProperty(const char* name) {
+    std::string result;
+    const prop_info* pi = __system_property_find(name);
+    if (pi == nullptr) {
+        return {};
+    }
+
+#if __ANDROID_API__ >= 26
+    // use callback to retrieve > 92 character sys prop values, if available
+    __system_property_read_callback(
+        pi,
+        [](void* cookie, const char*, const char* value, uint32_t) {
+            auto property_value = reinterpret_cast<std::string*>(cookie);
+            *property_value = value;
+        },
+        reinterpret_cast<void*>(&result));
+#endif  // __ANDROID_API__ >= 26
+    // fallback to __system_property_get if no value retrieved via callback
+    if (result.empty()) {
+        char value[PROP_VALUE_MAX] = {};
+        if (__system_property_get(name, value) != 0) {
+            result = value;
+        }
+    }
+
+    return result;
+}
+
 #else  // Not Linux, Apple, nor Windows
 
 static inline bool PlatformUtilsGetEnvSet(const char* /* name */) {
@@ -400,11 +403,6 @@ static inline std::string PlatformUtilsGetEnv(const char* /* name */) {
 static inline std::string PlatformUtilsGetSecureEnv(const char* /* name */) {
     // Stub func
     return {};
-}
-
-static inline bool PlatformUtilsSetEnv(const char* /* name */, const char* /* value */) {
-    // Stub func
-    return false;
 }
 
 static inline bool PlatformGetGlobalRuntimeFileName(uint16_t /* major_version */, std::string const& /* file_name */) {


### PR DESCRIPTION
This PR updates the OpenXR thirdparty library to v1.1.38.

This also required a small change in the OpenXR instance creation as we are currently staying with OpenXR 1.0.x.
Updating Godot to OpenXR 1.1 we'll look into at a later stage but as many XR runtimes do not support 1.1.x yet and we need to make potentially breaking changes, we are holding off on this.