### PR TITLE
Update GDExtension related CI after Godot 4.3-stable's release

### DIFF
--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   # Used for the godot-cpp checkout.
-  GODOT_CPP_BRANCH: '4.2'
+  GODOT_CPP_BRANCH: '4.3'
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -1,0 +1,9 @@
+This file contains the expected output of --validate-extension-api when run against the extension_api.json of the
+4.3-stable tag (the basename of this file).
+
+Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored. They
+should instead be used to justify these changes and describe how users should work around these changes.
+
+Add new entries at the end of the file.
+
+## Changes between 4.3-stable and 4.4-stable


### PR DESCRIPTION
Updates godot-cpp tests to use the 4.3 version (we always test Godot against godot-cpp N-1), and adds the `4.3-stable.expected`