### PR TITLE
Correct rotation gizmo plane math for off-center perspective view

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5001,14 +5001,24 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 		} break;
 
 		case TRANSFORM_ROTATE: {
-			Plane plane = Plane(_get_camera_normal(), _edit.center);
+			Plane plane;
+			if (camera->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
+				Vector3 cam_to_obj = _edit.center - _get_camera_position();
+				if (!cam_to_obj.is_zero_approx()) {
+					plane = Plane(cam_to_obj.normalized(), _edit.center);
+				} else {
+					plane = Plane(_get_camera_normal(), _edit.center);
+				}
+			} else {
+				plane = Plane(_get_camera_normal(), _edit.center);
+			}
 
 			Vector3 local_axis;
 			Vector3 global_axis;
 			switch (_edit.plane) {
 				case TRANSFORM_VIEW:
 					// local_axis unused
-					global_axis = _get_camera_normal();
+					global_axis = plane.normal;
 					break;
 				case TRANSFORM_X_AXIS:
 					local_axis = Vector3(1, 0, 0);
@@ -5039,7 +5049,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 				break;
 			}
 
-			static const float orthogonal_threshold = Math::cos(Math::deg_to_rad(87.0f));
+			static const float orthogonal_threshold = Math::cos(Math::deg_to_rad(85.0f));
 			bool axis_is_orthogonal = ABS(plane.normal.dot(global_axis)) < orthogonal_threshold;
 
 			double angle = 0.0f;


### PR DESCRIPTION
### Summary

The rotation gizmo currently uses the camera's forward vector to determine the plane of interaction. This works fine in ortho viewports, and works in perspective viewports _if the gizmo is near the center of the viewport_. As the gizmo gets closer to the peripheral of the viewport, this results in the gizmo selecting the incorrect style of interaction (scrolling vs winding), and it also results in incorrect rotation when using view-aligned rotation. Below are GIFs of the three cases, comparing the old and new, corrected behaviour.

**Fixes**: #95367

### Linear Scrolling Tangential to Axis
In this case, the old behaviour incorrectly determines that it should use a radial interaction, and can choose an incorrect winding direction as well.
![Linear](https://github.com/user-attachments/assets/f8e2e80a-cd0a-41f2-8861-77d03ed6e2b3)

### Radial Winding Around Axis
In this case, the old behaviour incorrectly determines that it should use a linear interaction.
![Radial](https://github.com/user-attachments/assets/64a2aa94-96e5-4fe8-ac39-55941649e8b5)

### Radial Winding in View-Space
In this case, the old behaviour rotates the object around an inaccurate axis, causing the view of the object to change as you rotate it. The new behaviour uses the correct axis, and keeps the object visually consistent as you rotate it.
![View](https://github.com/user-attachments/assets/d4dafa17-c425-4fcd-925b-3bd65470b486)

### Additional Notes
I've also slightly adjusted the orthogonal angle threshold for distinguishing between scroll/winding by 3 degrees, as the old threshold was determined whilst having to account for the erroneous behaviour. The new value makes it slightly easier to choose the linear scrolling interaction.