### PR TITLE
Optimize .hdr loading and RGB9E5 conversion

### DIFF
--- a/modules/hdr/image_loader_hdr.h
+++ b/modules/hdr/image_loader_hdr.h
@@ -37,6 +37,7 @@ class ImageLoaderHDR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+
 	ImageLoaderHDR();
 };
 


### PR DESCRIPTION
Improves .hdr file loading/importing times by doing the following:
- changing the RGBF - RGB9E5 conversion code to the one from https://github.com/microsoft/DirectX-Graphics-Samples/blob/master/MiniEngine/Core/Color.cpp,
- directly converting low-range RGBE8 to RGB9E5, from https://github.com/george-steel/rgbe-rs/blob/main/src/types.rs,
- more efficiently loading RLE-compressed data from the disk.

Results:
Optimized x64 build
OS: Windows 10 64-bit
CPU: AMD Ryzen 9 5900X 12-Core
RAM: 64 GB DDR4

Loading only:
| master | PR |  Image |
|---------|----|---------|
| 7354 ms | 329 ms | https://polyhaven.com/a/symmetrical_garden_02 - 8K |
| 6901 ms | 283 ms | https://polyhaven.com/a/zwartkops_straight_sunset - 8K |
| 1865 ms | 78 ms | https://polyhaven.com/a/cobblestone_street_night - 4K |
| 114 ms | 4 ms | https://polyhaven.com/a/st_peters_square_night - 1K |

On average, this PR loads data ~25x faster.

Whole import:
| master w mips | PR w mips | master no mips | PR no mips | Image |
|-----------------|-------------|------------------|--------------|---------|
| 12318 ms | 3227 ms | 9268 ms | 2227 ms | https://polyhaven.com/a/symmetrical_garden_02 - 8K |
| 11845 ms | 3240 ms | 8884 ms | 2212 ms | https://polyhaven.com/a/zwartkops_straight_sunset - 8K |
| 3190 ms | 820 ms | 2380 ms | 602 ms | https://polyhaven.com/a/cobblestone_street_night - 4K |
| 204 ms | 69 ms | 142 ms | 32 ms | https://polyhaven.com/a/st_peters_square_night - 1K |

On average, the import time for images with mipmaps is ~3.5x faster. Without mipmaps, it is ~4x faster.
The engine also generates mipmaps, saves the data to the import directory and reloads it again, which is bottlenecked by the disk's read/write speeds (The project was on an HDD).

TODO:
- [x] verify whether the converted values are accurate,
- [x] add more accurate performance benchmarks.