### PR TITLE
Fix slow editor load on large projects

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -255,6 +255,21 @@ void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_sca
 	}
 
 	for (const String &scan_file : p_scan_dir->files) {
+		// Optimization to skip the ResourceLoader::get_resource_type for files
+		// that are not scripts. Some loader get_resource_type methods read the file
+		// which can be very slow on large projects.
+		String ext = scan_file.get_extension().to_lower();
+		bool is_script = false;
+		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+			if (ScriptServer::get_language(i)->get_extension() == ext) {
+				is_script = true;
+				break;
+			}
+		}
+		if (!is_script) {
+			continue; // Not a script.
+		}
+
 		String path = p_scan_dir->full_path.path_join(scan_file);
 		String type = ResourceLoader::get_resource_type(path);
 


### PR DESCRIPTION
- Fixes partially #94917

I tested a project with all the image from https://github.com/PMDCollab/SpriteCollab/tree/master/sprite which contains 61332 png.

Problem found:
- In the new `EditorFileSystem::_first_scan_process_scripts`, the method `ResourceLoader::get_resource_type` was called on each file and this method loops on all the loader and calls `get_resource_type` which for some loader read the resource file. So all files were read multiple times.


Before this PR:
- First scan (before Filesystem Dock progress bar appears): 1 min

After this PR:
- First scan (before Filesystem Dock progress bar appears): 4-5 sec.


I found another performance problem with `EditorFileSystem::_test_for_reimport` but that will take more modifications to fix, I'll create another PR later.