### PR TITLE
Fix Godot not quitting with `--doctool --gdscript-docs`.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1511,6 +1511,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				main_args.push_back(arg);
 				main_args.push_back(N->get());
 				N = N->next();
+				// GDScript docgen requires Autoloads, but loading those also creates a main loop.
+				// This forces main loop to quit without adding more GDScript-specific exceptions to setup.
+				quit_after = 1;
 			} else {
 				OS::get_singleton()->print("Missing relative or absolute path to project for --gdscript-docs, aborting.\n");
 				goto error;


### PR DESCRIPTION
#82116 moved GDScript doctool code to after Autoloads were loaded. However, to get there, `Main::start()` also selects a main loop, and thus starts running and does not quit. This PR fixes the issue by forcing Godot to quit after 1 main loop iteration.

It feels a lot easier than untangling the exact dependencies (and no more, e.g. Autoloads, which use ResourceLoader and may `preload` lots of different things, etc) that are needed to generate docs and then refactoring `Main::start()` order to have GDScript doctool happen at the exact "right time". It also feels better than adding GDScript-specific code that deletes previously created main loops!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
