### PR TITLE
C#: Destroy script before clearing owner

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2351,8 +2351,8 @@ CSharpInstance *CSharpScript::_create_instance(const Variant **p_args, int p_arg
 	if (!ok) {
 		// Important to clear this before destroying the script instance here
 		instance->script = Ref<CSharpScript>();
-		instance->owner = nullptr;
 		p_owner->set_script_instance(nullptr);
+		instance->owner = nullptr;
 
 		return nullptr;
 	}


### PR DESCRIPTION
The C# script destructor needs to access the owner (i.e.: to disconnect signals) so we now clear it after the script has been destroyed.

- Fixes https://github.com/godotengine/godot/issues/95663.