### PR TITLE
Tweak shader compilation error messages

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -717,7 +717,7 @@ void ShaderGLES3::_initialize_version(Version *p_version) {
 
 void ShaderGLES3::version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize) {
 	Version *version = version_owner.get_or_null(p_version);
-	ERR_FAIL_NULL(version);
+	ERR_FAIL_NULL_MSG(version, "Can't set shader code for a nonexistent shader version. This may happen because the shader previously failed to compile.");
 
 	_clear_version(version); //clear if existing
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2673,7 +2673,7 @@ void CanvasShaderData::set_code(const String &p_code) {
 
 	actions.uniforms = &uniforms;
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_canvas.compile(RSE::SHADER_CANVAS_ITEM, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "CanvasItem shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = MaterialStorage::get_singleton()->shaders.canvas_shader.version_create();
@@ -2853,7 +2853,7 @@ void SkyShaderData::set_code(const String &p_code) {
 	actions.uniforms = &uniforms;
 
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_sky.compile(RSE::SHADER_SKY, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Sky shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = MaterialStorage::get_singleton()->shaders.sky_shader.version_create();
@@ -3094,7 +3094,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	actions.uniforms = &uniforms;
 
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_scene.compile(RSE::SHADER_SPATIAL, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = MaterialStorage::get_singleton()->shaders.scene_shader.version_create();
@@ -3288,7 +3288,7 @@ void ParticlesShaderData::set_code(const String &p_code) {
 	actions.uniforms = &uniforms;
 
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_particles.compile(RSE::SHADER_PARTICLES, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Particles shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = MaterialStorage::get_singleton()->shaders.particles_process_shader.version_create();

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -189,7 +189,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	ShaderCompiler::GeneratedCode gen_code;
 
 	Error err = MaterialStorage::get_singleton()->dummy_compiler.compile(new_mode, p_code, &actions, "", gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, vformat("%s shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.", mode_string.capitalize()));
 }
 
 void MaterialStorage::get_shader_parameter_list(RID p_shader, List<PropertyInfo> *p_param_list) const {

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -379,7 +379,7 @@ void Fog::FogShaderData::set_code(const String &p_code) {
 	Fog *fog_singleton = Fog::get_singleton();
 
 	Error err = fog_singleton->volumetric_fog.compiler.compile(RSE::SHADER_FOG, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Fog shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Fog shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = fog_singleton->volumetric_fog.shader.version_create();

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -107,7 +107,7 @@ void SkyRD::SkyShaderData::set_code(const String &p_code) {
 	RendererSceneRenderRD *scene_singleton = static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton);
 
 	Error err = scene_singleton->sky.sky_shader.compiler.compile(RSE::SHADER_SKY, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Sky shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = scene_singleton->sky.sky_shader.shader.version_create();

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -179,7 +179,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 			SceneShaderForwardClustered::singleton->shader.version_free(version);
 			version = RID();
 		}
-		ERR_FAIL_MSG("Shader compilation failed.");
+		ERR_FAIL_MSG("Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 	}
 
 	if (version.is_null()) {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -174,7 +174,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 			SceneShaderForwardMobile::singleton->shader.version_free(version);
 			version = RID();
 		}
-		ERR_FAIL_MSG("Shader compilation failed.");
+		ERR_FAIL_MSG("Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 	}
 
 	if (version.is_null()) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1585,7 +1585,7 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 			canvas_singleton->shader.canvas_shader.version_free(version);
 			version = RID();
 		}
-		ERR_FAIL_MSG("Shader compilation failed.");
+		ERR_FAIL_MSG("CanvasItem shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 	}
 
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -816,7 +816,7 @@ void ShaderRD::version_set_code(RID p_version, const HashMap<String, String> &p_
 	ERR_FAIL_COND(pipeline_type != RD::PIPELINE_TYPE_RASTERIZATION);
 
 	Version *version = version_owner.get_or_null(p_version);
-	ERR_FAIL_NULL(version);
+	ERR_FAIL_NULL_MSG(version, "Can't set shader code for a nonexistent shader version. This may happen because the shader previously failed to compile.");
 
 	MutexLock lock(*version->mutex);
 
@@ -833,7 +833,7 @@ void ShaderRD::version_set_compute_code(RID p_version, const HashMap<String, Str
 	ERR_FAIL_COND(pipeline_type != RD::PIPELINE_TYPE_COMPUTE);
 
 	Version *version = version_owner.get_or_null(p_version);
-	ERR_FAIL_NULL(version);
+	ERR_FAIL_NULL_MSG(version, "Can't set compute shader code for a nonexistent shader version. This may happen because the shader previously failed to compile.");
 
 	MutexLock lock(*version->mutex);
 
@@ -1180,7 +1180,7 @@ Vector<RD::ShaderStageSPIRVData> ShaderRD::compile_stages(const Vector<String> &
 		ERR_PRINT(error);
 
 #ifdef DEBUG_ENABLED
-		ERR_PRINT("code:\n" + p_stage_sources[compilation_failed_stage].get_with_code_lines());
+		ERR_PRINT("Code:\n" + p_stage_sources[compilation_failed_stage].get_with_code_lines());
 #endif
 
 		return Vector<RD::ShaderStageSPIRVData>();
@@ -1232,7 +1232,7 @@ bool ShaderRD::shader_cache_save_debug = true;
 ShaderRD::~ShaderRD() {
 	LocalVector<RID> remaining = version_owner.get_owned_list();
 	if (remaining.size()) {
-		ERR_PRINT(itos(remaining.size()) + " shaders of type " + name + " were never freed");
+		ERR_PRINT(itos(remaining.size()) + " shaders of type " + name + " were never freed.");
 		for (const RID &version_rid : remaining) {
 			version_free(version_rid);
 		}

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -200,7 +200,7 @@ public:
 		ERR_FAIL_COND_V(!variants_enabled[p_variant], RID());
 
 		Version *version = version_owner.get_or_null(p_version);
-		ERR_FAIL_NULL_V(version, RID());
+		ERR_FAIL_NULL_V_MSG(version, RID(), vformat("Can't get the shader version for variant %d (and therefore its shader code). This may happen because the shader previously failed to compile.", p_variant));
 
 		MutexLock lock(*version->mutex);
 
@@ -231,7 +231,7 @@ public:
 
 	bool version_free(RID p_version);
 
-	// Enable/disable variants for things that you know won't be used at engine initialization time .
+	// Enable/disable variants for things that you know won't be used at engine initialization time.
 	void set_variant_enabled(int p_variant, bool p_enabled);
 	bool is_variant_enabled(int p_variant) const;
 	int64_t get_variant_count() const;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1716,7 +1716,7 @@ void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code) {
 	actions.uniforms = &uniforms;
 
 	Error err = particles_storage->particles_shader.compiler.compile(RSE::SHADER_PARTICLES, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+	ERR_FAIL_COND_MSG(err != OK, "Particles shader compilation failed (most likely due to a syntax error). Shader code has been printed above for troubleshooting.");
 
 	if (version.is_null()) {
 		version = particles_storage->particles_shader.shader.version_create();


### PR DESCRIPTION
- Mention the shader type that failed compilation.
- Mention the most common cause for this error (which are syntax errors).
- Mention that the shader code is printed nearby for troubleshooting.

___

- This partially addresses https://github.com/godotengine/godot/issues/42719#issuecomment-2284866767
and https://github.com/godotengine/godot/issues/95443.

**Testing project:** [test_shader_error.zip](https://github.com/user-attachments/files/16603663/test_shader_error.zip)

## Preview

> [!NOTE]
> `ERROR: not enough arguments for format string` is not introduced by this PR; it also occurs in `master` with the MRP
> and is likely due to a script error in that MRP (check line 142 of `VSSimplexNoise3D.gd`, `%` arguments are missing).

### Forward+

```
--Main Shader--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp:146)
ERROR: not enough arguments for format string
   at: validated_evaluate (./core/variant/variant_op.h:951)
--res://node_3d.tres--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (res://node_3d.tres:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp:146)
ERROR: Shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: version_get_shader (./servers/rendering/renderer_rd/shader_rd.h:166)
```

### Mobile

```
--Main Shader--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp:147)
ERROR: not enough arguments for format string
   at: validated_evaluate (./core/variant/variant_op.h:951)
--res://node_3d.tres--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (res://node_3d.tres:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp:147)
ERROR: Shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: version_get_shader (./servers/rendering/renderer_rd/shader_rd.h:166)
```

### Compatibility

```
--Main Shader--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (drivers/gles3/storage/material_storage.cpp:2972)
ERROR: not enough arguments for format string
   at: validated_evaluate (./core/variant/variant_op.h:951)
--res://node_3d.tres--
    1 | shader_type spatial;
    2 | render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
    3 |
  ... | [...omitted from this preview to shorten the log...]
  107 |
  108 | }
  109 |
SHADER ERROR: Expected a ';'.
          at: (null) (res://node_3d.tres:101)
ERROR: Spatial shader compilation failed (most likely due to a syntax error). Shader code has been printed nearby for troubleshooting.
   at: set_code (drivers/gles3/storage/material_storage.cpp:2972)
```
