### PR TITLE
Make editor panel icons more discreet

### DIFF
--- a/editor/icons/Panels1.svg
+++ b/editor/icons/Panels1.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0h16v16h-16z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12.002a2 2 0 0 0 2 2h12.002a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h12v10H2z"/></svg>

--- a/editor/icons/Panels2.svg
+++ b/editor/icons/Panels2.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0v7h16v-7zm0 9v7h16v-7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h12v4H2zm12 6v4H2v-4z"/></svg>

--- a/editor/icons/Panels2Alt.svg
+++ b/editor/icons/Panels2Alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0v16h7v-16zm9 0v16h7v-16z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h5v10H2zm7 0h5v10H9z"/></svg>

--- a/editor/icons/Panels3.svg
+++ b/editor/icons/Panels3.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0v7h16v-7zm0 9v7h7v-7zm9 0v7h7v-7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h12v4H2zm0 6h5v4H2zm7 0h5v4H9z"/></svg>

--- a/editor/icons/Panels3Alt.svg
+++ b/editor/icons/Panels3Alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0v7h7v-7zm9 0v16h7v-16zm-9 9v7h7v-7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h5v4H2zm7 0h5v10H9zm-7 6h5v4H2z"/></svg>

--- a/editor/icons/Panels4.svg
+++ b/editor/icons/Panels4.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m0 0v7h7v-7zm9 0v7h7v-7zm-9 9v7h7v-7zm9 0v7h7v-7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 4h5v4H2zm7 0h5v4H9zm-7 6h5v4H2zm7 0h5v4H9z"/></svg>


### PR DESCRIPTION
The Godot panel icons in the main editor window is very "shouty". In a dark theme, especially at 200% display scaling, it's a huge, bright and shiny, near white flashlight in your eyes.

Also, not knowing what it was, I actually initially thought the icon was missing or bugged, as it's just a white square!

![image](https://github.com/user-attachments/assets/4d26a6c6-0009-4108-8df6-18243d42216d)

This alternative uses a dialog/window symbol to achieve the same effect while using only outlines so as to take less attention.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
