### PR TITLE
Fixing calculation of size of minimap when drawing for small files

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -800,7 +800,7 @@ void TextEdit::_notification(int p_what) {
 				// Calculate the first line.
 				int num_lines_before = round((viewport_offset_y) / minimap_line_height);
 				int minimap_line = (v_scroll->get_max() <= minimap_visible_lines) ? -1 : first_vis_line;
-				if (minimap_line >= 0) {
+				if (minimap_line > 0) {
 					minimap_line -= get_next_visible_line_index_offset_from(first_vis_line, 0, -num_lines_before).x;
 					minimap_line -= (minimap_line > 0 && smooth_scroll_enabled ? 1 : 0);
 				}


### PR DESCRIPTION
# Summary

Fixes issue described by https://github.com/godotengine/godot/issues/95727

This issue attempts to fix an error which occurs when loading small files and drawing the minimap in the text editor. See the linked issue for more details on how to get the error message to occur.

<img width="694" alt="Screenshot 2024-08-17 at 6 59 22 PM" src="https://github.com/user-attachments/assets/8a8cefb9-a441-456f-91ba-7cca98514868">

## Fix 
The changes in this PR adjust the conditions for which an index is modified when computing the size of the minimap. That modification causes the index to fall out of bounds (-1).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
