### PR TITLE
Fix huge tscn icon in FileSystem split mode using list view

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -953,7 +953,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_max_columns(1);
 		files->set_max_text_lines(1);
 		files->set_fixed_column_width(0);
-		files->set_fixed_icon_size(Size2());
+		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+		files->set_fixed_icon_size(Size2(icon_size, icon_size));
 	}
 
 	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon(SNAME("folder"), SNAME("FileDialog"));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92646

Same as https://github.com/godotengine/godot/pull/92669 but when using "View items as a list."

Before:
![Screenshot_20240808_115421](https://github.com/user-attachments/assets/563ee324-627b-4a03-88c9-27832e48febf)

After:
![Screenshot_20240808_115354](https://github.com/user-attachments/assets/9137f42f-9472-4bb5-8a1f-ddf134f296b4)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/95604*