### PR TITLE
Allow empty click in scene tree dock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3747,27 +3747,25 @@ void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {
 }
 
 void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
-	if (!EditorNode::get_singleton()->get_edited_scene()) {
-		menu->clear(false);
-		if (profile_allow_editing) {
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Add")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
-		}
-
-		menu->reset_size();
-		menu->set_position(get_screen_position() + p_menu_pos);
-		menu->popup();
-		return;
-	}
+	ERR_FAIL_COND(!EditorNode::get_singleton()->get_edited_scene());
+	menu->clear(false);
 
 	List<Node *> selection = editor_selection->get_top_selected_node_list();
 	List<Node *> full_selection = editor_selection->get_full_selected_node_list(); // Above method only returns nodes with common parent.
 
 	if (selection.is_empty()) {
+		if (!profile_allow_editing) {
+			return;
+		}
+
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Add")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
+
+		menu->reset_size();
+		menu->set_position(p_menu_pos);
+		menu->popup();
 		return;
 	}
-
-	menu->clear(false);
 
 	Ref<Script> existing_script;
 	bool existing_script_removable = true;


### PR DESCRIPTION
It bothered me that the empty space under scene tree is useless, so I handled it:

https://github.com/user-attachments/assets/b5dabb7d-78e4-41ec-bc47-f3634d759737

There is a bug though, where the menu appears empty if any node is selected:
![image](https://github.com/user-attachments/assets/37844c61-7fa4-412c-a5a0-6a939f7ed352)
No idea what causes it.