### PR TITLE
Improve `Node.get_child()` error messages

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1711,13 +1711,21 @@ Node *Node::get_child(int p_index, bool p_include_internal) const {
 		if (p_index < 0) {
 			p_index += data.children_cache.size();
 		}
-		ERR_FAIL_INDEX_V(p_index, (int)data.children_cache.size(), nullptr);
+		ERR_FAIL_INDEX_V_MSG(p_index, (int)data.children_cache.size(), nullptr,
+				vformat("%s: Can't get child node at index %d, since the node only has %d children (including internal children).",
+						is_inside_tree() ? String(get_path()) : String(get_name()) + " (out-of-tree)",
+						p_index,
+						(int)data.children_cache.size()));
 		return data.children_cache[p_index];
 	} else {
 		if (p_index < 0) {
 			p_index += (int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache;
 		}
-		ERR_FAIL_INDEX_V(p_index, (int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache, nullptr);
+		ERR_FAIL_INDEX_V_MSG(p_index, (int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache, nullptr,
+				vformat("%s: Can't get child node at index %d, since the node only has %d children.",
+						is_inside_tree() ? String(get_path()) : String(get_name()) + " (out-of-tree)",
+						p_index,
+						(int)data.children_cache.size()));
 		p_index += data.internal_children_front_count_cache;
 		return data.children_cache[p_index];
 	}
@@ -1750,7 +1758,7 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 		return nullptr;
 	}
 
-	ERR_FAIL_COND_V_MSG(!data.inside_tree && p_path.is_absolute(), nullptr, "Can't use get_node() with absolute paths from outside the active scene tree.");
+	ERR_FAIL_COND_V_MSG(!data.inside_tree && p_path.is_absolute(), nullptr, vformat("Can't use get_node() with absolute path \"%s\" from outside the active scene tree.", p_path));
 
 	Node *current = nullptr;
 	Node *root = nullptr;


### PR DESCRIPTION
- Mention node path (if inside tree) or node name (if not in tree), attempted node index and actual child count.
- Mention whether internal children were considered during the search.

___

- This addresses https://github.com/godotengine/godot/issues/42719#issuecomment-2165797117.

**Testing project:** [test_node_error_messages.zip](https://github.com/user-attachments/files/16627114/test_node_error_messages.zip)

## Preview

### Before

```
ERROR: Index p_index = 0 is out of bounds ((int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache = 0).
   at: get_child (scene/main/node.cpp:1694)

ERROR: Index p_index = 0 is out of bounds ((int)data.children_cache.size() = 0).
   at: get_child (scene/main/node.cpp:1688)

ERROR: Index p_index = 5 is out of bounds ((int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache = 1).
   at: get_child (scene/main/node.cpp:1694)

ERROR: Index p_index = 5 is out of bounds ((int)data.children_cache.size() = 1).
   at: get_child (scene/main/node.cpp:1688)

ERROR: Index p_index = 0 is out of bounds ((int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache = 0).
   at: get_child (scene/main/node.cpp:1694)
```

### After

```
ERROR: /root/Node2D/NodeNoChildren: Can't get child node at index 0, since the node only has 0 children.
   at: get_child (./scene/main/node.cpp:1698)

ERROR: /root/Node2D/NodeNoChildren: Can't get child node at index 0, since the node only has 0 children (including internal children).
   at: get_child (./scene/main/node.cpp:1688)

ERROR: /root/Node2D/Node1Children: Can't get child node at index 5, since the node only has 1 children.
   at: get_child (./scene/main/node.cpp:1698)

ERROR: /root/Node2D/Node1Children: Can't get child node at index 5, since the node only has 1 children (including internal children).
   at: get_child (./scene/main/node.cpp:1688)

ERROR: Child (out-of-tree): Can't get child node at index 0, since the node only has 0 children.
   at: get_child (./scene/main/node.cpp:1698)
```
