### PR TITLE
Allow changing the color for the Checkbox's checked and unchecked icons

### DIFF
--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -15,6 +15,12 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
+		<theme_item name="checkbox_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the checked icon when the checkbox is pressed.
+		</theme_item>
+		<theme_item name="checkbox_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the unchecked icon when the checkbox is not pressed.
+		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -14,6 +14,12 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
+		<theme_item name="button_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the checked icon when the checkbox is pressed.
+		</theme_item>
+		<theme_item name="button_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the unchecked icon when the checkbox is not pressed.
+		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -127,9 +127,9 @@ void CheckBox::_notification(int p_what) {
 			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())), false, theme_cache.checkbox_checked_color);
 			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())), false, theme_cache.checkbox_unchecked_color);
 			}
 		} break;
 	}
@@ -152,6 +152,9 @@ void CheckBox::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, unchecked_disabled);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, radio_checked_disabled);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, radio_unchecked_disabled);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckBox, checkbox_checked_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckBox, checkbox_unchecked_color);
 }
 
 CheckBox::CheckBox(const String &p_text) :

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -49,6 +49,9 @@ class CheckBox : public Button {
 		Ref<Texture2D> unchecked_disabled;
 		Ref<Texture2D> radio_checked_disabled;
 		Ref<Texture2D> radio_unchecked_disabled;
+
+		Color checkbox_checked_color;
+		Color checkbox_unchecked_color;
 	} theme_cache;
 
 protected:

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -134,9 +134,9 @@ void CheckButton::_notification(int p_what) {
 			ofs.y = (get_size().height - tex_size.height) / 2 + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())), false, theme_cache.button_checked_color);
 			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())), false, theme_cache.button_unchecked_color);
 			}
 		} break;
 	}
@@ -155,6 +155,9 @@ void CheckButton::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, unchecked_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, checked_disabled_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, unchecked_disabled_mirrored);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckButton, button_checked_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckButton, button_unchecked_color);
 }
 
 CheckButton::CheckButton(const String &p_text) :

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -49,6 +49,9 @@ class CheckButton : public Button {
 		Ref<Texture2D> unchecked_mirrored;
 		Ref<Texture2D> checked_disabled_mirrored;
 		Ref<Texture2D> unchecked_disabled_mirrored;
+
+		Color button_checked_color;
+		Color button_unchecked_color;
 	} theme_cache;
 
 protected:

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -326,6 +326,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("check_v_offset", "CheckBox", 0);
 	theme->set_constant("outline_size", "CheckBox", 0);
 
+	theme->set_color("checkbox_checked_color", "CheckBox", Color(1, 1, 1));
+	theme->set_color("checkbox_unchecked_color", "CheckBox", Color(1, 1, 1));
+
 	// CheckButton
 
 	Ref<StyleBox> cb_empty = memnew(StyleBoxEmpty);
@@ -362,6 +365,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("h_separation", "CheckButton", Math::round(4 * scale));
 	theme->set_constant("check_v_offset", "CheckButton", 0);
 	theme->set_constant("outline_size", "CheckButton", 0);
+
+	theme->set_color("button_checked_color", "CheckButton", Color(1, 1, 1));
+	theme->set_color("button_unchecked_color", "CheckButton", Color(1, 1, 1));
 
 	// Button variations
 


### PR DESCRIPTION
Close: https://github.com/godotengine/godot-proposals/issues/10492

Occasionally, the default white color for the icon does not meet our needs, and we would like to change it. However, the CheckBox does not currently have a mechanism to modify this color.


https://github.com/user-attachments/assets/04a5451a-2d46-43d4-af33-ca7dc53c5162




<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
