### PR TITLE
Fix check in `Object._ValidateProperty` example

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -341,7 +341,7 @@
 
 				    public override void _ValidateProperty(Godot.Collections.Dictionary property)
 				    {
-				        if (property["name"].AsStringName() == PropertyName.Number &amp;&amp; IsNumberEditable)
+				        if (property["name"].AsStringName() == PropertyName.Number &amp;&amp; !IsNumberEditable)
 				        {
 				            var usage = property["usage"].As&lt;PropertyUsageFlags&gt;() | PropertyUsageFlags.ReadOnly;
 				            property["usage"] = (int)usage;


### PR DESCRIPTION
The GDScript version above makes the `number` property read only whenever `is_number_editable` is false.

```gdscript
func _validate_property(property: Dictionary):
	if property.name == "number" and not is_number_editable:
		property.usage |= PROPERTY_USAGE_READ_ONLY
```

The C# version is similar, but omits the negation, so the Number property is made read only whenever `is_number_editable` is true.

This adds the negation to the C# example, making it match the GDScript example.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
