### PR TITLE
Make `Animation::capture_included` read-only

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -599,7 +599,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="capture_included" type="bool" setter="_set_capture_included" getter="is_capture_included" default="false">
+		<member name="capture_included" type="bool" setter="" getter="is_capture_included" default="false">
 			Returns [code]true[/code] if the capture track is included. This is a cached readonly value for performance.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="1.0">

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -969,10 +969,6 @@ void Animation::remove_track(int p_track) {
 	_check_capture_included();
 }
 
-void Animation::set_capture_included(bool p_capture_included) {
-	capture_included = p_capture_included;
-}
-
 bool Animation::is_capture_included() const {
 	return capture_included;
 }
@@ -3908,13 +3904,12 @@ void Animation::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("compress", "page_size", "fps", "split_tolerance"), &Animation::compress, DEFVAL(8192), DEFVAL(120), DEFVAL(4.0));
 
-	ClassDB::bind_method(D_METHOD("_set_capture_included", "capture_included"), &Animation::set_capture_included);
 	ClassDB::bind_method(D_METHOD("is_capture_included"), &Animation::is_capture_included);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "0.001,99999,0.001,suffix:s"), "set_length", "get_length");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Ping-Pong"), "set_loop_mode", "get_loop_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step", PROPERTY_HINT_RANGE, "0,4096,0.001,suffix:s"), "set_step", "get_step");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "capture_included", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_NO_EDITOR), "_set_capture_included", "is_capture_included");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "capture_included", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "", "is_capture_included");
 
 	BIND_ENUM_CONSTANT(TYPE_VALUE);
 	BIND_ENUM_CONSTANT(TYPE_POSITION_3D);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -396,7 +396,6 @@ public:
 	int add_track(TrackType p_type, int p_at_pos = -1);
 	void remove_track(int p_track);
 
-	void set_capture_included(bool p_capture_included);
 	bool is_capture_included() const;
 
 	int get_track_count() const;


### PR DESCRIPTION
The `PROPERTY_USAGE_READ_ONLY` flag only makes the property read-only in the inspector, but the property also has the `PROPERTY_USAGE_NO_EDITOR` flag which means it won't show up in the inspector. So it does nothing, while still making it editable from scripting.

To make it read-only for scripting too, this PR removes the setter from the `PropertyInfo`. And since the `set_capture_included` method is now unused, it was also removed.

- Follow-up to https://github.com/godotengine/godot/pull/91437.
- Contributes to https://github.com/godotengine/godot/issues/64429.
