### PR TITLE
Fix double free in FSR2 destructor

### DIFF
--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -800,9 +800,6 @@ FSR2Effect::~FSR2Effect() {
 	RD::get_singleton()->free(device.linear_clamp_sampler);
 
 	for (uint32_t i = 0; i < FFX_FSR2_PASS_COUNT; i++) {
-		if (device.passes[i].pipeline.pipeline_rid.is_valid()) {
-			RD::get_singleton()->free(device.passes[i].pipeline.pipeline_rid);
-		}
 		device.passes[i].shader->version_free(device.passes[i].shader_version);
 	}
 }


### PR DESCRIPTION
Before this change, using FSR2 resulted in the following error when the effect was destroyed:

	ERROR: Attempted to free invalid ID: 662734928609453
	   at: _free_internal (servers/rendering/rendering_device.cpp:4957)

This happened because ACCUMULATE and ACCUMULATE_SHARPEN passes shared the same shader_version object but had different pipeline IDs. When version_free was called for ACCUMULATE pass, it destroyed pipelines created from that version, including the pipeline for the ACCUMULATE_SHARPEN pass.

Using a unique version could work around this problem, but it's easier to rely on version_free destroying the created pipelines through the dependency mechanism.

I've verified that FSR2 works correctly after this change (on TPS demo) and that the pipelines are all destroyed; during the call of `version_free` for accumulate pass, both the pipelines created for accumulate and accumulate_sharpen passes are destroyed; the call in accumulate_sharpen becomes a no-op.