### PR TITLE
iOS: Fix typo in GodotApplicationDelegate

### DIFF
--- a/platform/ios/godot_app_delegate.h
+++ b/platform/ios/godot_app_delegate.h
@@ -32,7 +32,7 @@
 
 typedef NSObject<UIApplicationDelegate> ApplicationDelegateService;
 
-@interface GodotApplicalitionDelegate : NSObject <UIApplicationDelegate>
+@interface GodotApplicationDelegate : NSObject <UIApplicationDelegate>
 
 @property(class, readonly, strong) NSArray<ApplicationDelegateService *> *services;
 

--- a/platform/ios/godot_app_delegate.m
+++ b/platform/ios/godot_app_delegate.m
@@ -32,11 +32,11 @@
 
 #import "app_delegate.h"
 
-@interface GodotApplicalitionDelegate ()
+@interface GodotApplicationDelegate ()
 
 @end
 
-@implementation GodotApplicalitionDelegate
+@implementation GodotApplicationDelegate
 
 static NSMutableArray<ApplicationDelegateService *> *services = nil;
 

--- a/platform/ios/main.m
+++ b/platform/ios/main.m
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
 	gargv = argv;
 
 	@autoreleasepool {
-		NSString *className = NSStringFromClass([GodotApplicalitionDelegate class]);
+		NSString *className = NSStringFromClass([GodotApplicationDelegate class]);
 		UIApplicationMain(argc, argv, nil, className);
 	}
 	return 0;


### PR DESCRIPTION
- Fixes #90714.
- Supersedes #90773.