### PR TITLE
[3.x] Enable double precision for bullet physics library and set flag for more correct raycast results.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -170,6 +170,7 @@ opts.Add(
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_bullet", "Use the built-in Bullet library", True))
+opts.Add(BoolVariable("builtin_bullet_double_precision", "Use double precision for the built-in Bullet library", True))
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))
 opts.Add(BoolVariable("builtin_embree", "Use the built-in Embree library", True))
 opts.Add(BoolVariable("builtin_enet", "Use the built-in ENet library", True))

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -202,6 +202,8 @@ if env["builtin_bullet"]:
     env_bullet.Prepend(CPPPATH=[thirdparty_dir])
 
     env_bullet.Append(CPPDEFINES=["BT_USE_OLD_DAMPING_METHOD", "BT_THREADSAFE"])
+    if env["builtin_bullet_double_precision"]:
+        env_bullet.Append(CPPDEFINES=["BT_USE_DOUBLE_PRECISION"])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -48,6 +48,7 @@
 #include <BulletCollision/NarrowPhaseCollision/btGjkEpaPenetrationDepthSolver.h>
 #include <BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h>
 #include <BulletCollision/NarrowPhaseCollision/btPointCollector.h>
+#include <BulletCollision/NarrowPhaseCollision/btRaycastCallback.h>
 #include <BulletSoftBody/btSoftBodyRigidBodyCollisionConfiguration.h>
 #include <BulletSoftBody/btSoftRigidDynamicsWorld.h>
 #include <btBulletDynamicsCommon.h>
@@ -97,6 +98,7 @@ bool BulletPhysicsDirectSpaceState::intersect_ray(const Vector3 &p_from, const V
 	btResult.m_collisionFilterGroup = 0;
 	btResult.m_collisionFilterMask = p_collision_mask;
 	btResult.m_pickRay = p_pick_ray;
+	btResult.m_flags |= btTriangleRaycastCallback::kF_UseGjkConvexCastRaytest;
 
 	space->dynamicsWorld->rayTest(btVec_from, btVec_to, btResult);
 	if (btResult.hasHit()) {


### PR DESCRIPTION
This has a SIGNIFICANT improvement in physics quality to address things like https://github.com/godotengine/godot/issues/28032

I've been setting on it for a few years on my Fist of the Forgotten project and haven't noticed any negative side effects.  Figured I'd finally make a PR for it so anybody else still using 3.x can enjoy some more accurate physics collision detection.