### PR TITLE
AudioStreamPolyphonic: Implement stopping with sample playback

### DIFF
--- a/scene/resources/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio_stream_polyphonic.cpp
@@ -143,6 +143,10 @@ int AudioStreamPlaybackPolyphonic::mix(AudioFrame *p_buffer, float p_rate_scale,
 		}
 
 		if (s.stream_playback->get_is_sample()) {
+			if (s.finish_request.is_set()) {
+				s.active.clear();
+				AudioServer::get_singleton()->stop_sample_playback(s.stream_playback->get_sample_playback());
+			}
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #94724.

May not be complete, I didn't study the code for very long but I see a bunch of other flags like `pending_play` that may also need to be reset?

It will also stop abruptly, while the stream playback seems to do a fade out IIUC.

@adamscott Feel free to take this over, I just did a quick investigation to try to find a workaround for 4.3. This could either be merged as is if you think it's good enough, or further improved by you, and/or merged as is with a new issue opened for what still needs to be improved for 4.4.