### PR TITLE
Fix draw call count and object count for OverDraw display mode on Forward+ 

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1749,7 +1749,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	int *render_info = p_render_data->render_info ? p_render_data->render_info->info[RS::VIEWPORT_RENDER_INFO_TYPE_VISIBLE] : (int *)nullptr;
 	_fill_instance_data(RENDER_LIST_OPAQUE, render_info);
 	_fill_instance_data(RENDER_LIST_MOTION, render_info);
-	_fill_instance_data(RENDER_LIST_ALPHA);
+	_fill_instance_data(RENDER_LIST_ALPHA, render_info);
 
 	RD::get_singleton()->draw_command_end_label();
 


### PR DESCRIPTION
Fix draw call count and object count for OverDraw display mode on Forward+

![image](https://github.com/user-attachments/assets/bbff8711-82dd-4d14-980b-b92c9e7c18eb)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/95494*
