### PR TITLE
Fix wrong focus neighbor for grid-aligned 0 separation controls

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2358,6 +2358,24 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 		points[2] = xform.xform(c->get_size());
 		points[3] = xform.xform(Point2(0, c->get_size().y));
 
+		// Tie-breaking aims to address situations where a potential focus neighbor's bounding rect
+		// is right next to the currently focused control (e.g. in BoxContainer with
+		// separation overridden to 0). This needs specific handling so that the correct
+		// focus neighbor is selected.
+
+		// Calculate centers of the potential neighbor, currently focused, and closest controls.
+		Point2 center = xform.xform(0.5 * c->get_size());
+		// We only have the points, not an actual reference.
+		Point2 p_center = 0.25 * (p_points[0] + p_points[1] + p_points[2] + p_points[3]);
+		Point2 closest_center;
+		bool should_tiebreak = false;
+		if (*r_closest != nullptr) {
+			should_tiebreak = true;
+			Control *closest = *r_closest;
+			Transform2D closest_xform = closest->get_global_transform();
+			closest_center = closest_xform.xform(0.5 * closest->get_size());
+		}
+
 		real_t min = 1e7;
 
 		for (int i = 0; i < 4; i++) {
@@ -2378,10 +2396,15 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 
 					Vector2 pa, pb;
 					real_t d = Geometry2D::get_closest_points_between_segments(la, lb, fa, fb, pa, pb);
-					//real_t d = Geometry2D::get_closest_distance_between_segments(Vector3(la.x,la.y,0),Vector3(lb.x,lb.y,0),Vector3(fa.x,fa.y,0),Vector3(fb.x,fb.y,0));
 					if (d < r_closest_dist) {
 						r_closest_dist = d;
 						*r_closest = c;
+					} else if (should_tiebreak && d == r_closest_dist) {
+						// Tie-break in favor of the control most aligned with p_dir.
+						if (p_dir.dot((center - p_center).normalized()) > p_dir.dot((closest_center - p_center).normalized())) {
+							r_closest_dist = d;
+							*r_closest = c;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/42965.

In these videos, I am inputting "ui_right" by pressing the right arrow key.
Current behavior:

https://github.com/user-attachments/assets/f31b2d18-9117-4f4f-83ed-e220c4f4ca7a

This fix:

https://github.com/user-attachments/assets/127162be-c7f5-40b9-a243-9aefba2bed7a

The current algorithm for finding focus neighbors seems to check each side of a control against each side of a potential closest neighbor, and choose the control which is closest. In cases where there is non-zero separation between controls, this works just fine. But in cases where there is zero separation between controls, and the controls are arranged in a grid, multiple potential controls are equally close (e.g, up-left, up. and left will all have a distance of 0). This introduces a bias towards the first found neighbor control (empirically, controls that are to the left and/or up from the current control).

This fix adds a tie-breaking step in the case where multiple controls are equally close. It sorts by the minimum distance between the *centers* of the current control and prospective closest neighbors, which works nicely for grid-aligned controls. 

Since it only runs in the tied case, this shouldn't affect existing behavior in cases where there is any separation between controls. The default theme adds separation, and anyone using zero-separation grid containers is very unlikely to be dependent on incorrect existing behavior.

My C++ will need extensive changes for style and efficiency - it's been a while since I wrote any!

Edit: Okay, that's my best attempt at C++ style. I'm aware that my code is different in style than the surrounding function, but I wanted to leave in verbose names and comments in case the algorithm itself needs to be changed. I also don't know what I don't know in terms of helper functions to use.