### PR TITLE
Make `OptionButton::selected` read-only

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -222,7 +222,7 @@
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items to select from.
 		</member>
-		<member name="selected" type="int" setter="_select_int" getter="get_selected" default="-1">
+		<member name="selected" type="int" setter="" getter="get_selected" default="-1">
 			The index of the currently selected item, or [code]-1[/code] if no item is selected.
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -399,19 +399,6 @@ void OptionButton::_select(int p_which, bool p_emit) {
 	}
 }
 
-void OptionButton::_select_int(int p_which) {
-	if (p_which < NONE_SELECTED) {
-		return;
-	}
-	if (p_which >= popup->get_item_count()) {
-		if (!initialized) {
-			queued_current = p_which;
-		}
-		return;
-	}
-	_select(p_which, false);
-}
-
 void OptionButton::_refresh_size_cache() {
 	cache_refresh_pending = false;
 
@@ -530,7 +517,6 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selected_id"), &OptionButton::get_selected_id);
 	ClassDB::bind_method(D_METHOD("get_selected_metadata"), &OptionButton::get_selected_metadata);
 	ClassDB::bind_method(D_METHOD("remove_item", "idx"), &OptionButton::remove_item);
-	ClassDB::bind_method(D_METHOD("_select_int", "idx"), &OptionButton::_select_int);
 
 	ClassDB::bind_method(D_METHOD("get_popup"), &OptionButton::get_popup);
 	ClassDB::bind_method(D_METHOD("show_popup"), &OptionButton::show_popup);
@@ -545,7 +531,7 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &OptionButton::get_allow_reselect);
 	ClassDB::bind_method(D_METHOD("set_disable_shortcuts", "disabled"), &OptionButton::set_disable_shortcuts);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "", "get_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fit_to_longest_item"), "set_fit_to_longest_item", "is_fit_to_longest_item");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");


### PR DESCRIPTION
This PR makes the `selected` property read- only, the `select` method can be used to set the value instead.

The `select` method is already exposed and does the same thing as the property's setter `_select_int`, which is now unused so it was removed.

- Contributes to https://github.com/godotengine/godot/issues/64429.

### Alternative

Using the `select` method as the setter for the `selected` property is technically possible, since both methods have the same signature, and would prevent breaking compatibility. Unfortunately, this means the `select` method becomes hidden and I'm not sure that's what we want.