### PR TITLE
[macOS] Remove kill override.

### DIFF
--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -109,7 +109,6 @@ public:
 	virtual String get_executable_path() const override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
-	virtual Error kill(const ProcessID &p_pid) override;
 	virtual bool is_process_running(const ProcessID &p_pid) const override;
 
 	virtual String get_unique_id() const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -675,18 +675,6 @@ bool OS_MacOS::is_process_running(const ProcessID &p_pid) const {
 	return ![app isTerminated];
 }
 
-Error OS_MacOS::kill(const ProcessID &p_pid) {
-	NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)p_pid];
-	if (!app) {
-		return OS_Unix::kill(p_pid);
-	}
-	bool terminated = [app terminate];
-	if (!terminated) {
-		terminated = [app forceTerminate];
-	}
-	return terminated ? OK : ERR_INVALID_PARAMETER;
-}
-
 String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 


### PR DESCRIPTION
Partially reverts https://github.com/godotengine/godot/pull/94978, unlike `is_process_running` generic Unix `kill` is working with bundled apps, and macOS `terminate` seems to be slower.

Fixes https://github.com/godotengine/godot/issues/95289