### PR TITLE
Fix drag&drop between window on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4805,6 +4805,16 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				Input::get_singleton()->parse_input_event(mbd);
 			}
 
+			// Propagate the button up event to the window on which the button down
+			// event was triggered. This is needed for drag & drop to work between windows,
+			// because the engine expects events to keep being processed
+			// on the same window dragging started.
+			if (mb->is_pressed()) {
+				last_mouse_button_down_window = window_id;
+			} else if (last_mouse_button_down_window != INVALID_WINDOW_ID) {
+				mb->set_window_id(last_mouse_button_down_window);
+				last_mouse_button_down_window = INVALID_WINDOW_ID;
+			}
 		} break;
 
 		case WM_WINDOWPOSCHANGED: {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -531,7 +531,7 @@ class DisplayServerWindows : public DisplayServer {
 	RBMap<WindowID, WindowData> windows;
 
 	WindowID last_focused_window = INVALID_WINDOW_ID;
-
+	WindowID last_mouse_button_down_window = INVALID_WINDOW_ID;
 	HCURSOR hCursor;
 
 	WNDPROC user_proc = nullptr;


### PR DESCRIPTION
- Fixes #95639

I'm not sure exactly what caused this regression in 12fda2f (#91361) but I was able to find out that sometime the `window_id` received on `WM_LBUTTONUP` was not the same as the one on `WM_LBUTTONDOWN`. That usually happens when the button down is made on an unfocused window. 

The engine is built on the fact that the button up needs to be on the same window as the button down. I saw that in `DisplayServerX11::process_events` the other day:
```
// Propagate the event to the focused window,
// because it's received only on the topmost window.
// Note: This is needed for drag & drop to work between windows,
// because the engine expects events to keep being processed
// on the same window dragging started.
```

So I kept the last window id (`last_mouse_button_down_window`) on the button down and reused it for the button up event. What is weird is that the position in the  `InputEventMouseButton` correspond to the position in the last window id and not the window id received on button up. Therefore, I did not have to update position in the event object when updating the window_id.

Note: This PR only fixes the problem where the drag&drop does not work between window. It does not fix the missing control cursor on the destination window. That's a hole other problem and I guess it never worked. Also, I think #67531 implemented it??


https://github.com/user-attachments/assets/17832367-2b0f-432e-ac43-67236c2c8af5


