### PR TITLE
Add check on `Timer::start` method to prevent reset if it's already started

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -107,7 +107,9 @@ bool Timer::has_autostart() const {
 
 void Timer::start(double p_time) {
 	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
-
+	if (time_left > 0) {
+		return;
+	}
 	if (p_time > 0) {
 		set_wait_time(p_time);
 	}


### PR DESCRIPTION
The current `start` method doesn't do any checking whether the Timer is already started or not, it just sets the time as it is. 
This PR will add check so it match the functionality as described on the [docs](https://docs.godotengine.org/en/latest/classes/class_timer.html#class-timer-method-start). 

Fix #95480
