### PR TITLE
Make sure not to generate the compile_commands.json when not asked

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1011,11 +1011,12 @@ if env["vsproj"]:
     env.vs_incs = []
     env.vs_srcs = []
 
-if env["compiledb"] and env.scons_version < (4, 0, 0):
-    # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-    print_error("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
-    Exit(255)
-if env.scons_version >= (4, 0, 0):
+if env["compiledb"]:
+    if env.scons_version < (4, 0, 0):
+        # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
+        print_error("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
+        Exit(255)
+
     env.Tool("compilation_db")
     env.Alias("compiledb", env.CompilationDatabase())
 


### PR DESCRIPTION
Did not create an issue for this, as the fix is pretty simple.

Scons seems to always generate the `compile_commands.json`, regardless of whether the flag `compiledb` is set or not, and even with an explicit `compiledb=no`.

There are a whopping 3-4 seconds out of 6-10 seconds of build time saved on my machine when I don't need to recreate that file, which is pretty nice when iterating fast on small changes.