### PR TITLE
Remove empty `[b]Example:[/b]` lines from the class reference

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -667,12 +667,9 @@
 			<return type="float" />
 			<param index="0" name="lin" type="float" />
 			<description>
-				Converts from linear energy to decibels (audio). This can be used to implement volume sliders that behave as expected (since volume isn't linear).
-				[b]Example:[/b]
+				Converts from linear energy to decibels (audio). Since volume is not normally linear, this can be used to implement volume sliders that behave as expected.
+				[b]Example:[/b] Change the Master bus's volume through a [Slider] node, which ranges from [code]0.0[/code] to [code]1.0[/code]:
 				[codeblock]
-				# "Slider" refers to a node that inherits Range such as HSlider or VSlider.
-				# Its range must be configured to go from 0 to 1.
-				# Change the bus name if you'd like to change the volume of a specific bus only.
 				AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db($Slider.value))
 				[/codeblock]
 			</description>
@@ -2603,8 +2600,7 @@
 		</constant>
 		<constant name="OK" value="0" enum="Error">
 			Methods that return [enum Error] return [constant OK] when no error occurred.
-			Since [constant OK] has value 0, and all other error constants are positive integers, it can also be used in boolean checks.
-			[b]Example:[/b]
+			Since [constant OK] has value [code]0[/code], and all other error constants are positive integers, it can also be used in boolean checks.
 			[codeblock]
 			var error = method_that_returns_error()
 			if error != OK:
@@ -2867,7 +2863,7 @@
 			hintString = $"{Variant.Type.Array:D}:{Variant.Type.Array:D}:{elemType:D}/{elemHint:D}:{elemHintString}";
 			[/csharp]
 			[/codeblocks]
-			Examples:
+			[b]Examples:[/b]
 			[codeblocks]
 			[gdscript]
 			hint_string = "%d:" % [TYPE_INT] # Array of integers.

--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -54,12 +54,10 @@
 			<param index="0" name="frame" type="int" />
 			<param index="1" name="progress" type="float" />
 			<description>
-				The setter of [member frame] resets the [member frame_progress] to [code]0.0[/code] implicitly, but this method avoids that.
-				This is useful when you want to carry over the current [member frame_progress] to another [member frame].
-				[b]Example:[/b]
+				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
+				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress].
 				[codeblocks]
 				[gdscript]
-				# Change the animation with keeping the frame index and progress.
 				var current_frame = animated_sprite.get_frame()
 				var current_progress = animated_sprite.get_frame_progress()
 				animated_sprite.play("walk_another_skin")

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -53,12 +53,10 @@
 			<param index="0" name="frame" type="int" />
 			<param index="1" name="progress" type="float" />
 			<description>
-				The setter of [member frame] resets the [member frame_progress] to [code]0.0[/code] implicitly, but this method avoids that.
-				This is useful when you want to carry over the current [member frame_progress] to another [member frame].
-				[b]Example:[/b]
+				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
+				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress].
 				[codeblocks]
 				[gdscript]
-				# Change the animation with keeping the frame index and progress.
 				var current_frame = animated_sprite.get_frame()
 				var current_progress = animated_sprite.get_frame_progress()
 				animated_sprite.play("walk_another_skin")

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		Contains multiple [AnimationRootNode]s representing animation states, connected in a graph. State transitions can be configured to happen automatically or via code, using a shortest-path algorithm. Retrieve the [AnimationNodeStateMachinePlayback] object from the [AnimationTree] node to control it programmatically.
-		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
 		var state_machine = $AnimationTree.get("parameters/playback")

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		Allows control of [AnimationTree] state machines created with [AnimationNodeStateMachine]. Retrieve with [code]$AnimationTree.get("parameters/playback")[/code].
-		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
 		var state_machine = $AnimationTree.get("parameters/playback")

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -4,8 +4,7 @@
 		A built-in data structure that holds a sequence of elements.
 	</brief_description>
 	<description>
