### PR TITLE
Clarify usage of CompositorEffect as an abstract base class

### DIFF
--- a/doc/classes/CompositorEffect.xml
+++ b/doc/classes/CompositorEffect.xml
@@ -4,7 +4,7 @@
 		This resource allows for creating a custom rendering effect.
 	</brief_description>
 	<description>
-		This resource defines a custom rendering effect that can be applied to [Viewport]s through the viewports' [Environment]. You can implement a callback that is called during rendering at a given stage of the rendering pipeline and allows you to insert additional passes. Note that this callback happens on the rendering thread.
+		This resource defines a custom rendering effect that can be applied to [Viewport]s through the viewports' [Environment]. You can implement a callback that is called during rendering at a given stage of the rendering pipeline and allows you to insert additional passes. Note that this callback happens on the rendering thread. CompositorEffect is an abstract base class and must be extended to implement specific rendering logic.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The `CompositorEffect` documentation now explicitly states that it is an abstract
base class that must be extended to implement custom rendering logic. This clarification
addresses potential confusion for users attempting to directly instantiate the resource
without realizing it requires extension.

Fixes #89030
