### PR TITLE
Fix `!is_inside_tree` in csg node when reloading a scene

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1926,7 +1926,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 		}
 
 		if (mode == MODE_PATH) {
-			if (!path_local) {
+			if (!path_local && path->is_inside_tree()) {
 				base_xform = path->get_global_transform();
 			}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95401

The problem is that during reload, the csgnode will make several defered call to `_update_shape` which will get the `path`'s global transform, but at that time the path node is not inside the tree yet. 

Are there any better ways to fix this like post the `_update_shape` later ?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