-		An array data structure that can contain a sequence of elements of any [Variant] type. Elements are accessed by a numerical index starting at 0. Negative indices are used to count from the back (-1 is the last element, -2 is the second to last, etc.).
-		[b]Example:[/b]
+		An array data structure that can contain a sequence of elements of any [Variant] type. Elements are accessed by a numerical index starting at [code]0[/code]. Negative indices are used to count from the back ([code]-1[/code] is the last element, [code]-2[/code] is the second to last, etc.).
 		[codeblocks]
 		[gdscript]
 		var array = ["First", 2, 3, "Last"]

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		[Callable] is a built-in [Variant] type that represents a function. It can either be a method within an [Object] instance, or a custom callable used for different purposes (see [method is_custom]). Like all [Variant] types, it can be stored in variables and passed to other functions. It is most commonly used for signal callbacks.
-		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
 		func print_args(arg1, arg2, arg3 = ""):

--- a/doc/classes/CallbackTweener.xml
+++ b/doc/classes/CallbackTweener.xml
@@ -16,10 +16,10 @@
 			<param index="0" name="delay" type="float" />
 			<description>
 				Makes the callback call delayed by given time in seconds.
-				[b]Example:[/b]
+				[b]Example:[/b] Call [method Node.queue_free] after 2 seconds.
 				[codeblock]
 				var tween = get_tree().create_tween()
-				tween.tween_callback(queue_free).set_delay(2) #this will call queue_free() after 2 seconds
+				tween.tween_callback(queue_free).set_delay(2)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -301,7 +301,7 @@
 			<param index="1" name="valid_types" type="StringName[]" default="[]" />
 			<description>
 				Pops up an editor dialog for selecting a [Node] from the edited scene. The [param callback] must take a single argument of type [NodePath]. It is called on the selected [NodePath] or the empty path [code]^""[/code] if the dialog is canceled. If [param valid_types] is provided, the dialog will only show Nodes that match one of the listed Node types.
-				[b]Example:[/b]
+				[b]Example:[/b] Display the node selection dialog as soon as this node is added to the tree for the first time:
 				[codeblock]
 				func _ready():
 				    if Engine.is_editor_hint():
@@ -322,7 +322,6 @@
 			<param index="2" name="type_filter" type="PackedInt32Array" default="PackedInt32Array()" />
 			<description>
 				Pops up an editor dialog for selecting properties from [param object]. The [param callback] must take a single argument of type [NodePath]. It is called on the selected property path (see [method NodePath.get_as_property_path]) or the empty path [code]^""[/code] if the dialog is canceled. If [param type_filter] is provided, the dialog will only show properties that match one of the listed [enum Variant.Type] values.
-				[b]Example:[/b]
 				[codeblock]
 				func _ready():
 				    if Engine.is_editor_hint():

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -104,7 +104,6 @@
 			<param index="1" name="event" type="InputEvent" />
 			<description>
 				Called when there is a root node in the current edited scene, [method _handles] is implemented, and an [InputEvent] happens in the 3D viewport. The return value decides whether the [InputEvent] is consumed or forwarded to other [EditorPlugin]s. See [enum AfterGUIInput] for options.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				# Prevents the InputEvent from reaching other Editor classes.
@@ -119,8 +118,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				Must [code]return EditorPlugin.AFTER_GUI_INPUT_PASS[/code] in order to forward the [InputEvent] to other Editor classes.
-				[b]Example:[/b]
+				This method must return [constant AFTER_GUI_INPUT_PASS] in order to forward the [InputEvent] to other Editor classes.
 				[codeblocks]
 				[gdscript]
 				# Consumes InputEventMouseMotion and forwards other InputEvent types.
@@ -188,8 +186,7 @@
 			<return type="bool" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Called when there is a root node in the current edited scene, [method _handles] is implemented and an [InputEvent] happens in the 2D viewport. Intercepts the [InputEvent], if [code]return true[/code] [EditorPlugin] consumes the [param event], otherwise forwards [param event] to other Editor classes.
