### PR TITLE
Fail when submit or sync called on main rendering device

### DIFF
--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -88,6 +88,9 @@ private:
 	RenderingDeviceDriver *driver = nullptr;
 	RenderingContextDriver::Device device;
 
+	bool local_device_processing = false;
+	bool is_main_instance = false;
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
This fixes an unreported issue that results from users calling `submit()` or `sync()` on the main rendering device. 

Calling submit any time on the main rendering thread will result in a constant stream of validation layer errors and visual issues. 

In 4.2 and earlier we had similar checks to this but we lost them in the refactor. 

I found this issue while experimenting with https://github.com/SebLague/Godot-Marching-Cubes. I simply swapped the local rendering device for the main rendering device to reproduce the issue. 

CC @DarioSamo 