### PR TITLE
Improve Timer error messages

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -80,7 +80,7 @@ void Timer::_notification(int p_what) {
 }
 
 void Timer::set_wait_time(double p_time) {
-	ERR_FAIL_COND_MSG(p_time <= 0, "Time should be greater than zero.");
+	ERR_FAIL_COND_MSG(p_time <= 0, vformat("%s: The wait time should be greater than 0 seconds, but a wait time of %f was provided.", is_inside_tree() ? String(get_path()) : String(get_name()) + " (out-of-tree)", p_time));
 	wait_time = p_time;
 	update_configuration_warnings();
 }
@@ -106,7 +106,7 @@ bool Timer::has_autostart() const {
 }
 
 void Timer::start(double p_time) {
-	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
+	ERR_FAIL_COND_MSG(!is_inside_tree(), vformat("%s (out-of-tree): Timer was not added to the SceneTree. Either add it to the SceneTree using `add_child()`, or set the `autostart` property to `true`.", get_name()));
 
 	if (p_time > 0) {
 		set_wait_time(p_time);


### PR DESCRIPTION
- Mention the node path (or node name if not in tree).
- Mention the provided invalid wait time.

___

- This addresses https://github.com/godotengine/godot/issues/42719#issuecomment-2165807053.

**Testing project:** [test_timer_error_messages.zip](https://github.com/user-attachments/files/16627839/test_timer_error_messages.zip)

## Preview

### Before

```
ERROR: Timer was not added to the SceneTree. Either add it or set autostart to true.
   at: start (scene/main/timer.cpp:109)

ERROR: Time should be greater than zero.
   at: set_wait_time (scene/main/timer.cpp:83)
```

### After

```
ERROR: Timer (out-of-tree): Timer was not added to the SceneTree. Either add it to the SceneTree using `add_child()`, or set the `autostart` property to `true`.
   at: start (./scene/main/timer.cpp:109)

ERROR: Timer2 (out-of-tree): The wait time should be greater than 0 seconds, but a wait time of -0.500000 was provided.
   at: set_wait_time (./scene/main/timer.cpp:83)
```
