### PR TITLE
Make `Skeleton3D` bone simulator an internal child

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -300,7 +300,7 @@ void Skeleton3D::setup_simulator() {
 	simulator = sim;
 	sim->is_compat = true;
 	sim->set_active(false); // Don't run unneeded process.
-	add_child(simulator);
+	add_child(simulator, false, INTERNAL_MODE_BACK);
 	set_animate_physical_bones(animate_physical_bones);
 }
 #endif // _DISABLE_DEPRECATED


### PR DESCRIPTION
The documentation lists this as internal, and it makes sense to keep this internal

* Fixes: https://github.com/godotengine/godot/issues/95238
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
