### PR TITLE
Add an `Edit Now` option to project dialog to allow opting out of immediately opening a project after creation/import/install

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -711,14 +711,17 @@ void ProjectManager::_on_projects_updated() {
 	project_list->update_dock_menu();
 }
 
-void ProjectManager::_on_project_created(const String &dir) {
+void ProjectManager::_on_project_created(const String &dir, bool edit) {
 	project_list->add_project(dir, false);
 	project_list->save_config();
 	search_box->clear();
 	int i = project_list->refresh_project(dir);
 	project_list->select_project(i);
 	project_list->ensure_project_visible(i);
-	_open_selected_projects_ask();
+
+	if (edit) {
+		_open_selected_projects_ask();
+	}
 
 	project_list->update_dock_menu();
 }

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -187,7 +187,7 @@ class ProjectManager : public Control {
 	void _erase_missing_projects_confirm();
 	void _update_project_buttons();
 
-	void _on_project_created(const String &dir);
+	void _on_project_created(const String &dir, bool edit);
 	void _on_projects_updated();
 
 	void _on_order_option_changed(int p_idx);

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -671,7 +671,7 @@ void ProjectDialog::ok_pressed() {
 
 	hide();
 	if (mode == MODE_NEW || mode == MODE_IMPORT || mode == MODE_INSTALL) {
-		emit_signal(SNAME("project_created"), path);
+		emit_signal(SNAME("project_created"), path, edit_check_box->is_pressed());
 	} else if (mode == MODE_RENAME) {
 		emit_signal(SNAME("projects_updated"));
 	}
@@ -713,6 +713,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 		create_dir->hide();
 		project_status_rect->hide();
 		project_browse->hide();
+		edit_check_box->hide();
 
 		name_container->show();
 		install_path_container->hide();
@@ -742,10 +743,11 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 		create_dir->show();
 		project_status_rect->show();
 		project_browse->show();
+		edit_check_box->show();
 
 		if (mode == MODE_IMPORT) {
 			set_title(TTR("Import Existing Project"));
-			set_ok_button_text(TTR("Import & Edit"));
+			set_ok_button_text(TTR("Import"));
 
 			name_container->hide();
 			install_path_container->hide();
@@ -755,7 +757,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 			// Project path dialog is also opened; no need to change focus.
 		} else if (mode == MODE_NEW) {
 			set_title(TTR("Create New Project"));
-			set_ok_button_text(TTR("Create & Edit"));
+			set_ok_button_text(TTR("Create"));
 
 			name_container->show();
 			install_path_container->hide();
@@ -766,7 +768,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 			callable_mp(project_name, &LineEdit::select_all).call_deferred();
 		} else if (mode == MODE_INSTALL) {
 			set_title(TTR("Install Project:") + " " + zip_title);
-			set_ok_button_text(TTR("Install & Edit"));
+			set_ok_button_text(TTR("Install"));
 
 			project_name->set_text(zip_title);
 
@@ -992,6 +994,16 @@ ProjectDialog::ProjectDialog() {
 	fdialog_install->set_previews_enabled(false); //Crucial, otherwise the engine crashes.
 	fdialog_install->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	add_child(fdialog_install);
+
+	Control *spacer2 = memnew(Control);
+	spacer2->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->add_child(spacer2);
+
+	edit_check_box = memnew(CheckBox);
+	edit_check_box->set_text(TTR("Edit Now"));
+	edit_check_box->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	edit_check_box->set_pressed(true);
+	vb->add_child(edit_check_box);
 
 	project_name->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_name_changed).unbind(1));
 	project_path->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_path_changed).unbind(1));

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -34,6 +34,7 @@
 #include "scene/gui/dialogs.h"
 
 class Button;
+class CheckBox;
 class CheckButton;
 class EditorFileDialog;
 class LineEdit;
@@ -86,6 +87,8 @@ private:
 	TextureRect *install_status_rect = nullptr;
 
 	OptionButton *vcs_metadata_selection = nullptr;
+
+	CheckBox *edit_check_box = nullptr;
 
 	EditorFileDialog *fdialog_project = nullptr;
 	EditorFileDialog *fdialog_install = nullptr;


### PR DESCRIPTION
This PR adds a little check button to the project dialog so the user can opt out of immediately opening a project after creation/import/install, which is useful when you want to perform multiple imports or installs or creations without interruption/restarting.

The check button is checked by default, so the current default behaviour is unchanged.

I've opted to maintain the state of this checkbox *per session*. i.e. if you uncheck it while doing an import, it will remain unchecked if you try to perform another import right after. I believe this makes sense for the intended workflow of potential consecutive operations. The current "edit-immediately" workflow will not be impacted by this decision because once the project opens, the project manager is closed anyway, and the option will once again be on the default **true** state the next time the project manager is opened.

Adding a third button to the dialog was an option that I considered, but I decided that keeping the two buttons would be the less confusing change for users who like the current flow (they don't have to remember/choose which new button to press).

Fixes #88891 

![screenshot4](https://github.com/user-attachments/assets/8537336f-913b-4dee-bfa3-183a190afec8)
![screenshot5](https://github.com/user-attachments/assets/ce8651a1-5dd2-4642-b147-e508f2a4b6b3)
![screenshot6](https://github.com/user-attachments/assets/55924d4c-0d4c-47de-af27-19b34a42e27a)
