### PR TITLE
Expose `ScriptDebugger::get_breakpoints`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2005,6 +2005,22 @@ bool EngineDebugger::is_skipping_breakpoints() const {
 	return ::EngineDebugger::get_script_debugger()->is_skipping_breakpoints();
 }
 
+Dictionary EngineDebugger::get_breakpoints() const {
+	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), Dictionary(), "Can't get breakpoints. No active debugger");
+
+	Dictionary d;
+	for (const KeyValue<int, HashSet<StringName>> &E : ::EngineDebugger::get_script_debugger()->get_breakpoints()) {
+		Array a;
+		for (const StringName &F : E.value) {
+			a.push_back(F);
+		}
+
+		d[E.key] = a;
+	}
+
+	return d;
+}
+
 void EngineDebugger::insert_breakpoint(int p_line, const StringName &p_source) {
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't insert breakpoint. No active debugger");
 	::EngineDebugger::get_script_debugger()->insert_breakpoint(p_line, p_source);
@@ -2059,6 +2075,7 @@ void EngineDebugger::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_breakpoint", "line", "source"), &EngineDebugger::is_breakpoint);
 	ClassDB::bind_method(D_METHOD("is_skipping_breakpoints"), &EngineDebugger::is_skipping_breakpoints);
+	ClassDB::bind_method(D_METHOD("get_breakpoints"), &EngineDebugger::get_breakpoints);
 	ClassDB::bind_method(D_METHOD("insert_breakpoint", "line", "source"), &EngineDebugger::insert_breakpoint);
 	ClassDB::bind_method(D_METHOD("remove_breakpoint", "line", "source"), &EngineDebugger::remove_breakpoint);
 	ClassDB::bind_method(D_METHOD("clear_breakpoints"), &EngineDebugger::clear_breakpoints);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -596,6 +596,7 @@ public:
 
 	bool is_breakpoint(int p_line, const StringName &p_source) const;
 	bool is_skipping_breakpoints() const;
+	Dictionary get_breakpoints() const;
 	void insert_breakpoint(int p_line, const StringName &p_source);
 	void remove_breakpoint(int p_line, const StringName &p_source);
 	void clear_breakpoints();

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -23,6 +23,12 @@
 				Starts a debug break in script execution, optionally specifying whether the program can continue based on [param can_continue] and whether the break was due to a breakpoint.
 			</description>
 		</method>
+		<method name="get_breakpoints" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Gets all breakpoints in the debugging session. Returns a [Dictionary] mapping [int] line numbers to [Array]s of [StringName] representing the paths to the scripts where the breakpoints are set.
+			</description>
+		</method>
 		<method name="get_depth" qualifiers="const" experimental="">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
This binding is mostly carried over from #73967.

The current way that scripting languages determine when to break is by testing if there is a breakpoint on each line executed. [This works for GDScript](https://github.com/godotengine/godot/blob/1bd740d18d714f815486b04bf4c6154ef6c355d9/modules/gdscript/gdscript_vm.cpp#L3607-L3609), but for other use cases (e.g. Luau), it is easier and faster to sync the list of breakpoints with the language runtime.

For example, with Luau, there is [functionality](https://github.com/luau-lang/luau/blob/25f91aa8b82fa3a9e415afbb83574c56b43cad80/VM/src/ldebug.cpp#L346-L393) to inject bytecode into a script that causes it to break at a certain line. This only works if the list of breakpoints is exposed to the running game. It is not possible to hook into each line executed, only each instruction, which is far from ideal.

Closes godotengine/godot-proposals#10469