### PR TITLE
Consider visual layers for DirectionalLight

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3089,7 +3089,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		Vector<Instance *> lights_with_shadow;
 
 		for (Instance *E : scenario->directional_lights) {
-			if (!E->visible) {
+			if (!E->visible || !(E->layer_mask & p_visible_layers)) {
 				continue;
 			}
 


### PR DESCRIPTION
Here, I have applied the patch provided by @majikayogames, in an updated line number to reflect the updated rendering engine. This should close #74545.
A concern was brought up about the directional lights not being considered for culling earlier in the function, but I don't believe there is any way to be confident you can cull a directional light without first rendering the shadowmap. If I am wrong, let me know.
I have been running a version of Godot that contains this patch, and I have seen no issues thus far.