### PR TITLE
Add a context menu for the shader editor file list

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -45,6 +45,16 @@
 #include "scene/gui/item_list.h"
 #include "scene/gui/texture_rect.h"
 
+Ref<Resource> ShaderEditorPlugin::_get_current_shader() {
+	int index = shader_tabs->get_current_tab();
+	ERR_FAIL_INDEX_V(index, shader_tabs->get_tab_count(), Ref<Resource>());
+	if (edited_shaders[index].shader.is_valid()) {
+		return edited_shaders[index].shader;
+	} else {
+		return edited_shaders[index].shader_inc;
+	}
+}
+
 void ShaderEditorPlugin::_update_shader_list() {
 	shader_list->clear();
 	for (EditedShader &edited_shader : edited_shaders) {
@@ -93,9 +103,7 @@ void ShaderEditorPlugin::_update_shader_list() {
 		shader_list->select(shader_tabs->get_current_tab());
 	}
 
-	for (int i = FILE_SAVE; i < FILE_MAX; i++) {
-		file_menu->get_popup()->set_item_disabled(file_menu->get_popup()->get_item_index(i), edited_shaders.is_empty());
-	}
+	_set_file_specific_items_disabled(edited_shaders.is_empty());
 
 	_update_shader_list_status();
 }
@@ -362,6 +370,61 @@ void ShaderEditorPlugin::_shader_list_clicked(int p_item, Vector2 p_local_mouse_
 	if (p_mouse_button_index == MouseButton::MIDDLE) {
 		_close_shader(p_item);
 	}
+	if (p_mouse_button_index == MouseButton::RIGHT) {
+		_make_script_list_context_menu();
+	}
+}
+
+void ShaderEditorPlugin::_setup_popup_menu(PopupMenuType p_type, PopupMenu *p_menu) {
+	if (p_type == FILE) {
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/new", TTR("New Shader..."), KeyModifierMask::CMD_OR_CTRL | Key::N), FILE_NEW);
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/new_include", TTR("New Shader Include..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N), FILE_NEW_INCLUDE);
+		p_menu->add_separator();
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/open", TTR("Load Shader File..."), KeyModifierMask::CMD_OR_CTRL | Key::O), FILE_OPEN);
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/open_include", TTR("Load Shader Include File..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::O), FILE_OPEN_INCLUDE);
+	}
+
+	if (p_type == FILE || p_type == CONTEXT_VALID_ITEM) {
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/save", TTR("Save File"), KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_SAVE);
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/save_as", TTR("Save File As...")), FILE_SAVE_AS);
+	}
+
+	if (p_type == FILE) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Open File in Inspector"), FILE_INSPECT);
+		p_menu->add_separator();
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/close_file", TTR("Close File"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_CLOSE);
+	} else {
+		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/close_file", TTR("Close File"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_CLOSE);
+		p_menu->add_item(TTR("Close All"), CLOSE_ALL);
+		p_menu->add_item(TTR("Close Other Tabs"), CLOSE_OTHER_TABS);
+		if (p_type == CONTEXT_VALID_ITEM) {
+			p_menu->add_separator();
+			p_menu->add_item(TTR("Copy Script Path"), COPY_PATH);
+			p_menu->add_item(TTR("Show in File System"), SHOW_IN_FILE_SYSTEM);
+		}
+	}
+}
+
+void ShaderEditorPlugin::_make_script_list_context_menu() {
+	context_menu->clear();
+
+	int selected = shader_tabs->get_current_tab();
+	if (selected < 0 || selected >= shader_tabs->get_tab_count()) {
+		return;
+	}
+
+	Control *control = shader_tabs->get_tab_control(selected);
+	bool is_valid_editor_control = Object::cast_to<TextShaderEditor>(control) || Object::cast_to<VisualShaderEditor>(control);
+
+	_setup_popup_menu(is_valid_editor_control ? CONTEXT_VALID_ITEM : CONTEXT, context_menu);
+
+	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), shader_tabs->get_tab_count() <= 0);
+	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_OTHER_TABS), shader_tabs->get_tab_count() <= 1);
+
+	context_menu->set_position(main_split->get_screen_position() + main_split->get_local_mouse_position());
+	context_menu->reset_size();
+	context_menu->popup();
 }
 
 void ShaderEditorPlugin::_close_shader(int p_index) {
@@ -485,6 +548,31 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 		} break;
 		case FILE_CLOSE: {
 			_close_shader(shader_tabs->get_current_tab());
+		} break;
+		case CLOSE_ALL: {
+			while (shader_tabs->get_tab_count() > 0) {
+				_close_shader(0);
+			}
+		} break;
+		case CLOSE_OTHER_TABS: {
+			int index = shader_tabs->get_current_tab();
+			for (int i = 0; i < index; i++) {
+				_close_shader(0);
+			}
+			while (shader_tabs->get_tab_count() > 1) {
+				_close_shader(1);
+			}
+		} break;
+		case SHOW_IN_FILE_SYSTEM: {
+			Ref<Resource> shader = _get_current_shader();
+			String path = shader->get_path();
+			if (!path.is_empty()) {
+				FileSystemDock::get_singleton()->navigate_to_path(path);
+			}
+		} break;
+		case COPY_PATH: {
+			Ref<Resource> shader = _get_current_shader();
+			DisplayServer::get_singleton()->clipboard_set(shader->get_path());
 		} break;
 	}
 }
