### PR TITLE
Fix `uid://` paths fail to load at editor startup

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -386,6 +386,8 @@ void EditorFileSystem::_scan_filesystem() {
 	// On the first scan, the first_scan_root_dir is created in _first_scan_filesystem.
 	if (first_scan) {
 		sd = first_scan_root_dir;
+		// Will be updated on scan.
+		ResourceUID::get_singleton()->clear();
 	} else {
 		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		sd = memnew(ScannedDirectory);
@@ -3061,7 +3063,6 @@ EditorFileSystem::EditorFileSystem() {
 	using_fat32_or_exfat = (da->get_filesystem_type() == "FAT32" || da->get_filesystem_type() == "exFAT");
 
 	scan_total = 0;
-	callable_mp(ResourceUID::get_singleton(), &ResourceUID::clear).call_deferred(); // Will be updated on scan.
 	ResourceSaver::set_get_resource_id_for_path(_resource_saver_get_resource_id_for_path);
 }
 


### PR DESCRIPTION
- Fixes #95562
- Fixes #95535

The issue was caused by a call deferred to `ResourceUID::get_singleton()->clear` in the constructor of `EditorFileSystem`. Now that the plugin are created after the creation of `EditorFileSystem` the uid loaded from cache were removed before the plugins were created in the first scan process.

Note: Even in 4.2.2 when the uid cache file `uid_cache.bin` is missing, the same error occurs: `Condition "!unique_ids.has(p_id)" is true` because the uid are loaded only from the cache before the plugins are created. The same problem still occurs with this PR and short of scanning all the .import files before loading the plugins just for the uid, I don't see an solution for that.

Edit: Added the issue #95535