### PR TITLE
Update expected API validation files for the releases of Godot 4.2 & 4.3

### DIFF
--- a/misc/extension_api_validation/4.1-stable_4.2-stable.expected
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable.expected
@@ -1,10 +1,5 @@
-This file contains the expected output of --validate-extension-api when run against the extension_api.json of the
-4.1-stable tag (the basename of this file).
-
-Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored. They
-should instead be used to justify these changes and describe how users should work around these changes.
-
-Add new entries at the end of the file.
+This file contains, when concatenated to the expected output since 4.2, the expected output of --validate-extension-api
+when run against the extension_api.json of the 4.1-stable tag (first part of the basename of this file).
 
 ## Changes between 4.1-stable and 4.2-stable
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable.expected
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable.expected
@@ -1,10 +1,5 @@
-This file contains the expected output of --validate-extension-api when run against the extension_api.json of the
-4.2-stable tag (the basename of this file).
-
-Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored. They
-should instead be used to justify these changes and describe how users should work around these changes.
-
-Add new entries at the end of the file.
+This file contains, when concatenated to the expected output since 4.3, the expected output of --validate-extension-api
+when run against the extension_api.json of the 4.2-stable tag (first part of the basename of this file).
 
 ## Changes between 4.2-stable and 4.3-stable
 


### PR DESCRIPTION
This PR updates the 4.1->4.2 and 4.2->4.3 files with wording that matches the 4.0->4.1 file.

I had the 4.1->4.2 change inside of another PR since 4.2's release, but that never made it in before 4.3's release.