### PR TITLE
Fix Lock and Group for canvas items not updated in editor after changed in SceneTree

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4063,6 +4063,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			_update_lock_and_group_button();
 
+			SceneTreeDock::get_singleton()->get_tree_editor()->connect("node_changed", callable_mp(this, &CanvasItemEditor::_update_lock_and_group_button));
 			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CanvasItemEditor::_project_settings_changed));
 		} break;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95332

Before:

[Screencast_20240809_153144.webm](https://github.com/user-attachments/assets/5323efa5-444d-4fce-bb5c-493025710800)

After:

[Screencast_20240809_153339.webm](https://github.com/user-attachments/assets/d6753cc3-2994-47c8-a3c7-57a9619e3fec)
