### PR TITLE
Create RangeInt and EditorSpinSliderInt, int64_t versions of Range and EditorSpinSlider.

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -396,24 +396,24 @@ public:                                                             \
                                                                     \
 private:
 
-#define GDCLASS(m_class, m_inherits)                                                                                                             \
+#define GDCLASS_TEMPLATE(m_class, m_class_str, m_inherits, m_inherits_str, disable_token)                                                        \
 private:                                                                                                                                         \
 	void operator=(const m_class &p_rval) {}                                                                                                     \
 	friend class ::ClassDB;                                                                                                                      \
                                                                                                                                                  \
 public:                                                                                                                                          \
 	typedef m_class self_type;                                                                                                                   \
-	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##m_class)) && m_inherits::_class_is_enabled;                  \
+	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##disable_token)) && m_inherits::_class_is_enabled;            \
 	virtual String get_class() const override {                                                                                                  \
 		if (_get_extension()) {                                                                                                                  \
 			return _get_extension()->class_name.operator String();                                                                               \
 		}                                                                                                                                        \
-		return String(#m_class);                                                                                                                 \
+		return String(m_class_str);                                                                                                              \
 	}                                                                                                                                            \
 	virtual const StringName *_get_class_namev() const override {                                                                                \
 		static StringName _class_name_static;                                                                                                    \
 		if (unlikely(!_class_name_static)) {                                                                                                     \
-			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                          \
+			StringName::assign_static_unique_class_name(&_class_name_static, m_class_str);                                                       \
 		}                                                                                                                                        \
 		return &_class_name_static;                                                                                                              \
 	}                                                                                                                                            \
@@ -422,20 +422,20 @@ public:                                                                         
 		return &ptr;                                                                                                                             \
 	}                                                                                                                                            \
 	static _FORCE_INLINE_ String get_class_static() {                                                                                            \
-		return String(#m_class);                                                                                                                 \
+		return String(m_class_str);                                                                                                              \
 	}                                                                                                                                            \
 	static _FORCE_INLINE_ String get_parent_class_static() {                                                                                     \
 		return m_inherits::get_class_static();                                                                                                   \
 	}                                                                                                                                            \
 	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                                  \
 		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                             \
-		p_inheritance_list->push_back(String(#m_class));                                                                                         \
+		p_inheritance_list->push_back(String(m_class_str));                                                                                      \
 	}                                                                                                                                            \
 	virtual bool is_class(const String &p_class) const override {                                                                                \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                           \
 			return true;                                                                                                                         \
 		}                                                                                                                                        \
-		return (p_class == (#m_class)) ? true : m_inherits::is_class(p_class);                                                                   \
+		return (p_class == (m_class_str)) ? true : m_inherits::is_class(p_class);                                                                \
 	}                                                                                                                                            \
 	virtual bool is_class_ptr(void *p_ptr) const override { return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr); } \
                                                                                                                                                  \
@@ -508,13 +508,13 @@ protected:                                                                      
 		}                                                                                                                                        \
 		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY));      \
 		if (!_is_gpl_reversed()) {                                                                                                               \
-			::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                          \
+			::ClassDB::get_property_list(m_class_str, p_list, true, this);                                                                       \
 		}                                                                                                                                        \
 		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                         \
 			_get_property_list(p_list);                                                                                                          \
 		}                                                                                                                                        \
 		if (_is_gpl_reversed()) {                                                                                                                \
-			::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                          \
+			::ClassDB::get_property_list(m_class_str, p_list, true, this);                                                                       \
 		}                                                                                                                                        \
 		if (p_reversed) {                                                                                                                        \
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \
@@ -567,6 +567,8 @@ protected:                                                                      
 	}                                                                                                                                            \
                                                                                                                                                  \
 private:
+
+#define GDCLASS(m_class, m_inherits) GDCLASS_TEMPLATE(m_class, #m_class, m_inherits, #m_inherits, m_class)
 
 #define OBJ_SAVE_TYPE(m_class)                                          \
 public:                                                                 \

--- a/doc/classes/EditorSpinSliderInt.xml
+++ b/doc/classes/EditorSpinSliderInt.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorSpinSliderInt" inherits="RangeInt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Godot editor's control for editing integer values.
+	</brief_description>
+	<description>
+		This [Control] node is an integer-only version of [EditorSpinSlider] which doesn't lose precision when working with very large integers.
+		It's used in the editor's Inspector dock to allow editing of integer values. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
+		If the [member RangeInt.step] value is [code]1[/code], the [EditorSpinSliderInt] will display up/down arrows, similar to [SpinBox]. If the [member RangeInt.step] value is not [code]1[/code], a slider will be displayed instead.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
+			If [code]true[/code], the slider will not draw background.
+		</member>
+		<member name="hide_slider" type="bool" setter="set_hide_slider" getter="is_hiding_slider" default="false">
+			If [code]true[/code], the slider and up/down arrows are hidden.
+		</member>
+		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
+			The text that displays to the left of the value.
+		</member>
+		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false" keywords="enabled, disabled, editable">
+			If [code]true[/code], the slider can't be interacted with.
+		</member>
+		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
+			The suffix to display after the value (in a faded color). This should generally be a plural word. You may have to use an abbreviation if the suffix is too long to be displayed.
+		</member>
+	</members>
+	<signals>
+		<signal name="grabbed">
+			<description>
+				Emitted when the spinner/slider is grabbed.
+			</description>
+		</signal>
+		<signal name="ungrabbed">
+			<description>
+				Emitted when the spinner/slider is ungrabbed.
+			</description>
+		</signal>
+		<signal name="value_focus_entered">
+			<description>
+				Emitted when the value form gains focus.
+			</description>
+		</signal>
+		<signal name="value_focus_exited">
+			<description>
+				Emitted when the value form loses focus.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/RangeInt.xml
+++ b/doc/classes/RangeInt.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RangeInt" inherits="Control" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Abstract base class for controls that represent integers within a range.
+	</brief_description>
+	<description>
+		RangeInt is an integer-only version of [Range] which doesn't lose precision when working with very large integers.
+		It's an abstract base class for controls that represent a integer within a range, using a configured [member step] and [member page] size.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_value_changed" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="new_value" type="int" />
+			<description>
+				Called when the [RangeInt]'s value is changed (following the same conditions as [signal value_changed]).
+			</description>
+		</method>
+		<method name="set_value_no_signal">
+			<return type="void" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Sets the [RangeInt]'s current value to the specified [param value], without emitting the [signal value_changed] signal.
+			</description>
+		</method>
+		<method name="share">
+			<return type="void" />
+			<param index="0" name="with" type="Node" />
+			<description>
+				Binds two [RangeInt]s together along with any ranges previously grouped with either of them. When any of range's member variables change, it will share the new value with all other ranges in its group.
+			</description>
+		</method>
+		<method name="unshare">
+			<return type="void" />
+			<description>
+				Stops the [RangeInt] from sharing its member variables with any other.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="allow_greater" type="bool" setter="set_allow_greater" getter="is_greater_allowed" default="false">
+			If [code]true[/code], [member value] may be greater than [member max_value].
+		</member>
+		<member name="allow_lesser" type="bool" setter="set_allow_lesser" getter="is_lesser_allowed" default="false">
+			If [code]true[/code], [member value] may be less than [member min_value].
+		</member>
+		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp" default="false">
+			If [code]true[/code], and [member min_value] is greater than 0, [member value] will be represented exponentially rather than linearly.
+		</member>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="max_value" type="int" setter="set_max" getter="get_max" default="100">
+			Maximum value. RangeInt is clamped if [member value] is greater than [member max_value].
+		</member>
+		<member name="min_value" type="int" setter="set_min" getter="get_min" default="0">
+			Minimum value. RangeInt is clamped if [member value] is less than [member min_value].
+		</member>
+		<member name="page" type="int" setter="set_page" getter="get_page" default="0">
+			Page size. Used mainly for [ScrollBar]. ScrollBar's length is its size multiplied by [member page] over the difference between [member min_value] and [member max_value].
+		</member>
+		<member name="ratio" type="float" setter="set_as_ratio" getter="get_as_ratio">
+			The value mapped between 0 and 1.
+		</member>
+		<member name="step" type="int" setter="set_step" getter="get_step" default="1">
+			If greater than 0, [member value] will always be rounded to a multiple of this property's value.
+		</member>
+		<member name="value" type="int" setter="set_value" getter="get_value" default="0">
+			RangeInt's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.
+		</member>
+	</members>
+	<signals>
+		<signal name="changed">
+			<description>
+				Emitted when [member min_value], [member max_value], [member page], or [member step] change.
+			</description>
+		</signal>
+		<signal name="value_changed">
+			<param index="0" name="value" type="float" />
+			<description>
+				Emitted when [member value] changes. When used on a [Slider], this is called continuously while dragging (potentially every frame). If you are performing an expensive operation in a function connected to [signal value_changed], consider using a [i]debouncing[/i] [Timer] to call the function less often.
+				[b]Note:[/b] Unlike signals such as [signal LineEdit.text_changed], [signal value_changed] is also emitted when [param value] is set directly via code.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_data.h"
 #include "editor/editor_properties.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/property_selector.h"
 #include "scene/3d/node_3d.h"
 #include "scene/gui/control.h"
@@ -44,7 +45,6 @@
 class AnimationTrackEditor;
 class AnimationTrackEdit;
 class CheckBox;
