### PR TITLE
Expand the range of gamepad button keycodes to be consistent with SDL

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -309,7 +309,7 @@ void JoypadLinux::setup_joypad_properties(Joypad &p_joypad) {
 			p_joypad.key_map[i] = num_buttons++;
 		}
 	}
-	for (int i = BTN_MISC; i < BTN_JOYSTICK; ++i) {
+	for (int i = 0; i < BTN_JOYSTICK; ++i) {
 		if (test_bit(i, keybit)) {
 			p_joypad.key_map[i] = num_buttons++;
 		}


### PR DESCRIPTION
Recently I was testing another PR (#95486).

Although some devices use the mapping scheme in `core/input/gamecontrollerdb.txt`, the mapping of some keys still fails.

By using `evemu-record` to test the buttons, it is found that the key codes of some buttons are not in the range of Godot test. Comparing the [SDL code](https://github.com/libsdl-org/SDL/blob/a7bed810b3499d157655ae6dcc7cd5e8a34fa549/src/joystick/linux/SDL_sysjoystick.c#L1290-L1299), it is found that the test ranges of the two are inconsistent. This may be the reason why some devices [cannot work properly in Godot](https://github.com/mdqinc/SDL_GameControllerDB/pull/222#issuecomment-431639913).

The guid of the mapping scheme used by the device is `050000005e040000fd02000003090000`. The back button corresponds to `KEY_BACK` and the guide button corresponds to `KEY_HOMEPAGE`. I'm not sure if this is due to the device being unofficial.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Faulty device: `050000005e040000fd02000003090000`,Xbox One Controller (third-party manufacturer, not original)

https://github.com/godotengine/godot/blob/24d74510e5831960f79837e5297853cb3286594e/core/input/gamecontrollerdb.txt#L1718


[devinfo.txt](https://github.com/user-attachments/files/18373359/devinfo.txt)

There are buttons that send `KEY_HOMEPAGE`, `KEY_BACK` events. 