-				[b]Example:[/b]
+				Called when there is a root node in the current edited scene, [method _handles] is implemented, and an [InputEvent] happens in the 2D viewport. If this method returns [code]true[/code], [param event] is intercepted by this [EditorPlugin], otherwise [param event] is forwarded to other Editor classes.
 				[codeblocks]
 				[gdscript]
 				# Prevents the InputEvent from reaching other Editor classes.
@@ -204,8 +201,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				Must [code]return false[/code] in order to forward the [InputEvent] to other Editor classes.
-				[b]Example:[/b]
+				This method must return [code]false[/code] in order to forward the [InputEvent] to other Editor classes.
 				[codeblocks]
 				[gdscript]
 				# Consumes InputEventMouseMotion and forwards other InputEvent types.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -38,7 +38,6 @@
 				- [code]name[/code]: [String] (the name of the property)
 				- [code]type[/code]: [int] (see [enum Variant.Type])
 				- optionally [code]hint[/code]: [int] (see [enum PropertyHint]) and [code]hint_string[/code]: [String]
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var settings = EditorInterface.get_editor_settings()

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -59,8 +59,7 @@
 		<method name="get_response_headers_as_dictionary">
 			<return type="Dictionary" />
 			<description>
-				Returns all response headers as a Dictionary of structure [code]{ "key": "value1; value2" }[/code] where the case-sensitivity of the keys and values is kept like the server delivers it. A value is a simple String, this string can have more than one value where "; " is used as separator.
-				[b]Example:[/b]
+				Returns all response headers as a [Dictionary]. Each entry is composed by the header name, and a [String] containing the values separated by [code]"; "[/code]. The casing is kept the same as the headers were received.
 				[codeblock]
 				{
 				    "content-length": 12,

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -535,7 +535,6 @@
 			<param index="2" name="color" type="Color" />
 			<description>
 				Sets the [Color] of the pixel at [code](x, y)[/code] to [param color].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var img_width = 10
@@ -561,7 +560,6 @@
 			<param index="1" name="color" type="Color" />
 			<description>
 				Sets the [Color] of the pixel at [param point] to [param color].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var img_width = 10

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -286,7 +286,6 @@
 			<param index="0" name="event" type="InputEvent" />
 			<description>
 				Feeds an [InputEvent] to the game. Can be used to artificially trigger input events from code. Also generates [method Node._input] calls.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var cancel_event = InputEventAction.new()

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -6,8 +6,7 @@
 	<description>
 		The [JSON] class enables all data types to be converted to and from a JSON string. This is useful for serializing data, e.g. to save to a file or send over the network.
 		[method stringify] is used to convert any data type into a JSON string.
-		[method parse] is used to convert any existing JSON data into a [Variant] that can be used within Godot. If successfully parsed, use [member data] to retrieve the [Variant], and use [code]typeof[/code] to check if the Variant's type is what you expect. JSON Objects are converted into a [Dictionary], but JSON data can be used to store [Array]s, numbers, [String]s and even just a boolean.
-		[b]Example[/b]
+		[method parse] is used to convert any existing JSON data into a [Variant] that can be used within Godot. If successfully parsed, use [member data] to retrieve the [Variant], and use [method @GlobalScope.typeof] to check if the Variant's type is what you expect. JSON Objects are converted into a [Dictionary], but JSON data can be used to store [Array]s, numbers, [String]s and even just a boolean.
 		[codeblock]
 		var data_to_send = ["a", "b", "c"]
 		var json_string = JSON.stringify(data_to_send)
@@ -33,7 +32,7 @@
 		- Trailing commas in arrays or objects are ignored, instead of causing a parser error.
 		- New line and tab characters are accepted in string literals, and are treated like their corresponding escape sequences [code]\n[/code] and [code]\t[/code].
 		- Numbers are parsed using [method String.to_float] which is generally more lax than the JSON specification.
-		- Certain errors, such as invalid Unicode sequences, do not cause a parser error. Instead, the string is cleansed and an error is logged to the console.
+		- Certain errors, such as invalid Unicode sequences, do not cause a parser error. Instead, the string is cleaned up and an error is logged to the console.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/JavaScriptObject.xml
+++ b/doc/classes/JavaScriptObject.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		JavaScriptObject is used to interact with JavaScript objects retrieved or created via [method JavaScriptBridge.get_interface], [method JavaScriptBridge.create_object], or [method JavaScriptBridge.create_callback].
-		[b]Example:[/b]
 		[codeblock]
 		extends Node
 

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -231,8 +231,8 @@
 		</member>
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
 			Maximum number of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
-			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting. If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter.
-			[b]Example:[/b]
+			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting.
+			If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter:
 			[codeblocks]
 			[gdscript]
 			text = "Hello world"

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -32,7 +32,6 @@
 		</member>
 		<member name="uri" type="String" setter="set_uri" getter="get_uri" default="&quot;&quot;">
 			The [url=https://en.wikipedia.org/wiki/Uniform_Resource_Identifier]URI[/url] for this [LinkButton]. If set to a valid URI, pressing the button opens the URI using the operating system's default program for the protocol (via [method OS.shell_open]). HTTP and HTTPS URLs open the default web browser.
-			[b]Examples:[/b]
 			[codeblocks]
 			[gdscript]
 			uri = "https://godotengine.org"  # Opens the URL in the default web browser.

--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -139,8 +139,7 @@
 			<param index="1" name="vertex" type="int" />
 			<description>
 				Returns the specified vertex index of the given face.
-				Vertex argument must be either 0, 1, or 2 because faces contain three vertices.
-				[b]Example:[/b]
+				[param vertex] must be either [code]0[/code], [code]1[/code], or [code]2[/code] because faces contain three vertices.
 				[codeblocks]
 				[gdscript]
 				var index = mesh_data_tool.get_face_vertex(0, 1) # Gets the index of the second vertex of the first face.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -23,7 +23,6 @@
 				- [code]"name"[/code]: [String] (the property's name)
 				- [code]"type"[/code]: [int] (see [enum Variant.Type])
 				- optionally [code]"hint"[/code]: [int] (see [enum PropertyHint]) and [code]"hint_string"[/code]: [String]
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				ProjectSettings.set("category/property_name", 0)
@@ -85,7 +84,6 @@
 			<param index="1" name="default_value" type="Variant" default="null" />
 			<description>
 				Returns the value of the setting identified by [param name]. If the setting doesn't exist and [param default_value] is specified, the value of [param default_value] is returned. Otherwise, [code]null[/code] is returned.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				print(ProjectSettings.get_setting("application/config/name"))
@@ -104,8 +102,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Similar to [method get_setting], but applies feature tag overrides if any exists and is valid.
-				[b]Example:[/b]
-				If the following setting override exists "application/config/name.windows", and the following code is executed:
+				[b]Example:[/b]	If the setting override [code]"application/config/name.windows"[/code] exists, and the following code is executed on a [i]Windows[/i] operating system, the overridden setting is printed instead:
 				[codeblocks]
 				[gdscript]
 				print(ProjectSettings.get_setting_with_override("application/config/name"))
@@ -114,7 +111,6 @@
 				GD.Print(ProjectSettings.GetSettingWithOverride("application/config/name"));
 				[/csharp]
 				[/codeblocks]
-				Then the overridden setting will be returned instead if the project is running on the [i]Windows[/i] operating system.
 			</description>
 		</method>
 		<method name="globalize_path" qualifiers="const">
@@ -224,7 +220,6 @@
 			<param index="1" name="value" type="Variant" />
 			<description>
 				Sets the value of a setting.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				ProjectSettings.set_setting("application/config/name", "Example")

--- a/doc/classes/PropertyTweener.xml
+++ b/doc/classes/PropertyTweener.xml
@@ -14,10 +14,10 @@
 			<return type="PropertyTweener" />
 			<description>
 				When called, the final value will be used as a relative value instead.
-				[b]Example:[/b]
+				[b]Example:[/b] Move the node by [code]100[/code] pixels to the right.
 				[codeblock]
 				var tween = get_tree().create_tween()
-				tween.tween_property(self, "position", Vector2.RIGHT * 100, 1).as_relative() #the node will move by 100 pixels to the right
+				tween.tween_property(self, "position", Vector2.RIGHT * 100, 1).as_relative()
 				[/codeblock]
 			</description>
 		</method>
@@ -26,10 +26,10 @@
 			<param index="0" name="value" type="Variant" />
 			<description>
 				Sets a custom initial value to the [PropertyTweener].
-				[b]Example:[/b]
+				[b]Example:[/b] Move the node from position [code](100, 100)[/code] to [code](200, 100)[/code].
 				[codeblock]
 				var tween = get_tree().create_tween()
-				tween.tween_property(self, "position", Vector2(200, 100), 1).from(Vector2(100, 100)) #this will move the node from position (100, 100) to (200, 100)
+				tween.tween_property(self, "position", Vector2(200, 100), 1).from(Vector2(100, 100))
 				[/codeblock]
 			</description>
 		</method>
@@ -48,7 +48,6 @@
 			<param index="0" name="interpolator_method" type="Callable" />
 			<description>
 				Allows interpolating the value with a custom easing function. The provided [param interpolator_method] will be called with a value ranging from [code]0.0[/code] to [code]1.0[/code] and is expected to return a value within the same range (values outside the range can be used for overshoot). The return value of the method is then used for interpolation between initial and final value. Note that the parameter passed to the method is still subject to the tweener's own easing.
-				[b]Example:[/b]
 				[codeblock]
 				@export var curve: Curve
 

--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -40,7 +40,6 @@
 			<description>
 				Opens help for the given topic. The [param topic] is an encoded string that controls which class, method, constant, signal, annotation, property, or theme item should be focused.
 				The supported [param topic] formats include [code]class_name:class[/code], [code]class_method:class:method[/code], [code]class_constant:class:constant[/code], [code]class_signal:class:signal[/code], [code]class_annotation:class:@annotation[/code], [code]class_property:class:property[/code], and [code]class_theme_item:class:item[/code], where [code]class[/code] is the class name, [code]method[/code] is the method name, [code]constant[/code] is the constant name, [code]signal[/code] is the signal name, [code]annotation[/code] is the annotation name, [code]property[/code] is the property name, and [code]item[/code] is the theme item.
-				[b]Examples:[/b]
 				[codeblock]
 				# Shows help for the Node class.
 				class_name:Node

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[SpinBox] is a numerical input text field. It allows entering integers and floating-point numbers.
-		[b]Example:[/b]
+		[b]Example:[/b] Create a [SpinBox], disable its context menu and set its text alignment to right.
 		[codeblocks]
 		[gdscript]
 		var spin_box = SpinBox.new()
@@ -22,7 +22,6 @@
 		spinBox.AlignHorizontal = LineEdit.HorizontalAlignEnum.Right;
 		[/csharp]
 		[/codeblocks]
-		The above code will create a [SpinBox], disable context menu on it and set the text alignment to right.
 		See [Range] class for more options over the [SpinBox].
 		[b]Note:[/b] With the [SpinBox]'s context menu disabled, you can right-click the bottom half of the spinbox to set the value to its minimum, while right-clicking the top half sets the value to its maximum.
 		[b]Note:[/b] [SpinBox] relies on an underlying [LineEdit] node. To theme a [SpinBox]'s background, add theme items for [LineEdit] and customize them.

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -13,8 +13,8 @@
 		<method name="get_rect" qualifiers="const">
 			<return type="Rect2" />
 			<description>
-				Returns a [Rect2] representing the Sprite2D's boundary in local coordinates. Can be used to detect if the Sprite2D was clicked.
-				[b]Example:[/b]
+				Returns a [Rect2] representing the Sprite2D's boundary in local coordinates.
+				[b]Example:[/b] Detect if the Sprite2D was clicked:
 				[codeblocks]
 				[gdscript]
 				func _input(event):

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -324,7 +324,6 @@
 			<description>
 				Splits the string using a [param delimiter] and returns the substring at index [param slice]. Returns the original string if [param delimiter] does not occur in the string. Returns an empty string if the [param slice] does not exist.
 				This is faster than [method split], if you only need one substring.
-				[b]Example:[/b]
 				[codeblock]
 				print("i/am/example/hi".get_slice("/", 2)) # Prints "example"
 				[/codeblock]
@@ -527,7 +526,6 @@
 			<param index="0" name="parts" type="PackedStringArray" />
 			<description>
 				Returns the concatenation of [param parts]' elements, with each element separated by the string calling this method. This method is the opposite of [method split].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var fruits = ["Apple", "Orange", "Pear", "Kiwi"]
@@ -647,7 +645,6 @@
 				Converts a [float] to a string representation of a decimal number, with the number of decimal places specified in [param decimals].
 				If [param decimals] is [code]-1[/code] as by default, the string representation may only have up to 14 significant digits, with digits before the decimal point having priority over digits after.
 				Trailing zeros are not included in the string. The last digit is rounded, not truncated.
-				[b]Example:[/b]
 				[codeblock]
 				String.num(3.141593)     # Returns "3.141593"
 				String.num(3.141593, 3)  # Returns "3.142"
@@ -802,7 +799,6 @@
 				Splits the string using a [param delimiter] and returns an array of the substrings, starting from the end of the string. The splits in the returned array appear in the same order as the original string. If [param delimiter] is an empty string, each substring will be a single character.
 				If [param allow_empty] is [code]false[/code], empty strings between adjacent delimiters are excluded from the array.
 				If [param maxsplit] is greater than [code]0[/code], the number of splits may not exceed [param maxsplit]. By default, the entire string is split, which is mostly identical to [method split].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var some_string = "One,Two,Three,Four"
@@ -882,7 +878,6 @@
 				Splits the string using a [param delimiter] and returns an array of the substrings. If [param delimiter] is an empty string, each substring will be a single character. This method is the opposite of [method join].
 				If [param allow_empty] is [code]false[/code], empty strings between adjacent delimiters are excluded from the array.
 				If [param maxsplit] is greater than [code]0[/code], the number of splits may not exceed [param maxsplit]. By default, the entire string is split.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var some_array = "One,Two,Three,Four".split(",", true, 2)

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -301,7 +301,6 @@
 			<description>
 				Splits the string using a [param delimiter] and returns the substring at index [param slice]. Returns an empty string if the [param slice] does not exist.
 				This is faster than [method split], if you only need one substring.
-				[b]Example:[/b]
 				[codeblock]
 				print("i/am/example/hi".get_slice("/", 2)) # Prints "example"
 				[/codeblock]
@@ -496,7 +495,6 @@
 			<param index="0" name="parts" type="PackedStringArray" />
 			<description>
 				Returns the concatenation of [param parts]' elements, with each element separated by the string calling this method. This method is the opposite of [method split].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var fruits = ["Apple", "Orange", "Pear", "Kiwi"]
@@ -703,7 +701,6 @@
 				Splits the string using a [param delimiter] and returns an array of the substrings, starting from the end of the string. The splits in the returned array appear in the same order as the original string. If [param delimiter] is an empty string, each substring will be a single character.
 				If [param allow_empty] is [code]false[/code], empty strings between adjacent delimiters are excluded from the array.
 				If [param maxsplit] is greater than [code]0[/code], the number of splits may not exceed [param maxsplit]. By default, the entire string is split, which is mostly identical to [method split].
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var some_string = "One,Two,Three,Four"
@@ -783,7 +780,6 @@
 				Splits the string using a [param delimiter] and returns an array of the substrings. If [param delimiter] is an empty string, each substring will be a single character. This method is the opposite of [method join].
 				If [param allow_empty] is [code]false[/code], empty strings between adjacent delimiters are excluded from the array.
 				If [param maxsplit] is greater than [code]0[/code], the number of splits may not exceed [param maxsplit]. By default, the entire string is split.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var some_array = "One,Two,Three,Four".split(",", true, 2)

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -5,8 +5,7 @@
 	</brief_description>
 	<description>
 		By configuring various properties of this style box, you can achieve many common looks without the need of a texture. This includes optionally rounded borders, antialiasing, shadows, and skew.
-		Setting corner radius to high values is allowed. As soon as corners overlap, the stylebox will switch to a relative system.
-		[b]Example:[/b]
+		Setting corner radius to high values is allowed. As soon as corners overlap, the stylebox will switch to a relative system:
 		[codeblock lang=text]
 		height = 30
 		corner_radius_top_left = 50

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -183,7 +183,6 @@
 			<return type="Tween" />
 			<description>
 				Makes the next [Tweener] run parallelly to the previous one.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween()
@@ -410,7 +409,6 @@
 			<param index="3" name="duration" type="float" />
 			<description>
 				Creates and appends a [PropertyTweener]. This method tweens a [param property] of an [param object] between an initial value and [param final_val] in a span of time equal to [param duration], in seconds. The initial value by default is the property's value at the time the tweening of the [PropertyTweener] starts.
-				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween()

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -133,7 +133,7 @@
 				- An [Object]-derived class which exists in [ClassDB], for example [Node].
 				- A [Script] (you can use any class, including inner one).
 				Unlike the right operand of the [code]is[/code] operator, [param type] can be a non-constant value. The [code]is[/code] operator supports more features (such as typed arrays). Use the operator instead of this method if you do not need dynamic type checking.
-				Examples:
+				[b]Examples:[/b]
 				[codeblock]
 				print(is_instance_of(a, TYPE_INT))
 				print(is_instance_of(a, Node))
@@ -220,7 +220,7 @@
 				[code]range(b: int, n: int, s: int)[/code]: Starts from [code]b[/code], increases/decreases by steps of [code]s[/code], and stops [i]before[/i] [code]n[/code]. The arguments [code]b[/code] and [code]n[/code] are [b]inclusive[/b] and [b]exclusive[/b], respectively. The argument [code]s[/code] [b]can[/b] be negative, but not [code]0[/code]. If [code]s[/code] is [code]0[/code], an error message is printed.
 				[method range] converts all arguments to [int] before processing.
 				[b]Note:[/b] Returns an empty array if no value meets the value constraint (e.g. [code]range(2, 5, -1)[/code] or [code]range(5, 5, 1)[/code]).
-				Examples:
+				[b]Examples:[/b]
 				[codeblock]
 				print(range(4))        # Prints [0, 1, 2, 3]
 				print(range(2, 5))     # Prints [2, 3, 4]


### PR DESCRIPTION
This is part of a [personal gripe](https://chat.godotengine.org/channel/documentation?msg=xNcYb6c3PCkBHvXGX) that is relatively simple to address in one sweep.

To make it brief, here's a snippet of something I've been steadily writing to explain my writing style for the class reference:
>	- DO NOT introduce a codeblock example with `[b]Example:[/b]` and no further explanation. If there's no need for an additional statement, don't write it. Preferably make the example understandable on its own (without comments!). Every new line is important!

To reiterate, there's no point in preceding a codeblock with "_Example:_" if there's nothing to say. What else could it be there for?
For the built-in class reference, this does not even look good in practice, as these do not use `h1` or similar tags.

A good chunk of these came from https://github.com/godotengine/godot/pull/68120 f7c611ab71d292d64a6d4db8db8e36aaf0e2330b.

For the descriptions affected, additional tweaks have been made to justify a whole translation string change.
