### PR TITLE
ThemeDB: expose method for making a copy of the default theme

### DIFF
--- a/doc/classes/ThemeDB.xml
+++ b/doc/classes/ThemeDB.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="generate_default_theme">
+			<return type="Theme" />
+			<description>
+				Returns a new copy of the default engine [Theme]. Unlike [method get_default_theme], this theme resource can be overridden.
+			</description>
+		</method>
 		<method name="get_default_theme">
 			<return type="Theme" />
 			<description>

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -123,6 +123,39 @@ Ref<Theme> ThemeDB::get_default_theme() {
 	return default_theme;
 }
 
+Ref<Theme> ThemeDB::generate_default_theme() {
+	Ref<Theme> t;
+	t.instantiate();
+
+	float default_scale = default_theme->get_default_base_scale();
+	Ref<Font> default_font = default_theme->get_default_font();
+
+	Ref<Texture2D> default_icon;
+	Ref<StyleBox> default_style;
+
+	Ref<FontVariation> bold_font;
+	Ref<FontVariation> bold_italics_font;
+	Ref<FontVariation> italics_font;
+
+	if (default_font.is_valid()) {
+		bold_font.instantiate();
+		bold_font->set_base_font(default_font);
+		bold_font->set_variation_embolden(1.2);
+
+		bold_italics_font.instantiate();
+		bold_italics_font->set_base_font(default_font);
+		bold_italics_font->set_variation_embolden(1.2);
+		bold_italics_font->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+
+		italics_font.instantiate();
+		italics_font->set_base_font(default_font);
+		italics_font->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+	}
+
+	fill_default_theme(t, default_font, Ref<Font>(), Ref<Font>(), Ref<Font>(), default_icon, default_style, default_scale);
+	return t;
+}
+
 void ThemeDB::set_project_theme(const Ref<Theme> &p_project_default) {
 	project_theme = p_project_default;
 }
@@ -417,6 +450,7 @@ void ThemeDB::_sort_theme_items() {
 void ThemeDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_default_theme"), &ThemeDB::get_default_theme);
 	ClassDB::bind_method(D_METHOD("get_project_theme"), &ThemeDB::get_project_theme);
+	ClassDB::bind_method(D_METHOD("generate_default_theme"), &ThemeDB::generate_default_theme);
 
 	ClassDB::bind_method(D_METHOD("set_fallback_base_scale", "base_scale"), &ThemeDB::set_fallback_base_scale);
 	ClassDB::bind_method(D_METHOD("get_fallback_base_scale"), &ThemeDB::get_fallback_base_scale);

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -134,6 +134,8 @@ public:
 	void set_default_theme(const Ref<Theme> &p_default);
 	Ref<Theme> get_default_theme();
 
+	Ref<Theme> generate_default_theme();
+
 	void set_project_theme(const Ref<Theme> &p_project_default);
 	Ref<Theme> get_project_theme();
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-cpp/issues/1332
Supports making a copy of the default theme so it can be overridden to define a custom theme quickly, without affecting the engine default theme and slowing down the editor:
```gdscript
# Custom theme
@tool
extends Theme

func _init() -> void:
    merge_with(ThemeDB.generate_default_theme())
    # override theme styles, colors ...
```