### PR TITLE
[macOS] Load `OpenGL.framework` by path to avoid issues with non-Latin executable names.

### DIFF
--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -62,6 +62,7 @@ class GLManagerLegacy_MacOS {
 
 	Error create_context(GLWindow &win);
 
+	bool framework_loaded = false;
 	bool use_vsync = false;
 	CGLEnablePtr CGLEnable = nullptr;
 	CGLSetParameterPtr CGLSetParameter = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95173