### PR TITLE
Prevent to seek doubly on AnimationPlayerEditor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1295,7 +1295,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 	}
 	pos = CLAMP(pos, 0, (double)anim->get_length() - CMP_EPSILON2); // Hack: Avoid fposmod with LOOP_LINEAR.
 
-	if (!p_timeline_only && anim.is_valid()) {
+	if (!p_timeline_only && anim.is_valid() && (!player->is_valid() || !Math::is_equal_approx(pos, player->get_current_animation_position()))) {
 		player->seek_internal(pos, true, true, false);
 	}
 


### PR DESCRIPTION
- Fixes #95391

Perhaps the fix for updating the drawing (maybe https://github.com/godotengine/godot/pull/93980) caused a double seek.

As I commented in https://github.com/godotengine/godot/pull/94420, Discrete gets the value of the previous key during reverse playback. The second time of the double seek is always updated with a positive 0 value, so the key to be acquired changes immediately after the reverse playback, which is the cause of #95391.

Ideally, we would remove the method call for the second seek, but for now I fix this by preventing the seek to the same time on the editor.