### PR TITLE
Add metadata to TypedArray and validate at runtime

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -780,7 +780,7 @@ Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_nam
 	assign(p_from);
 }
 
-void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
+void Array::_set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script, uint32_t p_meta) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
@@ -790,9 +790,14 @@ void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Var
 	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
 
 	_p->typed.type = Variant::Type(p_type);
+	_p->typed.meta = GodotTypeInfo::Metadata(p_meta);
 	_p->typed.class_name = p_class_name;
 	_p->typed.script = script;
 	_p->typed.where = "TypedArray";
+}
+
+void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
+	_set_typed(p_type, p_class_name, p_script, GodotTypeInfo::METADATA_NONE);
 }
 
 bool Array::is_typed() const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -183,6 +183,8 @@ public:
 
 	const void *id() const;
 
+	void _set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script, uint32_t p_meta);
+
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	bool is_typed() const;
 	bool is_same_typed(const Array &p_other) const;

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -74,7 +74,7 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 
 //specialization for the rest of variant types
 
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
+#define MAKE_TYPED_ARRAY_WITH_META(m_type, m_variant_type, m_meta)                                               \
 	template <>                                                                                                  \
 	class TypedArray<m_type> : public Array {                                                                    \
 	public:                                                                                                      \
@@ -86,7 +86,7 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 				TypedArray(Array(p_variant)) {                                                                   \
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
+			_set_typed(m_variant_type, StringName(), Variant(), m_meta);                                         \
 			if (is_same_typed(p_array)) {                                                                        \
 				_ref(p_array);                                                                                   \
 			} else {                                                                                             \
@@ -94,23 +94,25 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 			}                                                                                                    \
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
+			_set_typed(m_variant_type, StringName(), Variant(), m_meta);                                         \
 		}                                                                                                        \
 	};
+
+#define MAKE_TYPED_ARRAY(m_type, m_variant_type) MAKE_TYPED_ARRAY_WITH_META(m_type, m_variant_type, GodotTypeInfo::METADATA_NONE);
 
 // All Variant::OBJECT types are intentionally omitted from this list because they are handled by
 // the unspecialized TypedArray definition.
 MAKE_TYPED_ARRAY(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY(double, Variant::FLOAT)
+MAKE_TYPED_ARRAY_WITH_META(uint8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT8)
+MAKE_TYPED_ARRAY_WITH_META(int8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT8)
+MAKE_TYPED_ARRAY_WITH_META(uint16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT16)
+MAKE_TYPED_ARRAY_WITH_META(int16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT16)
+MAKE_TYPED_ARRAY_WITH_META(uint32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT32)
+MAKE_TYPED_ARRAY_WITH_META(int32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT32)
+MAKE_TYPED_ARRAY_WITH_META(uint64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT64)
+MAKE_TYPED_ARRAY_WITH_META(int64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT64)
+MAKE_TYPED_ARRAY_WITH_META(float, Variant::FLOAT, GodotTypeInfo::METADATA_REAL_IS_FLOAT)
+MAKE_TYPED_ARRAY_WITH_META(double, Variant::FLOAT, GodotTypeInfo::METADATA_REAL_IS_DOUBLE)
 MAKE_TYPED_ARRAY(String, Variant::STRING)
 MAKE_TYPED_ARRAY(Vector2, Variant::VECTOR2)
 MAKE_TYPED_ARRAY(Vector2i, Variant::VECTOR2I)
@@ -184,11 +186,11 @@ struct GetTypeInfo<const TypedArray<T> &> {
 	}
 };
 
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                        \
+#define MAKE_TYPED_ARRAY_INFO_WITH_META(m_type, m_variant_type, m_metadata)                                                  \
 	template <>                                                                                                              \
 	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
 		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
+		static const GodotTypeInfo::Metadata METADATA = m_metadata;                                                          \
 		static inline PropertyInfo get_class_info() {                                                                        \
 			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
 		}                                                                                                                    \
