### PR TITLE
Improve gamepad support on Linux

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -149,6 +149,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"), &Input::get_vector, DEFVAL(-1.0f));
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
+	ClassDB::bind_method(D_METHOD("set_joy_button_need_reshow", "device", "need"), &Input::set_joy_button_need_reshow, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_joy_auto_mapped", "device"), &Input::is_joy_auto_mapped);
 	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &Input::is_joy_known);
 	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
@@ -1799,11 +1801,94 @@ void Input::set_fallback_mapping(const String &p_guid) {
 	}
 }
 
+bool Input::is_joy_button_need_reshow(int p_device) const {
+	ERR_FAIL_INDEX_V(p_device, (int)joy_names.size(), false);
+
+	return joy_names[p_device].need_reshow_buttons;
+}
+
+void Input::set_joy_button_need_reshow(int p_device, bool p_need) {
+	ERR_FAIL_INDEX(p_device, (int)joy_names.size());
+
+	joy_names[p_device].need_reshow_buttons = p_need;
+}
+
+void Input::set_unknown_gamepad_auto_mapped(bool p_auto) {
+	unknown_gamepad_auto_mapped = p_auto;
+}
+
+bool Input::is_unknown_gamepad_auto_mapped() const {
+	return unknown_gamepad_auto_mapped;
+}
+
+void Input::unknown_gamepad_auto_map(const StringName &p_guid, const String &p_name, const int *p_key_map, const int *p_axis_map, bool p_trigger_is_digital) {
+	JoyDeviceMapping mapping;
+	mapping.auto_generated = true;
+	mapping.uid = p_guid;
+	mapping.name = p_name;
+
+	for (int i = 0; i < int(JoyButton::SDL_MAX); i++) {
+		JoyBinding binding;
+
+		binding.outputType = TYPE_BUTTON;
+		binding.output.button = JoyButton(i);
+
+		binding.inputType = TYPE_BUTTON;
+		binding.input.button = JoyButton(p_key_map[i]);
+
+		mapping.bindings.push_back(binding);
+	}
+
+	for (int i = 0; i < int(JoyAxis::SDL_MAX); i++) {
+		JoyBinding binding;
+
+		binding.outputType = TYPE_AXIS;
+		binding.output.axis.axis = JoyAxis(i);
+		binding.output.axis.range = JoyAxisRange::FULL_AXIS;
+
+		if (p_trigger_is_digital && i >= int(JoyAxis::SDL_MAX) - 2) {
+			binding.inputType = TYPE_BUTTON;
+			binding.input.button = JoyButton(p_axis_map[i]);
+		} else {
+			binding.inputType = TYPE_AXIS;
+			binding.input.axis.axis = JoyAxis(p_axis_map[i]);
+			binding.input.axis.range = JoyAxisRange::FULL_AXIS;
+			binding.input.axis.invert = false;
+		}
+
+		mapping.bindings.push_back(binding);
+	}
+
+	map_db.push_back(mapping);
+}
+
+bool Input::is_mapping_known(const StringName &p_guid) const {
+	for (const JoyDeviceMapping &map : map_db) {
+		if (map.uid == p_guid) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Input::is_joy_auto_mapped(int p_device) const {
+	if (!joy_names.has(p_device)) {
+		return false;
+	}
+
+	int mapping = joy_names[p_device].mapping;
+	if (mapping == -1) {
+		return false;
+	}
+
+	return map_db[mapping].auto_generated;
+}
+
 //platforms that use the remapping system can override and call to these ones
 bool Input::is_joy_known(int p_device) {
 	if (joy_names.has(p_device)) {
 		int mapping = joy_names[p_device].mapping;
-		if (mapping != -1 && mapping != fallback_mapping) {
+		if (mapping != -1 && mapping != fallback_mapping && !map_db[mapping].auto_generated) {
 			return true;
 		}
 	}

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -170,6 +170,7 @@ private:
 		StringName name;
 		StringName uid;
 		bool connected = false;
+		bool need_reshow_buttons = false;
 		bool last_buttons[(size_t)JoyButton::MAX] = { false };
 		float last_axis[(size_t)JoyAxis::MAX] = { 0.0f };
 		HatMask last_hat = HatMask::CENTER;
@@ -185,6 +186,8 @@ private:
 	HashSet<uint32_t> ignored_device_ids;
 
 	int fallback_mapping = -1; // Index of the guid in map_db.
+
+	bool unknown_gamepad_auto_mapped = true;
 
 	CursorShape default_shape = CURSOR_ARROW;
 
@@ -238,6 +241,7 @@ private:
 	};
 
 	struct JoyDeviceMapping {
+		bool auto_generated = false;
 		String uid;
 		String name;
 		Vector<JoyBinding> bindings;
@@ -369,8 +373,17 @@ public:
 	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);
 	void remove_joy_mapping(const String &p_guid);
 
+	bool is_joy_button_need_reshow(int p_device) const;
+	void set_joy_button_need_reshow(int p_device, bool p_need);
+
+	void set_unknown_gamepad_auto_mapped(bool p_auto);
+	bool is_unknown_gamepad_auto_mapped() const;
+	void unknown_gamepad_auto_map(const StringName &p_guid, const String &p_name, const int *p_key_map, const int *p_axis_map, bool p_trigger_is_digital);
+
 	int get_unused_joy_id();
 
+	bool is_mapping_known(const StringName &p_guid) const;
+	bool is_joy_auto_mapped(int p_device) const;
 	bool is_joy_known(int p_device);
 	String get_joy_guid(int p_device) const;
 	bool should_ignore_device(int p_vendor_id, int p_product_id) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -238,6 +238,14 @@
 				Returns [code]true[/code] if any action, key, joypad button, or mouse button is being pressed. This will also return [code]true[/code] if any action is simulated via code by calling [method action_press].
 			</description>
 		</method>
+		<method name="is_joy_auto_mapped" qualifiers="const" keywords="is_gamepad_auto_mapped, is_controller_auto_mapped">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns [code]true[/code] if the specified device is currently auto mapped. See also [member ProjectSettings.input_devices/gamepad/unknown_gamepad_auto_mapped].
+				[b]Note:[/b] This method is only implemented on Linux.
+			</description>
+		</method>
 		<method name="is_joy_button_pressed" qualifiers="const" keywords="is_gamepad_button_pressed, is_controller_button_pressed">
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
@@ -251,6 +259,7 @@
 			<param index="0" name="device" type="int" />
 			<description>
 				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices. Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
+				[b]Note:[/b] This method returns [code]false[/code] even if the specified device is auto mapped (see [method is_joy_auto_mapped]).
 			</description>
 		</method>
 		<method name="is_key_label_pressed" qualifiers="const">
@@ -313,6 +322,7 @@
 			<description>
 				Removes all mappings from the internal database that match the given GUID. All currently connected joypads that use this GUID will become unmapped.
 				On Android, Godot will map to an internal fallback mapping.
+				[b]Note:[/b] If [member ProjectSettings.input_devices/gamepad/unknown_gamepad_auto_mapped] is enabled on Linux, it may not be possible to completely restore the device to its original unmapped state. If you need a more thorough recovery, please call [method set_joy_button_need_reshow] again.
 			</description>
 		</method>
 		<method name="set_accelerometer">
@@ -360,6 +370,15 @@
 			<description>
 				Sets the value of the rotation rate of the gyroscope sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_joy_button_need_reshow">
+			<return type="void" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="need" type="bool" default="true" />
+			<description>
+				If set to [code]true[/code], for devices with auto-mapping enabled, some hidden buttons will be restored so that users can use their own mappings. See also [method is_joy_auto_mapped].
+				[b]Note:[/b] This method is only effective on Linux. Recommended when some buttons cannot be found.
 			</description>
 		</method>
 		<method name="set_magnetometer">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1423,6 +1423,11 @@
 			If [code]false[/code], no input will be lost.
 			[b]Note:[/b] You should in nearly all cases prefer the [code]false[/code] setting. The legacy behavior is to enable supporting old projects that rely on the old logic, without changes to script.
 		</member>
+		<member name="input_devices/gamepad/unknown_gamepad_auto_mapped" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], allows unknown gamepads to be auto mapped, according to keycode semantics and convention. When the gamepad's mapping cannot be found in the built-in mapping database, a mapping will be auto generated as a fallback.
+			[b]Note:[/b] The gamepad is not guaranteed to work properly with the generated mapping.
+			[b]Note:[/b] This setting is only effective on Linux.
+		</member>
 		<member name="input_devices/pen_tablet/driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 			[b]Note:[/b] The driver in use can be overridden at runtime via the [code]--tablet-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3251,6 +3251,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 			bool agile_input_event_flushing = GLOBAL_DEF("input_devices/buffering/agile_event_flushing", false);
 			id->set_agile_input_event_flushing(agile_input_event_flushing);
 
+			bool unknown_gamepad_auto_mapped = GLOBAL_DEF("input_devices/gamepad/unknown_gamepad_auto_mapped", true);
+			id->set_unknown_gamepad_auto_mapped(unknown_gamepad_auto_mapped);
+
 			if (bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_touch_from_mouse", false)) &&
 					!(editor || project_manager)) {
 				if (!DisplayServer::get_singleton()->is_touchscreen_available()) {

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -309,7 +309,7 @@ void JoypadLinux::setup_joypad_properties(Joypad &p_joypad) {
 			p_joypad.key_map[i] = num_buttons++;
 		}
 	}
-	for (int i = BTN_MISC; i < BTN_JOYSTICK; ++i) {
+	for (int i = 0; i < BTN_JOYSTICK; ++i) {
 		if (test_bit(i, keybit)) {
 			p_joypad.key_map[i] = num_buttons++;
 		}

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -75,6 +75,9 @@ JoypadLinux::Joypad::~Joypad() {
 void JoypadLinux::Joypad::reset() {
 	dpad = 0;
 	fd = -1;
+	for (int i = 0; i < MAX_KEY; i++) {
+		key_map[i] = -1;
+	}
 	for (int i = 0; i < MAX_ABS; i++) {
 		abs_map[i] = -1;
 		curr_axis[i] = 0;
@@ -314,6 +317,7 @@ void JoypadLinux::setup_joypad_properties(Joypad &p_joypad) {
 			p_joypad.key_map[i] = num_buttons++;
 		}
 	}
+
 	for (int i = 0; i < ABS_MISC; ++i) {
 		/* Skip hats */
 		if (i == ABS_HAT0X) {
@@ -338,6 +342,159 @@ void JoypadLinux::setup_joypad_properties(Joypad &p_joypad) {
 			p_joypad.force_feedback = true;
 		}
 	}
+}
+
+void JoypadLinux::_auto_remap(Joypad &p_joypad, const StringName &p_guid, const String &p_name, bool p_hat0x_exist, bool p_hat0y_exist) {
+	if (p_joypad.key_map[BTN_GAMEPAD] == -1) {
+		return;
+	}
+
+	// Generate key mapping for JoyButton.
+
+	int joy_button_mappings[int(JoyButton::SDL_MAX)];
+	for (int i = 0; i < int(JoyButton::SDL_MAX); i++) {
+		joy_button_mappings[i] = -1;
+	}
+
+#define BUTTON_MAP_KEY(button, keycode) (joy_button_mappings[int(button)] = p_joypad.key_map[keycode])
+#define KEY_EXIST(keycode) (p_joypad.key_map[keycode] != -1)
+#define UNUSED_KEY_HIDE(keycode) (p_joypad.key_map[keycode] = -p_joypad.key_map[keycode] - 2) // Used for two events occur at one key press.
+
+	BUTTON_MAP_KEY(JoyButton::A, BTN_A);
+	BUTTON_MAP_KEY(JoyButton::B, BTN_B);
+	BUTTON_MAP_KEY(JoyButton::X, BTN_X);
+	BUTTON_MAP_KEY(JoyButton::Y, BTN_Y);
+
+	if (KEY_EXIST(KEY_BACK)) {
+		// Exceptions for certain Xbox devices. The BTN_SELECT event is supported, but KEY_BACK is actually emitted.
+		BUTTON_MAP_KEY(JoyButton::BACK, KEY_BACK);
+	} else if (KEY_EXIST(BTN_SELECT)) {
+		BUTTON_MAP_KEY(JoyButton::BACK, BTN_SELECT);
+	}
+
+	if (KEY_EXIST(KEY_HOMEPAGE)) {
+		// Exceptions for certain Xbox devices. The BTN_MODE event is supported, but KEY_HOMEPAGE is actually emitted.
+		BUTTON_MAP_KEY(JoyButton::GUIDE, KEY_HOMEPAGE);
+	} else if (KEY_EXIST(BTN_MODE)) {
+		BUTTON_MAP_KEY(JoyButton::GUIDE, BTN_MODE);
+	}
+
+	BUTTON_MAP_KEY(JoyButton::START, BTN_START);
+	BUTTON_MAP_KEY(JoyButton::LEFT_STICK, BTN_THUMBL);
+	BUTTON_MAP_KEY(JoyButton::RIGHT_STICK, BTN_THUMBR);
+	BUTTON_MAP_KEY(JoyButton::LEFT_SHOULDER, BTN_TL);
+	BUTTON_MAP_KEY(JoyButton::RIGHT_SHOULDER, BTN_TR);
+
+	if (!p_hat0y_exist) {
+		BUTTON_MAP_KEY(JoyButton::DPAD_UP, BTN_DPAD_UP);
+		BUTTON_MAP_KEY(JoyButton::DPAD_DOWN, BTN_DPAD_DOWN);
+	} else {
+		// D-pads may report both digital button events (BTN_DPAD_*) and analog button events
+		// (ABS_HAT0X and ABS_HAT0Y) on some devices. But Godot has hardcoded analog buttons
+		// events in process_joypads(), so it is necessary to hide possible digital buttons
+		// events to prevent triggering twice for one press.
+		UNUSED_KEY_HIDE(BTN_DPAD_UP);
+		UNUSED_KEY_HIDE(BTN_DPAD_DOWN);
+
+		// Some Xbox devices may report digital button events as BTN_TRIGGER_HAPPY3 ~ BTN_TRIGGER_HAPPY4,
+		// see https://github.com/godotengine/godot/issues/66878#issuecomment-2231491673 for more.
+		UNUSED_KEY_HIDE(BTN_TRIGGER_HAPPY3);
+		UNUSED_KEY_HIDE(BTN_TRIGGER_HAPPY4);
+
+		p_joypad.key_is_hidden = true;
+	}
+	if (!p_hat0x_exist) {
+		BUTTON_MAP_KEY(JoyButton::DPAD_LEFT, BTN_DPAD_LEFT);
+		BUTTON_MAP_KEY(JoyButton::DPAD_RIGHT, BTN_DPAD_RIGHT);
+	} else {
+		// D-pads may report both digital button events (BTN_DPAD_*) and analog button events
+		// (ABS_HAT0X and ABS_HAT0Y) on some devices. But Godot has hardcoded analog buttons
+		// events in process_joypads(), so it is necessary to hide possible digital buttons
+		// events to prevent triggering twice for one press.
+		UNUSED_KEY_HIDE(BTN_DPAD_LEFT);
+		UNUSED_KEY_HIDE(BTN_DPAD_RIGHT);
+
+		// Some Xbox devices may report digital button events as BTN_TRIGGER_HAPPY1 ~ BTN_TRIGGER_HAPPY2,
+		// see https://github.com/godotengine/godot/issues/66878#issuecomment-2231491673 for more.
+		UNUSED_KEY_HIDE(BTN_TRIGGER_HAPPY1);
+		UNUSED_KEY_HIDE(BTN_TRIGGER_HAPPY2);
+
+		p_joypad.key_is_hidden = true;
+	}
+
+	if (KEY_EXIST(KEY_RECORD)) {
+		// For certain Xbox devices.
+		BUTTON_MAP_KEY(JoyButton::MISC1, KEY_RECORD);
+	} else {
+		// For certain Nintendo Switch devices.
+		BUTTON_MAP_KEY(JoyButton::MISC1, BTN_Z);
+	}
+
+#undef BUTTON_MAP_KEY
+#undef KEY_EXIST
+
+	// Generate key mapping for JoyAxis.
+
+	int joy_axis_mappings[int(JoyAxis::SDL_MAX)];
+	for (int i = 0; i < int(JoyAxis::SDL_MAX); i++) {
+		joy_axis_mappings[i] = -1;
+	}
+
+#define AXIS_MAP_ABS(axis, abscode) (joy_axis_mappings[int(axis)] = p_joypad.abs_map[abscode])
+#define AXIS_MAP_KEY(axis, keycode) (joy_axis_mappings[int(axis)] = p_joypad.key_map[keycode])
+#define ABS_EXIST(abscode) (p_joypad.abs_map[abscode] != -1)
+
+	AXIS_MAP_ABS(JoyAxis::LEFT_X, ABS_X);
+	AXIS_MAP_ABS(JoyAxis::LEFT_Y, ABS_Y);
+
+	// Trigger buttons can be available as digital (BTN_TL2/BTN_TR2) or analog buttons or both.
+	bool trigger_is_digital = true;
+
+	if (ABS_EXIST(ABS_RX)) { // For certain Xbox or certain Nintendo Switch devices.
+		AXIS_MAP_ABS(JoyAxis::RIGHT_X, ABS_RX);
+		AXIS_MAP_ABS(JoyAxis::RIGHT_Y, ABS_RY);
+
+		if (ABS_EXIST(ABS_BRAKE)) {
+			// For possible devices. Typically used for TRIGGER_LEFT if the ABS_BRAKE event exists.
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_LEFT, ABS_BRAKE);
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_RIGHT, ABS_GAS);
+			trigger_is_digital = false;
+		} else if (ABS_EXIST(ABS_Z)) {
+			// For certain Xbox devices.
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_LEFT, ABS_Z);
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_RIGHT, ABS_RZ);
+			trigger_is_digital = false;
+		}
+	} else { // ABS_RX does not exist. Try another solution. Mainly for devices with wireless connections.
+		AXIS_MAP_ABS(JoyAxis::RIGHT_X, ABS_Z);
+		AXIS_MAP_ABS(JoyAxis::RIGHT_Y, ABS_RZ);
+
+		if (ABS_EXIST(ABS_BRAKE)) {
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_LEFT, ABS_BRAKE);
+			AXIS_MAP_ABS(JoyAxis::TRIGGER_RIGHT, ABS_GAS);
+			trigger_is_digital = false;
+		}
+	}
+
+	if (trigger_is_digital) {
+		// Only digital button events are reported. For certain Nintendo Switch devices.
+		AXIS_MAP_KEY(JoyAxis::TRIGGER_LEFT, BTN_TL2);
+		AXIS_MAP_KEY(JoyAxis::TRIGGER_RIGHT, BTN_TR2);
+	} else {
+		// Trigger buttons can be available as both digital and analog buttons. Prioritizes mapping
+		// of analog button events to axes. Hide extra events to prevent multiple triggering and
+		// interference. Shooting games may prefer digital button events (BTN_TL2/BTN_TR2).
+		UNUSED_KEY_HIDE(BTN_TL2);
+		UNUSED_KEY_HIDE(BTN_TR2);
+		p_joypad.key_is_hidden = true;
+	}
+
+#undef UNUSED_KEY_HIDE
+#undef AXIS_MAP_ABS
+#undef AXIS_MAP_KEY
+#undef ABS_EXIST
+
+	input->unknown_gamepad_auto_map(p_guid, p_name, joy_button_mappings, joy_axis_mappings, trigger_is_digital);
 }
 
 void JoypadLinux::open_joypad(const char *p_path) {
@@ -419,6 +576,12 @@ void JoypadLinux::open_joypad(const char *p_path) {
 				}
 			}
 
+			if (input->is_unknown_gamepad_auto_mapped() && !input->is_mapping_known(uid)) {
+				bool hat0x_exist = test_bit(ABS_HAT0X, absbit);
+				bool hat0y_exist = test_bit(ABS_HAT0Y, absbit);
+				_auto_remap(joypad, uid, name, hat0x_exist, hat0y_exist);
+			}
+
 			input->joy_connection_changed(joy_num, true, name, uid, joypad_info);
 		} else {
 			String uidname = uid;
@@ -427,6 +590,13 @@ void JoypadLinux::open_joypad(const char *p_path) {
 				uidname = uidname + _hex_str(name[i]);
 			}
 			uidname += "00";
+
+			if (input->is_unknown_gamepad_auto_mapped() && !input->is_mapping_known(uidname)) {
+				bool hat0x_exist = test_bit(ABS_HAT0X, absbit);
+				bool hat0y_exist = test_bit(ABS_HAT0Y, absbit);
+				_auto_remap(joypad, uidname, name, hat0x_exist, hat0y_exist);
+			}
+
 			input->joy_connection_changed(joy_num, true, name, uidname);
 		}
 	}
