### PR TITLE
docs: Highlight lack of joystick info on majority of platforms

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -133,6 +133,7 @@
 				[code]vendor_id[/code]: The USB vendor ID of the device.
 				[code]product_id[/code]: The USB product ID of the device.
 				[code]steam_input_index[/code]: The Steam Input gamepad index, if the device is not a Steam Input device this key won't be present.
+				[b]Note:[/b] The returned dictionary is always empty on Web, iOS, Android, and macOS.
 			</description>
 		</method>
 		<method name="get_joy_name">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Just thought I'd add a note to the Input class that explicitly describes the lack of platform-specific Joypad info on the majority of platforms. This is the silliest PR ever, but it actually tripped me up for a second.

I did check the source to verify that only Windows and Linux explicitly collect and pass system-specific Joypad information in before making this claim. 