### PR TITLE
Avoid indexing instances without a base in scene cull phase

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1636,6 +1636,8 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 		if (p_instance->scenario) {
 			RendererSceneOcclusionCull::get_singleton()->scenario_set_instance(p_instance->scenario->self, p_instance->self, p_instance->base, p_instance->transform, p_instance->visible);
 		}
+	} else if (p_instance->base_type == RS::INSTANCE_NONE) {
+		return;
 	}
 
 	if (!p_instance->aabb.has_surface()) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95466
Fixes: https://github.com/godotengine/godot/issues/92615
Fixes: https://github.com/godotengine/godot/issues/80749
Fixes: https://github.com/godotengine/godot/issues/69258
Fixes: https://github.com/godotengine/godot/issues/80504
Supersedes: https://github.com/godotengine/godot/pull/81069

At the core, this crash happens because an instance without a base is added to one of our BVHs and then we try to operate on that instance in the other BVH. 

There are 2 main ways this crash occurs:
1. The instance is updated while the base is still NONE. Then the base is set to a valid base type. And finally the base is set to an empty RID before the instance is updated. This can happen when freeing an instance the same frame it was created (https://github.com/godotengine/godot/issues/69258) or by a Node that sets its base to RID() during update (CSG or Sprite3D both do this). This crash occurs
2. The instance is updated while the base is still NONE, then the base is changed to a geometry type. This places the instance into the `VOLUME` BVH instead of the `GEOMETRY` BVH. And so the engine crashes when it tries to update the instance in the `GEOMETRY` BVH later. 

In both cases, the problem comes from the fact that the instance is added to the `VOLUME` BVH. The logic is: if an object is a `GEOMETRY` type, it goes in the `GEOMETRY` BVH, otherwise it goes into the `VOLUME` BVH. 

When we go to set the base of an instance, the logic is: if the previous base type _is not_ `NONE` then remove the instance from the BVH and clear all data. If the base type is `NONE` we are assuming it was never added to a BVH. However, that assumption is false.

This PR fixes the bug by making that assumption true. It adds an early out to `_update_instance` to ensure that when the base type is NONE, we don't add the instance to a BVH. This change is low risk since the instance gets queued for update again once the base type is set. Without a base, the instance can't do anything. So its safe to skip the pairing/indexing step when the base has not been assigned. 

The solution proposed by [jsjtxietian](https://github.com/jsjtxietian) in https://github.com/godotengine/godot/pull/81069 appears to work well for the Sprite3D case. It moves the instance from the `VOLUME` BVH to the `GEOMETRY` BVH if the base changes from `NONE` to `GEOMETRY`. However, it doesn't solve the other cases of the crash.

CC @jsjtxietian

