### PR TITLE
Fix for relative debug log paths

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -168,14 +168,19 @@ void RotatedFileLogger::rotate_file() {
 			clear_old_backups();
 		}
 	} else {
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+		Ref<DirAccess> da = DirAccess::create_for_path(base_path);
 		if (da.is_valid()) {
 			da->make_dir_recursive(base_path.get_base_dir());
 		}
 	}
 
-	file = FileAccess::open(base_path, FileAccess::WRITE);
-	file->detach_from_objectdb(); // Note: This FileAccess instance will exist longer than ObjectDB, therefore can't be registered in ObjectDB.
+	Error err = OK;
+	file = FileAccess::open(base_path, FileAccess::WRITE, &err);
+	if (file.is_valid() && err == OK) {
+		file->detach_from_objectdb(); // Note: This FileAccess instance will exist longer than ObjectDB, therefore can't be registered in ObjectDB.
+	} else {
+		ERR_FAIL_MSG(vformat("Error: %s. Unable to open log file %s for writing", error_names[err], base_path));
+	}
 }
 
 RotatedFileLogger::RotatedFileLogger(const String &p_base_path, int p_max_files) :


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95407

Previously, for relative paths, the file logger was creating missing directories under user:// while still trying to open the log file at the relative path. This would crash if the directory did not already exist. Now creates the relative path directories or user:// directories as needed.

Will now also print an error if it cannot open the file for writing.

Examples from bug report:
./logs/godot.log - creates /logs directory and file in the project folder
/logs/godot.log - creates the /logs directory and file in the root (e.g. C:)
logs/godot.log - creates /logs directory and file in the project folder

Example error message in console (after making the file read-only):
![image](https://github.com/user-attachments/assets/9f7436be-ebe9-4bc7-b092-6b97f86d5ab4)

