### PR TITLE
BoneMap.profile property is not available to import scripts

### DIFF
--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -40,6 +40,9 @@
 	<members>
 		<member name="profile" type="SkeletonProfile" setter="set_profile" getter="get_profile">
 			A [SkeletonProfile] of the mapping target. Key names in the [BoneMap] are synchronized with it.
+
+			
+			Note: this property is not accessible to import scripts. The [BoneMap.SkeletonProfile] is only accessible to the UI during import.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -40,8 +40,6 @@
 	<members>
 		<member name="profile" type="SkeletonProfile" setter="set_profile" getter="get_profile">
 			A [SkeletonProfile] of the mapping target. Key names in the [BoneMap] are synchronized with it.
-
-			
 			[b]Note:[/b] This property is not accessible to import scripts. The [SkeletonProfile] is only accessible to the UI during import.
 		</member>
 	</members>

--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -42,7 +42,7 @@
 			A [SkeletonProfile] of the mapping target. Key names in the [BoneMap] are synchronized with it.
 
 			
-			Note: this property is not accessible to import scripts. The [BoneMap.SkeletonProfile] is only accessible to the UI during import.
+			[b]Note:[/b] this property is not accessible to import scripts. The [SkeletonProfile] is only accessible to the UI during import.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -42,7 +42,7 @@
 			A [SkeletonProfile] of the mapping target. Key names in the [BoneMap] are synchronized with it.
 
 			
-			[b]Note:[/b] this property is not accessible to import scripts. The [SkeletonProfile] is only accessible to the UI during import.
+			[b]Note:[/b] This property is not accessible to import scripts. The [SkeletonProfile] is only accessible to the UI during import.
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
Added note that the profile property is not available to import scripts.

Reason this change is needed...a lot of time was wasted by several people looking for a solution to retargetting the bones via script and a LOT of time would have been saved if this was noted.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
