### PR TITLE
Report error when use const to decorate function name in gdshader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9664,6 +9664,11 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					}
 				}
 
+				if (is_constant) {
+					_set_error(RTR("Const functions are not supported."));
+					return ERR_PARSE_ERROR;
+				}
+
 				ShaderNode::Function function;
 
 				function.callable = !p_functions.has(name);


### PR DESCRIPTION
This should fix the const part of https://github.com/godotengine/godot/issues/95305

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