-class EditorSpinSlider;
 class HSlider;
 class OptionButton;
 class PanelContainer;

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1322,12 +1322,6 @@ void EditorPropertyInteger::_value_changed(int64_t val) {
 void EditorPropertyInteger::update_property() {
 	int64_t val = get_edited_property_value();
 	spin->set_value_no_signal(val);
-#ifdef DEBUG_ENABLED
-	// If spin (currently EditorSplinSlider : Range) is changed so that it can use int64_t, then the below warning wouldn't be a problem.
-	if (val != (int64_t)(double)(val)) {
-		WARN_PRINT("Cannot reliably represent '" + itos(val) + "' in the inspector, value is too large.");
-	}
-#endif
 }
 
 void EditorPropertyInteger::_bind_methods() {
@@ -1344,7 +1338,7 @@ void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, 
 }
 
 EditorPropertyInteger::EditorPropertyInteger() {
-	spin = memnew(EditorSpinSlider);
+	spin = memnew(EditorSpinSliderInt);
 	spin->set_flat(true);
 	add_child(spin);
 	add_focusable(spin);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -32,6 +32,7 @@
 #define EDITOR_PROPERTIES_H
 
 #include "editor/editor_inspector.h"
+#include "editor/gui/editor_spin_slider.h"
 
 class CheckBox;
 class ColorPickerButton;
@@ -39,7 +40,6 @@ class CreateDialog;
 class EditorFileDialog;
 class EditorLocaleDialog;
 class EditorResourcePicker;
-class EditorSpinSlider;
 class MenuButton;
 class PropertySelector;
 class SceneTreeDialog;
@@ -339,7 +339,7 @@ public:
 
 class EditorPropertyInteger : public EditorProperty {
 	GDCLASS(EditorPropertyInteger, EditorProperty);
-	EditorSpinSlider *spin = nullptr;
+	EditorSpinSliderInt *spin = nullptr;
 	void _value_changed(int64_t p_val);
 
 protected:

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -34,9 +34,9 @@
 #include "editor/editor_inspector.h"
 #include "editor/editor_locale_dialog.h"
 #include "editor/filesystem_dock.h"
+#include "editor/gui/editor_spin_slider.h"
 
 class Button;
-class EditorSpinSlider;
 class MarginContainer;
 
 class EditorPropertyArrayObject : public RefCounted {

--- a/editor/editor_properties_vector.h
+++ b/editor/editor_properties_vector.h
@@ -32,8 +32,8 @@
 #define EDITOR_PROPERTIES_VECTOR_H
 
 #include "editor/editor_inspector.h"
+#include "editor/gui/editor_spin_slider.h"
 
-class EditorSpinSlider;
 class TextureButton;
 
 class EditorPropertyVectorN : public EditorProperty {

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -35,8 +35,16 @@
 #include "scene/gui/range.h"
 #include "scene/gui/texture_rect.h"
 
-class EditorSpinSlider : public Range {
-	GDCLASS(EditorSpinSlider, Range);
+// clang-format off
+#define ESS_CLASS_MAP \
+	std::is_same_v<T, double> ? "EditorSpinSlider" : \
+	std::is_same_v<T, int64_t> ? "EditorSpinSliderInt" : \
+	"EditorSpinSliderInvalid"
+// clang-format on
+
+template <typename T>
+class EditorSpinSliderTemplate : public RangeTemplate<T> {
+	GDCLASS_TEMPLATE(EditorSpinSliderTemplate<T>, ESS_CLASS_MAP, RangeTemplate<T>, RANGE_CLASS_MAP, EditorSpinSliderTemplate)
 
 	String label;
 	String suffix;
@@ -62,7 +70,7 @@ class EditorSpinSlider : public Range {
 	float grabbing_spinner_dist_cache = 0.0f;
 	float grabbing_spinner_speed = 0.0f;
 	Vector2 grabbing_spinner_mouse_pos;
-	double pre_grab_value = 0.0;
+	T pre_grab_value = 0;
 
 	Control *value_input_popup = nullptr;
 	LineEdit *value_input = nullptr;
@@ -122,7 +130,10 @@ public:
 	LineEdit *get_line_edit();
 
 	virtual Size2 get_minimum_size() const override;
-	EditorSpinSlider();
+	EditorSpinSliderTemplate();
 };
+
+using EditorSpinSlider = EditorSpinSliderTemplate<double>;
+using EditorSpinSliderInt = EditorSpinSliderTemplate<int64_t>;
 
 #endif // EDITOR_SPIN_SLIDER_H

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -33,10 +33,10 @@
 
 #include "editor/editor_inspector.h"
 #include "editor/editor_resource_preview.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/resources/curve.h"
 
-class EditorSpinSlider;
 class MenuButton;
 class PopupMenu;
 

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -32,9 +32,9 @@
 #define GRADIENT_EDITOR_PLUGIN_H
 
 #include "editor/editor_inspector.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 
-class EditorSpinSlider;
 class ColorPicker;
 class PopupPanel;
 class GradientTexture1D;

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -32,10 +32,10 @@
 #define GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H
 
 #include "editor/editor_inspector.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 
 class Button;
-class EditorSpinSlider;
 class GradientTexture2D;
 
 class GradientTexture2DEdit : public Control {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef NODE_3D_EDITOR_PLUGIN_H
 #define NODE_3D_EDITOR_PLUGIN_H
 
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "editor/themes/editor_scale.h"
@@ -45,7 +46,6 @@ class ConfirmationDialog;
 class DirectionalLight3D;
 class EditorData;
 class EditorSelection;
-class EditorSpinSlider;
 class HSplitContainer;
 class LineEdit;
 class MenuButton;

--- a/editor/plugins/particle_process_material_editor_plugin.h
+++ b/editor/plugins/particle_process_material_editor_plugin.h
@@ -32,13 +32,15 @@
 #define PARTICLE_PROCESS_MATERIAL_EDITOR_PLUGIN_H
 
 #include "editor/editor_properties.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 
 class Button;
-class EditorSpinSlider;
 class Label;
 class ParticleProcessMaterial;
-class Range;
+template <typename T>
+class RangeTemplate;
+using Range = RangeTemplate<double>;
 class VBoxContainer;
 
 class ParticleProcessMaterialMinMaxPropertyEditor : public EditorProperty {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -173,6 +173,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ScriptCreateDialog);
 	GDREGISTER_CLASS(EditorFeatureProfile);
 	GDREGISTER_CLASS(EditorSpinSlider);
+	GDREGISTER_CLASS(EditorSpinSliderInt);
 	GDREGISTER_CLASS(EditorResourcePicker);
 	GDREGISTER_CLASS(EditorScriptPicker);
 	GDREGISTER_ABSTRACT_CLASS(EditorUndoRedoManager);

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,7 +30,8 @@
 
 #include "range.h"
 
-PackedStringArray Range::get_configuration_warnings() const {
+template <typename T>
+PackedStringArray RangeTemplate<T>::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
 	if (shared->exp_ratio && shared->min <= 0) {
@@ -40,18 +41,21 @@ PackedStringArray Range::get_configuration_warnings() const {
 	return warnings;
 }
 
-void Range::_value_changed(double p_value) {
+template <typename T>
+void RangeTemplate<T>::_value_changed(T p_value) {
 	GDVIRTUAL_CALL(_value_changed, p_value);
 }
-void Range::_value_changed_notify() {
+template <typename T>
+void RangeTemplate<T>::_value_changed_notify() {
 	_value_changed(shared->val);
 	emit_signal(SceneStringName(value_changed), shared->val);
 	queue_redraw();
 }
 
-void Range::Shared::emit_value_changed() {
-	for (Range *E : owners) {
-		Range *r = E;
+template <typename T>
+void RangeTemplate<T>::Shared::emit_value_changed() {
+	for (RangeTemplate<T> *E : owners) {
+		RangeTemplate<T> *r = E;
 		if (!r->is_inside_tree()) {
 			continue;
 		}
@@ -59,14 +63,17 @@ void Range::Shared::emit_value_changed() {
 	}
 }
 
-void Range::_changed_notify(const char *p_what) {
+template <typename T>
+void RangeTemplate<T>::_changed_notify(const char *p_what) {
+	// TODO: Include what changed as an argument to the signal.
 	emit_signal(CoreStringName(changed));
 	queue_redraw();
 }
 
-void Range::Shared::emit_changed(const char *p_what) {
-	for (Range *E : owners) {
-		Range *r = E;
+template <typename T>
+void RangeTemplate<T>::Shared::emit_changed(const char *p_what) {
+	for (RangeTemplate<T> *E : owners) {
+		RangeTemplate<T> *r = E;
 		if (!r->is_inside_tree()) {
 			continue;
 		}
@@ -74,9 +81,10 @@ void Range::Shared::emit_changed(const char *p_what) {
 	}
 }
 
-void Range::Shared::redraw_owners() {
-	for (Range *E : owners) {
-		Range *r = E;
+template <typename T>
+void RangeTemplate<T>::Shared::redraw_owners() {
+	for (RangeTemplate<T> *E : owners) {
+		RangeTemplate<T> *r = E;
 		if (!r->is_inside_tree()) {
 			continue;
 		}
@@ -84,8 +92,9 @@ void Range::Shared::redraw_owners() {
 	}
 }
 
-void Range::set_value(double p_val) {
-	double prev_val = shared->val;
+template <typename T>
+void RangeTemplate<T>::set_value(T p_val) {
+	T prev_val = shared->val;
 	_set_value_no_signal(p_val);
 
 	if (shared->val != prev_val) {
@@ -93,7 +102,8 @@ void Range::set_value(double p_val) {
 	}
 }
 
-void Range::_set_value_no_signal(double p_val) {
+template <>
+void RangeTemplate<double>::_set_value_no_signal(double p_val) {
 	if (!Math::is_finite(p_val)) {
 		return;
 	}
@@ -121,8 +131,36 @@ void Range::_set_value_no_signal(double p_val) {
 	shared->val = p_val;
 }
 
-void Range::set_value_no_signal(double p_val) {
-	double prev_val = shared->val;
+template <>
+void RangeTemplate<int64_t>::_set_value_no_signal(int64_t p_val) {
+	if (shared->step > 1) {
+		int64_t to_lower = (p_val - shared->min) % shared->step;
+		int64_t to_higher = shared->step - to_lower;
+		if (to_lower <= to_higher) {
+			p_val -= to_lower;
+		} else {
+			p_val += to_higher;
+		}
+	}
+
+	if (!shared->allow_greater && p_val > shared->max - shared->page) {
+		p_val = shared->max - shared->page;
+	}
+
+	if (!shared->allow_lesser && p_val < shared->min) {
+		p_val = shared->min;
+	}
+
+	if (shared->val == p_val) {
+		return;
+	}
+
+	shared->val = p_val;
+}
+
+template <typename T>
+void RangeTemplate<T>::set_value_no_signal(T p_val) {
+	T prev_val = shared->val;
 	_set_value_no_signal(p_val);
 
 	if (shared->val != prev_val) {
@@ -130,14 +168,15 @@ void Range::set_value_no_signal(double p_val) {
 	}
 }
 
-void Range::set_min(double p_min) {
+template <typename T>
+void RangeTemplate<T>::set_min(T p_min) {
 	if (shared->min == p_min) {
 		return;
 	}
 
 	shared->min = p_min;
 	shared->max = MAX(shared->max, shared->min);
-	shared->page = CLAMP(shared->page, 0, shared->max - shared->min);
+	_set_page_no_value(shared->page);
 	set_value(shared->val);
 
 	shared->emit_changed("min");
@@ -145,20 +184,22 @@ void Range::set_min(double p_min) {
 	update_configuration_warnings();
 }
 
-void Range::set_max(double p_max) {
-	double max_validated = MAX(p_max, shared->min);
+template <typename T>
+void RangeTemplate<T>::set_max(T p_max) {
+	T max_validated = MAX(p_max, shared->min);
 	if (shared->max == max_validated) {
 		return;
 	}
 
 	shared->max = max_validated;
-	shared->page = CLAMP(shared->page, 0, shared->max - shared->min);
+	_set_page_no_value(shared->page);
 	set_value(shared->val);
 
 	shared->emit_changed("max");
 }
 
-void Range::set_step(double p_step) {
+template <typename T>
+void RangeTemplate<T>::set_step(T p_step) {
 	if (shared->step == p_step) {
 		return;
 	}
@@ -167,45 +208,72 @@ void Range::set_step(double p_step) {
 	shared->emit_changed("step");
 }
 
-void Range::set_page(double p_page) {
-	double page_validated = CLAMP(p_page, 0, shared->max - shared->min);
-	if (shared->page == page_validated) {
-		return;
+template <typename T>
+bool RangeTemplate<T>::_set_page_no_value(T p_page) {
+	T page_max;
+	if (std::is_same_v<T, int64_t> && shared->min < 0 && shared->max > INT64_MAX + shared->min) {
+		page_max = shared->max;
+	} else {
+		page_max = shared->max - shared->min;
 	}
+	T page_validated = CLAMP(p_page, 0, page_max);
 
+	if (shared->page == page_validated) {
+		return false;
+	}
 	shared->page = page_validated;
-	set_value(shared->val);
-
 	shared->emit_changed("page");
+	return true;
 }
 
-double Range::get_value() const {
+template <typename T>
+void RangeTemplate<T>::set_page(T p_page) {
+	if (_set_page_no_value(p_page)) {
+		set_value(shared->val);
+	}
+}
+
+template <typename T>
+T RangeTemplate<T>::get_value() const {
 	return shared->val;
 }
 
-double Range::get_min() const {
+template <typename T>
+T RangeTemplate<T>::get_min() const {
 	return shared->min;
 }
 
-double Range::get_max() const {
+template <typename T>
+T RangeTemplate<T>::get_max() const {
 	return shared->max;
 }
 
-double Range::get_step() const {
+template <typename T>
+T RangeTemplate<T>::get_step() const {
 	return shared->step;
 }
 
-double Range::get_page() const {
+template <typename T>
+T RangeTemplate<T>::get_page() const {
 	return shared->page;
 }
 
-void Range::set_as_ratio(double p_value) {
-	double v;
+template <typename T>
+void RangeTemplate<T>::set_as_ratio(double p_value) {
+	T v;
 
-	if (shared->exp_ratio && get_min() >= 0) {
-		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
-		double exp_max = Math::log(get_max()) / Math::log((double)2);
+	// When T is int64_t, make sure precision loss from floating point calculations
+	// doesn't prevent the min or max value from being set for a ratio of 0 and 1 respectively.
+	if (p_value == 1) {
+		v = get_max();
+	} else if (shared->exp_ratio && get_min() >= 0) {
+		// TODO: if get_min() < 0, should we CLAMP rather than fall back to liner?
+		// Or should we return zero or NaN?
+		double exp_min = get_min() == 0 ? 0.0 : Math::log((double)get_min()) / Math::log((double)2);
+		double exp_max = Math::log((double)get_max()) / Math::log((double)2);
 		v = Math::pow(2, exp_min + (exp_max - exp_min) * p_value);
+	} else if (p_value == 0) {
+		v = get_min();
 	} else {
 		double percent = (get_max() - get_min()) * p_value;
 		if (get_step() > 0) {
@@ -219,16 +287,24 @@ void Range::set_as_ratio(double p_value) {
 	set_value(v);
 }
 
-double Range::get_as_ratio() const {
-	if (Math::is_equal_approx(get_max(), get_min())) {
+template <typename T>
+double RangeTemplate<T>::get_as_ratio() const {
+	if constexpr (std::is_same_v<T, int64_t>) {
+		if (get_value() == get_min()) {
+			return 0.0;
+		}
+		if (get_value() == get_max()) {
+			return 1.0;
+		}
+	} else if (Math::is_equal_approx((double)get_max(), (double)get_min())) {
 		// Avoid division by zero.
 		return 1.0;
 	}
 
 	if (shared->exp_ratio && get_min() >= 0) {
-		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
-		double exp_max = Math::log(get_max()) / Math::log((double)2);
-		float value = CLAMP(get_value(), shared->min, shared->max);
+		double exp_min = get_min() == 0 ? 0.0 : Math::log((double)get_min()) / Math::log((double)2);
+		double exp_max = Math::log((double)get_max()) / Math::log((double)2);
+		float value = CLAMP((double)get_value(), shared->min, shared->max);
 		double v = Math::log(value) / Math::log((double)2);
 
 		return CLAMP((v - exp_min) / (exp_max - exp_min), 0, 1);
@@ -238,13 +314,15 @@ double Range::get_as_ratio() const {
 	}
 }
 
-void Range::_share(Node *p_range) {
-	Range *r = Object::cast_to<Range>(p_range);
+template <typename T>
+void RangeTemplate<T>::_share(Node *p_range) {
+	RangeTemplate<T> *r = Object::cast_to<RangeTemplate<T>>(p_range);
 	ERR_FAIL_NULL(r);
 	share(r);
 }
 
-void Range::share(Range *p_range) {
+template <typename T>
+void RangeTemplate<T>::share(RangeTemplate<T> *p_range) {
 	ERR_FAIL_NULL(p_range);
 
 	p_range->_ref_shared(shared);
@@ -252,7 +330,8 @@ void Range::share(Range *p_range) {
 	p_range->_value_changed_notify();
 }
 
-void Range::unshare() {
+template <typename T>
+void RangeTemplate<T>::unshare() {
 	Shared *nshared = memnew(Shared);
 	nshared->min = shared->min;
 	nshared->max = shared->max;
@@ -266,7 +345,8 @@ void Range::unshare() {
 	_ref_shared(nshared);
 }
 
-void Range::_ref_shared(Shared *p_shared) {
+template <typename T>
+void RangeTemplate<T>::_ref_shared(Shared *p_shared) {
 	if (shared && p_shared == shared) {
 		return;
 	}
@@ -276,7 +356,8 @@ void Range::_ref_shared(Shared *p_shared) {
 	shared->owners.insert(this);
 }
 
-void Range::_unref_shared() {
+template <typename T>
+void RangeTemplate<T>::_unref_shared() {
 	if (shared) {
 		shared->owners.erase(this);
 		if (shared->owners.size() == 0) {
@@ -286,31 +367,34 @@ void Range::_unref_shared() {
 	}
 }
 
-void Range::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_value"), &Range::get_value);
-	ClassDB::bind_method(D_METHOD("get_min"), &Range::get_min);
-	ClassDB::bind_method(D_METHOD("get_max"), &Range::get_max);
-	ClassDB::bind_method(D_METHOD("get_step"), &Range::get_step);
-	ClassDB::bind_method(D_METHOD("get_page"), &Range::get_page);
-	ClassDB::bind_method(D_METHOD("get_as_ratio"), &Range::get_as_ratio);
-	ClassDB::bind_method(D_METHOD("set_value", "value"), &Range::set_value);
-	ClassDB::bind_method(D_METHOD("set_value_no_signal", "value"), &Range::set_value_no_signal);
-	ClassDB::bind_method(D_METHOD("set_min", "minimum"), &Range::set_min);
-	ClassDB::bind_method(D_METHOD("set_max", "maximum"), &Range::set_max);
-	ClassDB::bind_method(D_METHOD("set_step", "step"), &Range::set_step);
-	ClassDB::bind_method(D_METHOD("set_page", "pagesize"), &Range::set_page);
-	ClassDB::bind_method(D_METHOD("set_as_ratio", "value"), &Range::set_as_ratio);
-	ClassDB::bind_method(D_METHOD("set_use_rounded_values", "enabled"), &Range::set_use_rounded_values);
-	ClassDB::bind_method(D_METHOD("is_using_rounded_values"), &Range::is_using_rounded_values);
-	ClassDB::bind_method(D_METHOD("set_exp_ratio", "enabled"), &Range::set_exp_ratio);
-	ClassDB::bind_method(D_METHOD("is_ratio_exp"), &Range::is_ratio_exp);
-	ClassDB::bind_method(D_METHOD("set_allow_greater", "allow"), &Range::set_allow_greater);
-	ClassDB::bind_method(D_METHOD("is_greater_allowed"), &Range::is_greater_allowed);
-	ClassDB::bind_method(D_METHOD("set_allow_lesser", "allow"), &Range::set_allow_lesser);
-	ClassDB::bind_method(D_METHOD("is_lesser_allowed"), &Range::is_lesser_allowed);
+template <typename T>
+void RangeTemplate<T>::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_value"), &RangeTemplate<T>::get_value);
+	ClassDB::bind_method(D_METHOD("get_min"), &RangeTemplate<T>::get_min);
+	ClassDB::bind_method(D_METHOD("get_max"), &RangeTemplate<T>::get_max);
+	ClassDB::bind_method(D_METHOD("get_step"), &RangeTemplate<T>::get_step);
+	ClassDB::bind_method(D_METHOD("get_page"), &RangeTemplate<T>::get_page);
+	ClassDB::bind_method(D_METHOD("get_as_ratio"), &RangeTemplate<T>::get_as_ratio);
+	ClassDB::bind_method(D_METHOD("set_value", "value"), &RangeTemplate<T>::set_value);
+	ClassDB::bind_method(D_METHOD("set_value_no_signal", "value"), &RangeTemplate<T>::set_value_no_signal);
+	ClassDB::bind_method(D_METHOD("set_min", "minimum"), &RangeTemplate<T>::set_min);
+	ClassDB::bind_method(D_METHOD("set_max", "maximum"), &RangeTemplate<T>::set_max);
+	ClassDB::bind_method(D_METHOD("set_step", "step"), &RangeTemplate<T>::set_step);
+	ClassDB::bind_method(D_METHOD("set_page", "pagesize"), &RangeTemplate<T>::set_page);
+	ClassDB::bind_method(D_METHOD("set_as_ratio", "value"), &RangeTemplate<T>::set_as_ratio);
+	if (std::is_same<T, double>::value) {
+		ClassDB::bind_method(D_METHOD("set_use_rounded_values", "enabled"), &RangeTemplate<T>::set_use_rounded_values);
+		ClassDB::bind_method(D_METHOD("is_using_rounded_values"), &RangeTemplate<T>::is_using_rounded_values);
+	}
+	ClassDB::bind_method(D_METHOD("set_exp_ratio", "enabled"), &RangeTemplate<T>::set_exp_ratio);
+	ClassDB::bind_method(D_METHOD("is_ratio_exp"), &RangeTemplate<T>::is_ratio_exp);
+	ClassDB::bind_method(D_METHOD("set_allow_greater", "allow"), &RangeTemplate<T>::set_allow_greater);
+	ClassDB::bind_method(D_METHOD("is_greater_allowed"), &RangeTemplate<T>::is_greater_allowed);
+	ClassDB::bind_method(D_METHOD("set_allow_lesser", "allow"), &RangeTemplate<T>::set_allow_lesser);
+	ClassDB::bind_method(D_METHOD("is_lesser_allowed"), &RangeTemplate<T>::is_lesser_allowed);
 
-	ClassDB::bind_method(D_METHOD("share", "with"), &Range::_share);
-	ClassDB::bind_method(D_METHOD("unshare"), &Range::unshare);
+	ClassDB::bind_method(D_METHOD("share", "with"), &RangeTemplate<T>::_share);
+	ClassDB::bind_method(D_METHOD("unshare"), &RangeTemplate<T>::unshare);
 
 	ADD_SIGNAL(MethodInfo("value_changed", PropertyInfo(Variant::FLOAT, "value")));
 	ADD_SIGNAL(MethodInfo("changed"));
@@ -322,7 +406,9 @@ void Range::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "value"), "set_value", "get_value");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ratio", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_NONE), "set_as_ratio", "get_as_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exp_edit"), "set_exp_ratio", "is_ratio_exp");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rounded"), "set_use_rounded_values", "is_using_rounded_values");
+	if (std::is_same<T, double>::value) {
+		ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rounded"), "set_use_rounded_values", "is_using_rounded_values");
+	}
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_greater"), "set_allow_greater", "is_greater_allowed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_lesser"), "set_allow_lesser", "is_lesser_allowed");
 
@@ -335,15 +421,20 @@ void Range::_bind_methods() {
 	ADD_LINKED_PROPERTY("max_value", "page");
 }
 
-void Range::set_use_rounded_values(bool p_enable) {
+template <typename T>
+void RangeTemplate<T>::set_use_rounded_values(bool p_enable) {
 	_rounded_values = p_enable;
+	// TODO: If set to true, should we reset the value?
+	// TODO: Should we emit the "changed" signal?
 }
 
-bool Range::is_using_rounded_values() const {
+template <typename T>
+bool RangeTemplate<T>::is_using_rounded_values() const {
 	return _rounded_values;
 }
 
-void Range::set_exp_ratio(bool p_enable) {
+template <typename T>
+void RangeTemplate<T>::set_exp_ratio(bool p_enable) {
 	if (shared->exp_ratio == p_enable) {
 		return;
 	}
@@ -353,31 +444,45 @@ void Range::set_exp_ratio(bool p_enable) {
 	update_configuration_warnings();
 }
 
-bool Range::is_ratio_exp() const {
+template <typename T>
+bool RangeTemplate<T>::is_ratio_exp() const {
 	return shared->exp_ratio;
 }
 
-void Range::set_allow_greater(bool p_allow) {
+template <typename T>
+void RangeTemplate<T>::set_allow_greater(bool p_allow) {
 	shared->allow_greater = p_allow;
+	// TODO: If set to false, should we reset the value?
+	// TODO: Should we emit the "changed" signal?
 }
 
-bool Range::is_greater_allowed() const {
+template <typename T>
+bool RangeTemplate<T>::is_greater_allowed() const {
 	return shared->allow_greater;
 }
 
-void Range::set_allow_lesser(bool p_allow) {
+template <typename T>
+void RangeTemplate<T>::set_allow_lesser(bool p_allow) {
 	shared->allow_lesser = p_allow;
+	// TODO: If set to false, should we reset the value?
+	// TODO: Should we emit the "changed" signal?
 }
 
-bool Range::is_lesser_allowed() const {
+template <typename T>
+bool RangeTemplate<T>::is_lesser_allowed() const {
 	return shared->allow_lesser;
 }
 
-Range::Range() {
+template <typename T>
+RangeTemplate<T>::RangeTemplate() {
 	shared = memnew(Shared);
 	shared->owners.insert(this);
 }
 
-Range::~Range() {
+template <typename T>
+RangeTemplate<T>::~RangeTemplate() {
 	_unref_shared();
 }
+
+template class RangeTemplate<double>;
+template class RangeTemplate<int64_t>;

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -33,19 +33,27 @@
 
 #include "scene/gui/control.h"
 
-class Range : public Control {
-	GDCLASS(Range, Control);
+// clang-format off
+#define RANGE_CLASS_MAP \
+	std::is_same_v<T, double> ? "Range" : \
+	std::is_same_v<T, int64_t> ? "RangeInt" : \
+	"RangeInvalid"
+// clang-format on
+
+template <typename T>
+class RangeTemplate : public Control {
+	GDCLASS_TEMPLATE(RangeTemplate<T>, RANGE_CLASS_MAP, Control, "Control", RangeTemplate)
 
 	struct Shared {
-		double val = 0.0;
-		double min = 0.0;
-		double max = 100.0;
-		double step = 1.0;
-		double page = 0.0;
+		T val = 0.0;
+		T min = 0.0;
+		T max = 100.0;
+		T step = 1.0;
+		T page = 0.0;
 		bool exp_ratio = false;
 		bool allow_greater = false;
 		bool allow_lesser = false;
-		HashSet<Range *> owners;
+		HashSet<RangeTemplate<T> *> owners;
 		void emit_value_changed();
 		void emit_changed(const char *p_what = "");
 		void redraw_owners();
@@ -60,32 +68,33 @@ class Range : public Control {
 
 	void _value_changed_notify();
 	void _changed_notify(const char *p_what = "");
-	void _set_value_no_signal(double p_val);
+	void _set_value_no_signal(T p_val);
+	bool _set_page_no_value(T p_page);
 
 protected:
-	virtual void _value_changed(double p_value);
+	virtual void _value_changed(T p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); };
 
 	static void _bind_methods();
 
 	bool _rounded_values = false;
 
-	GDVIRTUAL1(_value_changed, double)
+	GDVIRTUAL1(_value_changed, T)
 
 public:
-	void set_value(double p_val);
-	void set_value_no_signal(double p_val);
-	void set_min(double p_min);
-	void set_max(double p_max);
-	void set_step(double p_step);
-	void set_page(double p_page);
+	void set_value(T p_val);
+	void set_value_no_signal(T p_val);
+	void set_min(T p_min);
+	void set_max(T p_max);
+	void set_step(T p_step);
+	void set_page(T p_page);
 	void set_as_ratio(double p_value);
 
-	double get_value() const;
-	double get_min() const;
-	double get_max() const;
-	double get_step() const;
-	double get_page() const;
+	T get_value() const;
+	T get_min() const;
+	T get_max() const;
+	T get_step() const;
+	T get_page() const;
 	double get_as_ratio() const;
 
 	void set_use_rounded_values(bool p_enable);
@@ -100,13 +109,16 @@ public:
 	void set_allow_lesser(bool p_allow);
 	bool is_lesser_allowed() const;
 
-	void share(Range *p_range);
+	void share(RangeTemplate<T> *p_range);
 	void unshare();
 
 	PackedStringArray get_configuration_warnings() const override;
 
-	Range();
-	~Range();
+	RangeTemplate<T>();
+	~RangeTemplate<T>();
 };
+
+using Range = RangeTemplate<double>;
+using RangeInt = RangeTemplate<int64_t>;
 
 #endif // RANGE_H

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -79,7 +79,7 @@ protected:
 
 	bool _rounded_values = false;
 
-	GDVIRTUAL1(_value_changed, T)
+	GDVIRTUAL1(_value_changed, T);
 
 public:
 	void set_value(T p_val);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -409,6 +409,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(LinkButton);
 	GDREGISTER_CLASS(Panel);
 	GDREGISTER_VIRTUAL_CLASS(Range);
+	GDREGISTER_VIRTUAL_CLASS(RangeInt);
 
 	OS::get_singleton()->yield(); // may take time to init
 

--- a/tests/scene/test_range.h
+++ b/tests/scene/test_range.h
@@ -1,0 +1,1303 @@
+/**************************************************************************/
+/*  test_range.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_RANGE_H
+#define TEST_RANGE_H
+
+#include "scene/gui/range.h"
+
+#include "tests/test_macros.h"
+
+namespace TestRange {
+static inline Array build_array() {
+	return Array();
+}
+template <typename... Targs>
+static inline Array build_array(Variant item, Targs... Fargs) {
+	Array a = build_array(Fargs...);
+	a.push_front(item);
+	return a;
+}
+
+TEST_CASE("[SceneTree][Range] range control") {
+	Range *range = memnew(Range);
+	SceneTree::get_singleton()->get_root()->add_child(range);
+
+	SIGNAL_WATCH(range, "value_changed");
+	SIGNAL_WATCH(range, "changed");
+
+	REQUIRE(range->get_value() == doctest::Approx(0.0));
+	REQUIRE(range->get_min() == doctest::Approx(0.0));
+	REQUIRE(range->get_max() == doctest::Approx(100.0));
+	REQUIRE(range->get_step() == doctest::Approx(1.0));
+	REQUIRE(range->get_page() == doctest::Approx(0.0));
+	REQUIRE(range->is_lesser_allowed() == false);
+	REQUIRE(range->is_greater_allowed() == false);
+	REQUIRE(range->is_ratio_exp() == false);
+
+	SUBCASE("[SceneTree][Range] set_value default step") {
+		CHECK(range->get_step() == doctest::Approx(1.0));
+		range->set_value(43.6);
+		CHECK(range->get_value() == doctest::Approx(44.0));
+		SIGNAL_CHECK("value_changed", build_array(build_array(44.0)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_value(44.0);
+		SIGNAL_CHECK_FALSE("value_changed");
+	}
+
+	SUBCASE("[SceneTree][Range] set_value zero step") {
+		range->set_step(0);
+		CHECK(range->get_step() == doctest::Approx(0.0));
+		range->set_value(43.6);
+		CHECK(range->get_step() == doctest::Approx(0.0));
+		CHECK(range->get_value() == doctest::Approx(43.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(43.6)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(43.6);
+		SIGNAL_CHECK_FALSE("value_changed");
+	}
+
+	SUBCASE("[SceneTree][Range] set_min zero step") {
+		range->set_step(0);
+		SIGNAL_DISCARD("changed");
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == doctest::Approx(5.1));
+		CHECK(range->get_value() == doctest::Approx(5.1));
+		SIGNAL_CHECK("value_changed", build_array(build_array(5.1)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(13.2));
+		SIGNAL_CHECK("value_changed", build_array(build_array(13.2)));
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == doctest::Approx(5.1));
+		SIGNAL_CHECK("value_changed", build_array(build_array(5.1)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-43.9);
+		range->set_value(13.2);
+		CHECK(range->get_min() == doctest::Approx(-43.9));
+		CHECK(range->get_value() == doctest::Approx(13.2));
+		SIGNAL_CHECK("value_changed", build_array(build_array(13.2)));
+
+		range->set_value(-34.5);
+		CHECK(range->get_value() == doctest::Approx(-34.5));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-34.5)));
+
+		range->set_value(-54.8);
+		CHECK(range->get_value() == doctest::Approx(-43.9));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-43.9)));
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16.6)));
+	}
+
+	SUBCASE("[SceneTree][Range] set_min with step") {
+		range->set_step(3.4);
+		CHECK(range->get_step() == doctest::Approx(3.4));
+		SIGNAL_DISCARD("changed");
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == doctest::Approx(5.1));
+		CHECK(range->get_value() == doctest::Approx(5.1));
+		SIGNAL_CHECK("value_changed", build_array(build_array(5.1)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(11.9));
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == doctest::Approx(5.1));
+
+		range->set_min(-43.9);
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(13.9));
+
+		range->set_value(-34.5);
+		CHECK(range->get_value() == doctest::Approx(-33.7));
+
+		range->set_value(-54.8);
+		CHECK(range->get_value() == doctest::Approx(-43.9));
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+	}
+
+	SUBCASE("[SceneTree][Range] set_min allow_lesser") {
+		range->set_step(0);
+		SIGNAL_DISCARD("changed");
+
+		range->set_allow_lesser(true);
+		CHECK(range->is_lesser_allowed() == true);
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == doctest::Approx(5.1));
+		CHECK(range->get_value() == doctest::Approx(0.0));
+		SIGNAL_CHECK_FALSE("value_changed");
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == doctest::Approx(3.8));
+		SIGNAL_CHECK("value_changed", build_array(build_array(3.8)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-43.9);
+		range->set_value(-54.8);
+		CHECK(range->get_value() == doctest::Approx(-54.8));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-54.8)));
+
+		range->set_allow_lesser(false);
+		CHECK(range->is_lesser_allowed() == false);
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16.6)));
+	}
+
+	SUBCASE("[SceneTree][Range] set_max zero step") {
+		range->set_step(0);
+		range->set_value(90);
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == doctest::Approx(63.7));
+		CHECK(range->get_value() == doctest::Approx(63.7));
+		SIGNAL_CHECK("value_changed", build_array(build_array(63.7)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(25.2);
+		CHECK(range->get_value() == doctest::Approx(25.2));
+		SIGNAL_CHECK("value_changed", build_array(build_array(25.2)));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == doctest::Approx(63.7));
+		SIGNAL_CHECK("value_changed", build_array(build_array(63.7)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == doctest::Approx(-10.8));
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-10.8)));
+
+		range->set_value(-38.4);
+		CHECK(range->get_value() == doctest::Approx(-38.4));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-38.4)));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-10.8)));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+		SIGNAL_CHECK_FALSE("value_changed");
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16.6)));
+	}
+
+	SUBCASE("[SceneTree][Range] set_max with step") {
+		range->set_step(3.4);
+		range->set_value(90);
+		CHECK(range->get_step() == doctest::Approx(3.4));
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == doctest::Approx(63.7));
+		CHECK(range->get_value() == doctest::Approx(63.7));
+		SIGNAL_CHECK("value_changed", build_array(build_array(63.7)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(25.2);
+		CHECK(range->get_value() == doctest::Approx(23.8));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == doctest::Approx(63.7));
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == doctest::Approx(-10.8));
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+
+		range->set_value(-38.4);
+		CHECK(range->get_value() == doctest::Approx(-38.8));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == doctest::Approx(-10.8));
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+	}
+
+	SUBCASE("[SceneTree][Range] set_max allow_greater") {
+		range->set_step(0);
+		range->set_value(90);
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_allow_greater(true);
+		CHECK(range->is_greater_allowed() == true);
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == doctest::Approx(63.7));
+		CHECK(range->get_value() == doctest::Approx(90.0));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == doctest::Approx(85.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(85.6)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		range->set_value(13.2);
+		CHECK(range->get_value() == doctest::Approx(13.2));
+		SIGNAL_CHECK("value_changed", build_array(build_array(13.2)));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == doctest::Approx(-5.1));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-5.1)));
+
+		range->set_allow_greater(false);
+		CHECK(range->is_greater_allowed() == false);
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-16.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16.6)));
+	}
+
+	SUBCASE("[SceneTree][Range] set_max with page") {
+		range->set_page(7.2);
+		CHECK(range->get_page() == doctest::Approx(7.2));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(90);
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == doctest::Approx(63.7));
+		CHECK(range->get_value() == doctest::Approx(56.5));
+		SIGNAL_CHECK("value_changed", build_array(build_array(56.5)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == doctest::Approx(56.5));
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == doctest::Approx(-10.8));
+		CHECK(range->get_value() == doctest::Approx(-18.0));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == doctest::Approx(-18.0));
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-23.8));
+	}
+
+	SUBCASE("[SceneTree][Range] set_max with step and page") {
+		range->set_step(8.1);
+		range->set_page(2.3);
+		CHECK(range->get_step() == doctest::Approx(8.1));
+		CHECK(range->get_page() == doctest::Approx(2.3));
+		SIGNAL_CHECK("changed", build_array(build_array(), build_array()));
+
+		range->set_value(90);
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == doctest::Approx(63.7));
+		CHECK(range->get_value() == doctest::Approx(61.4));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == doctest::Approx(61.4));
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == doctest::Approx(-10.8));
+		CHECK(range->get_value() == doctest::Approx(-13.1));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == doctest::Approx(-13.1));
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == doctest::Approx(-16.6));
+		CHECK(range->get_value() == doctest::Approx(-18.9));
+
+		// This results in a different value than set_max() above because
+		// step is calulcated before page.
+		range->set_value(-16.6);
+		CHECK(range->get_value() == doctest::Approx(-19.0));
+	}
+
+	SUBCASE("[SceneTree][Range] set_value large step") {
+		range->set_max(10000000000000.0);
+		range->set_step(72389512.0);
+		CHECK(range->get_step() == doctest::Approx(72389512.0));
+
+		range->set_value(43.6);
+		CHECK(range->get_value() == doctest::Approx(0));
+
+		range->set_value(58395727.0);
+		CHECK(range->get_value() == doctest::Approx(72389512.0));
+
+		range->set_value(92957238.0);
+		CHECK(range->get_value() == doctest::Approx(72389512.0));
+
+		range->set_value(1094218303.0);
+		CHECK(range->get_value() == doctest::Approx(1085842680.0));
+	}
+
+	SUBCASE("[SceneTree][Range] ratio zero step") {
+		range->set_step(0);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.5));
+
+		range->set_value(100.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(0.0));
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == doctest::Approx(50.0));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(100.0));
+
+		range->set_min(30.0);
+		range->set_max(145.0);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == doctest::Approx(76.0));
+
+		range->set_value(92.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.53913043478));
+
+		range->set_min(-234.0);
+		range->set_max(-47.0);
+		range->set_as_ratio(0.8);
+		CHECK(range->get_value() == doctest::Approx(-84.4));
+
+		range->set_value(-199.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.1871657754));
+
+		range->set_min(-193.67);
+		range->set_max(68.29);
+		range->set_as_ratio(0.14);
+		CHECK(range->get_value() == doctest::Approx(-156.9956));
+
+		range->set_value(14.5);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.79466330737));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(-193.67));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(68.29));
+
+		range->set_as_ratio(7.0);
+		CHECK(range->get_value() == doctest::Approx(68.29));
+
+		range->set_as_ratio(-5.0);
+		CHECK(range->get_value() == doctest::Approx(-193.67));
+
+		range->set_allow_lesser(true);
+		range->set_allow_greater(true);
+
+		range->set_value(-5435.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(1926.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+	}
+
+	SUBCASE("[SceneTree][Range] ratio with step") {
+		range->set_step(3);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50.0);
+		CHECK(range->get_value() == doctest::Approx(51.0));
+		CHECK(range->get_as_ratio() == doctest::Approx(0.51));
+
+		range->set_value(100.0);
+		CHECK(range->get_value() == doctest::Approx(99.0));
+		CHECK(range->get_as_ratio() == doctest::Approx(0.99));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(0.0));
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == doctest::Approx(51.0));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(99.0));
+
+		range->set_min(30.0);
+		range->set_max(145.0);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == doctest::Approx(75.0));
+
+		range->set_value(92.0);
+		CHECK(range->get_value() == doctest::Approx(93.0));
+		CHECK(range->get_as_ratio() == doctest::Approx(0.54782608696));
+
+		range->set_min(-234.0);
+		range->set_max(-47.0);
+		range->set_as_ratio(0.8);
+		CHECK(range->get_value() == doctest::Approx(-84));
+
+		range->set_value(-199.0);
+		CHECK(range->get_value() == doctest::Approx(-198.0));
+		CHECK(range->get_as_ratio() == doctest::Approx(0.19251336898));
+
+		range->set_min(-193.67);
+		range->set_max(68.29);
+		range->set_as_ratio(0.14);
+		CHECK(range->get_value() == doctest::Approx(-157.67));
+
+		range->set_value(14.5);
+		CHECK(range->get_value() == doctest::Approx(13.33));
+		CHECK(range->get_as_ratio() == doctest::Approx(0.79019697664));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(-193.67));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(67.33));
+
+		range->set_as_ratio(7.0);
+		CHECK(range->get_value() == doctest::Approx(67.33));
+
+		range->set_as_ratio(-5.0);
+		CHECK(range->get_value() == doctest::Approx(-193.67));
+	}
+
+	SUBCASE("[SceneTree][Range] ratio as exp") {
+		range->set_step(0);
+		range->set_exp_ratio(true);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.84948500217));
+
+		range->set_value(100.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(1.0));
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == doctest::Approx(10.0));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(100.0));
+
+		range->set_min(30.0);
+		range->set_max(145.0);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == doctest::Approx(56.340403594));
+
+		range->set_value(92.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.71124426151));
+
+		// TODO: Test negative values once behavior is well defined.
+	}
+
+	SUBCASE("[SceneTree][Range] share") {
+		range->set_value(38.0);
+		range->set_min(10.0);
+		range->set_max(75.0);
+		range->set_step(4.0);
+		range->set_page(3.0);
+		range->set_exp_ratio(true);
+		range->set_allow_greater(true);
+		range->set_allow_lesser(true);
+
+		Range *alt1 = memnew(Range);
+		SceneTree::get_singleton()->get_root()->add_child(alt1);
+
+		range->share(alt1);
+		CHECK(alt1->get_value() == doctest::Approx(38.0));
+		CHECK(alt1->get_min() == doctest::Approx(10.0));
+		CHECK(alt1->get_max() == doctest::Approx(75.0));
+		CHECK(alt1->get_step() == doctest::Approx(4.0));
+		CHECK(alt1->get_page() == doctest::Approx(3.0));
+		CHECK(alt1->is_ratio_exp() == true);
+		CHECK(alt1->is_greater_allowed() == true);
+		CHECK(alt1->is_lesser_allowed() == true);
+
+		range->set_step(5.4);
+		CHECK(alt1->get_step() == doctest::Approx(5.4));
+
+		SIGNAL_DISCARD("changed");
+		alt1->set_max(87.0);
+		CHECK(range->get_max() == doctest::Approx(87.0));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		SIGNAL_DISCARD("value_changed");
+		alt1->set_value(64.0);
+		SIGNAL_CHECK("value_changed", build_array(build_array(64.0)));
+
+		Range *alt2 = memnew(Range);
+		SceneTree::get_singleton()->get_root()->add_child(alt2);
+
+		alt2->set_page(7.5);
+		alt1->share(alt2);
+		CHECK(alt2->get_page() == doctest::Approx(3.0));
+
+		alt2->set_min(9.0);
+		CHECK(range->get_min() == doctest::Approx(9.0));
+		CHECK(alt1->get_min() == doctest::Approx(9.0));
+
+		alt2->set_step(0.0);
+		SIGNAL_DISCARD("value_changed");
+		alt2->set_value(47.5);
+		CHECK(range->get_value() == doctest::Approx(47.5));
+		SIGNAL_CHECK("value_changed", build_array(build_array(47.5)));
+
+		alt1->unshare();
+		alt1->set_allow_lesser(false);
+		CHECK(range->is_lesser_allowed() == true);
+		CHECK(alt1->is_lesser_allowed() == false);
+		CHECK(alt2->is_lesser_allowed() == true);
+
+		SIGNAL_DISCARD("value_changed");
+		alt1->set_value(17.9);
+		CHECK(range->get_value() == doctest::Approx(47.5));
+		SIGNAL_CHECK_FALSE("value_changed");
+
+		SceneTree::get_singleton()->get_root()->remove_child(alt1);
+		SceneTree::get_singleton()->get_root()->remove_child(alt2);
+		memdelete(alt1);
+		memdelete(alt2);
+	}
+
+	SUBCASE("[SceneTree][Range] use rounded") {
+		range->set_step(3.4);
+		range->set_use_rounded_values(true);
+
+		range->set_value(47.6);
+		CHECK(range->get_value() == doctest::Approx(48.0));
+		SIGNAL_CHECK("value_changed", build_array(build_array(48.0)));
+
+		range->set_value(37.4);
+		CHECK(range->get_value() == doctest::Approx(37.0));
+		SIGNAL_CHECK("value_changed", build_array(build_array(37.0)));
+
+		// We round to closest step (20.4) before closest integer.
+		range->set_value(20.7);
+		CHECK(range->get_value() == doctest::Approx(20.0));
+		SIGNAL_CHECK("value_changed", build_array(build_array(20.0)));
+
+		range->set_use_rounded_values(false);
+
+		range->set_value(47.6);
+		CHECK(range->get_value() == doctest::Approx(47.6));
+		SIGNAL_CHECK("value_changed", build_array(build_array(47.6)));
+
+		range->set_value(37.4);
+		CHECK(range->get_value() == doctest::Approx(37.4));
+		SIGNAL_CHECK("value_changed", build_array(build_array(37.4)));
+
+		range->set_value(20.7);
+		CHECK(range->get_value() == doctest::Approx(20.4));
+		SIGNAL_CHECK("value_changed", build_array(build_array(20.4)));
+	}
+
+	SIGNAL_UNWATCH(range, "value_changed");
+	SIGNAL_UNWATCH(range, "changed");
+
+	SceneTree::get_singleton()->get_root()->remove_child(range);
+	memdelete(range);
+}
+
+TEST_CASE("[SceneTree][RangeInt] range control, integer") {
+	RangeInt *range = memnew(RangeInt);
+	SceneTree::get_singleton()->get_root()->add_child(range);
+
+	SIGNAL_WATCH(range, "value_changed");
+	SIGNAL_WATCH(range, "changed");
+
+	REQUIRE(range->get_value() == doctest::Approx(0.0));
+	REQUIRE(range->get_min() == doctest::Approx(0.0));
+	REQUIRE(range->get_max() == doctest::Approx(100.0));
+	REQUIRE(range->get_step() == doctest::Approx(1.0));
+	REQUIRE(range->get_page() == doctest::Approx(0.0));
+	REQUIRE(range->is_lesser_allowed() == false);
+	REQUIRE(range->is_greater_allowed() == false);
+	REQUIRE(range->is_ratio_exp() == false);
+
+	SUBCASE("[SceneTree][RangeInt] set_value default step") {
+		CHECK(range->get_step() == 1);
+		range->set_value(43.6);
+		CHECK(range->get_value() == 43);
+		SIGNAL_CHECK("value_changed", build_array(build_array(43)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_value(43);
+		SIGNAL_CHECK_FALSE("value_changed");
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_value zero step") {
+		range->set_step(0);
+		CHECK(range->get_step() == 0);
+		range->set_value(43.6);
+		CHECK(range->get_value() == 43);
+		SIGNAL_CHECK("value_changed", build_array(build_array(43)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(43.6);
+		SIGNAL_CHECK_FALSE("value_changed");
+	}
+
+	// TODO: Better testing of large step values
+
+	SUBCASE("[SceneTree][RangeInt] set_min zero step") {
+		range->set_step(0);
+		SIGNAL_DISCARD("changed")
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == 5);
+		SIGNAL_CHECK("value_changed", build_array(build_array(5)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == 13);
+		SIGNAL_CHECK("value_changed", build_array(build_array(13)));
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == 5);
+		SIGNAL_CHECK("value_changed", build_array(build_array(5)));
+
+		range->set_min(-43.9);
+		range->set_value(13.2);
+		CHECK(range->get_min() == -43);
+		CHECK(range->get_value() == 13);
+		SIGNAL_CHECK("value_changed", build_array(build_array(13)));
+
+		range->set_value(-34.5);
+		CHECK(range->get_value() == -34);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-34)));
+
+		range->set_value(-54.8);
+		CHECK(range->get_value() == -43);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-43)));
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == -16);
+		CHECK(range->get_value() == -16);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16)));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_min with step") {
+		range->set_step(3.4);
+		CHECK(range->get_step() == 3);
+		SIGNAL_DISCARD("changed")
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == 5);
+		CHECK(range->get_value() == 5);
+		SIGNAL_CHECK("value_changed", build_array(build_array(5)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == 14);
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == 5);
+
+		range->set_min(-43.9);
+		range->set_value(13.2);
+		CHECK(range->get_value() == 14);
+
+		range->set_value(-34.5);
+		CHECK(range->get_value() == -34);
+
+		range->set_value(-54.8);
+		CHECK(range->get_value() == -43);
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == -16);
+		CHECK(range->get_value() == -16);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_min allow_lesser") {
+		range->set_step(0);
+		SIGNAL_DISCARD("changed");
+
+		range->set_allow_lesser(true);
+		CHECK(range->is_lesser_allowed() == true);
+
+		range->set_min(5.1);
+		CHECK(range->get_min() == 5);
+		CHECK(range->get_value() == 0);
+		SIGNAL_CHECK_FALSE("value_changed");
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(3.8);
+		CHECK(range->get_value() == 3);
+		SIGNAL_CHECK("value_changed", build_array(build_array(3)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-43.9);
+		range->set_value(-54.8);
+		CHECK(range->get_value() == -54);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-54)));
+
+		range->set_allow_lesser(false);
+		CHECK(range->is_lesser_allowed() == false);
+
+		range->set_min(-16.6);
+		CHECK(range->get_min() == -16);
+		CHECK(range->get_value() == -16);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16)));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_max zero step") {
+		range->set_step(0);
+		range->set_value(90);
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == 63);
+		CHECK(range->get_value() == 63);
+		SIGNAL_CHECK("value_changed", build_array(build_array(63)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(25);
+		CHECK(range->get_value() == 25);
+		SIGNAL_CHECK("value_changed", build_array(build_array(25)));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == 63);
+		SIGNAL_CHECK("value_changed", build_array(build_array(63)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == -10);
+		CHECK(range->get_value() == -10);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-10)));
+
+		range->set_value(-38.4);
+		CHECK(range->get_value() == -38);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-38)));
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == -10);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-10)));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == -10);
+		SIGNAL_CHECK_FALSE("value_changed");
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == -16);
+		CHECK(range->get_value() == -16);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16)));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_max with step") {
+		range->set_step(3.4);
+		range->set_value(90);
+		CHECK(range->get_step() == 3);
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == 63);
+		CHECK(range->get_value() == 63);
+		SIGNAL_CHECK("value_changed", build_array(build_array(63)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(25.2);
+		CHECK(range->get_value() == 24);
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == 63);
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == -10);
+		CHECK(range->get_value() == -10);
+
+		range->set_value(-38.4);
+		CHECK(range->get_value() == -37);
+
+		range->set_value(13.2);
+		CHECK(range->get_value() == -10);
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == -10);
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == -16);
+		CHECK(range->get_value() == -16);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_max allow_greater") {
+		range->set_step(0);
+		range->set_value(90);
+		SIGNAL_DISCARD("changed");
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_allow_greater(true);
+		CHECK(range->is_greater_allowed() == true);
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == 63);
+		CHECK(range->get_value() == 90);
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == 85);
+		SIGNAL_CHECK("value_changed", build_array(build_array(85)));
+		SIGNAL_CHECK_FALSE("changed");
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		range->set_value(13.2);
+		CHECK(range->get_value() == 13);
+		SIGNAL_CHECK("value_changed", build_array(build_array(13)));
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == -5);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-5)));
+
+		range->set_allow_greater(false);
+		CHECK(range->is_greater_allowed() == false);
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == -16);
+		CHECK(range->get_value() == -16);
+		SIGNAL_CHECK("value_changed", build_array(build_array(-16)));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_max with page") {
+		range->set_page(7.2);
+		CHECK(range->get_page() == 7);
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(90);
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == 63);
+		CHECK(range->get_value() == 56);
+		SIGNAL_CHECK("value_changed", build_array(build_array(56)));
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == 56);
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == -10);
+		CHECK(range->get_value() == -17);
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == -17);
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == -16);
+		CHECK(range->get_value() == -23);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_max with step and page") {
+		range->set_step(8.1);
+		range->set_page(2.3);
+		CHECK(range->get_step() == 8);
+		CHECK(range->get_page() == 2);
+		SIGNAL_CHECK("changed", build_array(build_array(), build_array()));
+
+		range->set_value(90);
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_max(63.7);
+		CHECK(range->get_max() == 63);
+		CHECK(range->get_value() == 61);
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		range->set_value(85.6);
+		CHECK(range->get_value() == 61);
+
+		range->set_min(-100.0);
+		range->set_max(-10.8);
+		CHECK(range->get_max() == -10);
+		CHECK(range->get_value() == -12);
+
+		range->set_value(-5.1);
+		CHECK(range->get_value() == -12);
+
+		range->set_max(-16.6);
+		CHECK(range->get_max() == -16);
+		CHECK(range->get_value() == -18);
+
+		// This results in a different value than set_max() above because
+		// step is calulcated before page.
+		range->set_value(-16.6);
+		CHECK(range->get_value() == -20);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] set_value large step") {
+		range->set_max(10000000000000);
+		range->set_step(72389512);
+		CHECK(range->get_step() == 72389512);
+
+		range->set_value(43);
+		CHECK(range->get_value() == 0);
+
+		range->set_value(58395727);
+		CHECK(range->get_value() == 72389512);
+
+		range->set_value(92957238);
+		CHECK(range->get_value() == 72389512);
+
+		range->set_value(1094218303);
+		CHECK(range->get_value() == 1085842680);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] ratio zero step") {
+		range->set_step(0);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.5));
+
+		range->set_value(100);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == 0);
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == 50);
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == 100);
+
+		range->set_min(30);
+		range->set_max(145);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == 76);
+
+		range->set_value(92);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.53913043478));
+
+		range->set_min(-234);
+		range->set_max(-47);
+		range->set_as_ratio(0.8);
+		CHECK(range->get_value() == -84);
+
+		range->set_value(-199);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.1871657754));
+
+		range->set_min(-193);
+		range->set_max(68);
+		range->set_as_ratio(0.14);
+		CHECK(range->get_value() == -156);
+
+		range->set_value(14);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.79310344827));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == -193);
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == 68);
+
+		range->set_as_ratio(7.0);
+		CHECK(range->get_value() == 68);
+
+		range->set_as_ratio(-5.0);
+		CHECK(range->get_value() == -193);
+
+		range->set_allow_lesser(true);
+		range->set_allow_greater(true);
+
+		range->set_value(-5435);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(1926);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] ratio with step") {
+		range->set_step(3);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50);
+		CHECK(range->get_value() == 51.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.51));
+
+		range->set_value(100);
+		CHECK(range->get_value() == 99);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.99));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == 0);
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == 51);
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == 99);
+
+		range->set_min(30);
+		range->set_max(145);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == 75.0);
+
+		range->set_value(92);
+		CHECK(range->get_value() == 93);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.54782608696));
+
+		range->set_min(-234);
+		range->set_max(-47);
+		range->set_as_ratio(0.8);
+		CHECK(range->get_value() == -84);
+
+		range->set_value(-199.0);
+		CHECK(range->get_value() == -198.0);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.19251336898));
+
+		range->set_min(-193);
+		range->set_max(68);
+		range->set_as_ratio(0.14);
+		CHECK(range->get_value() == -157);
+
+		range->set_value(14);
+		CHECK(range->get_value() == 14);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.79310344828));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == doctest::Approx(-193));
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == doctest::Approx(68));
+
+		range->set_as_ratio(7.0);
+		CHECK(range->get_value() == doctest::Approx(68));
+
+		range->set_as_ratio(-5.0);
+		CHECK(range->get_value() == doctest::Approx(-193));
+	}
+
+	SUBCASE("[SceneTree][RangeInt] ratio as exp") {
+		range->set_step(0);
+		range->set_exp_ratio(true);
+
+		CHECK(range->get_as_ratio() == doctest::Approx(0.0));
+
+		range->set_value(50);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.84948500217));
+
+		range->set_value(100);
+		CHECK(range->get_as_ratio() == doctest::Approx(1.0));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == 1);
+
+		range->set_as_ratio(0.5);
+		CHECK(range->get_value() == 10);
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == 100);
+
+		range->set_min(30);
+		range->set_max(145);
+		range->set_as_ratio(0.4);
+		CHECK(range->get_value() == 56);
+
+		range->set_value(92);
+		CHECK(range->get_as_ratio() == doctest::Approx(0.71124426151));
+
+		// TODO: Test negative values once behavior is well defined.
+	}
+
+	SUBCASE("[SceneTree][RangeInt] share") {
+		range->set_value(38);
+		range->set_min(10);
+		range->set_max(75);
+		range->set_step(4);
+		range->set_page(3);
+		range->set_exp_ratio(true);
+		range->set_allow_greater(true);
+		range->set_allow_lesser(true);
+
+		RangeInt *alt1 = memnew(RangeInt);
+		SceneTree::get_singleton()->get_root()->add_child(alt1);
+
+		range->share(alt1);
+		CHECK(alt1->get_value() == 38);
+		CHECK(alt1->get_min() == 10);
+		CHECK(alt1->get_max() == 75);
+		CHECK(alt1->get_step() == 4);
+		CHECK(alt1->get_page() == 3);
+		CHECK(alt1->is_ratio_exp() == true);
+		CHECK(alt1->is_greater_allowed() == true);
+		CHECK(alt1->is_lesser_allowed() == true);
+
+		range->set_step(5);
+		CHECK(alt1->get_step() == 5);
+
+		SIGNAL_DISCARD("changed");
+		alt1->set_max(87.0);
+		CHECK(range->get_max() == 87);
+		SIGNAL_CHECK("changed", build_array(build_array()));
+
+		SIGNAL_DISCARD("value_changed");
+		alt1->set_value(65);
+		SIGNAL_CHECK("value_changed", build_array(build_array(65)));
+
+		RangeInt *alt2 = memnew(RangeInt);
+		SceneTree::get_singleton()->get_root()->add_child(alt2);
+
+		alt2->set_page(7);
+		alt1->share(alt2);
+		CHECK(alt2->get_page() == 3);
+
+		alt2->set_min(9);
+		CHECK(range->get_min() == 9);
+		CHECK(alt1->get_min() == 9);
+
+		alt2->set_step(0);
+		SIGNAL_DISCARD("value_changed");
+		alt2->set_value(47);
+		CHECK(range->get_value() == 47);
+		SIGNAL_CHECK("value_changed", build_array(build_array(47)));
+
+		alt1->unshare();
+		alt1->set_allow_lesser(false);
+		CHECK(range->is_lesser_allowed() == true);
+		CHECK(alt1->is_lesser_allowed() == false);
+		CHECK(alt2->is_lesser_allowed() == true);
+
+		SIGNAL_DISCARD("value_changed");
+		alt1->set_value(17);
+		CHECK(range->get_value() == 47);
+		SIGNAL_CHECK_FALSE("value_changed");
+
+		SceneTree::get_singleton()->get_root()->remove_child(alt1);
+		SceneTree::get_singleton()->get_root()->remove_child(alt2);
+		memdelete(alt1);
+		memdelete(alt2);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] large values") {
+		range->set_min(INT64_MIN);
+		CHECK(range->get_min() == INT64_MIN);
+		CHECK(range->get_value() == 0);
+
+		range->set_max(INT64_MAX);
+		CHECK(range->get_max() == INT64_MAX);
+		CHECK(range->get_value() == 0);
+
+		SIGNAL_DISCARD("value_changed")
+		for (int64_t i = 9223372036854775790; i < INT64_MAX; i++) {
+			range->set_value(i + 1);
+			CHECK(range->get_value() == i + 1);
+			SIGNAL_CHECK("value_changed", build_array(build_array(i + 1)));
+		}
+
+		for (int64_t i = -9223372036854775790; i > INT64_MIN; i--) {
+			range->set_value(i - 1);
+			CHECK(range->get_value() == i - 1);
+			SIGNAL_CHECK("value_changed", build_array(build_array(i - 1)));
+		}
+
+		range->set_page(INT64_MAX);
+		range->set_value(INT64_MAX);
+		CHECK(range->get_value() == 0);
+	}
+
+	SUBCASE("[SceneTree][RangeInt] large values ratio") {
+		range->set_min(INT64_MIN);
+		range->set_max(INT64_MAX);
+		SIGNAL_DISCARD("value_changed")
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == INT64_MAX);
+		SIGNAL_CHECK("value_changed", build_array(build_array(INT64_MAX)));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == INT64_MIN);
+		SIGNAL_CHECK("value_changed", build_array(build_array(INT64_MIN)));
+
+		range->set_min(0);
+		range->set_exp_ratio(true);
+		SIGNAL_DISCARD("value_changed");
+
+		range->set_as_ratio(1.0);
+		CHECK(range->get_value() == INT64_MAX);
+		SIGNAL_CHECK("value_changed", build_array(build_array(INT64_MAX)));
+
+		range->set_as_ratio(0.0);
+		CHECK(range->get_value() == 1);
+		SIGNAL_CHECK("value_changed", build_array(build_array(1)));
+	}
+
+	SIGNAL_UNWATCH(range, "value_changed");
+	SIGNAL_UNWATCH(range, "changed");
+
+	SceneTree::get_singleton()->get_root()->remove_child(range);
+	memdelete(range);
+}
+
+} // namespace TestRange
+
+#endif // TEST_RANGE_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -118,6 +118,7 @@
 #include "tests/scene/test_packed_scene.h"
 #include "tests/scene/test_path_2d.h"
 #include "tests/scene/test_path_follow_2d.h"
+#include "tests/scene/test_range.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"


### PR DESCRIPTION
### Issues Resolved

Currently, `EditorPropertyInteger` is used for viewing and editing integers in the editor, such as node properties and viewing local integers in the debugger. As a floating point type is used internally, this results in loss of precision for very positive and very negative integers. This is particularly problematic when doing bit twiddling. Making  `EditorPropertyInteger` use `int64_t` to store the value resolves this problem. However, as it accomplishes this via `EditorSpinSlider` which inherits the relevant functionality from `Range`, integer versions of these classes are needed.

I believe this pull request fixes #94686 and fixes #32106. It either unblocks or fixes #33095.

### Summary

This is done by converting the current `Range` class into a template, `RangeTemplate<T>`, and then creating the aliases `Range` and `RangeInt` that correspond to `RangeTemplate<double>` and `RangeTemplate<int64_t>` respectively. A template-compatible version of the `GDCLASS` macro is created: `GDCLASS_TEMPLATE`. These aliases are used transparently inside of the engine code. External language bindings (including C++) do not see the template.  Generated binding headers define real classes `Range` and `RangeInt`, which then get linked against the template instantiations.

Similarly, `EditorSpinSlider`, a subclass of `Range`, is also converted into a template, `EditorSpinSliderTemplate<T>`, and aliases `EditorSpinSlider` and `EditorSpinSliderInt` are created that logically inherit from `Range` and `RangeInt` respectively.

`EditorPropertyInteger` is updated to use `EditorSpinSliderInt` instead of `EditorSpinSlider`, finally making it safe to use with very large integers.

Tests for `Range` and `RangeInt` are also created.

### Implementation Details

`GDCLASS_TEMPLATE(m_class, m_class_str, m_inherits, m_inherits_str, disable_token)` works by allowing a type token and the string representing that type to be passed separately. For templates, `m_class` and/or `m_inherits` are the real template types, while `m_class_str` and `m_inherits_str` are strings representing friendly non-template aliases. The definition of `GDCLASS` simply becomes:
```cpp
#define GDCLASS(m_class, m_inherits) GDCLASS_TEMPLATE(m_class, #m_class, m_inherits, #m_inherits, m_class)
```

In the header file containing the template, a small expression needs to be passed to `GDCLASS_TEMPLATE` selecting the right string name for the template type. For example:
```cpp
#define RANGE_CLASS_MAP \
	std::is_same_v<T, double> ? "Range" : \
	std::is_same_v<T, int64_t> ? "RangeInt" : \
	"RangeInvalid"
```

### Advantages of this Approach
* Almost no code duplication, either in `Range` or `EditorSpinSlider`.
* Almost no boilerplate.
* The logical `GDCLASS` structure can now support templates and inheritance between templates in a way that's compatible with external language binding.
* For `Range` and `EditorSpinSlider`, full compatibility with existing GDScripts and GDExtensions. No changes required.

### Disadvantages of this Approach
* Ugly forward declarations in engine code.
  * As the friendly names are now aliases, forward declarations would have to contain both the template declaration and the alias declaration.
  * I solved this by simply including the header files range.h and editor_spin_slider.h where needed. Compile time doesn't appear to be appreciably affected.
  * GDExtensions are unaffected. They can continue to use `class Range` and `class EditorSpinSlider` forward declarations.
* To disable these classes at compile time using `disabled_classes`, the template name must be specified instead of the friendly alias.
  * This is probably fixable.

### Alternatives Considered

* PImpl Idiom
  * This doesn't work well because part of the implementation (e.g. `GDCLASS`, `_bind_methods()`, and virtual methods) must remain on the outer class.
  * Makes inheritance within the `GDCLASS` structure almost impossible to manage.
    * Templated inner implementation class would need to refer to outer class regularly. This requires a common base.
    * The only way to get a common base class in the child would be through multiple inheritance.
  * Lots of boilerplate.
* Duplicate implementation
  * The overhead of maintaining a separate implementation might be okay for `Range`, but is pretty ridiculous for `EditorSpinSlider`, which has a large amount of GUI logic that is unrelated to the underlying `Range` type.
  * The logic would only diverge over time leading to inconsistent behavior and harder to quash bugs.
* Make `Range` support both `double` and `int64_t`
  * Would require tracking two versions of the range value.
  * Leads to some convoluted logic to keep them in sync and some astonishing corner cases, such as when the `double` value becomes larger than the maximum integer value or less than the minimum integer value.
  * Might be acceptable if code was only used in engine, but would create more confusion that it's worth for external users via GDScript and GDExtension.