### PR TITLE
Add `BoneAttachment3D::get_skeleton()` method

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -15,6 +15,12 @@
 				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
 			</description>
 		</method>
+		<method name="get_skeleton">
+			<return type="Skeleton3D" />
+			<description>
+				Get parent or external [Skeleton3D] node if found.
+			</description>
+		</method>
 		<method name="get_use_external_skeleton" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -33,7 +33,7 @@
 
 void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "bone_name") {
-		// Because it is a constant function, we cannot use the _get_skeleton_3d function.
+		// Because it is a constant function, we cannot use the get_skeleton function.
 		const Skeleton3D *parent = nullptr;
 		if (use_external_skeleton) {
 			if (external_skeleton_node_cache.is_valid()) {
@@ -134,7 +134,7 @@ void BoneAttachment3D::_update_external_skeleton_cache() {
 }
 
 void BoneAttachment3D::_check_bind() {
-	Skeleton3D *sk = _get_skeleton3d();
+	Skeleton3D *sk = get_skeleton();
 
 	if (sk && !bound) {
 		if (bone_idx <= -1) {
@@ -148,7 +148,7 @@ void BoneAttachment3D::_check_bind() {
 	}
 }
 
-Skeleton3D *BoneAttachment3D::_get_skeleton3d() {
+Skeleton3D *BoneAttachment3D::get_skeleton() {
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_valid()) {
 			return Object::cast_to<Skeleton3D>(ObjectDB::get_instance(external_skeleton_node_cache));
@@ -166,7 +166,7 @@ Skeleton3D *BoneAttachment3D::_get_skeleton3d() {
 
 void BoneAttachment3D::_check_unbind() {
 	if (bound) {
-		Skeleton3D *sk = _get_skeleton3d();
+		Skeleton3D *sk = get_skeleton();
 
 		if (sk) {
 			sk->disconnect(SceneStringName(skeleton_updated), callable_mp(this, &BoneAttachment3D::on_skeleton_update));
@@ -181,7 +181,7 @@ void BoneAttachment3D::_transform_changed() {
 	}
 
 	if (override_pose && !overriding) {
-		Skeleton3D *sk = _get_skeleton3d();
+		Skeleton3D *sk = get_skeleton();
 
 		ERR_FAIL_NULL_MSG(sk, "Cannot override pose: Skeleton not found!");
 		ERR_FAIL_INDEX_MSG(bone_idx, sk->get_bone_count(), "Cannot override pose: Bone index is out of range!");
@@ -200,7 +200,7 @@ void BoneAttachment3D::_transform_changed() {
 
 void BoneAttachment3D::set_bone_name(const String &p_name) {
 	bone_name = p_name;
-	Skeleton3D *sk = _get_skeleton3d();
+	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		set_bone_idx(sk->find_bone(bone_name));
 	}
@@ -217,7 +217,7 @@ void BoneAttachment3D::set_bone_idx(const int &p_idx) {
 
 	bone_idx = p_idx;
 
-	Skeleton3D *sk = _get_skeleton3d();
+	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (bone_idx <= -1 || bone_idx >= sk->get_bone_count()) {
 			WARN_PRINT("Bone index out of range! Cannot connect BoneAttachment to node!");
@@ -247,7 +247,7 @@ void BoneAttachment3D::set_override_pose(bool p_override) {
 	set_notify_transform(override_pose);
 	set_process_internal(override_pose);
 	if (!override_pose && bone_idx >= 0) {
-		Skeleton3D *sk = _get_skeleton3d();
+		Skeleton3D *sk = get_skeleton();
 		if (sk) {
 			sk->reset_bone_pose(bone_idx);
 		}
@@ -318,7 +318,7 @@ void BoneAttachment3D::on_skeleton_update() {
 	}
 	updating = true;
 	if (bone_idx >= 0) {
-		Skeleton3D *sk = _get_skeleton3d();
+		Skeleton3D *sk = get_skeleton();
 		if (sk) {
 			if (!override_pose) {
 				if (use_external_skeleton) {
@@ -369,6 +369,8 @@ BoneAttachment3D::BoneAttachment3D() {
 }
 
 void BoneAttachment3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_skeleton"), &BoneAttachment3D::get_skeleton);
+
 	ClassDB::bind_method(D_METHOD("set_bone_name", "bone_name"), &BoneAttachment3D::set_bone_name);
 	ClassDB::bind_method(D_METHOD("get_bone_name"), &BoneAttachment3D::get_bone_name);
 

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -57,7 +57,6 @@ class BoneAttachment3D : public Node3D {
 	bool updating = false;
 	void _transform_changed();
 	void _update_external_skeleton_cache();
-	Skeleton3D *_get_skeleton3d();
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
@@ -78,6 +77,8 @@ public:
 #endif // TOOLS_ENABLED
 
 	virtual PackedStringArray get_configuration_warnings() const override;
+
+	Skeleton3D *get_skeleton();
 
 	void set_bone_name(const String &p_name);
 	String get_bone_name() const;


### PR DESCRIPTION
This adds a `get_skeleton()` method to `BoneAttachment3D` to make the node consistent with `SkeletonModifier3D`.

Not sure what we want to do with `get_external_skeleton()` - it really should be `get_external_skeleton_path()` but at this point I guess we just leave it to avoid breaking changes.

I don't know C++ so hopefully this is all correct.

Closes https://github.com/godotengine/godot-proposals/issues/10454

Sample project with attached, external attached and unattached `BoneAttachment3D`s. Hit play and the new `get_skeleton()` method will be called on all 3. [boneattachment.zip](https://github.com/user-attachments/files/16638649/boneattachment.zip)
