### PR TITLE
Improve error messages for invalid rendering drivers/methods on the command line

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2175,7 +2175,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (rendering_method != "forward_plus" &&
 				rendering_method != "mobile" &&
 				rendering_method != "gl_compatibility") {
-			OS::get_singleton()->print("Unknown renderer name '%s', aborting. Valid options are: %s\n", rendering_method.utf8().get_data(), renderer_hints.utf8().get_data());
+			OS::get_singleton()->print("Unknown rendering method '%s', aborting.\nValid options are ",
+					rendering_method.utf8().get_data());
+
+			const Vector<String> rendering_method_hints = renderer_hints.split(",");
+			for (int i = 0; i < rendering_method_hints.size(); i++) {
+				if (i == rendering_method_hints.size() - 1) {
+					OS::get_singleton()->print(" and ");
+				} else if (i != 0) {
+					OS::get_singleton()->print(", ");
+				}
+				OS::get_singleton()->print("'%s'", rendering_method_hints[i].utf8().get_data());
+			}
+
+			OS::get_singleton()->print(".\n");
 			goto error;
 		}
 	}
@@ -2201,12 +2214,25 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			OS::get_singleton()->print("Unknown rendering driver '%s', aborting.\nValid options are ",
 					rendering_driver.utf8().get_data());
 
+			// Deduplicate driver entries, as a rendering driver may be supported by several display servers.
+			Vector<String> unique_rendering_drivers;
 			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 				Vector<String> r_drivers = DisplayServer::get_create_function_rendering_drivers(i);
 
 				for (int d = 0; d < r_drivers.size(); d++) {
-					OS::get_singleton()->print("'%s', ", r_drivers[d].utf8().get_data());
+					if (!unique_rendering_drivers.has(r_drivers[d])) {
+						unique_rendering_drivers.append(r_drivers[d]);
+					}
 				}
+			}
+
+			for (int i = 0; i < unique_rendering_drivers.size(); i++) {
+				if (i == unique_rendering_drivers.size() - 1) {
+					OS::get_singleton()->print(" and ");
+				} else if (i != 0) {
+					OS::get_singleton()->print(", ");
+				}
+				OS::get_singleton()->print("'%s'", unique_rendering_drivers[i].utf8().get_data());
 			}
 
 			OS::get_singleton()->print(".\n");


### PR DESCRIPTION
- Deduplicate rendering driver names.
- Tweak grammar and punctuation to be consistent across both messages.
- Use "rendering method" terminology in the relevant error message.

## Preview

*Linux X11 is used for this demonstration.*

### Before

```
--rendering-driver unknown:

Unknown rendering driver 'unknown', aborting.
Valid options are 'vulkan', 'opengl3', 'opengl3_es', 'vulkan', 'opengl3', 'opengl3_es', 'dummy', .

--rendering-method unknown:

Unknown renderer name 'unknown', aborting. Valid options are: forward_plus,mobile,gl_compatibility
```

### After

```
--rendering-driver unknown:

Unknown rendering driver 'unknown', aborting.
Valid options are 'vulkan', 'opengl3', 'opengl3_es' and 'dummy'.

--rendering-method unknown:

Unknown rendering method 'unknown', aborting.
Valid options are 'forward_plus', 'mobile' and 'gl_compatibility'.
```