@@ -196,23 +198,25 @@ struct GetTypeInfo<const TypedArray<T> &> {
 	template <>                                                                                                              \
 	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                         \
 		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
+		static const GodotTypeInfo::Metadata METADATA = m_metadata;                                                          \
 		static inline PropertyInfo get_class_info() {                                                                        \
 			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
 		}                                                                                                                    \
 	};
 
+#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type) MAKE_TYPED_ARRAY_INFO_WITH_META(m_type, m_variant_type, GodotTypeInfo::METADATA_NONE)
+
 MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY_INFO(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(double, Variant::FLOAT)
+MAKE_TYPED_ARRAY_INFO_WITH_META(uint8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT8)
+MAKE_TYPED_ARRAY_INFO_WITH_META(int8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT8)
+MAKE_TYPED_ARRAY_INFO_WITH_META(uint16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT16)
+MAKE_TYPED_ARRAY_INFO_WITH_META(int16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT16)
+MAKE_TYPED_ARRAY_INFO_WITH_META(uint32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT32)
+MAKE_TYPED_ARRAY_INFO_WITH_META(int32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT32)
+MAKE_TYPED_ARRAY_INFO_WITH_META(uint64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT64)
+MAKE_TYPED_ARRAY_INFO_WITH_META(int64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT64)
+MAKE_TYPED_ARRAY_INFO_WITH_META(float, Variant::FLOAT, GodotTypeInfo::METADATA_REAL_IS_FLOAT)
+MAKE_TYPED_ARRAY_INFO_WITH_META(double, Variant::FLOAT, GodotTypeInfo::METADATA_REAL_IS_DOUBLE)
 MAKE_TYPED_ARRAY_INFO(String, Variant::STRING)
 MAKE_TYPED_ARRAY_INFO(Vector2, Variant::VECTOR2)
 MAKE_TYPED_ARRAY_INFO(Vector2i, Variant::VECTOR2I)

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -634,6 +634,40 @@ TEST_CASE("[Array] Typed copying") {
 	a6.clear();
 }
 
+TEST_CASE("[Array] Typed insertion") {
+	TypedArray<int32_t> int32_array;
+	TypedArray<int64_t> int64_array;
+	TypedArray<float> float_array;
+
+	int32_t int32_value = 42;
+	int64_t int64_value = 10000000000;
+	float float_value = 4.2;
+
+	int32_array.push_back(int32_value);
+	int64_array.push_back(int32_value);
+	float_array.push_back(int32_value);
+
+	// Can't insert a int64_t in a TypedArray<int32_t>.
+	ERR_PRINT_OFF
+	int32_array.push_back(int64_value);
+	ERR_PRINT_ON
+	int64_array.push_back(int64_value);
+	float_array.push_back(int64_value);
+
+	// Can't insert a float in a TypedArray<int>.
+	ERR_PRINT_OFF
+	int32_array.push_back(float_value);
+	int64_array.push_back(float_value);
+	ERR_PRINT_ON
+	float_array.push_back(float_value);
+
+	// Check that only the compatible values were added to the array,
+	// otherwise it would have printed an error and ignored the value.
+	CHECK_EQ(int32_array.size(), 1);
+	CHECK_EQ(int64_array.size(), 2);
+	CHECK_EQ(float_array.size(), 3);
+}
+
 } // namespace TestArray
 
 #endif // TEST_ARRAY_H


### PR DESCRIPTION
- Adds metadata to `ContainerTypeValidate` to validate at runtime that elements added to TypedArray fit the the element type.
- Adds metadata to TypedArray's `GetTypeInfo<>` so it's included in `extension_api.json` and language bindings can use the right element type for the Array.

As an example, the method `CodeEdit::get_folded_lines` that returns `TypedArray<int>`:

https://github.com/godotengine/godot/blob/c184105cf55614078b509b0a57c4bbd0beb62be7/scene/gui/code_edit.cpp#L1722

```diff
{
    "name": "get_folded_lines",
    "is_const": true,
    "is_vararg": false,
    "is_static": false,
    "is_virtual": false,
    "hash": 3995934104,
    "return_value": {
        "type": "typedarray::int",
+       "meta": "int32"
    }
},
```