### PR TITLE
Fix Marshalls `raw/utf8_to_base64` from erroring on empty input.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1142,6 +1142,9 @@ Variant Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) 
 }
 
 String Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
+	if (p_arr.is_empty()) {
+		return "";
+	}
 	String ret = CryptoCore::b64_encode_str(p_arr.ptr(), p_arr.size());
 	ERR_FAIL_COND_V(ret.is_empty(), ret);
 	return ret;
@@ -1165,6 +1168,9 @@ Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 }
 
 String Marshalls::utf8_to_base64(const String &p_str) {
+	if (p_str.is_empty()) {
+		return "";
+	}
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
 	ERR_FAIL_COND_V(ret.is_empty(), ret);


### PR DESCRIPTION
As per [RFC  4648](https://www.rfc-editor.org/rfc/rfc4648#section-10), the base64 encoding for an empty ("") input is also empty. The functionality in the Marshalls package coincedentially returns the correct result, but produces an error as well.

The `variant_to_base64` function remains unchanged since an encoded variant cannot be empty.

CC: @adamscott 
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
