### PR TITLE
Fix glTF capitalization in error messages

### DIFF
--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -170,7 +170,7 @@ Light3D *GLTFLight::to_node() const {
 }
 
 Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
-	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFLight>(), "Failed to parse GLTF light, missing required field 'type'.");
+	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFLight>(), "Failed to parse glTF light, missing required field 'type'.");
 	Ref<GLTFLight> light;
 	light.instantiate();
 	const String &type = p_dictionary["type"];
@@ -181,7 +181,7 @@ Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
 		if (arr.size() == 3) {
 			light->color = Color(arr[0], arr[1], arr[2]).linear_to_srgb();
 		} else {
-			ERR_PRINT("Error parsing GLTF light: The color must have exactly 3 numbers.");
+			ERR_PRINT("Error parsing glTF light: The color must have exactly 3 numbers.");
 		}
 	}
 	if (p_dictionary.has("intensity")) {
@@ -195,10 +195,10 @@ Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
 		light->inner_cone_angle = spot["innerConeAngle"];
 		light->outer_cone_angle = spot["outerConeAngle"];
 		if (light->inner_cone_angle >= light->outer_cone_angle) {
-			ERR_PRINT("Error parsing GLTF light: The inner angle must be smaller than the outer angle.");
+			ERR_PRINT("Error parsing glTF light: The inner angle must be smaller than the outer angle.");
 		}
 	} else if (type != "point" && type != "directional") {
-		ERR_PRINT("Error parsing GLTF light: Light type '" + type + "' is unknown.");
+		ERR_PRINT("Error parsing glTF light: Light type '" + type + "' is unknown.");
 	}
 	return light;
 }

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -88,7 +88,7 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 			// "collider" is the index of the collider in the state colliders array.
 			int node_collider_index = node_collider_ext["collider"];
 			Array state_colliders = p_state->get_additional_data(StringName("GLTFPhysicsShapes"));
