### PR TITLE
Update the Android `fileLastModified` method to return values in seconds instead of milliseconds

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileData.kt
@@ -53,7 +53,7 @@ internal class FileData(filePath: String, accessFlag: FileAccessFlags) : DataAcc
 
 		fun fileLastModified(filepath: String): Long {
 			return try {
-				File(filepath).lastModified()
+				File(filepath).lastModified() / 1000L
 			} catch (e: SecurityException) {
 				0L
 			}

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/MediaStoreData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/MediaStoreData.kt
@@ -203,7 +203,7 @@ internal class MediaStoreData(context: Context, filePath: String, accessFlag: Fi
 			}
 
 			val dataItem = result[0]
-			return dataItem.dateModified.toLong()
+			return dataItem.dateModified.toLong() / 1000L
 		}
 
 		fun rename(context: Context, from: String, to: String): Boolean {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95576

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
