### PR TITLE
Add a small, baseline WebAssembly interpreter

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -277,6 +277,7 @@ opts.Add(BoolVariable("builtin_pcre2_with_jit", "Use JIT compiler for the built-
 opts.Add(BoolVariable("builtin_recastnavigation", "Use the built-in Recast navigation library", True))
 opts.Add(BoolVariable("builtin_rvo2_2d", "Use the built-in RVO2 2D library", True))
 opts.Add(BoolVariable("builtin_rvo2_3d", "Use the built-in RVO2 3D library", True))
+opts.Add(BoolVariable("builtin_wasm3", "Use the built-in wasm3 library", True))
 opts.Add(BoolVariable("builtin_xatlas", "Use the built-in xatlas library", True))
 opts.Add(BoolVariable("builtin_zlib", "Use the built-in zlib library", True))
 opts.Add(BoolVariable("builtin_zstd", "Use the built-in Zstd library", True))

--- a/modules/wasm/SCsub
+++ b/modules/wasm/SCsub
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_wasm3 = env_modules.Clone()
+
+# Thirdparty source files
+
+thirdparty_obj = []
+
+# Recast Thirdparty source files
+if env["builtin_wasm3"]:
+    thirdparty_dir = "#thirdparty/wasm3/source/"
+    thirdparty_sources = [
+        # "m3_api_libc.c",
+        # "m3_api_meta_wasi.c",
+        # "m3_api_tracer.c",
+        # "m3_api_uvwasi.c",
+        # "m3_api_wasi.c",
+        "m3_bind.c",
+        "m3_code.c",
+        "m3_compile.c",
+        "m3_core.c",
+        "m3_env.c",
+        "m3_exec.c",
+        "m3_function.c",
+        "m3_info.c",
+        "m3_module.c",
+        "m3_parse.c",
+    ]
+    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
+    env_wasm3.Prepend(CPPPATH=[thirdparty_dir], CPPDEFINES=[])
+    if env_wasm3.msvc:  # MSVC
+        env_wasm3.Append(CCFLAGS=["/wd4200"])
+
+    env_thirdparty = env_wasm3.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+
+
+env.modules_sources += thirdparty_obj
+
+# Godot source files
+
+module_obj = []
+
+env_wasm3.add_source_files(module_obj, "*.cpp")
+
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/wasm/config.py
+++ b/modules/wasm/config.py
@@ -1,0 +1,14 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return ["Wasm", "WasmMemory"]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/wasm/doc_classes/Wasm.xml
+++ b/modules/wasm/doc_classes/Wasm.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Wasm" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		An instance of a Wasm module.
+		Before being able to be used, the module must be compiled and instantiated.
+	</brief_description>
+	<description>
+		An instance of a Wasm module.
+		Before being able to be used, the module must be compiled and instantiated.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="compile">
+			<return type="int" enum="Error" />
+			<param index="0" name="bytecode" type="PackedByteArray" />
+			<description>
+				Compile the Wasm module provided Wasm binary [param bytecode].
+				This must be called before instantiating the module. Alternatively, the module can be compiled and instantiated in a single step with [method load].
+			</description>
+		</method>
+		<method name="function" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="args" type="Array" />
+			<description>
+				Call an exported function of the instantiated Wasm module.
+				The [param args] argument array must be provided even if no arguments are required.
+				Returns either a single float or integer.
+			</description>
+		</method>
+		<method name="global" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Access an exported global of the instantiated Wasm module.
+				Returns either a single float or integer.
+			</description>
+		</method>
+		<method name="inspect" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Inspect the imports, exports, and memories of a compiled Wasm module.
+				Note that this may be called before instantiating a module and may even inform the imports provided [method instantiate].
+			</description>
+		</method>
+		<method name="instantiate">
+			<return type="int" enum="Error" />
+			<param index="0" name="import_map" type="Dictionary" />
+			<description>
+				Instantiate a compiled Wasm module.
+				Before this can be called, the module must be compiled via [method compile].
+				Imported functions can be provided in [param import_map] in the form [code]var imports = { "functions": { "index.function": [self, "function"] } }[/code].
+				Each key of the [code]import_map.functions[/code] should be an array whose members are the object containing the imported method and a string specifying the name of the method.
+				Alternatively, the module can be compiled and instantiated in a single step with [method load].
+			</description>
+		</method>
+		<method name="load">
+			<return type="int" enum="Error" />
+			<param index="0" name="bytecode" type="PackedByteArray" />
+			<param index="1" name="import_map" type="Dictionary" />
+			<description>
+				Compile and instantiate a Wasm module in a single step.
+				Equivalent to calling [method compile] and [method instantiate].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="memory" type="WasmMemory" setter="" getter="get_memory">
+			A [StreamPeer] interface for interacting with the memory of an instantiated Wasm module.
+		</member>
+	</members>
+</class>

--- a/modules/wasm/doc_classes/WasmMemory.xml
+++ b/modules/wasm/doc_classes/WasmMemory.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="WasmMemory" inherits="StreamPeer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A [StreamPeer] interface for interacting with the memory of an instantiated Wasm module.
+	</brief_description>
+	<description>
+		A [StreamPeer] interface for interacting with the memory of an instantiated Wasm module.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_position" qualifiers="const">
+			<return type="int" />
+			<description>
+				The current memory offset of the [StreamPeer].
+				Can be set using [method seek].
+			</description>
+		</method>
+		<method name="grow">
+			<return type="int" enum="Error" />
+			<param index="0" name="pages" type="int" />
+			<description>
+				Grow the memory by a number of pages.
+				Per WebAssembly specifications, each memory page is 65536 bytes.
+				Memory can be created by an instantiated Wasm module or created externally to be used as a module import.
+				External memory must be grown before being used as a module import.
+				Allocated memory can not be decreased i.e. grown by a negative number of pages.
+			</description>
+		</method>
+		<method name="inspect" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Inspect the minimum, maximum, and current memory sizes.
+			</description>
+		</method>
+		<method name="seek">
+			<return type="WasmMemory" />
+			<param index="0" name="p_pos" type="int" />
+			<description>
+				Set the memory offset of the [StreamPeer].
+				Values will be read from and written to this position.
+				This method returns the [code]SteamPeerWasm[/code] and can therefore be chained e.g. [code]wasm.memory.seek(0).get_64()[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/wasm/register_types.cpp
+++ b/modules/wasm/register_types.cpp
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "wasm.h"
+
+void initialize_wasm_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	GDREGISTER_CLASS(Wasm);
+	GDREGISTER_CLASS(WasmMemory);
+}
+
+void uninitialize_wasm_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}

--- a/modules/wasm/register_types.h
+++ b/modules/wasm/register_types.h
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_wasm_module(ModuleInitializationLevel p_level);
+void uninitialize_wasm_module(ModuleInitializationLevel p_level);

--- a/modules/wasm/wasm.cpp
+++ b/modules/wasm/wasm.cpp
@@ -1,0 +1,466 @@
+/**************************************************************************/
+/*  wasm.cpp                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "core/os/memory.h"
+
+#include "wasm.h"
+#include "wasm3.h"
+
+#include "m3_env.h"
+
+Wasm::Wasm() :
+		module(nullptr) {
+	env = m3_NewEnvironment();
+	runtime = m3_NewRuntime(env, 10000, nullptr);
+	memiface = Ref(memnew(WasmMemory));
+	memiface->runtime = runtime;
+}
+
+Wasm::~Wasm() {
+	m3_FreeRuntime(runtime);
+	m3_FreeEnvironment(env);
+}
+
+Error Wasm::compile(PackedByteArray bytecode) {
+	code = bytecode;
+	M3Result result = m3_ParseModule(env, &module, code.ptr(), code.size());
+	ERR_FAIL_COND_V_EDMSG(result, ERR_COMPILATION_FAILED, result);
+
+	result = m3_LoadModule(runtime, module);
+	if (result) {
+		m3_FreeModule(module);
+		module = nullptr;
+		ERR_PRINT_ED(result);
+		return ERR_COMPILATION_FAILED;
+	}
+
+	return OK;
+}
+
+inline Variant dict_safe_get(const Dictionary &d, String k, Variant e) {
+	return d.has(k) && d[k].get_type() == e.get_type() ? d[k] : e;
+}
+
+const void *handler(IM3Runtime runtime, IM3ImportContext ctx, uint64_t *sp, void *mem) {
+	Callable *callable = (Callable *)ctx->userdata;
+	Array args;
+	for (uint32_t i = 0; i < m3_GetArgCount(ctx->function); ++i) {
+		switch (m3_GetArgType(ctx->function, i)) {
+			case c_m3Type_none:
+				ERR_PRINT_ED("Argument was type none");
+				break;
+			case c_m3Type_unknown:
+				ERR_PRINT_ED("Argument was type unknown");
+				break;
+			case c_m3Type_i32:
+				args.push_back(*((int32_t *)(sp + i)));
+				break;
+			case c_m3Type_i64:
+				args.push_back(*((int64_t *)(sp + i)));
+				break;
+			case c_m3Type_f32:
+				args.push_back(*((float *)(sp + i)));
+				break;
+			case c_m3Type_f64:
+				args.push_back(*((double *)(sp + i)));
+				break;
+		}
+	}
+
+	Variant result = callable->callv(args);
+
+	if (m3_GetRetCount(ctx->function) > 0) {
+		switch (m3_GetRetType(ctx->function, 0)) {
+			case c_m3Type_none:
+				ERR_PRINT_ED("Return was type none");
+				break;
+			case c_m3Type_unknown:
+				ERR_PRINT_ED("Return was type unknown");
+				break;
+			case c_m3Type_i32:
+				*((int32_t *)(sp + 0)) = (int32_t)result;
+				break;
+			case c_m3Type_i64:
+				*((int64_t *)(sp + 0)) = (int64_t)result;
+				break;
+			case c_m3Type_f32:
+				*((float *)(sp + 0)) = (float)result;
+				break;
+			case c_m3Type_f64:
+				*((double *)(sp + 0)) = (double)result;
+				break;
+		}
+	}
+	return m3Err_none;
+}
+
+Error Wasm::instantiate(const Dictionary import_map) {
+	ERR_FAIL_COND_V_MSG(!module, Error::ERR_UNCONFIGURED, "No module loaded");
+	const Dictionary &functions = dict_safe_get(import_map, "functions", Dictionary());
+	for (const auto &key : functions.keys()) {
+		String name = key;
+		Vector<String> parts = name.split(".");
+		Variant value = functions[key];
+		if (value.is_array() && value.operator Array().size() == 2) {
+			Array arr = value;
+			Object *o = arr[0];
+			if (!o || arr[1].get_type() != Variant::STRING) {
+				ERR_PRINT_ED("Argument to input isn't that callable");
+				continue;
+			}
+			callables.push_back(Callable(o->get_instance_id(), (String)arr[1]));
+		} else if (value.get_type() == Variant::CALLABLE) {
+			callables.push_back(value.operator Callable());
+		} else {
+			ERR_PRINT_ED("Argument to import doesn't look callable");
+		}
+		M3Result result = m3_LinkRawFunctionEx(module, parts[0].utf8().ptr(), parts[1].utf8().ptr(), nullptr, handler, callables.back());
+		if (result) {
+			ERR_PRINT_ED(result);
+		}
+	}
+	return OK;
+}
+
+Error Wasm::load(PackedByteArray bytecode, const Dictionary import_map) {
+	Error err = compile(bytecode);
+	if (err != OK) {
+		return err;
+	}
+	return instantiate(import_map);
+}
+
+Dictionary Wasm::inspect() const {
+	Dictionary result;
+
+	if (!module) {
+		return result;
+	}
+
+	Dictionary memory;
+	Dictionary import_functions, export_globals, export_functions;
+
+	for (uint32_t func_num = 0; func_num < module->numFunctions; ++func_num) {
+		Array args;
+		for (uint32_t i = 0; i < m3_GetArgCount(&module->functions[func_num]); ++i) {
+			switch (m3_GetArgType(&module->functions[func_num], i)) {
+				case c_m3Type_none:
+					ERR_PRINT_ED("Argument was type none");
+					break;
+				case c_m3Type_unknown:
+					ERR_PRINT_ED("Argument was type unknown");
+					break;
+				case c_m3Type_i32:
+					args.push_back(Variant::INT);
+					break;
+				case c_m3Type_i64:
+					args.push_back(Variant::INT);
+					break;
+				case c_m3Type_f32:
+					args.push_back(Variant::FLOAT);
+					break;
+				case c_m3Type_f64:
+					args.push_back(Variant::FLOAT);
+					break;
+			}
+		}
+
+		Array ret;
+		for (uint32_t i = 0; i < m3_GetRetCount(&module->functions[func_num]); ++i) {
+			switch (m3_GetRetType(&module->functions[func_num], i)) {
+				case c_m3Type_none:
+					ERR_PRINT_ED("Argument was type none");
+					break;
+				case c_m3Type_unknown:
+					ERR_PRINT_ED("Argument was type unknown");
+					break;
+				case c_m3Type_i32:
+					ret.push_back(Variant::INT);
+					break;
+				case c_m3Type_i64:
+					ret.push_back(Variant::INT);
+					break;
+				case c_m3Type_f32:
+					ret.push_back(Variant::FLOAT);
+					break;
+				case c_m3Type_f64:
+					ret.push_back(Variant::FLOAT);
+					break;
+			}
+		}
+
+		Array tuple;
+		tuple.push_back(args);
+		tuple.push_back(ret);
+
+		export_functions[m3_GetFunctionName(&module->functions[func_num])] = tuple;
+	}
+
+	memory["min"] = 0;
+	memory["max"] = m3_GetMemorySize(runtime);
+
+	result["memory"] = memory;
+	result["import_functions"] = import_functions;
+	result["export_globals"] = export_globals;
+	result["export_functions"] = export_functions;
+
+	return result;
+}
+
+Variant Wasm::function(String name, Array args) const {
+	Array ret;
+	IM3Function func;
+	M3Result result = m3_FindFunction(&func, runtime, name.ascii().get_data());
+	ERR_FAIL_COND_V_EDMSG(result, Variant(), result);
+
+	uint32_t arg_count = m3_GetArgCount(func);
+	uint32_t ret_count = m3_GetRetCount(func);
+	if (static_cast<uint32_t>(args.size()) < arg_count) {
+		return "not enough arguments";
+	} else if (static_cast<uint32_t>(args.size()) > arg_count) {
+		return "too many arguments";
+	}
+
+	const void **ptrs = (const void **)memalloc(sizeof(void *) * arg_count);
+	uint8_t *data = (uint8_t *)memalloc(8 * arg_count);
+	uint8_t *write = data;
+
+	for (uint32_t i = 0; i < arg_count; ++i) {
+		ptrs[i] = write;
+		switch (m3_GetArgType(func, i)) {
+			case c_m3Type_none:
+				ERR_FAIL_V_EDMSG(Variant(), "Argument had none as argument type");
+			case c_m3Type_unknown:
+				ERR_FAIL_V_EDMSG(Variant(), "Argument had unknown as argument type");
+			case c_m3Type_i32: {
+				int32_t vi32 = args[i];
+				memcpy(write, &vi32, sizeof(i32));
+				write += sizeof(vi32);
+				break;
+			}
+			case c_m3Type_i64: {
+				int64_t vi64 = args[i];
+				memcpy(write, &vi64, sizeof(i64));
+				write += sizeof(vi64);
+				break;
+			}
+			case c_m3Type_f32: {
+				float vf32 = args[i];
+				memcpy(write, &vf32, sizeof(f32));
+				write += sizeof(vf32);
+				break;
+			}
+			case c_m3Type_f64: {
+				double vf64 = args[i];
+				memcpy(write, &vf64, sizeof(f64));
+				write += sizeof(vf64);
+				break;
+			}
+		}
+	}
+
+	result = m3_Call(func, arg_count, ptrs);
+	if (result) {
+		goto fail;
+	}
+
+	for (uint32_t i = 0; i < ret_count; i++) {
+		ptrs[i] = data + i * sizeof(int64_t);
+	}
+
+	result = m3_GetResults(func, ret_count, ptrs);
+	if (result) {
+		goto fail;
+	}
+
+	for (uint32_t i = 0; i < ret_count; ++i) {
+		switch (m3_GetRetType(func, i)) {
+			case c_m3Type_i32:
+				ret.push_back(*(i32 *)ptrs[i]);
+				break;
+			case c_m3Type_i64:
+				ret.push_back(*(i64 *)ptrs[i]);
+				break;
+			case c_m3Type_f32:
+				ret.push_back(*(f32 *)ptrs[i]);
+				break;
+			case c_m3Type_f64:
+				ret.push_back(*(f64 *)ptrs[i]);
+				break;
+			default:
+				ERR_PRINT_ED("Return value had unknown type");
+		}
+	}
+
+	memfree(ptrs);
+	memfree(data);
+
+	if (ret_count == 0) {
+		return Variant();
+	} else if (ret_count == 1) {
+		return ret[0];
+	} else {
+		return ret;
+	}
+fail:
+	memfree(ptrs);
+	memfree(data);
+	ERR_FAIL_V_EDMSG(Variant(), result);
+}
+
+Variant Wasm::global(String name) const {
+	ERR_FAIL_COND_V_EDMSG(runtime->modules == nullptr, Variant(), "No modules loaded");
+	IM3Global g = m3_FindGlobal(runtime->modules, name.ascii().get_data());
+
+	M3TaggedValue tagged;
+	M3Result err = m3_GetGlobal(g, &tagged);
+	if (err) {
+		return Variant();
+	}
+
+	switch (tagged.type) {
+		case c_m3Type_i32:
+			return tagged.value.i32;
+		case c_m3Type_i64:
+			return tagged.value.i64;
+		case c_m3Type_f32:
+			return tagged.value.f32;
+		case c_m3Type_f64:
+			return tagged.value.f64;
+		default:
+			return Variant();
+	}
+}
+
+Ref<WasmMemory> Wasm::get_memory() const {
+	return memiface;
+}
+
+void Wasm::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("compile", "bytecode"), &Wasm::compile);
+	ClassDB::bind_method(D_METHOD("instantiate", "import_map"), &Wasm::instantiate);
+	ClassDB::bind_method(D_METHOD("load", "bytecode", "import_map"), &Wasm::load);
+	ClassDB::bind_method(D_METHOD("inspect"), &Wasm::inspect);
+	ClassDB::bind_method(D_METHOD("global", "name"), &Wasm::global);
+	ClassDB::bind_method(D_METHOD("function", "name", "args"), &Wasm::function);
+	ClassDB::bind_method(D_METHOD("get_memory"), &Wasm::get_memory);
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "memory"), "", "get_memory");
+}
+
+/////////////////////
+
+Error WasmMemory::get_data(uint8_t *buffer, int32_t bytes) {
+	ERR_FAIL_COND_V_EDMSG(!runtime, Error::ERR_UNCONFIGURED, "No Memory Attached");
+	uint32_t size;
+	uint8_t *mem = m3_GetMemory(runtime, &size, 0);
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset + bytes - 1, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+
+	memcpy(buffer, mem + offset, bytes);
+	offset += bytes;
+	return OK;
+}
+
+Error WasmMemory::get_partial_data(uint8_t *buffer, int32_t bytes, int32_t &received) {
+	ERR_FAIL_COND_V_EDMSG(!runtime, Error::ERR_UNCONFIGURED, "No Memory Attached");
+	uint32_t size;
+	uint8_t *mem = m3_GetMemory(runtime, &size, 0);
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset + bytes - 1, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+
+	memcpy(buffer, mem + offset, bytes);
+	offset += bytes;
+	received = bytes;
+	return OK;
+}
+
+Error WasmMemory::put_data(const uint8_t *buffer, int32_t bytes) {
+	ERR_FAIL_COND_V_EDMSG(!runtime, Error::ERR_UNCONFIGURED, "No Memory Attached");
+	uint32_t size;
+	uint8_t *mem = m3_GetMemory(runtime, &size, 0);
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset + bytes - 1, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+
+	memcpy(mem + offset, buffer, bytes);
+	offset += bytes;
+	return OK;
+}
+
+Error WasmMemory::put_partial_data(const uint8_t *buffer, int bytes, int32_t &sent) {
+	ERR_FAIL_COND_V_EDMSG(!runtime, Error::ERR_UNCONFIGURED, "No Memory Attached");
+	uint32_t size;
+	uint8_t *mem = m3_GetMemory(runtime, &size, 0);
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+	ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(offset + bytes - 1, size, Error::ERR_PARAMETER_RANGE_ERROR, "Access outside memory");
+
+	memcpy(mem + offset, buffer, bytes);
+	offset += bytes;
+	sent = bytes;
+	return OK;
+}
+
+Ref<WasmMemory> WasmMemory::seek(int p_pos) {
+	Ref<WasmMemory> ref = Ref<WasmMemory>(this);
+	ERR_FAIL_COND_V_MSG(p_pos < 0, ref, "Invalid memory position");
+	offset = p_pos;
+	return ref;
+}
+
+Error WasmMemory::grow(uint32_t pages) {
+	ERR_FAIL_COND_V_EDMSG(!runtime, Error::ERR_UNCONFIGURED, "No Memory Attached");
+	IM3Memory memory = &runtime->memory;
+	if (pages > 0) {
+		uint32_t requiredPages = memory->numPages + pages;
+		M3Result r = ResizeMemory(runtime, requiredPages);
+		ERR_FAIL_COND_V_EDMSG(r, Error::ERR_OUT_OF_MEMORY, r);
+	}
+	return OK;
+}
+
+Dictionary WasmMemory::inspect() const {
+	Dictionary result;
+
+	return result;
+}
+
+uint32_t WasmMemory::get_position() const {
+	return offset;
+}
+
+int32_t WasmMemory::get_available_bytes() const {
+	return 0;
+}
+
+void WasmMemory::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("inspect"), &WasmMemory::inspect);
+	ClassDB::bind_method(D_METHOD("grow", "pages"), &WasmMemory::grow);
+	ClassDB::bind_method(D_METHOD("seek", "p_pos"), &WasmMemory::seek);
+	ClassDB::bind_method(D_METHOD("get_position"), &WasmMemory::get_position);
+}

--- a/modules/wasm/wasm.h
+++ b/modules/wasm/wasm.h
@@ -1,0 +1,91 @@
+/**************************************************************************/
+/*  wasm.h                                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/stream_peer.h"
+#include "core/object/ref_counted.h"
+#include "core/os/memory.h"
+#include "core/variant/variant_utility.h"
+
+class WasmMemory : public StreamPeer {
+	GDCLASS(WasmMemory, StreamPeer);
+	friend class Wasm;
+
+public:
+	Dictionary inspect() const;
+	Error grow(uint32_t pages);
+	Ref<WasmMemory> seek(int p_pos);
+	uint32_t get_position() const;
+
+	Error get_data(uint8_t *buffer, int32_t bytes) override;
+	Error get_partial_data(uint8_t *buffer, int32_t bytes, int32_t &received) override;
+	Error put_data(const uint8_t *buffer, int32_t bytes) override;
+	Error put_partial_data(const uint8_t *buffer, int bytes, int32_t &sent) override;
+	int32_t get_available_bytes() const override;
+
+protected:
+	static void _bind_methods();
+
+private:
+	struct M3Runtime *runtime;
+	uint32_t offset;
+	WasmMemory() :
+			runtime(nullptr), offset(0) {}
+	WasmMemory(M3Runtime *_runtime) :
+			runtime(_runtime), offset(0) {}
+};
+
+class Wasm : public RefCounted {
+	GDCLASS(Wasm, RefCounted);
+
+public:
+	Wasm();
+	~Wasm();
+
+	Error compile(PackedByteArray bytecode);
+	Error instantiate(const Dictionary import_map);
+	Error load(PackedByteArray bytecode, const Dictionary import_map);
+	Dictionary inspect() const;
+	Variant function(String name, Array args) const;
+	Variant global(String name) const;
+	Ref<WasmMemory> get_memory() const;
+
+protected:
+	static void _bind_methods();
+
+private:
+	PackedByteArray code;
+	List<Callable> callables;
+	struct M3Environment *env;
+	struct M3Runtime *runtime;
+	struct M3Module *module;
+	Ref<WasmMemory> memiface;
+};

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -300,6 +300,10 @@ def configure(env: "SConsEnvironment"):
         # No pkgconfig file so far, hardcode expected lib name.
         env.Append(LIBS=["embree4"])
 
+    if not env["builtin_wasm3"]:
+        # No pkgconfig file so far, hardcode expected lib name.
+        env.Append(LIBS=["wasm3"])
+
     if not env["builtin_openxr"]:
         env.ParseConfig("pkg-config openxr --cflags --libs")
 

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1064,6 +1064,17 @@ Patches:
 - `0003-VMA-add-vmaCalculateLazilyAllocatedBytes.patch` (GH-99257)
 
 
+## wasm3
+
+- Upstream: https://github.com/wasm3/wasm3
+- Version: master (35b5e2fb53c5cbc1ff3d7e42c381cd7cfa14f308, 2024)
+- License: MIT
+
+Files extracted from upstream source:
+
+- `source/*.{c,h}`
+- `source/extra/wasi_core.h`
+- `LICENSE`
 
 ## wayland
 

--- a/thirdparty/wasm3/LICENSE
+++ b/thirdparty/wasm3/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Steven Massey, Volodymyr Shymanskyy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/wasm3/source/extra/wasi_core.h
+++ b/thirdparty/wasm3/source/extra/wasi_core.h
@@ -1,0 +1,2764 @@
+/**
+ * THIS FILE IS AUTO-GENERATED from the following files:
+ *   typenames.witx, wasi_snapshot_preview1.witx
+ *
+ * @file
+ * This file describes the [WASI] interface, consisting of functions, types,
+ * and defined values (macros).
+ *
+ * The interface described here is greatly inspired by [CloudABI]'s clean,
+ * thoughtfully-designed, capability-oriented, POSIX-style API.
+ *
+ * [CloudABI]: https://github.com/NuxiNL/cloudlibc
+ * [WASI]: https://github.com/WebAssembly/WASI/
+ */
+
+/*
+ * File origin:
+ *   https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/api.h
+ * Revision:
+ *   2c2fc9a2fddd0927a66f1c142e65c8dab6f5c5d7
+ * License:
+ *   CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+ *   https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+#ifndef __wasi_api_h
+#define __wasi_api_h
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+// Hacks alert
+#undef _Static_assert
+#define _Static_assert(...)
+#undef _Noreturn
+#define _Noreturn
+#endif
+
+_Static_assert(_Alignof(int8_t) == 1, "non-wasi data layout");
+_Static_assert(_Alignof(uint8_t) == 1, "non-wasi data layout");
+_Static_assert(_Alignof(int16_t) == 2, "non-wasi data layout");
+_Static_assert(_Alignof(uint16_t) == 2, "non-wasi data layout");
+_Static_assert(_Alignof(int32_t) == 4, "non-wasi data layout");
+_Static_assert(_Alignof(uint32_t) == 4, "non-wasi data layout");
+_Static_assert(_Alignof(int64_t) == 8, "non-wasi data layout");
+_Static_assert(_Alignof(uint64_t) == 8, "non-wasi data layout");
+// _Static_assert(_Alignof(void*) == 4, "non-wasi data layout");
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// TODO: Encoding this in witx.
+#define __WASI_DIRCOOKIE_START (UINT64_C(0))
+// typedef __SIZE_TYPE__ __wasi_size_t;
+typedef uint32_t __wasi_size_t; // fixme for wasm64
+
+// _Static_assert(sizeof(__wasi_size_t) == 4, "witx calculated size");
+// _Static_assert(_Alignof(__wasi_size_t) == 4, "witx calculated align");
+
+/**
+ * Non-negative file size or length of a region within a file.
+ */
+typedef uint64_t __wasi_filesize_t;
+
+_Static_assert(sizeof(__wasi_filesize_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_filesize_t) == 8, "witx calculated align");
+
+/**
+ * Timestamp in nanoseconds.
+ */
+typedef uint64_t __wasi_timestamp_t;
+
+_Static_assert(sizeof(__wasi_timestamp_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_timestamp_t) == 8, "witx calculated align");
+
+/**
+ * Identifiers for clocks.
+ */
+typedef uint32_t __wasi_clockid_t;
+
+/**
+ * The clock measuring real time. Time value zero corresponds with
+ * 1970-01-01T00:00:00Z.
+ */
+#define __WASI_CLOCKID_REALTIME (UINT32_C(0))
+
+/**
+ * The store-wide monotonic clock, which is defined as a clock measuring
+ * real time, whose value cannot be adjusted and which cannot have negative
+ * clock jumps. The epoch of this clock is undefined. The absolute time
+ * value of this clock therefore has no meaning.
+ */
+#define __WASI_CLOCKID_MONOTONIC (UINT32_C(1))
+
+/**
+ * The CPU-time clock associated with the current process.
+ */
+#define __WASI_CLOCKID_PROCESS_CPUTIME_ID (UINT32_C(2))
+
+/**
+ * The CPU-time clock associated with the current thread.
+ */
+#define __WASI_CLOCKID_THREAD_CPUTIME_ID (UINT32_C(3))
+
+_Static_assert(sizeof(__wasi_clockid_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_clockid_t) == 4, "witx calculated align");
+
+/**
+ * Error codes returned by functions.
+ * Not all of these error codes are returned by the functions provided by this
+ * API; some are used in higher-level library layers, and others are provided
+ * merely for alignment with POSIX.
+ */
+typedef uint16_t __wasi_errno_t;
+
+/**
+ * No error occurred. System call completed successfully.
+ */
+#define __WASI_ERRNO_SUCCESS (UINT16_C(0))
+
+/**
+ * Argument list too long.
+ */
+#define __WASI_ERRNO_2BIG (UINT16_C(1))
+
+/**
+ * Permission denied.
+ */
+#define __WASI_ERRNO_ACCES (UINT16_C(2))
+
+/**
+ * Address in use.
+ */
+#define __WASI_ERRNO_ADDRINUSE (UINT16_C(3))
+
+/**
+ * Address not available.
+ */
+#define __WASI_ERRNO_ADDRNOTAVAIL (UINT16_C(4))
+
+/**
+ * Address family not supported.
+ */
+#define __WASI_ERRNO_AFNOSUPPORT (UINT16_C(5))
+
+/**
+ * Resource unavailable, or operation would block.
+ */
+#define __WASI_ERRNO_AGAIN (UINT16_C(6))
+
+/**
+ * Connection already in progress.
+ */
+#define __WASI_ERRNO_ALREADY (UINT16_C(7))
+
+/**
+ * Bad file descriptor.
+ */
+#define __WASI_ERRNO_BADF (UINT16_C(8))
+
+/**
+ * Bad message.
+ */
+#define __WASI_ERRNO_BADMSG (UINT16_C(9))
+
+/**
+ * Device or resource busy.
+ */
+#define __WASI_ERRNO_BUSY (UINT16_C(10))
+
+/**
+ * Operation canceled.
+ */
+#define __WASI_ERRNO_CANCELED (UINT16_C(11))
+
+/**
+ * No child processes.
+ */
+#define __WASI_ERRNO_CHILD (UINT16_C(12))
+
+/**
+ * Connection aborted.
+ */
+#define __WASI_ERRNO_CONNABORTED (UINT16_C(13))
+
+/**
+ * Connection refused.
+ */
+#define __WASI_ERRNO_CONNREFUSED (UINT16_C(14))
+
+/**
+ * Connection reset.
+ */
+#define __WASI_ERRNO_CONNRESET (UINT16_C(15))
+
+/**
+ * Resource deadlock would occur.
+ */
+#define __WASI_ERRNO_DEADLK (UINT16_C(16))
+
+/**
+ * Destination address required.
+ */
+#define __WASI_ERRNO_DESTADDRREQ (UINT16_C(17))
+
+/**
+ * Mathematics argument out of domain of function.
+ */
+#define __WASI_ERRNO_DOM (UINT16_C(18))
+
+/**
+ * Reserved.
+ */
+#define __WASI_ERRNO_DQUOT (UINT16_C(19))
+
+/**
+ * File exists.
+ */
+#define __WASI_ERRNO_EXIST (UINT16_C(20))
+
+/**
+ * Bad address.
+ */
+#define __WASI_ERRNO_FAULT (UINT16_C(21))
+
+/**
+ * File too large.
+ */
+#define __WASI_ERRNO_FBIG (UINT16_C(22))
+
+/**
+ * Host is unreachable.
+ */
+#define __WASI_ERRNO_HOSTUNREACH (UINT16_C(23))
+
+/**
+ * Identifier removed.
+ */
+#define __WASI_ERRNO_IDRM (UINT16_C(24))
+
+/**
+ * Illegal byte sequence.
+ */
+#define __WASI_ERRNO_ILSEQ (UINT16_C(25))
+
+/**
+ * Operation in progress.
+ */
+#define __WASI_ERRNO_INPROGRESS (UINT16_C(26))
+
+/**
+ * Interrupted function.
+ */
+#define __WASI_ERRNO_INTR (UINT16_C(27))
+
+/**
+ * Invalid argument.
+ */
+#define __WASI_ERRNO_INVAL (UINT16_C(28))
+
+/**
+ * I/O error.
+ */
+#define __WASI_ERRNO_IO (UINT16_C(29))
+
+/**
+ * Socket is connected.
+ */
+#define __WASI_ERRNO_ISCONN (UINT16_C(30))
+
+/**
+ * Is a directory.
+ */
+#define __WASI_ERRNO_ISDIR (UINT16_C(31))
+
+/**
+ * Too many levels of symbolic links.
+ */
+#define __WASI_ERRNO_LOOP (UINT16_C(32))
+
+/**
+ * File descriptor value too large.
+ */
+#define __WASI_ERRNO_MFILE (UINT16_C(33))
+
+/**
+ * Too many links.
+ */
+#define __WASI_ERRNO_MLINK (UINT16_C(34))
+
+/**
+ * Message too large.
+ */
+#define __WASI_ERRNO_MSGSIZE (UINT16_C(35))
+
+/**
+ * Reserved.
+ */
+#define __WASI_ERRNO_MULTIHOP (UINT16_C(36))
+
+/**
+ * Filename too long.
+ */
+#define __WASI_ERRNO_NAMETOOLONG (UINT16_C(37))
+
+/**
+ * Network is down.
+ */
+#define __WASI_ERRNO_NETDOWN (UINT16_C(38))
+
+/**
+ * Connection aborted by network.
+ */
+#define __WASI_ERRNO_NETRESET (UINT16_C(39))
+
+/**
+ * Network unreachable.
+ */
+#define __WASI_ERRNO_NETUNREACH (UINT16_C(40))
+
+/**
+ * Too many files open in system.
+ */
+#define __WASI_ERRNO_NFILE (UINT16_C(41))
+
+/**
+ * No buffer space available.
+ */
+#define __WASI_ERRNO_NOBUFS (UINT16_C(42))
+
+/**
+ * No such device.
+ */
+#define __WASI_ERRNO_NODEV (UINT16_C(43))
+
+/**
+ * No such file or directory.
+ */
+#define __WASI_ERRNO_NOENT (UINT16_C(44))
+
+/**
+ * Executable file format error.
+ */
+#define __WASI_ERRNO_NOEXEC (UINT16_C(45))
+
+/**
+ * No locks available.
+ */
+#define __WASI_ERRNO_NOLCK (UINT16_C(46))
+
+/**
+ * Reserved.
+ */
+#define __WASI_ERRNO_NOLINK (UINT16_C(47))
+
+/**
+ * Not enough space.
+ */
+#define __WASI_ERRNO_NOMEM (UINT16_C(48))
+
+/**
+ * No message of the desired type.
+ */
+#define __WASI_ERRNO_NOMSG (UINT16_C(49))
+
+/**
+ * Protocol not available.
+ */
+#define __WASI_ERRNO_NOPROTOOPT (UINT16_C(50))
+
+/**
+ * No space left on device.
+ */
+#define __WASI_ERRNO_NOSPC (UINT16_C(51))
+
+/**
+ * Function not supported.
+ */
+#define __WASI_ERRNO_NOSYS (UINT16_C(52))
+
+/**
+ * The socket is not connected.
+ */
+#define __WASI_ERRNO_NOTCONN (UINT16_C(53))
+
+/**
+ * Not a directory or a symbolic link to a directory.
+ */
+#define __WASI_ERRNO_NOTDIR (UINT16_C(54))
+
+/**
+ * Directory not empty.
+ */
+#define __WASI_ERRNO_NOTEMPTY (UINT16_C(55))
+
+/**
+ * State not recoverable.
+ */
+#define __WASI_ERRNO_NOTRECOVERABLE (UINT16_C(56))
+
+/**
+ * Not a socket.
+ */
+#define __WASI_ERRNO_NOTSOCK (UINT16_C(57))
+
+/**
+ * Not supported, or operation not supported on socket.
+ */
+#define __WASI_ERRNO_NOTSUP (UINT16_C(58))
+
+/**
+ * Inappropriate I/O control operation.
+ */
+#define __WASI_ERRNO_NOTTY (UINT16_C(59))
+
+/**
+ * No such device or address.
+ */
+#define __WASI_ERRNO_NXIO (UINT16_C(60))
+
+/**
+ * Value too large to be stored in data type.
+ */
+#define __WASI_ERRNO_OVERFLOW (UINT16_C(61))
+
+/**
+ * Previous owner died.
+ */
+#define __WASI_ERRNO_OWNERDEAD (UINT16_C(62))
+
+/**
+ * Operation not permitted.
+ */
+#define __WASI_ERRNO_PERM (UINT16_C(63))
+
+/**
+ * Broken pipe.
+ */
+#define __WASI_ERRNO_PIPE (UINT16_C(64))
+
+/**
+ * Protocol error.
+ */
+#define __WASI_ERRNO_PROTO (UINT16_C(65))
+
+/**
+ * Protocol not supported.
+ */
+#define __WASI_ERRNO_PROTONOSUPPORT (UINT16_C(66))
+
+/**
+ * Protocol wrong type for socket.
+ */
+#define __WASI_ERRNO_PROTOTYPE (UINT16_C(67))
+
+/**
+ * Result too large.
+ */
+#define __WASI_ERRNO_RANGE (UINT16_C(68))
+
+/**
+ * Read-only file system.
+ */
+#define __WASI_ERRNO_ROFS (UINT16_C(69))
+
+/**
+ * Invalid seek.
+ */
+#define __WASI_ERRNO_SPIPE (UINT16_C(70))
+
+/**
+ * No such process.
+ */
+#define __WASI_ERRNO_SRCH (UINT16_C(71))
+
+/**
+ * Reserved.
+ */
+#define __WASI_ERRNO_STALE (UINT16_C(72))
+
+/**
+ * Connection timed out.
+ */
+#define __WASI_ERRNO_TIMEDOUT (UINT16_C(73))
+
+/**
+ * Text file busy.
+ */
+#define __WASI_ERRNO_TXTBSY (UINT16_C(74))
+
+/**
+ * Cross-device link.
+ */
+#define __WASI_ERRNO_XDEV (UINT16_C(75))
+
+/**
+ * Extension: Capabilities insufficient.
+ */
+#define __WASI_ERRNO_NOTCAPABLE (UINT16_C(76))
+
+_Static_assert(sizeof(__wasi_errno_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_errno_t) == 2, "witx calculated align");
+
+/**
+ * File descriptor rights, determining which actions may be performed.
+ */
+typedef uint64_t __wasi_rights_t;
+
+/**
+ * The right to invoke `fd_datasync`.
+ * If `path_open` is set, includes the right to invoke
+ * `path_open` with `fdflags::dsync`.
+ */
+#define __WASI_RIGHTS_FD_DATASYNC (UINT64_C(1))
+
+/**
+ * The right to invoke `fd_read` and `sock_recv`.
+ * If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
+ */
+#define __WASI_RIGHTS_FD_READ (UINT64_C(2))
+
+/**
+ * The right to invoke `fd_seek`. This flag implies `rights::fd_tell`.
+ */
+#define __WASI_RIGHTS_FD_SEEK (UINT64_C(4))
+
+/**
+ * The right to invoke `fd_fdstat_set_flags`.
+ */
+#define __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS (UINT64_C(8))
+
+/**
+ * The right to invoke `fd_sync`.
+ * If `path_open` is set, includes the right to invoke
+ * `path_open` with `fdflags::rsync` and `fdflags::dsync`.
+ */
+#define __WASI_RIGHTS_FD_SYNC (UINT64_C(16))
+
+/**
+ * The right to invoke `fd_seek` in such a way that the file offset
+ * remains unaltered (i.e., `whence::cur` with offset zero), or to
+ * invoke `fd_tell`.
+ */
+#define __WASI_RIGHTS_FD_TELL (UINT64_C(32))
+
+/**
+ * The right to invoke `fd_write` and `sock_send`.
+ * If `rights::fd_seek` is set, includes the right to invoke `fd_pwrite`.
+ */
+#define __WASI_RIGHTS_FD_WRITE (UINT64_C(64))
+
+/**
+ * The right to invoke `fd_advise`.
+ */
+#define __WASI_RIGHTS_FD_ADVISE (UINT64_C(128))
+
+/**
+ * The right to invoke `fd_allocate`.
+ */
+#define __WASI_RIGHTS_FD_ALLOCATE (UINT64_C(256))
+
+/**
+ * The right to invoke `path_create_directory`.
+ */
+#define __WASI_RIGHTS_PATH_CREATE_DIRECTORY (UINT64_C(512))
+
+/**
+ * If `path_open` is set, the right to invoke `path_open` with `oflags::creat`.
+ */
+#define __WASI_RIGHTS_PATH_CREATE_FILE (UINT64_C(1024))
+
+/**
+ * The right to invoke `path_link` with the file descriptor as the
+ * source directory.
+ */
+#define __WASI_RIGHTS_PATH_LINK_SOURCE (UINT64_C(2048))
+
+/**
+ * The right to invoke `path_link` with the file descriptor as the
+ * target directory.
+ */
+#define __WASI_RIGHTS_PATH_LINK_TARGET (UINT64_C(4096))
+
+/**
+ * The right to invoke `path_open`.
+ */
+#define __WASI_RIGHTS_PATH_OPEN (UINT64_C(8192))
+
+/**
+ * The right to invoke `fd_readdir`.
+ */
+#define __WASI_RIGHTS_FD_READDIR (UINT64_C(16384))
+
+/**
+ * The right to invoke `path_readlink`.
+ */
+#define __WASI_RIGHTS_PATH_READLINK (UINT64_C(32768))
+
+/**
+ * The right to invoke `path_rename` with the file descriptor as the source directory.
+ */
+#define __WASI_RIGHTS_PATH_RENAME_SOURCE (UINT64_C(65536))
+
+/**
+ * The right to invoke `path_rename` with the file descriptor as the target directory.
+ */
+#define __WASI_RIGHTS_PATH_RENAME_TARGET (UINT64_C(131072))
+
+/**
+ * The right to invoke `path_filestat_get`.
+ */
+#define __WASI_RIGHTS_PATH_FILESTAT_GET (UINT64_C(262144))
+
+/**
+ * The right to change a file's size (there is no `path_filestat_set_size`).
+ * If `path_open` is set, includes the right to invoke `path_open` with `oflags::trunc`.
+ */
+#define __WASI_RIGHTS_PATH_FILESTAT_SET_SIZE (UINT64_C(524288))
+
+/**
+ * The right to invoke `path_filestat_set_times`.
+ */
+#define __WASI_RIGHTS_PATH_FILESTAT_SET_TIMES (UINT64_C(1048576))
+
+/**
+ * The right to invoke `fd_filestat_get`.
+ */
+#define __WASI_RIGHTS_FD_FILESTAT_GET (UINT64_C(2097152))
+
+/**
+ * The right to invoke `fd_filestat_set_size`.
+ */
+#define __WASI_RIGHTS_FD_FILESTAT_SET_SIZE (UINT64_C(4194304))
+
+/**
+ * The right to invoke `fd_filestat_set_times`.
+ */
+#define __WASI_RIGHTS_FD_FILESTAT_SET_TIMES (UINT64_C(8388608))
+
+/**
+ * The right to invoke `path_symlink`.
+ */
+#define __WASI_RIGHTS_PATH_SYMLINK (UINT64_C(16777216))
+
+/**
+ * The right to invoke `path_remove_directory`.
+ */
+#define __WASI_RIGHTS_PATH_REMOVE_DIRECTORY (UINT64_C(33554432))
+
+/**
+ * The right to invoke `path_unlink_file`.
+ */
+#define __WASI_RIGHTS_PATH_UNLINK_FILE (UINT64_C(67108864))
+
+/**
+ * If `rights::fd_read` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_read`.
+ * If `rights::fd_write` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_write`.
+ */
+#define __WASI_RIGHTS_POLL_FD_READWRITE (UINT64_C(134217728))
+
+/**
+ * The right to invoke `sock_shutdown`.
+ */
+#define __WASI_RIGHTS_SOCK_SHUTDOWN (UINT64_C(268435456))
+
+_Static_assert(sizeof(__wasi_rights_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_rights_t) == 8, "witx calculated align");
+
+/**
+ * A file descriptor index.
+ */
+typedef uint32_t __wasi_fd_t;
+
+_Static_assert(sizeof(__wasi_fd_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_fd_t) == 4, "witx calculated align");
+
+/**
+ * A region of memory for scatter/gather reads.
+ */
+typedef struct __wasi_iovec_t {
+    /**
+     * The address of the buffer to be filled.
+     */
+    uint8_t * buf;
+
+    /**
+     * The length of the buffer to be filled.
+     */
+    __wasi_size_t buf_len;
+
+} __wasi_iovec_t;
+
+// _Static_assert(sizeof(__wasi_iovec_t) == 8, "witx calculated size");
+// _Static_assert(_Alignof(__wasi_iovec_t) == 4, "witx calculated align");
+// _Static_assert(offsetof(__wasi_iovec_t, buf) == 0, "witx calculated offset");
+// _Static_assert(offsetof(__wasi_iovec_t, buf_len) == 4, "witx calculated offset");
+
+/**
+ * A region of memory for scatter/gather writes.
+ */
+typedef struct __wasi_ciovec_t {
+    /**
+     * The address of the buffer to be written.
+     */
+    const uint8_t * buf;
+
+    /**
+     * The length of the buffer to be written.
+     */
+    __wasi_size_t buf_len;
+
+} __wasi_ciovec_t;
+
+// _Static_assert(sizeof(__wasi_ciovec_t) == 8, "witx calculated size");
+// _Static_assert(_Alignof(__wasi_ciovec_t) == 4, "witx calculated align");
+// _Static_assert(offsetof(__wasi_ciovec_t, buf) == 0, "witx calculated offset");
+// _Static_assert(offsetof(__wasi_ciovec_t, buf_len) == 4, "witx calculated offset");
+
+/**
+ * Relative offset within a file.
+ */
+typedef int64_t __wasi_filedelta_t;
+
+_Static_assert(sizeof(__wasi_filedelta_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_filedelta_t) == 8, "witx calculated align");
+
+/**
+ * The position relative to which to set the offset of the file descriptor.
+ */
+typedef uint8_t __wasi_whence_t;
+
+/**
+ * Seek relative to start-of-file.
+ */
+#define __WASI_WHENCE_SET (UINT8_C(0))
+
+/**
+ * Seek relative to current position.
+ */
+#define __WASI_WHENCE_CUR (UINT8_C(1))
+
+/**
+ * Seek relative to end-of-file.
+ */
+#define __WASI_WHENCE_END (UINT8_C(2))
+
+_Static_assert(sizeof(__wasi_whence_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_whence_t) == 1, "witx calculated align");
+
+/**
+ * A reference to the offset of a directory entry.
+ *
+ * The value 0 signifies the start of the directory.
+ */
+typedef uint64_t __wasi_dircookie_t;
+
+_Static_assert(sizeof(__wasi_dircookie_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_dircookie_t) == 8, "witx calculated align");
+
+/**
+ * The type for the $d_namlen field of $dirent.
+ */
+typedef uint32_t __wasi_dirnamlen_t;
+
+_Static_assert(sizeof(__wasi_dirnamlen_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_dirnamlen_t) == 4, "witx calculated align");
+
+/**
+ * File serial number that is unique within its file system.
+ */
+typedef uint64_t __wasi_inode_t;
+
+_Static_assert(sizeof(__wasi_inode_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_inode_t) == 8, "witx calculated align");
+
+/**
+ * The type of a file descriptor or file.
+ */
+typedef uint8_t __wasi_filetype_t;
+
+/**
+ * The type of the file descriptor or file is unknown or is different from any of the other types specified.
+ */
+#define __WASI_FILETYPE_UNKNOWN (UINT8_C(0))
+
+/**
+ * The file descriptor or file refers to a block device inode.
+ */
+#define __WASI_FILETYPE_BLOCK_DEVICE (UINT8_C(1))
+
+/**
+ * The file descriptor or file refers to a character device inode.
+ */
+#define __WASI_FILETYPE_CHARACTER_DEVICE (UINT8_C(2))
+
+/**
+ * The file descriptor or file refers to a directory inode.
+ */
+#define __WASI_FILETYPE_DIRECTORY (UINT8_C(3))
+
+/**
+ * The file descriptor or file refers to a regular file inode.
+ */
+#define __WASI_FILETYPE_REGULAR_FILE (UINT8_C(4))
+
+/**
+ * The file descriptor or file refers to a datagram socket.
+ */
+#define __WASI_FILETYPE_SOCKET_DGRAM (UINT8_C(5))
+
+/**
+ * The file descriptor or file refers to a byte-stream socket.
+ */
+#define __WASI_FILETYPE_SOCKET_STREAM (UINT8_C(6))
+
+/**
+ * The file refers to a symbolic link inode.
+ */
+#define __WASI_FILETYPE_SYMBOLIC_LINK (UINT8_C(7))
+
+_Static_assert(sizeof(__wasi_filetype_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_filetype_t) == 1, "witx calculated align");
+
+/**
+ * A directory entry.
+ */
+typedef struct __wasi_dirent_t {
+    /**
+     * The offset of the next directory entry stored in this directory.
+     */
+    __wasi_dircookie_t d_next;
+
+    /**
+     * The serial number of the file referred to by this directory entry.
+     */
+    __wasi_inode_t d_ino;
+
+    /**
+     * The length of the name of the directory entry.
+     */
+    __wasi_dirnamlen_t d_namlen;
+
+    /**
+     * The type of the file referred to by this directory entry.
+     */
+    __wasi_filetype_t d_type;
+
+} __wasi_dirent_t;
+
+_Static_assert(sizeof(__wasi_dirent_t) == 24, "witx calculated size");
+_Static_assert(_Alignof(__wasi_dirent_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_dirent_t, d_next) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_dirent_t, d_ino) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_dirent_t, d_namlen) == 16, "witx calculated offset");
+_Static_assert(offsetof(__wasi_dirent_t, d_type) == 20, "witx calculated offset");
+
+/**
+ * File or memory access pattern advisory information.
+ */
+typedef uint8_t __wasi_advice_t;
+
+/**
+ * The application has no advice to give on its behavior with respect to the specified data.
+ */
+#define __WASI_ADVICE_NORMAL (UINT8_C(0))
+
+/**
+ * The application expects to access the specified data sequentially from lower offsets to higher offsets.
+ */
+#define __WASI_ADVICE_SEQUENTIAL (UINT8_C(1))
+
+/**
+ * The application expects to access the specified data in a random order.
+ */
+#define __WASI_ADVICE_RANDOM (UINT8_C(2))
+
+/**
+ * The application expects to access the specified data in the near future.
+ */
+#define __WASI_ADVICE_WILLNEED (UINT8_C(3))
+
+/**
+ * The application expects that it will not access the specified data in the near future.
+ */
+#define __WASI_ADVICE_DONTNEED (UINT8_C(4))
+
+/**
+ * The application expects to access the specified data once and then not reuse it thereafter.
+ */
+#define __WASI_ADVICE_NOREUSE (UINT8_C(5))
+
+_Static_assert(sizeof(__wasi_advice_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_advice_t) == 1, "witx calculated align");
+
+/**
+ * File descriptor flags.
+ */
+typedef uint16_t __wasi_fdflags_t;
+
+/**
+ * Append mode: Data written to the file is always appended to the file's end.
+ */
+#define __WASI_FDFLAGS_APPEND (UINT16_C(1))
+
+/**
+ * Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
+ */
+#define __WASI_FDFLAGS_DSYNC (UINT16_C(2))
+
+/**
+ * Non-blocking mode.
+ */
+#define __WASI_FDFLAGS_NONBLOCK (UINT16_C(4))
+
+/**
+ * Synchronized read I/O operations.
+ */
+#define __WASI_FDFLAGS_RSYNC (UINT16_C(8))
+
+/**
+ * Write according to synchronized I/O file integrity completion. In
+ * addition to synchronizing the data stored in the file, the implementation
+ * may also synchronously update the file's metadata.
+ */
+#define __WASI_FDFLAGS_SYNC (UINT16_C(16))
+
+_Static_assert(sizeof(__wasi_fdflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_fdflags_t) == 2, "witx calculated align");
+
+/**
+ * File descriptor attributes.
+ */
+typedef struct __wasi_fdstat_t {
+    /**
+     * File type.
+     */
+    __wasi_filetype_t fs_filetype;
+
+    /**
+     * File descriptor flags.
+     */
+    __wasi_fdflags_t fs_flags;
+
+    /**
+     * Rights that apply to this file descriptor.
+     */
+    __wasi_rights_t fs_rights_base;
+
+    /**
+     * Maximum set of rights that may be installed on new file descriptors that
+     * are created through this file descriptor, e.g., through `path_open`.
+     */
+    __wasi_rights_t fs_rights_inheriting;
+
+} __wasi_fdstat_t;
+
+_Static_assert(sizeof(__wasi_fdstat_t) == 24, "witx calculated size");
+_Static_assert(_Alignof(__wasi_fdstat_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_fdstat_t, fs_filetype) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_fdstat_t, fs_flags) == 2, "witx calculated offset");
+_Static_assert(offsetof(__wasi_fdstat_t, fs_rights_base) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_fdstat_t, fs_rights_inheriting) == 16, "witx calculated offset");
+
+/**
+ * Identifier for a device containing a file system. Can be used in combination
+ * with `inode` to uniquely identify a file or directory in the filesystem.
+ */
+typedef uint64_t __wasi_device_t;
+
+_Static_assert(sizeof(__wasi_device_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_device_t) == 8, "witx calculated align");
+
+/**
+ * Which file time attributes to adjust.
+ */
+typedef uint16_t __wasi_fstflags_t;
+
+/**
+ * Adjust the last data access timestamp to the value stored in `filestat::atim`.
+ */
+#define __WASI_FSTFLAGS_ATIM (UINT16_C(1))
+
+/**
+ * Adjust the last data access timestamp to the time of clock `clockid::realtime`.
+ */
+#define __WASI_FSTFLAGS_ATIM_NOW (UINT16_C(2))
+
+/**
+ * Adjust the last data modification timestamp to the value stored in `filestat::mtim`.
+ */
+#define __WASI_FSTFLAGS_MTIM (UINT16_C(4))
+
+/**
+ * Adjust the last data modification timestamp to the time of clock `clockid::realtime`.
+ */
+#define __WASI_FSTFLAGS_MTIM_NOW (UINT16_C(8))
+
+_Static_assert(sizeof(__wasi_fstflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_fstflags_t) == 2, "witx calculated align");
+
+/**
+ * Flags determining the method of how paths are resolved.
+ */
+typedef uint32_t __wasi_lookupflags_t;
+
+/**
+ * As long as the resolved path corresponds to a symbolic link, it is expanded.
+ */
+#define __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW (UINT32_C(1))
+
+_Static_assert(sizeof(__wasi_lookupflags_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_lookupflags_t) == 4, "witx calculated align");
+
+/**
+ * Open flags used by `path_open`.
+ */
+typedef uint16_t __wasi_oflags_t;
+
+/**
+ * Create file if it does not exist.
+ */
+#define __WASI_OFLAGS_CREAT (UINT16_C(1))
+
+/**
+ * Fail if not a directory.
+ */
+#define __WASI_OFLAGS_DIRECTORY (UINT16_C(2))
+
+/**
+ * Fail if file already exists.
+ */
+#define __WASI_OFLAGS_EXCL (UINT16_C(4))
+
+/**
+ * Truncate file to size 0.
+ */
+#define __WASI_OFLAGS_TRUNC (UINT16_C(8))
+
+_Static_assert(sizeof(__wasi_oflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_oflags_t) == 2, "witx calculated align");
+
+/**
+ * Number of hard links to an inode.
+ */
+typedef uint64_t __wasi_linkcount_t;
+
+_Static_assert(sizeof(__wasi_linkcount_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_linkcount_t) == 8, "witx calculated align");
+
+/**
+ * File attributes.
+ */
+typedef struct __wasi_filestat_t {
+    /**
+     * Device ID of device containing the file.
+     */
+    __wasi_device_t dev;
+
+    /**
+     * File serial number.
+     */
+    __wasi_inode_t ino;
+
+    /**
+     * File type.
+     */
+    __wasi_filetype_t filetype;
+
+    /**
+     * Number of hard links to the file.
+     */
+    __wasi_linkcount_t nlink;
+
+    /**
+     * For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+     */
+    __wasi_filesize_t size;
+
+    /**
+     * Last data access timestamp.
+     */
+    __wasi_timestamp_t atim;
+
+    /**
+     * Last data modification timestamp.
+     */
+    __wasi_timestamp_t mtim;
+
+    /**
+     * Last file status change timestamp.
+     */
+    __wasi_timestamp_t ctim;
+
+} __wasi_filestat_t;
+
+_Static_assert(sizeof(__wasi_filestat_t) == 64, "witx calculated size");
+_Static_assert(_Alignof(__wasi_filestat_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_filestat_t, dev) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, ino) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, filetype) == 16, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, nlink) == 24, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, size) == 32, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, atim) == 40, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, mtim) == 48, "witx calculated offset");
+_Static_assert(offsetof(__wasi_filestat_t, ctim) == 56, "witx calculated offset");
+
+/**
+ * User-provided value that may be attached to objects that is retained when
+ * extracted from the implementation.
+ */
+typedef uint64_t __wasi_userdata_t;
+
+_Static_assert(sizeof(__wasi_userdata_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_userdata_t) == 8, "witx calculated align");
+
+/**
+ * Type of a subscription to an event or its occurrence.
+ */
+typedef uint8_t __wasi_eventtype_t;
+
+/**
+ * The time value of clock `subscription_clock::id` has
+ * reached timestamp `subscription_clock::timeout`.
+ */
+#define __WASI_EVENTTYPE_CLOCK (UINT8_C(0))
+
+/**
+ * File descriptor `subscription_fd_readwrite::file_descriptor` has data
+ * available for reading. This event always triggers for regular files.
+ */
+#define __WASI_EVENTTYPE_FD_READ (UINT8_C(1))
+
+/**
+ * File descriptor `subscription_fd_readwrite::file_descriptor` has capacity
+ * available for writing. This event always triggers for regular files.
+ */
+#define __WASI_EVENTTYPE_FD_WRITE (UINT8_C(2))
+
+_Static_assert(sizeof(__wasi_eventtype_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_eventtype_t) == 1, "witx calculated align");
+
+/**
+ * The state of the file descriptor subscribed to with
+ * `eventtype::fd_read` or `eventtype::fd_write`.
+ */
+typedef uint16_t __wasi_eventrwflags_t;
+
+/**
+ * The peer of this socket has closed or disconnected.
+ */
+#define __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP (UINT16_C(1))
+
+_Static_assert(sizeof(__wasi_eventrwflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_eventrwflags_t) == 2, "witx calculated align");
+
+/**
+ * The contents of an $event when type is `eventtype::fd_read` or
+ * `eventtype::fd_write`.
+ */
+typedef struct __wasi_event_fd_readwrite_t {
+    /**
+     * The number of bytes available for reading or writing.
+     */
+    __wasi_filesize_t nbytes;
+
+    /**
+     * The state of the file descriptor.
+     */
+    __wasi_eventrwflags_t flags;
+
+} __wasi_event_fd_readwrite_t;
+
+_Static_assert(sizeof(__wasi_event_fd_readwrite_t) == 16, "witx calculated size");
+_Static_assert(_Alignof(__wasi_event_fd_readwrite_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_event_fd_readwrite_t, nbytes) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_event_fd_readwrite_t, flags) == 8, "witx calculated offset");
+
+/**
+ * The contents of an $event.
+ */
+typedef union __wasi_event_u_t {
+    /**
+     * When type is `eventtype::fd_read` or `eventtype::fd_write`:
+     */
+    __wasi_event_fd_readwrite_t fd_readwrite;
+
+} __wasi_event_u_t;
+
+_Static_assert(sizeof(__wasi_event_u_t) == 16, "witx calculated size");
+_Static_assert(_Alignof(__wasi_event_u_t) == 8, "witx calculated align");
+
+/**
+ * An event that occurred.
+ */
+typedef struct __wasi_event_t {
+    /**
+     * User-provided value that got attached to `subscription::userdata`.
+     */
+    __wasi_userdata_t userdata;
+
+    /**
+     * If non-zero, an error that occurred while processing the subscription request.
+     */
+    __wasi_errno_t error;
+
+    /**
+     * The type of the event that occurred.
+     */
+    __wasi_eventtype_t type;
+
+    /**
+     * The contents of the event.
+     */
+    __wasi_event_u_t u;
+
+} __wasi_event_t;
+
+_Static_assert(sizeof(__wasi_event_t) == 32, "witx calculated size");
+_Static_assert(_Alignof(__wasi_event_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_event_t, userdata) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_event_t, error) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_event_t, type) == 10, "witx calculated offset");
+_Static_assert(offsetof(__wasi_event_t, u) == 16, "witx calculated offset");
+
+/**
+ * Flags determining how to interpret the timestamp provided in
+ * `subscription_clock::timeout`.
+ */
+typedef uint16_t __wasi_subclockflags_t;
+
+/**
+ * If set, treat the timestamp provided in
+ * `subscription_clock::timeout` as an absolute timestamp of clock
+ * `subscription_clock::id`. If clear, treat the timestamp
+ * provided in `subscription_clock::timeout` relative to the
+ * current time value of clock `subscription_clock::id`.
+ */
+#define __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME (UINT16_C(1))
+
+_Static_assert(sizeof(__wasi_subclockflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_subclockflags_t) == 2, "witx calculated align");
+
+/**
+ * The contents of a $subscription when type is `eventtype::clock`.
+ */
+typedef struct __wasi_subscription_clock_t {
+    /**
+     * The clock against which to compare the timestamp.
+     */
+    __wasi_clockid_t id;
+
+    /**
+     * The absolute or relative timestamp.
+     */
+    __wasi_timestamp_t timeout;
+
+    /**
+     * The amount of time that the implementation may wait additionally
+     * to coalesce with other events.
+     */
+    __wasi_timestamp_t precision;
+
+    /**
+     * Flags specifying whether the timeout is absolute or relative
+     */
+    __wasi_subclockflags_t flags;
+
+} __wasi_subscription_clock_t;
+
+_Static_assert(sizeof(__wasi_subscription_clock_t) == 32, "witx calculated size");
+_Static_assert(_Alignof(__wasi_subscription_clock_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_subscription_clock_t, id) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_subscription_clock_t, timeout) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_subscription_clock_t, precision) == 16, "witx calculated offset");
+_Static_assert(offsetof(__wasi_subscription_clock_t, flags) == 24, "witx calculated offset");
+
+/**
+ * The contents of a $subscription when type is type is
+ * `eventtype::fd_read` or `eventtype::fd_write`.
+ */
+typedef struct __wasi_subscription_fd_readwrite_t {
+    /**
+     * The file descriptor on which to wait for it to become ready for reading or writing.
+     */
+    __wasi_fd_t file_descriptor;
+
+} __wasi_subscription_fd_readwrite_t;
+
+_Static_assert(sizeof(__wasi_subscription_fd_readwrite_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_subscription_fd_readwrite_t) == 4, "witx calculated align");
+_Static_assert(offsetof(__wasi_subscription_fd_readwrite_t, file_descriptor) == 0, "witx calculated offset");
+
+/**
+ * The contents of a $subscription.
+ */
+typedef union __wasi_subscription_u_t {
+    /**
+     * When type is `eventtype::clock`:
+     */
+    __wasi_subscription_clock_t clock;
+
+    /**
+     * When type is `eventtype::fd_read` or `eventtype::fd_write`:
+     */
+    __wasi_subscription_fd_readwrite_t fd_readwrite;
+
+} __wasi_subscription_u_t;
+
+_Static_assert(sizeof(__wasi_subscription_u_t) == 32, "witx calculated size");
+_Static_assert(_Alignof(__wasi_subscription_u_t) == 8, "witx calculated align");
+
+/**
+ * Subscription to an event.
+ */
+typedef struct __wasi_subscription_t {
+    /**
+     * User-provided value that is attached to the subscription in the
+     * implementation and returned through `event::userdata`.
+     */
+    __wasi_userdata_t userdata;
+
+    /**
+     * The type of the event to which to subscribe.
+     */
+    __wasi_eventtype_t type;
+
+    /**
+     * The contents of the subscription.
+     */
+    __wasi_subscription_u_t u;
+
+} __wasi_subscription_t;
+
+_Static_assert(sizeof(__wasi_subscription_t) == 48, "witx calculated size");
+_Static_assert(_Alignof(__wasi_subscription_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_subscription_t, userdata) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_subscription_t, type) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_subscription_t, u) == 16, "witx calculated offset");
+
+/**
+ * Exit code generated by a process when exiting.
+ */
+typedef uint32_t __wasi_exitcode_t;
+
+_Static_assert(sizeof(__wasi_exitcode_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_exitcode_t) == 4, "witx calculated align");
+
+/**
+ * Signal condition.
+ */
+typedef uint8_t __wasi_signal_t;
+
+/**
+ * No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
+ * so this value is reserved.
+ */
+#define __WASI_SIGNAL_NONE (UINT8_C(0))
+
+/**
+ * Hangup.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_HUP (UINT8_C(1))
+
+/**
+ * Terminate interrupt signal.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_INT (UINT8_C(2))
+
+/**
+ * Terminal quit signal.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_QUIT (UINT8_C(3))
+
+/**
+ * Illegal instruction.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_ILL (UINT8_C(4))
+
+/**
+ * Trace/breakpoint trap.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_TRAP (UINT8_C(5))
+
+/**
+ * Process abort signal.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_ABRT (UINT8_C(6))
+
+/**
+ * Access to an undefined portion of a memory object.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_BUS (UINT8_C(7))
+
+/**
+ * Erroneous arithmetic operation.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_FPE (UINT8_C(8))
+
+/**
+ * Kill.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_KILL (UINT8_C(9))
+
+/**
+ * User-defined signal 1.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_USR1 (UINT8_C(10))
+
+/**
+ * Invalid memory reference.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_SEGV (UINT8_C(11))
+
+/**
+ * User-defined signal 2.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_USR2 (UINT8_C(12))
+
+/**
+ * Write on a pipe with no one to read it.
+ * Action: Ignored.
+ */
+#define __WASI_SIGNAL_PIPE (UINT8_C(13))
+
+/**
+ * Alarm clock.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_ALRM (UINT8_C(14))
+
+/**
+ * Termination signal.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_TERM (UINT8_C(15))
+
+/**
+ * Child process terminated, stopped, or continued.
+ * Action: Ignored.
+ */
+#define __WASI_SIGNAL_CHLD (UINT8_C(16))
+
+/**
+ * Continue executing, if stopped.
+ * Action: Continues executing, if stopped.
+ */
+#define __WASI_SIGNAL_CONT (UINT8_C(17))
+
+/**
+ * Stop executing.
+ * Action: Stops executing.
+ */
+#define __WASI_SIGNAL_STOP (UINT8_C(18))
+
+/**
+ * Terminal stop signal.
+ * Action: Stops executing.
+ */
+#define __WASI_SIGNAL_TSTP (UINT8_C(19))
+
+/**
+ * Background process attempting read.
+ * Action: Stops executing.
+ */
+#define __WASI_SIGNAL_TTIN (UINT8_C(20))
+
+/**
+ * Background process attempting write.
+ * Action: Stops executing.
+ */
+#define __WASI_SIGNAL_TTOU (UINT8_C(21))
+
+/**
+ * High bandwidth data is available at a socket.
+ * Action: Ignored.
+ */
+#define __WASI_SIGNAL_URG (UINT8_C(22))
+
+/**
+ * CPU time limit exceeded.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_XCPU (UINT8_C(23))
+
+/**
+ * File size limit exceeded.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_XFSZ (UINT8_C(24))
+
+/**
+ * Virtual timer expired.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_VTALRM (UINT8_C(25))
+
+/**
+ * Profiling timer expired.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_PROF (UINT8_C(26))
+
+/**
+ * Window changed.
+ * Action: Ignored.
+ */
+#define __WASI_SIGNAL_WINCH (UINT8_C(27))
+
+/**
+ * I/O possible.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_POLL (UINT8_C(28))
+
+/**
+ * Power failure.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_PWR (UINT8_C(29))
+
+/**
+ * Bad system call.
+ * Action: Terminates the process.
+ */
+#define __WASI_SIGNAL_SYS (UINT8_C(30))
+
+_Static_assert(sizeof(__wasi_signal_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_signal_t) == 1, "witx calculated align");
+
+/**
+ * Flags provided to `sock_recv`.
+ */
+typedef uint16_t __wasi_riflags_t;
+
+/**
+ * Returns the message without removing it from the socket's receive queue.
+ */
+#define __WASI_RIFLAGS_RECV_PEEK (UINT16_C(1))
+
+/**
+ * On byte-stream sockets, block until the full amount of data can be returned.
+ */
+#define __WASI_RIFLAGS_RECV_WAITALL (UINT16_C(2))
+
+_Static_assert(sizeof(__wasi_riflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_riflags_t) == 2, "witx calculated align");
+
+/**
+ * Flags returned by `sock_recv`.
+ */
+typedef uint16_t __wasi_roflags_t;
+
+/**
+ * Returned by `sock_recv`: Message data has been truncated.
+ */
+#define __WASI_ROFLAGS_RECV_DATA_TRUNCATED (UINT16_C(1))
+
+_Static_assert(sizeof(__wasi_roflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_roflags_t) == 2, "witx calculated align");
+
+/**
+ * Flags provided to `sock_send`. As there are currently no flags
+ * defined, it must be set to zero.
+ */
+typedef uint16_t __wasi_siflags_t;
+
+_Static_assert(sizeof(__wasi_siflags_t) == 2, "witx calculated size");
+_Static_assert(_Alignof(__wasi_siflags_t) == 2, "witx calculated align");
+
+/**
+ * Which channels on a socket to shut down.
+ */
+typedef uint8_t __wasi_sdflags_t;
+
+/**
+ * Disables further receive operations.
+ */
+#define __WASI_SDFLAGS_RD (UINT8_C(1))
+
+/**
+ * Disables further send operations.
+ */
+#define __WASI_SDFLAGS_WR (UINT8_C(2))
+
+_Static_assert(sizeof(__wasi_sdflags_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_sdflags_t) == 1, "witx calculated align");
+
+/**
+ * Identifiers for preopened capabilities.
+ */
+typedef uint8_t __wasi_preopentype_t;
+
+/**
+ * A pre-opened directory.
+ */
+#define __WASI_PREOPENTYPE_DIR (UINT8_C(0))
+
+_Static_assert(sizeof(__wasi_preopentype_t) == 1, "witx calculated size");
+_Static_assert(_Alignof(__wasi_preopentype_t) == 1, "witx calculated align");
+
+/**
+ * The contents of a $prestat when type is `preopentype::dir`.
+ */
+typedef struct __wasi_prestat_dir_t {
+    /**
+     * The length of the directory name for use with `fd_prestat_dir_name`.
+     */
+    __wasi_size_t pr_name_len;
+
+} __wasi_prestat_dir_t;
+
+_Static_assert(sizeof(__wasi_prestat_dir_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_prestat_dir_t) == 4, "witx calculated align");
+_Static_assert(offsetof(__wasi_prestat_dir_t, pr_name_len) == 0, "witx calculated offset");
+
+/**
+ * The contents of an $prestat.
+ */
+typedef union __wasi_prestat_u_t {
+    /**
+     * When type is `preopentype::dir`:
+     */
+    __wasi_prestat_dir_t dir;
+
+} __wasi_prestat_u_t;
+
+_Static_assert(sizeof(__wasi_prestat_u_t) == 4, "witx calculated size");
+_Static_assert(_Alignof(__wasi_prestat_u_t) == 4, "witx calculated align");
+
+/**
+ * Information about a pre-opened capability.
+ */
+typedef struct __wasi_prestat_t {
+    /**
+     * The type of the pre-opened capability.
+     */
+    __wasi_preopentype_t pr_type;
+
+    /**
+     * The contents of the information.
+     */
+    __wasi_prestat_u_t u;
+
+} __wasi_prestat_t;
+
+_Static_assert(sizeof(__wasi_prestat_t) == 8, "witx calculated size");
+_Static_assert(_Alignof(__wasi_prestat_t) == 4, "witx calculated align");
+_Static_assert(offsetof(__wasi_prestat_t, pr_type) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_prestat_t, u) == 4, "witx calculated offset");
+
+/**
+ * @defgroup wasi_snapshot_preview1
+ * @{
+ */
+
+/**
+ * Read command-line argument data.
+ * The size of the array should match that returned by `args_sizes_get`
+ */
+__wasi_errno_t __wasi_args_get(
+    uint8_t * * argv,
+
+    uint8_t * argv_buf
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("args_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Return command-line argument data sizes.
+ */
+__wasi_errno_t __wasi_args_sizes_get(
+    /**
+     * The number of arguments.
+     */
+    __wasi_size_t *argc,
+    /**
+     * The size of the argument string data.
+     */
+    __wasi_size_t *argv_buf_size
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("args_sizes_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Read environment variable data.
+ * The sizes of the buffers should match that returned by `environ_sizes_get`.
+ */
+__wasi_errno_t __wasi_environ_get(
+    uint8_t * * environ,
+
+    uint8_t * environ_buf
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("environ_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Return command-line argument data sizes.
+ */
+__wasi_errno_t __wasi_environ_sizes_get(
+    /**
+     * The number of arguments.
+     */
+    __wasi_size_t *argc,
+    /**
+     * The size of the argument string data.
+     */
+    __wasi_size_t *argv_buf_size
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("environ_sizes_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Return the resolution of a clock.
+ * Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
+ * return `errno::inval`.
+ * Note: This is similar to `clock_getres` in POSIX.
+ */
+__wasi_errno_t __wasi_clock_res_get(
+    /**
+     * The clock for which to return the resolution.
+     */
+    __wasi_clockid_t id,
+
+    /**
+     * The resolution of the clock.
+     */
+    __wasi_timestamp_t *resolution
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("clock_res_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Return the time value of a clock.
+ * Note: This is similar to `clock_gettime` in POSIX.
+ */
+__wasi_errno_t __wasi_clock_time_get(
+    /**
+     * The clock for which to return the time.
+     */
+    __wasi_clockid_t id,
+
+    /**
+     * The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
+     */
+    __wasi_timestamp_t precision,
+
+    /**
+     * The time value of the clock.
+     */
+    __wasi_timestamp_t *time
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("clock_time_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Provide file advisory information on a file descriptor.
+ * Note: This is similar to `posix_fadvise` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_advise(
+    __wasi_fd_t fd,
+
+    /**
+     * The offset within the file to which the advisory applies.
+     */
+    __wasi_filesize_t offset,
+
+    /**
+     * The length of the region to which the advisory applies.
+     */
+    __wasi_filesize_t len,
+
+    /**
+     * The advice.
+     */
+    __wasi_advice_t advice
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_advise"),
+    __warn_unused_result__
+));
+
+/**
+ * Force the allocation of space in a file.
+ * Note: This is similar to `posix_fallocate` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_allocate(
+    __wasi_fd_t fd,
+
+    /**
+     * The offset at which to start the allocation.
+     */
+    __wasi_filesize_t offset,
+
+    /**
+     * The length of the area that is allocated.
+     */
+    __wasi_filesize_t len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_allocate"),
+    __warn_unused_result__
+));
+
+/**
+ * Close a file descriptor.
+ * Note: This is similar to `close` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_close(
+    __wasi_fd_t fd
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_close"),
+    __warn_unused_result__
+));
+
+/**
+ * Synchronize the data of a file to disk.
+ * Note: This is similar to `fdatasync` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_datasync(
+    __wasi_fd_t fd
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_datasync"),
+    __warn_unused_result__
+));
+
+/**
+ * Get the attributes of a file descriptor.
+ * Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
+ */
+__wasi_errno_t __wasi_fd_fdstat_get(
+    __wasi_fd_t fd,
+
+    /**
+     * The buffer where the file descriptor's attributes are stored.
+     */
+    __wasi_fdstat_t *stat
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_fdstat_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Adjust the flags associated with a file descriptor.
+ * Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_fdstat_set_flags(
+    __wasi_fd_t fd,
+
+    /**
+     * The desired values of the file descriptor flags.
+     */
+    __wasi_fdflags_t flags
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_fdstat_set_flags"),
+    __warn_unused_result__
+));
+
+/**
+ * Adjust the rights associated with a file descriptor.
+ * This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
+ */
+__wasi_errno_t __wasi_fd_fdstat_set_rights(
+    __wasi_fd_t fd,
+
+    /**
+     * The desired rights of the file descriptor.
+     */
+    __wasi_rights_t fs_rights_base,
+
+    __wasi_rights_t fs_rights_inheriting
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_fdstat_set_rights"),
+    __warn_unused_result__
+));
+
+/**
+ * Return the attributes of an open file.
+ */
+__wasi_errno_t __wasi_fd_filestat_get(
+    __wasi_fd_t fd,
+
+    /**
+     * The buffer where the file's attributes are stored.
+     */
+    __wasi_filestat_t *buf
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_filestat_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+ * Note: This is similar to `ftruncate` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_filestat_set_size(
+    __wasi_fd_t fd,
+
+    /**
+     * The desired file size.
+     */
+    __wasi_filesize_t size
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_filestat_set_size"),
+    __warn_unused_result__
+));
+
+/**
+ * Adjust the timestamps of an open file or directory.
+ * Note: This is similar to `futimens` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_filestat_set_times(
+    __wasi_fd_t fd,
+
+    /**
+     * The desired values of the data access timestamp.
+     */
+    __wasi_timestamp_t atim,
+
+    /**
+     * The desired values of the data modification timestamp.
+     */
+    __wasi_timestamp_t mtim,
+
+    /**
+     * A bitmask indicating which timestamps to adjust.
+     */
+    __wasi_fstflags_t fst_flags
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_filestat_set_times"),
+    __warn_unused_result__
+));
+
+/**
+ * Read from a file descriptor, without using and updating the file descriptor's offset.
+ * Note: This is similar to `preadv` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_pread(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors in which to store data.
+     */
+    const __wasi_iovec_t *iovs,
+
+    /**
+     * The length of the array pointed to by `iovs`.
+     */
+    size_t iovs_len,
+
+    /**
+     * The offset within the file at which to read.
+     */
+    __wasi_filesize_t offset,
+
+    /**
+     * The number of bytes read.
+     */
+    __wasi_size_t *nread
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_pread"),
+    __warn_unused_result__
+));
+
+/**
+ * Return a description of the given preopened file descriptor.
+ */
+__wasi_errno_t __wasi_fd_prestat_get(
+    __wasi_fd_t fd,
+
+    /**
+     * The buffer where the description is stored.
+     */
+    __wasi_prestat_t *buf
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_prestat_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Return a description of the given preopened file descriptor.
+ */
+__wasi_errno_t __wasi_fd_prestat_dir_name(
+    __wasi_fd_t fd,
+
+    /**
+     * A buffer into which to write the preopened directory name.
+     */
+    uint8_t * path,
+
+    __wasi_size_t path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_prestat_dir_name"),
+    __warn_unused_result__
+));
+
+/**
+ * Write to a file descriptor, without using and updating the file descriptor's offset.
+ * Note: This is similar to `pwritev` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_pwrite(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors from which to retrieve data.
+     */
+    const __wasi_ciovec_t *iovs,
+
+    /**
+     * The length of the array pointed to by `iovs`.
+     */
+    size_t iovs_len,
+
+    /**
+     * The offset within the file at which to write.
+     */
+    __wasi_filesize_t offset,
+
+    /**
+     * The number of bytes written.
+     */
+    __wasi_size_t *nwritten
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_pwrite"),
+    __warn_unused_result__
+));
+
+/**
+ * Read from a file descriptor.
+ * Note: This is similar to `readv` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_read(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors to which to store data.
+     */
+    const __wasi_iovec_t *iovs,
+
+    /**
+     * The length of the array pointed to by `iovs`.
+     */
+    size_t iovs_len,
+
+    /**
+     * The number of bytes read.
+     */
+    __wasi_size_t *nread
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_read"),
+    __warn_unused_result__
+));
+
+/**
+ * Read directory entries from a directory.
+ * When successful, the contents of the output buffer consist of a sequence of
+ * directory entries. Each directory entry consists of a dirent_t object,
+ * followed by dirent_t::d_namlen bytes holding the name of the directory
+ * entry.
+ * This function fills the output buffer as much as possible, potentially
+ * truncating the last directory entry. This allows the caller to grow its
+ * read buffer size in case it's too small to fit a single large directory
+ * entry, or skip the oversized directory entry.
+ */
+__wasi_errno_t __wasi_fd_readdir(
+    __wasi_fd_t fd,
+
+    /**
+     * The buffer where directory entries are stored
+     */
+    uint8_t * buf,
+
+    __wasi_size_t buf_len,
+
+    /**
+     * The location within the directory to start reading
+     */
+    __wasi_dircookie_t cookie,
+
+    /**
+     * The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
+     */
+    __wasi_size_t *bufused
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_readdir"),
+    __warn_unused_result__
+));
+
+/**
+ * Atomically replace a file descriptor by renumbering another file descriptor.
+ * Due to the strong focus on thread safety, this environment does not provide
+ * a mechanism to duplicate or renumber a file descriptor to an arbitrary
+ * number, like `dup2()`. This would be prone to race conditions, as an actual
+ * file descriptor with the same number could be allocated by a different
+ * thread at the same time.
+ * This function provides a way to atomically renumber file descriptors, which
+ * would disappear if `dup2()` were to be removed entirely.
+ */
+__wasi_errno_t __wasi_fd_renumber(
+    __wasi_fd_t fd,
+
+    /**
+     * The file descriptor to overwrite.
+     */
+    __wasi_fd_t to
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_renumber"),
+    __warn_unused_result__
+));
+
+/**
+ * Move the offset of a file descriptor.
+ * Note: This is similar to `lseek` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_seek(
+    __wasi_fd_t fd,
+
+    /**
+     * The number of bytes to move.
+     */
+    __wasi_filedelta_t offset,
+
+    /**
+     * The base from which the offset is relative.
+     */
+    __wasi_whence_t whence,
+
+    /**
+     * The new offset of the file descriptor, relative to the start of the file.
+     */
+    __wasi_filesize_t *newoffset
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_seek"),
+    __warn_unused_result__
+));
+
+/**
+ * Synchronize the data and metadata of a file to disk.
+ * Note: This is similar to `fsync` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_sync(
+    __wasi_fd_t fd
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_sync"),
+    __warn_unused_result__
+));
+
+/**
+ * Return the current offset of a file descriptor.
+ * Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_tell(
+    __wasi_fd_t fd,
+
+    /**
+     * The current offset of the file descriptor, relative to the start of the file.
+     */
+    __wasi_filesize_t *offset
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_tell"),
+    __warn_unused_result__
+));
+
+/**
+ * Write to a file descriptor.
+ * Note: This is similar to `writev` in POSIX.
+ */
+__wasi_errno_t __wasi_fd_write(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors from which to retrieve data.
+     */
+    const __wasi_ciovec_t *iovs,
+
+    /**
+     * The length of the array pointed to by `iovs`.
+     */
+    size_t iovs_len,
+
+    /**
+     * The number of bytes written.
+     */
+    __wasi_size_t *nwritten
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("fd_write"),
+    __warn_unused_result__
+));
+
+/**
+ * Create a directory.
+ * Note: This is similar to `mkdirat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_create_directory(
+    __wasi_fd_t fd,
+
+    /**
+     * The path at which to create the directory.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_create_directory"),
+    __warn_unused_result__
+));
+
+/**
+ * Return the attributes of a file or directory.
+ * Note: This is similar to `stat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_filestat_get(
+    __wasi_fd_t fd,
+
+    /**
+     * Flags determining the method of how the path is resolved.
+     */
+    __wasi_lookupflags_t flags,
+
+    /**
+     * The path of the file or directory to inspect.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len,
+
+    /**
+     * The buffer where the file's attributes are stored.
+     */
+    __wasi_filestat_t *buf
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_filestat_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Adjust the timestamps of a file or directory.
+ * Note: This is similar to `utimensat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_filestat_set_times(
+    __wasi_fd_t fd,
+
+    /**
+     * Flags determining the method of how the path is resolved.
+     */
+    __wasi_lookupflags_t flags,
+
+    /**
+     * The path of the file or directory to operate on.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len,
+
+    /**
+     * The desired values of the data access timestamp.
+     */
+    __wasi_timestamp_t atim,
+
+    /**
+     * The desired values of the data modification timestamp.
+     */
+    __wasi_timestamp_t mtim,
+
+    /**
+     * A bitmask indicating which timestamps to adjust.
+     */
+    __wasi_fstflags_t fst_flags
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_filestat_set_times"),
+    __warn_unused_result__
+));
+
+/**
+ * Create a hard link.
+ * Note: This is similar to `linkat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_link(
+    __wasi_fd_t old_fd,
+
+    /**
+     * Flags determining the method of how the path is resolved.
+     */
+    __wasi_lookupflags_t old_flags,
+
+    /**
+     * The source path from which to link.
+     */
+    const char *old_path,
+
+    /**
+     * The length of the buffer pointed to by `old_path`.
+     */
+    size_t old_path_len,
+
+    /**
+     * The working directory at which the resolution of the new path starts.
+     */
+    __wasi_fd_t new_fd,
+
+    /**
+     * The destination path at which to create the hard link.
+     */
+    const char *new_path,
+
+    /**
+     * The length of the buffer pointed to by `new_path`.
+     */
+    size_t new_path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_link"),
+    __warn_unused_result__
+));
+
+/**
+ * Open a file or directory.
+ * The returned file descriptor is not guaranteed to be the lowest-numbered
+ * file descriptor not currently open; it is randomized to prevent
+ * applications from depending on making assumptions about indexes, since this
+ * is error-prone in multi-threaded contexts. The returned file descriptor is
+ * guaranteed to be less than 2**31.
+ * Note: This is similar to `openat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_open(
+    __wasi_fd_t fd,
+
+    /**
+     * Flags determining the method of how the path is resolved.
+     */
+    __wasi_lookupflags_t dirflags,
+
+    /**
+     * The relative path of the file or directory to open, relative to the
+     * `path_open::fd` directory.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len,
+
+    /**
+     * The method by which to open the file.
+     */
+    __wasi_oflags_t oflags,
+
+    /**
+     * The initial rights of the newly created file descriptor. The
+     * implementation is allowed to return a file descriptor with fewer rights
+     * than specified, if and only if those rights do not apply to the type of
+     * file being opened.
+     * The *base* rights are rights that will apply to operations using the file
+     * descriptor itself, while the *inheriting* rights are rights that apply to
+     * file descriptors derived from it.
+     */
+    __wasi_rights_t fs_rights_base,
+
+    __wasi_rights_t fs_rights_inherting,
+
+    __wasi_fdflags_t fdflags,
+
+    /**
+     * The file descriptor of the file that has been opened.
+     */
+    __wasi_fd_t *opened_fd
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_open"),
+    __warn_unused_result__
+));
+
+/**
+ * Read the contents of a symbolic link.
+ * Note: This is similar to `readlinkat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_readlink(
+    __wasi_fd_t fd,
+
+    /**
+     * The path of the symbolic link from which to read.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len,
+
+    /**
+     * The buffer to which to write the contents of the symbolic link.
+     */
+    uint8_t * buf,
+
+    __wasi_size_t buf_len,
+
+    /**
+     * The number of bytes placed in the buffer.
+     */
+    __wasi_size_t *bufused
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_readlink"),
+    __warn_unused_result__
+));
+
+/**
+ * Remove a directory.
+ * Return `errno::notempty` if the directory is not empty.
+ * Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+ */
+__wasi_errno_t __wasi_path_remove_directory(
+    __wasi_fd_t fd,
+
+    /**
+     * The path to a directory to remove.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_remove_directory"),
+    __warn_unused_result__
+));
+
+/**
+ * Rename a file or directory.
+ * Note: This is similar to `renameat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_rename(
+    __wasi_fd_t fd,
+
+    /**
+     * The source path of the file or directory to rename.
+     */
+    const char *old_path,
+
+    /**
+     * The length of the buffer pointed to by `old_path`.
+     */
+    size_t old_path_len,
+
+    /**
+     * The working directory at which the resolution of the new path starts.
+     */
+    __wasi_fd_t new_fd,
+
+    /**
+     * The destination path to which to rename the file or directory.
+     */
+    const char *new_path,
+
+    /**
+     * The length of the buffer pointed to by `new_path`.
+     */
+    size_t new_path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_rename"),
+    __warn_unused_result__
+));
+
+/**
+ * Create a symbolic link.
+ * Note: This is similar to `symlinkat` in POSIX.
+ */
+__wasi_errno_t __wasi_path_symlink(
+    /**
+     * The contents of the symbolic link.
+     */
+    const char *old_path,
+
+    /**
+     * The length of the buffer pointed to by `old_path`.
+     */
+    size_t old_path_len,
+
+    __wasi_fd_t fd,
+
+    /**
+     * The destination path at which to create the symbolic link.
+     */
+    const char *new_path,
+
+    /**
+     * The length of the buffer pointed to by `new_path`.
+     */
+    size_t new_path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_symlink"),
+    __warn_unused_result__
+));
+
+/**
+ * Unlink a file.
+ * Return `errno::isdir` if the path refers to a directory.
+ * Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+ */
+__wasi_errno_t __wasi_path_unlink_file(
+    __wasi_fd_t fd,
+
+    /**
+     * The path to a file to unlink.
+     */
+    const char *path,
+
+    /**
+     * The length of the buffer pointed to by `path`.
+     */
+    size_t path_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("path_unlink_file"),
+    __warn_unused_result__
+));
+
+/**
+ * Concurrently poll for the occurrence of a set of events.
+ */
+__wasi_errno_t __wasi_poll_oneoff(
+    /**
+     * The events to which to subscribe.
+     */
+    const __wasi_subscription_t * in,
+
+    /**
+     * The events that have occurred.
+     */
+    __wasi_event_t * out,
+
+    /**
+     * Both the number of subscriptions and events.
+     */
+    __wasi_size_t nsubscriptions,
+
+    /**
+     * The number of events stored.
+     */
+    __wasi_size_t *nevents
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("poll_oneoff"),
+    __warn_unused_result__
+));
+
+/**
+ * Terminate the process normally. An exit code of 0 indicates successful
+ * termination of the program. The meanings of other values is dependent on
+ * the environment.
+ */
+_Noreturn void __wasi_proc_exit(
+    /**
+     * The exit code returned by the process.
+     */
+    __wasi_exitcode_t rval
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("proc_exit"))
+));
+
+/**
+ * Send a signal to the process of the calling thread.
+ * Note: This is similar to `raise` in POSIX.
+ */
+__wasi_errno_t __wasi_proc_raise(
+    /**
+     * The signal condition to trigger.
+     */
+    __wasi_signal_t sig
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("proc_raise"),
+    __warn_unused_result__
+));
+
+/**
+ * Temporarily yield execution of the calling thread.
+ * Note: This is similar to `sched_yield` in POSIX.
+ */
+__wasi_errno_t __wasi_sched_yield(
+    void
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("sched_yield"),
+    __warn_unused_result__
+));
+
+/**
+ * Write high-quality random data into a buffer.
+ * This function blocks when the implementation is unable to immediately
+ * provide sufficient high-quality random data.
+ * This function may execute slowly, so when large mounts of random data are
+ * required, it's advisable to use this function to seed a pseudo-random
+ * number generator, rather than to provide the random data directly.
+ */
+__wasi_errno_t __wasi_random_get(
+    /**
+     * The buffer to fill with random data.
+     */
+    uint8_t * buf,
+
+    __wasi_size_t buf_len
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("random_get"),
+    __warn_unused_result__
+));
+
+/**
+ * Receive a message from a socket.
+ * Note: This is similar to `recv` in POSIX, though it also supports reading
+ * the data into multiple buffers in the manner of `readv`.
+ */
+__wasi_errno_t __wasi_sock_recv(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors to which to store data.
+     */
+    const __wasi_iovec_t *ri_data,
+
+    /**
+     * The length of the array pointed to by `ri_data`.
+     */
+    size_t ri_data_len,
+
+    /**
+     * Message flags.
+     */
+    __wasi_riflags_t ri_flags,
+
+    /**
+     * Number of bytes stored in ri_data.
+     */
+    __wasi_size_t *ro_datalen,
+    /**
+     * Message flags.
+     */
+    __wasi_roflags_t *ro_flags
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("sock_recv"),
+    __warn_unused_result__
+));
+
+/**
+ * Send a message on a socket.
+ * Note: This is similar to `send` in POSIX, though it also supports writing
+ * the data from multiple buffers in the manner of `writev`.
+ */
+__wasi_errno_t __wasi_sock_send(
+    __wasi_fd_t fd,
+
+    /**
+     * List of scatter/gather vectors to which to retrieve data
+     */
+    const __wasi_ciovec_t *si_data,
+
+    /**
+     * The length of the array pointed to by `si_data`.
+     */
+    size_t si_data_len,
+
+    /**
+     * Message flags.
+     */
+    __wasi_siflags_t si_flags,
+
+    /**
+     * Number of bytes transmitted.
+     */
+    __wasi_size_t *so_datalen
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // __import_name__("sock_send"),
+    __warn_unused_result__
+));
+
+/**
+ * Shut down socket send and receive channels.
+ * Note: This is similar to `shutdown` in POSIX.
+ */
+__wasi_errno_t __wasi_sock_shutdown(
+    __wasi_fd_t fd,
+
+    /**
+     * Which channels on the socket to shut down.
+     */
+    __wasi_sdflags_t how
+) __attribute__((
+    // __import_module__("wasi_snapshot_preview1"),
+    // // __import_name__("sock_shutdown"),
+    __warn_unused_result__
+));
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/thirdparty/wasm3/source/m3_api_libc.c
+++ b/thirdparty/wasm3/source/m3_api_libc.c
@@ -1,0 +1,245 @@
+//
+//  m3_api_libc.c
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "m3_api_libc.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+
+typedef uint32_t wasm_ptr_t;
+typedef uint32_t wasm_size_t;
+
+m3ApiRawFunction(m3_libc_abort)
+{
+    m3ApiTrap(m3Err_trapAbort);
+}
+
+m3ApiRawFunction(m3_libc_exit)
+{
+    m3ApiGetArg     (int32_t, code)
+
+    m3ApiTrap(m3Err_trapExit);
+}
+
+
+m3ApiRawFunction(m3_libc_memset)
+{
+    m3ApiReturnType (int32_t)
+
+    m3ApiGetArgMem  (void*,           i_ptr)
+    m3ApiGetArg     (int32_t,         i_value)
+    m3ApiGetArg     (wasm_size_t,     i_size)
+
+    m3ApiCheckMem(i_ptr, i_size);
+
+    u32 result = m3ApiPtrToOffset(memset (i_ptr, i_value, i_size));
+    m3ApiReturn(result);
+}
+
+m3ApiRawFunction(m3_libc_memmove)
+{
+    m3ApiReturnType (int32_t)
+
+    m3ApiGetArgMem  (void*,           o_dst)
+    m3ApiGetArgMem  (void*,           i_src)
+    m3ApiGetArg     (wasm_size_t,     i_size)
+
+    m3ApiCheckMem(o_dst, i_size);
+    m3ApiCheckMem(i_src, i_size);
+
+    u32 result = m3ApiPtrToOffset(memmove (o_dst, i_src, i_size));
+    m3ApiReturn(result);
+}
+
+m3ApiRawFunction(m3_libc_print)
+{
+    m3ApiReturnType (uint32_t)
+
+    m3ApiGetArgMem  (void*,           i_ptr)
+    m3ApiGetArg     (wasm_size_t,     i_size)
+
+    m3ApiCheckMem(i_ptr, i_size);
+
+    fwrite(i_ptr, i_size, 1, stdout);
+    fflush(stdout);
+
+    m3ApiReturn(i_size);
+}
+
+static
+void internal_itoa(int n, char s[], int radix)
+{
+    static char const HEXDIGITS[0x10] = {
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+
+    int i, j, sign;
+    char c;
+
+    if ((sign = n) < 0) { n = -n; }
+    i = 0;
+    do {
+        s[i++] = HEXDIGITS[n % radix];
+    } while ((n /= radix) > 0);
+
+    if (sign < 0) { s[i++] = '-'; }
+    s[i] = '\0';
+
+    // reverse
+    for (i = 0, j = strlen(s)-1; i<j; i++, j--) {
+        c = s[i];
+        s[i] = s[j];
+        s[j] = c;
+    }
+}
+
+m3ApiRawFunction(m3_libc_printf)
+{
+    m3ApiReturnType (int32_t)
+
+    m3ApiGetArgMem  (const char*,    i_fmt)
+    m3ApiGetArgMem  (wasm_ptr_t*,    i_args)
+
+    if (m3ApiIsNullPtr(i_fmt)) {
+        m3ApiReturn(0);
+    }
+
+    m3ApiCheckMem(i_fmt, 1);
+    size_t fmt_len = strnlen(i_fmt, 1024);
+    m3ApiCheckMem(i_fmt, fmt_len+1); // include `\0`
+
+    FILE* file = stdout;
+
+    int32_t length = 0;
+    char ch;
+    while ((ch = *i_fmt++)) {
+        if ( '%' != ch ) {
+            putc(ch, file);
+            length++;
+            continue;
+        }
+        ch = *i_fmt++;
+        switch (ch) {
+            case 'c': {
+                m3ApiCheckMem(i_args, sizeof(wasm_ptr_t));
+                char char_temp = *i_args++;
+                fputc(char_temp, file);
+                length++;
+                break;
+            }
+            case 'd':
+            case 'x': {
+                m3ApiCheckMem(i_args, sizeof(wasm_ptr_t));
+                int int_temp = *i_args++;
+                char buffer[32] = { 0, };
+                internal_itoa(int_temp, buffer, (ch == 'x') ? 16 : 10);
+                fputs(buffer, file);
+                length += strnlen(buffer, sizeof(buffer));
+                break;
+            }
+            case 's': {
+                m3ApiCheckMem(i_args, sizeof(wasm_ptr_t));
+                const char* string_temp;
+                size_t string_len;
+
+                string_temp = (const char*)m3ApiOffsetToPtr(*i_args++);
+                if (m3ApiIsNullPtr(string_temp)) {
+                    string_temp = "(null)";
+                    string_len = 6;
+                } else {
+                    string_len = strnlen(string_temp, 1024);
+                    m3ApiCheckMem(string_temp, string_len+1);
+                }
+
+                fwrite(string_temp, 1, string_len, file);
+                length += string_len;
+                break;
+            default:
+                fputc(ch, file);
+                length++;
+                break;
+            }
+        }
+    }
+
+    m3ApiReturn(length);
+}
+
+m3ApiRawFunction(m3_libc_clock_ms)
+{
+    m3ApiReturnType (uint32_t)
+#ifdef CLOCKS_PER_SEC
+    uint32_t clock_divider = CLOCKS_PER_SEC/1000;
+    if (clock_divider != 0) {
+        m3ApiReturn(clock() / clock_divider);
+    } else {
+        m3ApiReturn(clock());
+    }
+#else
+    m3ApiReturn(clock());
+#endif
+}
+
+static
+M3Result  SuppressLookupFailure (M3Result i_result)
+{
+    if (i_result == m3Err_functionLookupFailed)
+        return m3Err_none;
+    else
+        return i_result;
+}
+
+m3ApiRawFunction(m3_spectest_dummy)
+{
+    m3ApiSuccess();
+}
+
+M3Result  m3_LinkSpecTest  (IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    const char* spectest = "spectest";
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print",         "v()",      &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_i32",     "v(i)",     &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_i64",     "v(I)",     &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_f32",     "v(f)",     &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_f64",     "v(F)",     &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_i32_f32", "v(if)",    &m3_spectest_dummy)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, spectest, "print_i64_f64", "v(IF)",    &m3_spectest_dummy)));
+
+_catch:
+    return result;
+}
+
+
+M3Result  m3_LinkLibC  (IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    const char* env = "env";
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_debug",            "i(*i)",   &m3_libc_print)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_memset",           "*(*ii)",  &m3_libc_memset)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_memmove",          "*(**i)",  &m3_libc_memmove)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_memcpy",           "*(**i)",  &m3_libc_memmove))); // just alias of memmove
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_abort",            "v()",     &m3_libc_abort)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "_exit",             "v(i)",    &m3_libc_exit)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "clock_ms",          "i()",     &m3_libc_clock_ms)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "printf",            "i(**)",   &m3_libc_printf)));
+
+_catch:
+    return result;
+}
+

--- a/thirdparty/wasm3/source/m3_api_libc.h
+++ b/thirdparty/wasm3/source/m3_api_libc.h
@@ -1,0 +1,20 @@
+//
+//  m3_api_libc.h
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef m3_api_libc_h
+#define m3_api_libc_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+M3Result    m3_LinkLibC     (IM3Module io_module);
+M3Result    m3_LinkSpecTest (IM3Module io_module);
+
+d_m3EndExternC
+
+#endif // m3_api_libc_h

--- a/thirdparty/wasm3/source/m3_api_meta_wasi.c
+++ b/thirdparty/wasm3/source/m3_api_meta_wasi.c
@@ -1,0 +1,1101 @@
+//
+//  m3_api_meta_wasi.c
+//
+//  Created by Volodymyr Shymanskyy on 01/08/20.
+//  Copyright © 2020 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#include "m3_api_wasi.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#if defined(d_m3HasMetaWASI)
+
+// NOTE: MetaWASI mostly redirects WASI calls to the host WASI environment
+
+#if !defined(__wasi__)
+# error "MetaWASI is only supported on WASI target"
+#endif
+
+#if __has_include("wasi/api.h")
+# include <wasi/api.h>
+# define USE_NEW_WASI
+# define WASI_STAT_FIELD(f) f
+
+#elif __has_include("wasi/core.h")
+# warning "Using legacy WASI headers"
+# include <wasi/core.h>
+# define __WASI_ERRNO_SUCCESS   __WASI_ESUCCESS
+# define __WASI_ERRNO_INVAL     __WASI_EINVAL
+# define WASI_STAT_FIELD(f) st_##f
+
+#else
+# error "Missing WASI headers"
+#endif
+
+static m3_wasi_context_t* wasi_context;
+
+typedef size_t __wasi_size_t;
+
+static inline
+const void* copy_iov_to_host(IM3Runtime runtime, void* _mem, __wasi_iovec_t* host_iov, __wasi_iovec_t* wasi_iov, int32_t iovs_len)
+{
+    // Convert wasi memory offsets to host addresses
+    for (int i = 0; i < iovs_len; i++) {
+        host_iov[i].buf = m3ApiOffsetToPtr(wasi_iov[i].buf);
+        host_iov[i].buf_len  = wasi_iov[i].buf_len;
+        m3ApiCheckMem(host_iov[i].buf,     host_iov[i].buf_len);
+    }
+    m3ApiSuccess();
+}
+
+#if d_m3EnableWasiTracing
+
+const char* wasi_errno2str(__wasi_errno_t err)
+{
+    switch (err) {
+    case  0: return "ESUCCESS";
+    case  1: return "E2BIG";
+    case  2: return "EACCES";
+    case  3: return "EADDRINUSE";
+    case  4: return "EADDRNOTAVAIL";
+    case  5: return "EAFNOSUPPORT";
+    case  6: return "EAGAIN";
+    case  7: return "EALREADY";
+    case  8: return "EBADF";
+    case  9: return "EBADMSG";
+    case 10: return "EBUSY";
+    case 11: return "ECANCELED";
+    case 12: return "ECHILD";
+    case 13: return "ECONNABORTED";
+    case 14: return "ECONNREFUSED";
+    case 15: return "ECONNRESET";
+    case 16: return "EDEADLK";
+    case 17: return "EDESTADDRREQ";
+    case 18: return "EDOM";
+    case 19: return "EDQUOT";
+    case 20: return "EEXIST";
+    case 21: return "EFAULT";
+    case 22: return "EFBIG";
+    case 23: return "EHOSTUNREACH";
+    case 24: return "EIDRM";
+    case 25: return "EILSEQ";
+    case 26: return "EINPROGRESS";
+    case 27: return "EINTR";
+    case 28: return "EINVAL";
+    case 29: return "EIO";
+    case 30: return "EISCONN";
+    case 31: return "EISDIR";
+    case 32: return "ELOOP";
+    case 33: return "EMFILE";
+    case 34: return "EMLINK";
+    case 35: return "EMSGSIZE";
+    case 36: return "EMULTIHOP";
+    case 37: return "ENAMETOOLONG";
+    case 38: return "ENETDOWN";
+    case 39: return "ENETRESET";
+    case 40: return "ENETUNREACH";
+    case 41: return "ENFILE";
+    case 42: return "ENOBUFS";
+    case 43: return "ENODEV";
+    case 44: return "ENOENT";
+    case 45: return "ENOEXEC";
+    case 46: return "ENOLCK";
+    case 47: return "ENOLINK";
+    case 48: return "ENOMEM";
+    case 49: return "ENOMSG";
+    case 50: return "ENOPROTOOPT";
+    case 51: return "ENOSPC";
+    case 52: return "ENOSYS";
+    case 53: return "ENOTCONN";
+    case 54: return "ENOTDIR";
+    case 55: return "ENOTEMPTY";
+    case 56: return "ENOTRECOVERABLE";
+    case 57: return "ENOTSOCK";
+    case 58: return "ENOTSUP";
+    case 59: return "ENOTTY";
+    case 60: return "ENXIO";
+    case 61: return "EOVERFLOW";
+    case 62: return "EOWNERDEAD";
+    case 63: return "EPERM";
+    case 64: return "EPIPE";
+    case 65: return "EPROTO";
+    case 66: return "EPROTONOSUPPORT";
+    case 67: return "EPROTOTYPE";
+    case 68: return "ERANGE";
+    case 69: return "EROFS";
+    case 70: return "ESPIPE";
+    case 71: return "ESRCH";
+    case 72: return "ESTALE";
+    case 73: return "ETIMEDOUT";
+    case 74: return "ETXTBSY";
+    case 75: return "EXDEV";
+    case 76: return "ENOTCAPABLE";
+    default: return "<unknown>";
+    }
+}
+
+const char* wasi_whence2str(__wasi_whence_t whence)
+{
+    switch (whence) {
+    case __WASI_WHENCE_SET: return "SET";
+    case __WASI_WHENCE_CUR: return "CUR";
+    case __WASI_WHENCE_END: return "END";
+    default:                return "<unknown>";
+    }
+}
+
+#  define WASI_TRACE(fmt, ...)    { fprintf(stderr, "%s " fmt, __FUNCTION__+16, ##__VA_ARGS__); fprintf(stderr, " => %s\n", wasi_errno2str(ret)); }
+#else
+#  define WASI_TRACE(fmt, ...)
+#endif
+
+/*
+ * WASI API implementation
+ */
+
+m3ApiRawFunction(m3_wasi_generic_args_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , argv)
+    m3ApiGetArgMem   (char *               , argv_buf)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(__WASI_ERRNO_INVAL); }
+
+    m3ApiCheckMem(argv, context->argc * sizeof(uint32_t));
+
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        m3ApiWriteMem32(&argv[i], m3ApiPtrToOffset(argv_buf));
+
+        size_t len = strlen (context->argv[i]);
+
+        m3ApiCheckMem(argv_buf, len);
+        memcpy (argv_buf, context->argv[i], len);
+        argv_buf += len;
+        * argv_buf++ = 0;
+    }
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_args_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (__wasi_size_t *      , argc)
+    m3ApiGetArgMem   (__wasi_size_t *      , argv_buf_size)
+
+    m3ApiCheckMem(argc,             sizeof(__wasi_size_t));
+    m3ApiCheckMem(argv_buf_size,    sizeof(__wasi_size_t));
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(__WASI_ERRNO_INVAL); }
+
+    __wasi_size_t buf_len = 0;
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        buf_len += strlen (context->argv[i]) + 1;
+    }
+
+    m3ApiWriteMem32(argc, context->argc);
+    m3ApiWriteMem32(argv_buf_size, buf_len);
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , env)
+    m3ApiGetArgMem   (char *               , env_buf)
+
+    __wasi_errno_t ret;
+    __wasi_size_t env_count, env_buf_size;
+
+    ret = __wasi_environ_sizes_get(&env_count, &env_buf_size);
+    if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
+
+    m3ApiCheckMem(env,      env_count * sizeof(uint32_t));
+    m3ApiCheckMem(env_buf,  env_buf_size);
+
+    ret = __wasi_environ_get(env, env_buf);
+    if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
+
+    for (u32 i = 0; i < env_count; ++i) {
+        env[i] = m3ApiPtrToOffset (env[i]);
+    }
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (__wasi_size_t *      , env_count)
+    m3ApiGetArgMem   (__wasi_size_t *      , env_buf_size)
+
+    m3ApiCheckMem(env_count,    sizeof(__wasi_size_t));
+    m3ApiCheckMem(env_buf_size, sizeof(__wasi_size_t));
+
+    __wasi_errno_t ret = __wasi_environ_sizes_get(env_count, env_buf_size);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_dir_name)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (char *               , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    __wasi_errno_t ret = __wasi_fd_prestat_dir_name(fd, path, path_len);
+
+    WASI_TRACE("fd:%d, len:%d | path:%s", fd, path_len, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_prestat_t *   , buf)
+
+    m3ApiCheckMem(buf, sizeof(__wasi_prestat_t));
+
+    __wasi_errno_t ret = __wasi_fd_prestat_get(fd, buf);
+
+    WASI_TRACE("fd:%d | type:%d, name_len:%d", fd, buf->pr_type, buf->u.dir.pr_name_len);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_fdstat_t *    , fdstat)
+
+    m3ApiCheckMem(fdstat, sizeof(__wasi_fdstat_t));
+
+    __wasi_errno_t ret = __wasi_fd_fdstat_get(fd, fdstat);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_set_flags)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_fdflags_t     , flags)
+
+    __wasi_errno_t ret = __wasi_fd_fdstat_set_flags(fd, flags);
+
+    WASI_TRACE("fd:%d, flags:0x%x", fd, flags);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_set_rights)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_rights_t      , rights_base)
+    m3ApiGetArg      (__wasi_rights_t      , rights_inheriting)
+
+#if 0
+    __wasi_errno_t ret = __wasi_fd_fdstat_set_rights(fd, rights_base, rights_inheriting);
+#else
+    __wasi_errno_t ret = __WASI_ERRNO_INVAL;
+#endif
+
+    WASI_TRACE("fd:%d, base:0x%" PRIx64 ", inheriting:0x%" PRIx64, fd, rights_base, rights_inheriting);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_filestat_set_size)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filesize_t    , size)
+
+    __wasi_errno_t ret = __wasi_fd_filestat_set_size(fd, size);
+
+    WASI_TRACE("fd:%d, size:%" PRIu64, fd, size);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_filestat_set_times)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_timestamp_t   , atim)
+    m3ApiGetArg      (__wasi_timestamp_t   , mtim)
+    m3ApiGetArg      (__wasi_fstflags_t    , fst_flags)
+
+    __wasi_errno_t ret = __wasi_fd_filestat_set_times(fd, atim, mtim, fst_flags);
+
+    WASI_TRACE("fd:%d, atim:%" PRIu64 ", mtim:%" PRIu64 ", flags:%d", fd, atim, mtim, fst_flags);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_fd_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 56); // wasi_filestat_t
+
+    __wasi_filestat_t stat;
+
+    __wasi_errno_t ret = __wasi_fd_filestat_get(fd, &stat);
+
+    WASI_TRACE("fd:%d | fs.size:%" PRIu64, fd, stat.WASI_STAT_FIELD(size));
+
+    if (ret != __WASI_ERRNO_SUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 56);
+    m3ApiWriteMem64(buf+0,  stat.WASI_STAT_FIELD(dev));
+    m3ApiWriteMem64(buf+8,  stat.WASI_STAT_FIELD(ino));
+    m3ApiWriteMem8 (buf+16, stat.WASI_STAT_FIELD(filetype));
+    m3ApiWriteMem32(buf+20, stat.WASI_STAT_FIELD(nlink));
+    m3ApiWriteMem64(buf+24, stat.WASI_STAT_FIELD(size));
+    m3ApiWriteMem64(buf+32, stat.WASI_STAT_FIELD(atim));
+    m3ApiWriteMem64(buf+40, stat.WASI_STAT_FIELD(mtim));
+    m3ApiWriteMem64(buf+48, stat.WASI_STAT_FIELD(ctim));
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_fd_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 64); // wasi_filestat_t
+
+    __wasi_filestat_t stat;
+
+    __wasi_errno_t ret = __wasi_fd_filestat_get(fd, &stat);
+
+    WASI_TRACE("fd:%d | fs.size:%" PRIu64, fd, stat.WASI_STAT_FIELD(size));
+
+    if (ret != __WASI_ERRNO_SUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 64);
+    m3ApiWriteMem64(buf+0,  stat.WASI_STAT_FIELD(dev));
+    m3ApiWriteMem64(buf+8,  stat.WASI_STAT_FIELD(ino));
+    m3ApiWriteMem8 (buf+16, stat.WASI_STAT_FIELD(filetype));
+    m3ApiWriteMem64(buf+24, stat.WASI_STAT_FIELD(nlink));
+    m3ApiWriteMem64(buf+32, stat.WASI_STAT_FIELD(size));
+    m3ApiWriteMem64(buf+40, stat.WASI_STAT_FIELD(atim));
+    m3ApiWriteMem64(buf+48, stat.WASI_STAT_FIELD(mtim));
+    m3ApiWriteMem64(buf+56, stat.WASI_STAT_FIELD(ctim));
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (__wasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(__wasi_filesize_t));
+
+    __wasi_whence_t whence = -1;
+    switch (wasi_whence) {
+    case 0: whence = __WASI_WHENCE_CUR; break;
+    case 1: whence = __WASI_WHENCE_END; break;
+    case 2: whence = __WASI_WHENCE_SET; break;
+    }
+
+    __wasi_filesize_t pos;
+    __wasi_errno_t ret = __wasi_fd_seek(fd, offset, whence, &pos);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", whence:%s | result:%" PRIu64,
+               fd, offset, wasi_whence2str(whence), pos);
+
+    *result = pos;
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (__wasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(__wasi_filesize_t));
+
+    __wasi_whence_t whence = -1;
+    switch (wasi_whence) {
+    case 0: whence = __WASI_WHENCE_SET; break;
+    case 1: whence = __WASI_WHENCE_CUR; break;
+    case 2: whence = __WASI_WHENCE_END; break;
+    }
+
+    __wasi_filesize_t pos;
+    __wasi_errno_t ret = __wasi_fd_seek(fd, offset, whence, &pos);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", whence:%s | result:%" PRIu64,
+               fd, offset, wasi_whence2str(whence), pos);
+
+    *result = pos;
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_renumber)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , from)
+    m3ApiGetArg      (__wasi_fd_t          , to)
+
+    __wasi_errno_t ret = __wasi_fd_renumber(from, to);
+
+    WASI_TRACE("from:%d, to:%d", from, to);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_sync)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+
+    __wasi_errno_t ret = __wasi_fd_sync(fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_tell)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(__wasi_filesize_t));
+
+    __wasi_filesize_t pos;
+    __wasi_errno_t ret = __wasi_fd_tell(fd, &pos);
+
+    WASI_TRACE("fd:%d | result:%" PRIu64, fd, pos);
+
+    *result = pos;
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_create_directory)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    __wasi_errno_t ret = __wasi_path_create_directory(fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_readlink)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+    m3ApiGetArgMem   (char *               , buf)
+    m3ApiGetArg      (__wasi_size_t        , buf_len)
+    m3ApiGetArgMem   (__wasi_size_t *      , bufused)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf, buf_len);
+    m3ApiCheckMem(bufused, sizeof(__wasi_size_t));
+
+    __wasi_errno_t ret = __wasi_path_readlink(fd, path, path_len, buf, buf_len, bufused);
+
+    WASI_TRACE("fd:%d, path:%s | buf:%s, bufused:%d", fd, path, buf, *bufused);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_remove_directory)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    __wasi_errno_t ret = __wasi_path_remove_directory(fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_rename)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , old_fd)
+    m3ApiGetArgMem   (const char *         , old_path)
+    m3ApiGetArg      (__wasi_size_t        , old_path_len)
+    m3ApiGetArg      (__wasi_fd_t          , new_fd)
+    m3ApiGetArgMem   (const char *         , new_path)
+    m3ApiGetArg      (__wasi_size_t        , new_path_len)
+
+    m3ApiCheckMem(old_path, old_path_len);
+    m3ApiCheckMem(new_path, new_path_len);
+
+    __wasi_errno_t ret = __wasi_path_rename(old_fd, old_path, old_path_len,
+                                            new_fd, new_path, new_path_len);
+
+    WASI_TRACE("old_fd:%d, old_path:%s, new_fd:%d, new_path:%s", old_fd, old_path, new_fd, new_path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_symlink)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (const char *         , old_path)
+    m3ApiGetArg      (__wasi_size_t        , old_path_len)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , new_path)
+    m3ApiGetArg      (__wasi_size_t        , new_path_len)
+
+    m3ApiCheckMem(old_path, old_path_len);
+    m3ApiCheckMem(new_path, new_path_len);
+
+    __wasi_errno_t ret = __wasi_path_symlink(old_path, old_path_len,
+                                                  fd, new_path, new_path_len);
+
+    WASI_TRACE("old_path:%s, fd:%d, new_path:%s", old_path, fd, new_path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_unlink_file)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    __wasi_errno_t ret = __wasi_path_unlink_file(fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_open)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , dirfd)
+    m3ApiGetArg      (__wasi_lookupflags_t , dirflags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+    m3ApiGetArg      (__wasi_oflags_t      , oflags)
+    m3ApiGetArg      (__wasi_rights_t      , fs_rights_base)
+    m3ApiGetArg      (__wasi_rights_t      , fs_rights_inheriting)
+    m3ApiGetArg      (__wasi_fdflags_t     , fs_flags)
+    m3ApiGetArgMem   (__wasi_fd_t *        , fd)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(fd,   sizeof(__wasi_fd_t));
+
+    __wasi_errno_t ret = __wasi_path_open(dirfd,
+                                 dirflags,
+                                 path,
+                                 path_len,
+                                 oflags,
+                                 fs_rights_base,
+                                 fs_rights_inheriting,
+                                 fs_flags,
+                                 fd);
+
+    WASI_TRACE("dirfd:%d, dirflags:0x%x, path:%s, oflags:0x%x, fs_flags:0x%x | fd:%d", dirfd, dirflags, path, oflags, fs_flags, *fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_path_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_lookupflags_t , flags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uint32_t             , path_len)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf,  56); // wasi_filestat_t
+
+    __wasi_filestat_t stat;
+
+    __wasi_errno_t ret = __wasi_path_filestat_get(fd, flags, path, path_len, &stat);
+
+    WASI_TRACE("fd:%d, flags:0x%x, path:%s | fs.size:%" PRIu64, fd, flags, path, stat.WASI_STAT_FIELD(size));
+
+    if (ret != __WASI_ERRNO_SUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 56);
+    m3ApiWriteMem64(buf+0,  stat.WASI_STAT_FIELD(dev));
+    m3ApiWriteMem64(buf+8,  stat.WASI_STAT_FIELD(ino));
+    m3ApiWriteMem8 (buf+16, stat.WASI_STAT_FIELD(filetype));
+    m3ApiWriteMem32(buf+20, stat.WASI_STAT_FIELD(nlink));
+    m3ApiWriteMem64(buf+24, stat.WASI_STAT_FIELD(size));
+    m3ApiWriteMem64(buf+32, stat.WASI_STAT_FIELD(atim));
+    m3ApiWriteMem64(buf+40, stat.WASI_STAT_FIELD(mtim));
+    m3ApiWriteMem64(buf+48, stat.WASI_STAT_FIELD(ctim));
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_path_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_lookupflags_t , flags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uint32_t             , path_len)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf,  64); // wasi_filestat_t
+
+    __wasi_filestat_t stat;
+
+    __wasi_errno_t ret = __wasi_path_filestat_get(fd, flags, path, path_len, &stat);
+
+    WASI_TRACE("fd:%d, flags:0x%x, path:%s | fs.size:%" PRIu64, fd, flags, path, stat.WASI_STAT_FIELD(size));
+
+    if (ret != __WASI_ERRNO_SUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 64);
+    m3ApiWriteMem64(buf+0,  stat.WASI_STAT_FIELD(dev));
+    m3ApiWriteMem64(buf+8,  stat.WASI_STAT_FIELD(ino));
+    m3ApiWriteMem8 (buf+16, stat.WASI_STAT_FIELD(filetype));
+    m3ApiWriteMem64(buf+24, stat.WASI_STAT_FIELD(nlink));
+    m3ApiWriteMem64(buf+32, stat.WASI_STAT_FIELD(size));
+    m3ApiWriteMem64(buf+40, stat.WASI_STAT_FIELD(atim));
+    m3ApiWriteMem64(buf+48, stat.WASI_STAT_FIELD(mtim));
+    m3ApiWriteMem64(buf+56, stat.WASI_STAT_FIELD(ctim));
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_pread)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_iovec_t *     , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArg      (__wasi_filesize_t    , offset)
+    m3ApiGetArgMem   (__wasi_size_t *      , nread)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(__wasi_iovec_t));
+    m3ApiCheckMem(nread,        sizeof(__wasi_size_t));
+
+    __wasi_iovec_t iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+
+    __wasi_errno_t ret = __wasi_fd_pread(fd, iovs, iovs_len, offset, nread);
+
+    WASI_TRACE("fd:%d | nread:%d", fd, *nread);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_read)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_iovec_t *     , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (__wasi_size_t *      , nread)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(__wasi_iovec_t));
+    m3ApiCheckMem(nread,        sizeof(__wasi_size_t));
+
+    __wasi_iovec_t iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+
+    __wasi_errno_t ret = __wasi_fd_read(fd, iovs, iovs_len, nread);
+
+    WASI_TRACE("fd:%d | nread:%d", fd, *nread);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_write)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_iovec_t *     , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (__wasi_size_t *      , nwritten)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(__wasi_iovec_t));
+    m3ApiCheckMem(nwritten,     sizeof(__wasi_size_t));
+
+    __wasi_iovec_t iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+
+    __wasi_errno_t ret = __wasi_fd_write(fd, (__wasi_ciovec_t*)iovs, iovs_len, nwritten);
+
+    WASI_TRACE("fd:%d | nwritten:%d", fd, *nwritten);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_pwrite)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_iovec_t *     , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArg      (__wasi_filesize_t    , offset)
+    m3ApiGetArgMem   (__wasi_size_t *      , nwritten)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(__wasi_iovec_t));
+    m3ApiCheckMem(nwritten,     sizeof(__wasi_size_t));
+
+    __wasi_iovec_t iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+    
+    __wasi_errno_t ret = __wasi_fd_pwrite(fd, (__wasi_ciovec_t*)iovs, iovs_len, offset, nwritten);
+
+    WASI_TRACE("fd:%d | nwritten:%d", fd, *nwritten);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_readdir)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (void *               , buf)
+    m3ApiGetArg      (__wasi_size_t        , buf_len)
+    m3ApiGetArg      (__wasi_dircookie_t   , cookie)
+    m3ApiGetArgMem   (__wasi_size_t *      , bufused)
+
+    m3ApiCheckMem(buf,      buf_len);
+    m3ApiCheckMem(bufused,  sizeof(__wasi_size_t));
+
+    __wasi_errno_t ret = __wasi_fd_readdir(fd, buf, buf_len, cookie, bufused);
+
+    WASI_TRACE("fd:%d | bufused:%d", fd, *bufused);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_advise)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filesize_t    , offset)
+    m3ApiGetArg      (__wasi_filesize_t    , length)
+    m3ApiGetArg      (__wasi_advice_t      , advice)
+
+    __wasi_errno_t ret = __wasi_fd_advise(fd, offset, length, advice);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", length:%" PRIu64 ", advice:%d", fd, offset, length, advice);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_allocate)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filesize_t    , offset)
+    m3ApiGetArg      (__wasi_filesize_t    , length)
+
+    __wasi_errno_t ret = __wasi_fd_allocate(fd, offset, length);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", length:%" PRIu64, fd, offset, length);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_close)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t, fd)
+
+    __wasi_errno_t ret = __wasi_fd_close(fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_datasync)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t, fd)
+
+    __wasi_errno_t ret = __wasi_fd_datasync(fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_random_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+    m3ApiGetArg      (__wasi_size_t        , buf_len)
+
+    m3ApiCheckMem(buf, buf_len);
+
+    __wasi_errno_t ret = __wasi_random_get(buf, buf_len);
+
+    WASI_TRACE("len:%d", buf_len);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_res_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArgMem   (__wasi_timestamp_t * , resolution)
+
+    m3ApiCheckMem(resolution, sizeof(__wasi_timestamp_t));
+
+    __wasi_timestamp_t t;
+    __wasi_errno_t ret = __wasi_clock_res_get(wasi_clk_id, &t);
+
+    WASI_TRACE("clk_id:%d | res:%" PRIu64, wasi_clk_id, t);
+
+    *resolution = t;
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_time_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArg      (__wasi_timestamp_t   , precision)
+    m3ApiGetArgMem   (__wasi_timestamp_t * , time)
+
+    m3ApiCheckMem(time, sizeof(__wasi_timestamp_t));
+
+    __wasi_timestamp_t t;
+    __wasi_errno_t ret = __wasi_clock_time_get(wasi_clk_id, precision, &t);
+
+    WASI_TRACE("clk_id:%d | res:%" PRIu64, wasi_clk_id, t);
+
+    *time = t;
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_poll_oneoff)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (const __wasi_subscription_t * , in)
+    m3ApiGetArgMem   (__wasi_event_t *              , out)
+    m3ApiGetArg      (__wasi_size_t                 , nsubscriptions)
+    m3ApiGetArgMem   (__wasi_size_t *               , nevents)
+
+    m3ApiCheckMem(in,       nsubscriptions * sizeof(__wasi_subscription_t));
+    m3ApiCheckMem(out,      nsubscriptions * sizeof(__wasi_event_t));
+    m3ApiCheckMem(nevents,  sizeof(__wasi_size_t));
+
+    // TODO: unstable/snapshot_preview1 compatibility
+
+    __wasi_errno_t ret = __wasi_poll_oneoff(in, out, nsubscriptions, nevents);
+
+    WASI_TRACE("nsubscriptions:%d | nevents:%d", nsubscriptions, *nevents);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_proc_exit)
+{
+    m3ApiGetArg      (uint32_t, code)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context) {
+        context->exit_code = code;
+    }
+
+    m3ApiTrap(m3Err_trapExit);
+}
+
+m3ApiRawFunction(m3_wasi_generic_proc_raise)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_signal_t, sig)
+
+    __wasi_errno_t ret = __WASI_ERRNO_INVAL;
+#if 0
+    ret = __wasi_proc_raise(sig);
+#endif
+
+    WASI_TRACE("sig:%d", sig);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_sched_yield)
+{
+    m3ApiReturnType  (uint32_t)
+    __wasi_errno_t ret = __wasi_sched_yield();
+
+    WASI_TRACE("");
+
+    m3ApiReturn(ret);
+}
+
+
+static
+M3Result SuppressLookupFailure(M3Result i_result)
+{
+    if (i_result == m3Err_functionLookupFailed)
+        return m3Err_none;
+    else
+        return i_result;
+}
+
+m3_wasi_context_t* m3_GetWasiContext()
+{
+    return wasi_context;
+}
+
+
+M3Result  m3_LinkWASI  (IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    if (!wasi_context) {
+        wasi_context = (m3_wasi_context_t*)malloc(sizeof(m3_wasi_context_t));
+        wasi_context->exit_code = 0;
+        wasi_context->argc = 0;
+        wasi_context->argv = 0;
+    }
+
+    static const char* namespaces[2] = { "wasi_unstable", "wasi_snapshot_preview1" };
+
+    // Some functions are incompatible between WASI versions
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_seek",           "i(iIi*)",   &m3_wasi_unstable_fd_seek)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_seek",           "i(iIi*)",   &m3_wasi_snapshot_preview1_fd_seek)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_filestat_get",   "i(i*)",     &m3_wasi_unstable_fd_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_filestat_get",   "i(i*)",     &m3_wasi_snapshot_preview1_fd_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "path_filestat_get", "i(ii*i*)",  &m3_wasi_unstable_path_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "path_filestat_get", "i(ii*i*)",  &m3_wasi_snapshot_preview1_path_filestat_get)));
+
+    for (int i=0; i<2; i++)
+    {
+        const char* wasi = namespaces[i];
+
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_get",           "i(**)",   &m3_wasi_generic_args_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_sizes_get",     "i(**)",   &m3_wasi_generic_args_sizes_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_res_get",        "i(i*)",   &m3_wasi_generic_clock_res_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_time_get",       "i(iI*)",  &m3_wasi_generic_clock_time_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",          "i(**)",   &m3_wasi_generic_environ_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get",    "i(**)",   &m3_wasi_generic_environ_sizes_get)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_advise",            "i(iIIi)", &m3_wasi_generic_fd_advise)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_allocate",          "i(iII)",  &m3_wasi_generic_fd_allocate)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_close",             "i(i)",    &m3_wasi_generic_fd_close)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_datasync",          "i(i)",    &m3_wasi_generic_fd_datasync)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_get",        "i(i*)",   &m3_wasi_generic_fd_fdstat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_flags",  "i(ii)",   &m3_wasi_generic_fd_fdstat_set_flags)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_rights", "i(iII)",  &m3_wasi_generic_fd_fdstat_set_rights)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_size", "i(iI)",   &m3_wasi_generic_fd_filestat_set_size)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_times","i(iIIi)", &m3_wasi_generic_fd_filestat_set_times)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pread",             "i(i*iI*)",&m3_wasi_generic_fd_pread)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_get",       "i(i*)",   &m3_wasi_generic_fd_prestat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_dir_name",  "i(i*i)",  &m3_wasi_generic_fd_prestat_dir_name)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pwrite",            "i(i*iI*)",&m3_wasi_generic_fd_pwrite)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_read",              "i(i*i*)", &m3_wasi_generic_fd_read)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_readdir",           "i(i*iI*)",&m3_wasi_generic_fd_readdir)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_renumber",          "i(ii)",   &m3_wasi_generic_fd_renumber)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_sync",              "i(i)",    &m3_wasi_generic_fd_sync)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_tell",              "i(i*)",   &m3_wasi_generic_fd_tell)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_write",             "i(i*i*)", &m3_wasi_generic_fd_write)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_create_directory",    "i(i*i)",       &m3_wasi_generic_path_create_directory)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_filestat_set_times",  "i(ii*iIIi)",   )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_link",                "i(ii*ii*i)",   )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_open",                "i(ii*iiIIi*)", &m3_wasi_generic_path_open)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_readlink",            "i(i*i*i*)",    &m3_wasi_generic_path_readlink)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_remove_directory",    "i(i*i)",       &m3_wasi_generic_path_remove_directory)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_rename",              "i(i*ii*i)",    &m3_wasi_generic_path_rename)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_symlink",             "i(*ii*i)",     &m3_wasi_generic_path_symlink)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_unlink_file",         "i(i*i)",       &m3_wasi_generic_path_unlink_file)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "poll_oneoff",          "i(**i*)", &m3_wasi_generic_poll_oneoff)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "proc_exit",          "v(i)",    &m3_wasi_generic_proc_exit, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "proc_raise",           "i(i)",    &m3_wasi_generic_proc_raise)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "random_get",           "i(*i)",   &m3_wasi_generic_random_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sched_yield",          "i()",     &m3_wasi_generic_sched_yield)));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_recv",            "i(i*ii**)",        )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_send",            "i(i*ii*)",         )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_shutdown",        "i(ii)",            )));
+    }
+
+_catch:
+    return result;
+}
+
+#endif // d_m3HasMetaWASI
+

--- a/thirdparty/wasm3/source/m3_api_tracer.c
+++ b/thirdparty/wasm3/source/m3_api_tracer.c
@@ -1,0 +1,168 @@
+//
+//  m3_api_tracer.c
+//
+//  Created by Volodymyr Shymanskyy on 02/18/20.
+//  Copyright © 2020 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#include "m3_api_tracer.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#if defined(d_m3HasTracer)
+
+
+static FILE* trace = NULL;
+
+m3ApiRawFunction(m3_env_log_execution)
+{
+    m3ApiGetArg      (uint32_t, id)
+    fprintf(trace, "exec;%d\n", id);
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(m3_env_log_exec_enter)
+{
+    m3ApiGetArg      (uint32_t, id)
+    m3ApiGetArg      (uint32_t, func)
+    fprintf(trace, "enter;%d;%d\n", id, func);
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(m3_env_log_exec_exit)
+{
+    m3ApiGetArg      (uint32_t, id)
+    m3ApiGetArg      (uint32_t, func)
+    fprintf(trace, "exit;%d;%d\n", id, func);
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(m3_env_log_exec_loop)
+{
+    m3ApiGetArg      (uint32_t, id)
+    fprintf(trace, "loop;%d\n", id);
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(m3_env_load_ptr)
+{
+    m3ApiReturnType (uint32_t)
+    m3ApiGetArg      (uint32_t, id)
+    m3ApiGetArg      (uint32_t, align)
+    m3ApiGetArg      (uint32_t, offset)
+    m3ApiGetArg      (uint32_t, address)
+    fprintf(trace, "load ptr;%d;%d;%d;%d\n", id, align, offset, address);
+    m3ApiReturn(address);
+}
+
+m3ApiRawFunction(m3_env_store_ptr)
+{
+    m3ApiReturnType (uint32_t)
+    m3ApiGetArg      (uint32_t, id)
+    m3ApiGetArg      (uint32_t, align)
+    m3ApiGetArg      (uint32_t, offset)
+    m3ApiGetArg      (uint32_t, address)
+    fprintf(trace, "store ptr;%d;%d;%d;%d\n", id, align, offset, address);
+    m3ApiReturn(address);
+}
+
+
+#define d_m3TraceMemory(FUNC, NAME, TYPE, FMT)                \
+m3ApiRawFunction(m3_env_##FUNC)                               \
+{                                                             \
+    m3ApiReturnType (TYPE)                                    \
+    m3ApiGetArg      (uint32_t, id)                           \
+    m3ApiGetArg      (TYPE,     val)                          \
+    fprintf(trace, NAME ";%d;" FMT "\n", id, val);            \
+    m3ApiReturn(val);                                         \
+}
+
+d_m3TraceMemory( load_val_i32,  "load i32", int32_t, "%" PRIi32)
+d_m3TraceMemory(store_val_i32, "store i32", int32_t, "%" PRIi32)
+d_m3TraceMemory( load_val_i64,  "load i64", int64_t, "%" PRIi64)
+d_m3TraceMemory(store_val_i64, "store i64", int64_t, "%" PRIi64)
+d_m3TraceMemory( load_val_f32,  "load f32", float,   "%" PRIf32)
+d_m3TraceMemory(store_val_f32, "store f32", float,   "%" PRIf32)
+d_m3TraceMemory( load_val_f64,  "load f64", double,  "%" PRIf64)
+d_m3TraceMemory(store_val_f64, "store f64", double,  "%" PRIf64)
+
+
+#define d_m3TraceLocal(FUNC, NAME, TYPE, FMT)                 \
+m3ApiRawFunction(m3_env_##FUNC)                               \
+{                                                             \
+    m3ApiReturnType (TYPE)                                    \
+    m3ApiGetArg      (uint32_t, id)                           \
+    m3ApiGetArg      (uint32_t, local)                        \
+    m3ApiGetArg      (TYPE,     val)                          \
+    fprintf(trace, NAME ";%d;%d;" FMT "\n", id, local, val); \
+    m3ApiReturn(val);                                         \
+}
+
+
+d_m3TraceLocal(get_i32, "get i32", int32_t, "%" PRIi32)
+d_m3TraceLocal(set_i32, "set i32", int32_t, "%" PRIi32)
+d_m3TraceLocal(get_i64, "get i64", int64_t, "%" PRIi64)
+d_m3TraceLocal(set_i64, "set i64", int64_t, "%" PRIi64)
+d_m3TraceLocal(get_f32, "get f32", float,   "%" PRIf32)
+d_m3TraceLocal(set_f32, "set f32", float,   "%" PRIf32)
+d_m3TraceLocal(get_f64, "get f64", double,  "%" PRIf64)
+d_m3TraceLocal(set_f64, "set f64", double,  "%" PRIf64)
+
+
+static
+M3Result SuppressLookupFailure(M3Result i_result)
+{
+    if (i_result == m3Err_none) {
+        // If any trace function is found in the module, open the trace file
+        if (!trace) {
+            trace = fopen ("wasm3_trace.csv","w");
+        }
+    } else if (i_result == m3Err_functionLookupFailed) {
+        i_result = m3Err_none;
+    }
+    return i_result;
+}
+
+
+M3Result  m3_LinkTracer  (IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    const char* env  = "env";
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "log_execution",       "v(i)",     &m3_env_log_execution)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "log_exec_enter",      "v(ii)",    &m3_env_log_exec_enter)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "log_exec_exit",       "v(ii)",    &m3_env_log_exec_exit)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "log_exec_loop",       "v(i)",     &m3_env_log_exec_loop)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "load_ptr",            "i(iiii)",  &m3_env_load_ptr)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "store_ptr",           "i(iiii)",  &m3_env_store_ptr)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "load_val_i32",        "i(ii)",    &m3_env_load_val_i32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "load_val_i64",        "I(iI)",    &m3_env_load_val_i64)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "load_val_f32",        "f(if)",    &m3_env_load_val_f32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "load_val_f64",        "F(iF)",    &m3_env_load_val_f64)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "store_val_i32",       "i(ii)",    &m3_env_store_val_i32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "store_val_i64",       "I(iI)",    &m3_env_store_val_i64)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "store_val_f32",       "f(if)",    &m3_env_store_val_f32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "store_val_f64",       "F(iF)",    &m3_env_store_val_f64)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "get_i32",             "i(iii)",   &m3_env_get_i32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "get_i64",             "I(iiI)",   &m3_env_get_i64)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "get_f32",             "f(iif)",   &m3_env_get_f32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "get_f64",             "F(iiF)",   &m3_env_get_f64)));
+
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "set_i32",             "i(iii)",   &m3_env_set_i32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "set_i64",             "I(iiI)",   &m3_env_set_i64)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "set_f32",             "f(iif)",   &m3_env_set_f32)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, env, "set_f64",             "F(iiF)",   &m3_env_set_f64)));
+
+_catch:
+    return result;
+}
+
+#endif // d_m3HasTracer
+

--- a/thirdparty/wasm3/source/m3_api_tracer.h
+++ b/thirdparty/wasm3/source/m3_api_tracer.h
@@ -1,0 +1,19 @@
+//
+//  m3_api_tracer.h
+//
+//  Created by Volodymyr Shymanskyy on 02/18/20.
+//  Copyright © 2020 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef m3_api_tracer_h
+#define m3_api_tracer_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+M3Result    m3_LinkTracer       (IM3Module io_module);
+
+d_m3EndExternC
+
+#endif // m3_api_tracer_h

--- a/thirdparty/wasm3/source/m3_api_uvwasi.c
+++ b/thirdparty/wasm3/source/m3_api_uvwasi.c
@@ -1,0 +1,1219 @@
+//
+//  m3_api_uvwasi.c
+//
+//  Created by Colin J. Ihrig on 4/20/20.
+//  Copyright © 2020 Colin J. Ihrig, Volodymyr Shymanskyy. All rights reserved.
+//
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "m3_api_wasi.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#if defined(d_m3HasUVWASI)
+
+#include <stdio.h>
+#include <string.h>
+
+#ifdef __APPLE__
+# include <crt_externs.h>
+# define environ (*_NSGetEnviron())
+#elif !defined(_MSC_VER)
+extern char** environ;
+#endif
+
+static m3_wasi_context_t* wasi_context;
+static uvwasi_t uvwasi;
+
+typedef struct wasi_iovec_t
+{
+    uvwasi_size_t buf;
+    uvwasi_size_t buf_len;
+} wasi_iovec_t;
+
+#if d_m3EnableWasiTracing
+
+const char* wasi_errno2str(uvwasi_errno_t err)
+{
+    switch (err) {
+    case  0: return "ESUCCESS";
+    case  1: return "E2BIG";
+    case  2: return "EACCES";
+    case  3: return "EADDRINUSE";
+    case  4: return "EADDRNOTAVAIL";
+    case  5: return "EAFNOSUPPORT";
+    case  6: return "EAGAIN";
+    case  7: return "EALREADY";
+    case  8: return "EBADF";
+    case  9: return "EBADMSG";
+    case 10: return "EBUSY";
+    case 11: return "ECANCELED";
+    case 12: return "ECHILD";
+    case 13: return "ECONNABORTED";
+    case 14: return "ECONNREFUSED";
+    case 15: return "ECONNRESET";
+    case 16: return "EDEADLK";
+    case 17: return "EDESTADDRREQ";
+    case 18: return "EDOM";
+    case 19: return "EDQUOT";
+    case 20: return "EEXIST";
+    case 21: return "EFAULT";
+    case 22: return "EFBIG";
+    case 23: return "EHOSTUNREACH";
+    case 24: return "EIDRM";
+    case 25: return "EILSEQ";
+    case 26: return "EINPROGRESS";
+    case 27: return "EINTR";
+    case 28: return "EINVAL";
+    case 29: return "EIO";
+    case 30: return "EISCONN";
+    case 31: return "EISDIR";
+    case 32: return "ELOOP";
+    case 33: return "EMFILE";
+    case 34: return "EMLINK";
+    case 35: return "EMSGSIZE";
+    case 36: return "EMULTIHOP";
+    case 37: return "ENAMETOOLONG";
+    case 38: return "ENETDOWN";
+    case 39: return "ENETRESET";
+    case 40: return "ENETUNREACH";
+    case 41: return "ENFILE";
+    case 42: return "ENOBUFS";
+    case 43: return "ENODEV";
+    case 44: return "ENOENT";
+    case 45: return "ENOEXEC";
+    case 46: return "ENOLCK";
+    case 47: return "ENOLINK";
+    case 48: return "ENOMEM";
+    case 49: return "ENOMSG";
+    case 50: return "ENOPROTOOPT";
+    case 51: return "ENOSPC";
+    case 52: return "ENOSYS";
+    case 53: return "ENOTCONN";
+    case 54: return "ENOTDIR";
+    case 55: return "ENOTEMPTY";
+    case 56: return "ENOTRECOVERABLE";
+    case 57: return "ENOTSOCK";
+    case 58: return "ENOTSUP";
+    case 59: return "ENOTTY";
+    case 60: return "ENXIO";
+    case 61: return "EOVERFLOW";
+    case 62: return "EOWNERDEAD";
+    case 63: return "EPERM";
+    case 64: return "EPIPE";
+    case 65: return "EPROTO";
+    case 66: return "EPROTONOSUPPORT";
+    case 67: return "EPROTOTYPE";
+    case 68: return "ERANGE";
+    case 69: return "EROFS";
+    case 70: return "ESPIPE";
+    case 71: return "ESRCH";
+    case 72: return "ESTALE";
+    case 73: return "ETIMEDOUT";
+    case 74: return "ETXTBSY";
+    case 75: return "EXDEV";
+    case 76: return "ENOTCAPABLE";
+    default: return "<unknown>";
+    }
+}
+
+const char* wasi_whence2str(uvwasi_whence_t whence)
+{
+    switch (whence) {
+    case UVWASI_WHENCE_SET: return "SET";
+    case UVWASI_WHENCE_CUR: return "CUR";
+    case UVWASI_WHENCE_END: return "END";
+    default:                return "<unknown>";
+    }
+}
+
+#  define WASI_TRACE(fmt, ...)    { fprintf(stderr, "%s " fmt, __FUNCTION__+16, ##__VA_ARGS__); fprintf(stderr, " => %s\n", wasi_errno2str(ret)); }
+#else
+#  define WASI_TRACE(fmt, ...)
+#endif
+
+/*
+ * WASI API implementation
+ */
+
+m3ApiRawFunction(m3_wasi_generic_args_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , argv)
+    m3ApiGetArgMem   (char *               , argv_buf)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(UVWASI_EINVAL); }
+
+    m3ApiCheckMem(argv, context->argc * sizeof(uint32_t));
+
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        m3ApiWriteMem32(&argv[i], m3ApiPtrToOffset(argv_buf));
+
+        size_t len = strlen (context->argv[i]);
+
+        m3ApiCheckMem(argv_buf, len);
+        memcpy (argv_buf, context->argv[i], len);
+        argv_buf += len;
+        * argv_buf++ = 0;
+    }
+
+    m3ApiReturn(UVWASI_ESUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_args_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uvwasi_size_t *      , argc)
+    m3ApiGetArgMem   (uvwasi_size_t *      , argv_buf_size)
+
+    m3ApiCheckMem(argc,             sizeof(uvwasi_size_t));
+    m3ApiCheckMem(argv_buf_size,    sizeof(uvwasi_size_t));
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(UVWASI_EINVAL); }
+
+    uvwasi_size_t buf_len = 0;
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        buf_len += strlen (context->argv[i]) + 1;
+    }
+
+    m3ApiWriteMem32(argc, context->argc);
+    m3ApiWriteMem32(argv_buf_size, buf_len);
+
+    m3ApiReturn(UVWASI_ESUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , env)
+    m3ApiGetArgMem   (char *               , env_buf)
+
+    char **environment;
+    uvwasi_errno_t ret;
+    uvwasi_size_t env_count, env_buf_size;
+
+    ret = uvwasi_environ_sizes_get(&uvwasi, &env_count, &env_buf_size);
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    m3ApiCheckMem(env,      env_count * sizeof(uint32_t));
+    m3ApiCheckMem(env_buf,  env_buf_size);
+
+    environment = calloc(env_count, sizeof(char *));
+    if (environment == NULL) {
+        m3ApiReturn(UVWASI_ENOMEM);
+    }
+
+    ret = uvwasi_environ_get(&uvwasi, environment, env_buf);
+    if (ret != UVWASI_ESUCCESS) {
+        free(environment);
+        m3ApiReturn(ret);
+    }
+
+    uint32_t environ_buf_offset = m3ApiPtrToOffset(env_buf);
+
+    for (u32 i = 0; i < env_count; ++i)
+    {
+        uint32_t offset = environ_buf_offset +
+                          (environment[i] - environment[0]);
+        m3ApiWriteMem32(&env[i], offset);
+    }
+
+    free(environment);
+    m3ApiReturn(UVWASI_ESUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uvwasi_size_t *      , env_count)
+    m3ApiGetArgMem   (uvwasi_size_t *      , env_buf_size)
+
+    m3ApiCheckMem(env_count,    sizeof(uvwasi_size_t));
+    m3ApiCheckMem(env_buf_size, sizeof(uvwasi_size_t));
+
+    uvwasi_size_t count;
+    uvwasi_size_t buf_size;
+
+    uvwasi_errno_t ret = uvwasi_environ_sizes_get(&uvwasi, &count, &buf_size);
+
+    m3ApiWriteMem32(env_count,    count);
+    m3ApiWriteMem32(env_buf_size, buf_size);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_dir_name)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (char *               , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    uvwasi_errno_t ret = uvwasi_fd_prestat_dir_name(&uvwasi, fd, path, path_len);
+
+    WASI_TRACE("fd:%d, len:%d | path:%s", fd, path_len, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 8);
+
+    uvwasi_prestat_t prestat;
+
+    uvwasi_errno_t ret = uvwasi_fd_prestat_get(&uvwasi, fd, &prestat);
+
+    WASI_TRACE("fd:%d | type:%d, name_len:%d", fd, prestat.pr_type, prestat.u.dir.pr_name_len);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    m3ApiWriteMem32(buf+0, prestat.pr_type);
+    m3ApiWriteMem32(buf+4, prestat.u.dir.pr_name_len);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 24);
+
+    uvwasi_fdstat_t stat;
+    uvwasi_errno_t ret = uvwasi_fd_fdstat_get(&uvwasi, fd, &stat);
+
+    WASI_TRACE("fd:%d", fd);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 24);
+    m3ApiWriteMem8 (buf+0, stat.fs_filetype);
+    m3ApiWriteMem16(buf+2, stat.fs_flags);
+    m3ApiWriteMem64(buf+8, stat.fs_rights_base);
+    m3ApiWriteMem64(buf+16, stat.fs_rights_inheriting);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_set_flags)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_fdflags_t     , flags)
+
+    uvwasi_errno_t ret = uvwasi_fd_fdstat_set_flags(&uvwasi, fd, flags);
+
+    WASI_TRACE("fd:%d, flags:0x%x", fd, flags);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_set_rights)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_rights_t      , rights_base)
+    m3ApiGetArg      (uvwasi_rights_t      , rights_inheriting)
+
+    uvwasi_errno_t ret = uvwasi_fd_fdstat_set_rights(&uvwasi, fd, rights_base, rights_inheriting);
+
+    WASI_TRACE("fd:%d, base:0x%" PRIx64 ", inheriting:0x%" PRIx64, fd, rights_base, rights_inheriting);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_filestat_set_size)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_filesize_t    , size)
+
+    uvwasi_errno_t ret = uvwasi_fd_filestat_set_size(&uvwasi, fd, size);
+
+    WASI_TRACE("fd:%d, size:%" PRIu64, fd, size);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_filestat_set_times)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_timestamp_t   , atim)
+    m3ApiGetArg      (uvwasi_timestamp_t   , mtim)
+    m3ApiGetArg      (uvwasi_fstflags_t    , fst_flags)
+
+    uvwasi_errno_t ret = uvwasi_fd_filestat_set_times(&uvwasi, fd, atim, mtim, fst_flags);
+
+    WASI_TRACE("fd:%d, atim:%" PRIu64 ", mtim:%" PRIu64 ", flags:%d", fd, atim, mtim, fst_flags);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_fd_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 56); // wasi_filestat_t
+
+    uvwasi_filestat_t stat;
+
+    uvwasi_errno_t ret = uvwasi_fd_filestat_get(&uvwasi, fd, &stat);
+
+    WASI_TRACE("fd:%d | fs.size:%" PRIu64, fd, stat.st_size);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 56);
+    m3ApiWriteMem64(buf+0,  stat.st_dev);
+    m3ApiWriteMem64(buf+8,  stat.st_ino);
+    m3ApiWriteMem8 (buf+16, stat.st_filetype);
+    m3ApiWriteMem32(buf+20, stat.st_nlink);
+    m3ApiWriteMem64(buf+24, stat.st_size);
+    m3ApiWriteMem64(buf+32, stat.st_atim);
+    m3ApiWriteMem64(buf+40, stat.st_mtim);
+    m3ApiWriteMem64(buf+48, stat.st_ctim);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_fd_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 64); // wasi_filestat_t
+
+    uvwasi_filestat_t stat;
+
+    uvwasi_errno_t ret = uvwasi_fd_filestat_get(&uvwasi, fd, &stat);
+
+    WASI_TRACE("fd:%d | fs.size:%" PRIu64, fd, stat.st_size);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 64);
+    m3ApiWriteMem64(buf+0,  stat.st_dev);
+    m3ApiWriteMem64(buf+8,  stat.st_ino);
+    m3ApiWriteMem8 (buf+16, stat.st_filetype);
+    m3ApiWriteMem64(buf+24, stat.st_nlink);
+    m3ApiWriteMem64(buf+32, stat.st_size);
+    m3ApiWriteMem64(buf+40, stat.st_atim);
+    m3ApiWriteMem64(buf+48, stat.st_mtim);
+    m3ApiWriteMem64(buf+56, stat.st_ctim);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (uvwasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(uvwasi_filesize_t));
+
+    uvwasi_whence_t whence = -1;
+    switch (wasi_whence) {
+    case 0: whence = UVWASI_WHENCE_CUR; break;
+    case 1: whence = UVWASI_WHENCE_END; break;
+    case 2: whence = UVWASI_WHENCE_SET; break;
+    }
+
+    uvwasi_filesize_t pos;
+    uvwasi_errno_t ret = uvwasi_fd_seek(&uvwasi, fd, offset, whence, &pos);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", whence:%s | result:%" PRIu64,
+               fd, offset, wasi_whence2str(whence), pos);
+
+    m3ApiWriteMem64(result, pos);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (uvwasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(uvwasi_filesize_t));
+
+    uvwasi_whence_t whence = -1;
+    switch (wasi_whence) {
+    case 0: whence = UVWASI_WHENCE_SET; break;
+    case 1: whence = UVWASI_WHENCE_CUR; break;
+    case 2: whence = UVWASI_WHENCE_END; break;
+    }
+
+    uvwasi_filesize_t pos;
+    uvwasi_errno_t ret = uvwasi_fd_seek(&uvwasi, fd, offset, whence, &pos);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", whence:%s | result:%" PRIu64,
+               fd, offset, wasi_whence2str(whence), pos);
+
+    m3ApiWriteMem64(result, pos);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_renumber)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , from)
+    m3ApiGetArg      (uvwasi_fd_t          , to)
+
+    uvwasi_errno_t ret = uvwasi_fd_renumber(&uvwasi, from, to);
+
+    WASI_TRACE("from:%d, to:%d", from, to);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_sync)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+
+    uvwasi_errno_t ret = uvwasi_fd_sync(&uvwasi, fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_tell)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (uvwasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(uvwasi_filesize_t));
+
+    uvwasi_filesize_t pos;
+    uvwasi_errno_t ret = uvwasi_fd_tell(&uvwasi, fd, &pos);
+
+    WASI_TRACE("fd:%d | result:%" PRIu64, fd, pos);
+
+    m3ApiWriteMem64(result, pos);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_create_directory)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    uvwasi_errno_t ret = uvwasi_path_create_directory(&uvwasi, fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_readlink)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+    m3ApiGetArgMem   (char *               , buf)
+    m3ApiGetArg      (uvwasi_size_t        , buf_len)
+    m3ApiGetArgMem   (uvwasi_size_t *      , bufused)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf, buf_len);
+    m3ApiCheckMem(bufused, sizeof(uvwasi_size_t));
+
+    uvwasi_size_t uvbufused;
+
+    uvwasi_errno_t ret = uvwasi_path_readlink(&uvwasi, fd, path, path_len, buf, buf_len, &uvbufused);
+
+    WASI_TRACE("fd:%d, path:%s | buf:%s, bufused:%d", fd, path, buf, uvbufused);
+
+    m3ApiWriteMem32(bufused, uvbufused);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_remove_directory)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    uvwasi_errno_t ret = uvwasi_path_remove_directory(&uvwasi, fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_rename)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , old_fd)
+    m3ApiGetArgMem   (const char *         , old_path)
+    m3ApiGetArg      (uvwasi_size_t        , old_path_len)
+    m3ApiGetArg      (uvwasi_fd_t          , new_fd)
+    m3ApiGetArgMem   (const char *         , new_path)
+    m3ApiGetArg      (uvwasi_size_t        , new_path_len)
+
+    m3ApiCheckMem(old_path, old_path_len);
+    m3ApiCheckMem(new_path, new_path_len);
+
+    uvwasi_errno_t ret = uvwasi_path_rename(&uvwasi, old_fd, old_path, old_path_len,
+                                                     new_fd, new_path, new_path_len);
+
+    WASI_TRACE("old_fd:%d, old_path:%s, new_fd:%d, new_path:%s", old_fd, old_path, new_fd, new_path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_symlink)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (const char *         , old_path)
+    m3ApiGetArg      (uvwasi_size_t        , old_path_len)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , new_path)
+    m3ApiGetArg      (uvwasi_size_t        , new_path_len)
+
+    m3ApiCheckMem(old_path, old_path_len);
+    m3ApiCheckMem(new_path, new_path_len);
+
+    uvwasi_errno_t ret = uvwasi_path_symlink(&uvwasi, old_path, old_path_len,
+                                                  fd, new_path, new_path_len);
+
+    WASI_TRACE("old_path:%s, fd:%d, new_path:%s", old_path, fd, new_path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_unlink_file)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    uvwasi_errno_t ret = uvwasi_path_unlink_file(&uvwasi, fd, path, path_len);
+
+    WASI_TRACE("fd:%d, path:%s", fd, path);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_path_open)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , dirfd)
+    m3ApiGetArg      (uvwasi_lookupflags_t , dirflags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uvwasi_size_t        , path_len)
+    m3ApiGetArg      (uvwasi_oflags_t      , oflags)
+    m3ApiGetArg      (uvwasi_rights_t      , fs_rights_base)
+    m3ApiGetArg      (uvwasi_rights_t      , fs_rights_inheriting)
+    m3ApiGetArg      (uvwasi_fdflags_t     , fs_flags)
+    m3ApiGetArgMem   (uvwasi_fd_t *        , fd)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(fd,   sizeof(uvwasi_fd_t));
+
+    uvwasi_fd_t uvfd;
+
+    uvwasi_errno_t ret = uvwasi_path_open(&uvwasi,
+                                 dirfd,
+                                 dirflags,
+                                 path,
+                                 path_len,
+                                 oflags,
+                                 fs_rights_base,
+                                 fs_rights_inheriting,
+                                 fs_flags,
+                                 &uvfd);
+
+    WASI_TRACE("dirfd:%d, dirflags:0x%x, path:%s, oflags:0x%x, fs_flags:0x%x | fd:%d", dirfd, dirflags, path, oflags, fs_flags, uvfd);
+
+    m3ApiWriteMem32(fd, uvfd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_path_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_lookupflags_t , flags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uint32_t             , path_len)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf,  56); // wasi_filestat_t
+
+    uvwasi_filestat_t stat;
+
+    uvwasi_errno_t ret = uvwasi_path_filestat_get(&uvwasi, fd, flags, path, path_len, &stat);
+
+    WASI_TRACE("fd:%d, flags:0x%x, path:%s | fs.size:%" PRIu64, fd, flags, path, stat.st_size);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 56);
+    m3ApiWriteMem64(buf+0,  stat.st_dev);
+    m3ApiWriteMem64(buf+8,  stat.st_ino);
+    m3ApiWriteMem8 (buf+16, stat.st_filetype);
+    m3ApiWriteMem32(buf+20, stat.st_nlink);
+    m3ApiWriteMem64(buf+24, stat.st_size);
+    m3ApiWriteMem64(buf+32, stat.st_atim);
+    m3ApiWriteMem64(buf+40, stat.st_mtim);
+    m3ApiWriteMem64(buf+48, stat.st_ctim);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_path_filestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_lookupflags_t , flags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (uint32_t             , path_len)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(buf,  64); // wasi_filestat_t
+
+    uvwasi_filestat_t stat;
+
+    uvwasi_errno_t ret = uvwasi_path_filestat_get(&uvwasi, fd, flags, path, path_len, &stat);
+
+    WASI_TRACE("fd:%d, flags:0x%x, path:%s | fs.size:%" PRIu64, fd, flags, path, stat.st_size);
+
+    if (ret != UVWASI_ESUCCESS) {
+        m3ApiReturn(ret);
+    }
+
+    memset(buf, 0, 64);
+    m3ApiWriteMem64(buf+0,  stat.st_dev);
+    m3ApiWriteMem64(buf+8,  stat.st_ino);
+    m3ApiWriteMem8 (buf+16, stat.st_filetype);
+    m3ApiWriteMem64(buf+24, stat.st_nlink);
+    m3ApiWriteMem64(buf+32, stat.st_size);
+    m3ApiWriteMem64(buf+40, stat.st_atim);
+    m3ApiWriteMem64(buf+48, stat.st_mtim);
+    m3ApiWriteMem64(buf+56, stat.st_ctim);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_pread)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (uvwasi_size_t        , iovs_len)
+    m3ApiGetArg      (uvwasi_filesize_t    , offset)
+    m3ApiGetArgMem   (uvwasi_size_t *      , nread)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nread,        sizeof(uvwasi_size_t));
+
+#if defined(M3_COMPILER_MSVC)
+    if (iovs_len > 32) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_iovec_t  iovs[32];
+#else
+    if (iovs_len > 128) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_iovec_t  iovs[iovs_len];
+#endif
+
+    for (uvwasi_size_t i = 0; i < iovs_len; ++i) {
+        iovs[i].buf = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        iovs[i].buf_len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        m3ApiCheckMem(iovs[i].buf,     iovs[i].buf_len);
+        //fprintf(stderr, "> fd_pread fd:%d iov%d.len:%d\n", fd, i, iovs[i].buf_len);
+    }
+
+    uvwasi_size_t num_read;
+
+    uvwasi_errno_t ret = uvwasi_fd_pread(&uvwasi, fd, iovs, iovs_len, offset, &num_read);
+
+    WASI_TRACE("fd:%d | nread:%d", fd, num_read);
+
+    m3ApiWriteMem32(nread, num_read);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_read)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (uvwasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (uvwasi_size_t *      , nread)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nread,        sizeof(uvwasi_size_t));
+
+#if defined(M3_COMPILER_MSVC)
+    if (iovs_len > 32) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_iovec_t  iovs[32];
+#else
+    if (iovs_len > 128) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_iovec_t  iovs[iovs_len];
+#endif
+    uvwasi_size_t num_read;
+    uvwasi_errno_t ret;
+
+    for (uvwasi_size_t i = 0; i < iovs_len; ++i) {
+        iovs[i].buf = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        iovs[i].buf_len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        m3ApiCheckMem(iovs[i].buf,     iovs[i].buf_len);
+        //fprintf(stderr, "> fd_read fd:%d iov%d.len:%d\n", fd, i, iovs[i].buf_len);
+    }
+
+    ret = uvwasi_fd_read(&uvwasi, fd, iovs, iovs_len, &num_read);
+
+    WASI_TRACE("fd:%d | nread:%d", fd, num_read);
+
+    m3ApiWriteMem32(nread, num_read);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_write)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (uvwasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (uvwasi_size_t *      , nwritten)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nwritten,     sizeof(uvwasi_size_t));
+
+#if defined(M3_COMPILER_MSVC)
+    if (iovs_len > 32) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_ciovec_t  iovs[32];
+#else
+    if (iovs_len > 128) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_ciovec_t  iovs[iovs_len];
+#endif
+    uvwasi_size_t num_written;
+    uvwasi_errno_t ret;
+
+    for (uvwasi_size_t i = 0; i < iovs_len; ++i) {
+        iovs[i].buf = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        iovs[i].buf_len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        m3ApiCheckMem(iovs[i].buf,     iovs[i].buf_len);
+    }
+
+    ret = uvwasi_fd_write(&uvwasi, fd, iovs, iovs_len, &num_written);
+
+    WASI_TRACE("fd:%d | nwritten:%d", fd, num_written);
+
+    m3ApiWriteMem32(nwritten, num_written);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_pwrite)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (uvwasi_size_t        , iovs_len)
+    m3ApiGetArg      (uvwasi_filesize_t    , offset)
+    m3ApiGetArgMem   (uvwasi_size_t *      , nwritten)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nwritten,     sizeof(uvwasi_size_t));
+
+#if defined(M3_COMPILER_MSVC)
+    if (iovs_len > 32) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_ciovec_t  iovs[32];
+#else
+    if (iovs_len > 128) m3ApiReturn(UVWASI_EINVAL);
+    uvwasi_ciovec_t  iovs[iovs_len];
+#endif
+    uvwasi_size_t num_written;
+    uvwasi_errno_t ret;
+
+    for (uvwasi_size_t i = 0; i < iovs_len; ++i) {
+        iovs[i].buf = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        iovs[i].buf_len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        m3ApiCheckMem(iovs[i].buf,     iovs[i].buf_len);
+    }
+
+    ret = uvwasi_fd_pwrite(&uvwasi, fd, iovs, iovs_len, offset, &num_written);
+
+    WASI_TRACE("fd:%d | nwritten:%d", fd, num_written);
+
+    m3ApiWriteMem32(nwritten, num_written);
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_readdir)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArgMem   (void *               , buf)
+    m3ApiGetArg      (uvwasi_size_t        , buf_len)
+    m3ApiGetArg      (uvwasi_dircookie_t   , cookie)
+    m3ApiGetArgMem   (uvwasi_size_t *      , bufused)
+
+    m3ApiCheckMem(buf,      buf_len);
+    m3ApiCheckMem(bufused,  sizeof(uvwasi_size_t));
+
+    uvwasi_size_t uvbufused;
+    uvwasi_errno_t ret = uvwasi_fd_readdir(&uvwasi, fd, buf, buf_len, cookie, &uvbufused);
+
+    WASI_TRACE("fd:%d | bufused:%d", fd, uvbufused);
+
+    m3ApiWriteMem32(bufused, uvbufused);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_advise)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_filesize_t    , offset)
+    m3ApiGetArg      (uvwasi_filesize_t    , length)
+    m3ApiGetArg      (uvwasi_advice_t      , advice)
+
+    uvwasi_errno_t ret = uvwasi_fd_advise(&uvwasi, fd, offset, length, advice);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", length:%" PRIu64 ", advice:%d", fd, offset, length, advice);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_allocate)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t          , fd)
+    m3ApiGetArg      (uvwasi_filesize_t    , offset)
+    m3ApiGetArg      (uvwasi_filesize_t    , length)
+
+    uvwasi_errno_t ret = uvwasi_fd_allocate(&uvwasi, fd, offset, length);
+
+    WASI_TRACE("fd:%d, offset:%" PRIu64 ", length:%" PRIu64, fd, offset, length);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_close)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t, fd)
+
+    uvwasi_errno_t ret = uvwasi_fd_close(&uvwasi, fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_datasync)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_fd_t, fd)
+
+    uvwasi_errno_t ret = uvwasi_fd_datasync(&uvwasi, fd);
+
+    WASI_TRACE("fd:%d", fd);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_random_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+    m3ApiGetArg      (uvwasi_size_t        , buf_len)
+
+    m3ApiCheckMem(buf, buf_len);
+
+    uvwasi_errno_t ret = uvwasi_random_get(&uvwasi, buf, buf_len);
+
+    WASI_TRACE("len:%d", buf_len);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_res_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArgMem   (uvwasi_timestamp_t * , resolution)
+
+    m3ApiCheckMem(resolution, sizeof(uvwasi_timestamp_t));
+
+    uvwasi_timestamp_t t;
+    uvwasi_errno_t ret = uvwasi_clock_res_get(&uvwasi, wasi_clk_id, &t);
+
+    WASI_TRACE("clk_id:%d | res:%" PRIu64, wasi_clk_id, t);
+
+    m3ApiWriteMem64(resolution, t);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_time_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArg      (uvwasi_timestamp_t   , precision)
+    m3ApiGetArgMem   (uvwasi_timestamp_t * , time)
+
+    m3ApiCheckMem(time, sizeof(uvwasi_timestamp_t));
+
+    uvwasi_timestamp_t t;
+    uvwasi_errno_t ret = uvwasi_clock_time_get(&uvwasi, wasi_clk_id, precision, &t);
+
+    WASI_TRACE("clk_id:%d | res:%" PRIu64, wasi_clk_id, t);
+
+    m3ApiWriteMem64(time, t);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_poll_oneoff)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (const uvwasi_subscription_t * , in)
+    m3ApiGetArgMem   (uvwasi_event_t *              , out)
+    m3ApiGetArg      (uvwasi_size_t                 , nsubscriptions)
+    m3ApiGetArgMem   (uvwasi_size_t *               , nevents)
+
+    m3ApiCheckMem(in,       nsubscriptions * sizeof(uvwasi_subscription_t));
+    m3ApiCheckMem(out,      nsubscriptions * sizeof(uvwasi_event_t));
+    m3ApiCheckMem(nevents,  sizeof(uvwasi_size_t));
+
+    // TODO: unstable/snapshot_preview1 compatibility
+
+    uvwasi_errno_t ret = uvwasi_poll_oneoff(&uvwasi, in, out, nsubscriptions, nevents);
+
+    WASI_TRACE("nsubscriptions:%d | nevents:%d", nsubscriptions, *nevents);
+
+    //TODO: m3ApiWriteMem
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_proc_exit)
+{
+    m3ApiGetArg      (uint32_t, code)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context) {
+        context->exit_code = code;
+    }
+
+    //TODO: fprintf(stderr, "proc_exit code:%d\n", code);
+
+    m3ApiTrap(m3Err_trapExit);
+}
+
+m3ApiRawFunction(m3_wasi_generic_proc_raise)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (uvwasi_signal_t, sig)
+
+    uvwasi_errno_t ret = uvwasi_proc_raise(&uvwasi, sig);
+
+    WASI_TRACE("sig:%d", sig);
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_sched_yield)
+{
+    m3ApiReturnType  (uint32_t)
+    uvwasi_errno_t ret = uvwasi_sched_yield(&uvwasi);
+
+    WASI_TRACE("");
+
+    m3ApiReturn(ret);
+}
+
+
+static
+M3Result SuppressLookupFailure(M3Result i_result)
+{
+    if (i_result == m3Err_functionLookupFailed)
+        return m3Err_none;
+    else
+        return i_result;
+}
+
+m3_wasi_context_t* m3_GetWasiContext()
+{
+    return wasi_context;
+}
+
+
+M3Result  m3_LinkWASI  (IM3Module module)
+{
+    #define ENV_COUNT       9
+
+    char* env[ENV_COUNT];
+    env[0] = "TERM=xterm-256color";
+    env[1] = "COLORTERM=truecolor";
+    env[2] = "LANG=en_US.UTF-8";
+    env[3] = "PWD=/";
+    env[4] = "HOME=/";
+    env[5] = "PATH=/";
+    env[6] = "WASM3=1";
+    env[7] = "WASM3_ARCH=" M3_ARCH;
+    env[8] = NULL;
+
+    #define PREOPENS_COUNT  2
+
+    uvwasi_preopen_t preopens[PREOPENS_COUNT];
+    preopens[0].mapped_path = "/";
+    preopens[0].real_path = ".";
+    preopens[1].mapped_path = "./";
+    preopens[1].real_path = ".";
+
+    uvwasi_options_t init_options;
+    uvwasi_options_init(&init_options);
+    init_options.argc = 0;      // runtime->argc is not initialized at this point, so we implement args_get directly
+    init_options.envp = (const char **) env;
+    init_options.preopenc = PREOPENS_COUNT;
+    init_options.preopens = preopens;
+
+    return m3_LinkWASIWithOptions(module, init_options);
+}
+
+M3Result  m3_LinkWASIWithOptions  (IM3Module module, uvwasi_options_t init_options)
+{
+    M3Result result = m3Err_none;
+
+    if (!wasi_context) {
+        wasi_context = (m3_wasi_context_t*)malloc(sizeof(m3_wasi_context_t));
+        wasi_context->exit_code = 0;
+        wasi_context->argc = 0;
+        wasi_context->argv = 0;
+
+        uvwasi_errno_t ret = uvwasi_init(&uvwasi, &init_options);
+
+        if (ret != UVWASI_ESUCCESS) {
+            return "uvwasi_init failed";
+        }
+    }
+
+    static const char* namespaces[2] = { "wasi_unstable", "wasi_snapshot_preview1" };
+
+    // Some functions are incompatible between WASI versions
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_seek",           "i(iIi*)",   &m3_wasi_unstable_fd_seek)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_seek",           "i(iIi*)",   &m3_wasi_snapshot_preview1_fd_seek)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_filestat_get",   "i(i*)",     &m3_wasi_unstable_fd_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_filestat_get",   "i(i*)",     &m3_wasi_snapshot_preview1_fd_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "path_filestat_get", "i(ii*i*)",  &m3_wasi_unstable_path_filestat_get)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "path_filestat_get", "i(ii*i*)",  &m3_wasi_snapshot_preview1_path_filestat_get)));
+
+    for (int i=0; i<2; i++)
+    {
+        const char* wasi = namespaces[i];
+
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_get",           "i(**)",   &m3_wasi_generic_args_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_sizes_get",     "i(**)",   &m3_wasi_generic_args_sizes_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_res_get",        "i(i*)",   &m3_wasi_generic_clock_res_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_time_get",       "i(iI*)",  &m3_wasi_generic_clock_time_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",          "i(**)",   &m3_wasi_generic_environ_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get",    "i(**)",   &m3_wasi_generic_environ_sizes_get)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_advise",            "i(iIIi)", &m3_wasi_generic_fd_advise)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_allocate",          "i(iII)",  &m3_wasi_generic_fd_allocate)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_close",             "i(i)",    &m3_wasi_generic_fd_close)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_datasync",          "i(i)",    &m3_wasi_generic_fd_datasync)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_get",        "i(i*)",   &m3_wasi_generic_fd_fdstat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_flags",  "i(ii)",   &m3_wasi_generic_fd_fdstat_set_flags)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_rights", "i(iII)",  &m3_wasi_generic_fd_fdstat_set_rights)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_size", "i(iI)",   &m3_wasi_generic_fd_filestat_set_size)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_times","i(iIIi)", &m3_wasi_generic_fd_filestat_set_times)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pread",             "i(i*iI*)",&m3_wasi_generic_fd_pread)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_get",       "i(i*)",   &m3_wasi_generic_fd_prestat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_dir_name",  "i(i*i)",  &m3_wasi_generic_fd_prestat_dir_name)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pwrite",            "i(i*iI*)",&m3_wasi_generic_fd_pwrite)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_read",              "i(i*i*)", &m3_wasi_generic_fd_read)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_readdir",           "i(i*iI*)",&m3_wasi_generic_fd_readdir)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_renumber",          "i(ii)",   &m3_wasi_generic_fd_renumber)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_sync",              "i(i)",    &m3_wasi_generic_fd_sync)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_tell",              "i(i*)",   &m3_wasi_generic_fd_tell)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_write",             "i(i*i*)", &m3_wasi_generic_fd_write)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_create_directory",    "i(i*i)",       &m3_wasi_generic_path_create_directory)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_filestat_set_times",  "i(ii*iIIi)",   )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_link",                "i(ii*ii*i)",   )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_open",                "i(ii*iiIIi*)", &m3_wasi_generic_path_open)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_readlink",            "i(i*i*i*)",    &m3_wasi_generic_path_readlink)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_remove_directory",    "i(i*i)",       &m3_wasi_generic_path_remove_directory)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_rename",              "i(i*ii*i)",    &m3_wasi_generic_path_rename)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_symlink",             "i(*ii*i)",     &m3_wasi_generic_path_symlink)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_unlink_file",         "i(i*i)",       &m3_wasi_generic_path_unlink_file)));
+
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "poll_oneoff",          "i(**i*)", &m3_wasi_generic_poll_oneoff)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "proc_exit",          "v(i)",    &m3_wasi_generic_proc_exit, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "proc_raise",           "i(i)",    &m3_wasi_generic_proc_raise)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "random_get",           "i(*i)",   &m3_wasi_generic_random_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sched_yield",          "i()",     &m3_wasi_generic_sched_yield)));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_recv",            "i(i*ii**)",        )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_send",            "i(i*ii*)",         )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_shutdown",        "i(ii)",            )));
+    }
+
+_catch:
+    return result;
+}
+
+#endif // d_m3HasUVWASI
+

--- a/thirdparty/wasm3/source/m3_api_wasi.c
+++ b/thirdparty/wasm3/source/m3_api_wasi.c
@@ -1,0 +1,873 @@
+//
+//  m3_api_wasi.c
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "m3_api_wasi.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#if defined(d_m3HasWASI)
+
+// Fixup wasi_core.h
+#if defined (M3_COMPILER_MSVC)
+#  define _Static_assert(...)
+#  define __attribute__(...)
+#  define _Noreturn
+#endif
+
+#include "extra/wasi_core.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+#if defined(APE)
+// Actually Portable Executable
+// All functions are already included in cosmopolitan.h
+#elif defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__) || defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__CYGWIN__)
+#  include <unistd.h>
+#  include <sys/uio.h>
+#  if defined(__APPLE__)
+#      include <TargetConditionals.h>
+#      if TARGET_OS_OSX // TARGET_OS_MAC includes iOS
+#          include <sys/random.h>
+#      else // iOS / Simulator
+#          include <Security/Security.h>
+#      endif
+#  else
+#      include <sys/random.h>
+#  endif
+#  define HAS_IOVEC
+#elif defined(_WIN32)
+#  include <Windows.h>
+#  include <io.h>
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/aa387694.aspx
+#  define SystemFunction036 NTAPI SystemFunction036
+#  include <NTSecAPI.h>
+#  undef SystemFunction036
+#  define ssize_t SSIZE_T
+
+#  define open  _open
+#  define read  _read
+#  define write _write
+#  define close _close
+#endif
+
+static m3_wasi_context_t* wasi_context;
+
+typedef struct wasi_iovec_t
+{
+    __wasi_size_t buf;
+    __wasi_size_t buf_len;
+} wasi_iovec_t;
+
+#define PREOPEN_CNT   5
+
+typedef struct Preopen {
+    int         fd;
+    const char* path;
+    const char* real_path;
+} Preopen;
+
+Preopen preopen[PREOPEN_CNT] = {
+    {  0, "<stdin>" , "" },
+    {  1, "<stdout>", "" },
+    {  2, "<stderr>", "" },
+    { -1, "/"       , "." },
+    { -1, "./"      , "." },
+};
+
+#if defined(APE)
+#  define APE_SWITCH_BEG
+#  define APE_SWITCH_END          {}
+#  define APE_CASE_RET(e1,e2)     if (errnum == e1)    return e2;   else
+#else
+#  define APE_SWITCH_BEG          switch (errnum) {
+#  define APE_SWITCH_END          }
+#  define APE_CASE_RET(e1,e2)     case e1:   return e2;   break;
+#endif
+
+static
+__wasi_errno_t errno_to_wasi(int errnum) {
+    APE_SWITCH_BEG
+    APE_CASE_RET( EPERM   , __WASI_ERRNO_PERM   )
+    APE_CASE_RET( ENOENT  , __WASI_ERRNO_NOENT  )
+    APE_CASE_RET( ESRCH   , __WASI_ERRNO_SRCH   )
+    APE_CASE_RET( EINTR   , __WASI_ERRNO_INTR   )
+    APE_CASE_RET( EIO     , __WASI_ERRNO_IO     )
+    APE_CASE_RET( ENXIO   , __WASI_ERRNO_NXIO   )
+    APE_CASE_RET( E2BIG   , __WASI_ERRNO_2BIG   )
+    APE_CASE_RET( ENOEXEC , __WASI_ERRNO_NOEXEC )
+    APE_CASE_RET( EBADF   , __WASI_ERRNO_BADF   )
+    APE_CASE_RET( ECHILD  , __WASI_ERRNO_CHILD  )
+    APE_CASE_RET( EAGAIN  , __WASI_ERRNO_AGAIN  )
+    APE_CASE_RET( ENOMEM  , __WASI_ERRNO_NOMEM  )
+    APE_CASE_RET( EACCES  , __WASI_ERRNO_ACCES  )
+    APE_CASE_RET( EFAULT  , __WASI_ERRNO_FAULT  )
+    APE_CASE_RET( EBUSY   , __WASI_ERRNO_BUSY   )
+    APE_CASE_RET( EEXIST  , __WASI_ERRNO_EXIST  )
+    APE_CASE_RET( EXDEV   , __WASI_ERRNO_XDEV   )
+    APE_CASE_RET( ENODEV  , __WASI_ERRNO_NODEV  )
+    APE_CASE_RET( ENOTDIR , __WASI_ERRNO_NOTDIR )
+    APE_CASE_RET( EISDIR  , __WASI_ERRNO_ISDIR  )
+    APE_CASE_RET( EINVAL  , __WASI_ERRNO_INVAL  )
+    APE_CASE_RET( ENFILE  , __WASI_ERRNO_NFILE  )
+    APE_CASE_RET( EMFILE  , __WASI_ERRNO_MFILE  )
+    APE_CASE_RET( ENOTTY  , __WASI_ERRNO_NOTTY  )
+    APE_CASE_RET( ETXTBSY , __WASI_ERRNO_TXTBSY )
+    APE_CASE_RET( EFBIG   , __WASI_ERRNO_FBIG   )
+    APE_CASE_RET( ENOSPC  , __WASI_ERRNO_NOSPC  )
+    APE_CASE_RET( ESPIPE  , __WASI_ERRNO_SPIPE  )
+    APE_CASE_RET( EROFS   , __WASI_ERRNO_ROFS   )
+    APE_CASE_RET( EMLINK  , __WASI_ERRNO_MLINK  )
+    APE_CASE_RET( EPIPE   , __WASI_ERRNO_PIPE   )
+    APE_CASE_RET( EDOM    , __WASI_ERRNO_DOM    )
+    APE_CASE_RET( ERANGE  , __WASI_ERRNO_RANGE  )
+    APE_SWITCH_END
+    return __WASI_ERRNO_INVAL;
+}
+
+#if defined(_WIN32)
+
+#if !defined(__MINGW32__)
+
+static inline
+int clock_gettime(int clk_id, struct timespec *spec)
+{
+    __int64 wintime; GetSystemTimeAsFileTime((FILETIME*)&wintime);
+    wintime      -= 116444736000000000i64;           //1jan1601 to 1jan1970
+    spec->tv_sec  = wintime / 10000000i64;           //seconds
+    spec->tv_nsec = wintime % 10000000i64 *100;      //nano-seconds
+    return 0;
+}
+
+static inline
+int clock_getres(int clk_id, struct timespec *spec) {
+    return -1; // Defaults to 1000000
+}
+
+#endif
+
+static inline
+int convert_clockid(__wasi_clockid_t in) {
+    return 0;
+}
+
+#else // _WIN32
+
+static inline
+int convert_clockid(__wasi_clockid_t in) {
+    switch (in) {
+    case __WASI_CLOCKID_MONOTONIC:            return CLOCK_MONOTONIC;
+    case __WASI_CLOCKID_PROCESS_CPUTIME_ID:   return CLOCK_PROCESS_CPUTIME_ID;
+    case __WASI_CLOCKID_REALTIME:             return CLOCK_REALTIME;
+    case __WASI_CLOCKID_THREAD_CPUTIME_ID:    return CLOCK_THREAD_CPUTIME_ID;
+    default: return -1;
+    }
+}
+
+#endif // _WIN32
+
+static inline
+__wasi_timestamp_t convert_timespec(const struct timespec *ts) {
+    if (ts->tv_sec < 0)
+        return 0;
+    if ((__wasi_timestamp_t)ts->tv_sec >= UINT64_MAX / 1000000000)
+        return UINT64_MAX;
+    return (__wasi_timestamp_t)ts->tv_sec * 1000000000 + ts->tv_nsec;
+}
+
+#if defined(HAS_IOVEC)
+
+static inline
+const void* copy_iov_to_host(IM3Runtime runtime, void* _mem, struct iovec* host_iov, wasi_iovec_t* wasi_iov, int32_t iovs_len)
+{
+    // Convert wasi memory offsets to host addresses
+    for (int i = 0; i < iovs_len; i++) {
+        host_iov[i].iov_base = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iov[i].buf));
+        host_iov[i].iov_len  = m3ApiReadMem32(&wasi_iov[i].buf_len);
+        m3ApiCheckMem(host_iov[i].iov_base,     host_iov[i].iov_len);
+    }
+    m3ApiSuccess();
+}
+
+#endif
+
+/*
+ * WASI API implementation
+ */
+
+m3ApiRawFunction(m3_wasi_generic_args_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , argv)
+    m3ApiGetArgMem   (char *               , argv_buf)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(__WASI_ERRNO_INVAL); }
+
+    m3ApiCheckMem(argv, context->argc * sizeof(uint32_t));
+
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        m3ApiWriteMem32(&argv[i], m3ApiPtrToOffset(argv_buf));
+
+        size_t len = strlen (context->argv[i]);
+
+        m3ApiCheckMem(argv_buf, len);
+        memcpy (argv_buf, context->argv[i], len);
+        argv_buf += len;
+        * argv_buf++ = 0;
+    }
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_args_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (__wasi_size_t *      , argc)
+    m3ApiGetArgMem   (__wasi_size_t *      , argv_buf_size)
+
+    m3ApiCheckMem(argc,             sizeof(__wasi_size_t));
+    m3ApiCheckMem(argv_buf_size,    sizeof(__wasi_size_t));
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context == NULL) { m3ApiReturn(__WASI_ERRNO_INVAL); }
+
+    __wasi_size_t buf_len = 0;
+    for (u32 i = 0; i < context->argc; ++i)
+    {
+        buf_len += strlen (context->argv[i]) + 1;
+    }
+
+    m3ApiWriteMem32(argc, context->argc);
+    m3ApiWriteMem32(argv_buf_size, buf_len);
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , env)
+    m3ApiGetArgMem   (char *               , env_buf)
+
+    // TODO
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (__wasi_size_t *      , env_count)
+    m3ApiGetArgMem   (__wasi_size_t *      , env_buf_size)
+
+    m3ApiCheckMem(env_count,    sizeof(__wasi_size_t));
+    m3ApiCheckMem(env_buf_size, sizeof(__wasi_size_t));
+
+    // TODO
+    m3ApiWriteMem32(env_count,    0);
+    m3ApiWriteMem32(env_buf_size, 0);
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_dir_name)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (char *               , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+
+    m3ApiCheckMem(path, path_len);
+
+    if (fd < 3 || fd >= PREOPEN_CNT) { m3ApiReturn(__WASI_ERRNO_BADF); }
+    size_t slen = strlen(preopen[fd].path) + 1;
+    memcpy(path, preopen[fd].path, M3_MIN(slen, path_len));
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_prestat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+
+    m3ApiCheckMem(buf, 8);
+
+    if (fd < 3 || fd >= PREOPEN_CNT) { m3ApiReturn(__WASI_ERRNO_BADF); }
+
+    m3ApiWriteMem32(buf+0, __WASI_PREOPENTYPE_DIR);
+    m3ApiWriteMem32(buf+4, strlen(preopen[fd].path) + 1);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (__wasi_fdstat_t *    , fdstat)
+
+    m3ApiCheckMem(fdstat, sizeof(__wasi_fdstat_t));
+
+#ifdef _WIN32
+
+    // TODO: This needs a proper implementation
+    if (fd < PREOPEN_CNT) {
+        fdstat->fs_filetype= __WASI_FILETYPE_DIRECTORY;
+    } else {
+        fdstat->fs_filetype= __WASI_FILETYPE_REGULAR_FILE;
+    }
+
+    fdstat->fs_flags = 0;
+    fdstat->fs_rights_base = (uint64_t)-1; // all rights
+    fdstat->fs_rights_inheriting = (uint64_t)-1; // all rights
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#else
+    struct stat fd_stat;
+
+#if !defined(APE) // TODO: not implemented in Cosmopolitan
+    int fl = fcntl(fd, F_GETFL);
+    if (fl < 0) { m3ApiReturn(errno_to_wasi(errno)); }
+#endif
+
+    fstat(fd, &fd_stat);
+    int mode = fd_stat.st_mode;
+    fdstat->fs_filetype = (S_ISBLK(mode)   ? __WASI_FILETYPE_BLOCK_DEVICE     : 0) |
+                          (S_ISCHR(mode)   ? __WASI_FILETYPE_CHARACTER_DEVICE : 0) |
+                          (S_ISDIR(mode)   ? __WASI_FILETYPE_DIRECTORY        : 0) |
+                          (S_ISREG(mode)   ? __WASI_FILETYPE_REGULAR_FILE     : 0) |
+                          //(S_ISSOCK(mode)  ? __WASI_FILETYPE_SOCKET_STREAM    : 0) |
+                          (S_ISLNK(mode)   ? __WASI_FILETYPE_SYMBOLIC_LINK    : 0);
+#if !defined(APE)
+    m3ApiWriteMem16(&fdstat->fs_flags,
+                       ((fl & O_APPEND)    ? __WASI_FDFLAGS_APPEND    : 0) |
+                       ((fl & O_DSYNC)     ? __WASI_FDFLAGS_DSYNC     : 0) |
+                       ((fl & O_NONBLOCK)  ? __WASI_FDFLAGS_NONBLOCK  : 0) |
+                       //((fl & O_RSYNC)     ? __WASI_FDFLAGS_RSYNC     : 0) |
+                       ((fl & O_SYNC)      ? __WASI_FDFLAGS_SYNC      : 0));
+#endif // APE
+
+    fdstat->fs_rights_base = (uint64_t)-1; // all rights
+
+    // Make descriptors 0,1,2 look like a TTY
+    if (fd <= 2) {
+        fdstat->fs_rights_base &= ~(__WASI_RIGHTS_FD_SEEK | __WASI_RIGHTS_FD_TELL);
+    }
+
+    fdstat->fs_rights_inheriting = (uint64_t)-1; // all rights
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#endif
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_fdstat_set_flags)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_fdflags_t     , flags)
+
+    // TODO
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_unstable_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (__wasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(__wasi_filesize_t));
+
+    int whence;
+
+    switch (wasi_whence) {
+    case 0: whence = SEEK_CUR; break;
+    case 1: whence = SEEK_END; break;
+    case 2: whence = SEEK_SET; break;
+    default:                m3ApiReturn(__WASI_ERRNO_INVAL);
+    }
+
+    int64_t ret;
+#if defined(M3_COMPILER_MSVC) || defined(__MINGW32__)
+    ret = _lseeki64(fd, offset, whence);
+#else
+    ret = lseek(fd, offset, whence);
+#endif
+    if (ret < 0) { m3ApiReturn(errno_to_wasi(errno)); }
+    m3ApiWriteMem64(result, ret);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_snapshot_preview1_fd_seek)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArg      (__wasi_filedelta_t   , offset)
+    m3ApiGetArg      (uint32_t             , wasi_whence)
+    m3ApiGetArgMem   (__wasi_filesize_t *  , result)
+
+    m3ApiCheckMem(result, sizeof(__wasi_filesize_t));
+
+    int whence;
+
+    switch (wasi_whence) {
+    case 0: whence = SEEK_SET; break;
+    case 1: whence = SEEK_CUR; break;
+    case 2: whence = SEEK_END; break;
+    default:                m3ApiReturn(__WASI_ERRNO_INVAL);
+    }
+
+    int64_t ret;
+#if defined(M3_COMPILER_MSVC) || defined(__MINGW32__)
+    ret = _lseeki64(fd, offset, whence);
+#else
+    ret = lseek(fd, offset, whence);
+#endif
+    if (ret < 0) { m3ApiReturn(errno_to_wasi(errno)); }
+    m3ApiWriteMem64(result, ret);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+
+m3ApiRawFunction(m3_wasi_generic_path_open)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , dirfd)
+    m3ApiGetArg      (__wasi_lookupflags_t , dirflags)
+    m3ApiGetArgMem   (const char *         , path)
+    m3ApiGetArg      (__wasi_size_t        , path_len)
+    m3ApiGetArg      (__wasi_oflags_t      , oflags)
+    m3ApiGetArg      (__wasi_rights_t      , fs_rights_base)
+    m3ApiGetArg      (__wasi_rights_t      , fs_rights_inheriting)
+    m3ApiGetArg      (__wasi_fdflags_t     , fs_flags)
+    m3ApiGetArgMem   (__wasi_fd_t *        , fd)
+
+    m3ApiCheckMem(path, path_len);
+    m3ApiCheckMem(fd,   sizeof(__wasi_fd_t));
+
+    if (path_len >= 512)
+        m3ApiReturn(__WASI_ERRNO_INVAL);
+
+    // copy path so we can ensure it is NULL terminated
+#if defined(M3_COMPILER_MSVC)
+    char host_path[512];
+#else
+    char host_path[path_len+1];
+#endif
+    memcpy (host_path, path, path_len);
+    host_path[path_len] = '\0'; // NULL terminator
+
+#if defined(APE)
+    // TODO: This all needs a proper implementation
+
+    int flags = ((oflags & __WASI_OFLAGS_CREAT)             ? O_CREAT     : 0) |
+                ((oflags & __WASI_OFLAGS_EXCL)              ? O_EXCL      : 0) |
+                ((oflags & __WASI_OFLAGS_TRUNC)             ? O_TRUNC     : 0) |
+                ((fs_flags & __WASI_FDFLAGS_APPEND)     ? O_APPEND    : 0);
+
+    if ((fs_rights_base & __WASI_RIGHTS_FD_READ) &&
+        (fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= O_RDWR;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= O_WRONLY;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_READ)) {
+        flags |= O_RDONLY; // no-op because O_RDONLY is 0
+    }
+    int mode = 0644;
+
+    int host_fd = open (host_path, flags, mode);
+
+    if (host_fd < 0)
+    {
+        m3ApiReturn(errno_to_wasi (errno));
+    }
+    else
+    {
+        m3ApiWriteMem32(fd, host_fd);
+        m3ApiReturn(__WASI_ERRNO_SUCCESS);
+    }
+#elif defined(_WIN32)
+    // TODO: This all needs a proper implementation
+
+    int flags = ((oflags & __WASI_OFLAGS_CREAT)             ? _O_CREAT     : 0) |
+                ((oflags & __WASI_OFLAGS_EXCL)              ? _O_EXCL      : 0) |
+                ((oflags & __WASI_OFLAGS_TRUNC)             ? _O_TRUNC     : 0) |
+                ((fs_flags & __WASI_FDFLAGS_APPEND)         ? _O_APPEND    : 0) |
+                _O_BINARY;
+
+    if ((fs_rights_base & __WASI_RIGHTS_FD_READ) &&
+        (fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= _O_RDWR;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= _O_WRONLY;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_READ)) {
+        flags |= _O_RDONLY; // no-op because O_RDONLY is 0
+    }
+    int mode = 0644;
+
+    int host_fd = open (host_path, flags, mode);
+
+    if (host_fd < 0)
+    {
+        m3ApiReturn(errno_to_wasi (errno));
+    }
+    else
+    {
+        m3ApiWriteMem32(fd, host_fd);
+        m3ApiReturn(__WASI_ERRNO_SUCCESS);
+    }
+#else
+    // translate o_flags and fs_flags into flags and mode
+    int flags = ((oflags & __WASI_OFLAGS_CREAT)             ? O_CREAT     : 0) |
+                //((oflags & __WASI_OFLAGS_DIRECTORY)         ? O_DIRECTORY : 0) |
+                ((oflags & __WASI_OFLAGS_EXCL)              ? O_EXCL      : 0) |
+                ((oflags & __WASI_OFLAGS_TRUNC)             ? O_TRUNC     : 0) |
+                ((fs_flags & __WASI_FDFLAGS_APPEND)     ? O_APPEND    : 0) |
+                ((fs_flags & __WASI_FDFLAGS_DSYNC)      ? O_DSYNC     : 0) |
+                ((fs_flags & __WASI_FDFLAGS_NONBLOCK)   ? O_NONBLOCK  : 0) |
+                //((fs_flags & __WASI_FDFLAGS_RSYNC)      ? O_RSYNC     : 0) |
+                ((fs_flags & __WASI_FDFLAGS_SYNC)       ? O_SYNC      : 0);
+    if ((fs_rights_base & __WASI_RIGHTS_FD_READ) &&
+        (fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= O_RDWR;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_WRITE)) {
+        flags |= O_WRONLY;
+    } else if ((fs_rights_base & __WASI_RIGHTS_FD_READ)) {
+        flags |= O_RDONLY; // no-op because O_RDONLY is 0
+    }
+    int mode = 0644;
+    int host_fd = openat (preopen[dirfd].fd, host_path, flags, mode);
+
+    if (host_fd < 0)
+    {
+        m3ApiReturn(errno_to_wasi (errno));
+    }
+    else
+    {
+        m3ApiWriteMem32(fd, host_fd);
+        m3ApiReturn(__WASI_ERRNO_SUCCESS);
+    }
+#endif
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_read)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (__wasi_size_t *      , nread)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nread,        sizeof(__wasi_size_t));
+
+#if defined(HAS_IOVEC)
+    struct iovec iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+
+    ssize_t ret = readv(fd, iovs, iovs_len);
+    if (ret < 0) { m3ApiReturn(errno_to_wasi(errno)); }
+    m3ApiWriteMem32(nread, ret);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#else
+    ssize_t res = 0;
+    for (__wasi_size_t i = 0; i < iovs_len; i++) {
+        void* addr = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        size_t len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        if (len == 0) continue;
+        m3ApiCheckMem(addr,     len);
+        int ret = read (fd, addr, len);
+        if (ret < 0) m3ApiReturn(errno_to_wasi(errno));
+        res += ret;
+        if ((size_t)ret < len) break;
+    }
+    m3ApiWriteMem32(nread, res);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#endif
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_write)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t          , fd)
+    m3ApiGetArgMem   (wasi_iovec_t *       , wasi_iovs)
+    m3ApiGetArg      (__wasi_size_t        , iovs_len)
+    m3ApiGetArgMem   (__wasi_size_t *      , nwritten)
+
+    m3ApiCheckMem(wasi_iovs,    iovs_len * sizeof(wasi_iovec_t));
+    m3ApiCheckMem(nwritten,     sizeof(__wasi_size_t));
+
+#if defined(HAS_IOVEC)
+    struct iovec iovs[iovs_len];
+    const void* mem_check = copy_iov_to_host(runtime, _mem, iovs, wasi_iovs, iovs_len);
+    if (mem_check != m3Err_none) {
+        return mem_check;
+    }
+
+    ssize_t ret = writev(fd, iovs, iovs_len);
+    if (ret < 0) { m3ApiReturn(errno_to_wasi(errno)); }
+    m3ApiWriteMem32(nwritten, ret);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#else
+    ssize_t res = 0;
+    for (__wasi_size_t i = 0; i < iovs_len; i++) {
+        void* addr = m3ApiOffsetToPtr(m3ApiReadMem32(&wasi_iovs[i].buf));
+        size_t len = m3ApiReadMem32(&wasi_iovs[i].buf_len);
+        if (len == 0) continue;
+        m3ApiCheckMem(addr,     len);
+        int ret = write (fd, addr, len);
+        if (ret < 0) m3ApiReturn(errno_to_wasi(errno));
+        res += ret;
+        if ((size_t)ret < len) break;
+    }
+    m3ApiWriteMem32(nwritten, res);
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+#endif
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_close)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t, fd)
+
+    int ret = close(fd);
+    m3ApiReturn(ret == 0 ? __WASI_ERRNO_SUCCESS : ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_fd_datasync)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_fd_t, fd)
+
+#if defined(_WIN32)
+    int ret = _commit(fd);
+#elif defined(__APPLE__)
+    int ret = fsync(fd);
+#elif defined(__ANDROID_API__) || defined(__OpenBSD__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+    int ret = fdatasync(fd);
+#else
+    int ret = __WASI_ERRNO_NOSYS;
+#endif
+    m3ApiReturn(ret == 0 ? __WASI_ERRNO_SUCCESS : ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_random_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint8_t *            , buf)
+    m3ApiGetArg      (__wasi_size_t        , buf_len)
+
+    m3ApiCheckMem(buf, buf_len);
+
+    while (1) {
+        ssize_t retlen = 0;
+
+#if defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__)
+        size_t reqlen = M3_MIN (buf_len, 256);
+#   if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+        retlen = SecRandomCopyBytes(kSecRandomDefault, reqlen, buf) < 0 ? -1 : reqlen;
+#   else
+        retlen = getentropy(buf, reqlen) < 0 ? -1 : reqlen;
+#   endif
+#elif defined(__FreeBSD__) || defined(__linux__)
+        retlen = getrandom(buf, buf_len, 0);
+#elif defined(_WIN32)
+        if (RtlGenRandom(buf, buf_len) == TRUE) {
+            m3ApiReturn(__WASI_ERRNO_SUCCESS);
+        }
+#else
+        m3ApiReturn(__WASI_ERRNO_NOSYS);
+#endif
+        if (retlen < 0) {
+            if (errno == EINTR || errno == EAGAIN) {
+                continue;
+            }
+            m3ApiReturn(errno_to_wasi(errno));
+        } else if (retlen == buf_len) {
+            m3ApiReturn(__WASI_ERRNO_SUCCESS);
+        } else {
+            buf     += retlen;
+            buf_len -= retlen;
+        }
+    }
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_res_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArgMem   (__wasi_timestamp_t * , resolution)
+
+    m3ApiCheckMem(resolution, sizeof(__wasi_timestamp_t));
+
+    int clk = convert_clockid(wasi_clk_id);
+    if (clk < 0) m3ApiReturn(__WASI_ERRNO_INVAL);
+
+    struct timespec tp;
+    if (clock_getres(clk, &tp) != 0) {
+        m3ApiWriteMem64(resolution, 1000000);
+    } else {
+        m3ApiWriteMem64(resolution, convert_timespec(&tp));
+    }
+
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_clock_time_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArg      (__wasi_clockid_t     , wasi_clk_id)
+    m3ApiGetArg      (__wasi_timestamp_t   , precision)
+    m3ApiGetArgMem   (__wasi_timestamp_t * , time)
+
+    m3ApiCheckMem(time, sizeof(__wasi_timestamp_t));
+
+    int clk = convert_clockid(wasi_clk_id);
+    if (clk < 0) m3ApiReturn(__WASI_ERRNO_INVAL);
+
+    struct timespec tp;
+    if (clock_gettime(clk, &tp) != 0) {
+        m3ApiReturn(errno_to_wasi(errno));
+    }
+
+    m3ApiWriteMem64(time, convert_timespec(&tp));
+    m3ApiReturn(__WASI_ERRNO_SUCCESS);
+}
+
+m3ApiRawFunction(m3_wasi_generic_proc_exit)
+{
+    m3ApiGetArg      (uint32_t, code)
+
+    m3_wasi_context_t* context = (m3_wasi_context_t*)(_ctx->userdata);
+
+    if (context) {
+        context->exit_code = code;
+    }
+
+    m3ApiTrap(m3Err_trapExit);
+}
+
+
+static
+M3Result SuppressLookupFailure(M3Result i_result)
+{
+    if (i_result == m3Err_functionLookupFailed)
+        return m3Err_none;
+    else
+        return i_result;
+}
+
+m3_wasi_context_t* m3_GetWasiContext()
+{
+    return wasi_context;
+}
+
+
+M3Result  m3_LinkWASI  (IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+#ifdef _WIN32
+    setmode(fileno(stdin),  O_BINARY);
+    setmode(fileno(stdout), O_BINARY);
+    setmode(fileno(stderr), O_BINARY);
+
+#else
+    // Preopen dirs
+    for (int i = 3; i < PREOPEN_CNT; i++) {
+        preopen[i].fd = open(preopen[i].real_path, O_RDONLY);
+    }
+#endif
+
+    if (!wasi_context) {
+        wasi_context = (m3_wasi_context_t*)malloc(sizeof(m3_wasi_context_t));
+        wasi_context->exit_code = 0;
+        wasi_context->argc = 0;
+        wasi_context->argv = 0;
+    }
+
+    static const char* namespaces[2] = { "wasi_unstable", "wasi_snapshot_preview1" };
+
+    // Some functions are incompatible between WASI versions
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_seek",     "i(iIi*)", &m3_wasi_unstable_fd_seek)));
+_   (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_seek",     "i(iIi*)", &m3_wasi_snapshot_preview1_fd_seek)));
+//_ (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "fd_filestat_get",   "i(i*)",     &m3_wasi_unstable_fd_filestat_get)));
+//_ (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "fd_filestat_get",   "i(i*)",     &m3_wasi_snapshot_preview1_fd_filestat_get)));
+//_ (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_unstable",          "path_filestat_get", "i(ii*i*)",  &m3_wasi_unstable_path_filestat_get)));
+//_ (SuppressLookupFailure (m3_LinkRawFunction (module, "wasi_snapshot_preview1", "path_filestat_get", "i(ii*i*)",  &m3_wasi_snapshot_preview1_path_filestat_get)));
+
+    for (int i=0; i<2; i++)
+    {
+        const char* wasi = namespaces[i];
+
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_get",           "i(**)",   &m3_wasi_generic_args_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "args_sizes_get",     "i(**)",   &m3_wasi_generic_args_sizes_get, wasi_context)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_res_get",        "i(i*)",   &m3_wasi_generic_clock_res_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "clock_time_get",       "i(iI*)",  &m3_wasi_generic_clock_time_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",          "i(**)",   &m3_wasi_generic_environ_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get",    "i(**)",   &m3_wasi_generic_environ_sizes_get)));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_advise",            "i(iIIi)", )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_allocate",          "i(iII)",  )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_close",             "i(i)",    &m3_wasi_generic_fd_close)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_datasync",          "i(i)",    &m3_wasi_generic_fd_datasync)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_get",        "i(i*)",   &m3_wasi_generic_fd_fdstat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_flags",  "i(ii)",   &m3_wasi_generic_fd_fdstat_set_flags)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_fdstat_set_rights", "i(iII)",  )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_size", "i(iI)",   )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_filestat_set_times","i(iIIi)", )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pread",             "i(i*iI*)",)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_get",       "i(i*)",   &m3_wasi_generic_fd_prestat_get)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_prestat_dir_name",  "i(i*i)",  &m3_wasi_generic_fd_prestat_dir_name)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_pwrite",            "i(i*iI*)",)));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_read",              "i(i*i*)", &m3_wasi_generic_fd_read)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_readdir",           "i(i*iI*)",)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_renumber",          "i(ii)",   )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_sync",              "i(i)",    )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_tell",              "i(i*)",   )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_write",             "i(i*i*)", &m3_wasi_generic_fd_write)));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_create_directory",    "i(i*i)",       )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_filestat_set_times",  "i(ii*iIIi)",   )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_link",                "i(ii*ii*i)",   )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_open",                "i(ii*iiIIi*)", &m3_wasi_generic_path_open)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_readlink",            "i(i*i*i*)",    )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_remove_directory",    "i(i*i)",       )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_rename",              "i(i*ii*i)",    )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_symlink",             "i(*ii*i)",     )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "path_unlink_file",         "i(i*i)",       )));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "poll_oneoff",          "i(**i*)", &m3_wasi_generic_poll_oneoff)));
+_       (SuppressLookupFailure (m3_LinkRawFunctionEx (module, wasi, "proc_exit",          "v(i)",    &m3_wasi_generic_proc_exit, wasi_context)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "proc_raise",           "i(i)",    )));
+_       (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "random_get",           "i(*i)",   &m3_wasi_generic_random_get)));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sched_yield",          "i()",     )));
+
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_recv",            "i(i*ii**)",        )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_send",            "i(i*ii*)",         )));
+//_     (SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "sock_shutdown",        "i(ii)",            )));
+    }
+
+_catch:
+    return result;
+}
+
+#endif // d_m3HasWASI

--- a/thirdparty/wasm3/source/m3_api_wasi.h
+++ b/thirdparty/wasm3/source/m3_api_wasi.h
@@ -1,0 +1,38 @@
+//
+//  m3_api_wasi.h
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef m3_api_wasi_h
+#define m3_api_wasi_h
+
+#include "m3_core.h"
+
+#if defined(d_m3HasUVWASI)
+#include "uvwasi.h"
+#endif
+
+d_m3BeginExternC
+
+typedef struct m3_wasi_context_t
+{
+    i32                     exit_code;
+    u32                     argc;
+    ccstr_t *               argv;
+} m3_wasi_context_t;
+
+M3Result    m3_LinkWASI             (IM3Module io_module);
+
+#if defined(d_m3HasUVWASI)
+
+M3Result    m3_LinkWASIWithOptions  (IM3Module io_module, uvwasi_options_t uvwasiOptions);
+
+#endif
+
+m3_wasi_context_t* m3_GetWasiContext();
+
+d_m3EndExternC
+
+#endif // m3_api_wasi_h

--- a/thirdparty/wasm3/source/m3_bind.c
+++ b/thirdparty/wasm3/source/m3_bind.c
@@ -1,0 +1,175 @@
+//
+//  m3_bind.c
+//
+//  Created by Steven Massey on 4/29/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include "m3_env.h"
+#include "m3_exception.h"
+#include "m3_info.h"
+
+
+u8  ConvertTypeCharToTypeId (char i_code)
+{
+    switch (i_code) {
+    case 'v': return c_m3Type_none;
+    case 'i': return c_m3Type_i32;
+    case 'I': return c_m3Type_i64;
+    case 'f': return c_m3Type_f32;
+    case 'F': return c_m3Type_f64;
+    case '*': return c_m3Type_i32;
+    }
+    return c_m3Type_unknown;
+}
+
+
+M3Result  SignatureToFuncType  (IM3FuncType * o_functionType, ccstr_t i_signature)
+{
+    IM3FuncType funcType = NULL;
+
+_try {
+    if (not o_functionType)
+        _throw ("null function type");
+
+    if (not i_signature)
+        _throw ("null function signature");
+
+    cstr_t sig = i_signature;
+
+    size_t maxNumTypes = strlen (i_signature);
+
+    // assume min signature is "()"
+    _throwif (m3Err_malformedFunctionSignature, maxNumTypes < 2);
+    maxNumTypes -= 2;
+
+    _throwif (m3Err_tooManyArgsRets, maxNumTypes > d_m3MaxSaneFunctionArgRetCount);
+
+_   (AllocFuncType (& funcType, (u32) maxNumTypes));
+
+    u8 * typelist = funcType->types;
+
+    bool parsingRets = true;
+    while (* sig)
+    {
+        char typeChar = * sig++;
+
+        if (typeChar == '(')
+        {
+            parsingRets = false;
+            continue;
+        }
+        else if ( typeChar == ' ')
+            continue;
+        else if (typeChar == ')')
+            break;
+
+        u8 type = ConvertTypeCharToTypeId (typeChar);
+
+        _throwif ("unknown argument type char", c_m3Type_unknown == type);
+
+        if (type == c_m3Type_none)
+            continue;
+
+        if (parsingRets)
+        {
+            _throwif ("malformed signature; return count overflow", funcType->numRets >= maxNumTypes);
+            funcType->numRets++;
+            *typelist++ = type;
+        }
+        else
+        {
+            _throwif ("malformed signature; arg count overflow", (u32)(funcType->numRets) + funcType->numArgs >= maxNumTypes);
+            funcType->numArgs++;
+            *typelist++ = type;
+        }
+    }
+
+} _catch:
+
+    if (result)
+        m3_Free (funcType);
+
+    * o_functionType = funcType;
+
+    return result;
+}
+
+
+static
+M3Result  ValidateSignature  (IM3Function i_function, ccstr_t i_linkingSignature)
+{
+    M3Result result = m3Err_none;
+
+    IM3FuncType ftype = NULL;
+_   (SignatureToFuncType (& ftype, i_linkingSignature));
+
+    if (not AreFuncTypesEqual (ftype, i_function->funcType))
+    {
+        m3log (module, "expected: %s", SPrintFuncTypeSignature (ftype));
+        m3log (module, "   found: %s", SPrintFuncTypeSignature (i_function->funcType));
+
+        _throw ("function signature mismatch");
+    }
+
+    _catch:
+
+    m3_Free (ftype);
+
+    return result;
+}
+
+
+M3Result  FindAndLinkFunction      (IM3Module       io_module,
+                                    ccstr_t         i_moduleName,
+                                    ccstr_t         i_functionName,
+                                    ccstr_t         i_signature,
+                                    voidptr_t       i_function,
+                                    voidptr_t       i_userdata)
+{
+_try {
+    _throwif(m3Err_moduleNotLinked, !io_module->runtime);
+
+    const bool wildcardModule = (strcmp (i_moduleName, "*") == 0);
+
+    result = m3Err_functionLookupFailed;
+
+    for (u32 i = 0; i < io_module->numFunctions; ++i)
+    {
+        const IM3Function f = & io_module->functions [i];
+
+        if (f->import.moduleUtf8 and f->import.fieldUtf8)
+        {
+            if (strcmp (f->import.fieldUtf8, i_functionName) == 0 and
+               (wildcardModule or strcmp (f->import.moduleUtf8, i_moduleName) == 0))
+            {
+                if (i_signature) {
+_                   (ValidateSignature (f, i_signature));
+                }
+_               (CompileRawFunction (io_module, f, i_function, i_userdata));
+            }
+        }
+    }
+} _catch:
+    return result;
+}
+
+M3Result  m3_LinkRawFunctionEx  (IM3Module            io_module,
+                                const char * const    i_moduleName,
+                                const char * const    i_functionName,
+                                const char * const    i_signature,
+                                M3RawCall             i_function,
+                                const void *          i_userdata)
+{
+    return FindAndLinkFunction (io_module, i_moduleName, i_functionName, i_signature, (voidptr_t)i_function, i_userdata);
+}
+
+M3Result  m3_LinkRawFunction  (IM3Module            io_module,
+                              const char * const    i_moduleName,
+                              const char * const    i_functionName,
+                              const char * const    i_signature,
+                              M3RawCall             i_function)
+{
+    return FindAndLinkFunction (io_module, i_moduleName, i_functionName, i_signature, (voidptr_t)i_function, NULL);
+}
+

--- a/thirdparty/wasm3/source/m3_bind.h
+++ b/thirdparty/wasm3/source/m3_bind.h
@@ -1,0 +1,20 @@
+//
+//  m3_bind.h
+//
+//  Created by Steven Massey on 2/27/20.
+//  Copyright © 2020 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_bind_h
+#define m3_bind_h
+
+#include "m3_env.h"
+
+d_m3BeginExternC
+
+u8          ConvertTypeCharToTypeId     (char i_code);
+M3Result    SignatureToFuncType         (IM3FuncType * o_functionType, ccstr_t i_signature);
+
+d_m3EndExternC
+
+#endif /* m3_bind_h */

--- a/thirdparty/wasm3/source/m3_code.c
+++ b/thirdparty/wasm3/source/m3_code.c
@@ -1,0 +1,246 @@
+//
+//  m3_code.c
+//
+//  Created by Steven Massey on 4/19/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include <limits.h>
+#include "m3_code.h"
+#include "m3_env.h"
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+
+IM3CodePage  NewCodePage  (IM3Runtime i_runtime, u32 i_minNumLines)
+{
+    IM3CodePage page;
+
+    // check multiplication overflow
+    if (i_minNumLines > UINT_MAX / sizeof (code_t)) {
+        return NULL;
+    }
+    u32 pageSize = sizeof (M3CodePageHeader) + sizeof (code_t) * i_minNumLines;
+
+    // check addition overflow
+    if (pageSize < sizeof (M3CodePageHeader)) {
+        return NULL;
+    }
+
+    pageSize = (pageSize + (d_m3CodePageAlignSize-1)) & ~(d_m3CodePageAlignSize-1); // align
+    // check alignment overflow
+    if (pageSize == 0) {
+        return NULL;
+    }
+
+    page = (IM3CodePage)m3_Malloc ("M3CodePage", pageSize);
+
+    if (page)
+    {
+        page->info.sequence = ++i_runtime->newCodePageSequence;
+        page->info.numLines = (pageSize - sizeof (M3CodePageHeader)) / sizeof (code_t);
+
+#if d_m3RecordBacktraces
+        u32 pageSizeBt = sizeof (M3CodeMappingPage) + sizeof (M3CodeMapEntry) * page->info.numLines;
+        page->info.mapping = (M3CodeMappingPage *)m3_Malloc ("M3CodeMappingPage", pageSizeBt);
+
+        if (page->info.mapping)
+        {
+            page->info.mapping->size = 0;
+            page->info.mapping->capacity = page->info.numLines;
+        }
+        else
+        {
+            m3_Free (page);
+            return NULL;
+        }
+        page->info.mapping->basePC = GetPageStartPC(page);
+#endif // d_m3RecordBacktraces
+
+        m3log (runtime, "new page: %p; seq: %d; bytes: %d; lines: %d", GetPagePC (page), page->info.sequence, pageSize, page->info.numLines);
+    }
+
+    return page;
+}
+
+
+void  FreeCodePages  (IM3CodePage * io_list)
+{
+    IM3CodePage page = * io_list;
+
+    while (page)
+    {
+        m3log (code, "free page: %d; %p; util: %3.1f%%", page->info.sequence, page, 100. * page->info.lineIndex / page->info.numLines);
+
+        IM3CodePage next = page->info.next;
+#if d_m3RecordBacktraces
+        m3_Free (page->info.mapping);
+#endif // d_m3RecordBacktraces
+        m3_Free (page);
+        page = next;
+    }
+
+    * io_list = NULL;
+}
+
+
+u32  NumFreeLines  (IM3CodePage i_page)
+{
+    d_m3Assert (i_page->info.lineIndex <= i_page->info.numLines);
+
+    return i_page->info.numLines - i_page->info.lineIndex;
+}
+
+
+void  EmitWord_impl  (IM3CodePage i_page, void * i_word)
+{                                                                       d_m3Assert (i_page->info.lineIndex+1 <= i_page->info.numLines);
+    i_page->code [i_page->info.lineIndex++] = i_word;
+}
+
+void  EmitWord32  (IM3CodePage i_page, const u32 i_word)
+{                                                                       d_m3Assert (i_page->info.lineIndex+1 <= i_page->info.numLines);
+    memcpy (& i_page->code[i_page->info.lineIndex++], & i_word, sizeof(i_word));
+}
+
+void  EmitWord64  (IM3CodePage i_page, const u64 i_word)
+{
+#if M3_SIZEOF_PTR == 4
+                                                                        d_m3Assert (i_page->info.lineIndex+2 <= i_page->info.numLines);
+    memcpy (& i_page->code[i_page->info.lineIndex], & i_word, sizeof(i_word));
+    i_page->info.lineIndex += 2;
+#else
+                                                                        d_m3Assert (i_page->info.lineIndex+1 <= i_page->info.numLines);
+    memcpy (& i_page->code[i_page->info.lineIndex], & i_word, sizeof(i_word));
+    i_page->info.lineIndex += 1;
+#endif
+}
+
+
+#if d_m3RecordBacktraces
+void  EmitMappingEntry  (IM3CodePage i_page, u32 i_moduleOffset)
+{
+    M3CodeMappingPage * page = i_page->info.mapping;
+                                                                        d_m3Assert (page->size < page->capacity);
+
+    M3CodeMapEntry * entry = & page->entries[page->size++];
+    pc_t pc = GetPagePC (i_page);
+
+    entry->pcOffset = pc - page->basePC;
+    entry->moduleOffset = i_moduleOffset;
+}
+#endif // d_m3RecordBacktraces
+
+pc_t  GetPageStartPC  (IM3CodePage i_page)
+{
+    return & i_page->code [0];
+}
+
+
+pc_t  GetPagePC  (IM3CodePage i_page)
+{
+    if (i_page)
+        return & i_page->code [i_page->info.lineIndex];
+    else
+        return NULL;
+}
+
+
+void  PushCodePage  (IM3CodePage * i_list, IM3CodePage i_codePage)
+{
+    IM3CodePage next = * i_list;
+    i_codePage->info.next = next;
+    * i_list = i_codePage;
+}
+
+
+IM3CodePage  PopCodePage  (IM3CodePage * i_list)
+{
+    IM3CodePage page = * i_list;
+    * i_list = page->info.next;
+    page->info.next = NULL;
+
+    return page;
+}
+
+
+
+u32  FindCodePageEnd  (IM3CodePage i_list, IM3CodePage * o_end)
+{
+    u32 numPages = 0;
+    * o_end = NULL;
+
+    while (i_list)
+    {
+        * o_end = i_list;
+        ++numPages;
+        i_list = i_list->info.next;
+    }
+
+    return numPages;
+}
+
+
+u32  CountCodePages  (IM3CodePage i_list)
+{
+    IM3CodePage unused;
+    return FindCodePageEnd (i_list, & unused);
+}
+
+
+IM3CodePage GetEndCodePage  (IM3CodePage i_list)
+{
+    IM3CodePage end;
+    FindCodePageEnd (i_list, & end);
+
+    return end;
+}
+
+#if d_m3RecordBacktraces
+bool  ContainsPC  (IM3CodePage i_page, pc_t i_pc)
+{
+    return GetPageStartPC (i_page) <= i_pc && i_pc < GetPagePC (i_page);
+}
+
+
+bool  MapPCToOffset  (IM3CodePage i_page, pc_t i_pc, u32 * o_moduleOffset)
+{
+    M3CodeMappingPage * mapping = i_page->info.mapping;
+
+    u32 pcOffset = i_pc - mapping->basePC;
+
+    u32 left = 0;
+    u32 right = mapping->size;
+
+    while (left < right)
+    {
+        u32 mid = left + (right - left) / 2;
+
+        if (mapping->entries[mid].pcOffset < pcOffset)
+        {
+            left = mid + 1;
+        }
+        else if (mapping->entries[mid].pcOffset > pcOffset)
+        {
+            right = mid;
+        }
+        else
+        {
+            *o_moduleOffset = mapping->entries[mid].moduleOffset;
+            return true;
+        }
+    }
+
+    // Getting here means left is now one more than the element we want.
+    if (left > 0)
+    {
+        left--;
+        *o_moduleOffset = mapping->entries[left].moduleOffset;
+        return true;
+    }
+    else return false;
+}
+#endif // d_m3RecordBacktraces
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+

--- a/thirdparty/wasm3/source/m3_code.h
+++ b/thirdparty/wasm3/source/m3_code.h
@@ -1,0 +1,80 @@
+//
+//  m3_code.h
+//
+//  Created by Steven Massey on 4/19/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_code_h
+#define m3_code_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+typedef struct M3CodePage
+{
+    M3CodePageHeader        info;
+    code_t                  code                [1];
+}
+M3CodePage;
+
+typedef M3CodePage *    IM3CodePage;
+
+
+IM3CodePage             NewCodePage             (IM3Runtime i_runtime, u32 i_minNumLines);
+
+void                    FreeCodePages           (IM3CodePage * io_list);
+
+u32                     NumFreeLines            (IM3CodePage i_page);
+pc_t                    GetPageStartPC          (IM3CodePage i_page);
+pc_t                    GetPagePC               (IM3CodePage i_page);
+void                    EmitWord_impl           (IM3CodePage i_page, void* i_word);
+void                    EmitWord32              (IM3CodePage i_page, u32 i_word);
+void                    EmitWord64              (IM3CodePage i_page, u64 i_word);
+# if d_m3RecordBacktraces
+void                    EmitMappingEntry        (IM3CodePage i_page, u32 i_moduleOffset);
+# endif // d_m3RecordBacktraces
+
+void                    PushCodePage            (IM3CodePage * io_list, IM3CodePage i_codePage);
+IM3CodePage             PopCodePage             (IM3CodePage * io_list);
+
+IM3CodePage             GetEndCodePage          (IM3CodePage i_list); // i_list = NULL is valid
+u32                     CountCodePages          (IM3CodePage i_list); // i_list = NULL is valid
+
+# if d_m3RecordBacktraces
+bool                    ContainsPC              (IM3CodePage i_page, pc_t i_pc);
+bool                    MapPCToOffset           (IM3CodePage i_page, pc_t i_pc, u32 * o_moduleOffset);
+# endif // d_m3RecordBacktraces
+
+# ifdef DEBUG
+void                    dump_code_page            (IM3CodePage i_codePage, pc_t i_startPC);
+# endif
+
+#define EmitWord(page, val) EmitWord_impl(page, (void*)(val))
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+# if d_m3RecordBacktraces
+
+typedef struct M3CodeMapEntry
+{
+    u32          pcOffset;
+    u32          moduleOffset;
+}
+M3CodeMapEntry;
+
+typedef struct M3CodeMappingPage
+{
+    pc_t              basePC;
+    u32               size;
+    u32               capacity;
+    M3CodeMapEntry    entries     [];
+}
+M3CodeMappingPage;
+
+# endif // d_m3RecordBacktraces
+
+d_m3EndExternC
+
+#endif // m3_code_h

--- a/thirdparty/wasm3/source/m3_compile.c
+++ b/thirdparty/wasm3/source/m3_compile.c
@@ -1,0 +1,2931 @@
+//
+//  m3_compile.c
+//
+//  Created by Steven Massey on 4/17/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+// Allow using opcodes for compilation process
+#define M3_COMPILE_OPCODES
+
+#include "m3_env.h"
+#include "m3_compile.h"
+#include "m3_exec.h"
+#include "m3_exception.h"
+#include "m3_info.h"
+
+//----- EMIT --------------------------------------------------------------------------------------------------------------
+
+static inline
+pc_t GetPC (IM3Compilation o)
+{
+    return GetPagePC (o->page);
+}
+
+static M3_NOINLINE
+M3Result  EnsureCodePageNumLines  (IM3Compilation o, u32 i_numLines)
+{
+    M3Result result = m3Err_none;
+
+    i_numLines += 2; // room for Bridge
+
+    if (NumFreeLines (o->page) < i_numLines)
+    {
+        IM3CodePage page = AcquireCodePageWithCapacity (o->runtime, i_numLines);
+
+        if (page)
+        {
+            m3log (emit, "bridging new code page from: %d %p (free slots: %d) to: %d", o->page->info.sequence, GetPC (o), NumFreeLines (o->page), page->info.sequence);
+            d_m3Assert (NumFreeLines (o->page) >= 2);
+
+            EmitWord (o->page, op_Branch);
+            EmitWord (o->page, GetPagePC (page));
+
+            ReleaseCodePage (o->runtime, o->page);
+
+            o->page = page;
+        }
+        else result = m3Err_mallocFailedCodePage;
+    }
+
+    return result;
+}
+
+static M3_NOINLINE
+M3Result  EmitOp  (IM3Compilation o, IM3Operation i_operation)
+{
+    M3Result result = m3Err_none;                                 d_m3Assert (i_operation or IsStackPolymorphic (o));
+
+    // it's OK for page to be null; when compile-walking the bytecode without emitting
+    if (o->page)
+    {
+# if d_m3EnableOpTracing
+        if (i_operation != op_DumpStack)
+            o->numEmits++;
+# endif
+
+        // have execution jump to a new page if slots are critically low
+        result = EnsureCodePageNumLines (o, d_m3CodePageFreeLinesThreshold);
+
+        if (not result)
+        {                                                           if (d_m3LogEmit) log_emit (o, i_operation);
+# if d_m3RecordBacktraces
+            EmitMappingEntry (o->page, o->lastOpcodeStart - o->module->wasmStart);
+# endif // d_m3RecordBacktraces
+            EmitWord (o->page, i_operation);
+        }
+    }
+
+    return result;
+}
+
+// Push an immediate constant into the M3 codestream
+static M3_NOINLINE
+void  EmitConstant32  (IM3Compilation o, const u32 i_immediate)
+{
+    if (o->page)
+        EmitWord32 (o->page, i_immediate);
+}
+
+static M3_NOINLINE
+void  EmitSlotOffset  (IM3Compilation o, const i32 i_offset)
+{
+    if (o->page)
+        EmitWord32 (o->page, i_offset);
+}
+
+static M3_NOINLINE
+pc_t  EmitPointer  (IM3Compilation o, const void * const i_pointer)
+{
+    pc_t ptr = GetPagePC (o->page);
+
+    if (o->page)
+        EmitWord (o->page, i_pointer);
+
+    return ptr;
+}
+
+static M3_NOINLINE
+void * ReservePointer (IM3Compilation o)
+{
+    pc_t ptr = GetPagePC (o->page);
+    EmitPointer (o, NULL);
+    return (void *) ptr;
+}
+
+
+//-------------------------------------------------------------------------------------------------------------------------
+
+#define d_indent "     | %s"
+
+// just want less letters and numbers to stare at down the way in the compiler table
+#define i_32    c_m3Type_i32
+#define i_64    c_m3Type_i64
+#define f_32    c_m3Type_f32
+#define f_64    c_m3Type_f64
+#define none    c_m3Type_none
+#define any     (u8)-1
+
+#if d_m3HasFloat
+#   define FPOP(x) x
+#else
+#   define FPOP(x) NULL
+#endif
+
+static const IM3Operation c_preserveSetSlot [] = { NULL, op_PreserveSetSlot_i32,       op_PreserveSetSlot_i64,
+                                                    FPOP(op_PreserveSetSlot_f32), FPOP(op_PreserveSetSlot_f64) };
+static const IM3Operation c_setSetOps [] =       { NULL, op_SetSlot_i32,               op_SetSlot_i64,
+                                                    FPOP(op_SetSlot_f32),         FPOP(op_SetSlot_f64) };
+static const IM3Operation c_setGlobalOps [] =    { NULL, op_SetGlobal_i32,             op_SetGlobal_i64,
+                                                    FPOP(op_SetGlobal_f32),       FPOP(op_SetGlobal_f64) };
+static const IM3Operation c_setRegisterOps [] =  { NULL, op_SetRegister_i32,           op_SetRegister_i64,
+                                                    FPOP(op_SetRegister_f32),     FPOP(op_SetRegister_f64) };
+
+static const IM3Operation c_intSelectOps [2] [4] =      { { op_Select_i32_rss, op_Select_i32_srs, op_Select_i32_ssr, op_Select_i32_sss },
+                                                          { op_Select_i64_rss, op_Select_i64_srs, op_Select_i64_ssr, op_Select_i64_sss } };
+#if d_m3HasFloat
+static const IM3Operation c_fpSelectOps [2] [2] [3] = { { { op_Select_f32_sss, op_Select_f32_srs, op_Select_f32_ssr },        // selector in slot
+                                                          { op_Select_f32_rss, op_Select_f32_rrs, op_Select_f32_rsr } },      // selector in reg
+                                                        { { op_Select_f64_sss, op_Select_f64_srs, op_Select_f64_ssr },        // selector in slot
+                                                          { op_Select_f64_rss, op_Select_f64_rrs, op_Select_f64_rsr } } };    // selector in reg
+#endif
+
+// all args & returns are 64-bit aligned, so use 2 slots for a d_m3Use32BitSlots=1 build
+static const u16 c_ioSlotCount = sizeof (u64) / sizeof (m3slot_t);
+
+static
+M3Result  AcquireCompilationCodePage  (IM3Compilation o, IM3CodePage * o_codePage)
+{
+    M3Result result = m3Err_none;
+
+    IM3CodePage page = AcquireCodePage (o->runtime);
+
+    if (page)
+    {
+#       if (d_m3EnableCodePageRefCounting)
+        {
+            if (o->function)
+            {
+                IM3Function func = o->function;
+                page->info.usageCount++;
+
+                u32 index = func->numCodePageRefs++;
+_               (m3ReallocArray (& func->codePageRefs, IM3CodePage, func->numCodePageRefs, index));
+                func->codePageRefs [index] = page;
+            }
+        }
+#       endif
+    }
+    else _throw (m3Err_mallocFailedCodePage);
+
+    _catch:
+
+    * o_codePage = page;
+
+    return result;
+}
+
+static inline
+void  ReleaseCompilationCodePage  (IM3Compilation o)
+{
+    ReleaseCodePage (o->runtime, o->page);
+}
+
+static inline
+u16 GetTypeNumSlots (u8 i_type)
+{
+#   if d_m3Use32BitSlots
+        return Is64BitType (i_type) ? 2 : 1;
+#   else
+        return 1;
+#   endif
+}
+
+static inline
+void  AlignSlotToType  (u16 * io_slot, u8 i_type)
+{
+    // align 64-bit words to even slots (if d_m3Use32BitSlots)
+    u16 numSlots = GetTypeNumSlots (i_type);
+
+    u16 mask = numSlots - 1;
+    * io_slot = (* io_slot + mask) & ~mask;
+}
+
+static inline
+i16  GetStackTopIndex  (IM3Compilation o)
+{                                                           d_m3Assert (o->stackIndex > o->stackFirstDynamicIndex or IsStackPolymorphic (o));
+    return o->stackIndex - 1;
+}
+
+
+// Items in the static portion of the stack (args/locals) are hidden from GetStackTypeFromTop ()
+// In other words, only "real" Wasm stack items can be inspected.  This is important when
+// returning values, etc. and you need an accurate wasm-view of the stack.
+static
+u8  GetStackTypeFromTop  (IM3Compilation o, u16 i_offset)
+{
+    u8 type = c_m3Type_none;
+
+    ++i_offset;
+    if (o->stackIndex >= i_offset)
+    {
+        u16 index = o->stackIndex - i_offset;
+
+        if (index >= o->stackFirstDynamicIndex)
+            type = o->typeStack [index];
+    }
+
+    return type;
+}
+
+static inline
+u8  GetStackTopType  (IM3Compilation o)
+{
+    return GetStackTypeFromTop (o, 0);
+}
+
+static inline
+u8  GetStackTypeFromBottom  (IM3Compilation o, u16 i_offset)
+{
+    u8 type = c_m3Type_none;
+
+    if (i_offset < o->stackIndex)
+        type = o->typeStack [i_offset];
+
+    return type;
+}
+
+
+static inline bool  IsConstantSlot    (IM3Compilation o, u16 i_slot)  { return (i_slot >= o->slotFirstConstIndex and i_slot < o->slotMaxConstIndex); }
+static inline bool  IsSlotAllocated   (IM3Compilation o, u16 i_slot)  { return o->m3Slots [i_slot]; }
+
+static inline
+bool  IsStackIndexInRegister  (IM3Compilation o, i32 i_stackIndex)
+{                                                                           d_m3Assert (i_stackIndex < o->stackIndex or IsStackPolymorphic (o));
+    if (i_stackIndex >= 0 and i_stackIndex < o->stackIndex)
+        return (o->wasmStack [i_stackIndex] >= d_m3Reg0SlotAlias);
+    else
+        return false;
+}
+
+static inline u16   GetNumBlockValuesOnStack      (IM3Compilation o)  { return o->stackIndex - o->block.blockStackIndex; }
+
+static inline bool  IsStackTopInRegister          (IM3Compilation o)  { return IsStackIndexInRegister (o, (i32) GetStackTopIndex (o));       }
+static inline bool  IsStackTopMinus1InRegister    (IM3Compilation o)  { return IsStackIndexInRegister (o, (i32) GetStackTopIndex (o) - 1);   }
+static inline bool  IsStackTopMinus2InRegister    (IM3Compilation o)  { return IsStackIndexInRegister (o, (i32) GetStackTopIndex (o) - 2);   }
+
+static inline bool  IsStackTopInSlot              (IM3Compilation o)  { return not IsStackTopInRegister (o); }
+
+static inline bool  IsValidSlot                   (u16 i_slot)        { return (i_slot < d_m3MaxFunctionSlots); }
+
+static inline
+u16  GetStackTopSlotNumber  (IM3Compilation o)
+{
+    i16 i = GetStackTopIndex (o);
+
+    u16 slot = c_slotUnused;
+
+    if (i >= 0)
+        slot = o->wasmStack [i];
+
+    return slot;
+}
+
+
+// from bottom
+static inline
+u16  GetSlotForStackIndex  (IM3Compilation o, u16 i_stackIndex)
+{                                                                   d_m3Assert (i_stackIndex < o->stackIndex or IsStackPolymorphic (o));
+    u16 slot = c_slotUnused;
+
+    if (i_stackIndex < o->stackIndex)
+        slot = o->wasmStack [i_stackIndex];
+
+    return slot;
+}
+
+static inline
+u16  GetExtraSlotForStackIndex  (IM3Compilation o, u16 i_stackIndex)
+{
+    u16 baseSlot = GetSlotForStackIndex (o, i_stackIndex);
+
+    if (baseSlot != c_slotUnused)
+    {
+        u16 extraSlot = GetTypeNumSlots (GetStackTypeFromBottom (o, i_stackIndex)) - 1;
+        baseSlot += extraSlot;
+    }
+
+    return baseSlot;
+}
+
+
+static inline
+void  TouchSlot  (IM3Compilation o, u16 i_slot)
+{
+    // op_Entry uses this value to track and detect stack overflow
+    o->maxStackSlots = M3_MAX (o->maxStackSlots, i_slot + 1);
+}
+
+static inline
+void  MarkSlotAllocated  (IM3Compilation o, u16 i_slot)
+{                                                                   d_m3Assert (o->m3Slots [i_slot] == 0); // shouldn't be already allocated
+    o->m3Slots [i_slot] = 1;
+
+    o->slotMaxAllocatedIndexPlusOne = M3_MAX (o->slotMaxAllocatedIndexPlusOne, i_slot + 1);
+
+    TouchSlot (o, i_slot);
+}
+
+static inline
+void  MarkSlotsAllocated  (IM3Compilation o, u16 i_slot, u16 i_numSlots)
+{
+    while (i_numSlots--)
+        MarkSlotAllocated (o, i_slot++);
+}
+
+static inline
+void  MarkSlotsAllocatedByType  (IM3Compilation o, u16 i_slot, u8 i_type)
+{
+    u16 numSlots = GetTypeNumSlots (i_type);
+    MarkSlotsAllocated (o, i_slot, numSlots);
+}
+
+
+static
+M3Result  AllocateSlotsWithinRange  (IM3Compilation o, u16 * o_slot, u8 i_type, u16 i_startSlot, u16 i_endSlot)
+{
+    M3Result result = m3Err_functionStackOverflow;
+
+    u16 numSlots = GetTypeNumSlots (i_type);
+    u16 searchOffset = numSlots - 1;
+
+    AlignSlotToType (& i_startSlot, i_type);
+
+    // search for 1 or 2 consecutive slots in the execution stack
+    u16 i = i_startSlot;
+    while (i + searchOffset < i_endSlot)
+    {
+        if (o->m3Slots [i] == 0 and o->m3Slots [i + searchOffset] == 0)
+        {
+            MarkSlotsAllocated (o, i, numSlots);
+
+            * o_slot = i;
+            result = m3Err_none;
+            break;
+        }
+
+        // keep 2-slot allocations even-aligned
+        i += numSlots;
+    }
+
+    return result;
+}
+
+static inline
+M3Result  AllocateSlots  (IM3Compilation o, u16 * o_slot, u8 i_type)
+{
+    return AllocateSlotsWithinRange (o, o_slot, i_type, o->slotFirstDynamicIndex, d_m3MaxFunctionSlots);
+}
+
+static inline
+M3Result  AllocateConstantSlots  (IM3Compilation o, u16 * o_slot, u8 i_type)
+{
+    u16 maxTableIndex = o->slotFirstConstIndex + d_m3MaxConstantTableSize;
+    return AllocateSlotsWithinRange (o, o_slot, i_type, o->slotFirstConstIndex, M3_MIN(o->slotFirstDynamicIndex, maxTableIndex));
+}
+
+
+// TOQUE: this usage count system could be eliminated. real world code doesn't frequently trigger it.  just copy to multiple
+// unique slots.
+static inline
+M3Result  IncrementSlotUsageCount  (IM3Compilation o, u16 i_slot)
+{                                                                                       d_m3Assert (i_slot < d_m3MaxFunctionSlots);
+    M3Result result = m3Err_none;                                                       d_m3Assert (o->m3Slots [i_slot] > 0);
+
+    // OPTZ (memory): 'm3Slots' could still be fused with 'typeStack' if 4 bits were used to indicate: [0,1,2,many]. The many-case
+    // would scan 'wasmStack' to determine the actual usage count
+    if (o->m3Slots [i_slot] < 0xFF)
+    {
+        o->m3Slots [i_slot]++;
+    }
+    else result = "slot usage count overflow";
+
+    return result;
+}
+
+static inline
+void DeallocateSlot (IM3Compilation o, i16 i_slot, u8 i_type)
+{                                                                                       d_m3Assert (i_slot >= o->slotFirstDynamicIndex);
+                                                                                        d_m3Assert (i_slot < o->slotMaxAllocatedIndexPlusOne);
+    for (u16 i = 0; i < GetTypeNumSlots (i_type); ++i, ++i_slot)
+    {                                                                                   d_m3Assert (o->m3Slots [i_slot]);
+        -- o->m3Slots [i_slot];
+    }
+}
+
+
+static inline
+bool  IsRegisterTypeAllocated  (IM3Compilation o, u8 i_type)
+{
+    return IsRegisterAllocated (o, IsFpType (i_type));
+}
+
+static inline
+void  AllocateRegister  (IM3Compilation o, u32 i_register, u16 i_stackIndex)
+{                                                                                       d_m3Assert (not IsRegisterAllocated (o, i_register));
+    o->regStackIndexPlusOne [i_register] = i_stackIndex + 1;
+}
+
+static inline
+void  DeallocateRegister  (IM3Compilation o, u32 i_register)
+{                                                                                       d_m3Assert (IsRegisterAllocated (o, i_register));
+    o->regStackIndexPlusOne [i_register] = c_m3RegisterUnallocated;
+}
+
+static inline
+u16  GetRegisterStackIndex  (IM3Compilation o, u32 i_register)
+{                                                                                       d_m3Assert (IsRegisterAllocated (o, i_register));
+    return o->regStackIndexPlusOne [i_register] - 1;
+}
+
+u16  GetMaxUsedSlotPlusOne  (IM3Compilation o)
+{
+    while (o->slotMaxAllocatedIndexPlusOne > o->slotFirstDynamicIndex)
+    {
+        if (IsSlotAllocated (o, o->slotMaxAllocatedIndexPlusOne - 1))
+            break;
+
+        o->slotMaxAllocatedIndexPlusOne--;
+    }
+
+#   ifdef DEBUG
+        u16 maxSlot = o->slotMaxAllocatedIndexPlusOne;
+        while (maxSlot < d_m3MaxFunctionSlots)
+        {
+            d_m3Assert (o->m3Slots [maxSlot] == 0);
+            maxSlot++;
+        }
+#   endif
+
+    return o->slotMaxAllocatedIndexPlusOne;
+}
+
+static
+M3Result  PreserveRegisterIfOccupied  (IM3Compilation o, u8 i_registerType)
+{
+    M3Result result = m3Err_none;
+
+    u32 regSelect = IsFpType (i_registerType);
+
+    if (IsRegisterAllocated (o, regSelect))
+    {
+        u16 stackIndex = GetRegisterStackIndex (o, regSelect);
+        DeallocateRegister (o, regSelect);
+
+        u8 type = GetStackTypeFromBottom (o, stackIndex);
+
+        // and point to a exec slot
+        u16 slot = c_slotUnused;
+_       (AllocateSlots (o, & slot, type));
+        o->wasmStack [stackIndex] = slot;
+
+_       (EmitOp (o, c_setSetOps [type]));
+        EmitSlotOffset (o, slot);
+    }
+
+    _catch: return result;
+}
+
+
+// all values must be in slots before entering loop, if, and else blocks
+// otherwise they'd end up preserve-copied in the block to probably different locations (if/else)
+static inline
+M3Result  PreserveRegisters  (IM3Compilation o)
+{
+    M3Result result;
+
+_   (PreserveRegisterIfOccupied (o, c_m3Type_f64));
+_   (PreserveRegisterIfOccupied (o, c_m3Type_i64));
+
+    _catch: return result;
+}
+
+static
+M3Result  PreserveNonTopRegisters  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    i16 stackTop = GetStackTopIndex (o);
+
+    if (stackTop >= 0)
+    {
+        if (IsRegisterAllocated (o, 0))     // r0
+        {
+            if (GetRegisterStackIndex (o, 0) != stackTop)
+_               (PreserveRegisterIfOccupied (o, c_m3Type_i64));
+        }
+
+        if (IsRegisterAllocated (o, 1))     // fp0
+        {
+            if (GetRegisterStackIndex (o, 1) != stackTop)
+_               (PreserveRegisterIfOccupied (o, c_m3Type_f64));
+        }
+    }
+
+    _catch: return result;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+static
+M3Result  Push  (IM3Compilation o, u8 i_type, u16 i_slot)
+{
+    M3Result result = m3Err_none;
+
+#if !d_m3HasFloat
+    if (i_type == c_m3Type_f32 || i_type == c_m3Type_f64) {
+        return m3Err_unknownOpcode;
+    }
+#endif
+
+    u16 stackIndex = o->stackIndex++;                                       // printf ("push: %d\n", (i32) i);
+
+    if (stackIndex < d_m3MaxFunctionStackHeight)
+    {
+        o->wasmStack        [stackIndex] = i_slot;
+        o->typeStack        [stackIndex] = i_type;
+
+        if (IsRegisterSlotAlias (i_slot))
+        {
+            u32 regSelect = IsFpRegisterSlotAlias (i_slot);
+            AllocateRegister (o, regSelect, stackIndex);
+        }
+
+        if (d_m3LogWasmStack) dump_type_stack (o);
+    }
+    else result = m3Err_functionStackOverflow;
+
+    return result;
+}
+
+static inline
+M3Result  PushRegister  (IM3Compilation o, u8 i_type)
+{
+    M3Result result = m3Err_none;                                                       d_m3Assert ((u16) d_m3Reg0SlotAlias > (u16) d_m3MaxFunctionSlots);
+    u16 slot = IsFpType (i_type) ? d_m3Fp0SlotAlias : d_m3Reg0SlotAlias;                d_m3Assert (i_type or IsStackPolymorphic (o));
+
+_   (Push (o, i_type, slot));
+
+    _catch: return result;
+}
+
+static
+M3Result  Pop  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    if (o->stackIndex > o->block.blockStackIndex)
+    {
+        o->stackIndex--;                                                //  printf ("pop: %d\n", (i32) o->stackIndex);
+
+        u16 slot = o->wasmStack [o->stackIndex];
+        u8 type = o->typeStack [o->stackIndex];
+
+        if (IsRegisterSlotAlias (slot))
+        {
+            u32 regSelect = IsFpRegisterSlotAlias (slot);
+            DeallocateRegister (o, regSelect);
+        }
+        else if (slot >= o->slotFirstDynamicIndex)
+        {
+            DeallocateSlot (o, slot, type);
+        }
+    }
+    else if (not IsStackPolymorphic (o))
+        result = m3Err_functionStackUnderrun;
+
+    return result;
+}
+
+static
+M3Result  PopType  (IM3Compilation o, u8 i_type)
+{
+    M3Result result = m3Err_none;
+
+    u8 topType = GetStackTopType (o);
+
+    if (i_type == topType or o->block.isPolymorphic)
+    {
+_       (Pop (o));
+    }
+    else _throw (m3Err_typeMismatch);
+
+    _catch:
+    return result;
+}
+
+static
+M3Result  _PushAllocatedSlotAndEmit  (IM3Compilation o, u8 i_type, bool i_doEmit)
+{
+    M3Result result = m3Err_none;
+
+    u16 slot = c_slotUnused;
+
+_   (AllocateSlots (o, & slot, i_type));
+_   (Push (o, i_type, slot));
+
+    if (i_doEmit)
+        EmitSlotOffset (o, slot);
+
+//    printf ("push: %d\n", (u32) slot);
+
+    _catch: return result;
+}
+
+static inline
+M3Result  PushAllocatedSlotAndEmit  (IM3Compilation o, u8 i_type)
+{
+    return _PushAllocatedSlotAndEmit (o, i_type, true);
+}
+
+static inline
+M3Result  PushAllocatedSlot  (IM3Compilation o, u8 i_type)
+{
+    return _PushAllocatedSlotAndEmit (o, i_type, false);
+}
+
+static
+M3Result  PushConst  (IM3Compilation o, u64 i_word, u8 i_type)
+{
+    M3Result result = m3Err_none;
+
+    // Early-exit if we're not emitting
+    if (!o->page) return result;
+
+    bool matchFound = false;
+    bool is64BitType = Is64BitType (i_type);
+
+    u16 numRequiredSlots = GetTypeNumSlots (i_type);
+    u16 numUsedConstSlots = o->slotMaxConstIndex - o->slotFirstConstIndex;
+
+    // search for duplicate matching constant slot to reuse
+    if (numRequiredSlots == 2 and numUsedConstSlots >= 2)
+    {
+        u16 firstConstSlot = o->slotFirstConstIndex;
+        AlignSlotToType (& firstConstSlot, c_m3Type_i64);
+
+        for (u16 slot = firstConstSlot; slot < o->slotMaxConstIndex - 1; slot += 2)
+        {
+            if (IsSlotAllocated (o, slot) and IsSlotAllocated (o, slot + 1))
+            {
+                u64 constant;
+                memcpy (&constant, &o->constants [slot - o->slotFirstConstIndex], sizeof(constant));
+
+                if (constant == i_word)
+                {
+                    matchFound = true;
+_                   (Push (o, i_type, slot));
+                    break;
+                }
+            }
+        }
+    }
+    else if (numRequiredSlots == 1)
+    {
+        for (u16 i = 0; i < numUsedConstSlots; ++i)
+        {
+            u16 slot = o->slotFirstConstIndex + i;
+
+            if (IsSlotAllocated (o, slot))
+            {
+                bool matches;
+                if (is64BitType) {
+                    u64 constant;
+                    memcpy (&constant, &o->constants [i], sizeof(constant));
+                    matches = (constant == i_word);
+                } else {
+                    u32 constant;
+                    memcpy (&constant, &o->constants [i], sizeof(constant));
+                    matches = (constant == i_word);
+                }
+                if (matches)
+                {
+                    matchFound = true;
+_                   (Push (o, i_type, slot));
+                    break;
+                }
+            }
+        }
+    }
+
+    if (not matchFound)
+    {
+        u16 slot = c_slotUnused;
+        result = AllocateConstantSlots (o, & slot, i_type);
+
+        if (result || slot == c_slotUnused) // no more constant table space; use inline constants
+        {
+            result = m3Err_none;
+
+            if (is64BitType) {
+_               (EmitOp (o, op_Const64));
+                EmitWord64 (o->page, i_word);
+            } else {
+_               (EmitOp (o, op_Const32));
+                EmitWord32 (o->page, (u32) i_word);
+            }
+
+_           (PushAllocatedSlotAndEmit (o, i_type));
+        }
+        else
+        {
+            u16 constTableIndex = slot - o->slotFirstConstIndex;
+
+            d_m3Assert(constTableIndex < d_m3MaxConstantTableSize);
+
+            if (is64BitType) {
+                memcpy (& o->constants [constTableIndex], &i_word, sizeof(i_word));
+            } else {
+                u32 word32 = i_word;
+                memcpy (& o->constants [constTableIndex], &word32, sizeof(word32));
+            }
+
+_           (Push (o, i_type, slot));
+
+            o->slotMaxConstIndex = M3_MAX (slot + numRequiredSlots, o->slotMaxConstIndex);
+        }
+    }
+
+    _catch: return result;
+}
+
+static inline
+M3Result  EmitSlotNumOfStackTopAndPop  (IM3Compilation o)
+{
+    // no emit if value is in register
+    if (IsStackTopInSlot (o))
+        EmitSlotOffset (o, GetStackTopSlotNumber (o));
+
+    return Pop (o);
+}
+
+
+// Or, maybe: EmitTrappingOp
+M3Result  AddTrapRecord  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    if (o->function)
+    {
+    }
+
+    return result;
+}
+
+static
+M3Result  UnwindBlockStack  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    u32 popCount = 0;
+    while (o->stackIndex > o->block.blockStackIndex)
+    {
+_       (Pop (o));
+        ++popCount;
+    }
+
+    if (popCount)
+    {
+        m3log (compile, "unwound stack top: %d", popCount);
+    }
+
+    _catch: return result;
+}
+
+static inline
+M3Result  SetStackPolymorphic  (IM3Compilation o)
+{
+    o->block.isPolymorphic = true;                              m3log (compile, "stack set polymorphic");
+    return UnwindBlockStack (o);
+}
+
+static
+void  PatchBranches  (IM3Compilation o)
+{
+    pc_t pc = GetPC (o);
+
+    pc_t patches = o->block.patches;
+    o->block.patches = NULL;
+
+    while (patches)
+    {                                                           m3log (compile, "patching location: %p to pc: %p", patches, pc);
+        pc_t next = * (pc_t *) patches;
+        * (pc_t *) patches = pc;
+        patches = next;
+    }
+}
+
+//-------------------------------------------------------------------------------------------------------------------------
+
+static
+M3Result  CopyStackIndexToSlot  (IM3Compilation o, u16 i_destSlot, u16 i_stackIndex)  // NoPushPop
+{
+    M3Result result = m3Err_none;
+
+    IM3Operation op;
+
+    u8 type = GetStackTypeFromBottom (o, i_stackIndex);
+    bool inRegister = IsStackIndexInRegister (o, i_stackIndex);
+
+    if (inRegister)
+    {
+        op = c_setSetOps [type];
+    }
+    else op = Is64BitType (type) ? op_CopySlot_64 : op_CopySlot_32;
+
+_   (EmitOp (o, op));
+    EmitSlotOffset (o, i_destSlot);
+
+    if (not inRegister)
+    {
+        u16 srcSlot = GetSlotForStackIndex (o, i_stackIndex);
+        EmitSlotOffset (o, srcSlot);
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  CopyStackTopToSlot  (IM3Compilation o, u16 i_destSlot)  // NoPushPop
+{
+    M3Result result;
+
+    i16 stackTop = GetStackTopIndex (o);
+_   (CopyStackIndexToSlot (o, i_destSlot, (u16) stackTop));
+
+    _catch: return result;
+}
+
+
+// a copy-on-write strategy is used with locals. when a get local occurs, it's not copied anywhere. the stack
+// entry just has a index pointer to that local memory slot.
+// then, when a previously referenced local is set, the current value needs to be preserved for those references
+
+// TODO: consider getting rid of these specialized operations: PreserveSetSlot & PreserveCopySlot.
+// They likely just take up space (which seems to reduce performance) without improving performance.
+static
+M3Result  PreservedCopyTopSlot  (IM3Compilation o, u16 i_destSlot, u16 i_preserveSlot)
+{
+    M3Result result = m3Err_none;             d_m3Assert (i_destSlot != i_preserveSlot);
+
+    IM3Operation op;
+
+    u8 type = GetStackTopType (o);
+
+    if (IsStackTopInRegister (o))
+    {
+        op = c_preserveSetSlot [type];
+    }
+    else op = Is64BitType (type) ? op_PreserveCopySlot_64 : op_PreserveCopySlot_32;
+
+_   (EmitOp (o, op));
+    EmitSlotOffset (o, i_destSlot);
+
+    if (IsStackTopInSlot (o))
+        EmitSlotOffset (o, GetStackTopSlotNumber (o));
+
+    EmitSlotOffset (o, i_preserveSlot);
+
+    _catch: return result;
+}
+
+static
+M3Result  CopyStackTopToRegister  (IM3Compilation o, bool i_updateStack)
+{
+    M3Result result = m3Err_none;
+
+    if (IsStackTopInSlot (o))
+    {
+        u8 type = GetStackTopType (o);
+
+_       (PreserveRegisterIfOccupied (o, type));
+
+        IM3Operation op = c_setRegisterOps [type];
+
+_       (EmitOp (o, op));
+        EmitSlotOffset (o, GetStackTopSlotNumber (o));
+
+        if (i_updateStack)
+        {
+_           (PopType (o, type));
+_           (PushRegister (o, type));
+        }
+    }
+
+    _catch: return result;
+}
+
+
+// if local is unreferenced, o_preservedSlotNumber will be equal to localIndex on return
+static
+M3Result  FindReferencedLocalWithinCurrentBlock  (IM3Compilation o, u16 * o_preservedSlotNumber, u32 i_localSlot)
+{
+    M3Result result = m3Err_none;
+
+    IM3CompilationScope scope = & o->block;
+    u16 startIndex = scope->blockStackIndex;
+
+    while (scope->opcode == c_waOp_block)
+    {
+        scope = scope->outer;
+        if (not scope)
+            break;
+
+        startIndex = scope->blockStackIndex;
+    }
+
+    * o_preservedSlotNumber = (u16) i_localSlot;
+
+    for (u32 i = startIndex; i < o->stackIndex; ++i)
+    {
+        if (o->wasmStack [i] == i_localSlot)
+        {
+            if (* o_preservedSlotNumber == i_localSlot)
+            {
+                u8 type = GetStackTypeFromBottom (o, i);                    d_m3Assert (type != c_m3Type_none)
+
+_               (AllocateSlots (o, o_preservedSlotNumber, type));
+            }
+            else
+_               (IncrementSlotUsageCount (o, * o_preservedSlotNumber));
+
+            o->wasmStack [i] = * o_preservedSlotNumber;
+        }
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  GetBlockScope  (IM3Compilation o, IM3CompilationScope * o_scope, u32 i_depth)
+{
+    M3Result result = m3Err_none;
+
+    IM3CompilationScope scope = & o->block;
+
+    while (i_depth--)
+    {
+        scope = scope->outer;
+        _throwif ("invalid block depth", not scope);
+    }
+
+    * o_scope = scope;
+
+    _catch:
+    return result;
+}
+
+static
+M3Result  CopyStackSlotsR  (IM3Compilation o, u16 i_targetSlotStackIndex, u16 i_stackIndex, u16 i_endStackIndex, u16 i_tempSlot)
+{
+    M3Result result = m3Err_none;
+
+    if (i_stackIndex < i_endStackIndex)
+    {
+        u16 srcSlot = GetSlotForStackIndex (o, i_stackIndex);
+
+        u8 type = GetStackTypeFromBottom (o, i_stackIndex);
+        u16 numSlots = GetTypeNumSlots (type);
+        u16 extraSlot = numSlots - 1;
+
+        u16 targetSlot = GetSlotForStackIndex (o, i_targetSlotStackIndex);
+
+        u16 preserveIndex = i_stackIndex;
+        u16 collisionSlot = srcSlot;
+
+        if (targetSlot != srcSlot)
+        {
+            // search for collisions
+            u16 checkIndex = i_stackIndex + 1;
+            while (checkIndex < i_endStackIndex)
+            {
+                u16 otherSlot1 = GetSlotForStackIndex (o, checkIndex);
+                u16 otherSlot2 = GetExtraSlotForStackIndex (o, checkIndex);
+
+                if (targetSlot == otherSlot1 or
+                    targetSlot == otherSlot2 or
+                    targetSlot + extraSlot == otherSlot1)
+                {
+                    _throwif (m3Err_functionStackOverflow, i_tempSlot >= d_m3MaxFunctionSlots);
+
+_                   (CopyStackIndexToSlot (o, i_tempSlot, checkIndex));
+                    o->wasmStack [checkIndex] = i_tempSlot;
+                    i_tempSlot += GetTypeNumSlots (c_m3Type_i64);
+                    TouchSlot (o, i_tempSlot - 1);
+
+                    // restore this on the way back down
+                    preserveIndex = checkIndex;
+                    collisionSlot = otherSlot1;
+
+                    break;
+                }
+
+                ++checkIndex;
+            }
+
+_           (CopyStackIndexToSlot (o, targetSlot, i_stackIndex));                                               m3log (compile, " copying slot: %d to slot: %d", srcSlot, targetSlot);
+            o->wasmStack [i_stackIndex] = targetSlot;
+
+        }
+
+_       (CopyStackSlotsR (o, i_targetSlotStackIndex + 1, i_stackIndex + 1, i_endStackIndex, i_tempSlot));
+
+        // restore the stack state
+        o->wasmStack [i_stackIndex] = srcSlot;
+        o->wasmStack [preserveIndex] = collisionSlot;
+    }
+
+    _catch:
+    return result;
+}
+
+static
+M3Result  ResolveBlockResults  (IM3Compilation o, IM3CompilationScope i_targetBlock, bool i_isBranch)
+{
+    M3Result result = m3Err_none;                                   if (d_m3LogWasmStack) dump_type_stack (o);
+
+    bool isLoop = (i_targetBlock->opcode == c_waOp_loop and i_isBranch);
+
+    u16 numParams = GetFuncTypeNumParams (i_targetBlock->type);
+    u16 numResults = GetFuncTypeNumResults (i_targetBlock->type);
+
+    u16 slotRecords = i_targetBlock->exitStackIndex;
+
+    u16 numValues;
+
+    if (not isLoop)
+    {
+        numValues = numResults;
+        slotRecords += numParams;
+    }
+    else numValues = numParams;
+
+    u16 blockHeight = GetNumBlockValuesOnStack (o);
+
+    _throwif (m3Err_typeCountMismatch, i_isBranch ? (blockHeight < numValues) : (blockHeight != numValues));
+
+    if (numValues)
+    {
+        u16 endIndex = GetStackTopIndex (o) + 1;
+        u16 numRemValues = numValues;
+
+        // The last result is taken from _fp0. See PushBlockResults.
+        if (not isLoop and IsFpType (GetStackTopType (o)))
+        {
+_           (CopyStackTopToRegister (o, false));
+            --endIndex;
+            --numRemValues;
+        }
+
+        // TODO: tempslot affects maxStackSlots, so can grow unnecess each time.
+        u16 tempSlot = o->maxStackSlots;// GetMaxUsedSlotPlusOne (o); doesn't work cause can collide with slotRecords
+        AlignSlotToType (& tempSlot, c_m3Type_i64);
+
+_       (CopyStackSlotsR (o, slotRecords, endIndex - numRemValues, endIndex, tempSlot));
+
+        if (d_m3LogWasmStack) dump_type_stack (o);
+    }
+
+    _catch: return result;
+}
+
+
+static
+M3Result  ReturnValues  (IM3Compilation o, IM3CompilationScope i_functionBlock, bool i_isBranch)
+{
+    M3Result result = m3Err_none;                                               if (d_m3LogWasmStack) dump_type_stack (o);
+
+    u16 numReturns = GetFuncTypeNumResults (i_functionBlock->type);     // could just o->function too...
+    u16 blockHeight = GetNumBlockValuesOnStack (o);
+
+    if (not IsStackPolymorphic (o))
+        _throwif (m3Err_typeCountMismatch, i_isBranch ? (blockHeight < numReturns) : (blockHeight != numReturns));
+
+    if (numReturns)
+    {
+        // return slots like args are 64-bit aligned
+        u16 returnSlot = numReturns * c_ioSlotCount;
+        u16 stackTop = GetStackTopIndex (o);
+
+        for (u16 i = 0; i < numReturns; ++i)
+        {
+            u8 returnType = GetFuncTypeResultType (i_functionBlock->type, numReturns - 1 - i);
+
+            u8 stackType = GetStackTypeFromTop (o, i);  // using FromTop so that only dynamic items are checked
+
+            if (IsStackPolymorphic (o) and stackType == c_m3Type_none)
+                stackType = returnType;
+
+            _throwif (m3Err_typeMismatch, returnType != stackType);
+
+            if (not IsStackPolymorphic (o))
+            {
+                returnSlot -= c_ioSlotCount;
+_               (CopyStackIndexToSlot (o, returnSlot, stackTop--));
+            }
+        }
+
+        if (not i_isBranch)
+        {
+            while (numReturns--)
+_               (Pop (o));
+        }
+    }
+
+    _catch: return result;
+}
+
+
+//-------------------------------------------------------------------------------------------------------------------------
+
+static
+M3Result  Compile_Const_i32  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    i32 value;
+_   (ReadLEB_i32 (& value, & o->wasm, o->wasmEnd));
+_   (PushConst (o, value, c_m3Type_i32));                       m3log (compile, d_indent " (const i32 = %" PRIi32 ")", get_indention_string (o), value);
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Const_i64  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    i64 value;
+_   (ReadLEB_i64 (& value, & o->wasm, o->wasmEnd));
+_   (PushConst (o, value, c_m3Type_i64));                       m3log (compile, d_indent " (const i64 = %" PRIi64 ")", get_indention_string (o), value);
+    _catch: return result;
+}
+
+
+#if d_m3ImplementFloat
+static
+M3Result  Compile_Const_f32  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    union { u32 u; f32 f; } value = { 0 };
+
+_   (Read_f32 (& value.f, & o->wasm, o->wasmEnd));              m3log (compile, d_indent " (const f32 = %" PRIf32 ")", get_indention_string (o), value.f);
+_   (PushConst (o, value.u, c_m3Type_f32));
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Const_f64  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    union { u64 u; f64 f; } value = { 0 };
+
+_   (Read_f64 (& value.f, & o->wasm, o->wasmEnd));              m3log (compile, d_indent " (const f64 = %" PRIf64 ")", get_indention_string (o), value.f);
+_   (PushConst (o, value.u, c_m3Type_f64));
+
+    _catch: return result;
+}
+#endif
+
+#if d_m3CascadedOpcodes
+
+static
+M3Result  Compile_ExtendedOpcode  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    u8 opcode;
+_   (Read_u8 (& opcode, & o->wasm, o->wasmEnd));             m3log (compile, d_indent " (FC: %" PRIi32 ")", get_indention_string (o), opcode);
+
+    i_opcode = (i_opcode << 8) | opcode;
+
+    //printf("Extended opcode: 0x%x\n", i_opcode);
+
+    IM3OpInfo opInfo = GetOpInfo (i_opcode);
+    _throwif (m3Err_unknownOpcode, not opInfo);
+
+    M3Compiler compiler = opInfo->compiler;
+    _throwif (m3Err_noCompiler, not compiler);
+
+_   ((* compiler) (o, i_opcode));
+
+    o->previousOpcode = i_opcode;
+
+    } _catch: return result;
+}
+#endif
+
+static
+M3Result  Compile_Return  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = m3Err_none;
+
+    if (not IsStackPolymorphic (o))
+    {
+        IM3CompilationScope functionScope;
+_       (GetBlockScope (o, & functionScope, o->block.depth));
+
+_       (ReturnValues (o, functionScope, true));
+
+_       (EmitOp (o, op_Return));
+
+_       (SetStackPolymorphic (o));
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  ValidateBlockEnd  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+/*
+    u16 numResults = GetFuncTypeNumResults (o->block.type);
+    u16 blockHeight = GetNumBlockValuesOnStack (o);
+
+    if (IsStackPolymorphic (o))
+    {
+    }
+    else
+    {
+    }
+
+    _catch: */ return result;
+}
+
+static
+M3Result  Compile_End  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = m3Err_none;                   //dump_type_stack (o);
+
+    // function end:
+    if (o->block.depth == 0)
+    {
+        ValidateBlockEnd (o);
+
+//      if (not IsStackPolymorphic (o))
+        {
+            if (o->function)
+            {
+_               (ReturnValues (o, & o->block, false));
+            }
+
+_           (EmitOp (o, op_Return));
+        }
+    }
+
+    _catch: return result;
+}
+
+
+static
+M3Result  Compile_SetLocal  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    u32 localIndex;
+_   (ReadLEB_u32 (& localIndex, & o->wasm, o->wasmEnd));             //  printf ("--- set local: %d \n", localSlot);
+
+    if (localIndex < GetFunctionNumArgsAndLocals (o->function))
+    {
+        u16 localSlot = GetSlotForStackIndex (o, localIndex);
+
+        u16 preserveSlot;
+_       (FindReferencedLocalWithinCurrentBlock (o, & preserveSlot, localSlot));  // preserve will be different than local, if referenced
+
+        if (preserveSlot == localSlot)
+_           (CopyStackTopToSlot (o, localSlot))
+        else
+_           (PreservedCopyTopSlot (o, localSlot, preserveSlot))
+
+        if (i_opcode != c_waOp_teeLocal)
+_           (Pop (o));
+    }
+    else _throw ("local index out of bounds");
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_GetLocal  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+
+    u32 localIndex;
+_   (ReadLEB_u32 (& localIndex, & o->wasm, o->wasmEnd));
+
+    if (localIndex >= GetFunctionNumArgsAndLocals (o->function))
+        _throw ("local index out of bounds");
+
+    u8 type = GetStackTypeFromBottom (o, localIndex);
+    u16 slot = GetSlotForStackIndex (o, localIndex);
+
+_   (Push (o, type, slot));
+
+    } _catch: return result;
+}
+
+static
+M3Result  Compile_GetGlobal  (IM3Compilation o, M3Global * i_global)
+{
+    M3Result result;
+
+    IM3Operation op = Is64BitType (i_global->type) ? op_GetGlobal_s64 : op_GetGlobal_s32;
+_   (EmitOp (o, op));
+    EmitPointer (o, & i_global->i64Value);
+_   (PushAllocatedSlotAndEmit (o, i_global->type));
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_SetGlobal  (IM3Compilation o, M3Global * i_global)
+{
+    M3Result result = m3Err_none;
+
+    if (i_global->isMutable)
+    {
+        IM3Operation op;
+        u8 type = GetStackTopType (o);
+
+        if (IsStackTopInRegister (o))
+        {
+            op = c_setGlobalOps [type];
+        }
+        else op = Is64BitType (type) ? op_SetGlobal_s64 : op_SetGlobal_s32;
+
+_      (EmitOp (o, op));
+        EmitPointer (o, & i_global->i64Value);
+
+        if (IsStackTopInSlot (o))
+            EmitSlotOffset (o, GetStackTopSlotNumber (o));
+
+_      (Pop (o));
+    }
+    else _throw (m3Err_settingImmutableGlobal);
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_GetSetGlobal  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = m3Err_none;
+
+    u32 globalIndex;
+_   (ReadLEB_u32 (& globalIndex, & o->wasm, o->wasmEnd));
+
+    if (globalIndex < o->module->numGlobals)
+    {
+        if (o->module->globals)
+        {
+            M3Global * global = & o->module->globals [globalIndex];
+
+_           ((i_opcode == c_waOp_getGlobal) ? Compile_GetGlobal (o, global) : Compile_SetGlobal (o, global));
+        }
+        else _throw (ErrorCompile (m3Err_globalMemoryNotAllocated, o, "module '%s' is missing global memory", o->module->name));
+    }
+    else _throw (m3Err_globaIndexOutOfBounds);
+
+    _catch: return result;
+}
+
+static
+void  EmitPatchingBranchPointer  (IM3Compilation o, IM3CompilationScope i_scope)
+{
+    pc_t patch = EmitPointer (o, i_scope->patches);                     m3log (compile, "branch patch required at: %p", patch);
+    i_scope->patches = patch;
+}
+
+static
+M3Result  EmitPatchingBranch  (IM3Compilation o, IM3CompilationScope i_scope)
+{
+    M3Result result = m3Err_none;
+
+_   (EmitOp (o, op_Branch));
+    EmitPatchingBranchPointer (o, i_scope);
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Branch  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    u32 depth;
+_   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
+
+    IM3CompilationScope scope;
+_   (GetBlockScope (o, & scope, depth));
+
+    // branch target is a loop (continue)
+    if (scope->opcode == c_waOp_loop)
+    {
+        if (i_opcode == c_waOp_branchIf)
+        {
+            if (GetFuncTypeNumParams (scope->type))
+            {
+                IM3Operation op = IsStackTopInRegister (o) ? op_BranchIfPrologue_r : op_BranchIfPrologue_s;
+
+_               (EmitOp (o, op));
+_               (EmitSlotNumOfStackTopAndPop (o));
+
+                pc_t * jumpTo = (pc_t *) ReservePointer (o);
+
+_               (ResolveBlockResults (o, scope, /* isBranch: */ true));
+
+_               (EmitOp (o, op_ContinueLoop));
+                EmitPointer (o, scope->pc);
+
+                * jumpTo = GetPC (o);
+            }
+            else
+            {
+                // move the condition to a register
+_               (CopyStackTopToRegister (o, false));
+_               (PopType (o, c_m3Type_i32));
+
+_               (EmitOp (o, op_ContinueLoopIf));
+                EmitPointer (o, scope->pc);
+            }
+
+//          dump_type_stack(o);
+        }
+        else // is c_waOp_branch
+        {
+    _       (EmitOp (o, op_ContinueLoop));
+            EmitPointer (o, scope->pc);
+            o->block.isPolymorphic = true;
+        }
+    }
+    else // forward branch
+    {
+        pc_t * jumpTo = NULL;
+
+        bool isReturn = (scope->depth == 0);
+        bool targetHasResults = GetFuncTypeNumResults (scope->type);
+
+        if (i_opcode == c_waOp_branchIf)
+        {
+            if (targetHasResults or isReturn)
+            {
+                IM3Operation op = IsStackTopInRegister (o) ? op_BranchIfPrologue_r : op_BranchIfPrologue_s;
+
+    _           (EmitOp (o, op));
+    _           (EmitSlotNumOfStackTopAndPop (o)); // condition
+
+                // this is continuation point, if the branch isn't taken
+                jumpTo = (pc_t *) ReservePointer (o);
+            }
+            else
+            {
+                IM3Operation op = IsStackTopInRegister (o) ? op_BranchIf_r : op_BranchIf_s;
+
+    _           (EmitOp (o, op));
+    _           (EmitSlotNumOfStackTopAndPop (o)); // condition
+
+                EmitPatchingBranchPointer (o, scope);
+                goto _catch;
+            }
+        }
+
+        if (not IsStackPolymorphic (o))
+        {
+            if (isReturn)
+            {
+_               (ReturnValues (o, scope, true));
+_               (EmitOp (o, op_Return));
+            }
+            else
+            {
+_               (ResolveBlockResults (o, scope, true));
+_               (EmitPatchingBranch (o, scope));
+            }
+        }
+
+        if (jumpTo)
+        {
+            * jumpTo = GetPC (o);
+        }
+
+        if (i_opcode == c_waOp_branch)
+_           (SetStackPolymorphic (o));
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_BranchTable  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    u32 targetCount;
+_   (ReadLEB_u32 (& targetCount, & o->wasm, o->wasmEnd));
+
+_   (PreserveRegisterIfOccupied (o, c_m3Type_i64));         // move branch operand to a slot
+    u16 slot = GetStackTopSlotNumber (o);
+_   (Pop (o));
+
+    // OPTZ: according to spec: "forward branches that target a control instruction with a non-empty
+    // result type consume matching operands first and push them back on the operand stack after unwinding"
+    // So, this move-to-reg is only necessary if the target scopes have a type.
+
+    u32 numCodeLines = targetCount + 4; // 3 => IM3Operation + slot + target_count + default_target
+_   (EnsureCodePageNumLines (o, numCodeLines));
+
+_   (EmitOp (o, op_BranchTable));
+    EmitSlotOffset (o, slot);
+    EmitConstant32 (o, targetCount);
+
+    IM3CodePage continueOpPage = NULL;
+
+    ++targetCount; // include default
+    for (u32 i = 0; i < targetCount; ++i)
+    {
+        u32 target;
+_       (ReadLEB_u32 (& target, & o->wasm, o->wasmEnd));
+
+        IM3CompilationScope scope;
+_       (GetBlockScope (o, & scope, target));
+
+        // TODO: don't need codepage rigmarole for
+        // no-param forward-branch targets
+
+_       (AcquireCompilationCodePage (o, & continueOpPage));
+
+        pc_t startPC = GetPagePC (continueOpPage);
+        IM3CodePage savedPage = o->page;
+        o->page = continueOpPage;
+
+        if (scope->opcode == c_waOp_loop)
+        {
+_           (ResolveBlockResults (o, scope, true));
+
+_           (EmitOp (o, op_ContinueLoop));
+            EmitPointer (o, scope->pc);
+        }
+        else
+        {
+            // TODO: this could be fused with equivalent targets
+            if (not IsStackPolymorphic (o))
+            {
+                if (scope->depth == 0)
+                {
+_                   (ReturnValues (o, scope, true));
+_                   (EmitOp (o, op_Return));
+                }
+                else
+                {
+_                   (ResolveBlockResults (o, scope, true));
+
+_                   (EmitPatchingBranch (o, scope));
+                }
+            }
+        }
+
+        ReleaseCompilationCodePage (o);     // FIX: continueOpPage can get lost if thrown
+        o->page = savedPage;
+
+        EmitPointer (o, startPC);
+    }
+
+_   (SetStackPolymorphic (o));
+
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  CompileCallArgsAndReturn  (IM3Compilation o, u16 * o_stackOffset, IM3FuncType i_type, bool i_isIndirect)
+{
+_try {
+
+    u16 topSlot = GetMaxUsedSlotPlusOne (o);
+
+    // force use of at least one stack slot; this is to help ensure
+    // the m3 stack overflows (and traps) before the native stack can overflow.
+    // e.g. see Wasm spec test 'runaway' in call.wast
+    topSlot = M3_MAX (1, topSlot);
+
+    // stack frame is 64-bit aligned
+    AlignSlotToType (& topSlot, c_m3Type_i64);
+
+    * o_stackOffset = topSlot;
+
+    // wait to pop this here so that topSlot search is correct
+    if (i_isIndirect)
+_       (Pop (o));
+
+    u16 numArgs = GetFuncTypeNumParams (i_type);
+    u16 numRets = GetFuncTypeNumResults (i_type);
+
+    u16 argTop = topSlot + (numArgs + numRets) * c_ioSlotCount;
+
+    while (numArgs--)
+    {
+_       (CopyStackTopToSlot (o, argTop -= c_ioSlotCount));
+_       (Pop (o));
+    }
+
+    u16 i = 0;
+    while (numRets--)
+    {
+        u8 type = GetFuncTypeResultType (i_type, i++);
+
+_       (Push (o, type, topSlot));
+        MarkSlotsAllocatedByType (o, topSlot, type);
+
+        topSlot += c_ioSlotCount;
+    }
+
+    } _catch: return result;
+}
+
+static
+M3Result  Compile_Call  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    u32 functionIndex;
+_   (ReadLEB_u32 (& functionIndex, & o->wasm, o->wasmEnd));
+
+    IM3Function function = Module_GetFunction (o->module, functionIndex);
+
+    if (function)
+    {                                                                   m3log (compile, d_indent " (func= [%d] '%s'; args= %d)",
+                                                                                get_indention_string (o), functionIndex, m3_GetFunctionName (function), function->funcType->numArgs);
+        if (function->module)
+        {
+            u16 slotTop;
+_           (CompileCallArgsAndReturn (o, & slotTop, function->funcType, false));
+
+            IM3Operation op;
+            const void * operand;
+
+            if (function->compiled)
+            {
+                op = op_Call;
+                operand = function->compiled;
+            }
+            else
+            {
+                op = op_Compile;
+                operand = function;
+            }
+
+_           (EmitOp     (o, op));
+            EmitPointer (o, operand);
+            EmitSlotOffset  (o, slotTop);
+        }
+        else
+        {
+            _throw (ErrorCompile (m3Err_functionImportMissing, o, "'%s.%s'", GetFunctionImportModuleName (function), m3_GetFunctionName (function)));
+        }
+    }
+    else _throw (m3Err_functionLookupFailed);
+
+    } _catch: return result;
+}
+
+static
+M3Result  Compile_CallIndirect  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    u32 typeIndex;
+_   (ReadLEB_u32 (& typeIndex, & o->wasm, o->wasmEnd));
+
+    u32 tableIndex;
+_   (ReadLEB_u32 (& tableIndex, & o->wasm, o->wasmEnd));
+
+    _throwif ("function call type index out of range", typeIndex >= o->module->numFuncTypes);
+
+    if (IsStackTopInRegister (o))
+_       (PreserveRegisterIfOccupied (o, c_m3Type_i32));
+
+    u16 tableIndexSlot = GetStackTopSlotNumber (o);
+
+    u16 execTop;
+    IM3FuncType type = o->module->funcTypes [typeIndex];
+_   (CompileCallArgsAndReturn (o, & execTop, type, true));
+
+_   (EmitOp         (o, op_CallIndirect));
+    EmitSlotOffset  (o, tableIndexSlot);
+    EmitPointer     (o, o->module);
+    EmitPointer     (o, type);              // TODO: unify all types in M3Environment
+    EmitSlotOffset  (o, execTop);
+
+} _catch:
+    return result;
+}
+
+static
+M3Result  Compile_Memory_Size  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    i8 reserved;
+_   (ReadLEB_i7 (& reserved, & o->wasm, o->wasmEnd));
+
+_   (PreserveRegisterIfOccupied (o, c_m3Type_i32));
+
+_   (EmitOp     (o, op_MemSize));
+
+_   (PushRegister (o, c_m3Type_i32));
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Memory_Grow  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    i8 reserved;
+_   (ReadLEB_i7 (& reserved, & o->wasm, o->wasmEnd));
+
+_   (CopyStackTopToRegister (o, false));
+_   (PopType (o, c_m3Type_i32));
+
+_   (EmitOp     (o, op_MemGrow));
+
+_   (PushRegister (o, c_m3Type_i32));
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Memory_CopyFill  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = m3Err_none;
+
+    u32 sourceMemoryIdx, targetMemoryIdx;
+    IM3Operation op;
+    if (i_opcode == c_waOp_memoryCopy)
+    {
+_       (ReadLEB_u32 (& sourceMemoryIdx, & o->wasm, o->wasmEnd));
+        op = op_MemCopy;
+    }
+    else op = op_MemFill;
+
+_   (ReadLEB_u32 (& targetMemoryIdx, & o->wasm, o->wasmEnd));
+
+_   (CopyStackTopToRegister (o, false));
+
+_   (EmitOp  (o, op));
+_   (PopType (o, c_m3Type_i32));
+_   (EmitSlotNumOfStackTopAndPop (o));
+_   (EmitSlotNumOfStackTopAndPop (o));
+
+    _catch: return result;
+}
+
+
+static
+M3Result  ReadBlockType  (IM3Compilation o, IM3FuncType * o_blockType)
+{
+    M3Result result;
+
+    i64 type;
+_   (ReadLebSigned (& type, 33, & o->wasm, o->wasmEnd));
+
+    if (type < 0)
+    {
+        u8 valueType;
+_       (NormalizeType (&valueType, type));                                m3log (compile, d_indent " (type: %s)", get_indention_string (o), c_waTypes [valueType]);
+        *o_blockType = o->module->environment->retFuncTypes[valueType];
+    }
+    else
+    {
+        _throwif("func type out of bounds", type >= o->module->numFuncTypes);
+        *o_blockType = o->module->funcTypes[type];                         m3log (compile, d_indent " (type: %s)", get_indention_string (o), SPrintFuncTypeSignature (*o_blockType));
+    }
+    _catch: return result;
+}
+
+static
+M3Result  PreserveArgsAndLocals  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    if (o->stackIndex > o->stackFirstDynamicIndex)
+    {
+        u32 numArgsAndLocals = GetFunctionNumArgsAndLocals (o->function);
+
+        for (u32 i = 0; i < numArgsAndLocals; ++i)
+        {
+            u16 slot = GetSlotForStackIndex (o, i);
+
+            u16 preservedSlotNumber;
+_           (FindReferencedLocalWithinCurrentBlock (o, & preservedSlotNumber, slot));
+
+            if (preservedSlotNumber != slot)
+            {
+                u8 type = GetStackTypeFromBottom (o, i);                    d_m3Assert (type != c_m3Type_none)
+                IM3Operation op = Is64BitType (type) ? op_CopySlot_64 : op_CopySlot_32;
+
+                EmitOp          (o, op);
+                EmitSlotOffset  (o, preservedSlotNumber);
+                EmitSlotOffset  (o, slot);
+            }
+        }
+    }
+
+    _catch:
+    return result;
+}
+
+static
+M3Result  Compile_LoopOrBlock  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    // TODO: these shouldn't be necessary for non-loop blocks?
+_   (PreserveRegisters (o));
+_   (PreserveArgsAndLocals (o));
+
+    IM3FuncType blockType;
+_   (ReadBlockType (o, & blockType));
+
+    if (i_opcode == c_waOp_loop)
+    {
+        u16 numParams = GetFuncTypeNumParams (blockType);
+        if (numParams)
+        {
+            // instantiate constants
+            u16 numValues = GetNumBlockValuesOnStack (o);                   // CompileBlock enforces this at comptime
+                                                                            d_m3Assert (numValues >= numParams);
+            if (numValues >= numParams)
+            {
+                u16 stackTop = GetStackTopIndex (o) + 1;
+
+                for (u16 i = stackTop - numParams; i < stackTop; ++i)
+                {
+                    u16 slot = GetSlotForStackIndex (o, i);
+                    u8 type = GetStackTypeFromBottom (o, i);
+
+                    if (IsConstantSlot (o, slot))
+                    {
+                        u16 newSlot = c_slotUnused;
+_                       (AllocateSlots (o, & newSlot, type));
+_                       (CopyStackIndexToSlot (o, newSlot, i));
+                        o->wasmStack [i] = newSlot;
+                    }
+                }
+            }
+        }
+
+_       (EmitOp (o, op_Loop));
+    }
+    else
+    {
+    }
+
+_   (CompileBlock (o, blockType, i_opcode));
+
+    _catch: return result;
+}
+
+static
+M3Result  CompileElseBlock  (IM3Compilation o, pc_t * o_startPC, IM3FuncType i_blockType)
+{
+    IM3CodePage savedPage = o->page;
+_try {
+
+    IM3CodePage elsePage;
+_   (AcquireCompilationCodePage (o, & elsePage));
+
+    * o_startPC = GetPagePC (elsePage);
+
+    o->page = elsePage;
+
+_   (CompileBlock (o, i_blockType, c_waOp_else));
+
+_   (EmitOp (o, op_Branch));
+    EmitPointer (o, GetPagePC (savedPage));
+} _catch:
+    if(o->page != savedPage) {
+        ReleaseCompilationCodePage (o);
+    }
+    o->page = savedPage;
+    return result;
+}
+
+static
+M3Result  Compile_If  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    /*      [   op_If   ]
+            [ <else-pc> ]   ---->   [ ..else..  ]
+            [  ..if..   ]           [ ..block.. ]
+            [ ..block.. ]           [ op_Branch ]
+            [    end    ]  <-----   [  <end-pc> ]       */
+
+_try {
+
+_   (PreserveNonTopRegisters (o));
+_   (PreserveArgsAndLocals (o));
+
+    IM3Operation op = IsStackTopInRegister (o) ? op_If_r : op_If_s;
+
+_   (EmitOp (o, op));
+_   (EmitSlotNumOfStackTopAndPop (o));
+
+    pc_t * pc = (pc_t *) ReservePointer (o);
+
+    IM3FuncType blockType;
+_   (ReadBlockType (o, & blockType));
+
+//  dump_type_stack (o);
+
+    u16 stackIndex = o->stackIndex;
+
+_   (CompileBlock (o, blockType, i_opcode));
+
+    if (o->previousOpcode == c_waOp_else)
+    {
+        o->stackIndex = stackIndex;
+_       (CompileElseBlock (o, pc, blockType));
+    }
+    else
+    {
+        // if block produces values and there isn't a defined else
+        // case, then we need to make one up so that the pass-through
+        // results end up in the right place
+        if (GetFuncTypeNumResults (blockType))
+        {
+            // rewind to the if's end to create a fake else block
+            o->wasm--;
+            o->stackIndex = stackIndex;
+
+//          dump_type_stack (o);
+
+_           (CompileElseBlock (o, pc, blockType));
+        }
+        else * pc = GetPC (o);
+    }
+
+    } _catch: return result;
+}
+
+static
+M3Result  Compile_Select  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = m3Err_none;
+
+    u16 slots [3] = { c_slotUnused, c_slotUnused, c_slotUnused };
+
+    u8 type = GetStackTypeFromTop (o, 1); // get type of selection
+
+    IM3Operation op = NULL;
+
+    if (IsFpType (type))
+    {
+#   if d_m3HasFloat
+        // not consuming a fp reg, so preserve
+        if (not IsStackTopMinus1InRegister (o) and
+            not IsStackTopMinus2InRegister (o))
+        {
+_           (PreserveRegisterIfOccupied (o, type));
+        }
+
+        bool selectorInReg = IsStackTopInRegister (o);
+        slots [0] = GetStackTopSlotNumber (o);
+_       (Pop (o));
+
+        u32 opIndex = 0;
+
+        for (u32 i = 1; i <= 2; ++i)
+        {
+            if (IsStackTopInRegister (o))
+                opIndex = i;
+            else
+                slots [i] = GetStackTopSlotNumber (o);
+
+_          (Pop (o));
+        }
+
+        op = c_fpSelectOps [type - c_m3Type_f32] [selectorInReg] [opIndex];
+#   else
+        _throw (m3Err_unknownOpcode);
+#   endif
+    }
+    else if (IsIntType (type))
+    {
+        // 'sss' operation doesn't consume a register, so might have to protected its contents
+        if (not IsStackTopInRegister (o) and
+            not IsStackTopMinus1InRegister (o) and
+            not IsStackTopMinus2InRegister (o))
+        {
+_           (PreserveRegisterIfOccupied (o, type));
+        }
+
+        u32 opIndex = 3;  // op_Select_*_sss
+
+        for (u32 i = 0; i < 3; ++i)
+        {
+            if (IsStackTopInRegister (o))
+                opIndex = i;
+            else
+                slots [i] = GetStackTopSlotNumber (o);
+
+_          (Pop (o));
+        }
+
+        op = c_intSelectOps [type - c_m3Type_i32] [opIndex];
+    }
+    else if (not IsStackPolymorphic (o))
+        _throw (m3Err_functionStackUnderrun);
+
+    EmitOp (o, op);
+    for (u32 i = 0; i < 3; i++)
+    {
+        if (IsValidSlot (slots [i]))
+            EmitSlotOffset (o, slots [i]);
+    }
+_   (PushRegister (o, type));
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Drop  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result = Pop (o);                                              if (d_m3LogWasmStack) dump_type_stack (o);
+    return result;
+}
+
+static
+M3Result  Compile_Nop  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    return m3Err_none;
+}
+
+static
+M3Result  Compile_Unreachable  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+_   (AddTrapRecord (o));
+
+_   (EmitOp (o, op_Unreachable));
+_   (SetStackPolymorphic (o));
+
+    _catch:
+    return result;
+}
+
+
+// OPTZ: currently all stack slot indices take up a full word, but
+// dual stack source operands could be packed together
+static
+M3Result  Compile_Operator  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    M3Result result;
+
+    IM3OpInfo opInfo = GetOpInfo (i_opcode);
+    _throwif (m3Err_unknownOpcode, not opInfo);
+
+    IM3Operation op;
+
+    // This preserve is for for FP compare operations.
+    // either need additional slot destination operations or the
+    // easy fix, move _r0 out of the way.
+    // moving out the way might be the optimal solution most often?
+    // otherwise, the _r0 reg can get buried down in the stack
+    // and be idle & wasted for a moment.
+    if (IsFpType (GetStackTopType (o)) and IsIntType (opInfo->type))
+    {
+_       (PreserveRegisterIfOccupied (o, opInfo->type));
+    }
+
+    if (opInfo->stackOffset == 0)
+    {
+        if (IsStackTopInRegister (o))
+        {
+            op = opInfo->operations [0]; // _s
+        }
+        else
+        {
+_           (PreserveRegisterIfOccupied (o, opInfo->type));
+            op = opInfo->operations [1]; // _r
+        }
+    }
+    else
+    {
+        if (IsStackTopInRegister (o))
+        {
+            op = opInfo->operations [0];  // _rs
+
+            if (IsStackTopMinus1InRegister (o))
+            {                                       d_m3Assert (i_opcode == c_waOp_store_f32 or i_opcode == c_waOp_store_f64);
+                op = opInfo->operations [3]; // _rr for fp.store
+            }
+        }
+        else if (IsStackTopMinus1InRegister (o))
+        {
+            op = opInfo->operations [1]; // _sr
+
+            if (not op)  // must be commutative, then
+                op = opInfo->operations [0];
+        }
+        else
+        {
+_           (PreserveRegisterIfOccupied (o, opInfo->type));     // _ss
+            op = opInfo->operations [2];
+        }
+    }
+
+    if (op)
+    {
+_       (EmitOp (o, op));
+
+_       (EmitSlotNumOfStackTopAndPop (o));
+
+        if (opInfo->stackOffset < 0)
+_           (EmitSlotNumOfStackTopAndPop (o));
+
+        if (opInfo->type != c_m3Type_none)
+_           (PushRegister (o, opInfo->type));
+    }
+    else
+    {
+#       ifdef DEBUG
+            result = ErrorCompile ("no operation found for opcode", o, "'%s'", opInfo->name);
+#       else
+            result = ErrorCompile ("no operation found for opcode", o, "%x", i_opcode);
+#       endif
+        _throw (result);
+    }
+
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Convert  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    IM3OpInfo opInfo = GetOpInfo (i_opcode);
+    _throwif (m3Err_unknownOpcode, not opInfo);
+
+    bool destInSlot = IsRegisterTypeAllocated (o, opInfo->type);
+    bool sourceInSlot = IsStackTopInSlot (o);
+
+    IM3Operation op = opInfo->operations [destInSlot * 2 + sourceInSlot];
+
+_   (EmitOp (o, op));
+_   (EmitSlotNumOfStackTopAndPop (o));
+
+    if (destInSlot)
+_       (PushAllocatedSlotAndEmit (o, opInfo->type))
+    else
+_       (PushRegister (o, opInfo->type))
+
+}
+    _catch: return result;
+}
+
+static
+M3Result  Compile_Load_Store  (IM3Compilation o, m3opcode_t i_opcode)
+{
+_try {
+    u32 alignHint, memoryOffset;
+
+_   (ReadLEB_u32 (& alignHint, & o->wasm, o->wasmEnd));
+_   (ReadLEB_u32 (& memoryOffset, & o->wasm, o->wasmEnd));
+                                                                        m3log (compile, d_indent " (offset = %d)", get_indention_string (o), memoryOffset);
+    IM3OpInfo opInfo = GetOpInfo (i_opcode);
+    _throwif (m3Err_unknownOpcode, not opInfo);
+
+    if (IsFpType (opInfo->type))
+_       (PreserveRegisterIfOccupied (o, c_m3Type_f64));
+
+_   (Compile_Operator (o, i_opcode));
+
+    EmitConstant32 (o, memoryOffset);
+}
+    _catch: return result;
+}
+
+
+M3Result  CompileRawFunction  (IM3Module io_module,  IM3Function io_function, const void * i_function, const void * i_userdata)
+{
+    d_m3Assert (io_module->runtime);
+
+    IM3CodePage page = AcquireCodePageWithCapacity (io_module->runtime, 4);
+
+    if (page)
+    {
+        io_function->compiled = GetPagePC (page);
+        io_function->module = io_module;
+
+        EmitWord (page, op_CallRawFunction);
+        EmitWord (page, i_function);
+        EmitWord (page, io_function);
+        EmitWord (page, i_userdata);
+
+        ReleaseCodePage (io_module->runtime, page);
+        return m3Err_none;
+    }
+    else {
+        return m3Err_mallocFailedCodePage;
+    }
+}
+
+
+
+// d_logOp, d_logOp2 macros aren't actually used by the compiler, just codepage decoding (d_m3LogCodePages = 1)
+#define d_logOp(OP)                         { op_##OP,                  NULL,                       NULL,                       NULL }
+#define d_logOp2(OP1,OP2)                   { op_##OP1,                 op_##OP2,                   NULL,                       NULL }
+
+#define d_emptyOpList                       { NULL,                     NULL,                       NULL,                       NULL }
+#define d_unaryOpList(TYPE, NAME)           { op_##TYPE##_##NAME##_r,   op_##TYPE##_##NAME##_s,     NULL,                       NULL }
+#define d_binOpList(TYPE, NAME)             { op_##TYPE##_##NAME##_rs,  op_##TYPE##_##NAME##_sr,    op_##TYPE##_##NAME##_ss,    NULL }
+#define d_storeFpOpList(TYPE, NAME)         { op_##TYPE##_##NAME##_rs,  op_##TYPE##_##NAME##_sr,    op_##TYPE##_##NAME##_ss,    op_##TYPE##_##NAME##_rr }
+#define d_commutativeBinOpList(TYPE, NAME)  { op_##TYPE##_##NAME##_rs,  NULL,                       op_##TYPE##_##NAME##_ss,    NULL }
+#define d_convertOpList(OP)                 { op_##OP##_r_r,            op_##OP##_r_s,              op_##OP##_s_r,              op_##OP##_s_s }
+
+
+const M3OpInfo c_operations [] =
+{
+    M3OP( "unreachable",         0, none,   d_logOp (Unreachable),              Compile_Unreachable ),  // 0x00
+    M3OP( "nop",                 0, none,   d_emptyOpList,                      Compile_Nop ),          // 0x01 .
+    M3OP( "block",               0, none,   d_emptyOpList,                      Compile_LoopOrBlock ),  // 0x02
+    M3OP( "loop",                0, none,   d_logOp (Loop),                     Compile_LoopOrBlock ),  // 0x03
+    M3OP( "if",                 -1, none,   d_emptyOpList,                      Compile_If ),           // 0x04
+    M3OP( "else",                0, none,   d_emptyOpList,                      Compile_Nop ),          // 0x05
+
+    M3OP_RESERVED, M3OP_RESERVED, M3OP_RESERVED, M3OP_RESERVED, M3OP_RESERVED,                          // 0x06...0x0a
+
+    M3OP( "end",                 0, none,   d_emptyOpList,                      Compile_End ),          // 0x0b
+    M3OP( "br",                  0, none,   d_logOp (Branch),                   Compile_Branch ),       // 0x0c
+    M3OP( "br_if",              -1, none,   d_logOp2 (BranchIf_r, BranchIf_s),  Compile_Branch ),       // 0x0d
+    M3OP( "br_table",           -1, none,   d_logOp (BranchTable),              Compile_BranchTable ),  // 0x0e
+    M3OP( "return",              0, any,    d_logOp (Return),                   Compile_Return ),       // 0x0f
+    M3OP( "call",                0, any,    d_logOp (Call),                     Compile_Call ),         // 0x10
+    M3OP( "call_indirect",       0, any,    d_logOp (CallIndirect),             Compile_CallIndirect ), // 0x11
+    M3OP( "return_call",         0, any,    d_emptyOpList,                      Compile_Call ),         // 0x12 TODO: Optimize
+    M3OP( "return_call_indirect",0, any,    d_emptyOpList,                      Compile_CallIndirect ), // 0x13
+
+    M3OP_RESERVED,  M3OP_RESERVED,                                                                      // 0x14...
+    M3OP_RESERVED,  M3OP_RESERVED, M3OP_RESERVED, M3OP_RESERVED,                                        // ...0x19
+
+    M3OP( "drop",               -1, none,   d_emptyOpList,                      Compile_Drop ),         // 0x1a
+    M3OP( "select",             -2, any,    d_emptyOpList,                      Compile_Select  ),      // 0x1b
+
+    M3OP_RESERVED,  M3OP_RESERVED, M3OP_RESERVED, M3OP_RESERVED,                                        // 0x1c...0x1f
+
+    M3OP( "local.get",          1,  any,    d_emptyOpList,                      Compile_GetLocal ),     // 0x20
+    M3OP( "local.set",          1,  none,   d_emptyOpList,                      Compile_SetLocal ),     // 0x21
+    M3OP( "local.tee",          0,  any,    d_emptyOpList,                      Compile_SetLocal ),     // 0x22
+    M3OP( "global.get",         1,  none,   d_emptyOpList,                      Compile_GetSetGlobal ), // 0x23
+    M3OP( "global.set",         1,  none,   d_emptyOpList,                      Compile_GetSetGlobal ), // 0x24
+
+    M3OP_RESERVED,  M3OP_RESERVED, M3OP_RESERVED,                                                       // 0x25...0x27
+
+    M3OP( "i32.load",           0,  i_32,   d_unaryOpList (i32, Load_i32),      Compile_Load_Store ),   // 0x28
+    M3OP( "i64.load",           0,  i_64,   d_unaryOpList (i64, Load_i64),      Compile_Load_Store ),   // 0x29
+    M3OP_F( "f32.load",         0,  f_32,   d_unaryOpList (f32, Load_f32),      Compile_Load_Store ),   // 0x2a
+    M3OP_F( "f64.load",         0,  f_64,   d_unaryOpList (f64, Load_f64),      Compile_Load_Store ),   // 0x2b
+
+    M3OP( "i32.load8_s",        0,  i_32,   d_unaryOpList (i32, Load_i8),       Compile_Load_Store ),   // 0x2c
+    M3OP( "i32.load8_u",        0,  i_32,   d_unaryOpList (i32, Load_u8),       Compile_Load_Store ),   // 0x2d
+    M3OP( "i32.load16_s",       0,  i_32,   d_unaryOpList (i32, Load_i16),      Compile_Load_Store ),   // 0x2e
+    M3OP( "i32.load16_u",       0,  i_32,   d_unaryOpList (i32, Load_u16),      Compile_Load_Store ),   // 0x2f
+
+    M3OP( "i64.load8_s",        0,  i_64,   d_unaryOpList (i64, Load_i8),       Compile_Load_Store ),   // 0x30
+    M3OP( "i64.load8_u",        0,  i_64,   d_unaryOpList (i64, Load_u8),       Compile_Load_Store ),   // 0x31
+    M3OP( "i64.load16_s",       0,  i_64,   d_unaryOpList (i64, Load_i16),      Compile_Load_Store ),   // 0x32
+    M3OP( "i64.load16_u",       0,  i_64,   d_unaryOpList (i64, Load_u16),      Compile_Load_Store ),   // 0x33
+    M3OP( "i64.load32_s",       0,  i_64,   d_unaryOpList (i64, Load_i32),      Compile_Load_Store ),   // 0x34
+    M3OP( "i64.load32_u",       0,  i_64,   d_unaryOpList (i64, Load_u32),      Compile_Load_Store ),   // 0x35
+
+    M3OP( "i32.store",          -2, none,   d_binOpList (i32, Store_i32),       Compile_Load_Store ),   // 0x36
+    M3OP( "i64.store",          -2, none,   d_binOpList (i64, Store_i64),       Compile_Load_Store ),   // 0x37
+    M3OP_F( "f32.store",        -2, none,   d_storeFpOpList (f32, Store_f32),   Compile_Load_Store ),   // 0x38
+    M3OP_F( "f64.store",        -2, none,   d_storeFpOpList (f64, Store_f64),   Compile_Load_Store ),   // 0x39
+
+    M3OP( "i32.store8",         -2, none,   d_binOpList (i32, Store_u8),        Compile_Load_Store ),   // 0x3a
+    M3OP( "i32.store16",        -2, none,   d_binOpList (i32, Store_i16),       Compile_Load_Store ),   // 0x3b
+
+    M3OP( "i64.store8",         -2, none,   d_binOpList (i64, Store_u8),        Compile_Load_Store ),   // 0x3c
+    M3OP( "i64.store16",        -2, none,   d_binOpList (i64, Store_i16),       Compile_Load_Store ),   // 0x3d
+    M3OP( "i64.store32",        -2, none,   d_binOpList (i64, Store_i32),       Compile_Load_Store ),   // 0x3e
+
+    M3OP( "memory.size",        1,  i_32,   d_logOp (MemSize),                  Compile_Memory_Size ),  // 0x3f
+    M3OP( "memory.grow",        1,  i_32,   d_logOp (MemGrow),                  Compile_Memory_Grow ),  // 0x40
+
+    M3OP( "i32.const",          1,  i_32,   d_logOp (Const32),                  Compile_Const_i32 ),    // 0x41
+    M3OP( "i64.const",          1,  i_64,   d_logOp (Const64),                  Compile_Const_i64 ),    // 0x42
+    M3OP_F( "f32.const",        1,  f_32,   d_emptyOpList,                      Compile_Const_f32 ),    // 0x43
+    M3OP_F( "f64.const",        1,  f_64,   d_emptyOpList,                      Compile_Const_f64 ),    // 0x44
+
+    M3OP( "i32.eqz",            0,  i_32,   d_unaryOpList (i32, EqualToZero)        , NULL  ),          // 0x45
+    M3OP( "i32.eq",             -1, i_32,   d_commutativeBinOpList (i32, Equal)     , NULL  ),          // 0x46
+    M3OP( "i32.ne",             -1, i_32,   d_commutativeBinOpList (i32, NotEqual)  , NULL  ),          // 0x47
+    M3OP( "i32.lt_s",           -1, i_32,   d_binOpList (i32, LessThan)             , NULL  ),          // 0x48
+    M3OP( "i32.lt_u",           -1, i_32,   d_binOpList (u32, LessThan)             , NULL  ),          // 0x49
+    M3OP( "i32.gt_s",           -1, i_32,   d_binOpList (i32, GreaterThan)          , NULL  ),          // 0x4a
+    M3OP( "i32.gt_u",           -1, i_32,   d_binOpList (u32, GreaterThan)          , NULL  ),          // 0x4b
+    M3OP( "i32.le_s",           -1, i_32,   d_binOpList (i32, LessThanOrEqual)      , NULL  ),          // 0x4c
+    M3OP( "i32.le_u",           -1, i_32,   d_binOpList (u32, LessThanOrEqual)      , NULL  ),          // 0x4d
+    M3OP( "i32.ge_s",           -1, i_32,   d_binOpList (i32, GreaterThanOrEqual)   , NULL  ),          // 0x4e
+    M3OP( "i32.ge_u",           -1, i_32,   d_binOpList (u32, GreaterThanOrEqual)   , NULL  ),          // 0x4f
+
+    M3OP( "i64.eqz",            0,  i_32,   d_unaryOpList (i64, EqualToZero)        , NULL  ),          // 0x50
+    M3OP( "i64.eq",             -1, i_32,   d_commutativeBinOpList (i64, Equal)     , NULL  ),          // 0x51
+    M3OP( "i64.ne",             -1, i_32,   d_commutativeBinOpList (i64, NotEqual)  , NULL  ),          // 0x52
+    M3OP( "i64.lt_s",           -1, i_32,   d_binOpList (i64, LessThan)             , NULL  ),          // 0x53
+    M3OP( "i64.lt_u",           -1, i_32,   d_binOpList (u64, LessThan)             , NULL  ),          // 0x54
+    M3OP( "i64.gt_s",           -1, i_32,   d_binOpList (i64, GreaterThan)          , NULL  ),          // 0x55
+    M3OP( "i64.gt_u",           -1, i_32,   d_binOpList (u64, GreaterThan)          , NULL  ),          // 0x56
+    M3OP( "i64.le_s",           -1, i_32,   d_binOpList (i64, LessThanOrEqual)      , NULL  ),          // 0x57
+    M3OP( "i64.le_u",           -1, i_32,   d_binOpList (u64, LessThanOrEqual)      , NULL  ),          // 0x58
+    M3OP( "i64.ge_s",           -1, i_32,   d_binOpList (i64, GreaterThanOrEqual)   , NULL  ),          // 0x59
+    M3OP( "i64.ge_u",           -1, i_32,   d_binOpList (u64, GreaterThanOrEqual)   , NULL  ),          // 0x5a
+
+    M3OP_F( "f32.eq",           -1, i_32,   d_commutativeBinOpList (f32, Equal)     , NULL  ),          // 0x5b
+    M3OP_F( "f32.ne",           -1, i_32,   d_commutativeBinOpList (f32, NotEqual)  , NULL  ),          // 0x5c
+    M3OP_F( "f32.lt",           -1, i_32,   d_binOpList (f32, LessThan)             , NULL  ),          // 0x5d
+    M3OP_F( "f32.gt",           -1, i_32,   d_binOpList (f32, GreaterThan)          , NULL  ),          // 0x5e
+    M3OP_F( "f32.le",           -1, i_32,   d_binOpList (f32, LessThanOrEqual)      , NULL  ),          // 0x5f
+    M3OP_F( "f32.ge",           -1, i_32,   d_binOpList (f32, GreaterThanOrEqual)   , NULL  ),          // 0x60
+
+    M3OP_F( "f64.eq",           -1, i_32,   d_commutativeBinOpList (f64, Equal)     , NULL  ),          // 0x61
+    M3OP_F( "f64.ne",           -1, i_32,   d_commutativeBinOpList (f64, NotEqual)  , NULL  ),          // 0x62
+    M3OP_F( "f64.lt",           -1, i_32,   d_binOpList (f64, LessThan)             , NULL  ),          // 0x63
+    M3OP_F( "f64.gt",           -1, i_32,   d_binOpList (f64, GreaterThan)          , NULL  ),          // 0x64
+    M3OP_F( "f64.le",           -1, i_32,   d_binOpList (f64, LessThanOrEqual)      , NULL  ),          // 0x65
+    M3OP_F( "f64.ge",           -1, i_32,   d_binOpList (f64, GreaterThanOrEqual)   , NULL  ),          // 0x66
+
+    M3OP( "i32.clz",            0,  i_32,   d_unaryOpList (u32, Clz)                , NULL  ),          // 0x67
+    M3OP( "i32.ctz",            0,  i_32,   d_unaryOpList (u32, Ctz)                , NULL  ),          // 0x68
+    M3OP( "i32.popcnt",         0,  i_32,   d_unaryOpList (u32, Popcnt)             , NULL  ),          // 0x69
+
+    M3OP( "i32.add",            -1, i_32,   d_commutativeBinOpList (i32, Add)       , NULL  ),          // 0x6a
+    M3OP( "i32.sub",            -1, i_32,   d_binOpList (i32, Subtract)             , NULL  ),          // 0x6b
+    M3OP( "i32.mul",            -1, i_32,   d_commutativeBinOpList (i32, Multiply)  , NULL  ),          // 0x6c
+    M3OP( "i32.div_s",          -1, i_32,   d_binOpList (i32, Divide)               , NULL  ),          // 0x6d
+    M3OP( "i32.div_u",          -1, i_32,   d_binOpList (u32, Divide)               , NULL  ),          // 0x6e
+    M3OP( "i32.rem_s",          -1, i_32,   d_binOpList (i32, Remainder)            , NULL  ),          // 0x6f
+    M3OP( "i32.rem_u",          -1, i_32,   d_binOpList (u32, Remainder)            , NULL  ),          // 0x70
+    M3OP( "i32.and",            -1, i_32,   d_commutativeBinOpList (u32, And)       , NULL  ),          // 0x71
+    M3OP( "i32.or",             -1, i_32,   d_commutativeBinOpList (u32, Or)        , NULL  ),          // 0x72
+    M3OP( "i32.xor",            -1, i_32,   d_commutativeBinOpList (u32, Xor)       , NULL  ),          // 0x73
+    M3OP( "i32.shl",            -1, i_32,   d_binOpList (u32, ShiftLeft)            , NULL  ),          // 0x74
+    M3OP( "i32.shr_s",          -1, i_32,   d_binOpList (i32, ShiftRight)           , NULL  ),          // 0x75
+    M3OP( "i32.shr_u",          -1, i_32,   d_binOpList (u32, ShiftRight)           , NULL  ),          // 0x76
+    M3OP( "i32.rotl",           -1, i_32,   d_binOpList (u32, Rotl)                 , NULL  ),          // 0x77
+    M3OP( "i32.rotr",           -1, i_32,   d_binOpList (u32, Rotr)                 , NULL  ),          // 0x78
+
+    M3OP( "i64.clz",            0,  i_64,   d_unaryOpList (u64, Clz)                , NULL  ),          // 0x79
+    M3OP( "i64.ctz",            0,  i_64,   d_unaryOpList (u64, Ctz)                , NULL  ),          // 0x7a
+    M3OP( "i64.popcnt",         0,  i_64,   d_unaryOpList (u64, Popcnt)             , NULL  ),          // 0x7b
+
+    M3OP( "i64.add",            -1, i_64,   d_commutativeBinOpList (i64, Add)       , NULL  ),          // 0x7c
+    M3OP( "i64.sub",            -1, i_64,   d_binOpList (i64, Subtract)             , NULL  ),          // 0x7d
+    M3OP( "i64.mul",            -1, i_64,   d_commutativeBinOpList (i64, Multiply)  , NULL  ),          // 0x7e
+    M3OP( "i64.div_s",          -1, i_64,   d_binOpList (i64, Divide)               , NULL  ),          // 0x7f
+    M3OP( "i64.div_u",          -1, i_64,   d_binOpList (u64, Divide)               , NULL  ),          // 0x80
+    M3OP( "i64.rem_s",          -1, i_64,   d_binOpList (i64, Remainder)            , NULL  ),          // 0x81
+    M3OP( "i64.rem_u",          -1, i_64,   d_binOpList (u64, Remainder)            , NULL  ),          // 0x82
+    M3OP( "i64.and",            -1, i_64,   d_commutativeBinOpList (u64, And)       , NULL  ),          // 0x83
+    M3OP( "i64.or",             -1, i_64,   d_commutativeBinOpList (u64, Or)        , NULL  ),          // 0x84
+    M3OP( "i64.xor",            -1, i_64,   d_commutativeBinOpList (u64, Xor)       , NULL  ),          // 0x85
+    M3OP( "i64.shl",            -1, i_64,   d_binOpList (u64, ShiftLeft)            , NULL  ),          // 0x86
+    M3OP( "i64.shr_s",          -1, i_64,   d_binOpList (i64, ShiftRight)           , NULL  ),          // 0x87
+    M3OP( "i64.shr_u",          -1, i_64,   d_binOpList (u64, ShiftRight)           , NULL  ),          // 0x88
+    M3OP( "i64.rotl",           -1, i_64,   d_binOpList (u64, Rotl)                 , NULL  ),          // 0x89
+    M3OP( "i64.rotr",           -1, i_64,   d_binOpList (u64, Rotr)                 , NULL  ),          // 0x8a
+
+    M3OP_F( "f32.abs",          0,  f_32,   d_unaryOpList(f32, Abs)                 , NULL  ),          // 0x8b
+    M3OP_F( "f32.neg",          0,  f_32,   d_unaryOpList(f32, Negate)              , NULL  ),          // 0x8c
+    M3OP_F( "f32.ceil",         0,  f_32,   d_unaryOpList(f32, Ceil)                , NULL  ),          // 0x8d
+    M3OP_F( "f32.floor",        0,  f_32,   d_unaryOpList(f32, Floor)               , NULL  ),          // 0x8e
+    M3OP_F( "f32.trunc",        0,  f_32,   d_unaryOpList(f32, Trunc)               , NULL  ),          // 0x8f
+    M3OP_F( "f32.nearest",      0,  f_32,   d_unaryOpList(f32, Nearest)             , NULL  ),          // 0x90
+    M3OP_F( "f32.sqrt",         0,  f_32,   d_unaryOpList(f32, Sqrt)                , NULL  ),          // 0x91
+
+    M3OP_F( "f32.add",          -1, f_32,   d_commutativeBinOpList (f32, Add)       , NULL  ),          // 0x92
+    M3OP_F( "f32.sub",          -1, f_32,   d_binOpList (f32, Subtract)             , NULL  ),          // 0x93
+    M3OP_F( "f32.mul",          -1, f_32,   d_commutativeBinOpList (f32, Multiply)  , NULL  ),          // 0x94
+    M3OP_F( "f32.div",          -1, f_32,   d_binOpList (f32, Divide)               , NULL  ),          // 0x95
+    M3OP_F( "f32.min",          -1, f_32,   d_commutativeBinOpList (f32, Min)       , NULL  ),          // 0x96
+    M3OP_F( "f32.max",          -1, f_32,   d_commutativeBinOpList (f32, Max)       , NULL  ),          // 0x97
+    M3OP_F( "f32.copysign",     -1, f_32,   d_binOpList (f32, CopySign)             , NULL  ),          // 0x98
+
+    M3OP_F( "f64.abs",          0,  f_64,   d_unaryOpList(f64, Abs)                 , NULL  ),          // 0x99
+    M3OP_F( "f64.neg",          0,  f_64,   d_unaryOpList(f64, Negate)              , NULL  ),          // 0x9a
+    M3OP_F( "f64.ceil",         0,  f_64,   d_unaryOpList(f64, Ceil)                , NULL  ),          // 0x9b
+    M3OP_F( "f64.floor",        0,  f_64,   d_unaryOpList(f64, Floor)               , NULL  ),          // 0x9c
+    M3OP_F( "f64.trunc",        0,  f_64,   d_unaryOpList(f64, Trunc)               , NULL  ),          // 0x9d
+    M3OP_F( "f64.nearest",      0,  f_64,   d_unaryOpList(f64, Nearest)             , NULL  ),          // 0x9e
+    M3OP_F( "f64.sqrt",         0,  f_64,   d_unaryOpList(f64, Sqrt)                , NULL  ),          // 0x9f
+
+    M3OP_F( "f64.add",          -1, f_64,   d_commutativeBinOpList (f64, Add)       , NULL  ),          // 0xa0
+    M3OP_F( "f64.sub",          -1, f_64,   d_binOpList (f64, Subtract)             , NULL  ),          // 0xa1
+    M3OP_F( "f64.mul",          -1, f_64,   d_commutativeBinOpList (f64, Multiply)  , NULL  ),          // 0xa2
+    M3OP_F( "f64.div",          -1, f_64,   d_binOpList (f64, Divide)               , NULL  ),          // 0xa3
+    M3OP_F( "f64.min",          -1, f_64,   d_commutativeBinOpList (f64, Min)       , NULL  ),          // 0xa4
+    M3OP_F( "f64.max",          -1, f_64,   d_commutativeBinOpList (f64, Max)       , NULL  ),          // 0xa5
+    M3OP_F( "f64.copysign",     -1, f_64,   d_binOpList (f64, CopySign)             , NULL  ),          // 0xa6
+
+    M3OP( "i32.wrap/i64",       0,  i_32,   d_unaryOpList (i32, Wrap_i64),          NULL    ),          // 0xa7
+    M3OP_F( "i32.trunc_s/f32",  0,  i_32,   d_convertOpList (i32_Trunc_f32),        Compile_Convert ),  // 0xa8
+    M3OP_F( "i32.trunc_u/f32",  0,  i_32,   d_convertOpList (u32_Trunc_f32),        Compile_Convert ),  // 0xa9
+    M3OP_F( "i32.trunc_s/f64",  0,  i_32,   d_convertOpList (i32_Trunc_f64),        Compile_Convert ),  // 0xaa
+    M3OP_F( "i32.trunc_u/f64",  0,  i_32,   d_convertOpList (u32_Trunc_f64),        Compile_Convert ),  // 0xab
+
+    M3OP( "i64.extend_s/i32",   0,  i_64,   d_unaryOpList (i64, Extend_i32),        NULL    ),          // 0xac
+    M3OP( "i64.extend_u/i32",   0,  i_64,   d_unaryOpList (i64, Extend_u32),        NULL    ),          // 0xad
+
+    M3OP_F( "i64.trunc_s/f32",  0,  i_64,   d_convertOpList (i64_Trunc_f32),        Compile_Convert ),  // 0xae
+    M3OP_F( "i64.trunc_u/f32",  0,  i_64,   d_convertOpList (u64_Trunc_f32),        Compile_Convert ),  // 0xaf
+    M3OP_F( "i64.trunc_s/f64",  0,  i_64,   d_convertOpList (i64_Trunc_f64),        Compile_Convert ),  // 0xb0
+    M3OP_F( "i64.trunc_u/f64",  0,  i_64,   d_convertOpList (u64_Trunc_f64),        Compile_Convert ),  // 0xb1
+
+    M3OP_F( "f32.convert_s/i32",0,  f_32,   d_convertOpList (f32_Convert_i32),      Compile_Convert ),  // 0xb2
+    M3OP_F( "f32.convert_u/i32",0,  f_32,   d_convertOpList (f32_Convert_u32),      Compile_Convert ),  // 0xb3
+    M3OP_F( "f32.convert_s/i64",0,  f_32,   d_convertOpList (f32_Convert_i64),      Compile_Convert ),  // 0xb4
+    M3OP_F( "f32.convert_u/i64",0,  f_32,   d_convertOpList (f32_Convert_u64),      Compile_Convert ),  // 0xb5
+
+    M3OP_F( "f32.demote/f64",   0,  f_32,   d_unaryOpList (f32, Demote_f64),        NULL    ),          // 0xb6
+
+    M3OP_F( "f64.convert_s/i32",0,  f_64,   d_convertOpList (f64_Convert_i32),      Compile_Convert ),  // 0xb7
+    M3OP_F( "f64.convert_u/i32",0,  f_64,   d_convertOpList (f64_Convert_u32),      Compile_Convert ),  // 0xb8
+    M3OP_F( "f64.convert_s/i64",0,  f_64,   d_convertOpList (f64_Convert_i64),      Compile_Convert ),  // 0xb9
+    M3OP_F( "f64.convert_u/i64",0,  f_64,   d_convertOpList (f64_Convert_u64),      Compile_Convert ),  // 0xba
+
+    M3OP_F( "f64.promote/f32",  0,  f_64,   d_unaryOpList (f64, Promote_f32),       NULL    ),          // 0xbb
+
+    M3OP_F( "i32.reinterpret/f32",0,i_32,   d_convertOpList (i32_Reinterpret_f32),  Compile_Convert ),  // 0xbc
+    M3OP_F( "i64.reinterpret/f64",0,i_64,   d_convertOpList (i64_Reinterpret_f64),  Compile_Convert ),  // 0xbd
+    M3OP_F( "f32.reinterpret/i32",0,f_32,   d_convertOpList (f32_Reinterpret_i32),  Compile_Convert ),  // 0xbe
+    M3OP_F( "f64.reinterpret/i64",0,f_64,   d_convertOpList (f64_Reinterpret_i64),  Compile_Convert ),  // 0xbf
+
+    M3OP( "i32.extend8_s",       0,  i_32,   d_unaryOpList (i32, Extend8_s),        NULL    ),          // 0xc0
+    M3OP( "i32.extend16_s",      0,  i_32,   d_unaryOpList (i32, Extend16_s),       NULL    ),          // 0xc1
+    M3OP( "i64.extend8_s",       0,  i_64,   d_unaryOpList (i64, Extend8_s),        NULL    ),          // 0xc2
+    M3OP( "i64.extend16_s",      0,  i_64,   d_unaryOpList (i64, Extend16_s),       NULL    ),          // 0xc3
+    M3OP( "i64.extend32_s",      0,  i_64,   d_unaryOpList (i64, Extend32_s),       NULL    ),          // 0xc4
+
+# ifdef DEBUG // for codepage logging. the order doesn't matter:
+#   define d_m3DebugOp(OP) M3OP (#OP, 0, none, { op_##OP })
+
+# if d_m3HasFloat
+#   define d_m3DebugTypedOp(OP) M3OP (#OP, 0, none, { op_##OP##_i32, op_##OP##_i64, op_##OP##_f32, op_##OP##_f64, })
+# else
+#   define d_m3DebugTypedOp(OP) M3OP (#OP, 0, none, { op_##OP##_i32, op_##OP##_i64 })
+# endif
+
+    d_m3DebugOp (Compile),          d_m3DebugOp (Entry),            d_m3DebugOp (End),
+    d_m3DebugOp (Unsupported),      d_m3DebugOp (CallRawFunction),
+
+    d_m3DebugOp (GetGlobal_s32),    d_m3DebugOp (GetGlobal_s64),    d_m3DebugOp (ContinueLoop),     d_m3DebugOp (ContinueLoopIf),
+
+    d_m3DebugOp (CopySlot_32),      d_m3DebugOp (PreserveCopySlot_32), d_m3DebugOp (If_s),          d_m3DebugOp (BranchIfPrologue_s),
+    d_m3DebugOp (CopySlot_64),      d_m3DebugOp (PreserveCopySlot_64), d_m3DebugOp (If_r),          d_m3DebugOp (BranchIfPrologue_r),
+
+    d_m3DebugOp (Select_i32_rss),   d_m3DebugOp (Select_i32_srs),   d_m3DebugOp (Select_i32_ssr),   d_m3DebugOp (Select_i32_sss),
+    d_m3DebugOp (Select_i64_rss),   d_m3DebugOp (Select_i64_srs),   d_m3DebugOp (Select_i64_ssr),   d_m3DebugOp (Select_i64_sss),
+
+# if d_m3HasFloat
+    d_m3DebugOp (Select_f32_sss),   d_m3DebugOp (Select_f32_srs),   d_m3DebugOp (Select_f32_ssr),
+    d_m3DebugOp (Select_f32_rss),   d_m3DebugOp (Select_f32_rrs),   d_m3DebugOp (Select_f32_rsr),
+
+    d_m3DebugOp (Select_f64_sss),   d_m3DebugOp (Select_f64_srs),   d_m3DebugOp (Select_f64_ssr),
+    d_m3DebugOp (Select_f64_rss),   d_m3DebugOp (Select_f64_rrs),   d_m3DebugOp (Select_f64_rsr),
+# endif
+
+    d_m3DebugOp (MemFill),          d_m3DebugOp (MemCopy),
+
+    d_m3DebugTypedOp (SetGlobal),   d_m3DebugOp (SetGlobal_s32),    d_m3DebugOp (SetGlobal_s64),
+
+    d_m3DebugTypedOp (SetRegister), d_m3DebugTypedOp (SetSlot),     d_m3DebugTypedOp (PreserveSetSlot),
+# endif
+
+# if d_m3CascadedOpcodes
+    [c_waOp_extended] = M3OP( "0xFC", 0, c_m3Type_unknown,   d_emptyOpList,  Compile_ExtendedOpcode ),
+# endif
+
+# ifdef DEBUG
+    M3OP( "termination", 0, c_m3Type_unknown ) // for find_operation_info
+# endif
+};
+
+const M3OpInfo c_operationsFC [] =
+{
+    M3OP_F( "i32.trunc_s:sat/f32",0,  i_32,   d_convertOpList (i32_TruncSat_f32),        Compile_Convert ),  // 0x00
+    M3OP_F( "i32.trunc_u:sat/f32",0,  i_32,   d_convertOpList (u32_TruncSat_f32),        Compile_Convert ),  // 0x01
+    M3OP_F( "i32.trunc_s:sat/f64",0,  i_32,   d_convertOpList (i32_TruncSat_f64),        Compile_Convert ),  // 0x02
+    M3OP_F( "i32.trunc_u:sat/f64",0,  i_32,   d_convertOpList (u32_TruncSat_f64),        Compile_Convert ),  // 0x03
+    M3OP_F( "i64.trunc_s:sat/f32",0,  i_64,   d_convertOpList (i64_TruncSat_f32),        Compile_Convert ),  // 0x04
+    M3OP_F( "i64.trunc_u:sat/f32",0,  i_64,   d_convertOpList (u64_TruncSat_f32),        Compile_Convert ),  // 0x05
+    M3OP_F( "i64.trunc_s:sat/f64",0,  i_64,   d_convertOpList (i64_TruncSat_f64),        Compile_Convert ),  // 0x06
+    M3OP_F( "i64.trunc_u:sat/f64",0,  i_64,   d_convertOpList (u64_TruncSat_f64),        Compile_Convert ),  // 0x07
+
+    M3OP_RESERVED, M3OP_RESERVED,
+
+    M3OP( "memory.copy",            0,  none,   d_emptyOpList,                           Compile_Memory_CopyFill ), // 0x0a
+    M3OP( "memory.fill",            0,  none,   d_emptyOpList,                           Compile_Memory_CopyFill ), // 0x0b
+
+
+# ifdef DEBUG
+    M3OP( "termination", 0, c_m3Type_unknown ) // for find_operation_info
+# endif
+};
+
+
+IM3OpInfo  GetOpInfo  (m3opcode_t opcode)
+{
+    switch (opcode >> 8) {
+    case 0x00:
+        if (M3_LIKELY(opcode < M3_COUNT_OF(c_operations))) {
+            return &c_operations[opcode];
+        }
+        break;
+    case c_waOp_extended:
+        opcode &= 0xFF;
+        if (M3_LIKELY(opcode < M3_COUNT_OF(c_operationsFC))) {
+            return &c_operationsFC[opcode];
+        }
+        break;
+    }
+    return NULL;
+}
+
+M3Result  CompileBlockStatements  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+    bool validEnd = false;
+
+    while (o->wasm < o->wasmEnd)
+    {
+# if d_m3EnableOpTracing
+        if (o->numEmits)
+        {
+            EmitOp          (o, op_DumpStack);
+            EmitConstant32  (o, o->numOpcodes);
+            EmitConstant32  (o, GetMaxUsedSlotPlusOne(o));
+            EmitPointer     (o, o->function);
+
+            o->numEmits = 0;
+        }
+# endif
+        m3opcode_t opcode;
+        o->lastOpcodeStart = o->wasm;
+_       (Read_opcode (& opcode, & o->wasm, o->wasmEnd));                log_opcode (o, opcode);
+
+        // Restrict opcodes when evaluating expressions
+        if (not o->function) {
+            switch (opcode) {
+            case c_waOp_i32_const: case c_waOp_i64_const:
+            case c_waOp_f32_const: case c_waOp_f64_const:
+            case c_waOp_getGlobal: case c_waOp_end:
+                break;
+            default:
+                _throw(m3Err_restrictedOpcode);
+            }
+        }
+
+        IM3OpInfo opinfo = GetOpInfo (opcode);
+
+        if (opinfo == NULL)
+            _throw (ErrorCompile (m3Err_unknownOpcode, o, "opcode '%x' not available", opcode));
+
+        if (opinfo->compiler) {
+_           ((* opinfo->compiler) (o, opcode))
+        } else {
+_           (Compile_Operator (o, opcode));
+        }
+
+        o->previousOpcode = opcode;
+
+        if (opcode == c_waOp_else)
+        {
+            _throwif (m3Err_wasmMalformed, o->block.opcode != c_waOp_if);
+            validEnd = true;
+            break;
+        }
+        else if (opcode == c_waOp_end)
+        {
+            validEnd = true;
+            break;
+        }
+    }
+    _throwif(m3Err_wasmMalformed, !(validEnd));
+
+_catch:
+    return result;
+}
+
+static
+M3Result  PushBlockResults  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    u16 numResults = GetFuncTypeNumResults (o->block.type);
+
+    for (u16 i = 0; i < numResults; ++i)
+    {
+        u8 type = GetFuncTypeResultType (o->block.type, i);
+
+        if (i == numResults - 1 and IsFpType (type))
+        {
+_           (PushRegister (o, type));
+        }
+        else
+_           (PushAllocatedSlot (o, type));
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  CompileBlock  (IM3Compilation o, IM3FuncType i_blockType, m3opcode_t i_blockOpcode)
+{
+                                                                                        d_m3Assert (not IsRegisterAllocated (o, 0));
+                                                                                        d_m3Assert (not IsRegisterAllocated (o, 1));
+    M3CompilationScope outerScope = o->block;
+    M3CompilationScope * block = & o->block;
+
+    block->outer            = & outerScope;
+    block->pc               = GetPagePC (o->page);
+    block->patches          = NULL;
+    block->type             = i_blockType;
+    block->depth            ++;
+    block->opcode           = i_blockOpcode;
+
+    /*
+     The block stack frame is a little strange but for good reasons.  Because blocks need to be restarted to
+     compile different pathways (if/else), the incoming params must be saved.  The parameters are popped
+     and validated.  But, then the stack top is readjusted so they aren't subsequently overwritten.
+     Next, the result are preallocated to find destination slots.  But again these are immediately popped
+     (deallocated) and the stack top is readjusted to keep these records in pace. This allows branch instructions
+     to find their result landing pads.  Finally, the params are copied from the "dead" records and pushed back
+     onto the stack as active stack items for the CompileBlockStatements () call.
+
+    [     block      ]
+    [     params     ]
+    ------------------
+    [     result     ]  <---- blockStackIndex
+    [      slots     ]
+    ------------------
+    [   saved param  ]
+    [     records    ]
+                        <----- exitStackIndex
+    */
+
+_try {
+    // validate and dealloc params ----------------------------
+
+    u16 stackIndex = o->stackIndex;
+
+    u16 numParams = GetFuncTypeNumParams (i_blockType);
+
+    if (i_blockOpcode != c_waOp_else)
+    {
+        for (u16 i = 0; i < numParams; ++i)
+        {
+            u8 type = GetFuncTypeParamType (i_blockType, numParams - 1 - i);
+_           (PopType (o, type));
+        }
+    }
+    else {
+        if (IsStackPolymorphic (o) && o->block.blockStackIndex + numParams > o->stackIndex) {
+            o->stackIndex = o->block.blockStackIndex;
+        } else {
+            o->stackIndex -= numParams;
+        }
+    }
+
+    u16 paramIndex = o->stackIndex;
+    block->exitStackIndex = paramIndex; // consume the params at block exit
+
+    // keep copies of param slots in the stack
+    o->stackIndex = stackIndex;
+
+    // find slots for the results ----------------------------
+    PushBlockResults (o);
+
+    stackIndex = o->stackIndex;
+
+    // dealloc but keep record of the result slots in the stack
+    u16 numResults = GetFuncTypeNumResults (i_blockType);
+    while (numResults--)
+        Pop (o);
+
+    block->blockStackIndex = o->stackIndex = stackIndex;
+
+    // push the params back onto the stack -------------------
+    for (u16 i = 0; i < numParams; ++i)
+    {
+        u8 type = GetFuncTypeParamType (i_blockType, i);
+
+        u16 slot = GetSlotForStackIndex (o, paramIndex + i);
+        Push (o, type, slot);
+
+        if (slot >= o->slotFirstDynamicIndex && slot != c_slotUnused)
+            MarkSlotsAllocatedByType (o, slot, type);
+    }
+
+    //--------------------------------------------------------
+
+_   (CompileBlockStatements (o));
+
+_   (ValidateBlockEnd (o));
+
+    if (o->function)    // skip for expressions
+    {
+        if (not IsStackPolymorphic (o))
+_           (ResolveBlockResults (o, & o->block, /* isBranch: */ false));
+
+_       (UnwindBlockStack (o))
+
+        if (not ((i_blockOpcode == c_waOp_if and numResults) or o->previousOpcode == c_waOp_else))
+        {
+            o->stackIndex = o->block.exitStackIndex;
+_           (PushBlockResults (o));
+        }
+    }
+
+    PatchBranches (o);
+
+    o->block = outerScope;
+
+}   _catch: return result;
+}
+
+static
+M3Result  CompileLocals  (IM3Compilation o)
+{
+    M3Result result;
+
+    u32 numLocals = 0;
+    u32 numLocalBlocks;
+_   (ReadLEB_u32 (& numLocalBlocks, & o->wasm, o->wasmEnd));
+
+    for (u32 l = 0; l < numLocalBlocks; ++l)
+    {
+        u32 varCount;
+        i8 waType;
+        u8 localType;
+
+_       (ReadLEB_u32 (& varCount, & o->wasm, o->wasmEnd));
+_       (ReadLEB_i7 (& waType, & o->wasm, o->wasmEnd));
+_       (NormalizeType (& localType, waType));
+        numLocals += varCount;                                                          m3log (compile, "pushing locals. count: %d; type: %s", varCount, c_waTypes [localType]);
+        while (varCount--)
+_           (PushAllocatedSlot (o, localType));
+    }
+
+    if (o->function)
+        o->function->numLocals = numLocals;
+
+    _catch: return result;
+}
+
+static
+M3Result  ReserveConstants  (IM3Compilation o)
+{
+    M3Result result = m3Err_none;
+
+    // in the interest of speed, this blindly scans the Wasm code looking for any byte
+    // that looks like an const opcode.
+    u16 numConstantSlots = 0;
+
+    bytes_t wa = o->wasm;
+    while (wa < o->wasmEnd)
+    {
+        u8 code = * wa++;
+        u16 addSlots = 0;
+
+        if (code == c_waOp_i32_const or code == c_waOp_f32_const)
+            addSlots = 1;
+        else if (code == c_waOp_i64_const or code == c_waOp_f64_const)
+            addSlots = GetTypeNumSlots (c_m3Type_i64);
+
+        if (numConstantSlots + addSlots >= d_m3MaxConstantTableSize)
+            break;
+
+        numConstantSlots += addSlots;
+    }
+
+    // if constants overflow their reserved stack space, the compiler simply emits op_Const
+    // operations as needed. Compiled expressions (global inits) don't pass through this
+    // ReserveConstants function and thus always produce inline constants.
+
+    AlignSlotToType (& numConstantSlots, c_m3Type_i64);                                         m3log (compile, "reserved constant slots: %d", numConstantSlots);
+
+    o->slotFirstDynamicIndex = o->slotFirstConstIndex + numConstantSlots;
+
+    if (o->slotFirstDynamicIndex >= d_m3MaxFunctionSlots)
+        _throw (m3Err_functionStackOverflow);
+
+    _catch:
+    return result;
+}
+
+
+M3Result  CompileFunction  (IM3Function io_function)
+{
+    if (!io_function->wasm) return "function body is missing";
+
+    IM3FuncType funcType = io_function->funcType;                   m3log (compile, "compiling: [%d] %s %s; wasm-size: %d",
+                                                                        io_function->index, m3_GetFunctionName (io_function), SPrintFuncTypeSignature (funcType), (u32) (io_function->wasmEnd - io_function->wasm));
+    IM3Runtime runtime = io_function->module->runtime;
+
+    IM3Compilation o = & runtime->compilation;                      d_m3Assert (d_m3MaxFunctionSlots >= d_m3MaxFunctionStackHeight * (d_m3Use32BitSlots + 1))  // need twice as many slots in 32-bit mode
+    memset (o, 0x0, sizeof (M3Compilation));
+
+    o->runtime  = runtime;
+    o->module   = io_function->module;
+    o->function = io_function;
+    o->wasm     = io_function->wasm;
+    o->wasmEnd  = io_function->wasmEnd;
+    o->block.type = funcType;
+
+_try {
+    // skip over code size. the end was already calculated during parse phase
+    u32 size;
+_   (ReadLEB_u32 (& size, & o->wasm, o->wasmEnd));                  d_m3Assert (size == (o->wasmEnd - o->wasm))
+
+_   (AcquireCompilationCodePage (o, & o->page));
+
+    pc_t pc = GetPagePC (o->page);
+
+    u16 numRetSlots = GetFunctionNumReturns (o->function) * c_ioSlotCount;
+
+    for (u16 i = 0; i < numRetSlots; ++i)
+        MarkSlotAllocated (o, i);
+
+    o->function->numRetSlots = o->slotFirstDynamicIndex = numRetSlots;
+
+    u16 numArgs = GetFunctionNumArgs (o->function);
+
+    // push the arg types to the type stack
+    for (u16 i = 0; i < numArgs; ++i)
+    {
+        u8 type = GetFunctionArgType (o->function, i);
+_       (PushAllocatedSlot (o, type));
+
+        // prevent allocator fill-in
+        o->slotFirstDynamicIndex += c_ioSlotCount;
+    }
+
+    o->slotMaxAllocatedIndexPlusOne = o->function->numRetAndArgSlots = o->slotFirstLocalIndex = o->slotFirstDynamicIndex;
+
+_   (CompileLocals (o));
+
+    u16 maxSlot = GetMaxUsedSlotPlusOne (o);
+
+    o->function->numLocalBytes = (maxSlot - o->slotFirstLocalIndex) * sizeof (m3slot_t);
+
+    o->slotFirstConstIndex = o->slotMaxConstIndex = maxSlot;
+
+    // ReserveConstants initializes o->firstDynamicSlotNumber
+_   (ReserveConstants (o));
+
+    // start tracking the max stack used (Push() also updates this value) so that op_Entry can precisely detect stack overflow
+    o->maxStackSlots = o->slotMaxAllocatedIndexPlusOne = o->slotFirstDynamicIndex;
+
+    o->block.blockStackIndex = o->stackFirstDynamicIndex = o->stackIndex;                           m3log (compile, "start stack index: %d",
+                                                                                                          (u32) o->stackFirstDynamicIndex);
+_   (EmitOp (o, op_Entry));
+    EmitPointer (o, io_function);
+
+_   (CompileBlockStatements (o));
+
+    // TODO: validate opcode sequences
+    _throwif(m3Err_wasmMalformed, o->previousOpcode != c_waOp_end);
+
+    io_function->compiled = pc;
+    io_function->maxStackSlots = o->maxStackSlots;
+
+    u16 numConstantSlots = o->slotMaxConstIndex - o->slotFirstConstIndex;                           m3log (compile, "unique constant slots: %d; unused slots: %d",
+                                                                                                           numConstantSlots, o->slotFirstDynamicIndex - o->slotMaxConstIndex);
+    io_function->numConstantBytes = numConstantSlots * sizeof (m3slot_t);
+
+    if (numConstantSlots)
+    {
+        io_function->constants = m3_CopyMem (o->constants, io_function->numConstantBytes);
+        _throwifnull(io_function->constants);
+    }
+
+} _catch:
+
+    ReleaseCompilationCodePage (o);
+
+    return result;
+}

--- a/thirdparty/wasm3/source/m3_compile.h
+++ b/thirdparty/wasm3/source/m3_compile.h
@@ -1,0 +1,206 @@
+//
+//  m3_compile.h
+//
+//  Created by Steven Massey on 4/17/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_compile_h
+#define m3_compile_h
+
+#include "m3_code.h"
+#include "m3_exec_defs.h"
+#include "m3_function.h"
+
+d_m3BeginExternC
+
+enum
+{
+    c_waOp_block                = 0x02,
+    c_waOp_loop                 = 0x03,
+    c_waOp_if                   = 0x04,
+    c_waOp_else                 = 0x05,
+    c_waOp_end                  = 0x0b,
+    c_waOp_branch               = 0x0c,
+    c_waOp_branchTable          = 0x0e,
+    c_waOp_branchIf             = 0x0d,
+    c_waOp_call                 = 0x10,
+    c_waOp_getLocal             = 0x20,
+    c_waOp_setLocal             = 0x21,
+    c_waOp_teeLocal             = 0x22,
+
+    c_waOp_getGlobal            = 0x23,
+
+    c_waOp_store_f32            = 0x38,
+    c_waOp_store_f64            = 0x39,
+
+    c_waOp_i32_const            = 0x41,
+    c_waOp_i64_const            = 0x42,
+    c_waOp_f32_const            = 0x43,
+    c_waOp_f64_const            = 0x44,
+
+    c_waOp_extended             = 0xfc,
+
+    c_waOp_memoryCopy           = 0xfc0a,
+    c_waOp_memoryFill           = 0xfc0b
+};
+
+
+#define d_FuncRetType(ftype,i)  ((ftype)->types[(i)])
+#define d_FuncArgType(ftype,i)  ((ftype)->types[(ftype)->numRets + (i)])
+
+//-----------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3CompilationScope
+{
+    struct M3CompilationScope *     outer;
+
+    pc_t                            pc;                 // used by ContinueLoop's
+    pc_t                            patches;
+    i32                             depth;
+    u16                             exitStackIndex;
+    u16                             blockStackIndex;
+//    u16                             topSlot;
+    IM3FuncType                     type;
+    m3opcode_t                      opcode;
+    bool                            isPolymorphic;
+}
+M3CompilationScope;
+
+typedef M3CompilationScope *        IM3CompilationScope;
+
+typedef struct
+{
+    IM3Runtime          runtime;
+    IM3Module           module;
+
+    bytes_t             wasm;
+    bytes_t             wasmEnd;
+    bytes_t             lastOpcodeStart;
+
+    M3CompilationScope  block;
+
+    IM3Function         function;
+
+    IM3CodePage         page;
+
+#ifdef DEBUG
+    u32                 numEmits;
+    u32                 numOpcodes;
+#endif
+
+    u16                 stackFirstDynamicIndex;     // args and locals are pushed to the stack so that their slot locations can be tracked. the wasm model itself doesn't
+                                                    // treat these values as being on the stack, so stackFirstDynamicIndex marks the start of the real Wasm stack
+    u16                 stackIndex;                 // current stack top
+
+    u16                 slotFirstConstIndex;
+    u16                 slotMaxConstIndex;          // as const's are encountered during compilation this tracks their location in the "real" stack
+
+    u16                 slotFirstLocalIndex;
+    u16                 slotFirstDynamicIndex;      // numArgs + numLocals + numReservedConstants. the first mutable slot available to the compiler.
+
+    u16                 maxStackSlots;
+
+    m3slot_t            constants                   [d_m3MaxConstantTableSize];
+
+    // 'wasmStack' holds slot locations
+    u16                 wasmStack                   [d_m3MaxFunctionStackHeight];
+    u8                  typeStack                   [d_m3MaxFunctionStackHeight];
+
+    // 'm3Slots' contains allocation usage counts
+    u8                  m3Slots                     [d_m3MaxFunctionSlots];
+
+    u16                 slotMaxAllocatedIndexPlusOne;
+
+    u16                 regStackIndexPlusOne        [2];
+
+    m3opcode_t          previousOpcode;
+}
+M3Compilation;
+
+typedef M3Compilation *                 IM3Compilation;
+
+typedef M3Result (* M3Compiler)         (IM3Compilation, m3opcode_t);
+
+
+//-----------------------------------------------------------------------------------------------------------------------------------
+
+
+typedef struct M3OpInfo
+{
+#ifdef DEBUG
+    const char * const      name;
+#endif
+
+    i8                      stackOffset;
+    u8                      type;
+
+    // for most operations:
+    // [0]= top operand in register, [1]= top operand in stack, [2]= both operands in stack
+    IM3Operation            operations [4];
+
+    M3Compiler              compiler;
+}
+M3OpInfo;
+
+typedef const M3OpInfo *    IM3OpInfo;
+
+IM3OpInfo  GetOpInfo  (m3opcode_t opcode);
+
+// TODO: This helper should be removed, when MultiValue is implemented
+static inline
+u8 GetSingleRetType(IM3FuncType ftype) {
+    return (ftype && ftype->numRets) ? ftype->types[0] : (u8)c_m3Type_none;
+}
+
+static const u16 c_m3RegisterUnallocated = 0;
+static const u16 c_slotUnused = 0xffff;
+
+static inline
+bool  IsRegisterAllocated  (IM3Compilation o, u32 i_register)
+{
+    return (o->regStackIndexPlusOne [i_register] != c_m3RegisterUnallocated);
+}
+
+static inline
+bool  IsStackPolymorphic  (IM3Compilation o)
+{
+    return o->block.isPolymorphic;
+}
+
+static inline bool  IsRegisterSlotAlias        (u16 i_slot)    { return (i_slot >= d_m3Reg0SlotAlias and i_slot != c_slotUnused); }
+static inline bool  IsFpRegisterSlotAlias      (u16 i_slot)    { return (i_slot == d_m3Fp0SlotAlias);  }
+static inline bool  IsIntRegisterSlotAlias     (u16 i_slot)    { return (i_slot == d_m3Reg0SlotAlias); }
+
+
+#ifdef DEBUG
+    #define M3OP(...)       { __VA_ARGS__ }
+    #define M3OP_RESERVED   { "reserved" }
+#else
+    // Strip-off name
+    #define M3OP(name, ...) { __VA_ARGS__ }
+    #define M3OP_RESERVED   { 0 }
+#endif
+
+#if d_m3HasFloat
+    #define M3OP_F          M3OP
+#elif d_m3NoFloatDynamic
+    #define M3OP_F(n,o,t,op,...)        M3OP(n, o, t, { op_Unsupported, op_Unsupported, op_Unsupported, op_Unsupported }, __VA_ARGS__)
+#else
+    #define M3OP_F(...)     { 0 }
+#endif
+
+//-----------------------------------------------------------------------------------------------------------------------------------
+
+u16         GetMaxUsedSlotPlusOne       (IM3Compilation o);
+
+M3Result    CompileBlock                (IM3Compilation io, IM3FuncType i_blockType, m3opcode_t i_blockOpcode);
+
+M3Result    CompileBlockStatements      (IM3Compilation io);
+M3Result    CompileFunction             (IM3Function io_function);
+
+M3Result    CompileRawFunction          (IM3Module io_module, IM3Function io_function, const void * i_function, const void * i_userdata);
+
+d_m3EndExternC
+
+#endif // m3_compile_h

--- a/thirdparty/wasm3/source/m3_config.h
+++ b/thirdparty/wasm3/source/m3_config.h
@@ -1,0 +1,156 @@
+//
+//  m3_config.h
+//
+//  Created by Steven Massey on 5/4/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_config_h
+#define m3_config_h
+
+#include "m3_config_platforms.h"
+
+// general --------------------------------------------------------------------
+
+# ifndef d_m3CodePageAlignSize
+#   define d_m3CodePageAlignSize                32*1024
+# endif
+
+# ifndef d_m3MaxFunctionStackHeight
+#   define d_m3MaxFunctionStackHeight           2000    // max: 32768
+# endif
+
+# ifndef d_m3MaxLinearMemoryPages
+#   define d_m3MaxLinearMemoryPages             65536
+# endif
+
+# ifndef d_m3MaxFunctionSlots
+#   define d_m3MaxFunctionSlots                 ((d_m3MaxFunctionStackHeight)*2)
+# endif
+
+# ifndef d_m3MaxConstantTableSize
+#   define d_m3MaxConstantTableSize             120
+# endif
+
+# ifndef d_m3MaxDuplicateFunctionImpl
+#   define d_m3MaxDuplicateFunctionImpl         3
+# endif
+
+# ifndef d_m3CascadedOpcodes                            // Cascaded opcodes are slightly faster at the expense of some memory
+#   define d_m3CascadedOpcodes                  1       // Adds ~3Kb to operations table in m3_compile.c
+# endif
+
+# ifndef d_m3VerboseErrorMessages
+#   define d_m3VerboseErrorMessages             1
+# endif
+
+# ifndef d_m3FixedHeap
+#   define d_m3FixedHeap                        false
+//# define d_m3FixedHeap                        (32*1024)
+# endif
+
+# ifndef d_m3FixedHeapAlign
+#   define d_m3FixedHeapAlign                   16
+# endif
+
+# ifndef d_m3Use32BitSlots
+#   define d_m3Use32BitSlots                    1
+# endif
+
+# ifndef d_m3ProfilerSlotMask
+#   define d_m3ProfilerSlotMask                 0xFFFF
+# endif
+
+# ifndef d_m3RecordBacktraces
+#   define d_m3RecordBacktraces                 0
+# endif
+
+# ifndef d_m3EnableExceptionBreakpoint
+#   define d_m3EnableExceptionBreakpoint        0       // see m3_exception.h
+# endif
+
+
+// profiling and tracing ------------------------------------------------------
+
+# ifndef d_m3EnableOpProfiling
+#   define d_m3EnableOpProfiling                0       // opcode usage counters
+# endif
+
+# ifndef d_m3EnableOpTracing
+#   define d_m3EnableOpTracing                  0       // only works with DEBUG
+# endif
+
+# ifndef d_m3EnableWasiTracing
+#  define d_m3EnableWasiTracing                 0
+# endif
+
+# ifndef d_m3EnableStrace
+#   define d_m3EnableStrace                     0       // 1 - trace exported function calls
+                                                        // 2 - trace all calls (structured)
+                                                        // 3 - all calls + loops + memory operations
+# endif
+
+
+// logging --------------------------------------------------------------------
+
+# ifndef d_m3LogParse
+#   define d_m3LogParse                         0       // .wasm binary decoding info
+# endif
+
+# ifndef d_m3LogModule
+#   define d_m3LogModule                        0       // wasm module info
+# endif
+
+# ifndef d_m3LogCompile
+#   define d_m3LogCompile                       0       // wasm -> metacode generation phase
+# endif
+
+# ifndef d_m3LogWasmStack
+#   define d_m3LogWasmStack                     0       // dump the wasm stack when pushed or popped
+# endif
+
+# ifndef d_m3LogEmit
+#   define d_m3LogEmit                          0       // metacode generation info
+# endif
+
+# ifndef d_m3LogCodePages
+#   define d_m3LogCodePages                     0       // dump metacode pages when released
+# endif
+
+# ifndef d_m3LogRuntime
+#   define d_m3LogRuntime                       0       // higher-level runtime information
+# endif
+
+# ifndef d_m3LogNativeStack
+#   define d_m3LogNativeStack                   0       // track the memory usage of the C-stack
+# endif
+
+# ifndef d_m3LogHeapOps
+#   define d_m3LogHeapOps                       0       // track heap usage
+# endif
+
+# ifndef d_m3LogTimestamps
+#   define d_m3LogTimestamps                    0       // track timestamps on heap logs
+# endif
+
+// other ----------------------------------------------------------------------
+
+# ifndef d_m3HasFloat
+#   define d_m3HasFloat                         1       // implement floating point ops
+# endif
+
+#if !d_m3HasFloat && !defined(d_m3NoFloatDynamic)
+#   define d_m3NoFloatDynamic                   1       // if no floats, do not fail until flops are actually executed
+#endif
+
+# ifndef d_m3SkipStackCheck
+#   define d_m3SkipStackCheck                   0       // skip stack overrun checks
+# endif
+
+# ifndef d_m3SkipMemoryBoundsCheck
+#   define d_m3SkipMemoryBoundsCheck            0       // skip memory bounds checks
+# endif
+
+#define d_m3EnableCodePageRefCounting           0       // not supported currently
+
+#endif // m3_config_h

--- a/thirdparty/wasm3/source/m3_config_platforms.h
+++ b/thirdparty/wasm3/source/m3_config_platforms.h
@@ -1,0 +1,216 @@
+//
+//  m3_config_platforms.h
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef m3_config_platforms_h
+#define m3_config_platforms_h
+
+#include "wasm3_defs.h"
+
+/*
+ * Internal helpers
+ */
+
+# if !defined(__cplusplus) || defined(_MSC_VER)
+#   define not      !
+#   define and      &&
+#   define or       ||
+# endif
+
+/*
+ * Detect/define features
+ */
+
+# if defined(M3_COMPILER_MSVC)
+#  include <stdint.h>
+#  if UINTPTR_MAX == 0xFFFFFFFF
+#   define M3_SIZEOF_PTR 4
+#  elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+#   define M3_SIZEOF_PTR 8
+#  else
+#   error "Pointer size not supported"
+#  endif
+# elif defined(__SIZEOF_POINTER__)
+#  define M3_SIZEOF_PTR __SIZEOF_POINTER__
+#else
+#  error "Pointer size not detected"
+# endif
+
+# if defined(M3_BIG_ENDIAN)
+#  define M3_BSWAP_u8(X)  {}
+#  define M3_BSWAP_u16(X) { (X)=m3_bswap16((X)); }
+#  define M3_BSWAP_u32(X) { (X)=m3_bswap32((X)); }
+#  define M3_BSWAP_u64(X) { (X)=m3_bswap64((X)); }
+#  define M3_BSWAP_i8(X)  {}
+#  define M3_BSWAP_i16(X) M3_BSWAP_u16(X)
+#  define M3_BSWAP_i32(X) M3_BSWAP_u32(X)
+#  define M3_BSWAP_i64(X) M3_BSWAP_u64(X)
+#  define M3_BSWAP_f32(X) { union { f32 f; u32 i; } u; u.f = (X); M3_BSWAP_u32(u.i); (X) = u.f; }
+#  define M3_BSWAP_f64(X) { union { f64 f; u64 i; } u; u.f = (X); M3_BSWAP_u64(u.i); (X) = u.f; }
+# else
+#  define M3_BSWAP_u8(X)  {}
+#  define M3_BSWAP_u16(x) {}
+#  define M3_BSWAP_u32(x) {}
+#  define M3_BSWAP_u64(x) {}
+#  define M3_BSWAP_i8(X)  {}
+#  define M3_BSWAP_i16(X) {}
+#  define M3_BSWAP_i32(X) {}
+#  define M3_BSWAP_i64(X) {}
+#  define M3_BSWAP_f32(X) {}
+#  define M3_BSWAP_f64(X) {}
+# endif
+
+# if defined(M3_COMPILER_MSVC)
+#  define M3_WEAK //__declspec(selectany)
+#  define M3_NO_UBSAN
+#  define M3_NOINLINE
+# elif defined(__MINGW32__) || defined(__CYGWIN__)
+#  define M3_WEAK //__attribute__((selectany))
+#  define M3_NO_UBSAN
+#  define M3_NOINLINE   __attribute__((noinline))
+# else
+#  define M3_WEAK       __attribute__((weak))
+#  define M3_NO_UBSAN   //__attribute__((no_sanitize("undefined")))
+// Workaround for Cosmopolitan noinline conflict: https://github.com/jart/cosmopolitan/issues/310
+#  if defined(noinline)
+#    define M3_NOINLINE   noinline
+#  else
+#    define M3_NOINLINE   __attribute__((noinline))
+#  endif
+# endif
+
+# if !defined(M3_HAS_TAIL_CALL)
+#  if defined(__EMSCRIPTEN__)
+#   define M3_HAS_TAIL_CALL 0
+#  else
+#   define M3_HAS_TAIL_CALL 1
+#  endif
+# endif
+
+# if M3_HAS_TAIL_CALL && M3_COMPILER_HAS_ATTRIBUTE(musttail)
+#   define M3_MUSTTAIL __attribute__((musttail))
+# else
+#   define M3_MUSTTAIL
+# endif
+
+# ifndef M3_MIN
+#  define M3_MIN(A,B) (((A) < (B)) ? (A) : (B))
+# endif
+# ifndef M3_MAX
+#  define M3_MAX(A,B) (((A) > (B)) ? (A) : (B))
+# endif
+
+#define M3_INIT(field) memset(&field, 0, sizeof(field))
+
+#define M3_COUNT_OF(x) ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
+
+#if defined(__AVR__)
+
+#include <inttypes.h>
+
+# define PRIu64         "llu"
+# define PRIi64         "lli"
+
+# define d_m3ShortTypesDefined
+typedef double          f64;
+typedef float           f32;
+typedef uint64_t        u64;
+typedef int64_t         i64;
+typedef uint32_t        u32;
+typedef int32_t         i32;
+typedef short unsigned  u16;
+typedef short           i16;
+typedef uint8_t         u8;
+typedef int8_t          i8;
+
+#endif
+
+/*
+ * Apply settings
+ */
+
+# if defined (M3_COMPILER_MSVC)
+#   define vectorcall   // For MSVC, better not to specify any call convention
+# elif defined(__x86_64__)
+#   define vectorcall
+//# elif defined(__riscv) && (__riscv_xlen == 64)
+//#   define vectorcall
+# elif defined(__MINGW32__)
+#   define vectorcall
+# elif defined(WIN32)
+#   define vectorcall   __vectorcall
+# elif defined (ESP8266)
+#   include <c_types.h>
+#   define vectorcall   //ICACHE_FLASH_ATTR
+# elif defined (ESP32)
+#   if defined(M3_IN_IRAM)  // the interpreter is in IRAM, attribute not needed
+#     define vectorcall
+#   else
+#     include "esp_system.h"
+#     define vectorcall   IRAM_ATTR
+#   endif
+# elif defined (FOMU)
+#   define vectorcall   __attribute__((section(".ramtext")))
+# endif
+
+#ifndef vectorcall
+#define vectorcall
+#endif
+
+
+/*
+ * Device-specific defaults
+ */
+
+# ifndef d_m3MaxFunctionStackHeight
+#  if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AMEBA) || defined(TEENSYDUINO)
+#    define d_m3MaxFunctionStackHeight          256
+#  endif
+# endif
+
+# ifndef d_m3FixedHeap
+#  if defined(ARDUINO_AMEBA)
+#    define d_m3FixedHeap                       (128*1024)
+#  elif defined(BLUE_PILL) || defined(FOMU)
+#    define d_m3FixedHeap                       (12*1024)
+#  elif defined(ARDUINO_ARCH_ARC32) // Arduino 101
+#    define d_m3FixedHeap                       (10*1024)
+#  endif
+# endif
+
+/*
+ * Platform-specific defaults
+ */
+
+# if defined(ARDUINO) || defined(PARTICLE) || defined(PLATFORMIO) || defined(__MBED__) || \
+     defined(ESP8266) || defined(ESP32) || defined(BLUE_PILL) || defined(WM_W600) || defined(FOMU)
+# ifndef d_m3CascadedOpcodes
+#   define d_m3CascadedOpcodes                  0
+# endif
+#  ifndef d_m3VerboseErrorMessages
+#    define d_m3VerboseErrorMessages            0
+#  endif
+# ifndef d_m3MaxConstantTableSize
+#   define d_m3MaxConstantTableSize             64
+# endif
+#  ifndef d_m3MaxFunctionStackHeight
+#    define d_m3MaxFunctionStackHeight          128
+#  endif
+#  ifndef d_m3CodePageAlignSize
+#    define d_m3CodePageAlignSize               1024
+#  endif
+# endif
+
+/*
+ * Arch-specific defaults
+ */
+#if defined(__riscv) && (__riscv_xlen == 64)
+#  ifndef d_m3Use32BitSlots
+#    define d_m3Use32BitSlots                   0
+#  endif
+#endif
+
+#endif // m3_config_platforms_h

--- a/thirdparty/wasm3/source/m3_core.c
+++ b/thirdparty/wasm3/source/m3_core.c
@@ -1,0 +1,615 @@
+//
+//  m3_core.c
+//
+//  Created by Steven Massey on 4/15/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#define M3_IMPLEMENT_ERROR_STRINGS
+#include "m3_config.h"
+#include "wasm3.h"
+
+#include "m3_core.h"
+#include "m3_env.h"
+
+void m3_Abort(const char* message) {
+#ifdef DEBUG
+    fprintf(stderr, "Error: %s\n", message);
+#endif
+    abort();
+}
+
+M3_WEAK
+M3Result m3_Yield ()
+{
+    return m3Err_none;
+}
+
+#if d_m3LogTimestamps
+
+#include <time.h>
+
+#define SEC_TO_US(sec) ((sec)*1000000)
+#define NS_TO_US(ns)    ((ns)/1000)
+
+static uint64_t initial_ts = -1;
+
+uint64_t m3_GetTimestamp()
+{
+    if (initial_ts == -1) {
+        initial_ts = 0;
+        initial_ts = m3_GetTimestamp();
+    }
+    struct timespec ts;
+    timespec_get(&ts, TIME_UTC);
+    uint64_t us = SEC_TO_US((uint64_t)ts.tv_sec) + NS_TO_US((uint64_t)ts.tv_nsec);
+    return us - initial_ts;
+}
+
+#endif
+
+#if d_m3FixedHeap
+
+static u8 fixedHeap[d_m3FixedHeap];
+static u8* fixedHeapPtr = fixedHeap;
+static u8* const fixedHeapEnd = fixedHeap + d_m3FixedHeap;
+static u8* fixedHeapLast = NULL;
+
+#if d_m3FixedHeapAlign > 1
+#   define HEAP_ALIGN_PTR(P) P = (u8*)(((size_t)(P)+(d_m3FixedHeapAlign-1)) & ~ (d_m3FixedHeapAlign-1));
+#else
+#   define HEAP_ALIGN_PTR(P)
+#endif
+
+void *  m3_Malloc_Impl  (size_t i_size)
+{
+    u8 * ptr = fixedHeapPtr;
+
+    fixedHeapPtr += i_size;
+    HEAP_ALIGN_PTR(fixedHeapPtr);
+
+    if (fixedHeapPtr >= fixedHeapEnd)
+    {
+        return NULL;
+    }
+
+    memset (ptr, 0x0, i_size);
+    fixedHeapLast = ptr;
+
+    return ptr;
+}
+
+void  m3_Free_Impl  (void * i_ptr)
+{
+    // Handle the last chunk
+    if (i_ptr && i_ptr == fixedHeapLast) {
+        fixedHeapPtr = fixedHeapLast;
+        fixedHeapLast = NULL;
+    } else {
+        //printf("== free %p [failed]\n", io_ptr);
+    }
+}
+
+void *  m3_Realloc_Impl  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
+{
+    if (M3_UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+
+    void * newPtr;
+
+    // Handle the last chunk
+    if (i_ptr && i_ptr == fixedHeapLast) {
+        fixedHeapPtr = fixedHeapLast + i_newSize;
+        HEAP_ALIGN_PTR(fixedHeapPtr);
+        if (fixedHeapPtr >= fixedHeapEnd)
+        {
+            return NULL;
+        }
+        newPtr = i_ptr;
+    } else {
+        newPtr = m3_Malloc_Impl(i_newSize);
+        if (!newPtr) {
+            return NULL;
+        }
+        if (i_ptr) {
+            memcpy(newPtr, i_ptr, i_oldSize);
+        }
+    }
+
+    if (i_newSize > i_oldSize) {
+        memset ((u8 *) newPtr + i_oldSize, 0x0, i_newSize - i_oldSize);
+    }
+
+    return newPtr;
+}
+
+#else
+
+void *  m3_Malloc_Impl  (size_t i_size)
+{
+    return calloc (i_size, 1);
+}
+
+void  m3_Free_Impl  (void * io_ptr)
+{
+    free (io_ptr);
+}
+
+void *  m3_Realloc_Impl  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
+{
+    if (M3_UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+
+    void * newPtr = realloc (i_ptr, i_newSize);
+
+    if (M3_LIKELY(newPtr))
+    {
+        if (i_newSize > i_oldSize) {
+            memset ((u8 *) newPtr + i_oldSize, 0x0, i_newSize - i_oldSize);
+        }
+        return newPtr;
+    }
+    return NULL;
+}
+
+#endif
+
+void *  m3_CopyMem  (const void * i_from, size_t i_size)
+{
+    void * ptr = m3_Malloc("CopyMem", i_size);
+    if (ptr) {
+        memcpy (ptr, i_from, i_size);
+    }
+    return ptr;
+}
+
+//--------------------------------------------------------------------------------------------
+
+#if d_m3LogNativeStack
+
+static size_t stack_start;
+static size_t stack_end;
+
+void        m3StackCheckInit ()
+{
+    char stack;
+    stack_end = stack_start = (size_t)&stack;
+}
+
+void        m3StackCheck ()
+{
+    char stack;
+    size_t addr = (size_t)&stack;
+
+    size_t stackEnd = stack_end;
+    stack_end = M3_MIN (stack_end, addr);
+
+//    if (stackEnd != stack_end)
+//        printf ("maxStack: %ld\n", m3StackGetMax ());
+}
+
+int      m3StackGetMax  ()
+{
+    return stack_start - stack_end;
+}
+
+#endif
+
+//--------------------------------------------------------------------------------------------
+
+M3Result NormalizeType (u8 * o_type, i8 i_convolutedWasmType)
+{
+    M3Result result = m3Err_none;
+
+    u8 type = -i_convolutedWasmType;
+
+    if (type == 0x40)
+        type = c_m3Type_none;
+    else if (type < c_m3Type_i32 or type > c_m3Type_f64)
+        result = m3Err_invalidTypeId;
+
+    * o_type = type;
+
+    return result;
+}
+
+
+bool  IsFpType  (u8 i_m3Type)
+{
+    return (i_m3Type == c_m3Type_f32 or i_m3Type == c_m3Type_f64);
+}
+
+
+bool  IsIntType  (u8 i_m3Type)
+{
+    return (i_m3Type == c_m3Type_i32 or i_m3Type == c_m3Type_i64);
+}
+
+
+bool  Is64BitType  (u8 i_m3Type)
+{
+    if (i_m3Type == c_m3Type_i64 or i_m3Type == c_m3Type_f64)
+        return true;
+    else if (i_m3Type == c_m3Type_i32 or i_m3Type == c_m3Type_f32 or i_m3Type == c_m3Type_none)
+        return false;
+    else
+        return (sizeof (voidptr_t) == 8); // all other cases are pointers
+}
+
+u32  SizeOfType  (u8 i_m3Type)
+{
+    if (i_m3Type == c_m3Type_i32 or i_m3Type == c_m3Type_f32)
+        return sizeof (i32);
+
+    return sizeof (i64);
+}
+
+
+//-- Binary Wasm parsing utils  ------------------------------------------------------------------------------------------
+
+
+M3Result  Read_u64  (u64 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+    ptr += sizeof (u64);
+
+    if (ptr <= i_end)
+    {
+        memcpy(o_value, * io_bytes, sizeof(u64));
+        M3_BSWAP_u64(*o_value);
+        * io_bytes = ptr;
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+
+M3Result  Read_u32  (u32 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+    ptr += sizeof (u32);
+
+    if (ptr <= i_end)
+    {
+        memcpy(o_value, * io_bytes, sizeof(u32));
+        M3_BSWAP_u32(*o_value);
+        * io_bytes = ptr;
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+#if d_m3ImplementFloat
+
+M3Result  Read_f64  (f64 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+    ptr += sizeof (f64);
+
+    if (ptr <= i_end)
+    {
+        memcpy(o_value, * io_bytes, sizeof(f64));
+        M3_BSWAP_f64(*o_value);
+        * io_bytes = ptr;
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+
+M3Result  Read_f32  (f32 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+    ptr += sizeof (f32);
+
+    if (ptr <= i_end)
+    {
+        memcpy(o_value, * io_bytes, sizeof(f32));
+        M3_BSWAP_f32(*o_value);
+        * io_bytes = ptr;
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+#endif
+
+M3Result  Read_u8  (u8 * o_value, bytes_t  * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+
+    if (ptr < i_end)
+    {
+        * o_value = * ptr;
+        * io_bytes = ptr + 1;
+
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+M3Result  Read_opcode  (m3opcode_t * o_value, bytes_t  * io_bytes, cbytes_t i_end)
+{
+    const u8 * ptr = * io_bytes;
+
+    if (ptr < i_end)
+    {
+        m3opcode_t opcode = * ptr++;
+
+#if d_m3CascadedOpcodes == 0
+        if (M3_UNLIKELY(opcode == c_waOp_extended))
+        {
+            if (ptr < i_end)
+            {
+                opcode = (opcode << 8) | (* ptr++);
+            }
+            else return m3Err_wasmUnderrun;
+        }
+#endif
+        * o_value = opcode;
+        * io_bytes = ptr;
+
+        return m3Err_none;
+    }
+    else return m3Err_wasmUnderrun;
+}
+
+
+M3Result  ReadLebUnsigned  (u64 * o_value, u32 i_maxNumBits, bytes_t * io_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_wasmUnderrun;
+
+    u64 value = 0;
+
+    u32 shift = 0;
+    const u8 * ptr = * io_bytes;
+
+    while (ptr < i_end)
+    {
+        u64 byte = * (ptr++);
+
+        value |= ((byte & 0x7f) << shift);
+        shift += 7;
+
+        if ((byte & 0x80) == 0)
+        {
+            result = m3Err_none;
+            break;
+        }
+
+        if (shift >= i_maxNumBits)
+        {
+            result = m3Err_lebOverflow;
+            break;
+        }
+    }
+
+    * o_value = value;
+    * io_bytes = ptr;
+
+    return result;
+}
+
+
+M3Result  ReadLebSigned  (i64 * o_value, u32 i_maxNumBits, bytes_t * io_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_wasmUnderrun;
+
+    i64 value = 0;
+
+    u32 shift = 0;
+    const u8 * ptr = * io_bytes;
+
+    while (ptr < i_end)
+    {
+        u64 byte = * (ptr++);
+
+        value |= ((byte & 0x7f) << shift);
+        shift += 7;
+
+        if ((byte & 0x80) == 0)
+        {
+            result = m3Err_none;
+
+            if ((byte & 0x40) and (shift < 64))    // do sign extension
+            {
+                u64 extend = 0;
+                value |= (~extend << shift);
+            }
+
+            break;
+        }
+
+        if (shift >= i_maxNumBits)
+        {
+            result = m3Err_lebOverflow;
+            break;
+        }
+    }
+
+    * o_value = value;
+    * io_bytes = ptr;
+
+    return result;
+}
+
+
+M3Result  ReadLEB_u32  (u32 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    u64 value;
+    M3Result result = ReadLebUnsigned (& value, 32, io_bytes, i_end);
+    * o_value = (u32) value;
+
+    return result;
+}
+
+
+M3Result  ReadLEB_u7  (u8 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    u64 value;
+    M3Result result = ReadLebUnsigned (& value, 7, io_bytes, i_end);
+    * o_value = (u8) value;
+
+    return result;
+}
+
+
+M3Result  ReadLEB_i7  (i8 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    i64 value;
+    M3Result result = ReadLebSigned (& value, 7, io_bytes, i_end);
+    * o_value = (i8) value;
+
+    return result;
+}
+
+
+M3Result  ReadLEB_i32  (i32 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    i64 value;
+    M3Result result = ReadLebSigned (& value, 32, io_bytes, i_end);
+    * o_value = (i32) value;
+
+    return result;
+}
+
+
+M3Result  ReadLEB_i64  (i64 * o_value, bytes_t * io_bytes, cbytes_t i_end)
+{
+    i64 value;
+    M3Result result = ReadLebSigned (& value, 64, io_bytes, i_end);
+    * o_value = value;
+
+    return result;
+}
+
+
+M3Result  Read_utf8  (cstr_t * o_utf8, bytes_t * io_bytes, cbytes_t i_end)
+{
+    *o_utf8 = NULL;
+
+    u32 utf8Length;
+    M3Result result = ReadLEB_u32 (& utf8Length, io_bytes, i_end);
+
+    if (not result)
+    {
+        if (utf8Length <= d_m3MaxSaneUtf8Length)
+        {
+            const u8 * ptr = * io_bytes;
+            const u8 * end = ptr + utf8Length;
+
+            if (end <= i_end)
+            {
+                char * utf8 = (char *)m3_Malloc ("UTF8", utf8Length + 1);
+
+                if (utf8)
+                {
+                    memcpy (utf8, ptr, utf8Length);
+                    utf8 [utf8Length] = 0;
+                    * o_utf8 = utf8;
+                }
+
+                * io_bytes = end;
+            }
+            else result = m3Err_wasmUnderrun;
+        }
+        else result = m3Err_missingUTF8;
+    }
+
+    return result;
+}
+
+#if d_m3RecordBacktraces
+u32  FindModuleOffset  (IM3Runtime i_runtime, pc_t i_pc)
+{
+    // walk the code pages
+    IM3CodePage curr = i_runtime->pagesOpen;
+    bool pageFound = false;
+
+    while (curr)
+    {
+        if (ContainsPC (curr, i_pc))
+        {
+            pageFound = true;
+            break;
+        }
+        curr = curr->info.next;
+    }
+
+    if (!pageFound)
+    {
+        curr = i_runtime->pagesFull;
+        while (curr)
+        {
+            if (ContainsPC (curr, i_pc))
+            {
+                pageFound = true;
+                break;
+            }
+            curr = curr->info.next;
+        }
+    }
+
+    if (pageFound)
+    {
+        u32 result = 0;
+
+        bool pcFound = MapPCToOffset (curr, i_pc, & result);
+                                                                                d_m3Assert (pcFound);
+
+        return result;
+    }
+    else return 0;
+}
+
+
+void  PushBacktraceFrame  (IM3Runtime io_runtime, pc_t i_pc)
+{
+    // don't try to push any more frames if we've already had an alloc failure
+    if (M3_UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
+        return;
+
+    M3BacktraceFrame * newFrame = m3_AllocStruct(M3BacktraceFrame);
+
+    if (!newFrame)
+    {
+        io_runtime->backtrace.lastFrame = M3_BACKTRACE_TRUNCATED;
+        return;
+    }
+
+    newFrame->moduleOffset = FindModuleOffset (io_runtime, i_pc);
+
+    if (!io_runtime->backtrace.frames || !io_runtime->backtrace.lastFrame)
+        io_runtime->backtrace.frames = newFrame;
+    else
+        io_runtime->backtrace.lastFrame->next = newFrame;
+    io_runtime->backtrace.lastFrame = newFrame;
+}
+
+
+void  FillBacktraceFunctionInfo  (IM3Runtime io_runtime, IM3Function i_function)
+{
+    // If we've had an alloc failure then the last frame doesn't refer to the
+    // frame we want to fill in the function info for.
+    if (M3_UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
+        return;
+
+    if (!io_runtime->backtrace.lastFrame)
+        return;
+
+    io_runtime->backtrace.lastFrame->function = i_function;
+}
+
+
+void  ClearBacktrace  (IM3Runtime io_runtime)
+{
+    M3BacktraceFrame * currentFrame = io_runtime->backtrace.frames;
+    while (currentFrame)
+    {
+        M3BacktraceFrame * nextFrame = currentFrame->next;
+        m3_Free (currentFrame);
+        currentFrame = nextFrame;
+    }
+
+    io_runtime->backtrace.frames = NULL;
+    io_runtime->backtrace.lastFrame = NULL;
+}
+#endif // d_m3RecordBacktraces

--- a/thirdparty/wasm3/source/m3_core.h
+++ b/thirdparty/wasm3/source/m3_core.h
@@ -1,0 +1,311 @@
+//
+//  m3_core.h
+//
+//  Created by Steven Massey on 4/15/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_core_h
+#define m3_core_h
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+
+#include "wasm3.h"
+#include "m3_config.h"
+
+# if defined(__cplusplus)
+#   define d_m3BeginExternC     extern "C" {
+#   define d_m3EndExternC       }
+# else
+#   define d_m3BeginExternC
+#   define d_m3EndExternC
+# endif
+
+d_m3BeginExternC
+
+#define d_m3ImplementFloat (d_m3HasFloat || d_m3NoFloatDynamic)
+
+#if !defined(d_m3ShortTypesDefined)
+
+typedef uint64_t        u64;
+typedef int64_t         i64;
+typedef uint32_t        u32;
+typedef int32_t         i32;
+typedef uint16_t        u16;
+typedef int16_t         i16;
+typedef uint8_t         u8;
+typedef int8_t          i8;
+
+#if d_m3ImplementFloat
+typedef double          f64;
+typedef float           f32;
+#endif
+
+#endif // d_m3ShortTypesDefined
+
+#define PRIf32          "f"
+#define PRIf64          "lf"
+
+typedef const void *            m3ret_t;
+typedef const void *            voidptr_t;
+typedef const char *            cstr_t;
+typedef const char * const      ccstr_t;
+typedef const u8 *              bytes_t;
+typedef const u8 * const        cbytes_t;
+
+typedef u16                     m3opcode_t;
+
+typedef i64                     m3reg_t;
+
+# if d_m3Use32BitSlots
+typedef u32                     m3slot_t;
+# else
+typedef u64                     m3slot_t;
+# endif
+
+typedef m3slot_t *              m3stack_t;
+
+typedef
+const void * const  cvptr_t;
+
+# if defined (DEBUG)
+
+#   define d_m3Log(CATEGORY, FMT, ...)                  printf (" %8s  |  " FMT, #CATEGORY, ##__VA_ARGS__);
+
+#   if d_m3LogParse
+#       define m3log_parse(CATEGORY, FMT, ...)          d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_parse(...) {}
+#   endif
+
+#   if d_m3LogCompile
+#       define m3log_compile(CATEGORY, FMT, ...)        d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_compile(...) {}
+#   endif
+
+#   if d_m3LogEmit
+#       define m3log_emit(CATEGORY, FMT, ...)           d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_emit(...) {}
+#   endif
+
+#   if d_m3LogCodePages
+#       define m3log_code(CATEGORY, FMT, ...)           d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_code(...) {}
+#   endif
+
+#   if d_m3LogModule
+#       define m3log_module(CATEGORY, FMT, ...)         d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_module(...) {}
+#   endif
+
+#   if d_m3LogRuntime
+#       define m3log_runtime(CATEGORY, FMT, ...)        d_m3Log(CATEGORY, FMT, ##__VA_ARGS__)
+#   else
+#       define m3log_runtime(...) {}
+#   endif
+
+#   define m3log(CATEGORY, FMT, ...)                    m3log_##CATEGORY (CATEGORY, FMT "\n", ##__VA_ARGS__)
+# else
+#   define d_m3Log(CATEGORY, FMT, ...)                  {}
+#   define m3log(CATEGORY, FMT, ...)                    {}
+# endif
+
+
+# if defined(ASSERTS) || (defined(DEBUG) && !defined(NASSERTS))
+#   define d_m3Assert(ASS)  if (!(ASS)) { printf("Assertion failed at %s:%d : %s\n", __FILE__, __LINE__, #ASS); abort(); }
+# else
+#   define d_m3Assert(ASS)
+# endif
+
+typedef void /*const*/ *                    code_t;
+typedef code_t const * /*__restrict__*/     pc_t;
+
+
+typedef struct M3MemoryHeader
+{
+    IM3Runtime      runtime;
+    void *          maxStack;
+    size_t          length;
+}
+M3MemoryHeader;
+
+struct M3CodeMappingPage;
+
+typedef struct M3CodePageHeader
+{
+    struct M3CodePage *           next;
+
+    u32                           lineIndex;
+    u32                           numLines;
+    u32                           sequence;       // this is just used for debugging; could be removed
+    u32                           usageCount;
+
+# if d_m3RecordBacktraces
+    struct M3CodeMappingPage *    mapping;
+# endif // d_m3RecordBacktraces
+}
+M3CodePageHeader;
+
+
+#define d_m3CodePageFreeLinesThreshold      4+2       // max is: select _sss & CallIndirect + 2 for bridge
+
+#define d_m3DefaultMemPageSize              65536
+
+#define d_m3Reg0SlotAlias                   60000
+#define d_m3Fp0SlotAlias                    (d_m3Reg0SlotAlias + 2)
+
+#define d_m3MaxSaneTypesCount               1000000
+#define d_m3MaxSaneFunctionsCount           1000000
+#define d_m3MaxSaneImportsCount             100000
+#define d_m3MaxSaneExportsCount             100000
+#define d_m3MaxSaneGlobalsCount             1000000
+#define d_m3MaxSaneElementSegments          10000000
+#define d_m3MaxSaneDataSegments             100000
+#define d_m3MaxSaneTableSize                10000000
+#define d_m3MaxSaneUtf8Length               10000
+#define d_m3MaxSaneFunctionArgRetCount      1000    // still insane, but whatever
+
+#define d_externalKind_function             0
+#define d_externalKind_table                1
+#define d_externalKind_memory               2
+#define d_externalKind_global               3
+
+static const char * const c_waTypes []          = { "nil", "i32", "i64", "f32", "f64", "unknown" };
+static const char * const c_waCompactTypes []   = { "_", "i", "I", "f", "F", "?" };
+
+
+# if d_m3VerboseErrorMessages
+
+M3Result m3Error (M3Result i_result, IM3Runtime i_runtime, IM3Module i_module, IM3Function i_function,
+                  const char * const i_file, u32 i_lineNum, const char * const i_errorMessage, ...);
+
+#  define _m3Error(RESULT, RT, MOD, FUN, FILE, LINE, FORMAT, ...) \
+            m3Error (RESULT, RT, MOD, FUN, FILE, LINE, FORMAT, ##__VA_ARGS__)
+
+# else
+#  define _m3Error(RESULT, RT, MOD, FUN, FILE, LINE, FORMAT, ...) (RESULT)
+# endif
+
+#define ErrorRuntime(RESULT, RUNTIME, FORMAT, ...)      _m3Error (RESULT, RUNTIME, NULL, NULL,  __FILE__, __LINE__, FORMAT, ##__VA_ARGS__)
+#define ErrorModule(RESULT, MOD, FORMAT, ...)           _m3Error (RESULT, MOD->runtime, MOD, NULL,  __FILE__, __LINE__, FORMAT, ##__VA_ARGS__)
+#define ErrorCompile(RESULT, COMP, FORMAT, ...)         _m3Error (RESULT, COMP->runtime, COMP->module, NULL, __FILE__, __LINE__, FORMAT, ##__VA_ARGS__)
+
+#if d_m3LogNativeStack
+void        m3StackCheckInit        ();
+void        m3StackCheck            ();
+int         m3StackGetMax           ();
+#else
+#define     m3StackCheckInit()
+#define     m3StackCheck()
+#define     m3StackGetMax()         0
+#endif
+
+#if d_m3LogTimestamps
+#define     PRIts                   "%llu"
+uint64_t    m3_GetTimestamp         ();
+#else
+#define     PRIts                   "%s"
+#define     m3_GetTimestamp()       ""
+#endif
+
+void        m3_Abort                (const char* message);
+void *      m3_Malloc_Impl          (size_t i_size);
+void *      m3_Realloc_Impl         (void * i_ptr, size_t i_newSize, size_t i_oldSize);
+void        m3_Free_Impl            (void * i_ptr);
+void *      m3_CopyMem              (const void * i_from, size_t i_size);
+
+#if d_m3LogHeapOps
+
+// Tracing format: timestamp;heap:OpCode;name;size(bytes);new items;new ptr;old items;old ptr
+
+static inline void * m3_AllocStruct_Impl(ccstr_t name, size_t i_size) {
+    void * result = m3_Malloc_Impl(i_size);
+    fprintf(stderr, PRIts ";heap:AllocStruct;%s;%zu;;%p;;\n", m3_GetTimestamp(), name, i_size, result);
+    return result;
+}
+
+static inline void * m3_AllocArray_Impl(ccstr_t name, size_t i_num, size_t i_size) {
+    void * result = m3_Malloc_Impl(i_size * i_num);
+    fprintf(stderr, PRIts ";heap:AllocArr;%s;%zu;%zu;%p;;\n", m3_GetTimestamp(), name, i_size, i_num, result);
+    return result;
+}
+
+static inline void * m3_ReallocArray_Impl(ccstr_t name, void * i_ptr_old, size_t i_num_new, size_t i_num_old, size_t i_size) {
+    void * result = m3_Realloc_Impl (i_ptr_old, i_size * i_num_new, i_size * i_num_old);
+    fprintf(stderr, PRIts ";heap:ReallocArr;%s;%zu;%zu;%p;%zu;%p\n", m3_GetTimestamp(), name, i_size, i_num_new, result, i_num_old, i_ptr_old);
+    return result;
+}
+
+static inline void * m3_Malloc (ccstr_t name, size_t i_size) {
+    void * result = m3_Malloc_Impl (i_size);
+    fprintf(stderr, PRIts ";heap:AllocMem;%s;%zu;;%p;;\n", m3_GetTimestamp(), name, i_size, result);
+    return result;
+}
+static inline void * m3_Realloc (ccstr_t name, void * i_ptr, size_t i_newSize, size_t i_oldSize) {
+    void * result = m3_Realloc_Impl (i_ptr, i_newSize, i_oldSize);
+    fprintf(stderr, PRIts ";heap:ReallocMem;%s;;%zu;%p;%zu;%p\n", m3_GetTimestamp(), name, i_newSize, result, i_oldSize, i_ptr);
+    return result;
+}
+
+#define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_AllocStruct_Impl  (#STRUCT, sizeof (STRUCT))
+#define     m3_AllocArray(STRUCT, NUM)              (STRUCT *)m3_AllocArray_Impl   (#STRUCT, NUM, sizeof (STRUCT))
+#define     m3_ReallocArray(STRUCT, PTR, NEW, OLD)  (STRUCT *)m3_ReallocArray_Impl (#STRUCT, (void *)(PTR), (NEW), (OLD), sizeof (STRUCT))
+#define     m3_Free(P)                              do { void* p = (void*)(P);                                  \
+                                                        if (p) { fprintf(stderr, PRIts ";heap:FreeMem;;;;%p;\n", m3_GetTimestamp(), p); }     \
+                                                        m3_Free_Impl (p); (P) = NULL; } while(0)
+#else
+#define     m3_Malloc(NAME, SIZE)                   m3_Malloc_Impl(SIZE)
+#define     m3_Realloc(NAME, PTR, NEW, OLD)         m3_Realloc_Impl(PTR, NEW, OLD)
+#define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_Malloc_Impl (sizeof (STRUCT))
+#define     m3_AllocArray(STRUCT, NUM)              (STRUCT *)m3_Malloc_Impl (sizeof (STRUCT) * (NUM))
+#define     m3_ReallocArray(STRUCT, PTR, NEW, OLD)  (STRUCT *)m3_Realloc_Impl ((void *)(PTR), sizeof (STRUCT) * (NEW), sizeof (STRUCT) * (OLD))
+#define     m3_Free(P)                              do { m3_Free_Impl ((void*)(P)); (P) = NULL; } while(0)
+#endif
+
+M3Result    NormalizeType           (u8 * o_type, i8 i_convolutedWasmType);
+
+bool        IsIntType               (u8 i_wasmType);
+bool        IsFpType                (u8 i_wasmType);
+bool        Is64BitType             (u8 i_m3Type);
+u32         SizeOfType              (u8 i_m3Type);
+
+M3Result    Read_u64                (u64 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    Read_u32                (u32 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+#if d_m3ImplementFloat
+M3Result    Read_f64                (f64 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    Read_f32                (f32 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+#endif
+M3Result    Read_u8                 (u8  * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    Read_opcode             (m3opcode_t * o_value, bytes_t  * io_bytes, cbytes_t i_end);
+
+M3Result    ReadLebUnsigned         (u64 * o_value, u32 i_maxNumBits, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLebSigned           (i64 * o_value, u32 i_maxNumBits, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLEB_u32             (u32 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLEB_u7              (u8  * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLEB_i7              (i8  * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLEB_i32             (i32 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    ReadLEB_i64             (i64 * o_value, bytes_t * io_bytes, cbytes_t i_end);
+M3Result    Read_utf8               (cstr_t * o_utf8, bytes_t * io_bytes, cbytes_t i_end);
+
+cstr_t      SPrintValue             (void * i_value, u8 i_type);
+size_t      SPrintArg               (char * o_string, size_t i_stringBufferSize, voidptr_t i_sp, u8 i_type);
+
+void        ReportError             (IM3Runtime io_runtime, IM3Module i_module, IM3Function i_function, ccstr_t i_errorMessage, ccstr_t i_file, u32 i_lineNum);
+
+# if d_m3RecordBacktraces
+void        PushBacktraceFrame         (IM3Runtime io_runtime, pc_t i_pc);
+void        FillBacktraceFunctionInfo  (IM3Runtime io_runtime, IM3Function i_function);
+void        ClearBacktrace             (IM3Runtime io_runtime);
+# endif
+
+d_m3EndExternC
+
+#endif // m3_core_h

--- a/thirdparty/wasm3/source/m3_env.c
+++ b/thirdparty/wasm3/source/m3_env.c
@@ -1,0 +1,1239 @@
+//
+//  m3_env.c
+//
+//  Created by Steven Massey on 4/19/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include <stdarg.h>
+#include <limits.h>
+
+#include "m3_env.h"
+#include "m3_compile.h"
+#include "m3_exception.h"
+#include "m3_info.h"
+
+
+IM3Environment  m3_NewEnvironment  ()
+{
+    IM3Environment env = m3_AllocStruct (M3Environment);
+
+    if (env)
+    {
+        _try
+        {
+            // create FuncTypes for all simple block return ValueTypes
+            for (u8 t = c_m3Type_none; t <= c_m3Type_f64; t++)
+            {
+                IM3FuncType ftype;
+_               (AllocFuncType (& ftype, 1));
+
+                ftype->numArgs = 0;
+                ftype->numRets = (t == c_m3Type_none) ? 0 : 1;
+                ftype->types [0] = t;
+
+                Environment_AddFuncType (env, & ftype);
+
+                d_m3Assert (t < 5);
+                env->retFuncTypes [t] = ftype;
+            }
+        }
+
+        _catch:
+        if (result)
+        {
+            m3_FreeEnvironment (env);
+            env = NULL;
+        }
+    }
+
+    return env;
+}
+
+
+void  Environment_Release  (IM3Environment i_environment)
+{
+    IM3FuncType ftype = i_environment->funcTypes;
+
+    while (ftype)
+    {
+        IM3FuncType next = ftype->next;
+        m3_Free (ftype);
+        ftype = next;
+    }
+
+    m3log (runtime, "freeing %d pages from environment", CountCodePages (i_environment->pagesReleased));
+    FreeCodePages (& i_environment->pagesReleased);
+}
+
+
+void  m3_FreeEnvironment  (IM3Environment i_environment)
+{
+    if (i_environment)
+    {
+        Environment_Release (i_environment);
+        m3_Free (i_environment);
+    }
+}
+
+
+void m3_SetCustomSectionHandler  (IM3Environment i_environment, M3SectionHandler i_handler)
+{
+    if (i_environment) i_environment->customSectionHandler = i_handler;
+}
+
+
+// returns the same io_funcType or replaces it with an equivalent that's already in the type linked list
+void  Environment_AddFuncType  (IM3Environment i_environment, IM3FuncType * io_funcType)
+{
+    IM3FuncType addType = * io_funcType;
+    IM3FuncType newType = i_environment->funcTypes;
+
+    while (newType)
+    {
+        if (AreFuncTypesEqual (newType, addType))
+        {
+            m3_Free (addType);
+            break;
+        }
+
+        newType = newType->next;
+    }
+
+    if (newType == NULL)
+    {
+        newType = addType;
+        newType->next = i_environment->funcTypes;
+        i_environment->funcTypes = newType;
+    }
+
+    * io_funcType = newType;
+}
+
+
+IM3CodePage RemoveCodePageOfCapacity (M3CodePage ** io_list, u32 i_minimumLineCount)
+{
+    IM3CodePage prev = NULL;
+    IM3CodePage page = * io_list;
+
+    while (page)
+    {
+        if (NumFreeLines (page) >= i_minimumLineCount)
+        {                                                           d_m3Assert (page->info.usageCount == 0);
+            IM3CodePage next = page->info.next;
+            if (prev)
+                prev->info.next = next; // mid-list
+            else
+                * io_list = next;       // front of list
+
+            break;
+        }
+
+        prev = page;
+        page = page->info.next;
+    }
+
+    return page;
+}
+
+
+IM3CodePage  Environment_AcquireCodePage (IM3Environment i_environment, u32 i_minimumLineCount)
+{
+    return RemoveCodePageOfCapacity (& i_environment->pagesReleased, i_minimumLineCount);
+}
+
+
+void  Environment_ReleaseCodePages  (IM3Environment i_environment, IM3CodePage i_codePageList)
+{
+    IM3CodePage end = i_codePageList;
+
+    while (end)
+    {
+        end->info.lineIndex = 0; // reset page
+#if d_m3RecordBacktraces
+        end->info.mapping->size = 0;
+#endif // d_m3RecordBacktraces
+
+        IM3CodePage next = end->info.next;
+        if (not next)
+            break;
+
+        end = next;
+    }
+
+    if (end)
+    {
+        // push list to front
+        end->info.next = i_environment->pagesReleased;
+        i_environment->pagesReleased = i_codePageList;
+    }
+}
+
+
+IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes, void * i_userdata)
+{
+    IM3Runtime runtime = m3_AllocStruct (M3Runtime);
+
+    if (runtime)
+    {
+        m3_ResetErrorInfo(runtime);
+
+        runtime->environment = i_environment;
+        runtime->userdata = i_userdata;
+
+        runtime->originStack = m3_Malloc ("Wasm Stack", i_stackSizeInBytes + 4*sizeof (m3slot_t)); // TODO: more precise stack checks
+
+        if (runtime->originStack)
+        {
+            runtime->stack = runtime->originStack;
+            runtime->numStackSlots = i_stackSizeInBytes / sizeof (m3slot_t);         m3log (runtime, "new stack: %p", runtime->originStack);
+        }
+        else m3_Free (runtime);
+    }
+
+    return runtime;
+}
+
+void *  m3_GetUserData  (IM3Runtime i_runtime)
+{
+    return i_runtime ? i_runtime->userdata : NULL;
+}
+
+
+void *  ForEachModule  (IM3Runtime i_runtime, ModuleVisitor i_visitor, void * i_info)
+{
+    void * r = NULL;
+
+    IM3Module module = i_runtime->modules;
+
+    while (module)
+    {
+        IM3Module next = module->next;
+        r = i_visitor (module, i_info);
+        if (r)
+            break;
+
+        module = next;
+    }
+
+    return r;
+}
+
+
+void *  _FreeModule  (IM3Module i_module, void * i_info)
+{
+    m3_FreeModule (i_module);
+    return NULL;
+}
+
+
+void  Runtime_Release  (IM3Runtime i_runtime)
+{
+    ForEachModule (i_runtime, _FreeModule, NULL);                   d_m3Assert (i_runtime->numActiveCodePages == 0);
+
+    Environment_ReleaseCodePages (i_runtime->environment, i_runtime->pagesOpen);
+    Environment_ReleaseCodePages (i_runtime->environment, i_runtime->pagesFull);
+
+    m3_Free (i_runtime->originStack);
+    m3_Free (i_runtime->memory.mallocated);
+}
+
+
+void  m3_FreeRuntime  (IM3Runtime i_runtime)
+{
+    if (i_runtime)
+    {
+        m3_PrintProfilerInfo ();
+
+        Runtime_Release (i_runtime);
+        m3_Free (i_runtime);
+    }
+}
+
+M3Result  EvaluateExpression  (IM3Module i_module, void * o_expressed, u8 i_type, bytes_t * io_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    // OPTZ: use a simplified interpreter for expressions
+
+    // create a temporary runtime context
+#if defined(d_m3PreferStaticAlloc)
+    static M3Runtime runtime;
+#else
+    M3Runtime runtime;
+#endif
+    M3_INIT (runtime);
+
+    runtime.environment = i_module->runtime->environment;
+    runtime.numStackSlots = i_module->runtime->numStackSlots;
+    runtime.stack = i_module->runtime->stack;
+
+    m3stack_t stack = (m3stack_t)runtime.stack;
+
+    IM3Runtime savedRuntime = i_module->runtime;
+    i_module->runtime = & runtime;
+
+    IM3Compilation o = & runtime.compilation;
+    o->runtime = & runtime;
+    o->module =  i_module;
+    o->wasm =    * io_bytes;
+    o->wasmEnd = i_end;
+    o->lastOpcodeStart = o->wasm;
+
+    o->block.depth = -1;  // so that root compilation depth = 0
+
+    //  OPTZ: this code page could be erased after use.  maybe have 'empty' list in addition to full and open?
+    o->page = AcquireCodePage (& runtime);  // AcquireUnusedCodePage (...)
+
+    if (o->page)
+    {
+        IM3FuncType ftype = runtime.environment->retFuncTypes[i_type];
+
+        pc_t m3code = GetPagePC (o->page);
+        result = CompileBlock (o, ftype, c_waOp_block);
+
+        if (not result && o->maxStackSlots >= runtime.numStackSlots) {
+            result = m3Err_trapStackOverflow;
+        }
+
+        if (not result)
+        {
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+            m3ret_t r = RunCode (m3code, stack, NULL, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+            m3ret_t r = RunCode (m3code, stack, NULL, d_m3OpDefaultArgs);
+# endif
+            
+            if (r == 0)
+            {                                                                               m3log (runtime, "expression result: %s", SPrintValue (stack, i_type));
+                if (SizeOfType (i_type) == sizeof (u32))
+                {
+                    * (u32 *) o_expressed = * ((u32 *) stack);
+                }
+                else
+                {
+                    * (u64 *) o_expressed = * ((u64 *) stack);
+                }
+            }
+        }
+
+        // TODO: EraseCodePage (...) see OPTZ above
+        ReleaseCodePage (& runtime, o->page);
+    }
+    else result = m3Err_mallocFailedCodePage;
+
+    runtime.originStack = NULL;        // prevent free(stack) in ReleaseRuntime
+    Runtime_Release (& runtime);
+    i_module->runtime = savedRuntime;
+
+    * io_bytes = o->wasm;
+
+    return result;
+}
+
+
+M3Result  InitMemory  (IM3Runtime io_runtime, IM3Module i_module)
+{
+    M3Result result = m3Err_none;                                     //d_m3Assert (not io_runtime->memory.wasmPages);
+
+    if (not i_module->memoryImported)
+    {
+        u32 maxPages = i_module->memoryInfo.maxPages;
+        u32 pageSize = i_module->memoryInfo.pageSize;
+        io_runtime->memory.maxPages = maxPages ? maxPages : 65536;
+        io_runtime->memory.pageSize = pageSize ? pageSize : d_m3DefaultMemPageSize;
+
+        result = ResizeMemory (io_runtime, i_module->memoryInfo.initPages);
+    }
+
+    return result;
+}
+
+
+M3Result  ResizeMemory  (IM3Runtime io_runtime, u32 i_numPages)
+{
+    M3Result result = m3Err_none;
+
+    u32 numPagesToAlloc = i_numPages;
+
+    M3Memory * memory = & io_runtime->memory;
+
+#if 0 // Temporary fix for memory allocation
+    if (memory->mallocated) {
+        memory->numPages = i_numPages;
+        memory->mallocated->end = memory->wasmPages + (memory->numPages * io_runtime->memory.pageSize);
+        return result;
+    }
+
+    i_numPagesToAlloc = 256;
+#endif
+
+    if (numPagesToAlloc <= memory->maxPages)
+    {
+        size_t numPageBytes = numPagesToAlloc * io_runtime->memory.pageSize;
+
+#if d_m3MaxLinearMemoryPages > 0
+        _throwif("linear memory limitation exceeded", numPagesToAlloc > d_m3MaxLinearMemoryPages);
+#endif
+
+        // Limit the amount of memory that gets actually allocated
+        if (io_runtime->memoryLimit) {
+            numPageBytes = M3_MIN (numPageBytes, io_runtime->memoryLimit);
+        }
+
+        size_t numBytes = numPageBytes + sizeof (M3MemoryHeader);
+
+        size_t numPreviousBytes = memory->numPages * io_runtime->memory.pageSize;
+        if (numPreviousBytes)
+            numPreviousBytes += sizeof (M3MemoryHeader);
+
+        void* newMem = m3_Realloc ("Wasm Linear Memory", memory->mallocated, numBytes, numPreviousBytes);
+        _throwifnull(newMem);
+
+        memory->mallocated = (M3MemoryHeader*)newMem;
+
+# if d_m3LogRuntime
+        M3MemoryHeader * oldMallocated = memory->mallocated;
+# endif
+
+        memory->numPages = numPagesToAlloc;
+
+        memory->mallocated->length =  numPageBytes;
+        memory->mallocated->runtime = io_runtime;
+
+        memory->mallocated->maxStack = (m3slot_t *) io_runtime->stack + io_runtime->numStackSlots;
+
+        m3log (runtime, "resized old: %p; mem: %p; length: %zu; pages: %d", oldMallocated, memory->mallocated, memory->mallocated->length, memory->numPages);
+    }
+    else result = m3Err_wasmMemoryOverflow;
+
+    _catch: return result;
+}
+
+
+M3Result  InitGlobals  (IM3Module io_module)
+{
+    M3Result result = m3Err_none;
+
+    if (io_module->numGlobals)
+    {
+        // placing the globals in their structs isn't good for cache locality, but i don't really know what the global
+        // access patterns typically look like yet.
+
+        //          io_module->globalMemory = m3Alloc (m3reg_t, io_module->numGlobals);
+
+        //          if (io_module->globalMemory)
+        {
+            for (u32 i = 0; i < io_module->numGlobals; ++i)
+            {
+                M3Global * g = & io_module->globals [i];                        m3log (runtime, "initializing global: %d", i);
+
+                if (g->initExpr)
+                {
+                    bytes_t start = g->initExpr;
+
+                    result = EvaluateExpression (io_module, & g->i64Value, g->type, & start, g->initExpr + g->initExprSize);
+
+                    if (not result)
+                    {
+                        // io_module->globalMemory [i] = initValue;
+                    }
+                    else break;
+                }
+                else
+                {                                                               m3log (runtime, "importing global");
+
+                }
+            }
+        }
+        //          else result = ErrorModule (m3Err_mallocFailed, io_module, "could allocate globals for module: '%s", io_module->name);
+    }
+
+    return result;
+}
+
+
+M3Result  InitDataSegments  (M3Memory * io_memory, IM3Module io_module)
+{
+    M3Result result = m3Err_none;
+
+    _throwif ("unallocated linear memory", !(io_memory->mallocated));
+
+    for (u32 i = 0; i < io_module->numDataSegments; ++i)
+    {
+        M3DataSegment * segment = & io_module->dataSegments [i];
+
+        i32 segmentOffset;
+        bytes_t start = segment->initExpr;
+_       (EvaluateExpression (io_module, & segmentOffset, c_m3Type_i32, & start, segment->initExpr + segment->initExprSize));
+
+        m3log (runtime, "loading data segment: %d; size: %d; offset: %d", i, segment->size, segmentOffset);
+
+        if (segmentOffset >= 0 && (size_t)(segmentOffset) + segment->size <= io_memory->mallocated->length)
+        {
+            u8 * dest = m3MemData (io_memory->mallocated) + segmentOffset;
+            memcpy (dest, segment->data, segment->size);
+        } else {
+            _throw ("data segment out of bounds");
+        }
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  InitElements  (IM3Module io_module)
+{
+    M3Result result = m3Err_none;
+
+    bytes_t bytes = io_module->elementSection;
+    cbytes_t end = io_module->elementSectionEnd;
+
+    for (u32 i = 0; i < io_module->numElementSegments; ++i)
+    {
+        u32 index;
+_       (ReadLEB_u32 (& index, & bytes, end));
+
+        if (index == 0)
+        {
+            i32 offset;
+_           (EvaluateExpression (io_module, & offset, c_m3Type_i32, & bytes, end));
+            _throwif ("table underflow", offset < 0);
+
+            u32 numElements;
+_           (ReadLEB_u32 (& numElements, & bytes, end));
+
+            size_t endElement = (size_t) numElements + offset;
+            _throwif ("table overflow", endElement > d_m3MaxSaneTableSize);
+
+            // is there any requirement that elements must be in increasing sequence?
+            // make sure the table isn't shrunk.
+            if (endElement > io_module->table0Size)
+            {
+                io_module->table0 = m3_ReallocArray (IM3Function, io_module->table0, endElement, io_module->table0Size);
+                io_module->table0Size = (u32) endElement;
+            }
+            _throwifnull(io_module->table0);
+
+            for (u32 e = 0; e < numElements; ++e)
+            {
+                u32 functionIndex;
+_               (ReadLEB_u32 (& functionIndex, & bytes, end));
+                _throwif ("function index out of range", functionIndex >= io_module->numFunctions);
+                IM3Function function = & io_module->functions [functionIndex];      d_m3Assert (function); //printf ("table: %s\n", m3_GetFunctionName(function));
+                io_module->table0 [e + offset] = function;
+            }
+        }
+        else _throw ("element table index must be zero for MVP");
+    }
+
+    _catch: return result;
+}
+
+M3Result  m3_CompileModule  (IM3Module io_module)
+{
+    M3Result result = m3Err_none;
+
+    for (u32 i = 0; i < io_module->numFunctions; ++i)
+    {
+        IM3Function f = & io_module->functions [i];
+        if (f->wasm and not f->compiled)
+        {
+_           (CompileFunction (f));
+        }
+    }
+
+    _catch: return result;
+}
+
+M3Result  m3_RunStart  (IM3Module io_module)
+{
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // Execution disabled for fuzzing builds
+    return m3Err_none;
+#endif
+
+    M3Result result = m3Err_none;
+    i32 startFunctionTmp = -1;
+
+    if (io_module and io_module->startFunction >= 0)
+    {
+        IM3Function function = & io_module->functions [io_module->startFunction];
+
+        if (not function->compiled)
+        {
+_           (CompileFunction (function));
+        }
+
+        IM3FuncType ftype = function->funcType;
+        if (ftype->numArgs != 0 || ftype->numRets != 0)
+            _throw (m3Err_argumentCountMismatch);
+
+        IM3Module module = function->module;
+        IM3Runtime runtime = module->runtime;
+
+        startFunctionTmp = io_module->startFunction;
+        io_module->startFunction = -1;
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+        result = (M3Result) RunCode (function->compiled, (m3stack_t) runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+        result = (M3Result) RunCode (function->compiled, (m3stack_t) runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+
+        if (result)
+        {
+            io_module->startFunction = startFunctionTmp;
+            EXCEPTION_PRINT(result);
+            goto _catch;
+        }
+    }
+
+    _catch: return result;
+}
+
+// TODO: deal with main + side-modules loading efforcement
+M3Result  m3_LoadModule  (IM3Runtime io_runtime, IM3Module io_module)
+{
+    M3Result result = m3Err_none;
+
+    if (M3_UNLIKELY(io_module->runtime)) {
+        return m3Err_moduleAlreadyLinked;
+    }
+
+    io_module->runtime = io_runtime;
+    M3Memory * memory = & io_runtime->memory;
+
+_   (InitMemory (io_runtime, io_module));
+_   (InitGlobals (io_module));
+_   (InitDataSegments (memory, io_module));
+_   (InitElements (io_module));
+
+    // Start func might use imported functions, which are not liked here yet,
+    // so it will be called before a function call is attempted (in m3_FindFunction)
+
+#ifdef DEBUG
+    Module_GenerateNames(io_module);
+#endif
+
+    io_module->next = io_runtime->modules;
+    io_runtime->modules = io_module;
+    return result; // ok
+
+_catch:
+    io_module->runtime = NULL;
+    return result;
+}
+
+IM3Global  m3_FindGlobal  (IM3Module               io_module,
+                           const char * const      i_globalName)
+{
+    // Search exports
+    for (u32 i = 0; i < io_module->numGlobals; ++i)
+    {
+        IM3Global g = & io_module->globals [i];
+        if (g->name and strcmp (g->name, i_globalName) == 0)
+        {
+            return g;
+        }
+    }
+
+    // Search imports
+    for (u32 i = 0; i < io_module->numGlobals; ++i)
+    {
+        IM3Global g = & io_module->globals [i];
+
+        if (g->import.moduleUtf8 and g->import.fieldUtf8)
+        {
+            if (strcmp (g->import.fieldUtf8, i_globalName) == 0)
+            {
+                return g;
+            }
+        }
+    }
+    return NULL;
+}
+
+M3Result  m3_GetGlobal  (IM3Global                 i_global,
+                         IM3TaggedValue            o_value)
+{
+    if (not i_global) return m3Err_globalLookupFailed;
+
+    switch (i_global->type) {
+    case c_m3Type_i32: o_value->value.i32 = i_global->i32Value; break;
+    case c_m3Type_i64: o_value->value.i64 = i_global->i64Value; break;
+# if d_m3HasFloat
+    case c_m3Type_f32: o_value->value.f32 = i_global->f32Value; break;
+    case c_m3Type_f64: o_value->value.f64 = i_global->f64Value; break;
+# endif
+    default: return m3Err_invalidTypeId;
+    }
+
+    o_value->type = (M3ValueType)(i_global->type);
+    return m3Err_none;
+}
+
+M3Result  m3_SetGlobal  (IM3Global                 i_global,
+                         const IM3TaggedValue      i_value)
+{
+    if (not i_global) return m3Err_globalLookupFailed;
+    if (not i_global->isMutable) return m3Err_globalNotMutable;
+    if (i_global->type != i_value->type) return m3Err_globalTypeMismatch;
+
+    switch (i_value->type) {
+    case c_m3Type_i32: i_global->i32Value = i_value->value.i32; break;
+    case c_m3Type_i64: i_global->i64Value = i_value->value.i64; break;
+# if d_m3HasFloat
+    case c_m3Type_f32: i_global->f32Value = i_value->value.f32; break;
+    case c_m3Type_f64: i_global->f64Value = i_value->value.f64; break;
+# endif
+    default: return m3Err_invalidTypeId;
+    }
+
+    return m3Err_none;
+}
+
+M3ValueType  m3_GetGlobalType  (IM3Global          i_global)
+{
+    return (i_global) ? (M3ValueType)(i_global->type) : c_m3Type_none;
+}
+
+
+void *  v_FindFunction  (IM3Module i_module, const char * const i_name)
+{
+
+    // Prefer exported functions
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function f = & i_module->functions [i];
+        if (f->export_name and strcmp (f->export_name, i_name) == 0)
+            return f;
+    }
+
+    // Search internal functions
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function f = & i_module->functions [i];
+
+        bool isImported = f->import.moduleUtf8 or f->import.fieldUtf8;
+
+        if (isImported)
+            continue;
+
+        for (int j = 0; j < f->numNames; j++)
+        {
+            if (f->names [j] and strcmp (f->names [j], i_name) == 0)
+                return f;
+        }
+    }
+
+    return NULL;
+}
+
+
+M3Result  m3_FindFunction  (IM3Function * o_function, IM3Runtime i_runtime, const char * const i_functionName)
+{
+    M3Result result = m3Err_none;                               d_m3Assert (o_function and i_runtime and i_functionName);
+
+    IM3Function function = NULL;
+
+    if (not i_runtime->modules) {
+        _throw ("no modules loaded");
+    }
+
+    function = (IM3Function) ForEachModule (i_runtime, (ModuleVisitor) v_FindFunction, (void *) i_functionName);
+
+    if (function)
+    {
+        if (not function->compiled)
+        {
+_           (CompileFunction (function))
+        }
+    }
+    else _throw (ErrorModule (m3Err_functionLookupFailed, i_runtime->modules, "'%s'", i_functionName));
+
+    _catch:
+    if (result)
+        function = NULL;
+
+    * o_function = function;
+
+    return result;
+}
+
+
+M3Result  m3_GetTableFunction  (IM3Function * o_function, IM3Module i_module, uint32_t i_index)
+{
+_try {
+    if (i_index >= i_module->table0Size)
+    {
+        _throw ("function index out of range");
+    }
+
+    IM3Function function = i_module->table0[i_index];
+
+    if (function)
+    {
+        if (not function->compiled)
+        {
+_           (CompileFunction (function))
+        }
+    }
+
+    * o_function = function;
+}   _catch:
+    return result;
+}
+
+
+static
+M3Result checkStartFunction(IM3Module i_module)
+{
+    M3Result result = m3Err_none;                               d_m3Assert(i_module);
+
+    // Check if start function needs to be called
+    if (i_module->startFunction >= 0)
+    {
+        result = m3_RunStart (i_module);
+    }
+
+    return result;
+}
+
+uint32_t  m3_GetArgCount  (IM3Function i_function)
+{
+    if (i_function) {
+        IM3FuncType ft = i_function->funcType;
+        if (ft) {
+            return ft->numArgs;
+        }
+    }
+    return 0;
+}
+
+uint32_t  m3_GetRetCount  (IM3Function i_function)
+{
+    if (i_function) {
+        IM3FuncType ft = i_function->funcType;
+        if (ft) {
+            return ft->numRets;
+        }
+    }
+    return 0;
+}
+
+
+M3ValueType  m3_GetArgType  (IM3Function i_function, uint32_t index)
+{
+    if (i_function) {
+        IM3FuncType ft = i_function->funcType;
+        if (ft and index < ft->numArgs) {
+            return (M3ValueType)d_FuncArgType(ft, index);
+        }
+    }
+    return c_m3Type_none;
+}
+
+M3ValueType  m3_GetRetType  (IM3Function i_function, uint32_t index)
+{
+    if (i_function) {
+        IM3FuncType ft = i_function->funcType;
+        if (ft and index < ft->numRets) {
+            return (M3ValueType) d_FuncRetType (ft, index);
+        }
+    }
+    return c_m3Type_none;
+}
+
+
+u8 *  GetStackPointerForArgs  (IM3Function i_function)
+{
+    u64 * stack = (u64 *) i_function->module->runtime->stack;
+    IM3FuncType ftype = i_function->funcType;
+
+    stack += ftype->numRets;
+
+    return (u8 *) stack;
+}
+
+
+M3Result  m3_CallV  (IM3Function i_function, ...)
+{
+    va_list ap;
+    va_start(ap, i_function);
+    M3Result r = m3_CallVL(i_function, ap);
+    va_end(ap);
+    return r;
+}
+
+static
+void  ReportNativeStackUsage  ()
+{
+#   if d_m3LogNativeStack
+        int stackUsed =  m3StackGetMax();
+        fprintf (stderr, "Native stack used: %d\n", stackUsed);
+#   endif
+}
+
+
+M3Result  m3_CallVL  (IM3Function i_function, va_list i_args)
+{
+    IM3Runtime runtime = i_function->module->runtime;
+    IM3FuncType ftype = i_function->funcType;
+    M3Result result = m3Err_none;
+    u8* s = NULL;
+
+    if (!i_function->compiled) {
+        return m3Err_missingCompiledCode;
+    }
+
+# if d_m3RecordBacktraces
+    ClearBacktrace (runtime);
+# endif
+
+    m3StackCheckInit();
+
+_   (checkStartFunction(i_function->module))
+
+    s = GetStackPointerForArgs (i_function);
+
+    for (u32 i = 0; i < ftype->numArgs; ++i)
+    {
+        switch (d_FuncArgType(ftype, i)) {
+        case c_m3Type_i32:  *(i32*)(s) = va_arg(i_args, i32);  s += 8; break;
+        case c_m3Type_i64:  *(i64*)(s) = va_arg(i_args, i64);  s += 8; break;
+# if d_m3HasFloat
+        case c_m3Type_f32:  *(f32*)(s) = va_arg(i_args, f64);  s += 8; break; // f32 is passed as f64
+        case c_m3Type_f64:  *(f64*)(s) = va_arg(i_args, f64);  s += 8; break;
+# endif
+        default: return "unknown argument type";
+        }
+    }
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+    ReportNativeStackUsage ();
+
+    runtime->lastCalled = result ? NULL : i_function;
+
+    _catch: return result;
+}
+
+M3Result  m3_Call  (IM3Function i_function, uint32_t i_argc, const void * i_argptrs[])
+{
+    IM3Runtime runtime = i_function->module->runtime;
+    IM3FuncType ftype = i_function->funcType;
+    M3Result result = m3Err_none;
+    u8* s = NULL;
+
+    if (i_argc != ftype->numArgs) {
+        return m3Err_argumentCountMismatch;
+    }
+    if (!i_function->compiled) {
+        return m3Err_missingCompiledCode;
+    }
+
+# if d_m3RecordBacktraces
+    ClearBacktrace (runtime);
+# endif
+
+    m3StackCheckInit();
+
+_   (checkStartFunction(i_function->module))
+
+    s = GetStackPointerForArgs (i_function);
+
+    for (u32 i = 0; i < ftype->numArgs; ++i)
+    {
+        switch (d_FuncArgType(ftype, i)) {
+        case c_m3Type_i32:  *(i32*)(s) = *(i32*)i_argptrs[i];  s += 8; break;
+        case c_m3Type_i64:  *(i64*)(s) = *(i64*)i_argptrs[i];  s += 8; break;
+# if d_m3HasFloat
+        case c_m3Type_f32:  *(f32*)(s) = *(f32*)i_argptrs[i];  s += 8; break;
+        case c_m3Type_f64:  *(f64*)(s) = *(f64*)i_argptrs[i];  s += 8; break;
+# endif
+        default: return "unknown argument type";
+        }
+    }
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+
+    ReportNativeStackUsage ();
+
+    runtime->lastCalled = result ? NULL : i_function;
+
+    _catch: return result;
+}
+
+M3Result  m3_CallArgv  (IM3Function i_function, uint32_t i_argc, const char * i_argv[])
+{
+    IM3FuncType ftype = i_function->funcType;
+    IM3Runtime runtime = i_function->module->runtime;
+    M3Result result = m3Err_none;
+    u8* s = NULL;
+
+    if (i_argc != ftype->numArgs) {
+        return m3Err_argumentCountMismatch;
+    }
+    if (!i_function->compiled) {
+        return m3Err_missingCompiledCode;
+    }
+
+# if d_m3RecordBacktraces
+    ClearBacktrace (runtime);
+# endif
+
+    m3StackCheckInit();
+
+_   (checkStartFunction(i_function->module))
+
+    s = GetStackPointerForArgs (i_function);
+
+    for (u32 i = 0; i < ftype->numArgs; ++i)
+    {
+        switch (d_FuncArgType(ftype, i)) {
+        case c_m3Type_i32:  *(i32*)(s) = strtoul(i_argv[i], NULL, 10);  s += 8; break;
+        case c_m3Type_i64:  *(i64*)(s) = strtoull(i_argv[i], NULL, 10); s += 8; break;
+# if d_m3HasFloat
+        case c_m3Type_f32:  *(f32*)(s) = strtod(i_argv[i], NULL);       s += 8; break;  // strtof would be less portable
+        case c_m3Type_f64:  *(f64*)(s) = strtod(i_argv[i], NULL);       s += 8; break;
+# endif
+        default: return "unknown argument type";
+        }
+    }
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+    
+    ReportNativeStackUsage ();
+
+    runtime->lastCalled = result ? NULL : i_function;
+
+    _catch: return result;
+}
+
+
+//u8 * AlignStackPointerTo64Bits (const u8 * i_stack)
+//{
+//    uintptr_t ptr = (uintptr_t) i_stack;
+//    return (u8 *) ((ptr + 7) & ~7);
+//}
+
+
+M3Result  m3_GetResults  (IM3Function i_function, uint32_t i_retc, const void * o_retptrs[])
+{
+    IM3FuncType ftype = i_function->funcType;
+    IM3Runtime runtime = i_function->module->runtime;
+
+    if (i_retc != ftype->numRets) {
+        return m3Err_argumentCountMismatch;
+    }
+    if (i_function != runtime->lastCalled) {
+        return "function not called";
+    }
+
+    u8* s = (u8*) runtime->stack;
+
+    for (u32 i = 0; i < ftype->numRets; ++i)
+    {
+        switch (d_FuncRetType(ftype, i)) {
+        case c_m3Type_i32:  *(i32*)o_retptrs[i] = *(i32*)(s); s += 8; break;
+        case c_m3Type_i64:  *(i64*)o_retptrs[i] = *(i64*)(s); s += 8; break;
+# if d_m3HasFloat
+        case c_m3Type_f32:  *(f32*)o_retptrs[i] = *(f32*)(s); s += 8; break;
+        case c_m3Type_f64:  *(f64*)o_retptrs[i] = *(f64*)(s); s += 8; break;
+# endif
+        default: return "unknown return type";
+        }
+    }
+    return m3Err_none;
+}
+
+M3Result  m3_GetResultsV  (IM3Function i_function, ...)
+{
+    va_list ap;
+    va_start(ap, i_function);
+    M3Result r = m3_GetResultsVL(i_function, ap);
+    va_end(ap);
+    return r;
+}
+
+M3Result  m3_GetResultsVL  (IM3Function i_function, va_list o_rets)
+{
+    IM3Runtime runtime = i_function->module->runtime;
+    IM3FuncType ftype = i_function->funcType;
+
+    if (i_function != runtime->lastCalled) {
+        return "function not called";
+    }
+
+    u8* s = (u8*) runtime->stack;
+    for (u32 i = 0; i < ftype->numRets; ++i)
+    {
+        switch (d_FuncRetType(ftype, i)) {
+        case c_m3Type_i32:  *va_arg(o_rets, i32*) = *(i32*)(s);  s += 8; break;
+        case c_m3Type_i64:  *va_arg(o_rets, i64*) = *(i64*)(s);  s += 8; break;
+# if d_m3HasFloat
+        case c_m3Type_f32:  *va_arg(o_rets, f32*) = *(f32*)(s);  s += 8; break;
+        case c_m3Type_f64:  *va_arg(o_rets, f64*) = *(f64*)(s);  s += 8; break;
+# endif
+        default: return "unknown argument type";
+        }
+    }
+    return m3Err_none;
+}
+
+void  ReleaseCodePageNoTrack (IM3Runtime i_runtime, IM3CodePage i_codePage)
+{
+    if (i_codePage)
+    {
+        IM3CodePage * list;
+
+        bool pageFull = (NumFreeLines (i_codePage) < d_m3CodePageFreeLinesThreshold);
+        if (pageFull)
+            list = & i_runtime->pagesFull;
+        else
+            list = & i_runtime->pagesOpen;
+
+        PushCodePage (list, i_codePage);                        m3log (emit, "release page: %d to queue: '%s'", i_codePage->info.sequence, pageFull ? "full" : "open")
+    }
+}
+
+
+IM3CodePage  AcquireCodePageWithCapacity  (IM3Runtime i_runtime, u32 i_minLineCount)
+{
+    IM3CodePage page = RemoveCodePageOfCapacity (& i_runtime->pagesOpen, i_minLineCount);
+
+    if (not page)
+    {
+        page = Environment_AcquireCodePage (i_runtime->environment, i_minLineCount);
+
+        if (not page)
+            page = NewCodePage (i_runtime, i_minLineCount);
+
+        if (page)
+            i_runtime->numCodePages++;
+    }
+
+    if (page)
+    {                                                            m3log (emit, "acquire page: %d", page->info.sequence);
+        i_runtime->numActiveCodePages++;
+    }
+
+    return page;
+}
+
+
+IM3CodePage  AcquireCodePage  (IM3Runtime i_runtime)
+{
+    return AcquireCodePageWithCapacity (i_runtime, d_m3CodePageFreeLinesThreshold);
+}
+
+
+void  ReleaseCodePage  (IM3Runtime i_runtime, IM3CodePage i_codePage)
+{
+    if (i_codePage)
+    {
+        ReleaseCodePageNoTrack (i_runtime, i_codePage);
+        i_runtime->numActiveCodePages--;
+
+#       if defined (DEBUG)
+            u32 numOpen = CountCodePages (i_runtime->pagesOpen);
+            u32 numFull = CountCodePages (i_runtime->pagesFull);
+
+            m3log (runtime, "runtime: %p; open-pages: %d; full-pages: %d; active: %d; total: %d", i_runtime, numOpen, numFull, i_runtime->numActiveCodePages, i_runtime->numCodePages);
+
+            d_m3Assert (numOpen + numFull + i_runtime->numActiveCodePages == i_runtime->numCodePages);
+
+#           if d_m3LogCodePages
+                dump_code_page (i_codePage, /* startPC: */ NULL);
+#           endif
+#       endif
+    }
+}
+
+
+#if d_m3VerboseErrorMessages
+M3Result  m3Error  (M3Result i_result, IM3Runtime i_runtime, IM3Module i_module, IM3Function i_function,
+                    const char * const i_file, u32 i_lineNum, const char * const i_errorMessage, ...)
+{
+    if (i_runtime)
+    {
+        i_runtime->error = (M3ErrorInfo){ .result = i_result, .runtime = i_runtime, .module = i_module,
+                                          .function = i_function, .file = i_file, .line = i_lineNum };
+        i_runtime->error.message = i_runtime->error_message;
+
+        va_list args;
+        va_start (args, i_errorMessage);
+        vsnprintf (i_runtime->error_message, sizeof(i_runtime->error_message), i_errorMessage, args);
+        va_end (args);
+    }
+
+    return i_result;
+}
+#endif
+
+
+void  m3_GetErrorInfo  (IM3Runtime i_runtime, M3ErrorInfo* o_info)
+{
+    if (i_runtime)
+    {
+        *o_info = i_runtime->error;
+        m3_ResetErrorInfo (i_runtime);
+    }
+}
+
+
+void m3_ResetErrorInfo (IM3Runtime i_runtime)
+{
+    if (i_runtime)
+    {
+        M3_INIT(i_runtime->error);
+        i_runtime->error.message = "";
+    }
+}
+
+uint8_t *  m3_GetMemory  (IM3Runtime i_runtime, uint32_t * o_memorySizeInBytes, uint32_t i_memoryIndex)
+{
+    uint8_t * memory = NULL;                                                    d_m3Assert (i_memoryIndex == 0);
+
+    if (i_runtime)
+    {
+        u32 size = (u32) i_runtime->memory.mallocated->length;
+
+        if (o_memorySizeInBytes)
+            * o_memorySizeInBytes = size;
+
+        if (size)
+            memory = m3MemData (i_runtime->memory.mallocated);
+    }
+
+    return memory;
+}
+
+
+uint32_t  m3_GetMemorySize  (IM3Runtime i_runtime)
+{
+    return i_runtime->memory.mallocated->length;
+}
+
+
+M3BacktraceInfo *  m3_GetBacktrace  (IM3Runtime i_runtime)
+{
+# if d_m3RecordBacktraces
+    return & i_runtime->backtrace;
+# else
+    return NULL;
+# endif
+}
+

--- a/thirdparty/wasm3/source/m3_env.h
+++ b/thirdparty/wasm3/source/m3_env.h
@@ -1,0 +1,219 @@
+//
+//  m3_env.h
+//
+//  Created by Steven Massey on 4/19/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_env_h
+#define m3_env_h
+
+#include "wasm3.h"
+#include "m3_code.h"
+#include "m3_compile.h"
+
+d_m3BeginExternC
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3MemoryInfo
+{
+    u32     initPages;
+    u32     maxPages;
+    u32     pageSize;
+}
+M3MemoryInfo;
+
+
+typedef struct M3Memory
+{
+    M3MemoryHeader *        mallocated;
+
+    u32                     numPages;
+    u32                     maxPages;
+    u32                     pageSize;
+}
+M3Memory;
+
+typedef M3Memory *          IM3Memory;
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3DataSegment
+{
+    const u8 *              initExpr;           // wasm code
+    const u8 *              data;
+
+    u32                     initExprSize;
+    u32                     memoryRegion;
+    u32                     size;
+}
+M3DataSegment;
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3Global
+{
+    M3ImportInfo            import;
+
+    union
+    {
+        i32 i32Value;
+        i64 i64Value;
+#if d_m3HasFloat
+        f64 f64Value;
+        f32 f32Value;
+#endif
+    };
+
+    cstr_t                  name;
+    bytes_t                 initExpr;       // wasm code
+    u32                     initExprSize;
+    u8                      type;
+    bool                    imported;
+    bool                    isMutable;
+}
+M3Global;
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+typedef struct M3Module
+{
+    struct M3Runtime *      runtime;
+    struct M3Environment *  environment;
+
+    bytes_t                 wasmStart;
+    bytes_t                 wasmEnd;
+
+    cstr_t                  name;
+
+    u32                     numFuncTypes;
+    IM3FuncType *           funcTypes;              // array of pointers to list of FuncTypes
+
+    u32                     numFuncImports;
+    u32                     numFunctions;
+    u32                     allFunctions;           // allocated functions count
+    M3Function *            functions;
+
+    i32                     startFunction;
+
+    u32                     numDataSegments;
+    M3DataSegment *         dataSegments;
+
+    //u32                     importedGlobals;
+    u32                     numGlobals;
+    M3Global *              globals;
+
+    u32                     numElementSegments;
+    bytes_t                 elementSection;
+    bytes_t                 elementSectionEnd;
+
+    IM3Function *           table0;
+    u32                     table0Size;
+    const char*             table0ExportName;
+
+    M3MemoryInfo            memoryInfo;
+    M3ImportInfo            memoryImport;
+    bool                    memoryImported;
+    const char*             memoryExportName;
+
+    //bool                    hasWasmCodeCopy;
+
+    struct M3Module *       next;
+}
+M3Module;
+
+M3Result                    Module_AddGlobal            (IM3Module io_module, IM3Global * o_global, u8 i_type, bool i_mutable, bool i_isImported);
+
+M3Result                    Module_PreallocFunctions    (IM3Module io_module, u32 i_totalFunctions);
+M3Result                    Module_AddFunction          (IM3Module io_module, u32 i_typeIndex, IM3ImportInfo i_importInfo /* can be null */);
+IM3Function                 Module_GetFunction          (IM3Module i_module, u32 i_functionIndex);
+
+void                        Module_GenerateNames        (IM3Module i_module);
+
+void                        FreeImportInfo              (M3ImportInfo * i_info);
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3Environment
+{
+//    struct M3Runtime *      runtimes;
+
+    IM3FuncType             funcTypes;                          // linked list of unique M3FuncType structs that can be compared using pointer-equivalence
+
+    IM3FuncType             retFuncTypes [c_m3Type_unknown];    // these 'point' to elements in the linked list above.
+                                                                // the number of elements must match the basic types as per M3ValueType
+    M3CodePage *            pagesReleased;
+
+    M3SectionHandler        customSectionHandler;
+}
+M3Environment;
+
+void                        Environment_Release         (IM3Environment i_environment);
+
+// takes ownership of io_funcType and returns a pointer to the persistent version (could be same or different)
+void                        Environment_AddFuncType     (IM3Environment i_environment, IM3FuncType * io_funcType);
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3Runtime
+{
+    M3Compilation           compilation;
+
+    IM3Environment          environment;
+
+    M3CodePage *            pagesOpen;      // linked list of code pages with writable space on them
+    M3CodePage *            pagesFull;      // linked list of at-capacity pages
+
+    u32                     numCodePages;
+    u32                     numActiveCodePages;
+
+    IM3Module               modules;        // linked list of imported modules
+
+    void *                  stack;
+    void *                  originStack;
+    u32                     stackSize;
+    u32                     numStackSlots;
+    IM3Function             lastCalled;     // last function that successfully executed
+
+    void *                  userdata;
+
+    M3Memory                memory;
+    u32                     memoryLimit;
+
+#if d_m3EnableStrace >= 2
+    u32                     callDepth;
+#endif
+
+    M3ErrorInfo             error;
+#if d_m3VerboseErrorMessages
+    char                    error_message[256]; // the actual buffer. M3ErrorInfo can point to this
+#endif
+
+#if d_m3RecordBacktraces
+    M3BacktraceInfo         backtrace;
+#endif
+
+	u32						newCodePageSequence;
+}
+M3Runtime;
+
+void                        InitRuntime                 (IM3Runtime io_runtime, u32 i_stackSizeInBytes);
+void                        Runtime_Release             (IM3Runtime io_runtime);
+
+M3Result                    ResizeMemory                (IM3Runtime io_runtime, u32 i_numPages);
+
+typedef void *              (* ModuleVisitor)           (IM3Module i_module, void * i_info);
+void *                      ForEachModule               (IM3Runtime i_runtime, ModuleVisitor i_visitor, void * i_info);
+
+void *                      v_FindFunction              (IM3Module i_module, const char * const i_name);
+
+IM3CodePage                 AcquireCodePage             (IM3Runtime io_runtime);
+IM3CodePage                 AcquireCodePageWithCapacity (IM3Runtime io_runtime, u32 i_lineCount);
+void                        ReleaseCodePage             (IM3Runtime io_runtime, IM3CodePage i_codePage);
+
+d_m3EndExternC
+
+#endif // m3_env_h

--- a/thirdparty/wasm3/source/m3_exception.h
+++ b/thirdparty/wasm3/source/m3_exception.h
@@ -1,0 +1,33 @@
+//
+//  m3_exception.h
+//
+//  Created by Steven Massey on 7/5/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+//  some macros to emulate try/catch
+
+#ifndef m3_exception_h
+#define m3_exception_h
+
+#include "m3_config.h"
+
+# if d_m3EnableExceptionBreakpoint
+
+// declared in m3_info.c
+void ExceptionBreakpoint (cstr_t i_exception, cstr_t i_message);
+
+#   define EXCEPTION_PRINT(ERROR) ExceptionBreakpoint (ERROR, (__FILE__ ":" M3_STR(__LINE__)))
+
+# else
+#   define EXCEPTION_PRINT(...)
+# endif
+
+
+#define _try                                M3Result result = m3Err_none;
+#define _(TRY)                              { result = TRY; if (M3_UNLIKELY(result)) { EXCEPTION_PRINT (result); goto _catch; } }
+#define _throw(ERROR)                       { result = ERROR; EXCEPTION_PRINT (result); goto _catch; }
+#define _throwif(ERROR, COND)               if (M3_UNLIKELY(COND)) { _throw(ERROR); }
+
+#define _throwifnull(PTR)                   _throwif (m3Err_mallocFailed, !(PTR))
+
+#endif // m3_exception_h

--- a/thirdparty/wasm3/source/m3_exec.c
+++ b/thirdparty/wasm3/source/m3_exec.c
@@ -1,0 +1,8 @@
+//
+//  m3_exec.c
+//
+//  Created by Steven Massey on 4/17/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+// EMPTY FOR NOW

--- a/thirdparty/wasm3/source/m3_exec.h
+++ b/thirdparty/wasm3/source/m3_exec.h
@@ -1,0 +1,1527 @@
+//
+//  m3_exec.h
+//
+//  Created by Steven Massey on 4/17/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+
+
+#ifndef m3_exec_h
+#define m3_exec_h
+
+// TODO: all these functions could move over to the .c at some point. normally, I'd say screw it,
+// but it might prove useful to be able to compile m3_exec alone w/ optimizations while the remaining
+// code is at debug O0
+
+
+// About the naming convention of these operations/macros (_rs, _sr_, _ss, _srs, etc.)
+//------------------------------------------------------------------------------------------------------
+//   - 'r' means register and 's' means slot
+//   - the first letter is the top of the stack
+//
+//  so, for example, _rs means the first operand (the first thing pushed to the stack) is in a slot
+//  and the second operand (the top of the stack) is in a register
+//------------------------------------------------------------------------------------------------------
+
+#ifndef M3_COMPILE_OPCODES
+#  error "Opcodes should only be included in one compilation unit"
+#endif
+
+#include "m3_math_utils.h"
+#include "m3_compile.h"
+#include "m3_env.h"
+#include "m3_info.h"
+#include "m3_exec_defs.h"
+
+#include <limits.h>
+
+d_m3BeginExternC
+
+# define rewrite_op(OP)             * ((void **) (_pc-1)) = (void*)(OP)
+
+# define immediate(TYPE)            * ((TYPE *) _pc++)
+# define skip_immediate(TYPE)       (_pc++)
+
+# define slot(TYPE)                 * (TYPE *) (_sp + immediate (i32))
+# define slot_ptr(TYPE)             (TYPE *) (_sp + immediate (i32))
+
+
+# if d_m3EnableOpProfiling
+                                    d_m3RetSig  profileOp   (d_m3OpSig, cstr_t i_operationName);
+#   define nextOp()                 M3_MUSTTAIL return profileOp (d_m3OpAllArgs, __FUNCTION__)
+# elif d_m3EnableOpTracing
+                                    d_m3RetSig  debugOp     (d_m3OpSig, cstr_t i_operationName);
+#   define nextOp()                 M3_MUSTTAIL return debugOp (d_m3OpAllArgs, __FUNCTION__)
+# else
+#   define nextOp()                 nextOpDirect()
+# endif
+
+#define jumpOp(PC)                  jumpOpDirect(PC)
+
+#if d_m3RecordBacktraces
+    #define pushBacktraceFrame()            (PushBacktraceFrame (_mem->runtime, _pc - 1))
+    #define fillBacktraceFrame(FUNCTION)    (FillBacktraceFunctionInfo (_mem->runtime, function))
+
+    #define newTrap(err)                    return (pushBacktraceFrame (), err)
+    #define forwardTrap(err)                return err
+#else
+    #define pushBacktraceFrame()            do {} while (0)
+    #define fillBacktraceFrame(FUNCTION)    do {} while (0)
+
+    #define newTrap(err)                    return err
+    #define forwardTrap(err)                return err
+#endif
+
+
+#if d_m3EnableStrace == 1
+    // Flat trace
+    #define d_m3TracePrepare
+    #define d_m3TracePrint(fmt, ...)            fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+#elif d_m3EnableStrace >= 2
+    // Structured trace
+    #define d_m3TracePrepare                    const IM3Runtime trace_rt = m3MemRuntime(_mem);
+    #define d_m3TracePrint(fmt, ...)            fprintf(stderr, "%*s" fmt "\n", (trace_rt->callDepth)*2, "", ##__VA_ARGS__)
+#else
+    #define d_m3TracePrepare
+    #define d_m3TracePrint(fmt, ...)
+#endif
+
+#if d_m3EnableStrace >= 3
+    #define d_m3TraceLoad(TYPE,offset,val)      d_m3TracePrint("load." #TYPE "  0x%x = %" PRI##TYPE, offset, val)
+    #define d_m3TraceStore(TYPE,offset,val)     d_m3TracePrint("store." #TYPE " 0x%x , %" PRI##TYPE, offset, val)
+#else
+    #define d_m3TraceLoad(TYPE,offset,val)
+    #define d_m3TraceStore(TYPE,offset,val)
+#endif
+
+#ifdef DEBUG
+  #define d_outOfBounds newTrap (ErrorRuntime (m3Err_trapOutOfBoundsMemoryAccess,   \
+                        _mem->runtime, "memory size: %zu; access offset: %zu",      \
+                        _mem->length, operand))
+
+#   define d_outOfBoundsMemOp(OFFSET, SIZE) newTrap (ErrorRuntime (m3Err_trapOutOfBoundsMemoryAccess,   \
+                      _mem->runtime, "memory size: %zu; access offset: %zu; size: %u",     \
+                      _mem->length, OFFSET, SIZE))
+#else
+  #define d_outOfBounds newTrap (m3Err_trapOutOfBoundsMemoryAccess)
+
+#   define d_outOfBoundsMemOp(OFFSET, SIZE) newTrap (m3Err_trapOutOfBoundsMemoryAccess)
+
+#endif
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+d_m3RetSig  Call  (d_m3OpSig, cstr_t i_operationName)
+# else
+d_m3RetSig  Call  (d_m3OpSig)
+# endif
+{
+    m3ret_t possible_trap = m3_Yield ();
+    if (M3_UNLIKELY(possible_trap)) return possible_trap;
+
+    nextOpDirect();
+}
+
+// TODO: OK, this needs some explanation here ;0
+
+#define d_m3CommutativeOpMacro(RES, REG, TYPE, NAME, OP, ...) \
+d_m3Op(TYPE##_##NAME##_rs)                              \
+{                                                       \
+    TYPE operand = slot (TYPE);                         \
+    OP((RES), operand, ((TYPE) REG), ##__VA_ARGS__);    \
+    nextOp ();                                          \
+}                                                       \
+d_m3Op(TYPE##_##NAME##_ss)                              \
+{                                                       \
+    TYPE operand2 = slot (TYPE);                        \
+    TYPE operand1 = slot (TYPE);                        \
+    OP((RES), operand1, operand2, ##__VA_ARGS__);       \
+    nextOp ();                                          \
+}
+
+#define d_m3OpMacro(RES, REG, TYPE, NAME, OP, ...)      \
+d_m3Op(TYPE##_##NAME##_sr)                              \
+{                                                       \
+    TYPE operand = slot (TYPE);                         \
+    OP((RES), ((TYPE) REG), operand, ##__VA_ARGS__);    \
+    nextOp ();                                          \
+}                                                       \
+d_m3CommutativeOpMacro(RES, REG, TYPE,NAME, OP, ##__VA_ARGS__)
+
+// Accept macros
+#define d_m3CommutativeOpMacro_i(TYPE, NAME, MACRO, ...)    d_m3CommutativeOpMacro  ( _r0,  _r0, TYPE, NAME, MACRO, ##__VA_ARGS__)
+#define d_m3OpMacro_i(TYPE, NAME, MACRO, ...)               d_m3OpMacro             ( _r0,  _r0, TYPE, NAME, MACRO, ##__VA_ARGS__)
+#define d_m3CommutativeOpMacro_f(TYPE, NAME, MACRO, ...)    d_m3CommutativeOpMacro  (_fp0, _fp0, TYPE, NAME, MACRO, ##__VA_ARGS__)
+#define d_m3OpMacro_f(TYPE, NAME, MACRO, ...)               d_m3OpMacro             (_fp0, _fp0, TYPE, NAME, MACRO, ##__VA_ARGS__)
+
+#define M3_FUNC(RES, A, B, OP)  (RES) = OP((A), (B))        // Accept functions: res = OP(a,b)
+#define M3_OPER(RES, A, B, OP)  (RES) = ((A) OP (B))        // Accept operators: res = a OP b
+
+#define d_m3CommutativeOpFunc_i(TYPE, NAME, OP)     d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_FUNC, OP)
+#define d_m3OpFunc_i(TYPE, NAME, OP)                d_m3OpMacro_i               (TYPE, NAME, M3_FUNC, OP)
+#define d_m3CommutativeOpFunc_f(TYPE, NAME, OP)     d_m3CommutativeOpMacro_f    (TYPE, NAME, M3_FUNC, OP)
+#define d_m3OpFunc_f(TYPE, NAME, OP)                d_m3OpMacro_f               (TYPE, NAME, M3_FUNC, OP)
+
+#define d_m3CommutativeOp_i(TYPE, NAME, OP)         d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_OPER, OP)
+#define d_m3Op_i(TYPE, NAME, OP)                    d_m3OpMacro_i               (TYPE, NAME, M3_OPER, OP)
+#define d_m3CommutativeOp_f(TYPE, NAME, OP)         d_m3CommutativeOpMacro_f    (TYPE, NAME, M3_OPER, OP)
+#define d_m3Op_f(TYPE, NAME, OP)                    d_m3OpMacro_f               (TYPE, NAME, M3_OPER, OP)
+
+// compare needs to be distinct for fp 'cause the result must be _r0
+#define d_m3CompareOp_f(TYPE, NAME, OP)             d_m3OpMacro                 (_r0, _fp0, TYPE, NAME, M3_OPER, OP)
+#define d_m3CommutativeCmpOp_f(TYPE, NAME, OP)      d_m3CommutativeOpMacro      (_r0, _fp0, TYPE, NAME, M3_OPER, OP)
+
+
+//-----------------------
+
+// signed
+d_m3CommutativeOp_i (i32, Equal,            ==)     d_m3CommutativeOp_i (i64, Equal,            ==)
+d_m3CommutativeOp_i (i32, NotEqual,         !=)     d_m3CommutativeOp_i (i64, NotEqual,         !=)
+
+d_m3Op_i (i32, LessThan,                    < )     d_m3Op_i (i64, LessThan,                    < )
+d_m3Op_i (i32, GreaterThan,                 > )     d_m3Op_i (i64, GreaterThan,                 > )
+d_m3Op_i (i32, LessThanOrEqual,             <=)     d_m3Op_i (i64, LessThanOrEqual,             <=)
+d_m3Op_i (i32, GreaterThanOrEqual,          >=)     d_m3Op_i (i64, GreaterThanOrEqual,          >=)
+
+// unsigned
+d_m3Op_i (u32, LessThan,                    < )     d_m3Op_i (u64, LessThan,                    < )
+d_m3Op_i (u32, GreaterThan,                 > )     d_m3Op_i (u64, GreaterThan,                 > )
+d_m3Op_i (u32, LessThanOrEqual,             <=)     d_m3Op_i (u64, LessThanOrEqual,             <=)
+d_m3Op_i (u32, GreaterThanOrEqual,          >=)     d_m3Op_i (u64, GreaterThanOrEqual,          >=)
+
+#if d_m3HasFloat
+d_m3CommutativeCmpOp_f (f32, Equal,         ==)     d_m3CommutativeCmpOp_f (f64, Equal,         ==)
+d_m3CommutativeCmpOp_f (f32, NotEqual,      !=)     d_m3CommutativeCmpOp_f (f64, NotEqual,      !=)
+d_m3CompareOp_f (f32, LessThan,             < )     d_m3CompareOp_f (f64, LessThan,             < )
+d_m3CompareOp_f (f32, GreaterThan,          > )     d_m3CompareOp_f (f64, GreaterThan,          > )
+d_m3CompareOp_f (f32, LessThanOrEqual,      <=)     d_m3CompareOp_f (f64, LessThanOrEqual,      <=)
+d_m3CompareOp_f (f32, GreaterThanOrEqual,   >=)     d_m3CompareOp_f (f64, GreaterThanOrEqual,   >=)
+#endif
+
+#define OP_ADD_32(A,B) (i32)((u32)(A) + (u32)(B))
+#define OP_ADD_64(A,B) (i64)((u64)(A) + (u64)(B))
+#define OP_SUB_32(A,B) (i32)((u32)(A) - (u32)(B))
+#define OP_SUB_64(A,B) (i64)((u64)(A) - (u64)(B))
+#define OP_MUL_32(A,B) (i32)((u32)(A) * (u32)(B))
+#define OP_MUL_64(A,B) (i64)((u64)(A) * (u64)(B))
+
+d_m3CommutativeOpFunc_i (i32, Add,      OP_ADD_32)  d_m3CommutativeOpFunc_i (i64, Add,      OP_ADD_64)
+d_m3CommutativeOpFunc_i (i32, Multiply, OP_MUL_32)  d_m3CommutativeOpFunc_i (i64, Multiply, OP_MUL_64)
+
+d_m3OpFunc_i (i32, Subtract,            OP_SUB_32)  d_m3OpFunc_i (i64, Subtract,            OP_SUB_64)
+
+#define OP_SHL_32(X,N) ((X) << ((u32)(N) % 32))
+#define OP_SHL_64(X,N) ((X) << ((u64)(N) % 64))
+#define OP_SHR_32(X,N) ((X) >> ((u32)(N) % 32))
+#define OP_SHR_64(X,N) ((X) >> ((u64)(N) % 64))
+
+d_m3OpFunc_i (u32, ShiftLeft,       OP_SHL_32)      d_m3OpFunc_i (u64, ShiftLeft,       OP_SHL_64)
+d_m3OpFunc_i (i32, ShiftRight,      OP_SHR_32)      d_m3OpFunc_i (i64, ShiftRight,      OP_SHR_64)
+d_m3OpFunc_i (u32, ShiftRight,      OP_SHR_32)      d_m3OpFunc_i (u64, ShiftRight,      OP_SHR_64)
+
+d_m3CommutativeOp_i (u32, And,              &)
+d_m3CommutativeOp_i (u32, Or,               |)
+d_m3CommutativeOp_i (u32, Xor,              ^)
+
+d_m3CommutativeOp_i (u64, And,              &)
+d_m3CommutativeOp_i (u64, Or,               |)
+d_m3CommutativeOp_i (u64, Xor,              ^)
+
+#if d_m3HasFloat
+d_m3CommutativeOp_f (f32, Add,              +)      d_m3CommutativeOp_f (f64, Add,              +)
+d_m3CommutativeOp_f (f32, Multiply,         *)      d_m3CommutativeOp_f (f64, Multiply,         *)
+d_m3Op_f (f32, Subtract,                    -)      d_m3Op_f (f64, Subtract,                    -)
+d_m3Op_f (f32, Divide,                      /)      d_m3Op_f (f64, Divide,                      /)
+#endif
+
+d_m3OpFunc_i(u32, Rotl, rotl32)
+d_m3OpFunc_i(u32, Rotr, rotr32)
+d_m3OpFunc_i(u64, Rotl, rotl64)
+d_m3OpFunc_i(u64, Rotr, rotr64)
+
+d_m3OpMacro_i(u32, Divide, OP_DIV_U);
+d_m3OpMacro_i(i32, Divide, OP_DIV_S, INT32_MIN);
+d_m3OpMacro_i(u64, Divide, OP_DIV_U);
+d_m3OpMacro_i(i64, Divide, OP_DIV_S, INT64_MIN);
+
+d_m3OpMacro_i(u32, Remainder, OP_REM_U);
+d_m3OpMacro_i(i32, Remainder, OP_REM_S, INT32_MIN);
+d_m3OpMacro_i(u64, Remainder, OP_REM_U);
+d_m3OpMacro_i(i64, Remainder, OP_REM_S, INT64_MIN);
+
+#if d_m3HasFloat
+d_m3OpFunc_f(f32, Min, min_f32);
+d_m3OpFunc_f(f32, Max, max_f32);
+d_m3OpFunc_f(f64, Min, min_f64);
+d_m3OpFunc_f(f64, Max, max_f64);
+
+d_m3OpFunc_f(f32, CopySign, copysignf);
+d_m3OpFunc_f(f64, CopySign, copysign);
+#endif
+
+// Unary operations
+// Note: This macro follows the principle of d_m3OpMacro
+
+#define d_m3UnaryMacro(RES, REG, TYPE, NAME, OP, ...)   \
+d_m3Op(TYPE##_##NAME##_r)                           \
+{                                                   \
+    OP((RES), (TYPE) REG, ##__VA_ARGS__);           \
+    nextOp ();                                      \
+}                                                   \
+d_m3Op(TYPE##_##NAME##_s)                           \
+{                                                   \
+    TYPE operand = slot (TYPE);                     \
+    OP((RES), operand, ##__VA_ARGS__);              \
+    nextOp ();                                      \
+}
+
+#define M3_UNARY(RES, X, OP) (RES) = OP(X)
+#define d_m3UnaryOp_i(TYPE, NAME, OPERATION)        d_m3UnaryMacro( _r0,  _r0, TYPE, NAME, M3_UNARY, OPERATION)
+#define d_m3UnaryOp_f(TYPE, NAME, OPERATION)        d_m3UnaryMacro(_fp0, _fp0, TYPE, NAME, M3_UNARY, OPERATION)
+
+#if d_m3HasFloat
+d_m3UnaryOp_f (f32, Abs,        fabsf);         d_m3UnaryOp_f (f64, Abs,        fabs);
+d_m3UnaryOp_f (f32, Ceil,       ceilf);         d_m3UnaryOp_f (f64, Ceil,       ceil);
+d_m3UnaryOp_f (f32, Floor,      floorf);        d_m3UnaryOp_f (f64, Floor,      floor);
+d_m3UnaryOp_f (f32, Trunc,      truncf);        d_m3UnaryOp_f (f64, Trunc,      trunc);
+d_m3UnaryOp_f (f32, Sqrt,       sqrtf);         d_m3UnaryOp_f (f64, Sqrt,       sqrt);
+d_m3UnaryOp_f (f32, Nearest,    rintf);         d_m3UnaryOp_f (f64, Nearest,    rint);
+d_m3UnaryOp_f (f32, Negate,     -);             d_m3UnaryOp_f (f64, Negate,     -);
+#endif
+
+#define OP_EQZ(x) ((x) == 0)
+
+d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
+d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
+
+// clz(0), ctz(0) results are undefined for rest platforms, fix it
+#if (defined(__i386__) || defined(__x86_64__)) && !(defined(__AVX2__) || (defined(__ABM__) && defined(__BMI__)))
+    #define OP_CLZ_32(x) (M3_UNLIKELY((x) == 0) ? 32 : __builtin_clz(x))
+    #define OP_CTZ_32(x) (M3_UNLIKELY((x) == 0) ? 32 : __builtin_ctz(x))
+    // for 64-bit instructions branchless approach more preferable
+    #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
+    #define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
+#elif defined(__ppc__) || defined(__ppc64__)
+// PowerPC is defined for __builtin_clz(0) and __builtin_ctz(0).
+// See (https://github.com/aquynh/capstone/blob/master/MathExtras.h#L99)
+    #define OP_CLZ_32(x) __builtin_clz(x)
+    #define OP_CTZ_32(x) __builtin_ctz(x)
+    #define OP_CLZ_64(x) __builtin_clzll(x)
+    #define OP_CTZ_64(x) __builtin_ctzll(x)
+#else
+    #define OP_CLZ_32(x) (M3_UNLIKELY((x) == 0) ? 32 : __builtin_clz(x))
+    #define OP_CTZ_32(x) (M3_UNLIKELY((x) == 0) ? 32 : __builtin_ctz(x))
+    #define OP_CLZ_64(x) (M3_UNLIKELY((x) == 0) ? 64 : __builtin_clzll(x))
+    #define OP_CTZ_64(x) (M3_UNLIKELY((x) == 0) ? 64 : __builtin_ctzll(x))
+#endif
+
+d_m3UnaryOp_i (u32, Clz, OP_CLZ_32)
+d_m3UnaryOp_i (u64, Clz, OP_CLZ_64)
+
+d_m3UnaryOp_i (u32, Ctz, OP_CTZ_32)
+d_m3UnaryOp_i (u64, Ctz, OP_CTZ_64)
+
+d_m3UnaryOp_i (u32, Popcnt, __builtin_popcount)
+d_m3UnaryOp_i (u64, Popcnt, __builtin_popcountll)
+
+#define OP_WRAP_I64(X) ((X) & 0x00000000ffffffff)
+
+d_m3Op(i32_Wrap_i64_r)
+{
+    _r0 = OP_WRAP_I64((i64) _r0);
+    nextOp ();
+}
+
+d_m3Op(i32_Wrap_i64_s)
+{
+    i64 operand = slot (i64);
+    _r0 = OP_WRAP_I64(operand);
+    nextOp ();
+}
+
+// Integer sign extension operations
+#define OP_EXTEND8_S_I32(X)  ((int32_t)(int8_t)(X))
+#define OP_EXTEND16_S_I32(X) ((int32_t)(int16_t)(X))
+#define OP_EXTEND8_S_I64(X)  ((int64_t)(int8_t)(X))
+#define OP_EXTEND16_S_I64(X) ((int64_t)(int16_t)(X))
+#define OP_EXTEND32_S_I64(X) ((int64_t)(int32_t)(X))
+
+d_m3UnaryOp_i (i32, Extend8_s,  OP_EXTEND8_S_I32)
+d_m3UnaryOp_i (i32, Extend16_s, OP_EXTEND16_S_I32)
+d_m3UnaryOp_i (i64, Extend8_s,  OP_EXTEND8_S_I64)
+d_m3UnaryOp_i (i64, Extend16_s, OP_EXTEND16_S_I64)
+d_m3UnaryOp_i (i64, Extend32_s, OP_EXTEND32_S_I64)
+
+#define d_m3TruncMacro(DEST, SRC, TYPE, NAME, FROM, OP, ...)   \
+d_m3Op(TYPE##_##NAME##_##FROM##_r_r)                \
+{                                                   \
+    OP((DEST), (FROM) SRC, ##__VA_ARGS__);          \
+    nextOp ();                                      \
+}                                                   \
+d_m3Op(TYPE##_##NAME##_##FROM##_r_s)                \
+{                                                   \
+    FROM * stack = slot_ptr (FROM);                 \
+    OP((DEST), (* stack), ##__VA_ARGS__);           \
+    nextOp ();                                      \
+}                                                   \
+d_m3Op(TYPE##_##NAME##_##FROM##_s_r)                \
+{                                                   \
+    TYPE * dest = slot_ptr (TYPE);                  \
+    OP((* dest), (FROM) SRC, ##__VA_ARGS__);        \
+    nextOp ();                                      \
+}                                                   \
+d_m3Op(TYPE##_##NAME##_##FROM##_s_s)                \
+{                                                   \
+    FROM * stack = slot_ptr (FROM);                 \
+    TYPE * dest = slot_ptr (TYPE);                  \
+    OP((* dest), (* stack), ##__VA_ARGS__);         \
+    nextOp ();                                      \
+}
+
+#if d_m3HasFloat
+d_m3TruncMacro(_r0, _fp0, i32, Trunc, f32, OP_I32_TRUNC_F32)
+d_m3TruncMacro(_r0, _fp0, u32, Trunc, f32, OP_U32_TRUNC_F32)
+d_m3TruncMacro(_r0, _fp0, i32, Trunc, f64, OP_I32_TRUNC_F64)
+d_m3TruncMacro(_r0, _fp0, u32, Trunc, f64, OP_U32_TRUNC_F64)
+
+d_m3TruncMacro(_r0, _fp0, i64, Trunc, f32, OP_I64_TRUNC_F32)
+d_m3TruncMacro(_r0, _fp0, u64, Trunc, f32, OP_U64_TRUNC_F32)
+d_m3TruncMacro(_r0, _fp0, i64, Trunc, f64, OP_I64_TRUNC_F64)
+d_m3TruncMacro(_r0, _fp0, u64, Trunc, f64, OP_U64_TRUNC_F64)
+
+d_m3TruncMacro(_r0, _fp0, i32, TruncSat, f32, OP_I32_TRUNC_SAT_F32)
+d_m3TruncMacro(_r0, _fp0, u32, TruncSat, f32, OP_U32_TRUNC_SAT_F32)
+d_m3TruncMacro(_r0, _fp0, i32, TruncSat, f64, OP_I32_TRUNC_SAT_F64)
+d_m3TruncMacro(_r0, _fp0, u32, TruncSat, f64, OP_U32_TRUNC_SAT_F64)
+
+d_m3TruncMacro(_r0, _fp0, i64, TruncSat, f32, OP_I64_TRUNC_SAT_F32)
+d_m3TruncMacro(_r0, _fp0, u64, TruncSat, f32, OP_U64_TRUNC_SAT_F32)
+d_m3TruncMacro(_r0, _fp0, i64, TruncSat, f64, OP_I64_TRUNC_SAT_F64)
+d_m3TruncMacro(_r0, _fp0, u64, TruncSat, f64, OP_U64_TRUNC_SAT_F64)
+#endif
+
+#define d_m3TypeModifyOp(REG_TO, REG_FROM, TO, NAME, FROM)  \
+d_m3Op(TO##_##NAME##_##FROM##_r)                            \
+{                                                           \
+    REG_TO = (TO) ((FROM) REG_FROM);                        \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_##NAME##_##FROM##_s)                            \
+{                                                           \
+    FROM from = slot (FROM);                                \
+    REG_TO = (TO) (from);                                   \
+    nextOp ();                                              \
+}
+
+// Int to int
+d_m3TypeModifyOp (_r0, _r0, i64, Extend, i32);
+d_m3TypeModifyOp (_r0, _r0, i64, Extend, u32);
+
+// Float to float
+#if d_m3HasFloat
+d_m3TypeModifyOp (_fp0, _fp0, f32, Demote, f64);
+d_m3TypeModifyOp (_fp0, _fp0, f64, Promote, f32);
+#endif
+
+#define d_m3TypeConvertOp(REG_TO, REG_FROM, TO, NAME, FROM) \
+d_m3Op(TO##_##NAME##_##FROM##_r_r)                          \
+{                                                           \
+    REG_TO = (TO) ((FROM) REG_FROM);                        \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_##NAME##_##FROM##_s_r)                          \
+{                                                           \
+    slot (TO) = (TO) ((FROM) REG_FROM);                     \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_##NAME##_##FROM##_r_s)                          \
+{                                                           \
+    FROM from = slot (FROM);                                \
+    REG_TO = (TO) (from);                                   \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_##NAME##_##FROM##_s_s)                          \
+{                                                           \
+    FROM from = slot (FROM);                                \
+    slot (TO) = (TO) (from);                                \
+    nextOp ();                                              \
+}
+
+// Int to float
+#if d_m3HasFloat
+d_m3TypeConvertOp (_fp0, _r0, f64, Convert, i32);
+d_m3TypeConvertOp (_fp0, _r0, f64, Convert, u32);
+d_m3TypeConvertOp (_fp0, _r0, f64, Convert, i64);
+d_m3TypeConvertOp (_fp0, _r0, f64, Convert, u64);
+
+d_m3TypeConvertOp (_fp0, _r0, f32, Convert, i32);
+d_m3TypeConvertOp (_fp0, _r0, f32, Convert, u32);
+d_m3TypeConvertOp (_fp0, _r0, f32, Convert, i64);
+d_m3TypeConvertOp (_fp0, _r0, f32, Convert, u64);
+#endif
+
+#define d_m3ReinterpretOp(REG, TO, SRC, FROM)               \
+d_m3Op(TO##_Reinterpret_##FROM##_r_r)                       \
+{                                                           \
+    union { FROM c; TO t; } u;                              \
+    u.c = (FROM) SRC;                                       \
+    REG = u.t;                                              \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_Reinterpret_##FROM##_r_s)                       \
+{                                                           \
+    union { FROM c; TO t; } u;                              \
+    u.c = slot (FROM);                                      \
+    REG = u.t;                                              \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_Reinterpret_##FROM##_s_r)                       \
+{                                                           \
+    union { FROM c; TO t; } u;                              \
+    u.c = (FROM) SRC;                                       \
+    slot (TO) = u.t;                                        \
+    nextOp ();                                              \
+}                                                           \
+                                                            \
+d_m3Op(TO##_Reinterpret_##FROM##_s_s)                       \
+{                                                           \
+    union { FROM c; TO t; } u;                              \
+    u.c = slot (FROM);                                      \
+    slot (TO) = u.t;                                        \
+    nextOp ();                                              \
+}
+
+#if d_m3HasFloat
+d_m3ReinterpretOp (_r0, i32, _fp0, f32)
+d_m3ReinterpretOp (_r0, i64, _fp0, f64)
+d_m3ReinterpretOp (_fp0, f32, _r0, i32)
+d_m3ReinterpretOp (_fp0, f64, _r0, i64)
+#endif
+
+
+d_m3Op  (GetGlobal_s32)
+{
+    u32 * global = immediate (u32 *);
+    slot (u32) = * global;                        //  printf ("get global: %p %" PRIi64 "\n", global, *global);
+
+    nextOp ();
+}
+
+
+d_m3Op  (GetGlobal_s64)
+{
+    u64 * global = immediate (u64 *);
+    slot (u64) = * global;                        // printf ("get global: %p %" PRIi64 "\n", global, *global);
+
+    nextOp ();
+}
+
+
+d_m3Op  (SetGlobal_i32)
+{
+    u32 * global = immediate (u32 *);
+    * global = (u32) _r0;                         //  printf ("set global: %p %" PRIi64 "\n", global, _r0);
+
+    nextOp ();
+}
+
+
+d_m3Op  (SetGlobal_i64)
+{
+    u64 * global = immediate (u64 *);
+    * global = (u64) _r0;                         //  printf ("set global: %p %" PRIi64 "\n", global, _r0);
+
+    nextOp ();
+}
+
+
+d_m3Op  (Call)
+{
+    pc_t callPC                 = immediate (pc_t);
+    i32 stackOffset             = immediate (i32);
+    IM3Memory memory            = m3MemInfo (_mem);
+
+    m3stack_t sp = _sp + stackOffset;
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+    m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
+# endif
+
+    _mem = memory->mallocated;
+
+    if (M3_LIKELY(not r))
+        nextOp ();
+    else
+    {
+        pushBacktraceFrame ();
+        forwardTrap (r);
+    }
+}
+
+
+d_m3Op  (CallIndirect)
+{
+    u32 tableIndex              = slot (u32);
+    IM3Module module            = immediate (IM3Module);
+    IM3FuncType type            = immediate (IM3FuncType);
+    i32 stackOffset             = immediate (i32);
+    IM3Memory memory            = m3MemInfo (_mem);
+
+    m3stack_t sp = _sp + stackOffset;
+
+    m3ret_t r = m3Err_none;
+
+    if (M3_LIKELY(tableIndex < module->table0Size))
+    {
+        IM3Function function = module->table0 [tableIndex];
+
+        if (M3_LIKELY(function))
+        {
+            if (M3_LIKELY(type == function->funcType))
+            {
+                if (M3_UNLIKELY(not function->compiled))
+                    r = CompileFunction (function);
+
+                if (M3_LIKELY(not r))
+                {
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+                    r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
+                    r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
+# endif
+
+                    _mem = memory->mallocated;
+
+                    if (M3_LIKELY(not r))
+                        nextOpDirect ();
+                    else
+                    {
+                        pushBacktraceFrame ();
+                        forwardTrap (r);
+                    }
+                }
+            }
+            else r = m3Err_trapIndirectCallTypeMismatch;
+        }
+        else r = m3Err_trapTableElementIsNull;
+    }
+    else r = m3Err_trapTableIndexOutOfRange;
+
+    if (M3_UNLIKELY(r))
+        newTrap (r);
+    else forwardTrap (r);
+}
+
+
+d_m3Op  (CallRawFunction)
+{
+    d_m3TracePrepare
+
+    M3ImportContext ctx;
+
+    M3RawCall call = (M3RawCall) (* _pc++);
+    ctx.function = immediate (IM3Function);
+    ctx.userdata = immediate (void *);
+    u64* const sp = ((u64*)_sp);
+    IM3Memory memory = m3MemInfo (_mem);
+
+    IM3Runtime runtime = m3MemRuntime(_mem);
+
+#if d_m3EnableStrace
+    IM3FuncType ftype = ctx.function->funcType;
+
+    FILE* out = stderr;
+    char outbuff[1024];
+    char* outp = outbuff;
+    char* oute = outbuff+1024;
+
+    outp += snprintf(outp, oute-outp, "%s!%s(", ctx.function->import.moduleUtf8, ctx.function->import.fieldUtf8);
+
+    const int nArgs = ftype->numArgs;
+    const int nRets = ftype->numRets;
+    u64 * args = sp + nRets;
+    for (int i=0; i<nArgs; i++) {
+        const int type = ftype->types[nRets + i];
+        switch (type) {
+        case c_m3Type_i32:  outp += snprintf(outp, oute-outp, "%" PRIi32, *(i32*)(args+i)); break;
+        case c_m3Type_i64:  outp += snprintf(outp, oute-outp, "%" PRIi64, *(i64*)(args+i)); break;
+        case c_m3Type_f32:  outp += snprintf(outp, oute-outp, "%" PRIf32, *(f32*)(args+i)); break;
+        case c_m3Type_f64:  outp += snprintf(outp, oute-outp, "%" PRIf64, *(f64*)(args+i)); break;
+        default:            outp += snprintf(outp, oute-outp, "<type %d>", type);         break;
+        }
+        outp += snprintf(outp, oute-outp, (i < nArgs-1) ? ", " : ")");
+    }
+# if d_m3EnableStrace >= 2
+    outp += snprintf(outp, oute-outp, " { <native> }");
+# endif
+#endif
+
+    // m3_Call uses runtime->stack to set-up initial exported function stack.
+    // Reconfigure the stack to enable recursive invocations of m3_Call.
+    // I.e. exported/table function can be called from an impoted function.
+    void* stack_backup = runtime->stack;
+    runtime->stack = sp;
+    m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
+    runtime->stack = stack_backup;
+
+#if d_m3EnableStrace
+    if (M3_UNLIKELY(possible_trap)) {
+        d_m3TracePrint("%s -> %s", outbuff, (char*)possible_trap);
+    } else {
+        switch (GetSingleRetType(ftype)) {
+        case c_m3Type_none: d_m3TracePrint("%s", outbuff); break;
+        case c_m3Type_i32:  d_m3TracePrint("%s = %" PRIi32, outbuff, *(i32*)sp); break;
+        case c_m3Type_i64:  d_m3TracePrint("%s = %" PRIi64, outbuff, *(i64*)sp); break;
+        case c_m3Type_f32:  d_m3TracePrint("%s = %" PRIf32, outbuff, *(f32*)sp); break;
+        case c_m3Type_f64:  d_m3TracePrint("%s = %" PRIf64, outbuff, *(f64*)sp); break;
+        }
+    }
+#endif
+
+    if (M3_UNLIKELY(possible_trap)) {
+        _mem = memory->mallocated;
+        pushBacktraceFrame ();
+    }
+    forwardTrap (possible_trap);
+}
+
+
+d_m3Op  (MemSize)
+{
+    IM3Memory memory            = m3MemInfo (_mem);
+
+    _r0 = memory->numPages;
+
+    nextOp ();
+}
+
+
+d_m3Op  (MemGrow)
+{
+    IM3Runtime runtime          = m3MemRuntime(_mem);
+    IM3Memory memory            = & runtime->memory;
+
+    i32 numPagesToGrow = _r0;
+    if (numPagesToGrow >= 0) {
+        _r0 = memory->numPages;
+
+        if (M3_LIKELY(numPagesToGrow))
+        {
+            u32 requiredPages = memory->numPages + numPagesToGrow;
+
+            M3Result r = ResizeMemory (runtime, requiredPages);
+            if (r)
+                _r0 = -1;
+
+            _mem = memory->mallocated;
+        }
+    }
+    else
+    {
+        _r0 = -1;
+    }
+
+    nextOp ();
+}
+
+
+d_m3Op  (MemCopy)
+{
+    u32 size = (u32) _r0;
+    u64 source = slot (u32);
+    u64 destination = slot (u32);
+
+    if (M3_LIKELY(destination + size <= _mem->length))
+    {
+        if (M3_LIKELY(source + size <= _mem->length))
+        {
+            u8 * dst = m3MemData (_mem) + destination;
+            u8 * src = m3MemData (_mem) + source;
+            memmove (dst, src, size);
+
+            nextOp ();
+        }
+        else d_outOfBoundsMemOp (source, size);
+    }
+    else d_outOfBoundsMemOp (destination, size);
+}
+
+
+d_m3Op  (MemFill)
+{
+    u32 size = (u32) _r0;
+    u32 byte = slot (u32);
+    u64 destination = slot (u32);
+
+    if (M3_LIKELY(destination + size <= _mem->length))
+    {
+        u8 * mem8 = m3MemData (_mem) + destination;
+        memset (mem8, (u8) byte, size);
+        nextOp ();
+    }
+    else d_outOfBoundsMemOp (destination, size);
+}
+
+
+// it's a debate: should the compilation be trigger be the caller or callee page.
+// it's a much easier to put it in the caller pager. if it's in the callee, either the entire page
+// has be left dangling or it's just a stub that jumps to a newly acquired page.  In Gestalt, I opted
+// for the stub approach. Stubbing makes it easier to dynamically free the compilation. You can also
+// do both.
+d_m3Op  (Compile)
+{
+    rewrite_op (op_Call);
+
+    IM3Function function        = immediate (IM3Function);
+
+    m3ret_t result = m3Err_none;
+
+    if (M3_UNLIKELY(not function->compiled)) // check to see if function was compiled since this operation was emitted.
+        result = CompileFunction (function);
+
+    if (not result)
+    {
+        // patch up compiled pc and call rewritten op_Call
+        * ((void**) --_pc) = (void*) (function->compiled);
+        --_pc;
+        nextOpDirect ();
+    }
+
+    newTrap (result);
+}
+
+
+
+d_m3Op  (Entry)
+{
+    d_m3ClearRegisters
+
+    d_m3TracePrepare
+
+    IM3Function function = immediate (IM3Function);
+    IM3Memory memory = m3MemInfo (_mem);
+
+#if d_m3SkipStackCheck
+    if (true)
+#else
+    if (M3_LIKELY ((void *) (_sp + function->maxStackSlots) < _mem->maxStack))
+#endif
+    {
+#if defined(DEBUG)
+        function->hits++;
+#endif
+        u8 * stack = (u8 *) ((m3slot_t *) _sp + function->numRetAndArgSlots);
+
+        memset (stack, 0x0, function->numLocalBytes);
+        stack += function->numLocalBytes;
+
+        if (function->constants)
+        {
+            memcpy (stack, function->constants, function->numConstantBytes);
+        }
+
+#if d_m3EnableStrace >= 2
+        d_m3TracePrint("%s %s {", m3_GetFunctionName(function), SPrintFunctionArgList (function, _sp + function->numRetSlots));
+        trace_rt->callDepth++;
+#endif
+
+        m3ret_t r = nextOpImpl ();
+
+#if d_m3EnableStrace >= 2
+        trace_rt->callDepth--;
+
+        if (r) {
+            d_m3TracePrint("} !trap = %s", (char*)r);
+        } else {
+            int rettype = GetSingleRetType(function->funcType);
+            if (rettype != c_m3Type_none) {
+                char str [128] = { 0 };
+                SPrintArg (str, 127, _sp, rettype);
+                d_m3TracePrint("} = %s", str);
+            } else {
+                d_m3TracePrint("}");
+            }
+        }
+#endif
+
+        if (M3_UNLIKELY(r)) {
+            _mem = memory->mallocated;
+            fillBacktraceFrame ();
+        }
+        forwardTrap (r);
+    }
+    else newTrap (m3Err_trapStackOverflow);
+}
+
+
+d_m3Op  (Loop)
+{
+    d_m3TracePrepare
+
+    // regs are unused coming into a loop anyway
+    // this reduces code size & stack usage
+    d_m3ClearRegisters
+
+    m3ret_t r;
+
+    IM3Memory memory = m3MemInfo (_mem);
+
+    do
+    {
+#if d_m3EnableStrace >= 3
+        d_m3TracePrint("iter {");
+        trace_rt->callDepth++;
+#endif
+        r = nextOpImpl ();
+
+#if d_m3EnableStrace >= 3
+        trace_rt->callDepth--;
+        d_m3TracePrint("}");
+#endif
+        // linear memory pointer needs refreshed here because the block it's looping over
+        // can potentially invoke the grow operation.
+        _mem = memory->mallocated;
+    }
+    while (r == _pc);
+
+    forwardTrap (r);
+}
+
+
+d_m3Op  (Branch)
+{
+    jumpOp (* _pc);
+}
+
+
+d_m3Op  (If_r)
+{
+    i32 condition = (i32) _r0;
+
+    pc_t elsePC = immediate (pc_t);
+
+    if (condition)
+        nextOp ();
+    else
+        jumpOp (elsePC);
+}
+
+
+d_m3Op  (If_s)
+{
+    i32 condition = slot (i32);
+
+    pc_t elsePC = immediate (pc_t);
+
+    if (condition)
+        nextOp ();
+    else
+        jumpOp (elsePC);
+}
+
+
+d_m3Op  (BranchTable)
+{
+    u32 branchIndex = slot (u32);           // branch index is always in a slot
+    u32 numTargets  = immediate (u32);
+
+    pc_t * branches = (pc_t *) _pc;
+
+    if (branchIndex > numTargets)
+        branchIndex = numTargets; // the default index
+
+    jumpOp (branches [branchIndex]);
+}
+
+
+#define d_m3SetRegisterSetSlot(TYPE, REG) \
+d_m3Op  (SetRegister_##TYPE)            \
+{                                       \
+    REG = slot (TYPE);                  \
+    nextOp ();                          \
+}                                       \
+                                        \
+d_m3Op (SetSlot_##TYPE)                 \
+{                                       \
+    slot (TYPE) = (TYPE) REG;           \
+    nextOp ();                          \
+}                                       \
+                                        \
+d_m3Op (PreserveSetSlot_##TYPE)         \
+{                                       \
+    TYPE * stack     = slot_ptr (TYPE); \
+    TYPE * preserve  = slot_ptr (TYPE); \
+                                        \
+    * preserve = * stack;               \
+    * stack = (TYPE) REG;               \
+                                        \
+    nextOp ();                          \
+}
+
+d_m3SetRegisterSetSlot (i32, _r0)
+d_m3SetRegisterSetSlot (i64, _r0)
+#if d_m3HasFloat
+d_m3SetRegisterSetSlot (f32, _fp0)
+d_m3SetRegisterSetSlot (f64, _fp0)
+#endif
+
+d_m3Op (CopySlot_32)
+{
+    u32 * dst = slot_ptr (u32);
+    u32 * src = slot_ptr (u32);
+
+    * dst = * src;
+
+    nextOp ();
+}
+
+
+d_m3Op (PreserveCopySlot_32)
+{
+    u32 * dest      = slot_ptr (u32);
+    u32 * src       = slot_ptr (u32);
+    u32 * preserve  = slot_ptr (u32);
+
+    * preserve = * dest;
+    * dest = * src;
+
+    nextOp ();
+}
+
+
+d_m3Op (CopySlot_64)
+{
+    u64 * dst = slot_ptr (u64);
+    u64 * src = slot_ptr (u64);
+
+    * dst = * src;                  // printf ("copy: %p <- %" PRIi64 " <- %p\n", dst, * dst, src);
+
+    nextOp ();
+}
+
+
+d_m3Op (PreserveCopySlot_64)
+{
+    u64 * dest      = slot_ptr (u64);
+    u64 * src       = slot_ptr (u64);
+    u64 * preserve  = slot_ptr (u64);
+
+    * preserve = * dest;
+    * dest = * src;
+
+    nextOp ();
+}
+
+
+#if d_m3EnableOpTracing
+//--------------------------------------------------------------------------------------------------------
+d_m3Op  (DumpStack)
+{
+    u32 opcodeIndex         = immediate (u32);
+    u32 stackHeight         = immediate (u32);
+    IM3Function function    = immediate (IM3Function);
+
+    cstr_t funcName = (function) ? m3_GetFunctionName(function) : "";
+
+    printf (" %4d ", opcodeIndex);
+    printf (" %-25s     r0: 0x%016" PRIx64 "  i:%" PRIi64 "  u:%" PRIu64 "\n", funcName, _r0, _r0, _r0);
+#if d_m3HasFloat
+    printf ("                                    fp0: %" PRIf64 "\n", _fp0);
+#endif
+    m3stack_t sp = _sp;
+
+    for (u32 i = 0; i < stackHeight; ++i)
+    {
+        cstr_t kind = "";
+
+        printf ("%p  %5s  %2d: 0x%" PRIx64 "  i:%" PRIi64 "\n", sp, kind, i, (u64) *(sp), (i64) *(sp));
+
+        ++sp;
+    }
+    printf ("---------------------------------------------------------------------------------------------------------\n");
+
+    nextOpDirect();
+}
+#endif
+
+
+#define d_m3Select_i(TYPE, REG)                 \
+d_m3Op  (Select_##TYPE##_rss)                   \
+{                                               \
+    i32 condition = (i32) _r0;                  \
+                                                \
+    TYPE operand2 = slot (TYPE);                \
+    TYPE operand1 = slot (TYPE);                \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}                                               \
+                                                \
+d_m3Op  (Select_##TYPE##_srs)                   \
+{                                               \
+    i32 condition = slot (i32);                 \
+                                                \
+    TYPE operand2 = (TYPE) REG;                 \
+    TYPE operand1 = slot (TYPE);                \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}                                               \
+                                                \
+d_m3Op  (Select_##TYPE##_ssr)                   \
+{                                               \
+    i32 condition = slot (i32);                 \
+                                                \
+    TYPE operand2 = slot (TYPE);                \
+    TYPE operand1 = (TYPE) REG;                 \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}                                               \
+                                                \
+d_m3Op  (Select_##TYPE##_sss)                   \
+{                                               \
+    i32 condition = slot (i32);                 \
+                                                \
+    TYPE operand2 = slot (TYPE);                \
+    TYPE operand1 = slot (TYPE);                \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}
+
+
+d_m3Select_i (i32, _r0)
+d_m3Select_i (i64, _r0)
+
+
+#define d_m3Select_f(TYPE, REG, LABEL, SELECTOR)  \
+d_m3Op  (Select_##TYPE##_##LABEL##ss)           \
+{                                               \
+    i32 condition = (i32) SELECTOR;             \
+                                                \
+    TYPE operand2 = slot (TYPE);                \
+    TYPE operand1 = slot (TYPE);                \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}                                               \
+                                                \
+d_m3Op  (Select_##TYPE##_##LABEL##rs)           \
+{                                               \
+    i32 condition = (i32) SELECTOR;             \
+                                                \
+    TYPE operand2 = (TYPE) REG;                 \
+    TYPE operand1 = slot (TYPE);                \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}                                               \
+                                                \
+d_m3Op  (Select_##TYPE##_##LABEL##sr)           \
+{                                               \
+    i32 condition = (i32) SELECTOR;             \
+                                                \
+    TYPE operand2 = slot (TYPE);                \
+    TYPE operand1 = (TYPE) REG;                 \
+                                                \
+    REG = (condition) ? operand1 : operand2;    \
+                                                \
+    nextOp ();                                  \
+}
+
+#if d_m3HasFloat
+d_m3Select_f (f32, _fp0, r, _r0)
+d_m3Select_f (f32, _fp0, s, slot (i32))
+
+d_m3Select_f (f64, _fp0, r, _r0)
+d_m3Select_f (f64, _fp0, s, slot (i32))
+#endif
+
+d_m3Op  (Return)
+{
+    m3StackCheck();
+    return m3Err_none;
+}
+
+
+d_m3Op  (BranchIf_r)
+{
+    i32 condition   = (i32) _r0;
+    pc_t branch     = immediate (pc_t);
+
+    if (condition)
+    {
+        jumpOp (branch);
+    }
+    else nextOp ();
+}
+
+
+d_m3Op  (BranchIf_s)
+{
+    i32 condition   = slot (i32);
+    pc_t branch     = immediate (pc_t);
+
+    if (condition)
+    {
+        jumpOp (branch);
+    }
+    else nextOp ();
+}
+
+
+d_m3Op  (BranchIfPrologue_r)
+{
+    i32 condition   = (i32) _r0;
+    pc_t branch     = immediate (pc_t);
+
+    if (condition)
+    {
+        // this is the "prologue" that ends with
+        // a plain branch to the actual target
+        nextOp ();
+    }
+    else jumpOp (branch); // jump over the prologue
+}
+
+
+d_m3Op  (BranchIfPrologue_s)
+{
+    i32 condition   = slot (i32);
+    pc_t branch     = immediate (pc_t);
+
+    if (condition)
+    {
+        nextOp ();
+    }
+    else jumpOp (branch);
+}
+
+
+d_m3Op  (ContinueLoop)
+{
+    m3StackCheck();
+
+    // TODO: this is where execution can "escape" the M3 code and callback to the client / fiber switch
+    // OR it can go in the Loop operation. I think it's best to do here. adding code to the loop operation
+    // has the potential to increase its native-stack usage. (don't forget ContinueLoopIf too.)
+
+    void * loopId = immediate (void *);
+    return loopId;
+}
+
+
+d_m3Op  (ContinueLoopIf)
+{
+    i32 condition = (i32) _r0;
+    void * loopId = immediate (void *);
+
+    if (condition)
+    {
+        return loopId;
+    }
+    else nextOp ();
+}
+
+
+d_m3Op  (Const32)
+{
+    u32 value = * (u32 *)_pc++;
+    slot (u32) = value;
+    nextOp ();
+}
+
+
+d_m3Op  (Const64)
+{
+    u64 value = * (u64 *)_pc;
+    _pc += (M3_SIZEOF_PTR == 4) ? 2 : 1;
+    slot (u64) = value;
+    nextOp ();
+}
+
+d_m3Op  (Unsupported)
+{
+    newTrap ("unsupported instruction executed");
+}
+
+d_m3Op  (Unreachable)
+{
+    m3StackCheck();
+    newTrap (m3Err_trapUnreachable);
+}
+
+
+d_m3Op  (End)
+{
+    m3StackCheck();
+    return m3Err_none;
+}
+
+
+d_m3Op  (SetGlobal_s32)
+{
+    u32 * global = immediate (u32 *);
+    * global = slot (u32);
+
+    nextOp ();
+}
+
+
+d_m3Op  (SetGlobal_s64)
+{
+    u64 * global = immediate (u64 *);
+    * global = slot (u64);
+
+    nextOp ();
+}
+
+#if d_m3HasFloat
+d_m3Op  (SetGlobal_f32)
+{
+    f32 * global = immediate (f32 *);
+    * global = _fp0;
+
+    nextOp ();
+}
+
+
+d_m3Op  (SetGlobal_f64)
+{
+    f64 * global = immediate (f64 *);
+    * global = _fp0;
+
+    nextOp ();
+}
+#endif
+
+
+#if d_m3SkipMemoryBoundsCheck
+#  define m3MemCheck(x) true
+#else
+#  define m3MemCheck(x) M3_LIKELY(x)
+#endif
+
+// memcpy here is to support non-aligned access on some platforms.
+
+#define d_m3Load(REG,DEST_TYPE,SRC_TYPE)                \
+d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_r)                 \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u32 offset = immediate (u32);                       \
+    u64 operand = (u32) _r0;                            \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (SRC_TYPE) <= _mem->length     \
+    )) {                                                \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + operand;       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            M3_BSWAP_##SRC_TYPE(value);                 \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_s)                 \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (SRC_TYPE) <= _mem->length     \
+    )) {                                                \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + operand;       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            M3_BSWAP_##SRC_TYPE(value);                 \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+
+//  printf ("get: %d -> %d\n", operand + offset, (i64) REG);
+
+
+#define d_m3Load_i(DEST_TYPE, SRC_TYPE) d_m3Load(_r0, DEST_TYPE, SRC_TYPE)
+#define d_m3Load_f(DEST_TYPE, SRC_TYPE) d_m3Load(_fp0, DEST_TYPE, SRC_TYPE)
+
+#if d_m3HasFloat
+d_m3Load_f (f32, f32);
+d_m3Load_f (f64, f64);
+#endif
+
+d_m3Load_i (i32, i8);
+d_m3Load_i (i32, u8);
+d_m3Load_i (i32, i16);
+d_m3Load_i (i32, u16);
+d_m3Load_i (i32, i32);
+
+d_m3Load_i (i64, i8);
+d_m3Load_i (i64, u8);
+d_m3Load_i (i64, i16);
+d_m3Load_i (i64, u16);
+d_m3Load_i (i64, i32);
+d_m3Load_i (i64, u32);
+d_m3Load_i (i64, i64);
+
+#define d_m3Store(REG, SRC_TYPE, DEST_TYPE)             \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_rs)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, REG);     \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) REG;            \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_sr)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    const SRC_TYPE value = slot (SRC_TYPE);             \
+    u64 operand = (u32) _r0;                            \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_ss)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    const SRC_TYPE value = slot (SRC_TYPE);             \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+
+// both operands can be in regs when storing a float
+#define d_m3StoreFp(REG, TYPE)                          \
+d_m3Op  (TYPE##_Store_##TYPE##_rr)                      \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = (u32) _r0;                            \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (TYPE) <= _mem->length         \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(TYPE, operand, REG);         \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            TYPE val = (TYPE) REG;                      \
+            M3_BSWAP_##TYPE(val);                       \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+
+
+#define d_m3Store_i(SRC_TYPE, DEST_TYPE) d_m3Store(_r0, SRC_TYPE, DEST_TYPE)
+#define d_m3Store_f(SRC_TYPE, DEST_TYPE) d_m3Store(_fp0, SRC_TYPE, DEST_TYPE) d_m3StoreFp (_fp0, SRC_TYPE);
+
+#if d_m3HasFloat
+d_m3Store_f (f32, f32)
+d_m3Store_f (f64, f64)
+#endif
+
+d_m3Store_i (i32, u8)
+d_m3Store_i (i32, i16)
+d_m3Store_i (i32, i32)
+
+d_m3Store_i (i64, u8)
+d_m3Store_i (i64, i16)
+d_m3Store_i (i64, i32)
+d_m3Store_i (i64, i64)
+
+#undef m3MemCheck
+
+
+//---------------------------------------------------------------------------------------------------------------------
+// debug/profiling
+//---------------------------------------------------------------------------------------------------------------------
+#if d_m3EnableOpTracing
+d_m3RetSig  debugOp  (d_m3OpSig, cstr_t i_opcode)
+{
+    char name [100];
+    strcpy (name, strstr (i_opcode, "op_") + 3);
+    char * bracket = strstr (name, "(");
+    if (bracket) {
+        *bracket  = 0;
+    }
+
+    puts (name);
+    nextOpDirect();
+}
+# endif
+
+# if d_m3EnableOpProfiling
+d_m3RetSig  profileOp  (d_m3OpSig, cstr_t i_operationName)
+{
+    ProfileHit (i_operationName);
+
+    nextOpDirect();
+}
+# endif
+
+d_m3EndExternC
+
+#endif // m3_exec_h

--- a/thirdparty/wasm3/source/m3_exec_defs.h
+++ b/thirdparty/wasm3/source/m3_exec_defs.h
@@ -1,0 +1,76 @@
+//
+//  m3_exec_defs.h
+//
+//  Created by Steven Massey on 5/1/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_exec_defs_h
+#define m3_exec_defs_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+# define m3MemData(mem)                 (u8*)(((M3MemoryHeader*)(mem))+1)
+# define m3MemRuntime(mem)              (((M3MemoryHeader*)(mem))->runtime)
+# define m3MemInfo(mem)                 (&(((M3MemoryHeader*)(mem))->runtime->memory))
+
+# define d_m3BaseOpSig                  pc_t _pc, m3stack_t _sp, M3MemoryHeader * _mem, m3reg_t _r0
+# define d_m3BaseOpArgs                 _sp, _mem, _r0
+# define d_m3BaseOpAllArgs              _pc, _sp, _mem, _r0
+# define d_m3BaseOpDefaultArgs          0
+# define d_m3BaseClearRegisters         _r0 = 0;
+# define d_m3BaseCstr                   ""
+
+# define d_m3ExpOpSig(...)              d_m3BaseOpSig, __VA_ARGS__
+# define d_m3ExpOpArgs(...)             d_m3BaseOpArgs, __VA_ARGS__
+# define d_m3ExpOpAllArgs(...)          d_m3BaseOpAllArgs, __VA_ARGS__
+# define d_m3ExpOpDefaultArgs(...)      d_m3BaseOpDefaultArgs, __VA_ARGS__
+# define d_m3ExpClearRegisters(...)     d_m3BaseClearRegisters; __VA_ARGS__
+
+# if d_m3HasFloat
+#   define d_m3OpSig                d_m3ExpOpSig            (f64 _fp0)
+#   define d_m3OpArgs               d_m3ExpOpArgs           (_fp0)
+#   define d_m3OpAllArgs            d_m3ExpOpAllArgs        (_fp0)
+#   define d_m3OpDefaultArgs        d_m3ExpOpDefaultArgs    (0.)
+#   define d_m3ClearRegisters       d_m3ExpClearRegisters   (_fp0 = 0.;)
+# else
+#   define d_m3OpSig                d_m3BaseOpSig
+#   define d_m3OpArgs               d_m3BaseOpArgs
+#   define d_m3OpAllArgs            d_m3BaseOpAllArgs
+#   define d_m3OpDefaultArgs        d_m3BaseOpDefaultArgs
+#   define d_m3ClearRegisters       d_m3BaseClearRegisters
+# endif
+
+
+#define d_m3RetSig                  static inline m3ret_t vectorcall
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig, cstr_t i_operationName);
+#    define d_m3Op(NAME)                M3_NO_UBSAN d_m3RetSig op_##NAME (d_m3OpSig, cstr_t i_operationName)
+
+#    define nextOpImpl()            ((IM3Operation)(* _pc))(_pc + 1, d_m3OpArgs, __FUNCTION__)
+#    define jumpOpImpl(PC)          ((IM3Operation)(*  PC))( PC + 1, d_m3OpArgs, __FUNCTION__)
+# else
+    typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
+#    define d_m3Op(NAME)                M3_NO_UBSAN d_m3RetSig op_##NAME (d_m3OpSig)
+
+#    define nextOpImpl()            ((IM3Operation)(* _pc))(_pc + 1, d_m3OpArgs)
+#    define jumpOpImpl(PC)          ((IM3Operation)(*  PC))( PC + 1, d_m3OpArgs)
+# endif
+
+#define nextOpDirect()              M3_MUSTTAIL return nextOpImpl()
+#define jumpOpDirect(PC)            M3_MUSTTAIL return jumpOpImpl((pc_t)(PC))
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+d_m3RetSig  RunCode  (d_m3OpSig, cstr_t i_operationName)
+# else
+d_m3RetSig  RunCode  (d_m3OpSig)
+# endif
+{
+    nextOpDirect();
+}
+
+d_m3EndExternC
+
+#endif // m3_exec_defs_h

--- a/thirdparty/wasm3/source/m3_function.c
+++ b/thirdparty/wasm3/source/m3_function.c
@@ -1,0 +1,233 @@
+//
+//  m3_function.c
+//
+//  Created by Steven Massey on 4/7/21.
+//  Copyright © 2021 Steven Massey. All rights reserved.
+//
+
+#include "m3_function.h"
+#include "m3_env.h"
+
+
+M3Result AllocFuncType (IM3FuncType * o_functionType, u32 i_numTypes)
+{
+    *o_functionType = (IM3FuncType) m3_Malloc ("M3FuncType", sizeof (M3FuncType) + i_numTypes);
+    return (*o_functionType) ? m3Err_none : m3Err_mallocFailed;
+}
+
+
+bool  AreFuncTypesEqual  (const IM3FuncType i_typeA, const IM3FuncType i_typeB)
+{
+    if (i_typeA->numRets == i_typeB->numRets && i_typeA->numArgs == i_typeB->numArgs)
+    {
+        return (memcmp (i_typeA->types, i_typeB->types, i_typeA->numRets + i_typeA->numArgs) == 0);
+    }
+
+    return false;
+}
+
+u16  GetFuncTypeNumParams  (const IM3FuncType i_funcType)
+{
+    return i_funcType ? i_funcType->numArgs : 0;
+}
+
+
+u8  GetFuncTypeParamType  (const IM3FuncType i_funcType, u16 i_index)
+{
+    u8 type = c_m3Type_unknown;
+
+    if (i_funcType)
+    {
+        if (i_index < i_funcType->numArgs)
+        {
+            type = i_funcType->types [i_funcType->numRets + i_index];
+        }
+    }
+
+    return type;
+}
+
+
+
+u16  GetFuncTypeNumResults  (const IM3FuncType i_funcType)
+{
+    return i_funcType ? i_funcType->numRets : 0;
+}
+
+
+u8  GetFuncTypeResultType  (const IM3FuncType i_funcType, u16 i_index)
+{
+    u8 type = c_m3Type_unknown;
+
+    if (i_funcType)
+    {
+        if (i_index < i_funcType->numRets)
+        {
+            type = i_funcType->types [i_index];
+        }
+    }
+
+    return type;
+}
+
+
+//---------------------------------------------------------------------------------------------------------------
+
+
+void FreeImportInfo (M3ImportInfo * i_info)
+{
+    m3_Free (i_info->moduleUtf8);
+    m3_Free (i_info->fieldUtf8);
+}
+
+
+void  Function_Release  (IM3Function i_function)
+{
+    m3_Free (i_function->constants);
+
+    for (int i = 0; i < i_function->numNames; i++)
+    {
+        // name can be an alias of fieldUtf8
+        if (i_function->names[i] != i_function->import.fieldUtf8)
+        {
+            m3_Free (i_function->names[i]);
+        }
+    }
+
+    FreeImportInfo (& i_function->import);
+
+    if (i_function->ownsWasmCode)
+        m3_Free (i_function->wasm);
+
+    // Function_FreeCompiledCode (func);
+
+#   if (d_m3EnableCodePageRefCounting)
+    {
+        m3_Free (i_function->codePageRefs);
+        i_function->numCodePageRefs = 0;
+    }
+#   endif
+}
+
+
+void  Function_FreeCompiledCode (IM3Function i_function)
+{
+#   if (d_m3EnableCodePageRefCounting)
+    {
+        i_function->compiled = NULL;
+
+        while (i_function->numCodePageRefs--)
+        {
+            IM3CodePage page = i_function->codePageRefs [i_function->numCodePageRefs];
+
+            if (--(page->info.usageCount) == 0)
+            {
+//                printf ("free %p\n", page);
+            }
+        }
+
+        m3_Free (i_function->codePageRefs);
+
+        Runtime_ReleaseCodePages (i_function->module->runtime);
+    }
+#   endif
+}
+
+
+cstr_t  m3_GetFunctionName  (IM3Function i_function)
+{
+    u16 numNames = 0;
+    cstr_t *names = GetFunctionNames(i_function, &numNames);
+    if (numNames > 0)
+        return names[0];
+    else
+        return "<unnamed>";
+}
+
+
+IM3Module  m3_GetFunctionModule  (IM3Function i_function)
+{
+    return i_function ? i_function->module : NULL;
+}
+
+
+cstr_t *  GetFunctionNames  (IM3Function i_function, u16 * o_numNames)
+{
+    if (!i_function || !o_numNames)
+        return NULL;
+
+    if (i_function->import.fieldUtf8)
+    {
+        *o_numNames = 1;
+        return &i_function->import.fieldUtf8;
+    }
+    else
+    {
+        *o_numNames = i_function->numNames;
+        return i_function->names;
+    }
+}
+
+
+cstr_t  GetFunctionImportModuleName  (IM3Function i_function)
+{
+    return (i_function->import.moduleUtf8) ? i_function->import.moduleUtf8 : "";
+}
+
+
+u16  GetFunctionNumArgs  (IM3Function i_function)
+{
+    u16 numArgs = 0;
+
+    if (i_function)
+    {
+        if (i_function->funcType)
+            numArgs = i_function->funcType->numArgs;
+    }
+
+    return numArgs;
+}
+
+u8  GetFunctionArgType  (IM3Function i_function, u32 i_index)
+{
+    u8 type = c_m3Type_none;
+
+    if (i_index < GetFunctionNumArgs (i_function))
+    {
+        u32 numReturns = i_function->funcType->numRets;
+
+        type = i_function->funcType->types [numReturns + i_index];
+    }
+
+    return type;
+}
+
+
+u16  GetFunctionNumReturns  (IM3Function i_function)
+{
+    u16 numReturns = 0;
+
+    if (i_function)
+    {
+        if (i_function->funcType)
+            numReturns = i_function->funcType->numRets;
+    }
+
+    return numReturns;
+}
+
+
+u8  GetFunctionReturnType  (const IM3Function i_function, u16 i_index)
+{
+    return i_function ? GetFuncTypeResultType (i_function->funcType, i_index) : c_m3Type_unknown;
+}
+
+
+u32  GetFunctionNumArgsAndLocals (IM3Function i_function)
+{
+    if (i_function)
+        return i_function->numLocals + GetFunctionNumArgs (i_function);
+    else
+        return 0;
+}
+

--- a/thirdparty/wasm3/source/m3_function.h
+++ b/thirdparty/wasm3/source/m3_function.h
@@ -1,0 +1,103 @@
+//
+//  m3_function.h
+//
+//  Created by Steven Massey on 4/7/21.
+//  Copyright © 2021 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_function_h
+#define m3_function_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3FuncType
+{
+    struct M3FuncType *     next;
+
+    u16                     numRets;
+    u16                     numArgs;
+    u8                      types [];        // returns, then args
+}
+M3FuncType;
+
+typedef M3FuncType *        IM3FuncType;
+
+
+M3Result    AllocFuncType                   (IM3FuncType * o_functionType, u32 i_numTypes);
+bool        AreFuncTypesEqual               (const IM3FuncType i_typeA, const IM3FuncType i_typeB);
+
+u16         GetFuncTypeNumParams            (const IM3FuncType i_funcType);
+u8          GetFuncTypeParamType            (const IM3FuncType i_funcType, u16 i_index);
+
+u16         GetFuncTypeNumResults           (const IM3FuncType i_funcType);
+u8          GetFuncTypeResultType           (const IM3FuncType i_funcType, u16 i_index);
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+typedef struct M3Function
+{
+    struct M3Module *       module;
+
+    M3ImportInfo            import;
+
+    bytes_t                 wasm;
+    bytes_t                 wasmEnd;
+
+    cstr_t                  names[d_m3MaxDuplicateFunctionImpl];
+    cstr_t                  export_name;                            // should be a part of "names"
+    u16                     numNames;                               // maximum of d_m3MaxDuplicateFunctionImpl
+
+    IM3FuncType             funcType;
+
+    pc_t                    compiled;
+
+# if (d_m3EnableCodePageRefCounting)
+    IM3CodePage *           codePageRefs;                           // array of all pages used
+    u32                     numCodePageRefs;
+# endif
+
+# if defined (DEBUG)
+    u32                     hits;
+    u32                     index;
+# endif
+
+    u16                     maxStackSlots;
+
+    u16                     numRetSlots;
+    u16                     numRetAndArgSlots;
+
+    u16                     numLocals;                              // not including args
+    u16                     numLocalBytes;
+
+    bool                    ownsWasmCode;
+
+    u16                     numConstantBytes;
+    void *                  constants;
+}
+M3Function;
+
+void        Function_Release            (IM3Function i_function);
+void        Function_FreeCompiledCode   (IM3Function i_function);
+
+cstr_t      GetFunctionImportModuleName (IM3Function i_function);
+cstr_t *    GetFunctionNames            (IM3Function i_function, u16 * o_numNames);
+u16         GetFunctionNumArgs          (IM3Function i_function);
+u8          GetFunctionArgType          (IM3Function i_function, u32 i_index);
+
+u16         GetFunctionNumReturns       (IM3Function i_function);
+u8          GetFunctionReturnType       (const IM3Function i_function, u16 i_index);
+
+u32         GetFunctionNumArgsAndLocals (IM3Function i_function);
+
+cstr_t      SPrintFunctionArgList       (IM3Function i_function, m3stack_t i_sp);
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+
+d_m3EndExternC
+
+#endif /* m3_function_h */

--- a/thirdparty/wasm3/source/m3_info.c
+++ b/thirdparty/wasm3/source/m3_info.c
@@ -1,0 +1,564 @@
+//
+//  m3_info.c
+//
+//  Created by Steven Massey on 4/27/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include "m3_env.h"
+#include "m3_info.h"
+#include "m3_compile.h"
+
+#if defined(DEBUG) || (d_m3EnableStrace >= 2)
+
+size_t  SPrintArg  (char * o_string, size_t i_stringBufferSize, voidptr_t i_sp, u8 i_type)
+{
+    int len = 0;
+
+    * o_string = 0;
+
+    if      (i_type == c_m3Type_i32)
+        len = snprintf (o_string, i_stringBufferSize, "%" PRIi32, * (i32 *) i_sp);
+    else if (i_type == c_m3Type_i64)
+        len = snprintf (o_string, i_stringBufferSize, "%" PRIi64, * (i64 *) i_sp);
+#if d_m3HasFloat
+    else if (i_type == c_m3Type_f32)
+        len = snprintf (o_string, i_stringBufferSize, "%" PRIf32, * (f32 *) i_sp);
+    else if (i_type == c_m3Type_f64)
+        len = snprintf (o_string, i_stringBufferSize, "%" PRIf64, * (f64 *) i_sp);
+#endif
+
+    len = M3_MAX (0, len);
+
+    return len;
+}
+
+
+cstr_t  SPrintFunctionArgList  (IM3Function i_function, m3stack_t i_sp)
+{
+    int ret;
+    static char string [256];
+
+    char * s = string;
+    ccstr_t e = string + sizeof(string) - 1;
+
+    ret = snprintf (s, e-s, "(");
+    s += M3_MAX (0, ret);
+
+    u64 * argSp = (u64 *) i_sp;
+
+    IM3FuncType funcType = i_function->funcType;
+    if (funcType)
+    {
+        u32 numArgs = funcType->numArgs;
+
+        for (u32 i = 0; i < numArgs; ++i)
+        {
+            u8 type = d_FuncArgType(funcType, i);
+
+            ret = snprintf (s, e-s, "%s: ", c_waTypes [type]);
+            s += M3_MAX (0, ret);
+
+            s += SPrintArg (s, e-s, argSp + i, type);
+
+            if (i != numArgs - 1) {
+                ret = snprintf (s, e-s, ", ");
+                s += M3_MAX (0, ret);
+            }
+        }
+    }
+    else printf ("null signature");
+
+    ret = snprintf (s, e-s, ")");
+    s += M3_MAX (0, ret);
+
+    return string;
+}
+
+#endif
+
+#ifdef DEBUG
+
+// a central function you can be breakpoint:
+void ExceptionBreakpoint (cstr_t i_exception, cstr_t i_message)
+{
+    printf ("\nexception: '%s' @ %s\n", i_exception, i_message);
+    return;
+}
+
+
+typedef struct OpInfo
+{
+    IM3OpInfo   info;
+    m3opcode_t  opcode;
+}
+OpInfo;
+
+void  m3_PrintM3Info  ()
+{
+    printf ("\n-- m3 configuration --------------------------------------------\n");
+//  printf (" sizeof M3CodePage    : %zu bytes  (%d slots) \n", sizeof (M3CodePage), c_m3CodePageNumSlots);
+    printf (" sizeof M3MemPage     : %u bytes              \n", d_m3DefaultMemPageSize);
+    printf (" sizeof M3Compilation : %zu bytes             \n", sizeof (M3Compilation));
+    printf (" sizeof M3Function    : %zu bytes             \n", sizeof (M3Function));
+    printf ("----------------------------------------------------------------\n\n");
+}
+
+
+void *  v_PrintEnvModuleInfo  (IM3Module i_module, u32 * io_index)
+{
+    printf (" module [%u]  name: '%s'; funcs: %d  \n", * io_index++, i_module->name, i_module->numFunctions);
+
+    return NULL;
+}
+
+
+void  m3_PrintRuntimeInfo  (IM3Runtime i_runtime)
+{
+    printf ("\n-- m3 runtime -------------------------------------------------\n");
+
+    printf (" stack-size: %zu   \n\n", i_runtime->numStackSlots * sizeof (m3slot_t));
+
+    u32 moduleIndex = 0;
+    ForEachModule (i_runtime, (ModuleVisitor) v_PrintEnvModuleInfo, & moduleIndex);
+
+    printf ("----------------------------------------------------------------\n\n");
+}
+
+
+cstr_t  GetTypeName  (u8 i_m3Type)
+{
+    if (i_m3Type < 5)
+        return c_waTypes [i_m3Type];
+    else
+        return "?";
+}
+
+
+// TODO: these 'static char string []' aren't thread-friendly.  though these functions are
+// mainly for simple diagnostics during development, it'd be nice if they were fully reliable.
+
+cstr_t  SPrintFuncTypeSignature  (IM3FuncType i_funcType)
+{
+    static char string [256];
+
+    sprintf (string, "(");
+
+    for (u32 i = 0; i < i_funcType->numArgs; ++i)
+    {
+        if (i != 0)
+            strcat (string, ", ");
+
+        strcat (string, GetTypeName (d_FuncArgType(i_funcType, i)));
+    }
+
+    strcat (string, ") -> ");
+
+    for (u32 i = 0; i < i_funcType->numRets; ++i)
+    {
+        if (i != 0)
+            strcat (string, ", ");
+
+        strcat (string, GetTypeName (d_FuncRetType(i_funcType, i)));
+    }
+
+    return string;
+}
+
+
+cstr_t  SPrintValue  (void * i_value, u8 i_type)
+{
+    static char string [100];
+    SPrintArg (string, 100, (m3stack_t) i_value, i_type);
+    return string;
+}
+
+static
+OpInfo find_operation_info  (IM3Operation i_operation)
+{
+    OpInfo opInfo = { NULL, 0 };
+
+    if (!i_operation) return opInfo;
+
+    // TODO: find also extended opcodes
+    for (u32 i = 0; i <= 0xff; ++i)
+    {
+        IM3OpInfo oi = GetOpInfo (i);
+
+        if (oi->type != c_m3Type_unknown)
+        {
+            for (u32 o = 0; o < 4; ++o)
+            {
+                if (oi->operations [o] == i_operation)
+                {
+                    opInfo.info = oi;
+                    opInfo.opcode = i;
+                    break;
+                }
+            }
+        }
+        else break;
+    }
+
+    return opInfo;
+}
+
+
+#undef fetch
+#define fetch(TYPE) (* (TYPE *) ((*o_pc)++))
+
+#define d_m3Decoder(FUNC) void Decode_##FUNC (char * o_string, u8 i_opcode, IM3Operation i_operation, IM3OpInfo i_opInfo, pc_t * o_pc)
+
+d_m3Decoder  (Call)
+{
+    void * function = fetch (void *);
+    i32 stackOffset = fetch (i32);
+
+    sprintf (o_string, "%p; stack-offset: %d", function, stackOffset);
+}
+
+
+d_m3Decoder (Entry)
+{
+    IM3Function function = fetch (IM3Function);
+
+    // only prints out the first registered name for the function
+    sprintf (o_string, "%s", m3_GetFunctionName(function));
+}
+
+
+d_m3Decoder (f64_Store)
+{
+    if (i_operation == i_opInfo->operations [0])
+    {
+        u32 operand = fetch (u32);
+        u32 offset = fetch (u32);
+
+        sprintf (o_string, "offset= slot:%d + immediate:%d", operand, offset);
+    }
+
+//    sprintf (o_string, "%s", function->name);
+}
+
+
+d_m3Decoder  (Branch)
+{
+    void * target = fetch (void *);
+    sprintf (o_string, "%p", target);
+}
+
+d_m3Decoder  (BranchTable)
+{
+    u32 slot = fetch (u32);
+
+    o_string += sprintf (o_string, "slot: %" PRIu32 "; targets: ", slot);
+
+//    IM3Function function = fetch2 (IM3Function);
+
+    i32 targets = fetch (i32);
+
+    for (i32 i = 0; i < targets; ++i)
+    {
+        pc_t addr = fetch (pc_t);
+        o_string += sprintf (o_string, "%" PRIi32 "=%p, ", i, addr);
+    }
+
+    pc_t addr = fetch (pc_t);
+    sprintf (o_string, "def=%p ", addr);
+}
+
+
+d_m3Decoder  (Const)
+{
+    u64 value = fetch (u64); i32 offset = fetch (i32);
+    sprintf (o_string, " slot [%d] = %" PRIu64, offset, value);
+}
+
+
+#undef fetch
+
+void  DecodeOperation  (char * o_string, u8 i_opcode, IM3Operation i_operation, IM3OpInfo i_opInfo, pc_t * o_pc)
+{
+    #define d_m3Decode(OPCODE, FUNC) case OPCODE: Decode_##FUNC (o_string, i_opcode, i_operation, i_opInfo, o_pc); break;
+
+    switch (i_opcode)
+    {
+//        d_m3Decode (0xc0,                  Const)
+        d_m3Decode (0xc5,                  Entry)
+        d_m3Decode (c_waOp_call,           Call)
+        d_m3Decode (c_waOp_branch,         Branch)
+        d_m3Decode (c_waOp_branchTable,    BranchTable)
+        d_m3Decode (0x39,                  f64_Store)
+    }
+}
+
+// WARNING/TODO: this isn't fully implemented. it blindly assumes each word is a Operation pointer
+// and, if an operation happens to missing from the c_operations table it won't be recognized here
+void  dump_code_page  (IM3CodePage i_codePage, pc_t i_startPC)
+{
+        m3log (code, "code page seq: %d", i_codePage->info.sequence);
+
+        pc_t pc = i_startPC ? i_startPC : GetPageStartPC (i_codePage);
+        pc_t end = GetPagePC (i_codePage);
+
+        m3log (code, "---------------------------------------------------------------------------------------");
+
+        while (pc < end)
+        {
+            pc_t operationPC = pc;
+            IM3Operation op = (IM3Operation) (* pc++);
+
+                OpInfo i = find_operation_info (op);
+
+                if (i.info)
+                {
+                    char infoString [8*1024] = { 0 };
+
+                    DecodeOperation (infoString, i.opcode, op, i.info, & pc);
+
+                    m3log (code, "%p | %20s  %s", operationPC, i.info->name, infoString);
+                }
+                else
+                    m3log (code, "%p | %p", operationPC, op);
+
+        }
+
+        m3log (code, "---------------------------------------------------------------------------------------");
+
+        m3log (code, "free-lines: %d", i_codePage->info.numLines - i_codePage->info.lineIndex);
+}
+
+
+void  dump_type_stack  (IM3Compilation o)
+{
+    /* Reminders about how the stack works! :)
+     -- args & locals remain on the type stack for duration of the function. Denoted with a constant 'A' and 'L' in this dump.
+     -- the initial stack dumps originate from the CompileLocals () function, so these identifiers won't/can't be
+     applied until this compilation stage is finished
+     -- constants are not statically represented in the type stack (like args & constants) since they don't have/need
+     write counts
+
+     -- the number shown for static args and locals (value in wasmStack [i]) represents the write count for the variable
+
+     -- (does Wasm ever write to an arg? I dunno/don't remember.)
+     -- the number for the dynamic stack values represents the slot number.
+     -- if the slot index points to arg, local or constant it's denoted with a lowercase 'a', 'l' or 'c'
+
+     */
+
+    // for the assert at end of dump:
+    i32 regAllocated [2] = { (i32) IsRegisterAllocated (o, 0), (i32) IsRegisterAllocated (o, 1) };
+
+    // display whether r0 or fp0 is allocated. these should then also be reflected somewhere in the stack too.
+    d_m3Log(stack, "\n");
+    d_m3Log(stack, "        ");
+    printf ("%s %s    ", regAllocated [0] ? "(r0)" : "    ", regAllocated [1] ? "(fp0)" : "     ");
+    printf("\n");
+
+    for (u32 p = 1; p <= 2; ++p)
+    {
+        d_m3Log(stack, "        ");
+
+        for (u16 i = 0; i < o->stackIndex; ++i)
+        {
+            if (i > 0 and i == o->stackFirstDynamicIndex)
+                printf ("#");
+
+            if (i == o->block.blockStackIndex)
+                printf (">");
+
+            const char * type = c_waCompactTypes [o->typeStack [i]];
+
+            const char * location = "";
+
+            i32 slot = o->wasmStack [i];
+
+            if (IsRegisterSlotAlias (slot))
+            {
+                bool isFp = IsFpRegisterSlotAlias (slot);
+                location = isFp ? "/f" : "/r";
+
+                regAllocated [isFp]--;
+                slot = -1;
+            }
+            else
+            {
+                if (slot < o->slotFirstDynamicIndex)
+                {
+                    if (slot >= o->slotFirstConstIndex)
+                        location = "c";
+                    else if (slot >= o->function->numRetAndArgSlots)
+                        location = "L";
+                    else
+                        location = "a";
+                }
+            }
+
+            char item [100];
+
+            if (slot >= 0)
+                sprintf (item, "%s%s%d", type, location, slot);
+            else
+                sprintf (item, "%s%s", type, location);
+
+            if (p == 1)
+            {
+                size_t s = strlen (item);
+
+                sprintf (item, "%d", i);
+
+                while (strlen (item) < s)
+                    strcat (item, " ");
+            }
+
+            printf ("|%s ", item);
+
+        }
+        printf ("\n");
+    }
+
+//    for (u32 r = 0; r < 2; ++r)
+//        d_m3Assert (regAllocated [r] == 0);         // reg allocation & stack out of sync
+
+    u16 maxSlot = GetMaxUsedSlotPlusOne (o);
+
+    if (maxSlot > o->slotFirstDynamicIndex)
+    {
+        d_m3Log (stack, "                      -");
+
+        for (u16 i = o->slotFirstDynamicIndex; i < maxSlot; ++i)
+            printf ("----");
+
+        printf ("\n");
+
+        d_m3Log (stack, "                 slot |");
+        for (u16 i = o->slotFirstDynamicIndex; i < maxSlot; ++i)
+            printf ("%3d|", i);
+
+        printf ("\n");
+        d_m3Log (stack, "                alloc |");
+
+        for (u16 i = o->slotFirstDynamicIndex; i < maxSlot; ++i)
+        {
+            printf ("%3d|", o->m3Slots [i]);
+        }
+
+        printf ("\n");
+    }
+    d_m3Log(stack, "\n");
+}
+
+
+static const char *  GetOpcodeIndentionString  (i32 blockDepth)
+{
+    blockDepth += 1;
+
+    if (blockDepth < 0)
+        blockDepth = 0;
+
+    static const char * s_spaces = ".......................................................................................";
+    const char * indent = s_spaces + strlen (s_spaces);
+    indent -= (blockDepth * 2);
+    if (indent < s_spaces)
+        indent = s_spaces;
+
+    return indent;
+}
+
+
+const char *  get_indention_string  (IM3Compilation o)
+{
+    return GetOpcodeIndentionString (o->block.depth+4);
+}
+
+
+void  log_opcode  (IM3Compilation o, m3opcode_t i_opcode)
+{
+    i32 depth = o->block.depth;
+    if (i_opcode == c_waOp_end or i_opcode == c_waOp_else)
+        depth--;
+
+    m3log (compile, "%4d | 0x%02x  %s %s", o->numOpcodes++, i_opcode, GetOpcodeIndentionString (depth), GetOpInfo(i_opcode)->name);
+}
+
+
+void  log_emit  (IM3Compilation o, IM3Operation i_operation)
+{
+    OpInfo i = find_operation_info (i_operation);
+
+    d_m3Log(emit, "");
+    if (i.info)
+    {
+        printf ("%p: %s\n", GetPagePC (o->page),  i.info->name);
+    }
+    else printf ("not found: %p\n", i_operation);
+}
+
+#endif // DEBUG
+
+
+# if d_m3EnableOpProfiling
+
+typedef struct M3ProfilerSlot
+{
+    cstr_t      opName;
+    u64         hitCount;
+}
+M3ProfilerSlot;
+
+static M3ProfilerSlot s_opProfilerCounts [d_m3ProfilerSlotMask + 1] = {};
+
+void  ProfileHit  (cstr_t i_operationName)
+{
+    u64 ptr = (u64) i_operationName;
+
+    M3ProfilerSlot * slot = & s_opProfilerCounts [ptr & d_m3ProfilerSlotMask];
+
+    if (slot->opName)
+    {
+        if (slot->opName != i_operationName)
+        {
+            m3_Abort ("profiler slot collision; increase d_m3ProfilerSlotMask");
+        }
+    }
+
+    slot->opName = i_operationName;
+    slot->hitCount++;
+}
+
+
+void  m3_PrintProfilerInfo  ()
+{
+    M3ProfilerSlot dummy;
+    M3ProfilerSlot * maxSlot = & dummy;
+
+    do
+    {
+        maxSlot->hitCount = 0;
+
+        for (u32 i = 0; i <= d_m3ProfilerSlotMask; ++i)
+        {
+            M3ProfilerSlot * slot = & s_opProfilerCounts [i];
+
+            if (slot->opName)
+            {
+                if (slot->hitCount > maxSlot->hitCount)
+                    maxSlot = slot;
+            }
+        }
+
+        if (maxSlot->opName)
+        {
+            fprintf (stderr, "%13llu  %s\n", maxSlot->hitCount, maxSlot->opName);
+            maxSlot->opName = NULL;
+        }
+    }
+    while (maxSlot->hitCount);
+}
+
+# else
+
+void  m3_PrintProfilerInfo  () {}
+
+# endif
+

--- a/thirdparty/wasm3/source/m3_info.h
+++ b/thirdparty/wasm3/source/m3_info.h
@@ -1,0 +1,38 @@
+//
+//  m3_info.h
+//
+//  Created by Steven Massey on 12/6/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#ifndef m3_info_h
+#define m3_info_h
+
+#include "m3_compile.h"
+
+d_m3BeginExternC
+
+void            ProfileHit              (cstr_t i_operationName);
+
+#ifdef DEBUG
+
+void            dump_type_stack         (IM3Compilation o);
+void            log_opcode              (IM3Compilation o, m3opcode_t i_opcode);
+const char *    get_indention_string    (IM3Compilation o);
+void            log_emit                (IM3Compilation o, IM3Operation i_operation);
+
+cstr_t          SPrintFuncTypeSignature (IM3FuncType i_funcType);
+
+#else // DEBUG
+
+#define         dump_type_stack(...)      {}
+#define         log_opcode(...)           {}
+#define         get_indention_string(...) ""
+#define         emit_stack_dump(...)      {}
+#define         log_emit(...)             {}
+
+#endif // DEBUG
+
+d_m3EndExternC
+
+#endif // m3_info_h

--- a/thirdparty/wasm3/source/m3_math_utils.h
+++ b/thirdparty/wasm3/source/m3_math_utils.h
@@ -1,0 +1,268 @@
+//
+//  m3_math_utils.h
+//
+//  Created by Volodymyr Shymanksyy on 8/10/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef m3_math_utils_h
+#define m3_math_utils_h
+
+#include "m3_core.h"
+
+#include <limits.h>
+
+#if defined(M3_COMPILER_MSVC)
+
+#include <intrin.h>
+
+#define __builtin_popcount    __popcnt
+
+static inline
+int __builtin_ctz(uint32_t x) {
+    unsigned long ret;
+    _BitScanForward(&ret, x);
+    return (int)ret;
+}
+
+static inline
+int __builtin_clz(uint32_t x) {
+    unsigned long ret;
+    _BitScanReverse(&ret, x);
+    return (int)(31 ^ ret);
+}
+
+
+
+#ifdef _WIN64
+
+#define __builtin_popcountll  __popcnt64
+
+static inline
+int __builtin_ctzll(uint64_t value) {
+    unsigned long ret;
+     _BitScanForward64(&ret, value);
+    return (int)ret;
+}
+
+static inline
+int __builtin_clzll(uint64_t value) {
+    unsigned long ret;
+    _BitScanReverse64(&ret, value);
+    return (int)(63 ^ ret);
+}
+
+#else // _WIN64
+
+#define __builtin_popcountll(x)  (__popcnt((x) & 0xFFFFFFFF) + __popcnt((x) >> 32))
+
+static inline
+int __builtin_ctzll(uint64_t value) {
+    //if (value == 0) return 64; // Note: ctz(0) result is undefined anyway
+    uint32_t msh = (uint32_t)(value >> 32);
+    uint32_t lsh = (uint32_t)(value & 0xFFFFFFFF);
+    if (lsh != 0) return __builtin_ctz(lsh);
+    return 32 + __builtin_ctz(msh);
+}
+
+static inline
+int __builtin_clzll(uint64_t value) {
+    //if (value == 0) return 64; // Note: clz(0) result is undefined anyway
+    uint32_t msh = (uint32_t)(value >> 32);
+    uint32_t lsh = (uint32_t)(value & 0xFFFFFFFF);
+    if (msh != 0) return __builtin_clz(msh);
+    return 32 + __builtin_clz(lsh);
+}
+
+#endif // _WIN64
+
+#endif // defined(M3_COMPILER_MSVC)
+
+
+// TODO: not sure why, signbit is actually defined in math.h
+#if (defined(ESP8266) || defined(ESP32)) && !defined(signbit)
+    #define signbit(__x) \
+            ((sizeof(__x) == sizeof(float))  ?  __signbitf(__x) : __signbitd(__x))
+#endif
+
+#if defined(__AVR__)
+
+static inline
+float rintf( float arg ) {
+  union { float f; uint32_t i; } u;
+  u.f = arg;
+  uint32_t ux = u.i & 0x7FFFFFFF;
+  if (M3_UNLIKELY(ux == 0 || ux > 0x5A000000)) {
+    return arg;
+  }
+  return (float)lrint(arg);
+}
+
+static inline
+double rint( double arg ) {
+  union { double f; uint32_t i[2]; } u;
+  u.f = arg;
+  uint32_t ux = u.i[1] & 0x7FFFFFFF;
+  if (M3_UNLIKELY((ux == 0 && u.i[0] == 0) || ux > 0x433FFFFF)) {
+    return arg;
+  }
+  return (double)lrint(arg);
+}
+
+//TODO
+static inline
+uint64_t strtoull(const char* str, char** endptr, int base) {
+  return 0;
+}
+
+#endif
+
+/*
+ * Rotr, Rotl
+ */
+
+static inline
+u32 rotl32(u32 n, unsigned c) {
+    const unsigned mask = CHAR_BIT * sizeof(n) - 1;
+    c &= mask & 31;
+    return (n << c) | (n >> ((-c) & mask));
+}
+
+static inline
+u32 rotr32(u32 n, unsigned c) {
+    const unsigned mask = CHAR_BIT * sizeof(n) - 1;
+    c &= mask & 31;
+    return (n >> c) | (n << ((-c) & mask));
+}
+
+static inline
+u64 rotl64(u64 n, unsigned c) {
+    const unsigned mask = CHAR_BIT * sizeof(n) - 1;
+    c &= mask & 63;
+    return (n << c) | (n >> ((-c) & mask));
+}
+
+static inline
+u64 rotr64(u64 n, unsigned c) {
+    const unsigned mask = CHAR_BIT * sizeof(n) - 1;
+    c &= mask & 63;
+    return (n >> c) | (n << ((-c) & mask));
+}
+
+/*
+ * Integer Div, Rem
+ */
+
+#define OP_DIV_U(RES, A, B)                                      \
+    if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
+    RES = A / B;
+
+#define OP_REM_U(RES, A, B)                                      \
+    if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
+    RES = A % B;
+
+// 2's complement detection
+#if (INT_MIN != -INT_MAX)
+
+    #define OP_DIV_S(RES, A, B, TYPE_MIN)                         \
+        if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
+        if (M3_UNLIKELY(B == -1 and A == TYPE_MIN)) {                \
+            newTrap (m3Err_trapIntegerOverflow);                  \
+        }                                                         \
+        RES = A / B;
+
+    #define OP_REM_S(RES, A, B, TYPE_MIN)                         \
+        if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
+        if (M3_UNLIKELY(B == -1 and A == TYPE_MIN)) RES = 0;         \
+        else RES = A % B;
+
+#else
+
+    #define OP_DIV_S(RES, A, B, TYPE_MIN) OP_DIV_U(RES, A, B)
+    #define OP_REM_S(RES, A, B, TYPE_MIN) OP_REM_U(RES, A, B)
+
+#endif
+
+/*
+ * Trunc
+ */
+
+#define OP_TRUNC(RES, A, TYPE, RMIN, RMAX)                  \
+    if (M3_UNLIKELY(isnan(A))) {                               \
+        newTrap (m3Err_trapIntegerConversion);              \
+    }                                                       \
+    if (M3_UNLIKELY(A <= RMIN or A >= RMAX)) {                 \
+        newTrap (m3Err_trapIntegerOverflow);                \
+    }                                                       \
+    RES = (TYPE)A;
+
+
+#define OP_I32_TRUNC_F32(RES, A)    OP_TRUNC(RES, A, i32, -2147483904.0f, 2147483648.0f)
+#define OP_U32_TRUNC_F32(RES, A)    OP_TRUNC(RES, A, u32,          -1.0f, 4294967296.0f)
+#define OP_I32_TRUNC_F64(RES, A)    OP_TRUNC(RES, A, i32, -2147483649.0 , 2147483648.0 )
+#define OP_U32_TRUNC_F64(RES, A)    OP_TRUNC(RES, A, u32,          -1.0 , 4294967296.0 )
+
+#define OP_I64_TRUNC_F32(RES, A)    OP_TRUNC(RES, A, i64, -9223373136366403584.0f,  9223372036854775808.0f)
+#define OP_U64_TRUNC_F32(RES, A)    OP_TRUNC(RES, A, u64,                   -1.0f, 18446744073709551616.0f)
+#define OP_I64_TRUNC_F64(RES, A)    OP_TRUNC(RES, A, i64, -9223372036854777856.0 ,  9223372036854775808.0 )
+#define OP_U64_TRUNC_F64(RES, A)    OP_TRUNC(RES, A, u64,                   -1.0 , 18446744073709551616.0 )
+
+#define OP_TRUNC_SAT(RES, A, TYPE, RMIN, RMAX, IMIN, IMAX)  \
+    if (M3_UNLIKELY(isnan(A))) {                               \
+        RES = 0;                                            \
+    } else if (M3_UNLIKELY(A <= RMIN)) {                       \
+        RES = IMIN;                                         \
+    } else if (M3_UNLIKELY(A >= RMAX)) {                       \
+        RES = IMAX;                                         \
+    } else {                                                \
+        RES = (TYPE)A;                                      \
+    }
+
+#define OP_I32_TRUNC_SAT_F32(RES, A)    OP_TRUNC_SAT(RES, A, i32, -2147483904.0f, 2147483648.0f,   INT32_MIN,  INT32_MAX)
+#define OP_U32_TRUNC_SAT_F32(RES, A)    OP_TRUNC_SAT(RES, A, u32,          -1.0f, 4294967296.0f,         0UL, UINT32_MAX)
+#define OP_I32_TRUNC_SAT_F64(RES, A)    OP_TRUNC_SAT(RES, A, i32, -2147483649.0 , 2147483648.0,    INT32_MIN,  INT32_MAX)
+#define OP_U32_TRUNC_SAT_F64(RES, A)    OP_TRUNC_SAT(RES, A, u32,          -1.0 , 4294967296.0,          0UL, UINT32_MAX)
+
+#define OP_I64_TRUNC_SAT_F32(RES, A)    OP_TRUNC_SAT(RES, A, i64, -9223373136366403584.0f,  9223372036854775808.0f, INT64_MIN,  INT64_MAX)
+#define OP_U64_TRUNC_SAT_F32(RES, A)    OP_TRUNC_SAT(RES, A, u64,                   -1.0f, 18446744073709551616.0f,      0ULL, UINT64_MAX)
+#define OP_I64_TRUNC_SAT_F64(RES, A)    OP_TRUNC_SAT(RES, A, i64, -9223372036854777856.0 ,  9223372036854775808.0,  INT64_MIN,  INT64_MAX)
+#define OP_U64_TRUNC_SAT_F64(RES, A)    OP_TRUNC_SAT(RES, A, u64,                   -1.0 , 18446744073709551616.0,       0ULL, UINT64_MAX)
+
+/*
+ * Min, Max
+ */
+
+#if d_m3HasFloat
+
+#include <math.h>
+
+static inline
+f32 min_f32(f32 a, f32 b) {
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
+    return a > b ? b : a;
+}
+
+static inline
+f32 max_f32(f32 a, f32 b) {
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
+    return a > b ? a : b;
+}
+
+static inline
+f64 min_f64(f64 a, f64 b) {
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
+    return a > b ? b : a;
+}
+
+static inline
+f64 max_f64(f64 a, f64 b) {
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
+    return a > b ? a : b;
+}
+#endif
+
+#endif // m3_math_utils_h

--- a/thirdparty/wasm3/source/m3_module.c
+++ b/thirdparty/wasm3/source/m3_module.c
@@ -1,0 +1,175 @@
+//
+//  m3_module.c
+//
+//  Created by Steven Massey on 5/7/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+
+void Module_FreeFunctions (IM3Module i_module)
+{
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function func = & i_module->functions [i];
+        Function_Release (func);
+    }
+}
+
+
+void  m3_FreeModule  (IM3Module i_module)
+{
+    if (i_module)
+    {
+        m3log (module, "freeing module: %s (funcs: %d; segments: %d)",
+               i_module->name, i_module->numFunctions, i_module->numDataSegments);
+
+        Module_FreeFunctions (i_module);
+
+        m3_Free (i_module->functions);
+        //m3_Free (i_module->imports);
+        m3_Free (i_module->funcTypes);
+        m3_Free (i_module->dataSegments);
+        m3_Free (i_module->table0);
+
+        for (u32 i = 0; i < i_module->numGlobals; ++i)
+        {
+            m3_Free (i_module->globals[i].name);
+            FreeImportInfo(&(i_module->globals[i].import));
+        }
+        m3_Free (i_module->globals);
+        m3_Free (i_module->memoryExportName);
+        m3_Free (i_module->table0ExportName);
+
+        FreeImportInfo(&i_module->memoryImport);
+
+        m3_Free (i_module);
+    }
+}
+
+
+M3Result  Module_AddGlobal  (IM3Module io_module, IM3Global * o_global, u8 i_type, bool i_mutable, bool i_isImported)
+{
+_try {
+    u32 index = io_module->numGlobals++;
+    io_module->globals = m3_ReallocArray (M3Global, io_module->globals, io_module->numGlobals, index);
+    _throwifnull (io_module->globals);
+    M3Global * global = & io_module->globals [index];
+
+    global->type = i_type;
+    global->imported = i_isImported;
+    global->isMutable = i_mutable;
+
+    if (o_global)
+        * o_global = global;
+
+} _catch:
+    return result;
+}
+
+M3Result  Module_PreallocFunctions  (IM3Module io_module, u32 i_totalFunctions)
+{
+_try {
+    if (i_totalFunctions > io_module->allFunctions) {
+        io_module->functions = m3_ReallocArray (M3Function, io_module->functions, i_totalFunctions, io_module->allFunctions);
+        io_module->allFunctions = i_totalFunctions;
+        _throwifnull (io_module->functions);
+    }
+} _catch:
+    return result;
+}
+
+M3Result  Module_AddFunction  (IM3Module io_module, u32 i_typeIndex, IM3ImportInfo i_importInfo)
+{
+_try {
+
+    u32 index = io_module->numFunctions++;
+_   (Module_PreallocFunctions(io_module, io_module->numFunctions));
+
+    _throwif ("type sig index out of bounds", i_typeIndex >= io_module->numFuncTypes);
+
+    IM3FuncType ft = io_module->funcTypes [i_typeIndex];
+
+    IM3Function func = Module_GetFunction (io_module, index);
+    func->funcType = ft;
+
+#   ifdef DEBUG
+    func->index = index;
+#   endif
+
+    if (i_importInfo and func->numNames == 0)
+    {
+        func->import = * i_importInfo;
+        func->names[0] = i_importInfo->fieldUtf8;
+        func->numNames = 1;
+    }
+
+    m3log (module, "   added function: %3d; sig: %d", index, i_typeIndex);
+
+} _catch:
+    return result;
+}
+
+#ifdef DEBUG
+void  Module_GenerateNames  (IM3Module i_module)
+{
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function func = & i_module->functions [i];
+
+        if (func->numNames == 0)
+        {
+            char* buff = m3_AllocArray(char, 16);
+            snprintf(buff, 16, "$func%d", i);
+            func->names[0] = buff;
+            func->numNames = 1;
+        }
+    }
+    for (u32 i = 0; i < i_module->numGlobals; ++i)
+    {
+        IM3Global global = & i_module->globals [i];
+
+        if (global->name == NULL)
+        {
+            char* buff = m3_AllocArray(char, 16);
+            snprintf(buff, 16, "$global%d", i);
+            global->name = buff;
+        }
+    }
+}
+#endif
+
+IM3Function  Module_GetFunction  (IM3Module i_module, u32 i_functionIndex)
+{
+    IM3Function func = NULL;
+
+    if (i_functionIndex < i_module->numFunctions)
+    {
+        func = & i_module->functions [i_functionIndex];
+        //func->module = i_module;
+    }
+
+    return func;
+}
+
+
+const char*  m3_GetModuleName  (IM3Module i_module)
+{
+    if (!i_module || !i_module->name)
+        return ".unnamed";
+
+    return i_module->name;
+}
+
+void  m3_SetModuleName  (IM3Module i_module, const char* name)
+{
+    if (i_module) i_module->name = name;
+}
+
+IM3Runtime  m3_GetModuleRuntime  (IM3Module i_module)
+{
+    return i_module ? i_module->runtime : NULL;
+}
+

--- a/thirdparty/wasm3/source/m3_parse.c
+++ b/thirdparty/wasm3/source/m3_parse.c
@@ -1,0 +1,671 @@
+//
+//  m3_parse.c
+//
+//  Created by Steven Massey on 4/19/19.
+//  Copyright © 2019 Steven Massey. All rights reserved.
+//
+
+#include "m3_env.h"
+#include "m3_compile.h"
+#include "m3_exception.h"
+#include "m3_info.h"
+
+
+M3Result  ParseType_Table  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    return result;
+}
+
+
+M3Result  ParseType_Memory  (M3MemoryInfo * o_memory, bytes_t * io_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u8 flag;
+
+_   (ReadLEB_u7 (& flag, io_bytes, i_end));                   // really a u1
+_   (ReadLEB_u32 (& o_memory->initPages, io_bytes, i_end));
+
+    o_memory->maxPages = 0;
+    if (flag & (1u << 0))
+_       (ReadLEB_u32 (& o_memory->maxPages, io_bytes, i_end));
+
+    o_memory->pageSize = 0;
+    if (flag & (1u << 3)) {
+        u32 logPageSize;
+_       (ReadLEB_u32 (& logPageSize, io_bytes, i_end));
+        o_memory->pageSize = 1u << logPageSize;
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Type  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    IM3FuncType ftype = NULL;
+
+_try {
+    u32 numTypes;
+_   (ReadLEB_u32 (& numTypes, & i_bytes, i_end));                                   m3log (parse, "** Type [%d]", numTypes);
+
+    _throwif("too many types", numTypes > d_m3MaxSaneTypesCount);
+
+    if (numTypes)
+    {
+        // table of IM3FuncType (that point to the actual M3FuncType struct in the Environment)
+        io_module->funcTypes = m3_AllocArray (IM3FuncType, numTypes);
+        _throwifnull (io_module->funcTypes);
+        io_module->numFuncTypes = numTypes;
+
+        for (u32 i = 0; i < numTypes; ++i)
+        {
+            i8 form;
+_           (ReadLEB_i7 (& form, & i_bytes, i_end));
+            _throwif (m3Err_wasmMalformed, form != -32); // for Wasm MVP
+
+            u32 numArgs;
+_           (ReadLEB_u32 (& numArgs, & i_bytes, i_end));
+
+            _throwif (m3Err_tooManyArgsRets, numArgs > d_m3MaxSaneFunctionArgRetCount);
+#if defined(M3_COMPILER_MSVC)
+            u8 argTypes [d_m3MaxSaneFunctionArgRetCount];
+#else
+            u8 argTypes[numArgs+1]; // make ubsan happy
+#endif
+            for (u32 a = 0; a < numArgs; ++a)
+            {
+                i8 wasmType;
+                u8 argType;
+_               (ReadLEB_i7 (& wasmType, & i_bytes, i_end));
+_               (NormalizeType (& argType, wasmType));
+
+                argTypes[a] = argType;
+            }
+
+            u32 numRets;
+_           (ReadLEB_u32 (& numRets, & i_bytes, i_end));
+            _throwif (m3Err_tooManyArgsRets, (u64)(numRets) + numArgs > d_m3MaxSaneFunctionArgRetCount);
+
+_           (AllocFuncType (& ftype, numRets + numArgs));
+            ftype->numArgs = numArgs;
+            ftype->numRets = numRets;
+
+            for (u32 r = 0; r < numRets; ++r)
+            {
+                i8 wasmType;
+                u8 retType;
+_               (ReadLEB_i7 (& wasmType, & i_bytes, i_end));
+_               (NormalizeType (& retType, wasmType));
+
+                ftype->types[r] = retType;
+            }
+            memcpy (ftype->types + numRets, argTypes, numArgs);                                 m3log (parse, "    type %2d: %s", i, SPrintFuncTypeSignature (ftype));
+
+            Environment_AddFuncType (io_module->environment, & ftype);
+            io_module->funcTypes [i] = ftype;
+            ftype = NULL; // ownership transferred to environment
+        }
+    }
+
+} _catch:
+
+    if (result)
+    {
+        m3_Free (ftype);
+        // FIX: M3FuncTypes in the table are leaked
+        m3_Free (io_module->funcTypes);
+        io_module->numFuncTypes = 0;
+    }
+
+    return result;
+}
+
+
+M3Result  ParseSection_Function  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u32 numFunctions;
+_   (ReadLEB_u32 (& numFunctions, & i_bytes, i_end));                               m3log (parse, "** Function [%d]", numFunctions);
+
+    _throwif("too many functions", numFunctions > d_m3MaxSaneFunctionsCount);
+
+_   (Module_PreallocFunctions(io_module, io_module->numFunctions + numFunctions));
+
+    for (u32 i = 0; i < numFunctions; ++i)
+    {
+        u32 funcTypeIndex;
+_       (ReadLEB_u32 (& funcTypeIndex, & i_bytes, i_end));
+
+_       (Module_AddFunction (io_module, funcTypeIndex, NULL /* import info */));
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Import  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    M3ImportInfo import = { NULL, NULL }, clearImport = { NULL, NULL };
+
+    u32 numImports;
+_   (ReadLEB_u32 (& numImports, & i_bytes, i_end));                                 m3log (parse, "** Import [%d]", numImports);
+
+    _throwif("too many imports", numImports > d_m3MaxSaneImportsCount);
+
+    // Most imports are functions, so we won't waste much space anyway (if any)
+_   (Module_PreallocFunctions(io_module, numImports));
+
+    for (u32 i = 0; i < numImports; ++i)
+    {
+        u8 importKind;
+
+_       (Read_utf8 (& import.moduleUtf8, & i_bytes, i_end));
+_       (Read_utf8 (& import.fieldUtf8, & i_bytes, i_end));
+_       (Read_u8 (& importKind, & i_bytes, i_end));                                 m3log (parse, "    kind: %d '%s.%s' ",
+                                                                                                (u32) importKind, import.moduleUtf8, import.fieldUtf8);
+        switch (importKind)
+        {
+            case d_externalKind_function:
+            {
+                u32 typeIndex;
+_               (ReadLEB_u32 (& typeIndex, & i_bytes, i_end))
+
+_               (Module_AddFunction (io_module, typeIndex, & import))
+                import = clearImport;
+
+                io_module->numFuncImports++;
+            }
+            break;
+
+            case d_externalKind_table:
+//                  result = ParseType_Table (& i_bytes, i_end);
+                break;
+
+            case d_externalKind_memory:
+            {
+_               (ParseType_Memory (& io_module->memoryInfo, & i_bytes, i_end));
+                io_module->memoryImported = true;
+                io_module->memoryImport = import;
+                import = clearImport;
+            }
+            break;
+
+            case d_externalKind_global:
+            {
+                i8 waType;
+                u8 type, isMutable;
+
+_               (ReadLEB_i7 (& waType, & i_bytes, i_end));
+_               (NormalizeType (& type, waType));
+_               (ReadLEB_u7 (& isMutable, & i_bytes, i_end));                     m3log (parse, "     global: %s mutable=%d", c_waTypes [type], (u32) isMutable);
+
+                IM3Global global;
+_               (Module_AddGlobal (io_module, & global, type, isMutable, true /* isImport */));
+                global->import = import;
+                import = clearImport;
+            }
+            break;
+
+            default:
+                _throw (m3Err_wasmMalformed);
+        }
+
+        FreeImportInfo (& import);
+    }
+
+    _catch:
+
+    FreeImportInfo (& import);
+
+    return result;
+}
+
+
+M3Result  ParseSection_Export  (IM3Module io_module, bytes_t i_bytes, cbytes_t  i_end)
+{
+    M3Result result = m3Err_none;
+    const char * utf8 = NULL;
+
+    u32 numExports;
+_   (ReadLEB_u32 (& numExports, & i_bytes, i_end));                                 m3log (parse, "** Export [%d]", numExports);
+
+    _throwif("too many exports", numExports > d_m3MaxSaneExportsCount);
+
+    for (u32 i = 0; i < numExports; ++i)
+    {
+        u8 exportKind;
+        u32 index;
+
+_       (Read_utf8 (& utf8, & i_bytes, i_end));
+_       (Read_u8 (& exportKind, & i_bytes, i_end));
+_       (ReadLEB_u32 (& index, & i_bytes, i_end));                                  m3log (parse, "    index: %3d; kind: %d; export: '%s'; ", index, (u32) exportKind, utf8);
+
+        if (exportKind == d_externalKind_function)
+        {
+            _throwif(m3Err_wasmMalformed, index >= io_module->numFunctions);
+            IM3Function func = &(io_module->functions [index]);
+            if (func->numNames < d_m3MaxDuplicateFunctionImpl)
+            {
+                func->names[func->numNames++] = utf8;
+                func->export_name = utf8;
+                utf8 = NULL; // ownership transferred to M3Function
+            }
+        }
+        else if (exportKind == d_externalKind_global)
+        {
+            _throwif(m3Err_wasmMalformed, index >= io_module->numGlobals);
+            IM3Global global = &(io_module->globals [index]);
+            m3_Free (global->name);
+            global->name = utf8;
+            utf8 = NULL; // ownership transferred to M3Global
+        }
+        else if (exportKind == d_externalKind_memory)
+        {
+            m3_Free (io_module->memoryExportName);
+            io_module->memoryExportName = utf8;
+            utf8 = NULL; // ownership transferred to M3Module
+        }
+        else if (exportKind == d_externalKind_table)
+        {
+            m3_Free (io_module->table0ExportName);
+            io_module->table0ExportName = utf8;
+            utf8 = NULL; // ownership transferred to M3Module
+        }
+
+        m3_Free (utf8);
+    }
+
+_catch:
+    m3_Free (utf8);
+    return result;
+}
+
+
+M3Result  ParseSection_Start  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u32 startFuncIndex;
+_   (ReadLEB_u32 (& startFuncIndex, & i_bytes, i_end));                               m3log (parse, "** Start Function: %d", startFuncIndex);
+
+    if (startFuncIndex < io_module->numFunctions)
+    {
+        io_module->startFunction = startFuncIndex;
+    }
+    else result = "start function index out of bounds";
+
+    _catch: return result;
+}
+
+
+M3Result  Parse_InitExpr  (M3Module * io_module, bytes_t * io_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    // this doesn't generate code pages. just walks the wasm bytecode to find the end
+
+#if defined(d_m3PreferStaticAlloc)
+    static M3Compilation compilation;
+#else
+    M3Compilation compilation;
+#endif
+    compilation = (M3Compilation){ .runtime = NULL, .module = io_module, .wasm = * io_bytes, .wasmEnd = i_end };
+
+    result = CompileBlockStatements (& compilation);
+
+    * io_bytes = compilation.wasm;
+
+    return result;
+}
+
+
+M3Result  ParseSection_Element  (IM3Module io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u32 numSegments;
+_   (ReadLEB_u32 (& numSegments, & i_bytes, i_end));                         m3log (parse, "** Element [%d]", numSegments);
+
+    _throwif ("too many element segments", numSegments > d_m3MaxSaneElementSegments);
+
+    io_module->elementSection = i_bytes;
+    io_module->elementSectionEnd = i_end;
+    io_module->numElementSegments = numSegments;
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Code  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result;
+
+    u32 numFunctions;
+_   (ReadLEB_u32 (& numFunctions, & i_bytes, i_end));                               m3log (parse, "** Code [%d]", numFunctions);
+
+    if (numFunctions != io_module->numFunctions - io_module->numFuncImports)
+    {
+        _throw ("mismatched function count in code section");
+    }
+
+    for (u32 f = 0; f < numFunctions; ++f)
+    {
+        const u8 * start = i_bytes;
+
+        u32 size;
+_       (ReadLEB_u32 (& size, & i_bytes, i_end));
+
+        if (size)
+        {
+            const u8 * ptr = i_bytes;
+            i_bytes += size;
+
+            if (i_bytes <= i_end)
+            {
+                /*
+                u32 numLocalBlocks;
+_               (ReadLEB_u32 (& numLocalBlocks, & ptr, i_end));                                      m3log (parse, "    code size: %-4d", size);
+
+                u32 numLocals = 0;
+
+                for (u32 l = 0; l < numLocalBlocks; ++l)
+                {
+                    u32 varCount;
+                    i8 wasmType;
+                    u8 normalType;
+
+_                   (ReadLEB_u32 (& varCount, & ptr, i_end));
+_                   (ReadLEB_i7 (& wasmType, & ptr, i_end));
+_                   (NormalizeType (& normalType, wasmType));
+
+                    numLocals += varCount;                                                      m3log (parse, "      %2d locals; type: '%s'", varCount, c_waTypes [normalType]);
+                }
+                 */
+
+                IM3Function func = Module_GetFunction (io_module, f + io_module->numFuncImports);
+
+                func->module = io_module;
+                func->wasm = start;
+                func->wasmEnd = i_bytes;
+                //func->ownsWasmCode = io_module->hasWasmCodeCopy;
+//                func->numLocals = numLocals;
+            }
+            else _throw (m3Err_wasmSectionOverrun);
+        }
+    }
+
+    _catch:
+
+    if (not result and i_bytes != i_end)
+        result = m3Err_wasmSectionUnderrun;
+
+    return result;
+}
+
+
+M3Result  ParseSection_Data  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u32 numDataSegments;
+_   (ReadLEB_u32 (& numDataSegments, & i_bytes, i_end));                            m3log (parse, "** Data [%d]", numDataSegments);
+
+    _throwif("too many data segments", numDataSegments > d_m3MaxSaneDataSegments);
+
+    io_module->dataSegments = m3_AllocArray (M3DataSegment, numDataSegments);
+    _throwifnull(io_module->dataSegments);
+    io_module->numDataSegments = numDataSegments;
+
+    for (u32 i = 0; i < numDataSegments; ++i)
+    {
+        M3DataSegment * segment = & io_module->dataSegments [i];
+
+_       (ReadLEB_u32 (& segment->memoryRegion, & i_bytes, i_end));
+
+        segment->initExpr = i_bytes;
+_       (Parse_InitExpr (io_module, & i_bytes, i_end));
+        segment->initExprSize = (u32) (i_bytes - segment->initExpr);
+
+        _throwif (m3Err_wasmMissingInitExpr, segment->initExprSize <= 1);
+
+_       (ReadLEB_u32 (& segment->size, & i_bytes, i_end));
+        segment->data = i_bytes;                                                    m3log (parse, "    segment [%u]  memory: %u;  expr-size: %d;  size: %d",
+                                                                                       i, segment->memoryRegion, segment->initExprSize, segment->size);
+        i_bytes += segment->size;
+
+        _throwif("data segment underflow", i_bytes > i_end);
+    }
+
+    _catch:
+
+    return result;
+}
+
+
+M3Result  ParseSection_Memory  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    // TODO: MVP; assert no memory imported
+
+    u32 numMemories;
+_   (ReadLEB_u32 (& numMemories, & i_bytes, i_end));                             m3log (parse, "** Memory [%d]", numMemories);
+
+    _throwif (m3Err_tooManyMemorySections, numMemories != 1);
+
+    ParseType_Memory (& io_module->memoryInfo, & i_bytes, i_end);
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Global  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result = m3Err_none;
+
+    u32 numGlobals;
+_   (ReadLEB_u32 (& numGlobals, & i_bytes, i_end));                                 m3log (parse, "** Global [%d]", numGlobals);
+
+    _throwif("too many globals", numGlobals > d_m3MaxSaneGlobalsCount);
+
+    for (u32 i = 0; i < numGlobals; ++i)
+    {
+        i8 waType;
+        u8 type, isMutable;
+
+_       (ReadLEB_i7 (& waType, & i_bytes, i_end));
+_       (NormalizeType (& type, waType));
+_       (ReadLEB_u7 (& isMutable, & i_bytes, i_end));                                 m3log (parse, "    global: [%d] %s mutable: %d", i, c_waTypes [type],   (u32) isMutable);
+
+        IM3Global global;
+_       (Module_AddGlobal (io_module, & global, type, isMutable, false /* isImport */));
+
+        global->initExpr = i_bytes;
+_       (Parse_InitExpr (io_module, & i_bytes, i_end));
+        global->initExprSize = (u32) (i_bytes - global->initExpr);
+
+        _throwif (m3Err_wasmMissingInitExpr, global->initExprSize <= 1);
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Name  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result;
+
+    cstr_t name;
+
+    while (i_bytes < i_end)
+    {
+        u8 nameType;
+        u32 payloadLength;
+
+_       (ReadLEB_u7 (& nameType, & i_bytes, i_end));
+_       (ReadLEB_u32 (& payloadLength, & i_bytes, i_end));
+
+        bytes_t start = i_bytes;
+        if (nameType == 1)
+        {
+            u32 numNames;
+_           (ReadLEB_u32 (& numNames, & i_bytes, i_end));
+
+            _throwif("too many names", numNames > d_m3MaxSaneFunctionsCount);
+
+            for (u32 i = 0; i < numNames; ++i)
+            {
+                u32 index;
+_               (ReadLEB_u32 (& index, & i_bytes, i_end));
+_               (Read_utf8 (& name, & i_bytes, i_end));
+
+                if (index < io_module->numFunctions)
+                {
+                    IM3Function func = &(io_module->functions [index]);
+                    if (func->numNames == 0)
+                    {
+                        func->names[0] = name;        m3log (parse, "    naming function%5d:  %s", index, name);
+                        func->numNames = 1;
+                        name = NULL; // transfer ownership
+                    }
+//                          else m3log (parse, "prenamed: %s", io_module->functions [index].name);
+                }
+
+                m3_Free (name);
+            }
+        }
+
+        i_bytes = start + payloadLength;
+    }
+
+    _catch: return result;
+}
+
+
+M3Result  ParseSection_Custom  (M3Module * io_module, bytes_t i_bytes, cbytes_t i_end)
+{
+    M3Result result;
+
+    cstr_t name;
+_   (Read_utf8 (& name, & i_bytes, i_end));
+                                                                                    m3log (parse, "** Custom: '%s'", name);
+    if (strcmp (name, "name") == 0) {
+_       (ParseSection_Name(io_module, i_bytes, i_end));
+    } else if (io_module->environment->customSectionHandler) {
+_       (io_module->environment->customSectionHandler(io_module, name, i_bytes, i_end));
+    }
+
+    m3_Free (name);
+
+    _catch: return result;
+}
+
+
+M3Result  ParseModuleSection  (M3Module * o_module, u8 i_sectionType, bytes_t i_bytes, u32 i_numBytes)
+{
+    M3Result result = m3Err_none;
+
+    typedef M3Result (* M3Parser) (M3Module *, bytes_t, cbytes_t);
+
+    static M3Parser s_parsers [] =
+    {
+        ParseSection_Custom,    // 0
+        ParseSection_Type,      // 1
+        ParseSection_Import,    // 2
+        ParseSection_Function,  // 3
+        NULL,                   // 4: TODO Table
+        ParseSection_Memory,    // 5
+        ParseSection_Global,    // 6
+        ParseSection_Export,    // 7
+        ParseSection_Start,     // 8
+        ParseSection_Element,   // 9
+        ParseSection_Code,      // 10
+        ParseSection_Data,      // 11
+        NULL,                   // 12: TODO DataCount
+    };
+
+    M3Parser parser = NULL;
+
+    if (i_sectionType <= 12)
+        parser = s_parsers [i_sectionType];
+
+    if (parser)
+    {
+        cbytes_t end = i_bytes + i_numBytes;
+        result = parser (o_module, i_bytes, end);
+    }
+    else
+    {
+        m3log (parse, " skipped section type: %d", (u32) i_sectionType);
+    }
+
+    return result;
+}
+
+
+M3Result  m3_ParseModule  (IM3Environment i_environment, IM3Module * o_module, cbytes_t i_bytes, u32 i_numBytes)
+{
+    IM3Module module;                                                               m3log (parse, "load module: %d bytes", i_numBytes);
+_try {
+    module = m3_AllocStruct (M3Module);
+    _throwifnull (module);
+    module->name = ".unnamed";                                                      m3log (parse, "load module: %d bytes", i_numBytes);
+    module->startFunction = -1;
+    //module->hasWasmCodeCopy = false;
+    module->environment = i_environment;
+
+    const u8 * pos = i_bytes;
+    const u8 * end = pos + i_numBytes;
+
+    module->wasmStart = pos;
+    module->wasmEnd = end;
+
+    u32 magic, version;
+_   (Read_u32 (& magic, & pos, end));
+_   (Read_u32 (& version, & pos, end));
+
+    _throwif (m3Err_wasmMalformed, magic != 0x6d736100);
+    _throwif (m3Err_incompatibleWasmVersion, version != 1);
+
+    static const u8 sectionsOrder[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 10, 11, 0 }; // 0 is a placeholder
+    u8 expectedSection = 0;
+
+    while (pos < end)
+    {
+        u8 section;
+_       (ReadLEB_u7 (& section, & pos, end));
+
+        if (section != 0) {
+            // Ensure sections appear only once and in order
+            while (sectionsOrder[expectedSection++] != section) {
+                _throwif(m3Err_misorderedWasmSection, expectedSection >= 12);
+            }
+        }
+
+        u32 sectionLength;
+_       (ReadLEB_u32 (& sectionLength, & pos, end));
+        _throwif(m3Err_wasmMalformed, pos + sectionLength > end);
+
+_       (ParseModuleSection (module, section, pos, sectionLength));
+
+        pos += sectionLength;
+    }
+
+} _catch:
+
+    if (result)
+    {
+        m3_FreeModule (module);
+        module = NULL;
+    }
+
+    * o_module = module;
+
+    return result;
+}

--- a/thirdparty/wasm3/source/wasm3.h
+++ b/thirdparty/wasm3/source/wasm3.h
@@ -1,0 +1,375 @@
+//
+//  Wasm3, high performance WebAssembly interpreter
+//
+//  Copyright © 2019 Steven Massey, Volodymyr Shymanskyy.
+//  All rights reserved.
+//
+
+#ifndef wasm3_h
+#define wasm3_h
+
+#define M3_VERSION_MAJOR 0
+#define M3_VERSION_MINOR 5
+#define M3_VERSION_REV   0
+#define M3_VERSION       "0.5.0"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdarg.h>
+
+#include "wasm3_defs.h"
+
+// Constants
+#define M3_BACKTRACE_TRUNCATED      (IM3BacktraceFrame)(SIZE_MAX)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef const char *    M3Result;
+
+struct M3Environment;   typedef struct M3Environment *  IM3Environment;
+struct M3Runtime;       typedef struct M3Runtime *      IM3Runtime;
+struct M3Module;        typedef struct M3Module *       IM3Module;
+struct M3Function;      typedef struct M3Function *     IM3Function;
+struct M3Global;        typedef struct M3Global *       IM3Global;
+
+typedef struct M3ErrorInfo
+{
+    M3Result        result;
+
+    IM3Runtime      runtime;
+    IM3Module       module;
+    IM3Function     function;
+
+    const char *    file;
+    uint32_t        line;
+
+    const char *    message;
+} M3ErrorInfo;
+
+typedef struct M3BacktraceFrame
+{
+    uint32_t                     moduleOffset;
+    IM3Function                  function;
+
+    struct M3BacktraceFrame *    next;
+}
+M3BacktraceFrame, * IM3BacktraceFrame;
+
+typedef struct M3BacktraceInfo
+{
+    IM3BacktraceFrame      frames;
+    IM3BacktraceFrame      lastFrame;    // can be M3_BACKTRACE_TRUNCATED
+}
+M3BacktraceInfo, * IM3BacktraceInfo;
+
+
+typedef enum M3ValueType
+{
+    c_m3Type_none   = 0,
+    c_m3Type_i32    = 1,
+    c_m3Type_i64    = 2,
+    c_m3Type_f32    = 3,
+    c_m3Type_f64    = 4,
+
+    c_m3Type_unknown
+} M3ValueType;
+
+typedef struct M3TaggedValue
+{
+    M3ValueType type;
+    union M3ValueUnion
+    {
+        uint32_t    i32;
+        uint64_t    i64;
+        float       f32;
+        double      f64;
+    } value;
+}
+M3TaggedValue, * IM3TaggedValue;
+
+typedef struct M3ImportInfo
+{
+    const char *    moduleUtf8;
+    const char *    fieldUtf8;
+}
+M3ImportInfo, * IM3ImportInfo;
+
+
+typedef struct M3ImportContext
+{
+    void *          userdata;
+    IM3Function     function;
+}
+M3ImportContext, * IM3ImportContext;
+
+// -------------------------------------------------------------------------------------------------------------------------------
+//  error codes
+// -------------------------------------------------------------------------------------------------------------------------------
+
+# if defined(M3_IMPLEMENT_ERROR_STRINGS)
+#   if defined(__cplusplus)
+#     define d_m3ErrorConst(LABEL, STRING)      extern const M3Result m3Err_##LABEL = { STRING };
+#   else
+#     define d_m3ErrorConst(LABEL, STRING)      const M3Result m3Err_##LABEL = { STRING };
+#   endif
+# else
+#   define d_m3ErrorConst(LABEL, STRING)        extern const M3Result m3Err_##LABEL;
+# endif
+
+// -------------------------------------------------------------------------------------------------------------------------------
+
+d_m3ErrorConst  (none,                          NULL)
+
+// general errors
+d_m3ErrorConst  (mallocFailed,                  "memory allocation failed")
+
+// parse errors
+d_m3ErrorConst  (incompatibleWasmVersion,       "incompatible Wasm binary version")
+d_m3ErrorConst  (wasmMalformed,                 "malformed Wasm binary")
+d_m3ErrorConst  (misorderedWasmSection,         "out of order Wasm section")
+d_m3ErrorConst  (wasmUnderrun,                  "underrun while parsing Wasm binary")
+d_m3ErrorConst  (wasmOverrun,                   "overrun while parsing Wasm binary")
+d_m3ErrorConst  (wasmMissingInitExpr,           "missing init_expr in Wasm binary")
+d_m3ErrorConst  (lebOverflow,                   "LEB encoded value overflow")
+d_m3ErrorConst  (missingUTF8,                   "invalid length UTF-8 string")
+d_m3ErrorConst  (wasmSectionUnderrun,           "section underrun while parsing Wasm binary")
+d_m3ErrorConst  (wasmSectionOverrun,            "section overrun while parsing Wasm binary")
+d_m3ErrorConst  (invalidTypeId,                 "unknown value_type")
+d_m3ErrorConst  (tooManyMemorySections,         "only one memory per module is supported")
+d_m3ErrorConst  (tooManyArgsRets,               "too many arguments or return values")
+
+// link errors
+d_m3ErrorConst  (moduleNotLinked,               "attempting to use module that is not loaded")
+d_m3ErrorConst  (moduleAlreadyLinked,           "attempting to bind module to multiple runtimes")
+d_m3ErrorConst  (functionLookupFailed,          "function lookup failed")
+d_m3ErrorConst  (functionImportMissing,         "missing imported function")
+
+d_m3ErrorConst  (malformedFunctionSignature,    "malformed function signature")
+
+// compilation errors
+d_m3ErrorConst  (noCompiler,                    "no compiler found for opcode")
+d_m3ErrorConst  (unknownOpcode,                 "unknown opcode")
+d_m3ErrorConst  (restrictedOpcode,              "restricted opcode")
+d_m3ErrorConst  (functionStackOverflow,         "compiling function overran its stack height limit")
+d_m3ErrorConst  (functionStackUnderrun,         "compiling function underran the stack")
+d_m3ErrorConst  (mallocFailedCodePage,          "memory allocation failed when acquiring a new M3 code page")
+d_m3ErrorConst  (settingImmutableGlobal,        "attempting to set an immutable global")
+d_m3ErrorConst  (typeMismatch,                  "incorrect type on stack")
+d_m3ErrorConst  (typeCountMismatch,             "incorrect value count on stack")
+
+// runtime errors
+d_m3ErrorConst  (missingCompiledCode,           "function is missing compiled m3 code")
+d_m3ErrorConst  (wasmMemoryOverflow,            "runtime ran out of memory")
+d_m3ErrorConst  (globalMemoryNotAllocated,      "global memory is missing from a module")
+d_m3ErrorConst  (globaIndexOutOfBounds,         "global index is too large")
+d_m3ErrorConst  (argumentCountMismatch,         "argument count mismatch")
+d_m3ErrorConst  (argumentTypeMismatch,          "argument type mismatch")
+d_m3ErrorConst  (globalLookupFailed,            "global lookup failed")
+d_m3ErrorConst  (globalTypeMismatch,            "global type mismatch")
+d_m3ErrorConst  (globalNotMutable,              "global is not mutable")
+
+// traps
+d_m3ErrorConst  (trapOutOfBoundsMemoryAccess,   "[trap] out of bounds memory access")
+d_m3ErrorConst  (trapDivisionByZero,            "[trap] integer divide by zero")
+d_m3ErrorConst  (trapIntegerOverflow,           "[trap] integer overflow")
+d_m3ErrorConst  (trapIntegerConversion,         "[trap] invalid conversion to integer")
+d_m3ErrorConst  (trapIndirectCallTypeMismatch,  "[trap] indirect call type mismatch")
+d_m3ErrorConst  (trapTableIndexOutOfRange,      "[trap] undefined element")
+d_m3ErrorConst  (trapTableElementIsNull,        "[trap] null table element")
+d_m3ErrorConst  (trapExit,                      "[trap] program called exit")
+d_m3ErrorConst  (trapAbort,                     "[trap] program called abort")
+d_m3ErrorConst  (trapUnreachable,               "[trap] unreachable executed")
+d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
+
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  configuration, can be found in m3_config.h, m3_config_platforms.h, m3_core.h)
+//-------------------------------------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  global environment than can host multiple runtimes
+//-------------------------------------------------------------------------------------------------------------------------------
+    IM3Environment      m3_NewEnvironment           (void);
+
+    void                m3_FreeEnvironment          (IM3Environment i_environment);
+
+    typedef M3Result (* M3SectionHandler) (IM3Module i_module, const char* name, const uint8_t * start, const uint8_t * end);
+
+    void                m3_SetCustomSectionHandler  (IM3Environment i_environment,    M3SectionHandler i_handler);
+
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  execution context
+//-------------------------------------------------------------------------------------------------------------------------------
+
+    IM3Runtime          m3_NewRuntime               (IM3Environment         io_environment,
+                                                     uint32_t               i_stackSizeInBytes,
+                                                     void *                 i_userdata);
+
+    void                m3_FreeRuntime              (IM3Runtime             i_runtime);
+
+    // Wasm currently only supports one memory region. i_memoryIndex should be zero.
+    uint8_t *           m3_GetMemory                (IM3Runtime             i_runtime,
+                                                     uint32_t *             o_memorySizeInBytes,
+                                                     uint32_t               i_memoryIndex);
+
+    // This is used internally by Raw Function helpers
+    uint32_t            m3_GetMemorySize            (IM3Runtime             i_runtime);
+
+    void *              m3_GetUserData              (IM3Runtime             i_runtime);
+
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  modules
+//-------------------------------------------------------------------------------------------------------------------------------
+
+    // i_wasmBytes data must be persistent during the lifetime of the module
+    M3Result            m3_ParseModule              (IM3Environment         i_environment,
+                                                     IM3Module *            o_module,
+                                                     const uint8_t * const  i_wasmBytes,
+                                                     uint32_t               i_numWasmBytes);
+
+    // Only modules not loaded into a M3Runtime need to be freed. A module is considered unloaded if
+    // a. m3_LoadModule has not yet been called on that module. Or,
+    // b. m3_LoadModule returned a result.
+    void                m3_FreeModule               (IM3Module i_module);
+
+    //  LoadModule transfers ownership of a module to the runtime. Do not free modules once successfully loaded into the runtime
+    M3Result            m3_LoadModule               (IM3Runtime io_runtime,  IM3Module io_module);
+
+    // Optional, compiles all functions in the module
+    M3Result            m3_CompileModule            (IM3Module io_module);
+
+    // Calling m3_RunStart is optional
+    M3Result            m3_RunStart                 (IM3Module i_module);
+
+    // Arguments and return values are passed in and out through the stack pointer _sp.
+    // Placeholder return value slots are first and arguments after. So, the first argument is at _sp [numReturns]
+    // Return values should be written into _sp [0] to _sp [num_returns - 1]
+    typedef const void * (* M3RawCall) (IM3Runtime runtime, IM3ImportContext _ctx, uint64_t * _sp, void * _mem);
+
+    M3Result            m3_LinkRawFunction          (IM3Module              io_module,
+                                                     const char * const     i_moduleName,
+                                                     const char * const     i_functionName,
+                                                     const char * const     i_signature,
+                                                     M3RawCall              i_function);
+
+    M3Result            m3_LinkRawFunctionEx        (IM3Module              io_module,
+                                                     const char * const     i_moduleName,
+                                                     const char * const     i_functionName,
+                                                     const char * const     i_signature,
+                                                     M3RawCall              i_function,
+                                                     const void *           i_userdata);
+
+    const char*         m3_GetModuleName            (IM3Module i_module);
+    void                m3_SetModuleName            (IM3Module i_module, const char* name);
+    IM3Runtime          m3_GetModuleRuntime         (IM3Module i_module);
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  globals
+//-------------------------------------------------------------------------------------------------------------------------------
+    IM3Global           m3_FindGlobal               (IM3Module              io_module,
+                                                     const char * const     i_globalName);
+
+    M3Result            m3_GetGlobal                (IM3Global              i_global,
+                                                     IM3TaggedValue         o_value);
+
+    M3Result            m3_SetGlobal                (IM3Global              i_global,
+                                                     const IM3TaggedValue   i_value);
+
+    M3ValueType         m3_GetGlobalType            (IM3Global              i_global);
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  functions
+//-------------------------------------------------------------------------------------------------------------------------------
+    M3Result            m3_Yield                    (void);
+
+    // o_function is valid during the lifetime of the originating runtime
+    M3Result            m3_FindFunction             (IM3Function *          o_function,
+                                                     IM3Runtime             i_runtime,
+                                                     const char * const     i_functionName);
+    M3Result            m3_GetTableFunction         (IM3Function *          o_function,
+                                                     IM3Module              i_module,
+                                                     uint32_t               i_index);
+
+    uint32_t            m3_GetArgCount              (IM3Function i_function);
+    uint32_t            m3_GetRetCount              (IM3Function i_function);
+    M3ValueType         m3_GetArgType               (IM3Function i_function, uint32_t i_index);
+    M3ValueType         m3_GetRetType               (IM3Function i_function, uint32_t i_index);
+
+    M3Result            m3_CallV                    (IM3Function i_function, ...);
+    M3Result            m3_CallVL                   (IM3Function i_function, va_list i_args);
+    M3Result            m3_Call                     (IM3Function i_function, uint32_t i_argc, const void * i_argptrs[]);
+    M3Result            m3_CallArgv                 (IM3Function i_function, uint32_t i_argc, const char * i_argv[]);
+
+    M3Result            m3_GetResultsV              (IM3Function i_function, ...);
+    M3Result            m3_GetResultsVL             (IM3Function i_function, va_list o_rets);
+    M3Result            m3_GetResults               (IM3Function i_function, uint32_t i_retc, const void * o_retptrs[]);
+
+
+    void                m3_GetErrorInfo             (IM3Runtime i_runtime, M3ErrorInfo* o_info);
+    void                m3_ResetErrorInfo           (IM3Runtime i_runtime);
+
+    const char*         m3_GetFunctionName          (IM3Function i_function);
+    IM3Module           m3_GetFunctionModule        (IM3Function i_function);
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  debug info
+//-------------------------------------------------------------------------------------------------------------------------------
+
+    void                m3_PrintRuntimeInfo         (IM3Runtime i_runtime);
+    void                m3_PrintM3Info              (void);
+    void                m3_PrintProfilerInfo        (void);
+
+    // The runtime owns the backtrace, do not free the backtrace you obtain. Returns NULL if there's no backtrace.
+    IM3BacktraceInfo    m3_GetBacktrace             (IM3Runtime i_runtime);
+
+//-------------------------------------------------------------------------------------------------------------------------------
+//  raw function definition helpers
+//-------------------------------------------------------------------------------------------------------------------------------
+
+# define m3ApiOffsetToPtr(offset)   (void*)((uint8_t*)_mem + (uint32_t)(offset))
+# define m3ApiPtrToOffset(ptr)      (uint32_t)((uint8_t*)ptr - (uint8_t*)_mem)
+
+# define m3ApiReturnType(TYPE)                 TYPE* raw_return = ((TYPE*) (_sp++));
+# define m3ApiMultiValueReturnType(TYPE, NAME) TYPE* NAME = ((TYPE*) (_sp++));
+# define m3ApiGetArg(TYPE, NAME)               TYPE NAME = * ((TYPE *) (_sp++));
+# define m3ApiGetArgMem(TYPE, NAME)            TYPE NAME = (TYPE)m3ApiOffsetToPtr(* ((uint32_t *) (_sp++)));
+
+# define m3ApiIsNullPtr(addr)       ((void*)(addr) <= _mem)
+# define m3ApiCheckMem(addr, len)   { if (M3_UNLIKELY(((void*)(addr) < _mem) || ((uint64_t)(uintptr_t)(addr) + (len)) > ((uint64_t)(uintptr_t)(_mem)+m3_GetMemorySize(runtime)))) m3ApiTrap(m3Err_trapOutOfBoundsMemoryAccess); }
+
+# define m3ApiRawFunction(NAME)     const void * NAME (IM3Runtime runtime, IM3ImportContext _ctx, uint64_t * _sp, void * _mem)
+# define m3ApiReturn(VALUE)                   { *raw_return = (VALUE); return m3Err_none;}
+# define m3ApiMultiValueReturn(NAME, VALUE)   { *NAME = (VALUE); }
+# define m3ApiTrap(VALUE)                     { return VALUE; }
+# define m3ApiSuccess()                       { return m3Err_none; }
+
+# if defined(M3_BIG_ENDIAN)
+#  define m3ApiReadMem8(ptr)         (* (uint8_t *)(ptr))
+#  define m3ApiReadMem16(ptr)        m3_bswap16((* (uint16_t *)(ptr)))
+#  define m3ApiReadMem32(ptr)        m3_bswap32((* (uint32_t *)(ptr)))
+#  define m3ApiReadMem64(ptr)        m3_bswap64((* (uint64_t *)(ptr)))
+#  define m3ApiWriteMem8(ptr, val)   { * (uint8_t  *)(ptr)  = (val); }
+#  define m3ApiWriteMem16(ptr, val)  { * (uint16_t *)(ptr) = m3_bswap16((val)); }
+#  define m3ApiWriteMem32(ptr, val)  { * (uint32_t *)(ptr) = m3_bswap32((val)); }
+#  define m3ApiWriteMem64(ptr, val)  { * (uint64_t *)(ptr) = m3_bswap64((val)); }
+# else
+#  define m3ApiReadMem8(ptr)         (* (uint8_t *)(ptr))
+#  define m3ApiReadMem16(ptr)        (* (uint16_t *)(ptr))
+#  define m3ApiReadMem32(ptr)        (* (uint32_t *)(ptr))
+#  define m3ApiReadMem64(ptr)        (* (uint64_t *)(ptr))
+#  define m3ApiWriteMem8(ptr, val)   { * (uint8_t  *)(ptr) = (val); }
+#  define m3ApiWriteMem16(ptr, val)  { * (uint16_t *)(ptr) = (val); }
+#  define m3ApiWriteMem32(ptr, val)  { * (uint32_t *)(ptr) = (val); }
+#  define m3ApiWriteMem64(ptr, val)  { * (uint64_t *)(ptr) = (val); }
+# endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // wasm3_h

--- a/thirdparty/wasm3/source/wasm3_defs.h
+++ b/thirdparty/wasm3/source/wasm3_defs.h
@@ -1,0 +1,293 @@
+//
+//  wasm3_defs.h
+//
+//  Created by Volodymyr Shymanskyy on 11/20/19.
+//  Copyright © 2019 Volodymyr Shymanskyy. All rights reserved.
+//
+
+#ifndef wasm3_defs_h
+#define wasm3_defs_h
+
+#define M3_STR__(x) #x
+#define M3_STR(x)   M3_STR__(x)
+
+#define M3_CONCAT__(a,b) a##b
+#define M3_CONCAT(a,b)   M3_CONCAT__(a,b)
+
+/*
+ * Detect compiler
+ */
+
+# if defined(__clang__)
+#  define M3_COMPILER_CLANG 1
+# elif defined(__INTEL_COMPILER)
+#  define M3_COMPILER_ICC 1
+# elif defined(__GNUC__) || defined(__GNUG__)
+#  define M3_COMPILER_GCC 1
+# elif defined(_MSC_VER)
+#  define M3_COMPILER_MSVC 1
+# else
+#  warning "Compiler not detected"
+# endif
+
+# if defined(M3_COMPILER_CLANG)
+#  if defined(WIN32)
+#   define M3_COMPILER_VER __VERSION__ " for Windows"
+#  else
+#   define M3_COMPILER_VER __VERSION__
+#  endif
+# elif defined(M3_COMPILER_GCC)
+#  define M3_COMPILER_VER "GCC " __VERSION__
+# elif defined(M3_COMPILER_ICC)
+#  define M3_COMPILER_VER __VERSION__
+# elif defined(M3_COMPILER_MSVC)
+#  define M3_COMPILER_VER "MSVC " M3_STR(_MSC_VER)
+# else
+#  define M3_COMPILER_VER "unknown"
+# endif
+
+# ifdef __has_feature
+#  define M3_COMPILER_HAS_FEATURE(x) __has_feature(x)
+# else
+#  define M3_COMPILER_HAS_FEATURE(x) 0
+# endif
+
+# ifdef __has_builtin
+#  define M3_COMPILER_HAS_BUILTIN(x) __has_builtin(x)
+# else
+#  define M3_COMPILER_HAS_BUILTIN(x) 0
+# endif
+
+# ifdef __has_attribute
+#  define M3_COMPILER_HAS_ATTRIBUTE(x) __has_attribute(x)
+# else
+#  define M3_COMPILER_HAS_ATTRIBUTE(x) 0
+# endif
+
+/*
+ * Detect endianness
+ */
+
+# if defined(M3_COMPILER_MSVC)
+#  define M3_LITTLE_ENDIAN
+# elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#  define M3_LITTLE_ENDIAN
+# elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#  define M3_BIG_ENDIAN
+# else
+#  error "Byte order not detected"
+# endif
+
+/*
+ * Detect platform
+ */
+
+# if defined(M3_COMPILER_CLANG) || defined(M3_COMPILER_GCC) || defined(M3_COMPILER_ICC)
+#  if defined(__wasm__)
+#   define M3_ARCH "wasm"
+
+#  elif defined(__x86_64__)
+#   define M3_ARCH "x86_64"
+
+#  elif defined(__i386__)
+#   define M3_ARCH "i386"
+
+#  elif defined(__aarch64__)
+#   define M3_ARCH "arm64-v8a"
+
+#  elif defined(__arm__)
+#   if defined(__ARM_ARCH_7A__)
+#    if defined(__ARM_NEON__)
+#     if defined(__ARM_PCS_VFP)
+#      define M3_ARCH "arm-v7a/NEON hard-float"
+#     else
+#      define M3_ARCH "arm-v7a/NEON"
+#     endif
+#    else
+#     if defined(__ARM_PCS_VFP)
+#      define M3_ARCH "arm-v7a hard-float"
+#     else
+#      define M3_ARCH "arm-v7a"
+#     endif
+#    endif
+#   else
+#    define M3_ARCH "arm"
+#   endif
+
+#  elif defined(__riscv)
+#   if defined(__riscv_32e)
+#    define _M3_ARCH_RV "rv32e"
+#   elif __riscv_xlen == 128
+#    define _M3_ARCH_RV "rv128i"
+#   elif __riscv_xlen == 64
+#    define _M3_ARCH_RV "rv64i"
+#   elif __riscv_xlen == 32
+#    define _M3_ARCH_RV "rv32i"
+#   endif
+#   if defined(__riscv_muldiv)
+#    define _M3_ARCH_RV_M _M3_ARCH_RV "m"
+#   else
+#    define _M3_ARCH_RV_M _M3_ARCH_RV
+#   endif
+#   if defined(__riscv_atomic)
+#    define _M3_ARCH_RV_A _M3_ARCH_RV_M "a"
+#   else
+#    define _M3_ARCH_RV_A _M3_ARCH_RV_M
+#   endif
+#   if defined(__riscv_flen)
+#    define _M3_ARCH_RV_F _M3_ARCH_RV_A "f"
+#   else
+#    define _M3_ARCH_RV_F _M3_ARCH_RV_A
+#   endif
+#   if defined(__riscv_flen) && __riscv_flen >= 64
+#    define _M3_ARCH_RV_D _M3_ARCH_RV_F "d"
+#   else
+#    define _M3_ARCH_RV_D _M3_ARCH_RV_F
+#   endif
+#   if defined(__riscv_compressed)
+#    define _M3_ARCH_RV_C _M3_ARCH_RV_D "c"
+#   else
+#    define _M3_ARCH_RV_C _M3_ARCH_RV_D
+#   endif
+#   define M3_ARCH _M3_ARCH_RV_C
+
+#  elif defined(__mips__)
+#   if defined(__MIPSEB__) && defined(__mips64)
+#    define M3_ARCH "mips64 " _MIPS_ARCH
+#   elif defined(__MIPSEL__) && defined(__mips64)
+#    define M3_ARCH "mips64el " _MIPS_ARCH
+#   elif defined(__MIPSEB__)
+#    define M3_ARCH "mips " _MIPS_ARCH
+#   elif defined(__MIPSEL__)
+#    define M3_ARCH "mipsel " _MIPS_ARCH
+#   endif
+
+#  elif defined(__PPC__)
+#   if defined(__PPC64__) && defined(__LITTLE_ENDIAN__)
+#    define M3_ARCH "ppc64le"
+#   elif defined(__PPC64__)
+#    define M3_ARCH "ppc64"
+#   else
+#    define M3_ARCH "ppc"
+#   endif
+
+#  elif defined(__sparc__)
+#   if defined(__arch64__)
+#    define M3_ARCH "sparc64"
+#   else
+#    define M3_ARCH "sparc"
+#   endif
+
+#  elif defined(__s390x__)
+#   define M3_ARCH "s390x"
+
+#  elif defined(__alpha__)
+#   define M3_ARCH "alpha"
+
+#  elif defined(__m68k__)
+#   define M3_ARCH "m68k"
+
+#  elif defined(__xtensa__)
+#   define M3_ARCH "xtensa"
+
+#  elif defined(__arc__)
+#   define M3_ARCH "arc32"
+
+#  elif defined(__AVR__)
+#   define M3_ARCH "avr"
+#  endif
+# endif
+
+# if defined(M3_COMPILER_MSVC)
+#  if defined(_M_X64)
+#   define M3_ARCH "x86_64"
+#  elif defined(_M_IX86)
+#   define M3_ARCH "i386"
+#  elif defined(_M_ARM64)
+#   define M3_ARCH "arm64"
+#  elif defined(_M_ARM)
+#   define M3_ARCH "arm"
+#  endif
+# endif
+
+# if !defined(M3_ARCH)
+#  warning "Architecture not detected"
+#  define M3_ARCH "unknown"
+# endif
+
+/*
+ * Byte swapping (for Big-Endian systems only)
+ */
+
+# if defined(M3_COMPILER_MSVC)
+#  define m3_bswap16(x)     _byteswap_ushort((x))
+#  define m3_bswap32(x)     _byteswap_ulong((x))
+#  define m3_bswap64(x)     _byteswap_uint64((x))
+# elif defined(M3_COMPILER_GCC) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
+// __builtin_bswap32/64 added in gcc 4.3, __builtin_bswap16 added in gcc 4.8
+#  define m3_bswap16(x)     __builtin_bswap16((x))
+#  define m3_bswap32(x)     __builtin_bswap32((x))
+#  define m3_bswap64(x)     __builtin_bswap64((x))
+# elif defined(M3_COMPILER_CLANG) && M3_COMPILER_HAS_BUILTIN(__builtin_bswap16)
+#  define m3_bswap16(x)     __builtin_bswap16((x))
+#  define m3_bswap32(x)     __builtin_bswap32((x))
+#  define m3_bswap64(x)     __builtin_bswap64((x))
+# elif defined(M3_COMPILER_ICC)
+#  define m3_bswap16(x)     __builtin_bswap16((x))
+#  define m3_bswap32(x)     __builtin_bswap32((x))
+#  define m3_bswap64(x)     __builtin_bswap64((x))
+# else
+#  ifdef __linux__
+#   include <endian.h>
+#  else
+#   include <stdint.h>
+#  endif
+#  if defined(__bswap_16)
+#   define m3_bswap16(x)     __bswap_16((x))
+#   define m3_bswap32(x)     __bswap_32((x))
+#   define m3_bswap64(x)     __bswap_64((x))
+#  else
+#   warning "Using naive (probably slow) bswap operations"
+    static inline
+    uint16_t m3_bswap16(uint16_t x) {
+      return ((( x  >> 8 ) & 0xffu ) | (( x  & 0xffu ) << 8 ));
+    }
+    static inline
+    uint32_t m3_bswap32(uint32_t x) {
+      return ((( x & 0xff000000u ) >> 24 ) |
+              (( x & 0x00ff0000u ) >> 8  ) |
+              (( x & 0x0000ff00u ) << 8  ) |
+              (( x & 0x000000ffu ) << 24 ));
+    }
+    static inline
+    uint64_t m3_bswap64(uint64_t x) {
+      return ((( x & 0xff00000000000000ull ) >> 56 ) |
+              (( x & 0x00ff000000000000ull ) >> 40 ) |
+              (( x & 0x0000ff0000000000ull ) >> 24 ) |
+              (( x & 0x000000ff00000000ull ) >> 8  ) |
+              (( x & 0x00000000ff000000ull ) << 8  ) |
+              (( x & 0x0000000000ff0000ull ) << 24 ) |
+              (( x & 0x000000000000ff00ull ) << 40 ) |
+              (( x & 0x00000000000000ffull ) << 56 ));
+    }
+#  endif
+# endif
+
+/*
+ * Bit ops
+ */
+#define m3_isBitSet(val, pos)           ((val & (1 << pos)) != 0)
+
+/*
+ * Other
+ */
+
+# if defined(M3_COMPILER_GCC) || defined(M3_COMPILER_CLANG) || defined(M3_COMPILER_ICC)
+#  define M3_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#  define M3_LIKELY(x)   __builtin_expect(!!(x), 1)
+# else
+#  define M3_UNLIKELY(x) (x)
+#  define M3_LIKELY(x)   (x)
+# endif
+
+#endif // wasm3_defs_h


### PR DESCRIPTION
Implements the plan described in https://github.com/godotengine/godot-proposals/issues/10488

Partially implements https://github.com/godotengine/godot-proposals/issues/147
One possible solution for https://github.com/godotengine/godot-proposals/issues/5010

This patch is still quite a work in progress, but I wanted to post it early to discuss and get early feedback.

### TODO

- [ ] Finalize API
- [ ] Is there a way the "Wasm" class to be 'late-bound' such that if a GDExtension implements it, we defer to that extension implementation?
- [ ] Add support for Wasm blobs that don't export their own memory.
- [ ] Is there better way to keep Callables alive than to store a linked list of them?
- [ ] The godot code has to reach directly into m3 to work around some methods missing from it's public API, consider adding public apis in wasm3 for these and upstream that.
- [ ] Add UnitTests / Integration Tests
- [ ] Better Examples