-			ERR_FAIL_INDEX_V_MSG(node_collider_index, state_colliders.size(), Error::ERR_FILE_CORRUPT, "GLTF Physics: On node " + p_gltf_node->get_name() + ", the collider index " + itos(node_collider_index) + " is not in the state colliders (size: " + itos(state_colliders.size()) + ").");
+			ERR_FAIL_INDEX_V_MSG(node_collider_index, state_colliders.size(), Error::ERR_FILE_CORRUPT, "glTF Physics: On node " + p_gltf_node->get_name() + ", the collider index " + itos(node_collider_index) + " is not in the state colliders (size: " + itos(state_colliders.size()) + ").");
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsShape"), state_colliders[node_collider_index]);
 		} else {
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsShape"), GLTFPhysicsShape::from_dictionary(node_collider_ext));
@@ -103,7 +103,7 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 			int node_shape_index = node_collider.get("shape", -1);
 			if (node_shape_index != -1) {
 				Array state_shapes = p_state->get_additional_data(StringName("GLTFPhysicsShapes"));
-				ERR_FAIL_INDEX_V_MSG(node_shape_index, state_shapes.size(), Error::ERR_FILE_CORRUPT, "GLTF Physics: On node " + p_gltf_node->get_name() + ", the shape index " + itos(node_shape_index) + " is not in the state shapes (size: " + itos(state_shapes.size()) + ").");
+				ERR_FAIL_INDEX_V_MSG(node_shape_index, state_shapes.size(), Error::ERR_FILE_CORRUPT, "glTF Physics: On node " + p_gltf_node->get_name() + ", the shape index " + itos(node_shape_index) + " is not in the state shapes (size: " + itos(state_shapes.size()) + ").");
 				p_gltf_node->set_additional_data(StringName("GLTFPhysicsColliderShape"), state_shapes[node_shape_index]);
 			} else {
 				// If this node is a collider but does not have a collider
@@ -117,7 +117,7 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 			int node_shape_index = node_trigger.get("shape", -1);
 			if (node_shape_index != -1) {
 				Array state_shapes = p_state->get_additional_data(StringName("GLTFPhysicsShapes"));
-				ERR_FAIL_INDEX_V_MSG(node_shape_index, state_shapes.size(), Error::ERR_FILE_CORRUPT, "GLTF Physics: On node " + p_gltf_node->get_name() + ", the shape index " + itos(node_shape_index) + " is not in the state shapes (size: " + itos(state_shapes.size()) + ").");
+				ERR_FAIL_INDEX_V_MSG(node_shape_index, state_shapes.size(), Error::ERR_FILE_CORRUPT, "glTF Physics: On node " + p_gltf_node->get_name() + ", the shape index " + itos(node_shape_index) + " is not in the state shapes (size: " + itos(state_shapes.size()) + ").");
 				p_gltf_node->set_additional_data(StringName("GLTFPhysicsTriggerShape"), state_shapes[node_shape_index]);
 			} else {
 				// If this node is a trigger but does not have a trigger shape,
@@ -150,7 +150,7 @@ void _setup_shape_mesh_resource_from_index_if_needed(Ref<GLTFState> p_state, Ref
 		return; // The mesh resource is already set up.
 	}
 	TypedArray<GLTFMesh> state_meshes = p_state->get_meshes();
-	ERR_FAIL_INDEX_MSG(shape_mesh_index, state_meshes.size(), "GLTF Physics: When importing '" + p_state->get_scene_name() + "', the shape mesh index " + itos(shape_mesh_index) + " is not in the state meshes (size: " + itos(state_meshes.size()) + ").");
+	ERR_FAIL_INDEX_MSG(shape_mesh_index, state_meshes.size(), "glTF Physics: When importing '" + p_state->get_scene_name() + "', the shape mesh index " + itos(shape_mesh_index) + " is not in the state meshes (size: " + itos(state_meshes.size()) + ").");
 	Ref<GLTFMesh> gltf_mesh = state_meshes[shape_mesh_index];
 	ERR_FAIL_COND(gltf_mesh.is_null());
 	importer_mesh = gltf_mesh->get_mesh();
@@ -164,12 +164,12 @@ CollisionObject3D *_generate_shape_with_body(Ref<GLTFState> p_state, Ref<GLTFNod
 	bool is_trigger = p_physics_shape->get_is_trigger();
 	// This method is used for the case where we must generate a parent body.
 	// This is can happen for multiple reasons. One possibility is that this
-	// GLTF file is using OMI_collider but not OMI_physics_body, or at least
+	// glTF file is using OMI_collider but not OMI_physics_body, or at least
 	// this particular node is not using it. Another possibility is that the
-	// physics body information is set up on the same GLTF node, not a parent.
+	// physics body information is set up on the same glTF node, not a parent.
 	CollisionObject3D *body;
 	if (p_physics_body.is_valid()) {
-		// This code is run when the physics body is on the same GLTF node.
+		// This code is run when the physics body is on the same glTF node.
 		body = p_physics_body->to_node();
 		if (is_trigger && (p_physics_body->get_body_type() != "trigger")) {
 			// Edge case: If the body's trigger and the collider's trigger
@@ -266,7 +266,7 @@ Node3D *GLTFDocumentExtensionPhysics::generate_scene_node(Ref<GLTFState> p_state
 	Ref<GLTFPhysicsShape> gltf_physics_shape = p_gltf_node->get_additional_data(StringName("GLTFPhysicsShape"));
 	if (gltf_physics_shape.is_valid()) {
 		_setup_shape_mesh_resource_from_index_if_needed(p_state, gltf_physics_shape);
-		// If this GLTF node specifies both a shape and a body, generate both.
+		// If this glTF node specifies both a shape and a body, generate both.
 		if (gltf_physics_body.is_valid()) {
 			return _generate_shape_with_body(p_state, p_gltf_node, gltf_physics_shape, gltf_physics_body);
 		}
@@ -309,7 +309,7 @@ Node3D *GLTFDocumentExtensionPhysics::generate_scene_node(Ref<GLTFState> p_state
 			}
 		} else if (!Object::cast_to<PhysicsBody3D>(ancestor_col_obj)) {
 			if (p_gltf_node->get_additional_data(StringName("GLTFPhysicsCompoundCollider"))) {
-				// If the GLTF file wants this node to group solid shapes together,
+				// If the glTF file wants this node to group solid shapes together,
 				// and there is no parent body, we need to create a static body.
 				ancestor_col_obj = memnew(StaticBody3D);
 				ret = ancestor_col_obj;
@@ -386,7 +386,7 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 	if (cast_to<CollisionShape3D>(p_scene_node)) {
 		CollisionShape3D *godot_shape = Object::cast_to<CollisionShape3D>(p_scene_node);
 		Ref<GLTFPhysicsShape> gltf_shape = GLTFPhysicsShape::from_node(godot_shape);
-		ERR_FAIL_COND_MSG(gltf_shape.is_null(), "GLTF Physics: Could not convert CollisionShape3D to GLTFPhysicsShape. Does it have a valid Shape3D?");
+		ERR_FAIL_COND_MSG(gltf_shape.is_null(), "glTF Physics: Could not convert CollisionShape3D to GLTFPhysicsShape. Does it have a valid Shape3D?");
 		{
 			Ref<ImporterMesh> importer_mesh = gltf_shape->get_importer_mesh();
 			if (importer_mesh.is_valid()) {

--- a/modules/gltf/extensions/physics/gltf_physics_body.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_body.cpp
@@ -108,7 +108,7 @@ void GLTFPhysicsBody::set_body_type(String p_body_type) {
 	} else if (p_body_type == "trigger") {
 		body_type = PhysicsBodyType::TRIGGER;
 	} else {
-		ERR_PRINT("Error setting GLTF physics body type: The body type must be one of \"static\", \"animatable\", \"character\", \"rigid\", \"vehicle\", or \"trigger\".");
+		ERR_PRINT("Error setting glTF physics body type: The body type must be one of \"static\", \"animatable\", \"character\", \"rigid\", \"vehicle\", or \"trigger\".");
 	}
 }
 
@@ -194,7 +194,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_node(const CollisionObject3D *p_body_
 		physics_body->center_of_mass = body->get_center_of_mass();
 		physics_body->inertia_diagonal = body->get_inertia();
 		if (body->get_center_of_mass() != Vector3()) {
-			WARN_PRINT("GLTFPhysicsBody: This rigid body has a center of mass offset from the origin, which will be ignored when exporting to GLTF.");
+			WARN_PRINT("GLTFPhysicsBody: This rigid body has a center of mass offset from the origin, which will be ignored when exporting to glTF.");
 		}
 		if (cast_to<VehicleBody3D>(p_body_node)) {
 			physics_body->body_type = PhysicsBodyType::VEHICLE;
@@ -289,7 +289,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 			physics_body->body_type = PhysicsBodyType::TRIGGER;
 #endif // DISABLE_DEPRECATED
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The body type in the GLTF file \"" + body_type_string + "\" was not recognized.");
+			ERR_PRINT("Error parsing glTF physics body: The body type in the glTF file \"" + body_type_string + "\" was not recognized.");
 		}
 	}
 	if (motion.has("mass")) {
@@ -300,7 +300,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 		if (arr.size() == 3) {
 			physics_body->set_linear_velocity(Vector3(arr[0], arr[1], arr[2]));
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The linear velocity vector must have exactly 3 numbers.");
+			ERR_PRINT("Error parsing glTF physics body: The linear velocity vector must have exactly 3 numbers.");
 		}
 	}
 	if (motion.has("angularVelocity")) {
@@ -308,7 +308,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 		if (arr.size() == 3) {
 			physics_body->set_angular_velocity(Vector3(arr[0], arr[1], arr[2]));
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The angular velocity vector must have exactly 3 numbers.");
+			ERR_PRINT("Error parsing glTF physics body: The angular velocity vector must have exactly 3 numbers.");
 		}
 	}
 	if (motion.has("centerOfMass")) {
@@ -316,7 +316,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 		if (arr.size() == 3) {
 			physics_body->set_center_of_mass(Vector3(arr[0], arr[1], arr[2]));
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The center of mass vector must have exactly 3 numbers.");
+			ERR_PRINT("Error parsing glTF physics body: The center of mass vector must have exactly 3 numbers.");
 		}
 	}
 	if (motion.has("inertiaDiagonal")) {
@@ -324,7 +324,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 		if (arr.size() == 3) {
 			physics_body->set_inertia_diagonal(Vector3(arr[0], arr[1], arr[2]));
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The inertia diagonal vector must have exactly 3 numbers.");
+			ERR_PRINT("Error parsing glTF physics body: The inertia diagonal vector must have exactly 3 numbers.");
 		}
 	}
 	if (motion.has("inertiaOrientation")) {
@@ -332,7 +332,7 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_diction
 		if (arr.size() == 4) {
 			physics_body->set_inertia_orientation(Quaternion(arr[0], arr[1], arr[2], arr[3]));
 		} else {
-			ERR_PRINT("Error parsing GLTF physics body: The inertia orientation quaternion must have exactly 4 numbers.");
+			ERR_PRINT("Error parsing glTF physics body: The inertia orientation quaternion must have exactly 4 numbers.");
 		}
 	}
 	return physics_body;

--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -134,7 +134,7 @@ void GLTFPhysicsShape::set_importer_mesh(Ref<ImporterMesh> p_importer_mesh) {
 
 Ref<ImporterMesh> _convert_hull_points_to_mesh(const Vector<Vector3> &p_hull_points) {
 	Ref<ImporterMesh> importer_mesh;
-	ERR_FAIL_COND_V_MSG(p_hull_points.size() < 3, importer_mesh, "GLTFPhysicsShape: Convex hull has fewer points (" + itos(p_hull_points.size()) + ") than the minimum of 3. At least 3 points are required in order to save to GLTF, since it uses a mesh to represent convex hulls.");
+	ERR_FAIL_COND_V_MSG(p_hull_points.size() < 3, importer_mesh, "GLTFPhysicsShape: Convex hull has fewer points (" + itos(p_hull_points.size()) + ") than the minimum of 3. At least 3 points are required in order to save to glTF, since it uses a mesh to represent convex hulls.");
 	if (p_hull_points.size() > 255) {
 		WARN_PRINT("GLTFPhysicsShape: Convex hull has more points (" + itos(p_hull_points.size()) + ") than the recommended maximum of 255. This may not load correctly in other engines.");
 	}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -620,7 +620,7 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 			for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 				ERR_CONTINUE(ext.is_null());
 				Error err = ext->parse_node_extensions(p_state, node, extensions);
-				ERR_CONTINUE_MSG(err != OK, "GLTF: Encountered error " + itos(err) + " when parsing node extensions for node " + node->get_name() + " in file " + p_state->filename + ". Continuing.");
+				ERR_CONTINUE_MSG(err != OK, "glTF: Encountered error " + itos(err) + " when parsing node extensions for node " + node->get_name() + " in file " + p_state->filename + ". Continuing.");
 			}
 		}
 
@@ -3353,7 +3353,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 		ERR_CONTINUE(image.is_null());
 		if (image->is_compressed()) {
 			image->decompress();
-			ERR_FAIL_COND_V_MSG(image->is_compressed(), ERR_INVALID_DATA, "GLTF: Image was compressed, but could not be decompressed.");
+			ERR_FAIL_COND_V_MSG(image->is_compressed(), ERR_INVALID_DATA, "glTF: Image was compressed, but could not be decompressed.");
 		}
 
 		if (p_state->filename.to_lower().ends_with("gltf")) {
@@ -3374,7 +3374,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 			if (_image_save_extension.is_valid()) {
 				img_name = img_name + _image_save_extension->get_image_file_extension();
 				Error err = _image_save_extension->save_image_at_path(p_state, image, full_texture_dir.path_join(img_name), _image_format, _lossy_quality);
-				ERR_FAIL_COND_V_MSG(err != OK, err, "GLTF: Failed to save image in '" + _image_format + "' format as a separate file.");
+				ERR_FAIL_COND_V_MSG(err != OK, err, "glTF: Failed to save image in '" + _image_format + "' format as a separate file.");
 			} else if (_image_format == "PNG") {
 				img_name = img_name + ".png";
 				image->save_png(full_texture_dir.path_join(img_name));
@@ -3382,7 +3382,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 				img_name = img_name + ".jpg";
 				image->save_jpg(full_texture_dir.path_join(img_name), _lossy_quality);
 			} else {
-				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "GLTF: Unknown image format '" + _image_format + "'.");
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "glTF: Unknown image format '" + _image_format + "'.");
 			}
 			image_dict["uri"] = relative_texture_dir.path_join(img_name).uri_encode();
 		} else {
@@ -3412,9 +3412,9 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 				buffer = image->save_jpg_to_buffer(_lossy_quality);
 				image_dict["mimeType"] = "image/jpeg";
 			} else {
-				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "GLTF: Unknown image format '" + _image_format + "'.");
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "glTF: Unknown image format '" + _image_format + "'.");
 			}
-			ERR_FAIL_COND_V_MSG(buffer.is_empty(), ERR_INVALID_DATA, "GLTF: Failed to save image in '" + _image_format + "' format.");
+			ERR_FAIL_COND_V_MSG(buffer.is_empty(), ERR_INVALID_DATA, "glTF: Failed to save image in '" + _image_format + "' format.");
 
 			bv->byte_length = buffer.size();
 			p_state->buffers.write[bi].resize(p_state->buffers[bi].size() + bv->byte_length);
@@ -3445,7 +3445,7 @@ Ref<Image> GLTFDocument::_parse_image_bytes_into_image(Ref<GLTFState> p_state, c
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());
 		Error err = ext->parse_image_data(p_state, p_bytes, p_mime_type, r_image);
-		ERR_CONTINUE_MSG(err != OK, "GLTF: Encountered error " + itos(err) + " when parsing image " + itos(p_index) + " in file " + p_state->filename + ". Continuing.");
+		ERR_CONTINUE_MSG(err != OK, "glTF: Encountered error " + itos(err) + " when parsing image " + itos(p_index) + " in file " + p_state->filename + ". Continuing.");
 		if (!r_image->is_empty()) {
 			r_file_extension = ext->get_image_file_extension();
 			return r_image;
@@ -3736,13 +3736,13 @@ Error GLTFDocument::_parse_textures(Ref<GLTFState> p_state) {
 		for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 			ERR_CONTINUE(ext.is_null());
 			Error err = ext->parse_texture_json(p_state, texture_dict, gltf_texture);
-			ERR_CONTINUE_MSG(err != OK, "GLTF: Encountered error " + itos(err) + " when parsing texture JSON " + String(Variant(texture_dict)) + " in file " + p_state->filename + ". Continuing.");
+			ERR_CONTINUE_MSG(err != OK, "glTF: Encountered error " + itos(err) + " when parsing texture JSON " + String(Variant(texture_dict)) + " in file " + p_state->filename + ". Continuing.");
 			if (gltf_texture->get_src_image() != -1) {
 				break;
 			}
 		}
 		if (gltf_texture->get_src_image() == -1) {
-			// No extensions handled it, so use the base GLTF source.
+			// No extensions handled it, so use the base glTF source.
 			// This may be the fallback, or the only option anyway.
 			ERR_FAIL_COND_V(!texture_dict.has("source"), ERR_PARSE_ERROR);
 			gltf_texture->set_src_image(texture_dict["source"]);
@@ -5631,7 +5631,7 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIn
 	// If none of our GLTFDocumentExtension classes generated us a node, we generate one.
 	if (!current_node) {
 		if (gltf_node->skin >= 0 && gltf_node->mesh >= 0 && !gltf_node->children.is_empty()) {
-			// GLTF specifies that skinned meshes should ignore their node transforms,
+			// glTF specifies that skinned meshes should ignore their node transforms,
 			// only being controlled by the skeleton, so Godot will reparent a skinned
 			// mesh to its skeleton. However, we still need to ensure any child nodes
 			// keep their place in the tree, so if there are any child nodes, the skinned
@@ -7138,9 +7138,9 @@ Node *GLTFDocument::_generate_scene_node_tree(Ref<GLTFState> p_state) {
 	HashMap<ObjectID, SkinSkeletonIndex> skeleton_map;
 	Error err = SkinTool::_create_skeletons(p_state->unique_names, p_state->skins, p_state->nodes,
 			skeleton_map, p_state->skeletons, p_state->scene_nodes);
-	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "GLTF: Failed to create skeletons.");
+	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "glTF: Failed to create skeletons.");
 	err = _create_skins(p_state);
-	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "GLTF: Failed to create skins.");
+	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "glTF: Failed to create skins.");
 	// Generate the node tree.
 	Node *single_root;
 	if (p_state->extensions_used.has("GODOT_single_root")) {
@@ -7459,7 +7459,7 @@ Error GLTFDocument::_parse_gltf_extensions(Ref<GLTFState> p_state) {
 	Error ret = OK;
 	for (int i = 0; i < p_state->extensions_required.size(); i++) {
 		if (!supported_extensions.has(p_state->extensions_required[i])) {
-			ERR_PRINT("GLTF: Can't import file '" + p_state->filename + "', required extension '" + String(p_state->extensions_required[i]) + "' is not supported. Are you missing a GLTFDocumentExtension plugin?");
+			ERR_PRINT("glTF: Can't import file '" + p_state->filename + "', required extension '" + String(p_state->extensions_required[i]) + "' is not supported. Are you missing a GLTFDocumentExtension plugin?");
 			ret = ERR_UNAVAILABLE;
 		}
 	}

--- a/modules/gltf/structures/gltf_camera.cpp
+++ b/modules/gltf/structures/gltf_camera.cpp
@@ -62,9 +62,9 @@ Ref<GLTFCamera> GLTFCamera::from_node(const Camera3D *p_camera) {
 	c.instantiate();
 	ERR_FAIL_NULL_V_MSG(p_camera, c, "Tried to create a GLTFCamera from a Camera3D node, but the given node was null.");
 	c->set_perspective(p_camera->get_projection() == Camera3D::ProjectionType::PROJECTION_PERSPECTIVE);
-	// GLTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
+	// glTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
 	c->set_fov(Math::deg_to_rad(p_camera->get_fov()));
-	// GLTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
+	// glTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
 	c->set_size_mag(p_camera->get_size() * 0.5f);
 	c->set_depth_far(p_camera->get_far());
 	c->set_depth_near(p_camera->get_near());
@@ -74,9 +74,9 @@ Ref<GLTFCamera> GLTFCamera::from_node(const Camera3D *p_camera) {
 Camera3D *GLTFCamera::to_node() const {
 	Camera3D *camera = memnew(Camera3D);
 	camera->set_projection(perspective ? Camera3D::PROJECTION_PERSPECTIVE : Camera3D::PROJECTION_ORTHOGONAL);
-	// GLTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
+	// glTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
 	camera->set_fov(Math::rad_to_deg(fov));
-	// GLTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
+	// glTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
 	camera->set_size(size_mag * 2.0f);
 	camera->set_near(depth_near);
 	camera->set_far(depth_far);
@@ -84,7 +84,7 @@ Camera3D *GLTFCamera::to_node() const {
 }
 
 Ref<GLTFCamera> GLTFCamera::from_dictionary(const Dictionary p_dictionary) {
-	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFCamera>(), "Failed to parse GLTF camera, missing required field 'type'.");
+	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFCamera>(), "Failed to parse glTF camera, missing required field 'type'.");
 	Ref<GLTFCamera> camera;
 	camera.instantiate();
 	const String &type = p_dictionary["type"];
@@ -107,7 +107,7 @@ Ref<GLTFCamera> GLTFCamera::from_dictionary(const Dictionary p_dictionary) {
 			camera->set_depth_near(ortho["znear"]);
 		}
 	} else {
-		ERR_PRINT("Error parsing GLTF camera: Camera type '" + type + "' is unknown, should be perspective or orthographic.");
+		ERR_PRINT("Error parsing glTF camera: Camera type '" + type + "' is unknown, should be perspective or orthographic.");
 	}
 	return camera;
 }

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -42,8 +42,8 @@ class GLTFCamera : public Resource {
 	GDCLASS(GLTFCamera, Resource);
 
 private:
-	// GLTF has no default camera values, they should always be specified in
-	// the GLTF file. Here we default to Godot's default camera settings.
+	// glTF has no default camera values, they should always be specified in
+	// the glTF file. Here we default to Godot's default camera settings.
 	bool perspective = true;
 	real_t fov = Math::deg_to_rad(75.0);
 	real_t size_mag = 0.5;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/95578. See also https://github.com/godotengine/godot-docs/issues/9750.

I looked through the glTF module for user-visible errors use "GLTF", and replaced usages of "GLTF" with "glTF".
If an error message was changed in a file, I replaced "GLTF" with "glTF" in comments of the same file.
If a .cpp file was changed, I also changed comments in the associated header file.

There are still some usages of "GLTF" in comments in other files, but they are no longer user-visible.