### PR TITLE
CI: Update Emscripten to 3.1.64

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes
-  EM_VERSION: 3.1.59
+  EM_VERSION: 3.1.64
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:


### PR DESCRIPTION
This is the version we're using for 4.3-stable.