### PR TITLE
Fix use-after-free in `FileAccess::exists`

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -119,6 +119,10 @@ void PackedData::_free_packed_dirs(PackedDir *p_dir) {
 }
 
 PackedData::~PackedData() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+
 	for (int i = 0; i < sources.size(); i++) {
 		memdelete(sources[i]);
 	}


### PR DESCRIPTION
Fixes #95310.

This adds a zeroing out of the `PackedData` singleton when it's destroyed, to ensure that any `nullptr` check, such as the one in `FileAccess::exists`, actually does what it's supposed to.