@@ -652,6 +740,14 @@ void ShaderEditorPlugin::_res_saved_callback(const Ref<Resource> &p_res) {
 	}
 }
 
+void ShaderEditorPlugin::_set_file_specific_items_disabled(bool p_disabled) {
+	PopupMenu *file_popup_menu = file_menu->get_popup();
+	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_SAVE), p_disabled);
+	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_SAVE_AS), p_disabled);
+	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_INSPECT), p_disabled);
+	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_CLOSE), p_disabled);
+}
+
 void ShaderEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
@@ -679,23 +775,15 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));
 	file_menu->set_shortcut_context(main_split);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/new", TTR("New Shader..."), KeyModifierMask::CMD_OR_CTRL | Key::N), FILE_NEW);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/new_include", TTR("New Shader Include..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N), FILE_NEW_INCLUDE);
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/open", TTR("Load Shader File..."), KeyModifierMask::CMD_OR_CTRL | Key::O), FILE_OPEN);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/open_include", TTR("Load Shader Include File..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::O), FILE_OPEN_INCLUDE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/save", TTR("Save File"), KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_SAVE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/save_as", TTR("Save File As...")), FILE_SAVE_AS);
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_item(TTR("Open File in Inspector"), FILE_INSPECT);
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("shader_editor/close_file", TTR("Close File"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_CLOSE);
+	_setup_popup_menu(FILE, file_menu->get_popup());
 	file_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ShaderEditorPlugin::_menu_item_pressed));
 	menu_hb->add_child(file_menu);
 
-	for (int i = FILE_SAVE; i < FILE_MAX; i++) {
-		file_menu->get_popup()->set_item_disabled(file_menu->get_popup()->get_item_index(i), true);
-	}
+	_set_file_specific_items_disabled(true);
+
+	context_menu = memnew(PopupMenu);
+	add_child(context_menu);
+	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ShaderEditorPlugin::_menu_item_pressed));
 
 	Control *padding = memnew(Control);
 	padding->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -718,6 +806,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	vb->add_child(shader_list);
 	shader_list->connect(SceneStringName(item_selected), callable_mp(this, &ShaderEditorPlugin::_shader_selected));
 	shader_list->connect("item_clicked", callable_mp(this, &ShaderEditorPlugin::_shader_list_clicked));
+	shader_list->set_allow_rmb_select(true);
 	SET_DRAG_FORWARDING_GCD(shader_list, ShaderEditorPlugin);
 
 	main_split->add_child(vb);

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -60,8 +60,6 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	LocalVector<EditedShader> edited_shaders;
 
-	// Always valid operations come first in the enum, file-specific ones
-	// should go after FILE_SAVE which is used to build the menu accordingly.
 	enum {
 		FILE_NEW,
 		FILE_NEW_INCLUDE,
@@ -71,7 +69,16 @@ class ShaderEditorPlugin : public EditorPlugin {
 		FILE_SAVE_AS,
 		FILE_INSPECT,
 		FILE_CLOSE,
-		FILE_MAX
+		CLOSE_ALL,
+		CLOSE_OTHER_TABS,
+		SHOW_IN_FILE_SYSTEM,
+		COPY_PATH,
+	};
+
+	enum PopupMenuType {
+		FILE,
+		CONTEXT,
+		CONTEXT_VALID_ITEM,
 	};
 
 	HSplitContainer *main_split = nullptr;
@@ -80,6 +87,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	Button *button = nullptr;
 	MenuButton *file_menu = nullptr;
+	PopupMenu *context_menu = nullptr;
 
 	WindowWrapper *window_wrapper = nullptr;
 	Button *make_floating = nullptr;
@@ -88,15 +96,19 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	float text_shader_zoom_factor = 1.0f;
 
+	Ref<Resource> _get_current_shader();
 	void _update_shader_list();
 	void _shader_selected(int p_index);
 	void _shader_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
+	void _setup_popup_menu(PopupMenuType p_type, PopupMenu *p_menu);
+	void _make_script_list_context_menu();
 	void _menu_item_pressed(int p_index);
 	void _resource_saved(Object *obj);
 	void _close_shader(int p_index);
 	void _close_builtin_shaders_from_scene(const String &p_scene);
 	void _file_removed(const String &p_removed_file);
 	void _res_saved_callback(const Ref<Resource> &p_res);
+	void _set_file_specific_items_disabled(bool p_disabled);
 
 	void _shader_created(Ref<Shader> p_shader);
 	void _shader_include_created(Ref<ShaderInclude> p_shader_inc);


### PR DESCRIPTION
I frequently right-click on items in the shader editor expecting a context menu like the script editor, and it's very jarring when nothing happens. This adds a basic context menu with the same structure as the one from the script editor; it includes a couple new options like "Close Other Tabs", "Close All", and "Show in File System."

Relevant issue: https://github.com/godotengine/godot/issues/75061

![Godot Shader Editor Context Menu](https://github.com/user-attachments/assets/65cf8556-4403-4ba8-b121-7dbc27e72460)
