### PR TITLE
Always show an unchecked box for CheckBox

### DIFF
--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -126,10 +126,9 @@ void CheckBox::_notification(int p_what) {
 			}
 			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
+			off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
 			if (is_pressed()) {
 				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
-			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
 			}
 		} break;
 	}


### PR DESCRIPTION
Close: https://github.com/godotengine/godot-proposals/issues/10491

When dealing with asset purchases from the store, there may be instances where the creator does not include the outer box for the 'checked' state. As a result, when the box is checked, nothing is displayed on the outside.

https://github.com/user-attachments/assets/675923ea-3e56-4de8-aacb-e7ca387c7bf7

<!--
Please target the `master` bra


nch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
