### PR TITLE
Fix incorrect warning on SkeletonModifier

### DIFF
--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -37,7 +37,7 @@ void SkeletonModifier3D::_validate_property(PropertyInfo &p_property) const {
 PackedStringArray SkeletonModifier3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node3D::get_configuration_warnings();
 	if (skeleton_id.is_null()) {
-		warnings.push_back(RTR("Skeleton3D node not set! SkeletonModifier3D must be child of Skeleton3D or set a path to an external skeleton."));
+		warnings.push_back(RTR("Skeleton3D node not set! SkeletonModifier3D must be child of Skeleton3D."));
 	}
 	return warnings;
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/95537

As noted in comment https://github.com/godotengine/godot/issues/95537#issuecomment-2290818158, SkeletonModifier has a different internal mechanism than BoneAttachment, so it will never have an external Skeleton.