### PR TITLE
Fix some differences between ShapeCast2D and ShapeCast3D documentation

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -15,7 +15,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject2D] node.
+				Adds a collision exception so the shape does not report collisions with the specified node.
 			</description>
 		</method>
 		<method name="add_exception_rid">
@@ -35,19 +35,19 @@
 			<return type="void" />
 			<description>
 				Updates the collision information for the shape immediately, without waiting for the next [code]_physics_process[/code] call. Use this method, for example, when the shape or its parent has changed state.
-				[b]Note:[/b] [code]enabled == true[/code] is not required for this to work.
+				[b]Note:[/b] Setting [member enabled] to [code]true[/code] is not required for this to work.
 			</description>
 		</method>
 		<method name="get_closest_collision_safe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
+				Returns the fraction from this cast's origin to its [member target_position] of how far the shape can move without triggering a collision, as a value between [code]0.0[/code] and [code]1.0[/code].
 			</description>
 		</method>
 		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+				Returns the fraction from this cast's origin to its [member target_position] of how far the shape must move to trigger a collision, as a value between [code]0.0[/code] and [code]1.0[/code].
 				In ideal conditions this would be the same as [method get_closest_collision_safe_fraction], however shape casting is calculated in discrete steps, so the precise point of collision can occur between two calculated positions.
 			</description>
 		</method>
@@ -97,7 +97,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the collision point of one of the multiple collisions at [param index] where the shape intersects the colliding object.
-				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
+				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
 		<method name="is_colliding" qualifiers="const">
@@ -110,7 +110,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Removes a collision exception so the shape does report collisions with the specified [CollisionObject2D] node.
+				Removes a collision exception so the shape does report collisions with the specified node.
 			</description>
 		</method>
 		<method name="remove_exception_rid">
@@ -137,7 +137,7 @@
 			If [code]true[/code], collisions with [PhysicsBody2D]s will be reported.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
-			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.
+			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="collision_result" type="Array" setter="" getter="get_collision_result" default="[]">
 			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState2D.get_rest_info] method.
@@ -155,10 +155,10 @@
 			The number of intersections can be limited with this parameter, to reduce the processing time.
 		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
-			The [Shape2D]-derived shape to be used for collision queries.
+			The shape to be used for collision queries.
 		</member>
 		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2(0, 50)">
-			The shape's destination point, relative to this node's [code]position[/code].
+			The shape's destination point, relative to this node's [member Node2D.position].
 		</member>
 	</members>
 </class>

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -15,7 +15,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="CollisionObject3D" />
 			<description>
-				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject3D] node.
+				Adds a collision exception so the shape does not report collisions with the specified node.
 			</description>
 		</method>
 		<method name="add_exception_rid">
@@ -28,26 +28,26 @@
 		<method name="clear_exceptions">
 			<return type="void" />
 			<description>
-				Removes all collision exceptions for this [ShapeCast3D].
+				Removes all collision exceptions for this shape.
 			</description>
 		</method>
 		<method name="force_shapecast_update">
 			<return type="void" />
 			<description>
 				Updates the collision information for the shape immediately, without waiting for the next [code]_physics_process[/code] call. Use this method, for example, when the shape or its parent has changed state.
-				[b]Note:[/b] [code]enabled == true[/code] is not required for this to work.
+				[b]Note:[/b] Setting [member enabled] to [code]true[/code] is not required for this to work.
 			</description>
 		</method>
 		<method name="get_closest_collision_safe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction from the [ShapeCast3D]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
+				Returns the fraction from this cast's origin to its [member target_position] of how far the shape can move without triggering a collision, as a value between [code]0.0[/code] and [code]1.0[/code].
 			</description>
 		</method>
 		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction from the [ShapeCast3D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+				Returns the fraction from this cast's origin to its [member target_position] of how far the shape must move to trigger a collision, as a value between [code]0.0[/code] and [code]1.0[/code].
 				In ideal conditions this would be the same as [method get_closest_collision_safe_fraction], however shape casting is calculated in discrete steps, so the precise point of collision can occur between two calculated positions.
 			</description>
 		</method>
@@ -97,7 +97,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the collision point of one of the multiple collisions at [param index] where the shape intersects the colliding object.
-				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
+				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
 		<method name="is_colliding" qualifiers="const">
@@ -110,7 +110,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="CollisionObject3D" />
 			<description>
-				Removes a collision exception so the shape does report collisions with the specified [CollisionObject3D] node.
+				Removes a collision exception so the shape does report collisions with the specified node.
 			</description>
 		</method>
 		<method name="remove_exception_rid">
@@ -166,10 +166,10 @@
 			The number of intersections can be limited with this parameter, to reduce the processing time.
 		</member>
 		<member name="shape" type="Shape3D" setter="set_shape" getter="get_shape">
-			The [Shape3D]-derived shape to be used for collision queries.
+			The shape to be used for collision queries.
 		</member>
 		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, -1, 0)">
-			The shape's destination point, relative to this node's [code]position[/code].
+			The shape's destination point, relative to this node's [member Node3D.position].
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
See also https://github.com/godotengine/godot/pull/95758

The PR's title is pretty self explanatory. There have been a few changes done to **ShapeCast3D**, but not applied to **ShapeCast2D**, or viceversa. This PR fixes that, and tweaks a few other miscellaneous things on the way.

Ideally, the two class references should be as identical as they can reasonably be. Even **one small** difference (2D vs 3D) adds a whole new string to translate.