### PR TITLE
Tweak missing tile source message in the TileSet editor

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -2368,7 +2368,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	tiles_bottom_panel->set_name(TTR("Tiles"));
 
 	missing_source_label = memnew(Label);
-	missing_source_label->set_text(TTR("This TileMap's TileSet has no source configured. Go to the TileSet bottom panel to add one."));
+	missing_source_label->set_text(TTR("This TileMap's TileSet has no Tile Source configured. Go to the TileSet bottom panel to add one."));
 	missing_source_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -818,7 +818,7 @@ TileSetEditor::TileSetEditor() {
 	tabs_bar = memnew(TabBar);
 	tabs_bar->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	tabs_bar->set_clip_tabs(false);
-	tabs_bar->add_tab(TTR("Tiles"));
+	tabs_bar->add_tab(TTR("Tile Sources"));
 	tabs_bar->add_tab(TTR("Patterns"));
 	tabs_bar->connect("tab_changed", callable_mp(this, &TileSetEditor::_tab_changed));
 


### PR DESCRIPTION
This also renames the Tiles tab in the TileSet bottom panel to Tile Sources to make it more explicit (and avoid using the same name as the Tiles tab in the TileMap editor).

- See https://github.com/godotengine/godot-proposals/issues/3874#issuecomment-2283019896.

cc @KaijuKoder2

## Preview

![image](https://github.com/user-attachments/assets/b253f6e4-bd77-4016-b3c8-351cad5530dd)

![image](https://github.com/user-attachments/assets/db3437ee-2665-4313-9e20-cddc3b9b666f)
