### PR TITLE
RenderingDevice non blocking sync

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -870,6 +870,15 @@
 				[b]Note:[/b] The existing [param texture] requires the [constant TEXTURE_USAGE_CAN_UPDATE_BIT] to be updatable.
 			</description>
 		</method>
+		<method name="try_sync">
+			<return type="bool" />
+			<description>
+				Similar to [method sync] but does not wait.
+				Returns [code]true[/code] if the sync was successful. Returns [code]false[/code] if more tries are needed.
+				[b]Note:[/b] Returns [code]false[/code] in case of failure.
+				[b]Note:[/b] Do not attempt to call this again if it returns [code]true[/code].
+			</description>
+		</method>
 		<method name="uniform_buffer_create">
 			<return type="RID" />
 			<param index="0" name="size_bytes" type="int" />

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2226,6 +2226,24 @@ Error RenderingDeviceDriverD3D12::fence_wait(FenceID p_fence) {
 	return (res == WAIT_FAILED) ? FAILED : OK;
 }
 
+Error RenderingDeviceDriverD3D12::fence_status(FenceID p_fence, bool &p_status) {
+	FenceInfo *fence = (FenceInfo *)(p_fence.id);
+	UINT64 currentFenceValue = fence->d3d_fence->GetCompletedValue();
+
+	if (currentFenceValue == fence->fence_value) {
+		p_status = true;
+		// Signaled
+#ifdef PIX_ENABLED
+		PIXNotifyWakeFromFenceSignal(fence->event_handle);
+#endif
+	} else {
+		p_status = false;
+		// Not signaled
+	}
+
+	return OK;
+}
+
 void RenderingDeviceDriverD3D12::fence_free(FenceID p_fence) {
 	FenceInfo *fence = (FenceInfo *)(p_fence.id);
 	CloseHandle(fence->event_handle);

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -410,6 +410,7 @@ public:
 	virtual FenceID fence_create() override;
 	virtual Error fence_wait(FenceID p_fence) override;
 	virtual void fence_free(FenceID p_fence) override;
+	virtual Error fence_status(FenceID p_fence, bool &p_status) override;
 
 private:
 	/********************/

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2088,6 +2088,45 @@ Error RenderingDeviceDriverVulkan::fence_wait(FenceID p_fence) {
 	return OK;
 }
 
+Error RenderingDeviceDriverVulkan::fence_status(FenceID p_fence, bool &p_status) {
+	Fence *fence = (Fence *)(p_fence.id);
+	VkResult result = vkGetFenceStatus(vk_device, fence->vk_fence);
+	if (result == VK_SUCCESS) {
+		// Fence was signaled.
+		result = vkResetFences(vk_device, 1, &fence->vk_fence);
+		ERR_FAIL_COND_V(result != VK_SUCCESS, FAILED);
+
+		if (fence->queue_signaled_from != nullptr) {
+			// Release all semaphores that the command queue associated to the fence waited on the last time it was submitted.
+			LocalVector<Pair<Fence *, uint32_t>> &pairs = fence->queue_signaled_from->image_semaphores_for_fences;
+			uint32_t i = 0;
+			while (i < pairs.size()) {
+				if (pairs[i].first == fence) {
+					_release_image_semaphore(fence->queue_signaled_from, pairs[i].second, true);
+					fence->queue_signaled_from->free_image_semaphores.push_back(pairs[i].second);
+					pairs.remove_at(i);
+				} else {
+					i++;
+				}
+			}
+
+			fence->queue_signaled_from = nullptr;
+		}
+
+		p_status = true;
+
+		return OK;
+	} else if (result == VK_NOT_READY) {
+		// Fence was not signaled. We try again another time.
+		p_status = false;
+		return OK;
+	} else {
+		// Error.
+		p_status = false;
+		ERR_FAIL_V(FAILED);
+	}
+}
+
 void RenderingDeviceDriverVulkan::fence_free(FenceID p_fence) {
 	Fence *fence = (Fence *)(p_fence.id);
 	vkDestroyFence(vk_device, fence->vk_fence, nullptr);

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -260,6 +260,7 @@ public:
 	virtual FenceID fence_create() override final;
 	virtual Error fence_wait(FenceID p_fence) override final;
 	virtual void fence_free(FenceID p_fence) override final;
+	virtual Error fence_status(FenceID p_fence, bool &status) override final;
 
 	/********************/
 	/**** SEMAPHORES ****/

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5080,6 +5080,21 @@ void RenderingDevice::sync() {
 	local_device_processing = false;
 }
 
+bool RenderingDevice::try_sync() {
+	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND_V_MSG(is_main_instance, false, "Only local devices can submit and sync.");
+	ERR_FAIL_COND_V_MSG(!local_device_processing, false, "sync can only be called after a submit");
+	bool status;
+	Error err = driver->fence_status(frames[frame].draw_fence, status);
+	ERR_FAIL_COND_V_MSG(err != OK, false, "Failed to get fence status");
+	if (status) {
+		frames[frame].draw_fence_signaled = false;
+		_begin_frame();
+	}
+
+	return status;
+}
+
 void RenderingDevice::_free_pending_resources(int p_frame) {
 	// Free in dependency usage order, so nothing weird happens.
 	// Pipelines.
@@ -5991,6 +6006,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frame_delay"), &RenderingDevice::get_frame_delay);
 	ClassDB::bind_method(D_METHOD("submit"), &RenderingDevice::submit);
 	ClassDB::bind_method(D_METHOD("sync"), &RenderingDevice::sync);
+	ClassDB::bind_method(D_METHOD("try_sync"), &RenderingDevice::try_sync);
 
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("barrier", "from", "to"), &RenderingDevice::barrier, DEFVAL(BARRIER_MASK_ALL_BARRIERS), DEFVAL(BARRIER_MASK_ALL_BARRIERS));

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1379,6 +1379,7 @@ public:
 
 	void submit();
 	void sync();
+	bool try_sync();
 
 	enum MemoryType {
 		MEMORY_TEXTURES,

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -389,6 +389,7 @@ public:
 	virtual FenceID fence_create() = 0;
 	virtual Error fence_wait(FenceID p_fence) = 0;
 	virtual void fence_free(FenceID p_fence) = 0;
+	virtual Error fence_status(FenceID p_fence, bool &p_signaled) = 0;
 
 	/********************/
 	/**** SEMAPHORES ****/


### PR DESCRIPTION
# What this adds
https://github.com/godotengine/godot-proposals/issues/10481
the function `try_sync` was added to `RenderingDevice`.
This function will not block. If the fence has been signaled (and thus the operation has finished) it will return `true`. Returns `false` otherwise.

Earlier you would've had to create a separate thread, call `sync` and let it get blocked till operation completes. That might add complications when trying to use the GPU compute in a certain way.

# Test project
https://github.com/darthLeviN/godot-compute/tree/1d26e56df3e6be6a53c992261850aed4a2cff79b

this project contains a simple loop that calls 
```gdscript
while(not rd.try_sync()):
    try_count += 1
    await get_tree().process_frame
```
and allows for logging the try count.

# Notes
When this succeeds side effects are the equivalent of calling sync. So you shouldn't keep calling it again.

# Issues 
Currently i think we don't have good error handling. In case of an error this fails and returns `false`. and there won't be any way to know if it failed or we just need to wait for it.
This is also true for `sync` because it's a `void` function.

Also, Signals can be implemented here. If desired, We can internally do the once per frame check if the pipeline is still processing. This improvement can be added on top of this implementation while keeping backwards compatibility.
# Docs 
Full docs entry with notes was added.

# Testing
I have tested this on ubuntu 22.04 with a RTX 3070 for vulkan.
DirectX12 needs to be tested.

I think running the test project will suffice.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10481*

</p>
</details> 