### PR TITLE
Increase precision of skeleton transforms in the skeleton shader in the Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/skeleton.glsl
+++ b/drivers/gles3/shaders/skeleton.glsl
@@ -59,7 +59,7 @@ layout(location = 10) in highp uvec4 in_bone_attrib;
 layout(location = 11) in mediump vec4 in_weight_attrib;
 #endif
 
-uniform mediump sampler2D skeleton_texture; // texunit:0
+uniform highp sampler2D skeleton_texture; // texunit:0
 #endif
 
 /* clang-format on */


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/91170

I was able to reproduce the issue locally on a Google Pixel 7. It turns out we only need to make the transform texture use highp in order for the shader to work properly without jittering. In hindsight, I'm not sure why the transform texture was ever mediump as the positional data should always use full precision (as it does in the RD renderers and in 3.x). 