### PR TITLE
Enable `SpriteFramesEditor` to "guess" the amount of rows and columns of a sprite sheet when loading it for the first time

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -234,6 +234,9 @@ class SpriteFramesEditor : public HSplitContainer {
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	void _open_sprite_sheet();
+	void _auto_slice_sprite_sheet();
+	bool _matches_background_color(const Color &p_background_color, const Color &p_pixel_color);
+	Size2i _estimate_sprite_sheet_size(const Ref<Texture2D> p_texture);
 	void _prepare_sprite_sheet(const String &p_file);
 	int _sheet_preview_position_to_frame_index(const Vector2 &p_position);
 	void _sheet_preview_draw();


### PR DESCRIPTION
Pull request for Proposal: https://github.com/godotengine/godot-proposals/issues/10415

Essentially when the sprite frames editor loads a spritesheet for the first time, it defaults to their being 4 rows and 4 columns regardless of the content of the image. With this PR the Editor makes a "best guess" at how many rows and columns are in the sheet by scanning the image.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10415*