### PR TITLE
Initialize project name when importing project

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -429,6 +429,10 @@ void ProjectDialog::_install_path_selected(const String &p_path) {
 	get_ok_button()->grab_focus();
 }
 
+void ProjectDialog::_reset_name() {
+	project_name->set_text(TTR("New Game Project"));
+}
+
 void ProjectDialog::_renderer_selected() {
 	ERR_FAIL_NULL(renderer_button_group->get_pressed_button());
 
@@ -694,6 +698,7 @@ void ProjectDialog::set_project_path(const String &p_path) {
 }
 
 void ProjectDialog::ask_for_path_and_show() {
+	_reset_name();
 	_browse_project_path();
 }
 
@@ -718,8 +723,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 		callable_mp(project_name, &LineEdit::select_all).call_deferred();
 	} else {
 		if (p_reset_name) {
-			String proj = TTR("New Game Project");
-			project_name->set_text(proj);
+			_reset_name();
 		}
 		project_path->set_editable(true);
 

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -122,6 +122,7 @@ private:
 	void _project_path_selected(const String &p_path);
 	void _install_path_selected(const String &p_path);
 
+	void _reset_name();
 	void _renderer_selected();
 	void _nonempty_confirmation_ok_pressed();
 


### PR DESCRIPTION
Fresh new hack to fix #95234
When importing project, the project dialog's validation still checks the project name, even though the field is hidden. This ensures that name is non-empty when importing.