### PR TITLE
Forbid function declaration with a const qualifier in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9640,6 +9640,11 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					break;
 				}
 
+				if (is_constant) {
+					_set_error(vformat(RTR("'%s' qualifier cannot be used with a function return type."), "const"));
+					return ERR_PARSE_ERROR;
+				}
+
 				FunctionInfo builtins;
 				if (p_functions.has(name)) {
 					builtins = p_functions[name];


### PR DESCRIPTION
Forbids invalid function initialization, e.g.:

```glsl
const int foo() {
	...
}
```

- Fix https://github.com/godotengine/godot/issues/95305