### PR TITLE
Fix shader incorrectly expects `int` on `uint` and vice-versa in cases

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -544,6 +544,9 @@ public:
 		bool use_comma_between_statements = false;
 		bool use_op_eval = true;
 
+		DataType expected_type = TYPE_VOID;
+		HashSet<int> constants;
+
 		BlockNode() :
 				Node(NODE_TYPE_BLOCK) {}
 	};


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/95453

This code will now compile correctly:

```glsl
shader_type spatial;

const int iOne = 1;
const uint uOne = 1u;

void fragment() {
	
	int i; uint u;
	switch (i) {
		case iOne: break;
	}
	switch (u) {
		case uOne: break;
	}
}
```

Also, I've placed the case label duplication check code into case processing branch, the reason for that is that it will print an error at the case label itself:

<details>
<summary>Details</summary>

![изображение](https://github.com/user-attachments/assets/7393017c-887a-4ee8-9f08-6bd57d40f9e2)

</details>

rather than

<details>
<summary>Details</summary>

![изображение](https://github.com/user-attachments/assets/e1e1596e-ca40-4bce-807f-8ab6afcd5081)

</details>


Besides that, I've fixed a shader compiler failure when declaring a switch like this:

```glsl
switch(1u) {
	default:
	break;

	case 1u:
	break;

	default:
	break;
}
```