### PR TITLE
Core: Mutual conversion operators to constructors

### DIFF
--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -30,7 +30,6 @@
 
 #include "rect2.h"
 
-#include "core/math/rect2i.h"
 #include "core/math/transform_2d.h"
 #include "core/string/ustring.h"
 
@@ -284,8 +283,4 @@ next4:
 
 Rect2::operator String() const {
 	return "[P: " + position.operator String() + ", S: " + size.operator String() + "]";
-}
-
-Rect2::operator Rect2i() const {
-	return Rect2i(position, size);
 }

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -359,7 +359,6 @@ struct [[nodiscard]] Rect2 {
 	}
 
 	operator String() const;
-	operator Rect2i() const;
 
 	Rect2() {}
 	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
@@ -370,6 +369,16 @@ struct [[nodiscard]] Rect2 {
 			position(p_pos),
 			size(p_size) {
 	}
+	_FORCE_INLINE_ Rect2(const Rect2i &p_rect);
 };
+
+#ifdef RECT2I_H
+Rect2::Rect2(const Rect2i &p_rect) :
+		position(p_rect.position),
+		size(p_rect.size) {}
+Rect2i::Rect2i(const Rect2 &p_rect) :
+		position(p_rect.position),
+		size(p_rect.size) {}
+#endif // RECT2I_H
 
 #endif // RECT2_H

--- a/core/math/rect2i.cpp
+++ b/core/math/rect2i.cpp
@@ -30,13 +30,8 @@
 
 #include "rect2i.h"
 
-#include "core/math/rect2.h"
 #include "core/string/ustring.h"
 
 Rect2i::operator String() const {
 	return "[P: " + position.operator String() + ", S: " + size + "]";
-}
-
-Rect2i::operator Rect2() const {
-	return Rect2(position, size);
 }

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -225,7 +225,6 @@ struct [[nodiscard]] Rect2i {
 	}
 
 	operator String() const;
-	operator Rect2() const;
 
 	Rect2i() {}
 	Rect2i(int p_x, int p_y, int p_width, int p_height) :
@@ -236,6 +235,16 @@ struct [[nodiscard]] Rect2i {
 			position(p_pos),
 			size(p_size) {
 	}
+	_FORCE_INLINE_ Rect2i(const Rect2 &p_rect);
 };
+
+#ifdef RECT2_H
+Rect2::Rect2(const Rect2i &p_rect) :
+		position(p_rect.position),
+		size(p_rect.size) {}
+Rect2i::Rect2i(const Rect2 &p_rect) :
+		position(p_rect.position),
+		size(p_rect.size) {}
+#endif // RECT2_H
 
 #endif // RECT2I_H

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -30,7 +30,6 @@
 
 #include "vector2.h"
 
