### PR TITLE
Fix Y-sorted root item having modulation applied twice

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -434,7 +434,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			child_items = (Item **)alloca(child_item_count * sizeof(Item *));
 
 			ci->ysort_xform = Transform2D();
-			ci->ysort_modulate = Color(1, 1, 1, 1);
+			ci->ysort_modulate = Color(1, 1, 1, 1) / ci->modulate;
 			ci->ysort_index = 0;
 			ci->ysort_parent_abs_z_index = parent_z;
 			child_items[0] = ci;


### PR DESCRIPTION
Fixes #95667.

For the y-sorted subtree's root modulation is obtained once again after gathering y-sorted items, just like e.g. transform. In the similar manner it needs to be cancelled out.
 (again fixing my own mistake, from #78134 :upside_down_face:)