### PR TITLE
Allow zooming in Editor Help

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -798,8 +798,6 @@ FindReplaceBar::FindReplaceBar() {
 
 /*** CODE EDITOR ****/
 
-static constexpr float ZOOM_FACTOR_PRESETS[7] = { 0.25f, 0.5f, 0.75f, 1.0f, 1.5f, 2.0f, 3.0f };
-
 // This function should be used to handle shortcuts that could otherwise
 // be handled too late if they weren't handled here.
 void CodeTextEditor::input(const Ref<InputEvent> &event) {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -153,6 +153,8 @@ public:
 
 typedef void (*CodeTextEditorCodeCompleteFunc)(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced);
 
+inline constexpr float ZOOM_FACTOR_PRESETS[7] = { 0.25f, 0.5f, 0.75f, 1.0f, 1.5f, 2.0f, 3.0f };
+
 class CodeTextEditor : public VBoxContainer {
 	GDCLASS(CodeTextEditor, VBoxContainer);
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -112,6 +112,9 @@ class EditorHelp : public VBoxContainer {
 	HashMap<String, HashMap<String, int>> enum_values_line;
 	int description_line = 0;
 
+	MenuButton *zoom_button = nullptr;
+	float zoom_factor = 1.0f;
+
 	RichTextLabel *class_desc = nullptr;
 	HSplitContainer *h_split = nullptr;
 	static DocTools *doc;
@@ -156,7 +159,6 @@ class EditorHelp : public VBoxContainer {
 	void _help_callback(const String &p_topic);
 
 	void _add_text(const String &p_bbcode);
-	bool scroll_locked = false;
 
 	//void _button_pressed(int p_idx);
 	void _add_type(const String &p_type, const String &p_enum = String(), bool p_is_bitfield = false);
@@ -178,6 +180,11 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_input(const Ref<InputEvent> &p_input);
 	void _class_desc_resized(bool p_force_update_theme);
 	int display_margin = 0;
+
+	void _zoom_popup_id_pressed(int p_idx);
+	void _zoom_in();
+	void _zoom_out();
+	void _zoom_to(float p_zoom_factor);
 
 	Error _goto_desc(const String &p_class);
 	//void _update_history_buttons();
@@ -242,6 +249,9 @@ public:
 
 	int get_scroll() const;
 	void set_scroll(int p_scroll);
+
+	void set_zoom_factor(float p_zoom_factor);
+	float get_zoom_factor() const;
 
 	void update_toggle_scripts_button();
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3503,11 +3503,13 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	EditorHelp *eh = memnew(EditorHelp);
 
 	eh->set_name(p_class);
+	eh->set_zoom_factor(zoom_factor);
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_class(p_class);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	eh->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
+	eh->connect("zoomed", callable_mp(this, &ScriptEditor::_set_zoom_factor));
 	_add_recent_script(p_class);
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -3524,9 +3526,11 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	EditorHelp *eh = memnew(EditorHelp);
 
 	eh->set_name(cname);
+	eh->set_zoom_factor(zoom_factor);
 	tab_container->add_child(eh);
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
+	eh->connect("zoomed", callable_mp(this, &ScriptEditor::_set_zoom_factor));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -3940,6 +3944,11 @@ void ScriptEditor::_set_zoom_factor(float p_zoom_factor) {
 				if (zoom_factor != cte->get_zoom_factor()) {
 					cte->set_zoom_factor(zoom_factor);
 				}
+			}
+		} else {
+			EditorHelp *help = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
+			if (help) {
+				help->set_zoom_factor(zoom_factor);
 			}
 		}
 	}


### PR DESCRIPTION
This is a clean, rewritten version of https://github.com/godotengine/godot/pull/37196.
Compared to that PR, it introduces a global zoom button at status bar:

![doc_zoom](https://github.com/user-attachments/assets/ae1db556-fce8-4cdd-9938-1ee81542a352)

(I did not add a co-author because I've almost redone it from scratch)
- Closes https://github.com/godotengine/godot-proposals/issues/1914