### PR TITLE
Simplify the printed file paths in the Linux/*BSD crash handler

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -133,7 +133,8 @@ static void handle_crash(int sig) {
 				}
 			}
 
-			print_error(vformat("[%d] %s (%s)", (int64_t)i, fname, err == OK ? addr2line_results[i] : ""));
+			// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
+			print_error(vformat("[%d] %s (%s)", (int64_t)i, fname, err == OK ? addr2line_results[i].replace("/./", "/") : ""));
 		}
 
 		free(strings);


### PR DESCRIPTION
This shortens the printed paths a bit when they would contain `/./`, which is redundant (e.g. `/opt/godot/./core` becomes `/opt/godot/core`). I noticed this while posting backtraces over the recent weeks, such as https://github.com/godotengine/godot/issues/95769.

To my knowledge, this change is only needed on Linux/*BSD. I haven't seen it occur on Windows (MinGW/MSVC) or macOS, but correct me if I'm wrong.

Note that curiously, `main` and `platform` folders are not affected by the original issue shown below (in the **Before** block), so this might hint at a buildsystem configuration issue.

## Preview

### Before

```
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.4.dev.custom_build (1bd740d18d714f815486b04bf4c6154ef6c355d9)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib64/libc.so.6(+0x40d00) [0x7f48f874ad00] (??:0)
[2] bin/godot.linuxbsd.editor.x86_64() [0x6a132e6] (/home/hugo/Documents/Git/godotengine/godot/./core/templates/hash_map.h:100)
[3] bin/godot.linuxbsd.editor.x86_64() [0x69adae6] (/home/hugo/Documents/Git/godotengine/godot/./core/templates/hash_map.h:310)
[4] bin/godot.linuxbsd.editor.x86_64() [0x501deee] (/home/hugo/Documents/Git/godotengine/godot/./core/string/string_name.h:187)
[5] bin/godot.linuxbsd.editor.x86_64() [0x50a2b04] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:304 (discriminator 2))
[6] bin/godot.linuxbsd.editor.x86_64() [0x509ef7f] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:419)
[7] bin/godot.linuxbsd.editor.x86_64() [0x5090d4a] (/home/hugo/Documents/Git/godotengine/godot/./core/object/callable_method_pointer.h:104)
[8] bin/godot.linuxbsd.editor.x86_64() [0x946669b] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/callable.cpp:57)
[9] bin/godot.linuxbsd.editor.x86_64() [0x9998f41] (/home/hugo/Documents/Git/godotengine/godot/./core/object/message_queue.cpp:221)
[10] bin/godot.linuxbsd.editor.x86_64() [0x99992ef] (/home/hugo/Documents/Git/godotengine/godot/./core/object/message_queue.cpp:270)
[11] bin/godot.linuxbsd.editor.x86_64() [0x5b8c1c4] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/scene_tree.cpp:540)
[12] bin/godot.linuxbsd.editor.x86_64() [0x2bb96ba] (/home/hugo/Documents/Git/godotengine/godot/main/main.cpp:4177 (discriminator 3))
[13] bin/godot.linuxbsd.editor.x86_64() [0x4aeabe3] (/home/hugo/Documents/Git/godotengine/godot/./editor/progress_dialog.cpp:135)
[14] bin/godot.linuxbsd.editor.x86_64() [0x4aeb61f] (/home/hugo/Documents/Git/godotengine/godot/./editor/progress_dialog.cpp:223)
[15] bin/godot.linuxbsd.editor.x86_64() [0x47dbb58] (/home/hugo/Documents/Git/godotengine/godot/./editor/editor_node.cpp:4910)
[16] bin/godot.linuxbsd.editor.x86_64() [0x433171c] (/home/hugo/Documents/Git/godotengine/godot/./editor/editor_node.h:959)
[17] bin/godot.linuxbsd.editor.x86_64() [0x47e8e46] (/home/hugo/Documents/Git/godotengine/godot/./editor/editor_node.cpp:6292 (discriminator 5))
[18] bin/godot.linuxbsd.editor.x86_64() [0x47b59ae] (/home/hugo/Documents/Git/godotengine/godot/./editor/editor_node.cpp:1093)
[19] bin/godot.linuxbsd.editor.x86_64() [0x4890e16] (/home/hugo/Documents/Git/godotengine/godot/./core/templates/vector.h:291)
[20] bin/godot.linuxbsd.editor.x86_64() [0x488533c] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:419)
[21] bin/godot.linuxbsd.editor.x86_64() [0x486ab90] (/home/hugo/Documents/Git/godotengine/godot/./core/object/callable_method_pointer.h:104)
[22] bin/godot.linuxbsd.editor.x86_64() [0x946669b] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/callable.cpp:57)
[23] bin/godot.linuxbsd.editor.x86_64() [0x99a52bd] (/home/hugo/Documents/Git/godotengine/godot/./core/object/object.cpp:1188)
[24] bin/godot.linuxbsd.editor.x86_64() [0x5ae3ba8] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/node.cpp:3924)
[25] bin/godot.linuxbsd.editor.x86_64() [0x46e3ced] (/home/hugo/Documents/Git/godotengine/godot/./core/object/object.h:936)
[26] bin/godot.linuxbsd.editor.x86_64() [0x46797d1] (/home/hugo/Documents/Git/godotengine/godot/./core/templates/vector.h:291)
[27] bin/godot.linuxbsd.editor.x86_64() [0x4a9a72c] (/home/hugo/Documents/Git/godotengine/godot/./editor/import_dock.cpp:691)
[28] bin/godot.linuxbsd.editor.x86_64() [0x4a98984] (/home/hugo/Documents/Git/godotengine/godot/./editor/import_dock.cpp:583)
[29] bin/godot.linuxbsd.editor.x86_64() [0x4a97c24] (/home/hugo/Documents/Git/godotengine/godot/./editor/import_dock.cpp:535)
[30] bin/godot.linuxbsd.editor.x86_64() [0x4ae38b6] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:309)
[31] bin/godot.linuxbsd.editor.x86_64() [0x4ae1511] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:419)
[32] bin/godot.linuxbsd.editor.x86_64() [0x4adb85a] (/home/hugo/Documents/Git/godotengine/godot/./core/object/callable_method_pointer.h:104)
[33] bin/godot.linuxbsd.editor.x86_64() [0x946669b] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/callable.cpp:57)
[34] bin/godot.linuxbsd.editor.x86_64() [0x99a52bd] (/home/hugo/Documents/Git/godotengine/godot/./core/object/object.cpp:1188)
[35] bin/godot.linuxbsd.editor.x86_64() [0x5ae3ba8] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/node.cpp:3924)
[36] bin/godot.linuxbsd.editor.x86_64() [0x359de88] (/home/hugo/Documents/Git/godotengine/godot/./core/object/object.h:936)
[37] bin/godot.linuxbsd.editor.x86_64() [0x5ca6209] (/home/hugo/Documents/Git/godotengine/godot/./scene/gui/base_button.cpp:138)
[38] bin/godot.linuxbsd.editor.x86_64() [0x5ca6a95] (/home/hugo/Documents/Git/godotengine/godot/./scene/gui/base_button.cpp:171)
[39] bin/godot.linuxbsd.editor.x86_64() [0x5ca5bbb] (/home/hugo/Documents/Git/godotengine/godot/./scene/gui/base_button.cpp:68 (discriminator 2))
[40] bin/godot.linuxbsd.editor.x86_64() [0x5da3a0a] (/home/hugo/Documents/Git/godotengine/godot/./scene/gui/control.cpp:1830)
[41] bin/godot.linuxbsd.editor.x86_64() [0x5baf927] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/viewport.cpp:1571)
[42] bin/godot.linuxbsd.editor.x86_64() [0x5bb1620] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/viewport.cpp:1837 (discriminator 2))
[43] bin/godot.linuxbsd.editor.x86_64() [0x5bbd884] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/viewport.cpp:3259 (discriminator 2))
[44] bin/godot.linuxbsd.editor.x86_64() [0x5bec96d] (/home/hugo/Documents/Git/godotengine/godot/./scene/main/window.cpp:1680)
[45] bin/godot.linuxbsd.editor.x86_64() [0x5ca2824] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:304 (discriminator 2))
[46] bin/godot.linuxbsd.editor.x86_64() [0x5c8fbd4] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:419)
[47] bin/godot.linuxbsd.editor.x86_64() [0x5c76dac] (/home/hugo/Documents/Git/godotengine/godot/./core/object/callable_method_pointer.h:104)
[48] bin/godot.linuxbsd.editor.x86_64() [0x946669b] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/callable.cpp:57)
[49] bin/godot.linuxbsd.editor.x86_64() [0x2b17c35] (/home/hugo/Documents/Git/godotengine/godot/./core/variant/variant.h:867)
[50] bin/godot.linuxbsd.editor.x86_64() [0x2aff29a] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/x11/display_server_x11.cpp:4063 (discriminator 1))
[51] bin/godot.linuxbsd.editor.x86_64() [0x2afef90] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/x11/display_server_x11.cpp:4040)
[52] bin/godot.linuxbsd.editor.x86_64() [0x93c985c] (/home/hugo/Documents/Git/godotengine/godot/./core/input/input.cpp:803)
[53] bin/godot.linuxbsd.editor.x86_64() [0x93cae2c] (/home/hugo/Documents/Git/godotengine/godot/./core/input/input.cpp:1084)
[54] bin/godot.linuxbsd.editor.x86_64() [0x2b05383] (/home/hugo/Documents/Git/godotengine/godot/./core/templates/local_vector.h:339)
[55] bin/godot.linuxbsd.editor.x86_64() [0x2ad4f48] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/os_linuxbsd.cpp:960)
[56] bin/godot.linuxbsd.editor.x86_64() [0x2aca431] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[57] /lib64/libc.so.6(+0x2a088) [0x7f48f8734088] (??:0)
[58] /lib64/libc.so.6(__libc_start_main+0x8b) [0x7f48f873414b] (??:0)
[59] bin/godot.linuxbsd.editor.x86_64() [0x2aca225] (??:?)
-- END OF BACKTRACE --
```

### After

```
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.4.dev.custom_build (1bd740d18d714f815486b04bf4c6154ef6c355d9)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib64/libc.so.6(+0x40d00) [0x7fb5a2c4fd00] (??:0)
[2] bin/godot.linuxbsd.editor.x86_64() [0x6a132c2] (/home/hugo/Documents/Git/godotengine/godot/core/templates/hash_map.h:100)
[3] bin/godot.linuxbsd.editor.x86_64() [0x69adac2] (/home/hugo/Documents/Git/godotengine/godot/core/templates/hash_map.h:310)
[4] bin/godot.linuxbsd.editor.x86_64() [0x501deca] (/home/hugo/Documents/Git/godotengine/godot/core/string/string_name.h:187)
[5] bin/godot.linuxbsd.editor.x86_64() [0x50a2ae0] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:304 (discriminator 2))
[6] bin/godot.linuxbsd.editor.x86_64() [0x509ef5b] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:419)
[7] bin/godot.linuxbsd.editor.x86_64() [0x5090d26] (/home/hugo/Documents/Git/godotengine/godot/core/object/callable_method_pointer.h:104)
[8] bin/godot.linuxbsd.editor.x86_64() [0x9466677] (/home/hugo/Documents/Git/godotengine/godot/core/variant/callable.cpp:57)
[9] bin/godot.linuxbsd.editor.x86_64() [0x9998f01] (/home/hugo/Documents/Git/godotengine/godot/core/object/message_queue.cpp:221)
[10] bin/godot.linuxbsd.editor.x86_64() [0x99992af] (/home/hugo/Documents/Git/godotengine/godot/core/object/message_queue.cpp:270)
[11] bin/godot.linuxbsd.editor.x86_64() [0x5b8c1a0] (/home/hugo/Documents/Git/godotengine/godot/scene/main/scene_tree.cpp:540)
[12] bin/godot.linuxbsd.editor.x86_64() [0x2bb9696] (/home/hugo/Documents/Git/godotengine/godot/main/main.cpp:4177 (discriminator 3))
[13] bin/godot.linuxbsd.editor.x86_64() [0x4aeabbf] (/home/hugo/Documents/Git/godotengine/godot/editor/progress_dialog.cpp:135)
[14] bin/godot.linuxbsd.editor.x86_64() [0x4aeb5fb] (/home/hugo/Documents/Git/godotengine/godot/editor/progress_dialog.cpp:223)
[15] bin/godot.linuxbsd.editor.x86_64() [0x47dbb34] (/home/hugo/Documents/Git/godotengine/godot/editor/editor_node.cpp:4910)
[16] bin/godot.linuxbsd.editor.x86_64() [0x43316f8] (/home/hugo/Documents/Git/godotengine/godot/editor/editor_node.h:959)
[17] bin/godot.linuxbsd.editor.x86_64() [0x47e8e22] (/home/hugo/Documents/Git/godotengine/godot/editor/editor_node.cpp:6292 (discriminator 5))
[18] bin/godot.linuxbsd.editor.x86_64() [0x47b598a] (/home/hugo/Documents/Git/godotengine/godot/editor/editor_node.cpp:1093)
[19] bin/godot.linuxbsd.editor.x86_64() [0x4890df2] (/home/hugo/Documents/Git/godotengine/godot/core/templates/vector.h:291)
[20] bin/godot.linuxbsd.editor.x86_64() [0x4885318] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:419)
[21] bin/godot.linuxbsd.editor.x86_64() [0x486ab6c] (/home/hugo/Documents/Git/godotengine/godot/core/object/callable_method_pointer.h:104)
[22] bin/godot.linuxbsd.editor.x86_64() [0x9466677] (/home/hugo/Documents/Git/godotengine/godot/core/variant/callable.cpp:57)
[23] bin/godot.linuxbsd.editor.x86_64() [0x99a527d] (/home/hugo/Documents/Git/godotengine/godot/core/object/object.cpp:1188)
[24] bin/godot.linuxbsd.editor.x86_64() [0x5ae3b84] (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:3924)
[25] bin/godot.linuxbsd.editor.x86_64() [0x46e3cc9] (/home/hugo/Documents/Git/godotengine/godot/core/object/object.h:936)
[26] bin/godot.linuxbsd.editor.x86_64() [0x46797ad] (/home/hugo/Documents/Git/godotengine/godot/core/templates/vector.h:291)
[27] bin/godot.linuxbsd.editor.x86_64() [0x4a9a708] (/home/hugo/Documents/Git/godotengine/godot/editor/import_dock.cpp:691)
[28] bin/godot.linuxbsd.editor.x86_64() [0x4a98960] (/home/hugo/Documents/Git/godotengine/godot/editor/import_dock.cpp:583)
[29] bin/godot.linuxbsd.editor.x86_64() [0x4a97c00] (/home/hugo/Documents/Git/godotengine/godot/editor/import_dock.cpp:535)
[30] bin/godot.linuxbsd.editor.x86_64() [0x4ae3892] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:309)
[31] bin/godot.linuxbsd.editor.x86_64() [0x4ae14ed] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:419)
[32] bin/godot.linuxbsd.editor.x86_64() [0x4adb836] (/home/hugo/Documents/Git/godotengine/godot/core/object/callable_method_pointer.h:104)
[33] bin/godot.linuxbsd.editor.x86_64() [0x9466677] (/home/hugo/Documents/Git/godotengine/godot/core/variant/callable.cpp:57)
[34] bin/godot.linuxbsd.editor.x86_64() [0x99a527d] (/home/hugo/Documents/Git/godotengine/godot/core/object/object.cpp:1188)
[35] bin/godot.linuxbsd.editor.x86_64() [0x5ae3b84] (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:3924)
[36] bin/godot.linuxbsd.editor.x86_64() [0x359de64] (/home/hugo/Documents/Git/godotengine/godot/core/object/object.h:936)
[37] bin/godot.linuxbsd.editor.x86_64() [0x5ca61e5] (/home/hugo/Documents/Git/godotengine/godot/scene/gui/base_button.cpp:138)
[38] bin/godot.linuxbsd.editor.x86_64() [0x5ca6a71] (/home/hugo/Documents/Git/godotengine/godot/scene/gui/base_button.cpp:171)
[39] bin/godot.linuxbsd.editor.x86_64() [0x5ca5b97] (/home/hugo/Documents/Git/godotengine/godot/scene/gui/base_button.cpp:68 (discriminator 2))
[40] bin/godot.linuxbsd.editor.x86_64() [0x5da39e6] (/home/hugo/Documents/Git/godotengine/godot/scene/gui/control.cpp:1830)
[41] bin/godot.linuxbsd.editor.x86_64() [0x5baf903] (/home/hugo/Documents/Git/godotengine/godot/scene/main/viewport.cpp:1571)
[42] bin/godot.linuxbsd.editor.x86_64() [0x5bb15fc] (/home/hugo/Documents/Git/godotengine/godot/scene/main/viewport.cpp:1837 (discriminator 2))
[43] bin/godot.linuxbsd.editor.x86_64() [0x5bbd860] (/home/hugo/Documents/Git/godotengine/godot/scene/main/viewport.cpp:3259 (discriminator 2))
[44] bin/godot.linuxbsd.editor.x86_64() [0x5bec949] (/home/hugo/Documents/Git/godotengine/godot/scene/main/window.cpp:1680)
[45] bin/godot.linuxbsd.editor.x86_64() [0x5ca2800] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:304 (discriminator 2))
[46] bin/godot.linuxbsd.editor.x86_64() [0x5c8fbb0] (/home/hugo/Documents/Git/godotengine/godot/core/variant/binder_common.h:419)
[47] bin/godot.linuxbsd.editor.x86_64() [0x5c76d88] (/home/hugo/Documents/Git/godotengine/godot/core/object/callable_method_pointer.h:104)
[48] bin/godot.linuxbsd.editor.x86_64() [0x9466677] (/home/hugo/Documents/Git/godotengine/godot/core/variant/callable.cpp:57)
[49] bin/godot.linuxbsd.editor.x86_64() [0x2b17c11] (/home/hugo/Documents/Git/godotengine/godot/core/variant/variant.h:867)
[50] bin/godot.linuxbsd.editor.x86_64() [0x2aff276] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/x11/display_server_x11.cpp:4063 (discriminator 1))
[51] bin/godot.linuxbsd.editor.x86_64() [0x2afef6c] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/x11/display_server_x11.cpp:4040)
[52] bin/godot.linuxbsd.editor.x86_64() [0x93c9838] (/home/hugo/Documents/Git/godotengine/godot/core/input/input.cpp:803)
[53] bin/godot.linuxbsd.editor.x86_64() [0x93cae08] (/home/hugo/Documents/Git/godotengine/godot/core/input/input.cpp:1084)
[54] bin/godot.linuxbsd.editor.x86_64() [0x2b0535f] (/home/hugo/Documents/Git/godotengine/godot/core/templates/local_vector.h:339)
[55] bin/godot.linuxbsd.editor.x86_64() [0x2ad4f24] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/os_linuxbsd.cpp:960)
[56] bin/godot.linuxbsd.editor.x86_64() [0x2aca431] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[57] /lib64/libc.so.6(+0x2a088) [0x7fb5a2c39088] (??:0)
[58] /lib64/libc.so.6(__libc_start_main+0x8b) [0x7fb5a2c3914b] (??:0)
[59] bin/godot.linuxbsd.editor.x86_64() [0x2aca225] (??:?)
-- END OF BACKTRACE --
```
