### PR TITLE
Fix documentation of `EditorImportPlugin._Import`

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -98,18 +98,18 @@
 		        };
 		    }
 
-		    public override int _Import(string sourceFile, string savePath, Godot.Collections.Dictionary options, Godot.Collections.Array&lt;string&gt; platformVariants, Godot.Collections.Array&lt;string&gt; genFiles)
+		    public override Error _Import(string sourceFile, string savePath, Godot.Collections.Dictionary options, Godot.Collections.Array&lt;string&gt; platformVariants, Godot.Collections.Array&lt;string&gt; genFiles)
 		    {
 		        using var file = FileAccess.Open(sourceFile, FileAccess.ModeFlags.Read);
 		        if (file.GetError() != Error.Ok)
 		        {
-		            return (int)Error.Failed;
+		            return Error.Failed;
 		        }
 
 		        var mesh = new ArrayMesh();
 		        // Fill the Mesh with data read in "file", left as an exercise to the reader.
 		        string filename = $"{savePath}.{_GetSaveExtension()}";
-		        return (int)ResourceSaver.Save(mesh, filename);
+		        return ResourceSaver.Save(mesh, filename);
 		    }
 		}
 		[/csharp]


### PR DESCRIPTION
The following is the currently generated `EditorImportPlugin.cs`:

```csharp
    public virtual Error _Import(string sourceFile, string savePath, Dictionary options, Array<string> platformVariants, Array<string> genFiles)
    {
        return Error.Ok;
    }
```

This fixes the type signature in the documentation's example to match the actual type signature.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
