### PR TITLE
Wayland: Avoid recreating input objects on capability change

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1263,23 +1263,25 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 
 	// Pointer handling.
 	if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
-		ss->cursor_surface = wl_compositor_create_surface(ss->registry->wl_compositor);
-		wl_surface_commit(ss->cursor_surface);
+		if (!ss->wl_pointer) {
+			ss->cursor_surface = wl_compositor_create_surface(ss->registry->wl_compositor);
+			wl_surface_commit(ss->cursor_surface);
 
-		ss->wl_pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(ss->wl_pointer, &wl_pointer_listener, ss);
+			ss->wl_pointer = wl_seat_get_pointer(wl_seat);
+			wl_pointer_add_listener(ss->wl_pointer, &wl_pointer_listener, ss);
 
-		if (ss->registry->wp_relative_pointer_manager) {
-			ss->wp_relative_pointer = zwp_relative_pointer_manager_v1_get_relative_pointer(ss->registry->wp_relative_pointer_manager, ss->wl_pointer);
-			zwp_relative_pointer_v1_add_listener(ss->wp_relative_pointer, &wp_relative_pointer_listener, ss);
+			if (ss->registry->wp_relative_pointer_manager) {
+				ss->wp_relative_pointer = zwp_relative_pointer_manager_v1_get_relative_pointer(ss->registry->wp_relative_pointer_manager, ss->wl_pointer);
+				zwp_relative_pointer_v1_add_listener(ss->wp_relative_pointer, &wp_relative_pointer_listener, ss);
+			}
+
+			if (ss->registry->wp_pointer_gestures) {
+				ss->wp_pointer_gesture_pinch = zwp_pointer_gestures_v1_get_pinch_gesture(ss->registry->wp_pointer_gestures, ss->wl_pointer);
+				zwp_pointer_gesture_pinch_v1_add_listener(ss->wp_pointer_gesture_pinch, &wp_pointer_gesture_pinch_listener, ss);
+			}
+
+			// TODO: Constrain new pointers if the global mouse mode is constrained.
 		}
-
-		if (ss->registry->wp_pointer_gestures) {
-			ss->wp_pointer_gesture_pinch = zwp_pointer_gestures_v1_get_pinch_gesture(ss->registry->wp_pointer_gestures, ss->wl_pointer);
-			zwp_pointer_gesture_pinch_v1_add_listener(ss->wp_pointer_gesture_pinch, &wp_pointer_gesture_pinch_listener, ss);
-		}
-
-		// TODO: Constrain new pointers if the global mouse mode is constrained.
 	} else {
 		if (ss->cursor_frame_callback) {
 			// Just in case. I got bitten by weird race-like conditions already.
@@ -1317,11 +1319,13 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 
 	// Keyboard handling.
 	if (capabilities & WL_SEAT_CAPABILITY_KEYBOARD) {
-		ss->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-		ERR_FAIL_NULL(ss->xkb_context);
+		if (!ss->wl_keyboard) {
+			ss->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+			ERR_FAIL_NULL(ss->xkb_context);
 
-		ss->wl_keyboard = wl_seat_get_keyboard(wl_seat);
-		wl_keyboard_add_listener(ss->wl_keyboard, &wl_keyboard_listener, ss);
+			ss->wl_keyboard = wl_seat_get_keyboard(wl_seat);
+			wl_keyboard_add_listener(ss->wl_keyboard, &wl_keyboard_listener, ss);
+		}
 	} else {
 		if (ss->xkb_context) {
 			xkb_context_unref(ss->xkb_context);


### PR DESCRIPTION
Fixes #95144.

Before, multiple capability events would instantiate the same object over and over as long as its bit was set. This caused issues with hotplug and device suspension.