### PR TITLE
Improve Object error messages

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2276,6 +2276,11 @@ NodePath Node::get_path() const {
 	return *data.path_cache;
 }
 
+// Helper method for use in engine error messages.
+String Node::get_debug_path() const {
+	return is_inside_tree() ? String(get_path()) : String(get_name()) + " (out-of-tree)";
+}
+
 bool Node::is_in_group(const StringName &p_identifier) const {
 	ERR_THREAD_GUARD_V(false);
 	return data.grouped.has(p_identifier);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -453,6 +453,7 @@ public:
 	bool is_greater_than(const Node *p_node) const;
 
 	NodePath get_path() const;
+	String get_debug_path() const;
 	NodePath get_path_to(const Node *p_node, bool p_use_unique_path = false) const;
 	Node *find_common_parent_with(const Node *p_node) const;
 


### PR DESCRIPTION
- Mention node paths and types if relevant.
- Ensure the object String representation (or at least the object type) is always mentioned in the error message for non-Node objects.
- Tweak styling for consistency.

This also adds `Node.get_debug_path()` which aids in creating those error messages. It returns the node path if the node is in the scene tree, or the node name with an "(out-of-tree)" suffix otherwise.

- This addresses https://github.com/godotengine/godot/issues/42719#issuecomment-2165885921.

**Testing project:** [test_object_error_messages.zip](https://github.com/user-attachments/files/16628355/test_object_error_messages.zip)

## Preview

### Before

```
ERROR: Cannot determine if connected to 'non_existing': the provided callable is null.
   at: is_connected (core/object/object.cpp:1429)
ERROR: Nonexistent signal: non_existing.
   at: is_connected (core/object/object.cpp:1441)
ERROR: In Object of type 'Node2D': Attempt to connect nonexistent signal 'non_existing' to callable 'Node2D(node_2d.gd)::_ready'.
   at: connect (core/object/object.cpp:1390)
ERROR: Disconnecting nonexistent signal 'non_existing' in SceneNodeExample:<Node2D#27766293758>.
   at: _disconnect (core/object/object.cpp:1460)

ERROR: Cannot determine if connected to 'non_existing': the provided callable is null.
   at: is_connected (core/object/object.cpp:1429)
ERROR: Nonexistent signal: non_existing.
   at: is_connected (core/object/object.cpp:1441)
ERROR: In Object of type 'Node': Attempt to connect nonexistent signal 'non_existing' to callable 'Node2D(node_2d.gd)::_ready'.
   at: connect (core/object/object.cpp:1390)
ERROR: Disconnecting nonexistent signal 'non_existing' in ExampleNode2:<Node#27783070975>.
   at: _disconnect (core/object/object.cpp:1460)

ERROR: Nonexistent signal: non_existing.
   at: is_connected (core/object/object.cpp:1441)
ERROR: In Object of type 'Image': Attempt to connect nonexistent signal 'non_existing' to callable 'Node2D(node_2d.gd)::_ready'.
   at: connect (core/object/object.cpp:1390)
ERROR: Disconnecting nonexistent signal 'non_existing' in <Image#-9223372009004595966>.
   at: _disconnect (core/object/object.cpp:1460)
```

### After

```
ERROR: /root/SceneNodeExample: Can't determine if connected to "Node2D" in node of type non_existing, as the the provided callable is null.
   at: is_connected (./core/object/object.cpp:1454)
ERROR: /root/SceneNodeExample: The signal "non_existing" does not exist in node of type Node2D.
   at: is_connected (./core/object/object.cpp:1476)
ERROR: /root/SceneNodeExample: Attempted to connect nonexistent signal "non_existing" to callable "Node2D(node_2d.gd)::_ready" in node of type Node2D.
   at: connect (./core/object/object.cpp:1405)
ERROR: /root/SceneNodeExample: The signal "non_existing" does not exist in node of type Node2D.
   at: _disconnect (./core/object/object.cpp:1526)

ERROR: ExampleNode2 (out-of-tree): Can't determine if connected to "Node" in node of type non_existing, as the the provided callable is null.
   at: is_connected (./core/object/object.cpp:1454)
ERROR: ExampleNode2 (out-of-tree): The signal "non_existing" does not exist in node of type Node.
   at: is_connected (./core/object/object.cpp:1476)
ERROR: ExampleNode2 (out-of-tree): Attempted to connect nonexistent signal "non_existing" to callable "Node2D(node_2d.gd)::_ready" in node of type Node.
   at: connect (./core/object/object.cpp:1405)
ERROR: ExampleNode2 (out-of-tree): The signal "non_existing" does not exist in node of type Node.
   at: _disconnect (./core/object/object.cpp:1526)

ERROR: The signal "non_existing" does not exist in the object of type Image.
   at: is_connected (./core/object/object.cpp:1478)
ERROR: Attempted to connect nonexistent signal "non_existing" to callable "Node2D(node_2d.gd)::_ready" in "<Image#-9223372009054927617>".
   at: connect (./core/object/object.cpp:1407)
ERROR: The signal "non_existing" does not exist in <Image#-9223372009054927617>.
   at: _disconnect (./core/object/object.cpp:1541)
```
