### PR TITLE
Fix reimport file multiple scenes

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -823,6 +823,7 @@ public:
 
 	struct InstanceModificationsEntry {
 		Node *original_node;
+		String instance_path;
 		List<Node *> instance_list;
 		HashMap<NodePath, ModificationNodeEntry> modifications;
 		List<AdditiveNodeEntry> addition_list;
@@ -907,8 +908,8 @@ public:
 	void reload_scene(const String &p_path);
 
 	void find_all_instances_inheriting_path_in_node(Node *p_root, Node *p_node, const String &p_instance_path, List<Node *> &p_instance_list);
-	void preload_reimporting_with_path_in_edited_scenes(const String &p_path);
-	void reload_instances_with_path_in_edited_scenes(const String &p_path);
+	void preload_reimporting_with_path_in_edited_scenes(const List<String> &p_scenes);
+	void reload_instances_with_path_in_edited_scenes();
 
 	bool is_exiting() const { return exiting; }
 


### PR DESCRIPTION
This PR fixes an issue that I introduced in #95225 when multiple Blender or GLB files are modified and reimported.

With PR #95225, only the last file was reloaded for each scene.

With this PR, I also managed to easily reload a scene only once, even if multiple objects need reloading in the scene.

Steps to reproduce the problem:
- Open the MRP.
- Open the scene "two_objects.tscn".
- Modify both Blender files (without going back to Godot).
- Go back to Godot.
- The two modified objects should be updated.

This is an MRP with two Blender files:
[two_objects.zip](https://github.com/user-attachments/files/16536068/two_objects.zip)
