### PR TITLE
Fix polygon drawing for transposed tiles in `TileSet` editor

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -372,7 +372,7 @@ void TileAtlasView::_draw_base_tiles_shape_grid() {
 	for (int i = 0; i < tile_set_atlas_source->get_tiles_count(); i++) {
 		Vector2i tile_id = tile_set_atlas_source->get_tile_id(i);
 		Vector2 in_tile_base_offset = tile_set_atlas_source->get_tile_data(tile_id, 0)->get_texture_origin();
-		if (tile_set_atlas_source->is_position_in_tile_texture_region(tile_id, 0, -tile_shape_size / 2) && tile_set_atlas_source->is_position_in_tile_texture_region(tile_id, 0, tile_shape_size / 2 - Vector2(1, 1))) {
+		if (tile_set_atlas_source->is_rect_in_tile_texture_region(tile_id, 0, Rect2(Vector2(-tile_shape_size) / 2, tile_shape_size))) {
 			for (int frame = 0; frame < tile_set_atlas_source->get_tile_animation_frames_count(tile_id); frame++) {
 				Color color = grid_color;
 				if (frame > 0) {

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -165,10 +165,14 @@ void GenericTilePolygonEditor::_base_control_draw() {
 	base_control->draw_set_transform_matrix(xform);
 
 	// Draw fill rect under texture region.
-	Rect2 texture_rect(-background_region.size / 2, background_region.size);
+	Rect2 texture_rect(Vector2(), background_region.size);
 	if (tile_data) {
 		texture_rect.position -= tile_data->get_texture_origin();
+		if (tile_data->get_transpose()) {
+			texture_rect.size = Size2(texture_rect.size.y, texture_rect.size.x);
+		}
 	}
+	texture_rect.position -= texture_rect.size / 2; // Half-size offset must be applied after transposing.
 	base_control->draw_rect(texture_rect, Color(1, 1, 1, 0.3));
 
 	// Draw the background.
@@ -180,18 +184,14 @@ void GenericTilePolygonEditor::_base_control_draw() {
 		if (tile_data->get_flip_v()) {
 			region_size.y = -region_size.y;
 		}
-		base_control->draw_texture_rect_region(background_atlas_source->get_texture(), Rect2(-background_region.size / 2 - tile_data->get_texture_origin(), region_size), background_region, tile_data->get_modulate(), tile_data->get_transpose());
+		// Destination rect position must account for transposing, size must not.
+		base_control->draw_texture_rect_region(background_atlas_source->get_texture(), Rect2(texture_rect.position, region_size), background_region, tile_data->get_modulate(), tile_data->get_transpose());
 	}
 
 	// Compute and draw the grid area.
 	Rect2 grid_area = Rect2(-base_tile_size / 2, base_tile_size);
-	if (tile_data) {
-		grid_area.expand_to(-background_region.get_size() / 2 - tile_data->get_texture_origin());
-		grid_area.expand_to(background_region.get_size() / 2 - tile_data->get_texture_origin());
-	} else {
-		grid_area.expand_to(-background_region.get_size() / 2);
-		grid_area.expand_to(background_region.get_size() / 2);
-	}
+	grid_area.expand_to(texture_rect.position);
+	grid_area.expand_to(texture_rect.get_end());
 	base_control->draw_rect(grid_area, Color(1, 1, 1, 0.3), false);
 
 	// Draw grid.

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1385,10 +1385,8 @@ void TileDataTextureOriginEditor::draw_over_tile(CanvasItem *p_canvas_item, Tran
 
 	TileSetSource *source = *(tile_set->get_source(p_cell.source_id));
 	TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
-	if (atlas_source->is_position_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, -tile_set_tile_size / 2) && atlas_source->is_position_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, tile_set_tile_size / 2 - Vector2(1, 1))) {
-		Transform2D tile_xform;
-		tile_xform.set_scale(tile_set_tile_size);
-		tile_set->draw_tile_shape(p_canvas_item, p_transform * tile_xform, color);
+	if (atlas_source->is_rect_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, Rect2(Vector2(-tile_set_tile_size) / 2, tile_set_tile_size))) {
+		tile_set->draw_tile_shape(p_canvas_item, p_transform.scaled_local(tile_set_tile_size), color);
 	}
 
 	if (atlas_source->is_position_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, Vector2())) {

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -5275,9 +5275,24 @@ Rect2i TileSetAtlasSource::get_tile_texture_region(Vector2i p_atlas_coords, int 
 
 bool TileSetAtlasSource::is_position_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Vector2 p_position) const {
 	Size2 size = get_tile_texture_region(p_atlas_coords).size;
-	Rect2 rect = Rect2(-size / 2 - get_tile_data(p_atlas_coords, p_alternative_tile)->get_texture_origin(), size);
+	TileData *tile_data = get_tile_data(p_atlas_coords, p_alternative_tile);
+	if (tile_data->get_transpose()) {
+		size = Size2(size.y, size.x);
+	}
+	Rect2 rect = Rect2(-size / 2 - tile_data->get_texture_origin(), size);
 
 	return rect.has_point(p_position);
+}
+
+bool TileSetAtlasSource::is_rect_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Rect2 p_rect) const {
+	Size2 size = get_tile_texture_region(p_atlas_coords).size;
+	TileData *tile_data = get_tile_data(p_atlas_coords, p_alternative_tile);
+	if (tile_data->get_transpose()) {
+		size = Size2(size.y, size.x);
+	}
+	Rect2 rect = Rect2(-size / 2 - tile_data->get_texture_origin(), size);
+
+	return p_rect.intersection(rect) == p_rect;
 }
 
 int TileSetAtlasSource::alternative_no_transform(int p_alternative_id) {

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -763,6 +763,7 @@ public:
 	Vector2i get_atlas_grid_size() const;
 	Rect2i get_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
 	bool is_position_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Vector2 p_position) const;
+	bool is_rect_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Rect2 p_rect) const;
 
 	static int alternative_no_transform(int p_alternative_id);
 


### PR DESCRIPTION
Fixes #73517, both issues mentioned in there:

_(used [2D platformer demo from `4.1` branch](https://github.com/godotengine/godot-demo-projects/tree/157b432c80a01749e4e387c9f06aec4e957e37e2/2d/platformer) for testing)_

- Drawing within TileAtlasView indicators for tile shape / texture origin. Checking whether they're in bounds was broken for odd size tile (glorious rect's integer half-size + checking points at the bottom/right edges) / transposed alternative tiles.

<a>|Before<br>(v4.3.rc3.official [03afb92ef])|After<br>(this PR)
-|-|-
![Godot_v4 3-rc3_win64_LO3WOdw3l9](https://github.com/user-attachments/assets/bfb3c35a-8a7a-43d2-83a2-be8549db1d1b)|![Godot_v4 3-rc3_win64_eDDUeveAF8](https://github.com/user-attachments/assets/6348fca9-98da-44dd-bfe8-a3df0947cda3)|![godot windows editor dev x86_64_Gk7kZ7vpB0](https://github.com/user-attachments/assets/b5a075e9-2b0a-4661-ba2b-e7076a2a881d)
![Godot_v4 3-rc3_win64_FqF50lNjgK](https://github.com/user-attachments/assets/7744fd22-11b0-4caa-86cc-4fac7cdad00f)|![OIMNZnSa0x](https://github.com/user-attachments/assets/e4b013a1-772d-4e72-9689-aa06bc648bc0)|![fX79kvAyHx](https://github.com/user-attachments/assets/f1e47a6a-90e9-4cb6-81c1-b8a604da0c49)


- Drawing in GenericTilePolygonEditor when editing a transposed alternative tile.

Before<br>(v4.3.rc3.official [03afb92ef])|After<br>(this PR)
-|-
![9p81eDEHq4](https://github.com/user-attachments/assets/c002c51f-e12e-4726-bbe7-a78a8b128e47)<br>![Godot_v4 3-rc3_win64_BqmwxxXuri](https://github.com/user-attachments/assets/5bb16e9d-6405-4846-9055-e8cb6844e304)|![godot windows editor dev x86_64_jZ9sXXvIuR](https://github.com/user-attachments/assets/542cc0cd-a262-4367-8119-674f43c7ce1a)<br>![godot windows editor dev x86_64_YJkKMG0JJ5](https://github.com/user-attachments/assets/02965ab0-512f-48f5-bc0b-e0baa98d3b9d)
![Godot_v4 3-rc3_win64_PxseEZiY6A](https://github.com/user-attachments/assets/87168c24-5e52-4731-991e-16ab1461d864)<br>![RuMezYNbr7](https://github.com/user-attachments/assets/79fb9e9f-7e61-4f60-9e62-b36b008ebcf3)|![godot windows editor dev x86_64_EYvHYXhAtt](https://github.com/user-attachments/assets/158c72d9-e221-4701-a201-b9cc2b2c2837)<br>![xFHswSbDpj](https://github.com/user-attachments/assets/cdb3caa7-aab4-413a-a9e3-dbcb981a8dec)

2D editor and runtime look all the same before/after.
![1bi8eJalAB](https://github.com/user-attachments/assets/b7384614-f1f3-4e01-832e-e7932d5fcf91)|![49eySUdfer](https://github.com/user-attachments/assets/2e811e4b-4aa1-4a62-a070-f871e53e3810)
-|-