-#include "core/math/vector2i.h"
 #include "core/string/ustring.h"
 
 real_t Vector2::angle() const {
@@ -204,8 +203,4 @@ bool Vector2::is_finite() const {
 
 Vector2::operator String() const {
 	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ")";
-}
-
-Vector2::operator Vector2i() const {
-	return Vector2i(x, y);
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -182,14 +182,21 @@ struct [[nodiscard]] Vector2 {
 	real_t aspect() const { return width / height; }
 
 	operator String() const;
-	operator Vector2i() const;
 
 	_FORCE_INLINE_ Vector2() {}
 	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
 		x = p_x;
 		y = p_y;
 	}
+	_FORCE_INLINE_ Vector2(const Vector2i &p_vec);
 };
+
+#ifdef VECTOR2I_H
+Vector2::Vector2(const Vector2i &p_vec) :
+		x(p_vec.x), y(p_vec.y) {}
+Vector2i::Vector2i(const Vector2 &p_vec) :
+		x(p_vec.x), y(p_vec.y) {}
+#endif // VECTOR2I_H
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {
 	return p_vec - *this * (dot(p_vec) - p_d);

--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -30,7 +30,6 @@
 
 #include "vector2i.h"
 
-#include "core/math/vector2.h"
 #include "core/string/ustring.h"
 
 Vector2i Vector2i::clamp(const Vector2i &p_min, const Vector2i &p_max) const {
@@ -136,8 +135,4 @@ bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 
 Vector2i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ")";
-}
-
-Vector2i::operator Vector2() const {
-	return Vector2((int32_t)x, (int32_t)y);
 }

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -140,14 +140,21 @@ struct [[nodiscard]] Vector2i {
 	Vector2i snappedi(int32_t p_step) const;
 
 	operator String() const;
-	operator Vector2() const;
 
 	inline Vector2i() {}
 	inline Vector2i(int32_t p_x, int32_t p_y) {
 		x = p_x;
 		y = p_y;
 	}
+	_FORCE_INLINE_ Vector2i(const Vector2 &p_vec);
 };
+
+#ifdef VECTOR2_H
+Vector2::Vector2(const Vector2i &p_vec) :
+		x(p_vec.x), y(p_vec.y) {}
+Vector2i::Vector2i(const Vector2 &p_vec) :
+		x(p_vec.x), y(p_vec.y) {}
+#endif // VECTOR2_H
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -32,7 +32,6 @@
 
 #include "core/math/basis.h"
 #include "core/math/vector2.h"
-#include "core/math/vector3i.h"
 #include "core/string/ustring.h"
 
 void Vector3::rotate(const Vector3 &p_axis, real_t p_angle) {
@@ -166,8 +165,4 @@ bool Vector3::is_finite() const {
 
 Vector3::operator String() const {
 	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ")";
-}
-
-Vector3::operator Vector3i() const {
-	return Vector3i(x, y, z);
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -184,7 +184,6 @@ struct [[nodiscard]] Vector3 {
 	_FORCE_INLINE_ bool operator>=(const Vector3 &p_v) const;
 
 	operator String() const;
-	operator Vector3i() const;
 
 	_FORCE_INLINE_ Vector3() {}
 	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
@@ -192,7 +191,15 @@ struct [[nodiscard]] Vector3 {
 		y = p_y;
 		z = p_z;
 	}
+	_FORCE_INLINE_ Vector3(const Vector3i &p_vec);
 };
+
+#ifdef VECTOR3I_H
+Vector3::Vector3(const Vector3i &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z) {}
+Vector3i::Vector3i(const Vector3 &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z) {}
+#endif // VECTOR3I_H
 
 Vector3 Vector3::cross(const Vector3 &p_with) const {
 	Vector3 ret(

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -30,7 +30,6 @@
 
 #include "vector3i.h"
 
-#include "core/math/vector3.h"
 #include "core/string/ustring.h"
 
 Vector3i::Axis Vector3i::min_axis_index() const {
@@ -71,8 +70,4 @@ Vector3i Vector3i::snappedi(int32_t p_step) const {
 
 Vector3i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ")";
-}
-
-Vector3i::operator Vector3() const {
-	return Vector3(x, y, z);
 }

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -130,7 +130,6 @@ struct [[nodiscard]] Vector3i {
 	_FORCE_INLINE_ bool operator>=(const Vector3i &p_v) const;
 
 	operator String() const;
-	operator Vector3() const;
 
 	_FORCE_INLINE_ Vector3i() {}
 	_FORCE_INLINE_ Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {
@@ -138,7 +137,15 @@ struct [[nodiscard]] Vector3i {
 		y = p_y;
 		z = p_z;
 	}
+	_FORCE_INLINE_ Vector3i(const Vector3 &p_vec);
 };
+
+#ifdef VECTOR3_H
+Vector3::Vector3(const Vector3i &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z) {}
+Vector3i::Vector3i(const Vector3 &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z) {}
+#endif // VECTOR3_H
 
 int64_t Vector3i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y + z * (int64_t)z;

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -31,7 +31,6 @@
 #include "vector4.h"
 
 #include "core/math/math_funcs.h"
-#include "core/math/vector4i.h"
 #include "core/string/ustring.h"
 
 Vector4::Axis Vector4::min_axis_index() const {
@@ -217,7 +216,3 @@ Vector4::operator String() const {
 }
 
 static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
-
-Vector4::operator Vector4i() const {
-	return Vector4i(x, y, z, w);
-}

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -142,7 +142,6 @@ struct [[nodiscard]] Vector4 {
 	_FORCE_INLINE_ bool operator<=(const Vector4 &p_vec4) const;
 
 	operator String() const;
-	operator Vector4i() const;
 
 	_FORCE_INLINE_ Vector4() {}
 	_FORCE_INLINE_ Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
@@ -151,7 +150,15 @@ struct [[nodiscard]] Vector4 {
 		z = p_z;
 		w = p_w;
 	}
+	_FORCE_INLINE_ Vector4(const Vector4i &p_vec);
 };
+
+#ifdef VECTOR4I_H
+Vector4::Vector4(const Vector4i &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z), w(p_vec.w) {}
+Vector4i::Vector4i(const Vector4 &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z), w(p_vec.w) {}
+#endif // VECTOR4I_H
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {
 	return x * p_vec4.x + y * p_vec4.y + z * p_vec4.z + w * p_vec4.w;

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -30,7 +30,6 @@
 
 #include "vector4i.h"
 
-#include "core/math/vector4.h"
 #include "core/string/ustring.h"
 
 Vector4i::Axis Vector4i::min_axis_index() const {
@@ -91,17 +90,6 @@ Vector4i Vector4i::snappedi(int32_t p_step) const {
 
 Vector4i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ", " + itos(w) + ")";
-}
-
-Vector4i::operator Vector4() const {
-	return Vector4(x, y, z, w);
-}
-
-Vector4i::Vector4i(const Vector4 &p_vec4) {
-	x = (int32_t)p_vec4.x;
-	y = (int32_t)p_vec4.y;
-	z = (int32_t)p_vec4.z;
-	w = (int32_t)p_vec4.w;
 }
 
 static_assert(sizeof(Vector4i) == 4 * sizeof(int32_t));

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -132,17 +132,23 @@ struct [[nodiscard]] Vector4i {
 	_FORCE_INLINE_ bool operator>=(const Vector4i &p_v) const;
 
 	operator String() const;
-	operator Vector4() const;
 
 	_FORCE_INLINE_ Vector4i() {}
-	Vector4i(const Vector4 &p_vec4);
 	_FORCE_INLINE_ Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
 		w = p_w;
 	}
+	_FORCE_INLINE_ Vector4i(const Vector4 &p_vec);
 };
+
+#ifdef VECTOR4_H
+Vector4::Vector4(const Vector4i &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z), w(p_vec.w) {}
+Vector4i::Vector4i(const Vector4 &p_vec) :
+		x(p_vec.x), y(p_vec.y), z(p_vec.z), w(p_vec.w) {}
+#endif // VECTOR4_H
 
 int64_t Vector4i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y + z * (int64_t)z + w * (int64_t)w;


### PR DESCRIPTION
While brainstorming ways to make the math struct types play nicely with each other in a `constexpr` environment, I eventually came across a C++ quirk I wasn't previously aware of: a function with a forward-declared type can *itself* be forward declared, **and** only needs to be properly defined if the type itself is resolved. With this in mind, any float-to-int conversions in math structs are able to not only utilize constructors instead of conversion operators, but are able to be safely defined in a `constexpr` context!

While this isn't a `constexpr` PR (see #92059), this *does* open the door for allowing proper interopability between structs defined in entirely separate headers. As for immediate benefits, this slightly simplifies logic by not needing both a constructor and conversion operator, as the former effectively replaces the latter.