### PR TITLE
Simplify Rect2/AABB `get_support` function

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -85,7 +85,7 @@ struct [[nodiscard]] AABB {
 	bool intersects_plane(const Plane &p_plane) const;
 
 	_FORCE_INLINE_ bool has_point(const Vector3 &p_point) const;
-	_FORCE_INLINE_ Vector3 get_support(const Vector3 &p_normal) const;
+	_FORCE_INLINE_ Vector3 get_support(const Vector3 &p_direction) const;
 
 	Vector3 get_longest_axis() const;
 	int get_longest_axis_index() const;
@@ -212,15 +212,18 @@ inline bool AABB::encloses(const AABB &p_aabb) const {
 			(src_max.z >= dst_max.z));
 }
 
-Vector3 AABB::get_support(const Vector3 &p_normal) const {
-	Vector3 half_extents = size * 0.5f;
-	Vector3 ofs = position + half_extents;
-
-	return Vector3(
-				   (p_normal.x > 0) ? half_extents.x : -half_extents.x,
-				   (p_normal.y > 0) ? half_extents.y : -half_extents.y,
-				   (p_normal.z > 0) ? half_extents.z : -half_extents.z) +
-			ofs;
+Vector3 AABB::get_support(const Vector3 &p_direction) const {
+	Vector3 support = position;
+	if (p_direction.x > 0.0f) {
+		support.x += size.x;
+	}
+	if (p_direction.y > 0.0f) {
+		support.y += size.y;
+	}
+	if (p_direction.z > 0.0f) {
+		support.z += size.z;
+	}
+	return support;
 }
 
 Vector3 AABB::get_endpoint(int p_point) const {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -285,13 +285,15 @@ struct [[nodiscard]] Rect2 {
 		return Rect2(position.round(), size.round());
 	}
 
-	Vector2 get_support(const Vector2 &p_normal) const {
-		Vector2 half_extents = size * 0.5f;
-		Vector2 ofs = position + half_extents;
-		return Vector2(
-					   (p_normal.x > 0) ? -half_extents.x : half_extents.x,
-					   (p_normal.y > 0) ? -half_extents.y : half_extents.y) +
-				ofs;
+	Vector2 get_support(const Vector2 &p_direction) const {
+		Vector2 support = position;
+		if (p_direction.x > 0.0f) {
+			support.x += size.x;
+		}
+		if (p_direction.y > 0.0f) {
+			support.y += size.y;
+		}
+		return support;
 	}
 
 	_FORCE_INLINE_ bool intersects_filled_polygon(const Vector2 *p_points, int p_point_count) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1849,6 +1849,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Rect2, intersection, sarray("b"), varray());
 	bind_method(Rect2, merge, sarray("b"), varray());
 	bind_method(Rect2, expand, sarray("to"), varray());
+	bind_method(Rect2, get_support, sarray("direction"), varray());
 	bind_method(Rect2, grow, sarray("amount"), varray());
 	bind_methodv(Rect2, grow_side, &Rect2::grow_side_bind, sarray("side", "amount"), varray());
 	bind_method(Rect2, grow_individual, sarray("left", "top", "right", "bottom"), varray());
@@ -2185,7 +2186,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(AABB, merge, sarray("with"), varray());
 	bind_method(AABB, expand, sarray("to_point"), varray());
 	bind_method(AABB, grow, sarray("by"), varray());
-	bind_method(AABB, get_support, sarray("dir"), varray());
+	bind_method(AABB, get_support, sarray("direction"), varray());
 	bind_method(AABB, get_longest_axis, sarray(), varray());
 	bind_method(AABB, get_longest_axis_index, sarray(), varray());
 	bind_method(AABB, get_longest_axis_size, sarray(), varray());

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -206,7 +206,7 @@
 		</method>
 		<method name="get_support" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="dir" type="Vector3" />
+			<param index="0" name="direction" type="Vector3" />
 			<description>
 				Returns the vertex's position of this bounding box that's the farthest in the given direction. This point is commonly known as the support point in collision detection algorithms.
 			</description>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -112,6 +112,13 @@
 				Returns the center point of the rectangle. This is the same as [code]position + (size / 2.0)[/code].
 			</description>
 		</method>
+		<method name="get_support" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="direction" type="Vector2" />
+			<description>
+				Returns the vertex's position of this rect that's the farthest in the given direction. This point is commonly known as the support point in collision detection algorithms.
+			</description>
+		</method>
 		<method name="grow" qualifiers="const">
 			<return type="Rect2" />
 			<param index="0" name="amount" type="float" />

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1734,7 +1734,7 @@ void RasterizerCanvasGLES3::light_update_directional_shadow(RID p_rid, int p_sha
 
 	Vector2 center = p_clip_rect.get_center();
 
-	float to_edge_distance = ABS(light_dir.dot(p_clip_rect.get_support(light_dir)) - light_dir.dot(center));
+	float to_edge_distance = ABS(light_dir.dot(p_clip_rect.get_support(-light_dir)) - light_dir.dot(center));
 
 	Vector2 from_pos = center - light_dir * (to_edge_distance + p_cull_distance);
 	float distance = to_edge_distance * 2.0 + p_cull_distance;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -314,13 +314,20 @@ namespace Godot
         /// <returns>A vector representing the support.</returns>
         public readonly Vector3 GetSupport(Vector3 dir)
         {
-            Vector3 halfExtents = _size * 0.5f;
-            Vector3 ofs = _position + halfExtents;
-
-            return ofs + new Vector3(
-                dir.X > 0f ? halfExtents.X : -halfExtents.X,
-                dir.Y > 0f ? halfExtents.Y : -halfExtents.Y,
-                dir.Z > 0f ? halfExtents.Z : -halfExtents.Z);
+            Vector3 support = _position;
+            if (dir.X > 0.0f)
+            {
+                support.X += _size.X;
+            }
+            if (dir.Y > 0.0f)
+            {
+                support.Y += _size.Y;
+            }
+            if (dir.Z > 0.0f)
+            {
+                support.Z += _size.Z;
+            }
+            return support;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -172,6 +172,26 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the support point in a given direction.
+        /// This is useful for collision detection algorithms.
+        /// </summary>
+        /// <param name="direction">The direction to find support for.</param>
+        /// <returns>A vector representing the support.</returns>
+        public readonly Vector2 GetSupport(Vector2 direction)
+        {
+            Vector2 support = _position;
+            if (direction.X > 0.0f)
+            {
+                support.X += _size.X;
+            }
+            if (direction.Y > 0.0f)
+            {
+                support.Y += _size.Y;
+            }
+            return support;
+        }
+
+        /// <summary>
         /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
         /// on all sides.
         /// </summary>

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1823,7 +1823,7 @@ void RendererCanvasRenderRD::light_update_directional_shadow(RID p_rid, int p_sh
 
 	Vector2 center = p_clip_rect.get_center();
 
-	float to_edge_distance = ABS(light_dir.dot(p_clip_rect.get_support(light_dir)) - light_dir.dot(center));
+	float to_edge_distance = ABS(light_dir.dot(p_clip_rect.get_support(-light_dir)) - light_dir.dot(center));
 
 	Vector2 from_pos = center - light_dir * (to_edge_distance + p_cull_distance);
 	float distance = to_edge_distance * 2.0 + p_cull_distance;

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -377,23 +377,23 @@ TEST_CASE("[AABB] Get longest/shortest axis") {
 TEST_CASE("[AABB] Get support") {
 	const AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(1, 0, 0)).is_equal_approx(Vector3(2.5, 2, -2.5)),
+			aabb.get_support(Vector3(1, 0, 0)) == Vector3(2.5, 2, -2.5),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0.5, 1, 0)).is_equal_approx(Vector3(2.5, 7, -2.5)),
+			aabb.get_support(Vector3(0.5, 1, 1)) == Vector3(2.5, 7, 3.5),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0.5, 1, -400)).is_equal_approx(Vector3(2.5, 7, -2.5)),
+			aabb.get_support(Vector3(0.5, 1, -400)) == Vector3(2.5, 7, -2.5),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0, -1, 0)).is_equal_approx(Vector3(-1.5, 2, -2.5)),
+			aabb.get_support(Vector3(0, -1, 0)) == Vector3(-1.5, 2, -2.5),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0, -0.1, 0)).is_equal_approx(Vector3(-1.5, 2, -2.5)),
+			aabb.get_support(Vector3(0, -0.1, 0)) == Vector3(-1.5, 2, -2.5),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3()).is_equal_approx(Vector3(-1.5, 2, -2.5)),
-			"get_support() should return the expected value with a null vector.");
+			aabb.get_support(Vector3()) == Vector3(-1.5, 2, -2.5),
+			"get_support() should return the AABB position when given a zero vector.");
 }
 
 TEST_CASE("[AABB] Grow") {

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -180,6 +180,28 @@ TEST_CASE("[Rect2] Expanding") {
 			"expand() with non-contained Vector2 should return the expected result.");
 }
 
