### PR TITLE
Add a `Node.create_timer` method

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -234,6 +234,24 @@
 				If the node is not inside the tree, returns [code]false[/code] no matter the value of [member process_mode].
 			</description>
 		</method>
+		<method name="create_timer">
+			<description>
+				Creates a [SceneTreeTimer] that will timeout after the specified time_sec. 
+				The timer will continue processing even during physics pauses if [code]process_always[/code] is [code]true[/code].
+				Returns an empty reference if the node is not inside the scene tree.
+				Example usage:
+				[codeblocks]
+				[gdscript]
+				var timer = create_timer(3.0, true)
+				if timer:
+					print("Timer created successfully!")
+				else:
+					print("Timer creation failed.")
+				[/gdscript]
+				[/codeblocks]
+				[b]Note:[/b] The method can only create a timer if the node is inside the scene tree.
+			</description>
+		</method>
 		<method name="create_tween">
 			<return type="Tween" />
 			<description>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1511,6 +1511,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				main_args.push_back(arg);
 				main_args.push_back(N->get());
 				N = N->next();
+				// GDScript docgen requires Autoloads, but loading those also creates a main loop.
+				// This forces main loop to quit without adding more GDScript-specific exceptions to setup.
+				quit_after = 1;
 			} else {
 				OS::get_singleton()->print("Missing relative or absolute path to project for --gdscript-docs, aborting.\n");
 				goto error;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1974,6 +1974,13 @@ Window *Node::get_last_exclusive_window() const {
 	return w;
 }
 
+Ref<SceneTreeTimer> Node::create_timer(float time_sec, bool process_always) {
+    if (is_inside_tree()) {
+        return get_tree()->create_timer(time_sec, process_always);
+    }
+    return Ref<SceneTreeTimer>();
+}
+
 bool Node::is_ancestor_of(const Node *p_node) const {
 	ERR_FAIL_NULL_V(p_node, false);
 	Node *p = p_node->data.parent;
@@ -3611,6 +3618,7 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_window"), &Node::get_window);
 	ClassDB::bind_method(D_METHOD("get_last_exclusive_window"), &Node::get_last_exclusive_window);
+	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always"), &Node::create_timer, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_tree"), &Node::get_tree);
 	ClassDB::bind_method(D_METHOD("create_tween"), &Node::create_tween);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -467,6 +467,8 @@ public:
 	Window *get_window() const;
 	Window *get_last_exclusive_window() const;
 
+	Ref<SceneTreeTimer> create_timer(float time_sec, bool process_always = false);
+
 	_FORCE_INLINE_ SceneTree *get_tree() const {
 		ERR_FAIL_NULL_V(data.tree, nullptr);
 		return data.tree;


### PR DESCRIPTION
Issue made in [godot-proposals#4908](https://github.com/godotengine/godot-proposals/issues/4908)
Adds a new method to the Node class to make timer creation more streamlined.

Node.create_tween() exists, so adding Node.create_timer() will make timer creation more intuitive.

CHANGED:
Node.h
Node.cpp
Node.xml

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/4908*