### PR TITLE
Fix crash by ensuring selected node is a descendant of the edited scene

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1064,21 +1064,23 @@ void Node3DEditorViewport::_select_region() {
 		if (found_nodes.has(sp)) {
 			continue;
 		}
-
 		found_nodes.insert(sp);
 
 		Node *node = Object::cast_to<Node>(sp);
-		if (node != edited_scene) {
-			node = edited_scene->get_deepest_editable_node(node);
-		}
 
-		// Prevent selection of nodes not owned by the edited scene.
-		while (node && node != edited_scene->get_parent()) {
-			Node *node_owner = node->get_owner();
-			if (node_owner == edited_scene || node == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
-				break;
+		// Selection requires that the node is the edited scene or its descendant, and has an owner.
+		if (node != edited_scene) {
+			if (!node->get_owner() || !edited_scene->is_ancestor_of(node)) {
+				continue;
 			}
-			node = node->get_parent();
+			node = edited_scene->get_deepest_editable_node(node);
+			while (node != edited_scene) {
+				Node *node_owner = node->get_owner();
+				if (node_owner == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
+					break;
+				}
+				node = node->get_parent();
+			}
 		}
 
 		// Replace the node by the group if grouped


### PR DESCRIPTION
Fixes #95356, 
Caused by regression #92188
*Bugsquad edit:* Fixes #94844

Previously this section of code allowed selecting nodes not descended from the edited scene, ascending beyond Godot's Window, resulting in a crash calling a function on a null.

This PR fixes that by requiring the selected node be a descendent of the edited scene (also a prereq of `ownership`), and fixes or reduces other aspects.

* Checking `is_ancestor_of` fixes both the error message (affecting 4.2.2-stable) and crash (affecting 4.3) identified in #95356
* Skipping on `node != edited_scene && !get_owner` is consistent with 2D https://github.com/godotengine/godot/blob/8e2141eac534f6984bb0bdbcefbd17de27ae0993/editor/plugins/canvas_item_editor_plugin.cpp#L706

