### PR TITLE
[PopupMenu] Increase mouse button release timeout and reset it from `post_popup`.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -608,7 +608,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 					return;
 				}
 				// Disable clicks under a time threshold to avoid selection right when opening the popup.
-				if (was_during_grabbed_click && OS::get_singleton()->get_ticks_msec() - popup_time_msec < 150) {
+				if (was_during_grabbed_click && OS::get_singleton()->get_ticks_msec() - popup_time_msec < 400) {
 					return;
 				}
 
@@ -1064,6 +1064,7 @@ void PopupMenu::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_POST_POPUP: {
+			popup_time_msec = OS::get_singleton()->get_ticks_msec();
 			initial_button_mask = Input::get_singleton()->get_mouse_button_mask();
 			during_grabbed_click = (bool)initial_button_mask;
 		} break;


### PR DESCRIPTION
Might fix https://github.com/godotengine/godot/issues/93265

It seems to be a timing issue. I can't reproduce it with the current settings, but I was able to do it by setting smaller timeout (100 ms). Current timeout is too small for a user interaction and counting from `popup` call (so it includes all window/surface/swapchain creation time, which can be slow).