### PR TITLE
Fix import for unused animation slice information.

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1298,8 +1298,15 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 					//fill with default values
 					List<ImportOption> iopts;
 					get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
+					bool has_slices = true;
+					String slice_str = "slice_" + itos((int)anim_settings["slices/amount"] + 1);
 					for (const ImportOption &F : iopts) {
-						if (!anim_settings.has(F.option.name)) {
+						bool is_slice = F.option.name.begins_with("slice_");
+						if (has_slices && F.option.name.begins_with(slice_str)) {
+							has_slices = false;
+						}
+
+						if (!anim_settings.has(F.option.name) && (!is_slice || has_slices)) {
 							anim_settings[F.option.name] = F.default_value;
 						}
 					}
@@ -1732,8 +1739,15 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						//fill with default values
 						List<ImportOption> iopts;
 						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
+						bool has_slices = true;
+						String slice_str = "slice_" + itos((int)anim_settings["slices/amount"] + 1);
 						for (const ImportOption &F : iopts) {
-							if (!anim_settings.has(F.option.name)) {
+							bool is_slice = F.option.name.begins_with("slice_");
+							if (has_slices && F.option.name.begins_with(slice_str)) {
+								has_slices = false;
+							}
+
+							if (!anim_settings.has(F.option.name) && (!is_slice || has_slices)) {
 								anim_settings[F.option.name] = F.default_value;
 							}
 						}


### PR DESCRIPTION
Fixes #68936 

Problem brief: The gltf importer would import 256 slice information for each animation if a single animation option was changed. Making the .import file unnecessarily big.

This makes the gltf importer only save slice data default values for slices created by the user.
This won't fix imported assets that have already been bloated. But it won't create bloat on new imported assets.

---
This is my first time with Godot source so I chose this simple approach first to see if it works. It did.

Maybe a better way to solve this is to avoid creating the 256 ImportOptions in the first place here
https://github.com/godotengine/godot/blob/33c30b9e63a58b860cb2f36957c5e25cee34a627/editor/import/3d/resource_importer_scene.cpp#L2028-L2036
This is created when the import settings window is loaded, and it will always create those 256 slice default data.
But as they are all the same anyways, maybe its better to just load something like "slice_data" and use a similar strategy, where I checked for the slice_amount to decide if the slice default values needs to be filled or not.
Inside both the `post_fix_node` and `post_fix_animation` where we have that value.


