### PR TITLE
Fix override error with `_reload_scripts` in `ScriptLanguageExtension`

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -142,6 +142,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_debug_get_current_stack_info);
 
 	GDVIRTUAL_BIND(_reload_all_scripts);
+	GDVIRTUAL_BIND(_reload_scripts, "scripts", "soft_reload");
 	GDVIRTUAL_BIND(_reload_tool_script, "script", "soft_reload");
 
 	GDVIRTUAL_BIND(_get_recognized_extensions);

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -314,6 +314,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_reload_scripts" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="scripts" type="Array" />
+			<param index="1" name="soft_reload" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_reload_tool_script" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="script" type="Script" />


### PR DESCRIPTION
Fixes #95770 

Error:
```
ERROR: Required virtual method MyLanguage::_reload_scripts must be overridden before calling.
   at: _gdvirtual__reload_scripts_call (./core/object/script_language_extension.h:589)
```

This blocks the ability for any custom language extension to hot reload scripts.