### PR TITLE
Tweak checkerboard colors to be easier on the eyes

### DIFF
--- a/editor/icons/Checkerboard.svg
+++ b/editor/icons/Checkerboard.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><g fill="#fff"><path fill-opacity=".2" d="M0 0h64v64H0z"/><path fill-opacity=".4" d="M0 0v16h16V0zm16 16v16h16V16zm16 0h16V0H32zm16 0v16h16V16zm0 16H32v16h16zm0 16v16h16V48zm-16 0H16v16h16zm-16 0V32H0v16z"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><path fill="#999" d="M0 0h64v64H0z"/><path fill="#666" d="M0 0v16h16V0zm16 16v16h16V16zm16 0h16V0H32zm16 0v16h16V16zm0 16H32v16h16zm0 16v16h16V48zm-16 0H16v16h16zm-16 0V32H0v16z"/></svg>

--- a/editor/icons/GuiMiniCheckerboard.svg
+++ b/editor/icons/GuiMiniCheckerboard.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="gray" d="M0 0v8h8V0zm8 8v8h8V8z"/><path fill="#fff" d="M8 0v8h8V0zm0 8H0v8h8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#666" d="M0 0v8h8V0zm8 8v8h8V8z"/><path fill="#999" d="M8 0v8h8V0zm0 8H0v8h8z"/></svg>

--- a/scene/theme/icons/mini_checkerboard.svg
+++ b/scene/theme/icons/mini_checkerboard.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="gray" d="M0 0v8h8V0zm8 8v8h8V8z"/><path fill="#fff" d="M8 0v8h8V0zm0 8H0v8h8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#666" d="M0 0v8h8V0zm8 8v8h8V8z"/><path fill="#999" d="M8 0v8h8V0zm0 8H0v8h8z"/></svg>


### PR DESCRIPTION
The colors match GIMP's `#666666` and `#999999` and are easier on the eyes (thanks to reduced contrast), especially on a dark theme.

This also inverts the pattern in `Checkerboard.svg` to match the other checkerboard icons (top-left square is dark).

## Preview

### Dark theme

Before | After
-|-
![Before](https://github.com/user-attachments/assets/7b3aa9ae-5c0a-447d-b6de-a3f773ab3f1a) | ![After](https://github.com/user-attachments/assets/c3483c08-9f08-40fc-abb2-55eeeb42cc45)

### Light theme

Before | After
-|-
![Before](https://github.com/user-attachments/assets/74d16b12-b8d7-4763-b3a6-2484bc50e8f3) | ![After](https://github.com/user-attachments/assets/5e7c0e0a-1940-4fc4-b6cb-41639848c89e)

