### PR TITLE
Add internal `_finish()` method to Tweener

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -61,6 +61,11 @@ Ref<Tween> Tweener::_get_tween() {
 	return Ref<Tween>(ObjectDB::get_instance(tween_id));
 }
 
+void Tweener::_finish() {
+	finished = true;
+	emit_signal(SceneStringName(finished));
+}
+
 void Tweener::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("finished"));
 }
@@ -612,9 +617,8 @@ bool PropertyTweener::step(double &r_delta) {
 		return true;
 	} else {
 		target_instance->set_indexed(property, final_val);
-		finished = true;
 		r_delta = elapsed_time - delay - duration;
-		emit_signal(SceneStringName(finished));
+		_finish();
 		return false;
 	}
 }
@@ -672,9 +676,8 @@ bool IntervalTweener::step(double &r_delta) {
 		r_delta = 0;
 		return true;
 	} else {
-		finished = true;
 		r_delta = elapsed_time - duration;
-		emit_signal(SceneStringName(finished));
+		_finish();
 		return false;
 	}
 }
@@ -715,9 +718,8 @@ bool CallbackTweener::step(double &r_delta) {
 			ERR_FAIL_V_MSG(false, "Error calling method from CallbackTweener: " + Variant::get_callable_error_text(callback, nullptr, 0, ce) + ".");
 		}
 
-		finished = true;
 		r_delta = elapsed_time - delay;
-		emit_signal(SceneStringName(finished));
+		_finish();
 		return false;
 	}
 
@@ -801,9 +803,8 @@ bool MethodTweener::step(double &r_delta) {
 		r_delta = 0;
 		return true;
 	} else {
-		finished = true;
 		r_delta = elapsed_time - delay - duration;
-		emit_signal(SceneStringName(finished));
+		_finish();
 		return false;
 	}
 }

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -50,6 +50,7 @@ protected:
 	static void _bind_methods();
 
 	Ref<Tween> _get_tween();
+	void _finish();
 
 	double elapsed_time = 0;
 	bool finished = false;


### PR DESCRIPTION
When Tweener finishes, it has to set `finished` to `true` and emit the `finished` signal. While making #79712 I had a bug, because I forgot one of them. This PR adds a helper method for reliability purposes.