### PR TITLE
Fix resolve class inheritance after file rename

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -155,15 +155,7 @@ void GDScriptCache::move_script(const String &p_from, const String &p_to) {
 		return;
 	}
 
-	if (singleton->parser_map.has(p_from) && !p_from.is_empty()) {
-		singleton->parser_map[p_to] = singleton->parser_map[p_from];
-	}
-	singleton->parser_map.erase(p_from);
-
-	if (singleton->parser_inverse_dependencies.has(p_from) && !p_from.is_empty()) {
-		singleton->parser_inverse_dependencies[p_to] = singleton->parser_inverse_dependencies[p_from];
-	}
-	singleton->parser_inverse_dependencies.erase(p_from);
+	remove_parser(p_from);
 
 	if (singleton->shallow_gdscript_cache.has(p_from) && !p_from.is_empty()) {
 		singleton->shallow_gdscript_cache[p_to] = singleton->shallow_gdscript_cache[p_from];


### PR DESCRIPTION
- Fixes #95266

This PR should fix an issue where some paths in the GDScriptCache are not updated when scripts are moved.

I'm really not familiar with GDScriptCache so maybe my fix is too simple.

Note: I was able in some circumstances to reproduce the problem with the internal Script Editor.

The main problem was caused by a invalid path (not updated) when calling `p_class->get_datatype().script_path` in 
`GDScriptAnalyzer::ensure_cached_external_parser_for_class`. With an invalid path, it was impossible to find the parser when calling `find_cached_external_parser_for_class`.