### PR TITLE
Fix `InputMap::event_get_index` to handle unmatched events correctly

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -253,8 +253,8 @@ bool InputMap::event_is_action(const Ref<InputEvent> &p_event, const StringName 
 
 int InputMap::event_get_index(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match) const {
 	int index = -1;
-	event_get_action_status(p_event, p_action, p_exact_match, nullptr, nullptr, nullptr, &index);
-	return index;
+	bool valid = event_get_action_status(p_event, p_action, p_exact_match, nullptr, nullptr, nullptr, &index);
+	return valid ? index : -1;
 }
 
 bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match, bool *r_pressed, float *r_strength, float *r_raw_strength, int *r_event_index) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #95716

Previously in #84685, the `InputMap::event_get_index` method always returned `event_index` regardless of whether the input event matched the action. This caused incorrect indices to be returned even when no match was found.

This issue impacted `Input::_parse_input_event_impl`, causing it to iterate over unrelated actions instead of skipping them when an unmatched event was encountered (`event_index == -1`). 
https://github.com/godotengine/godot/blob/1bd740d18d714f815486b04bf4c6154ef6c355d9/core/input/input.cpp#L763-L767

In the end, it releases all other pressed actions since `p_event->is_action_pressed(E.key, true)` always returns `false` when the event and action don't match.
https://github.com/godotengine/godot/blob/1bd740d18d714f815486b04bf4c6154ef6c355d9/core/input/input.cpp#L771
https://github.com/godotengine/godot/blob/1bd740d18d714f815486b04bf4c6154ef6c355d9/core/input/input.cpp#L776
https://github.com/godotengine/godot/blob/1bd740d18d714f815486b04bf4c6154ef6c355d9/core/input/input.cpp#L780-L784

This fix ensures that `InputMap::event_get_index` returns `-1` when no match is found, preventing the processing of unrelated actions and avoiding unintended input releases.