### PR TITLE
Add ConfirmationDialog when clicking on % button in SceneTree

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -174,13 +174,38 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		EditorDockManager::get_singleton()->focus_dock(NodeDock::get_singleton());
 		NodeDock::get_singleton()->show_groups();
 	} else if (p_id == BUTTON_UNIQUE) {
-		undo_redo->create_action(TTR("Disable Scene Unique Name"));
-		undo_redo->add_do_method(n, "set_unique_name_in_owner", false);
-		undo_redo->add_undo_method(n, "set_unique_name_in_owner", true);
-		undo_redo->add_do_method(this, "_update_tree");
-		undo_redo->add_undo_method(this, "_update_tree");
-		undo_redo->commit_action();
+		bool ask_before_revoking_unique_name = EDITOR_GET("docks/scene_tree/ask_before_revoking_unique_name");
+		revoke_node = n;
+		if (ask_before_revoking_unique_name) {
+			String msg = vformat(TTR("Revoke unique name for node \"%s\"?"), n->get_name());
+			ask_before_revoke_checkbox->set_pressed(false);
+			revoke_dialog_label->set_text(msg);
+			revoke_dialog->reset_size();
+			revoke_dialog->popup_centered();
+		} else {
+			_revoke_unique_name();
+		}
 	}
+}
+
+void SceneTreeEditor::_update_ask_before_revoking_unique_name() {
+	if (ask_before_revoke_checkbox->is_pressed()) {
+		EditorSettings::get_singleton()->set("docks/scene_tree/ask_before_revoking_unique_name", false);
+		ask_before_revoke_checkbox->set_pressed(false);
+	}
+
+	_revoke_unique_name();
+}
+
+void SceneTreeEditor::_revoke_unique_name() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	undo_redo->create_action(TTR("Disable Scene Unique Name"));
+	undo_redo->add_do_method(revoke_node, "set_unique_name_in_owner", false);
+	undo_redo->add_undo_method(revoke_node, "set_unique_name_in_owner", true);
+	undo_redo->add_do_method(this, "_update_tree");
+	undo_redo->add_undo_method(this, "_update_tree");
+	undo_redo->commit_action();
 }
 
 void SceneTreeEditor::_toggle_visible(Node *p_node) {
@@ -1601,6 +1626,18 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	update_node_tooltip_delay->set_wait_time(0.5);
 	update_node_tooltip_delay->set_one_shot(true);
 	add_child(update_node_tooltip_delay);
+
+	revoke_dialog = memnew(ConfirmationDialog);
+	revoke_dialog->set_ok_button_text(TTR("Revoke"));
+	add_child(revoke_dialog);
+	revoke_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SceneTreeEditor::_update_ask_before_revoking_unique_name));
+	VBoxContainer *vb = memnew(VBoxContainer);
+	revoke_dialog->add_child(vb);
+	revoke_dialog_label = memnew(Label);
+	vb->add_child(revoke_dialog_label);
+	ask_before_revoke_checkbox = memnew(CheckBox(TTR("Don't Ask Again")));
+	ask_before_revoke_checkbox->set_tooltip_text(TTR("This dialog can also be enabled/disabled in the Editor Settings: Docks > Scene Tree > Ask Before Revoking Unique Name."));
+	vb->add_child(ask_before_revoke_checkbox);
 
 	script_types = memnew(List<StringName>);
 	ClassDB::get_inheriters_from_class("Script", script_types);

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -31,6 +31,7 @@
 #ifndef SCENE_TREE_EDITOR_H
 #define SCENE_TREE_EDITOR_H
 
+#include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
@@ -67,6 +68,11 @@ class SceneTreeEditor : public Control {
 
 	AcceptDialog *error = nullptr;
 	AcceptDialog *warning = nullptr;
+
+	ConfirmationDialog *revoke_dialog = nullptr;
+	Label *revoke_dialog_label = nullptr;
+	CheckBox *ask_before_revoke_checkbox = nullptr;
+	Node *revoke_node = nullptr;
 
 	bool auto_expand_selected = true;
 	bool connect_to_script_mode = false;
@@ -143,6 +149,9 @@ class SceneTreeEditor : public Control {
 	bool _is_script_type(const StringName &p_type) const;
 
 	Vector<StringName> valid_types;
+
+	void _update_ask_before_revoking_unique_name();
+	void _revoke_unique_name();
 
 public:
 	// Public for use with callable_mp.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4619,6 +4619,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	EDITOR_DEF("interface/editors/show_scene_tree_root_selection", true);
 	EDITOR_DEF("interface/editors/derive_script_globals_by_name", true);
 	EDITOR_DEF("docks/scene_tree/ask_before_deleting_related_animation_tracks", true);
+	EDITOR_DEF("docks/scene_tree/ask_before_revoking_unique_name", true);
 	EDITOR_DEF("_use_favorites_root_selection", false);
 
 	Resource::_update_configuration_warning = _update_configuration_warning;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95315

First time trying to add a dialog with settings. Believe this should work okay.

![Screenshot_20240809_224816](https://github.com/user-attachments/assets/59d5f977-37a1-460e-9692-dc6d3d1c7ec1)

[Screencast_20240809_224842.webm](https://github.com/user-attachments/assets/8041b7b8-aae5-4d33-a42d-6102f0fe4232)