+TEST_CASE("[Rect2] Get support") {
+	const Rect2 rect = Rect2(Vector2(-1.5, 2), Vector2(4, 5));
+	CHECK_MESSAGE(
+			rect.get_support(Vector2(1, 0)) == Vector2(2.5, 2),
+			"get_support() should return the expected value.");
+	CHECK_MESSAGE(
+			rect.get_support(Vector2(0.5, 1)) == Vector2(2.5, 7),
+			"get_support() should return the expected value.");
+	CHECK_MESSAGE(
+			rect.get_support(Vector2(0.5, 1)) == Vector2(2.5, 7),
+			"get_support() should return the expected value.");
+	CHECK_MESSAGE(
+			rect.get_support(Vector2(0, -1)) == Vector2(-1.5, 2),
+			"get_support() should return the expected value.");
+	CHECK_MESSAGE(
+			rect.get_support(Vector2(0, -0.1)) == Vector2(-1.5, 2),
+			"get_support() should return the expected value.");
+	CHECK_MESSAGE(
+			rect.get_support(Vector2()) == Vector2(-1.5, 2),
+			"get_support() should return the Rect2 position when given a zero vector.");
+}
+
 TEST_CASE("[Rect2] Growing") {
 	CHECK_MESSAGE(
 			Rect2(0, 100, 1280, 720).grow(100).is_equal_approx(Rect2(-100, 0, 1480, 920)),


### PR DESCRIPTION
I was working on making a Rect4 to have a 4D version of Rect2/AABB, and I noticed this function:

```cpp
Vector3 AABB::get_support(const Vector3 &p_normal) const {
	Vector3 half_extents = size * 0.5f;
	Vector3 ofs = position + half_extents;

	return Vector3(
				   (p_normal.x > 0) ? half_extents.x : -half_extents.x,
				   (p_normal.y > 0) ? half_extents.y : -half_extents.y,
				   (p_normal.z > 0) ? half_extents.z : -half_extents.z) +
			ofs;
}
```

Looking at this carefully, we can see that the end result will either have half_extents added twice, or added then subtracted. This is the same as adding the size or adding zero, so it can be simplified to this:

```cpp
Vector3 AABB::get_support(const Vector3 &p_normal) const {
	const Vector3 size_support = Vector3(
			(p_normal.x > 0.0f) ? size.x : 0.0f,
			(p_normal.y > 0.0f) ? size.y : 0.0f,
			(p_normal.z > 0.0f) ? size.z : 0.0f);
	return position + size_support;
}
```

This is simpler and will produce more accurate results, since adding half twice, or adding then subtracting, can result in floating-point errors of one bit in some situations.

Furthermore, we can remove the addition of zero by changing these ternaries to if statements:

```cpp
Vector3 AABB::get_support(const Vector3 &p_direction) const {
	Vector3 support = position;
	if (p_direction.x > 0.0f) {
		support.x += size.x;
	}
	if (p_direction.y > 0.0f) {
		support.y += size.y;
	}
	if (p_direction.z > 0.0f) {
		support.z += size.z;
	}
	return support;
}
```

I was curious what the performance difference would be, so I benchmarked it in GDScript, and I was surprised that the performance difference was basically nothing, like 1% faster. Of course most of the execution time is overhead from GDScript so just the function by itself may be faster by more than this, but I don't know. Still, it's simpler, produces better results, and is at least as fast, so it's a good change.

Also, as a bonus, we currently don't have `get_support` on the Rect2i type. If we wanted to add this function there, then this new version will work fine for integers, because it doesn't involve dividing by 2.