### PR TITLE
Fix use-after-free in `EditorHelp`

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3024,6 +3024,7 @@ void EditorHelp::update_doc() {
 void EditorHelp::cleanup_doc() {
 	_wait_for_thread();
 	memdelete(doc);
+	doc = nullptr;
 }
 
 Vector<Pair<String, int>> EditorHelp::get_sections() {


### PR DESCRIPTION
Fixes #95306.

This adds a zeroing out of the `EditorHelp::doc` variable after it's been freed, to prevent any use-after-free from happening in places like `EditorHelp::remove_class`.

While this does fix the issue at hand, there are quite a lot of places in `EditorHelp` that use this `doc` variable without checking if it's `nullptr` first, so I'm not sure if there's a bigger problem lurking here or not.