### PR TITLE
Fix copy-paste and cut-paste in GridMap

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -643,6 +643,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 					_do_paste();
 					input_action = INPUT_NONE;
 					_update_paste_indicator();
+					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (mb->is_shift_pressed() && can_edit) {
 					input_action = INPUT_SELECT;
 					last_selection = selection;


### PR DESCRIPTION
fix #52608 which also makes "paste selects" option useful again.

The idea of the fix is to block the propagation of the click once the Gridmap has consumed it. 
