### PR TITLE
Remove `missing a category` warning in visual shader node

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -412,7 +412,6 @@ String VisualShaderNode::get_warning(Shader::Mode p_mode, VisualShader::Type p_t
 }
 
 VisualShaderNode::Category VisualShaderNode::get_category() const {
-	WARN_PRINT(get_caption() + " is missing a category.");
 	return CATEGORY_NONE;
 }
 


### PR DESCRIPTION
As suggested in https://github.com/godotengine/godot/issues/95443#issuecomment-2284851316,  But the warning is printed in the base method `get_category`, so if we remove that we will remove all the related warning. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
