### PR TITLE
Fix crash when re-importing model with AnimationPlayer panel open and node selected

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -802,7 +802,7 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 					player->connect(SNAME("animation_list_changed"), callable_mp(this, &AnimationPlayerEditor::_animation_libraries_updated), CONNECT_DEFERRED);
 				}
 				if (!player->is_connected(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed))) {
-					player->connect(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed), CONNECT_DEFERRED);
+					player->connect(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed));
 				}
 			}
 


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/95769
closes https://github.com/godotengine/godot/issues/95744

Edit:   Removed CONNECT_DEFERRED from connection
```cpp
player->connect(SNAME("current_animation_changed"), ... ), CONNECT_DEFERRED);
```
->
```cpp
player->connect(SNAME("current_animation_changed"), ... ));
```
The re-import process attempts to update the scene via **EditorNode::reload_instances_with_path_in_edited_scenes()**. I believe this function disassembles the scene and then reassembles it with the updated resource. During this process, the **AnimationPlayer player** is null, leading to the crash."

~~OLD FIX~~
~~added null check to **AnimationPlayer** before use within **AnimationPlayerEditor::_current_animation_changed**~~
