### PR TITLE
Add manual_fit_child_rect In BoxContainer

### DIFF
--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -10,6 +10,14 @@
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
+		<method name="_fit_child_in_rect" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="" type="Control" />
+			<param index="1" name="" type="Rect2" />
+			<description>
+				Manual do the fit a child control in a given rect, when it's called, it will override method `fit_child_in_rect` behaviour.
+			</description>
+		</method>
 		<method name="_get_allowed_size_flags_horizontal" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<description>

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -12,10 +12,10 @@
 	<methods>
 		<method name="_fit_child_in_rect" qualifiers="virtual">
 			<return type="void" />
-			<param index="0" name="" type="Control" />
-			<param index="1" name="" type="Rect2" />
+			<param index="0" name="child" type="Control" />
+			<param index="1" name="rect" type="Rect2" />
 			<description>
-				Manual do the fit a child control in a given rect, when it's called, it will override method `fit_child_in_rect` behaviour.
+				Manual do the fit a child control in a given rect, when it's called, it will override method `fit_child_in_rect`.
 			</description>
 		</method>
 		<method name="_get_allowed_size_flags_horizontal" qualifiers="virtual const">

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -93,6 +93,10 @@ void Container::_sort_children() {
 }
 
 void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
+	if (GDVIRTUAL_CALL(_fit_child_in_rect, p_child, p_rect)) {
+		return;
+	}
+
 	ERR_FAIL_NULL(p_child);
 	ERR_FAIL_COND(p_child->get_parent() != this);
 
@@ -214,6 +218,7 @@ void Container::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_allowed_size_flags_horizontal);
 	GDVIRTUAL_BIND(_get_allowed_size_flags_vertical);
+	GDVIRTUAL_BIND(_fit_child_in_rect);
 
 	BIND_CONSTANT(NOTIFICATION_PRE_SORT_CHILDREN);
 	BIND_CONSTANT(NOTIFICATION_SORT_CHILDREN);

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -56,6 +56,7 @@ protected:
 
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_horizontal)
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_vertical)
+	GDVIRTUAL2(_fit_child_in_rect, Control *, Rect2)
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -66,7 +67,7 @@ public:
 		NOTIFICATION_SORT_CHILDREN = 51,
 	};
 
-	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
+	virtual void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const;
 	virtual Vector<int> get_allowed_size_flags_vertical() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10437, related https://github.com/godotengine/godot-proposals/issues/9616

In `BoxContainer`,add a flag `manual_fit_child_in_rect` and signal `request_fit_child_in_rect`.

when `manual_fit_child_in_rect=true`, it will not call method `fit_child_in_rect` and emit signal `request_fit_child_in_rect`, so that user can implement custom positioning. 

usage for custom animation positioning in gdscript:
```gdscript
extends Control

# Called when the node enters the scene tree for the first time.
func _ready() -> void:
	$HBoxContainer.set_manual_fit_child_in_rect(true)
	$HBoxContainer.connect("request_fit_child_in_rect", self._handle_request_fit_child_in_rect)
	await self.get_tree().create_timer(1.0).timeout
	
	for i in range(5):
		var node = ColorRect.new()
		node.custom_minimum_size = Vector2(64, 64)
		node.size = node.custom_minimum_size
		node.color = Color("#fff")
		$HBoxContainer.add_child(node)
		await self.get_tree().create_timer(1.0).timeout
	pass


func _handle_request_fit_child_in_rect(c: Control, rect: Rect2) -> void:
	if c.has_meta("origin_pos"):
		var origin_pos = c.get_meta("origin_pos")
		c.global_position = origin_pos
	else:
		c.global_position.x = -240
	var target_pos = $HBoxContainer.global_position + rect.position
	c.set_meta("origin_pos", target_pos)
	var tween = self.create_tween()
	tween.tween_property(c, "global_position", target_pos, 0.2)

```

Feel free to give any feedback!