### PR TITLE
Use transformed roughness instead of raw roughness to calculate roughness fade in SSR

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -237,7 +237,7 @@ void main() {
 
 		// This is an ad-hoc term to fade out the SSR as roughness increases. Values used
 		// are meant to match the visual appearance of a ReflectionProbe.
-		float roughness_fade = smoothstep(0.4, 0.7, 1.0 - normal_roughness.w);
+		float roughness_fade = smoothstep(0.4, 0.7, 1.0 - roughness);
 
 		// Schlick term.
 		float metallic = texelFetch(source_metallic, ssC << 1, 0).w;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95388

https://github.com/godotengine/godot/pull/86316 changed the way we store roughness in the normal_roughness buffer. We can't use the buffer value directly. In the SSR shader we calculate the transformed roughness at the top, but we mistakenly continued to read from the non-transformed roughness for calculating the roughness_fade. 