### PR TITLE
Improve theme editor responsiveness when adding / removing overrides

### DIFF
--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -372,6 +372,7 @@ class ThemeTypeEditor : public MarginContainer {
 
 	VBoxContainer *_create_item_list(Theme::DataType p_data_type);
 	void _update_type_list();
+	void _update_type_list_internal();
 	void _update_type_list_debounced();
 	HashMap<StringName, bool> _get_type_items(String p_type_name, Theme::DataType p_type, bool p_include_default);
 	HBoxContainer *_create_property_control(Theme::DataType p_data_type, String p_item_name, bool p_editable);


### PR DESCRIPTION
This addresses a small personal gripe. Currently adding / removing overrides does not update the UI immediately. Instead, it relies on a half second timer for a debounced update.

I do realize updating the list is currently slow. I also assume the debounced update is to prevent massive slowdown and stutters during value updates in the inspector.

With both of the above in mind, this PR allows the list to update immediately if the theme editor is focused yet not focused in any of the internal value editors.

I could not find any related issues so this might not be a issue for some user. It would be optimal to have feedback about the UX change, so please try it by messing around in the theme editor.