@@ -526,6 +696,22 @@ void JoypadLinux::process_joypads() {
 		if (joypad.fd == -1) {
 			continue;
 		}
+
+		// Restore hidden keys to make it easier for users to create their own mappings.
+		if (input->is_joy_button_need_reshow(i)) {
+			input->set_joy_button_need_reshow(i, false);
+
+			if (joypad.key_is_hidden) {
+				for (int j = 0; j < MAX_KEY; j++) {
+					if (joypad.key_map[j] < -1) {
+						joypad.key_map[j] = -joypad.key_map[j] - 2;
+					}
+				}
+
+				joypad.key_is_hidden = false;
+			}
+		}
+
 		for (uint32_t j = 0; j < joypad.events.size(); j++) {
 			const JoypadEvent &joypad_event = joypad.events[j];
 			// joypad_event may be tainted and out of MAX_KEY range, which will cause
@@ -535,9 +721,13 @@ void JoypadLinux::process_joypads() {
 			}
 
 			switch (joypad_event.type) {
-				case EV_KEY:
-					input->joy_button(i, (JoyButton)joypad.key_map[joypad_event.code], joypad_event.value);
-					break;
+				case EV_KEY: {
+					int button_idx = joypad.key_map[joypad_event.code];
+					if (input->is_unknown_gamepad_auto_mapped() && button_idx < -1) {
+						break; // Some buttons may need to be hidden.
+					}
+					input->joy_button(i, (JoyButton)button_idx, joypad_event.value);
+				} break;
 
 				case EV_ABS:
 					switch (joypad_event.code) {

--- a/platform/linuxbsd/joypad_linux.h
+++ b/platform/linuxbsd/joypad_linux.h
@@ -66,6 +66,8 @@ private:
 		BitField<HatMask> dpad;
 		int fd = -1;
 
+		bool key_is_hidden = false;
+
 		String devpath;
 		input_absinfo *abs_info[MAX_ABS] = {};
 
@@ -111,6 +113,8 @@ private:
 
 	static void monitor_joypads_thread_func(void *p_user);
 	void monitor_joypads_thread_run();
+
+	void _auto_remap(Joypad &p_joypad, const StringName &p_guid, const String &p_name, bool p_hat0x_exist, bool p_hat0y_exist);
 
 	void open_joypad(const char *p_path);
 	void setup_joypad_properties(Joypad &p_joypad);


### PR DESCRIPTION
Previously, the controller input mapping relied on `core/input/gamecontrollerdb.txt`, so if the device is newer, the device input mapping may be confused.

For gamepads not documented in this file, they are now simply mapped according to the enumeration semantics.

Reference: [Linux Gamepad Specification](https://docs.kernel.org/input/gamepad.html#linux-gamepad-specification) and [Input event codes](https://docs.kernel.org/input/event-codes.html#input-event-codes).

Might help in closing #87112.

Fix #101215.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


*Keycode Mapping Table*
| [JoyButton](https://github.com/godotengine/godot/blob/06fbc8395b3c0ec6fa38588caea2ee94837f7b97/core/input/input_enums.h#L62-L84) / [JoyAxis](https://github.com/godotengine/godot/blob/06fbc8395b3c0ec6fa38588caea2ee94837f7b97/core/input/input_enums.h#L50C12-L57)| [input-event-codes.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) |
| :-----------: | :-----------: |
| `JoyButton.A` | `BTN_A`[^1] (`BTN_SOUTH`/`BTN_GAMEPAD`[^2])|
| `JoyButton.B` | `BTN_B`[^1] (`BTN_EAST`)|
| `JoyButton.X` | `BTN_X`[^1] (`BTN_NORTH`)|
| `JoyButton.Y` | `BTN_Y`[^1] (`BTN_WEST`)|
| `JoyButton.BACK` | `BTN_SELECT` |
| `JoyButton.GUIDE` | `BTN_MODE`|
| `JoyButton.START` | `BTN_START` |
| `JoyButton.LEFT_STICK` | `BTN_THUMBL` |
| `JoyButton.RIGHT_STICK` | `BTN_THUMBR`|
| `JoyButton.LEFT_SHOULDER` | `BTN_TL` |
| `JoyButton.RIGHT_SHOULDER` | `BTN_TR` |
| `JoyButton.DPAD_UP` | `BTN_DPAD_UP`[^3] |
| `JoyButton.DPAD_DOWN` | `BTN_DPAD_DOWN`[^3] |
| `JoyButton.DPAD_LEFT` | `BTN_DPAD_LEFT`[^3.1] |
| `JoyButton.DPAD_RIGHT` | `BTN_DPAD_RIGHT`[^3.1] |
| `JoyButton.MISC1`[^6] | `KEY_RECORD` / `BTN_Z`[^4] |
| `JoyButton.PADDLE1` | [^5]  |
| `JoyButton.PADDLE2` | [^5]  |
| `JoyButton.PADDLE3` | [^5]  |
| `JoyButton.PADDLE4` | [^5]  |
| `JoyButton.TOUCHPAD` | [^5]  |
| `JoyAxis.LEFT_X` | `ABS_X` |
| `JoyAxis.LEFT_Y` | `ABS_Y` |
| `JoyAxis.RIGHT_X`[^6] | `ABS_RX` / `ABS_Z` |
| `JoyAxis.RIGHT_Y`[^6] | `ABS_RY` / `ABS_RZ` |
| `JoyAxis.TRIGGER_LEFT`[^6] | `ABS_BRAKE`  /  `ABS_Z` /  `BTN_TL2` |
| `JoyAxis.TRIGGER_RIGHT`[^6] | `ABS_GAS` / `ABS_RZ`  /  `BTN_TR2` |




[^1]: While the _Linux Gamepad Specification_ recommends reporting events based on physical position, I don't have a gamepad that follows this convention. Perhaps reporting events by corresponding label name is a de facto convention.
[^2]: `BTN_GAMEPAD` is used to identify a gamepad. See the [Detection](https://docs.kernel.org/input/gamepad.html#detection) section of the _Linux Gamepad Specification_. Devices without this keycode will not be automatically mapped.
[^3]:  ~~These are the key codes for the digital buttons. But godot will automatically map the key codes (`ABS_HAT0X`/`ABS_HAT0Y`) for the analog buttons to these `JoyButton`s, and godot doesn't seem to detect the `EV_SYN` event, so a gamepad that reports both digital and analog buttons on one button might be a bit of a hassle. I don't have such a device.~~ Only mapped if `ABS_HAT0Y` is not present.
[^3.1]:  Only mapped if `ABS_HAT0X` is not present.
[^4]:  Not sure, there is only one unofficial device.
[^5]:  There is no such gamepad around me. But in order to prevent unexpected behavior, they are eventually mapped to `JoyButton.INVALID`.
[^6]:  There does not seem to be a consistent convention for these axes. If the analog-sticks that issue the key code do not exist, they will try the next.


**Note**: If the final mapped keycodes have no corresponding buttons/analog-sticks, they will be mapped to `-1`( `JoyButton.INVALID`/ `JoyAxis.INVALID`).

