### PR TITLE
Remove incorrect statement about TextureButton normal texture

### DIFF
--- a/doc/classes/TextureButton.xml
+++ b/doc/classes/TextureButton.xml
@@ -5,8 +5,8 @@
 	</brief_description>
 	<description>
 		[TextureButton] has the same functionality as [Button], except it uses sprites instead of Godot's [Theme] resource. It is faster to create, but it doesn't support localization like more complex [Control]s.
-		The "normal" state must contain a texture ([member texture_normal]); other textures are optional.
 		See also [BaseButton] which contains common properties and methods associated with this node.
+		[b]Note:[/b] Setting a texture for the "normal" state ([member texture_normal]) is recommended. If [member texture_normal] is not set, the [TextureButton] will still receive input events and be clickable, but the user will not be able to see it unless they activate another one of its states with a texture assigned (e.g., hover over it to show [member texture_hover]).
 	</description>
 	<tutorials>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/2755</link>
@@ -28,19 +28,19 @@
 			Pure black and white [BitMap] image to use for click detection. On the mask, white pixels represent the button's clickable area. Use it to create buttons with curved shapes.
 		</member>
 		<member name="texture_disabled" type="Texture2D" setter="set_texture_disabled" getter="get_texture_disabled">
-			Texture to display when the node is disabled. See [member BaseButton.disabled].
+			Texture to display when the node is disabled. See [member BaseButton.disabled]. If not assigned, the [TextureButton] displays [member texture_normal] instead.
 		</member>
 		<member name="texture_focused" type="Texture2D" setter="set_texture_focused" getter="get_texture_focused">
-			Texture to display when the node has mouse or keyboard focus. [member texture_focused] is displayed [i]over[/i] the base texture, so a partially transparent texture should be used to ensure the base texture remains visible. A texture that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a fully transparent texture of any size. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
+			Texture to [i]overlay on the base texture[/i] when the node has mouse or keyboard focus. Because [member texture_focused] is displayed on top of the base texture, a partially transparent texture should be used to ensure the base texture remains visible. A texture that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a fully transparent texture of any size. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</member>
 		<member name="texture_hover" type="Texture2D" setter="set_texture_hover" getter="get_texture_hover">
-			Texture to display when the mouse hovers the node.
+			Texture to display when the mouse hovers over the node. If not assigned, the [TextureButton] displays [member texture_normal] instead when hovered over.
 		</member>
 		<member name="texture_normal" type="Texture2D" setter="set_texture_normal" getter="get_texture_normal">
 			Texture to display by default, when the node is [b]not[/b] in the disabled, hover or pressed state. This texture is still displayed in the focused state, with [member texture_focused] drawn on top.
 		</member>
 		<member name="texture_pressed" type="Texture2D" setter="set_texture_pressed" getter="get_texture_pressed">
-			Texture to display on mouse down over the node, if the node has keyboard focus and the player presses the Enter key or if the player presses the [member BaseButton.shortcut] key.
+			Texture to display on mouse down over the node, if the node has keyboard focus and the player presses the Enter key or if the player presses the [member BaseButton.shortcut] key. If not assigned, the [TextureButton] displays [member texture_hover] instead when pressed.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
The documentation currently states that TextureButtons must have a texture for their "normal" state in `texture_normal`, but I found this didn't seem to be the case in practice, as noted here: https://github.com/godotengine/godot-docs/issues/9763

This PR simply removes that line about needing the texture from the TextureButton documentation page.

_Bugsquad edit: fixes https://github.com/godotengine/godot-docs/issues/9763_