### PR TITLE
Fix FileSystem not updated on file deletion

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2112,8 +2112,8 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		}
 		if (!is_scanning()) {
 			_process_update_pending();
-			call_deferred(SNAME("emit_signal"), "filesystem_changed"); //update later
 		}
+		call_deferred(SNAME("emit_signal"), "filesystem_changed"); // Update later
 	}
 }
 


### PR DESCRIPTION
- Fixes #95423

The issue was a regression from #93919. I removed the emission of the `filesystem_changed` signal in `EditorFileSystem::update_files` when `is_scanning` is true. When removing files in a large project, the scanning process can take a bit longer, enough to have the `scanning_changes` variable set to true when entering `EditorFileSystem::update_files`. I kept the `if (!is_scanning())` condition for `_process_update_pending` to prevent the original issue; anyway, it's called at the end of the scanning process.

It's really difficult to reproduce. I had to be in debug mode with a couple of breakpoints in `DependencyRemoveDialog::ok_pressed` and `EditorFileSystem::update_files` to reproduce the problem.
