### PR TITLE
Add Animation tutorial links to class reference by 4.3

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -8,6 +8,7 @@
 		After instantiating the playback information data within the extended class, the blending is processed by the [AnimationMixer].
 	</description>
 	<tutorials>
+		<link title="Migrating Animations from Godot 4.0 to 4.3">https://godotengine.org/article/migrating-animations-from-godot-4-0-to-4-3/</link>
 	</tutorials>
 	<methods>
 		<method name="_post_process_key_value" qualifiers="virtual const">
@@ -122,7 +123,7 @@
 				    move_and_slide()
 				[/gdscript]
 				[/codeblocks]
-				By using this in combination with [method get_root_motion_position_accumulator], you can apply the root motion position more correctly to account for the rotation of the node.
+				By using this in combination with [method get_root_motion_rotation_accumulator], you can apply the root motion position more correctly to account for the rotation of the node.
 				[codeblocks]
 				[gdscript]
 				func _process(delta):

--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -9,6 +9,7 @@
 		This node should be used to implement custom IK solvers, constraints, or skeleton physics.
 	</description>
 	<tutorials>
+		<link title="Design of the Skeleton Modifier 3D">https://godotengine.org/article/design-of-the-skeleton-modifier-3d/</link>
 	</tutorials>
 	<methods>
 		<method name="_process_modification" qualifiers="virtual">


### PR DESCRIPTION
- Add the link of [Migrating Animations from Godot 4.0 to 4.3](https://godotengine.org/article/migrating-animations-from-godot-4-0-to-4-3/) as an information about the differences in behavior of some options
- Add the link of [Design of the Skeleton Modifier 3D](https://godotengine.org/article/design-of-the-skeleton-modifier-3d/) as a tutorial of making custom SkeletonModifier3D

Includes correction of minor term error.