### PR TITLE
OpenGL: Unconditionally do `glDisable(GL_FRAMEBUFFER_SRGB)` because we do our own sRGB conversion

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -62,6 +62,10 @@
 #define _EXT_DEBUG_SEVERITY_LOW_ARB 0x9148
 #define _EXT_DEBUG_OUTPUT 0x92E0
 
+#ifndef GL_FRAMEBUFFER_SRGB
+#define GL_FRAMEBUFFER_SRGB 0x8DB9
+#endif
+
 #ifndef GLAPIENTRY
 #if defined(WINDOWS_ENABLED)
 #define GLAPIENTRY APIENTRY
@@ -344,6 +348,9 @@ RasterizerGLES3::RasterizerGLES3() {
 			}
 		}
 	}
+
+	// Disable OpenGL linear to sRGB conversion, because Godot will always do this conversion itself.
+	glDisable(GL_FRAMEBUFFER_SRGB);
 
 	// OpenGL needs to be initialized before initializing the Rasterizers
 	config = memnew(GLES3::Config);

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -56,11 +56,6 @@
 // feature off.
 // See: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt
 
-// On OpenGLES this is not defined in our standard headers..
-#ifndef GL_FRAMEBUFFER_SRGB
-#define GL_FRAMEBUFFER_SRGB 0x8DB9
-#endif
-
 HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions() {
 	HashMap<String, bool *> request_extensions;
 
@@ -194,23 +189,6 @@ void OpenXROpenGLExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_d
 	p_usable_depth_formats.push_back(GL_DEPTH24_STENCIL8);
 	p_usable_depth_formats.push_back(GL_DEPTH32F_STENCIL8);
 	p_usable_depth_formats.push_back(GL_DEPTH_COMPONENT24);
-}
-
-void OpenXROpenGLExtension::on_pre_draw_viewport(RID p_render_target) {
-	if (srgb_ext_is_available) {
-		hw_linear_to_srgb_is_enabled = glIsEnabled(GL_FRAMEBUFFER_SRGB);
-		if (hw_linear_to_srgb_is_enabled) {
-			// Disable this.
-			glDisable(GL_FRAMEBUFFER_SRGB);
-		}
-	}
-}
-
-void OpenXROpenGLExtension::on_post_draw_viewport(RID p_render_target) {
-	if (srgb_ext_is_available && hw_linear_to_srgb_is_enabled) {
-		// Re-enable this.
-		glEnable(GL_FRAMEBUFFER_SRGB);
-	}
 }
 
 bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, void **r_swapchain_graphics_data) {

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -49,9 +49,6 @@ public:
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 
-	virtual void on_pre_draw_viewport(RID p_render_target) override;
-	virtual void on_post_draw_viewport(RID p_render_target) override;
-
 	virtual void get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual void get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual String get_swapchain_format_name(int64_t p_swapchain_format) const override;
@@ -75,9 +72,6 @@ private:
 		bool is_multiview;
 		Vector<RID> texture_rids;
 	};
-
-	bool srgb_ext_is_available = true;
-	bool hw_linear_to_srgb_is_enabled = false;
 
 	bool check_graphics_api_support(XrVersion p_desired_version);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95313

I think this is the right thing to do, because:

- OpenGL will only do the linear to sRGB conversion enabled via `glEnable(GL_FRAMEBUFFER_SRGB)` on FBO's that have a color attachment which uses an sRGB internal format. So, it will do the conversion on `GL_SRGB8_ALPHA8`, but _not_ on `GL_RGBA8`
- Godot's renderer doesn't normally use any sRGB internal formats for render buffers, because we do the linear to sRGB conversion ourselves in our shaders
- We're only using `GL_SRGB8_ALPHA8` in OpenXR, because if we don't, the OpenXR compositor will assume the content is linear, and it'll do another linear to sRGB conversion. So, we're forced to use that as the internal format, in order to signal that we're giving it sRGB data
- It should be safe to do `glDisable(GL_FRAMEBUFFER_SRGB)` unconditionally, because Godot's OpenGL renderer isn't even relying on that anyway (as explained above in my second point in this list)

~~The main thing I'm not sure about, is if doing this in `RasterizerGLES3::begin_frame()` is the right place to do it? We don't actually need to do it every frame, but I couldn't find an obvious central place to do it, It works fine in `GLES3::Config::Config()` which only runs once, but we're only querying config there, not setting it, so it seemed inappropriate. I'd appreciate any advice about this!~~

**UPDATE:** Moved to `RasterizerGLES3::RasterizerGLES3()` based on advice from Clay.

This PR also partially reverts the changes from https://github.com/godotengine/godot/pull/74892, which did `glDisable(GL_FRAMEBUFFER_SRGB)`, but only when rendering viewports with `use_xr` set to `true` (which doesn't help the composition layers). With this PR doing it unconditionally, that is no longer necessary.
