### PR TITLE
Add fixed fog to the sky in the Compatibility renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -255,10 +255,6 @@ void main() {
 	frag_color.rgb = color;
 	frag_color.a = alpha;
 
-	// For mobile renderer we're multiplying by 0.5 as we're using a UNORM buffer.
-	// For both mobile and clustered, we also bake in the exposure value for the environment and camera.
-	frag_color.rgb = frag_color.rgb * params.luminance_multiplier;
-
 #if !defined(DISABLE_FOG) && !defined(USE_CUBEMAP_PASS)
 
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
@@ -277,6 +273,10 @@ void main() {
 	}
 
 #endif // DISABLE_FOG
+
+	// For mobile renderer we're multiplying by 0.5 as we're using a UNORM buffer.
+	// For both mobile and clustered, we also bake in the exposure value for the environment and camera.
+	frag_color.rgb = frag_color.rgb * params.luminance_multiplier;
 
 	// Blending is disabled for Sky, so alpha doesn't blend.
 	// Alpha is used for subsurface scattering so make sure it doesn't get applied to Sky.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66456

The entire implementation was missing. Some of the infrastructure was already there and just needed to be plugged in and finished