### PR TITLE
Fix errors about `UndoRedo` history mismatch when deleting bezier track

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1083,7 +1083,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					if (I.key == REMOVE_ICON) {
 						if (!read_only) {
 							EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-							undo_redo->create_action("Remove Bezier Track");
+							undo_redo->create_action("Remove Bezier Track", UndoRedo::MERGE_DISABLE, animation.ptr());
 
 							undo_redo->add_do_method(this, "_update_locked_tracks_after", track);
 							undo_redo->add_do_method(this, "_update_hidden_tracks_after", track);


### PR DESCRIPTION
Fixes #95516.

The issue seemed to be that this particular undo/redo action queues up do-methods for different objects, the first being the `AnimationBezierTrackEdit` and the second being the `Animation` itself, which causes this history mismatch.

I made use of ~~the recently introduced `EditorUndoRedoManager::force_fixed_history()` and~~ the `p_custom_context` parameter in `EditorUndoRedoManager::create_action` to force the history to be centered around one of these objects instead (the `AnimationBezierTrackEdit` instance) which seems to do the trick.