### PR TITLE
Fix graph node stretch not taking titlebar into account

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -208,7 +208,7 @@ void GraphNode::_resort() {
 	// Avoid negative stretch space.
 	stretch_diff = MAX(stretch_diff, 0);
 
-	available_stretch_space += stretch_diff - sb_panel->get_margin(SIDE_BOTTOM) - sb_panel->get_margin(SIDE_TOP);
+	available_stretch_space += stretch_diff - sb_panel->get_margin(SIDE_BOTTOM) - sb_panel->get_margin(SIDE_TOP) - titlebar_min_size.height - sb_titlebar->get_minimum_size().height;
 
 	// Second pass, discard elements that can't be stretched, this will run while stretchable elements exist.
 


### PR DESCRIPTION
Found an issue while using the DialogueNodes addon:
https://github.com/nagidev/DialogueNodes

Where the stretch was not taking the titlebar into account, causing children to spill out of the node.

Before:
![image](https://github.com/user-attachments/assets/dcff410f-9886-4945-ad6a-cfb8d8662b5c)

After:
![image](https://github.com/user-attachments/assets/22f1263f-1f51-4ab9-a6dc-b68313a62d99)

I made sure other GraphNodes (visual shaders) were not broken by this change.