### PR TITLE
Fix selecting files which doesn't exist in Dock filesystem

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3861,8 +3861,20 @@ void FileSystemDock::load_layout_from_config(Ref<ConfigFile> p_layout, const Str
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_selected_paths")) {
 		PackedStringArray dock_filesystem_selected_paths = p_layout->get_value(p_section, "dock_filesystem_selected_paths");
+		PackedStringArray dock_filesystem_really_selected_paths;
+		bool dock_filesystem_selected_paths_changed = false;
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		for (int i = 0; i < dock_filesystem_selected_paths.size(); i++) {
-			select_file(dock_filesystem_selected_paths[i]);
+			auto p_path = dock_filesystem_selected_paths[i];
+			if (da->file_exists(p_path) || da->dir_exists(p_path)) {
+				select_file(p_path);
+				dock_filesystem_really_selected_paths.push_back(p_path);
+			} else {
+				dock_filesystem_selected_paths_changed = true;
+			}
+		}
+		if (dock_filesystem_selected_paths_changed) {
+			p_layout->set_value(p_section, "dock_filesystem_selected_paths", dock_filesystem_really_selected_paths);
 		}
 	}
 


### PR DESCRIPTION
This is related to #95472

The approach is checking if dir or file exists before it attempts to select it and creates new list of only existing files. In case a file doesn't exist, it will store new version to the config section.

Repro steps:
Create godot project,
inside of it, edit {PROJECTNAME}/.godot/editor/editor_layout.cfg
Add some non existing files into 
```
dock_filesystem_selected_paths=PackedStringArray("res://icon.svg")
```
For example:
```
dock_filesystem_selected_paths=PackedStringArray("res://icon.svg", "res://bad_icon.svg", "res://bad_icon2.svg")
```

Result:
Output shows:
Cannot navigate to 'res://bad_icon.svg' as it has not been found in the file system!

![oie_DarDOTfzusfr](https://github.com/user-attachments/assets/9c7dd2ae-471d-4b6c-949a-4b41ce2e76f5)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
