### PR TITLE
Expose more Ninja-related build options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -233,6 +233,8 @@ opts.Add(BoolVariable("dev_mode", "Alias for dev options: verbose=yes warnings=e
 opts.Add(BoolVariable("tests", "Build the unit tests", False))
 opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
 opts.Add(BoolVariable("ninja", "Use the ninja backend for faster rebuilds", False))
+opts.Add(BoolVariable("ninja_auto_run", "Run ninja automatically after generating the ninja file", True))
+opts.Add("ninja_file", "Path to the generated ninja file", "build.ninja")
 opts.Add(BoolVariable("compiledb", "Generate compilation DB (`compile_commands.json`) for external tools", False))
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
@@ -1026,12 +1028,9 @@ if env["ninja"]:
         Exit(255)
 
     SetOption("experimental", "ninja")
+    env["NINJA_FILE_NAME"] = env["ninja_file"]
+    env["NINJA_DISABLE_AUTO_RUN"] = not env["ninja_auto_run"]
     env.Tool("ninja")
-
-    # By setting this we allow the user to run ninja by themselves with all
-    # the flags they need, as apparently automatically running from scons
-    # is way slower.
-    SetOption("disable_execute_ninja", True)
 
 # Threads
 if env["threads"]:


### PR DESCRIPTION
I've been testing out the `ninja=yes` build option (introduced in #89452) and found myself wanting a little bit more control out of it.

Instead of it always generating a `build.ninja` file regardless of build options, forcing me to run SCons whenever I want to switch said build options, it would be nice if you could have multiple Ninja files. As it turns out, this is already supported by SCons through the [`NINJA_FILE_NAME`](https://www.scons.org/doc/HTML/scons-man.html#cv-NINJA_FILE_NAME) construction variable, so this PR adds a build option (`ninja_file`) to set that variable.

I also noticed that the setting of the `disable_execute_ninja` option that's currently happening does not seem to work at all for me (on Windows with SCons 4.8.0). Ninja will always run after SCons has run, as opposed to just emitting the Ninja file and stopping. This is contrary to what [the documentation](https://www.scons.org/doc/HTML/scons-man.html#cv-NINJA_DISABLE_AUTO_RUN) states, but the documentation also mentions this other construction variable called [`NINJA_DISABLE_AUTO_RUN`](https://www.scons.org/doc/HTML/scons-man.html#cv-NINJA_DISABLE_AUTO_RUN) that serves the same purpose. That one does work for me, for some reason, so this PR switches to use that instead. I also threw in a build option to control it, rather than effectively hardcoding it to `false` like before, which seemed like it might be useful to anyone who wants to use Ninja but doesn't want to run it separately all the time.

I should also mention that I am relatively new to SCons, so I could be misunderstanding how these construction environments/variables work, or whether it's even appropriate to be setting them like this. If there's some way of injecting these `NINJA_FILE_NAME` and `NINJA_DISABLE_AUTO_RUN` construction variables from the system environment I'd love to know.