### PR TITLE
Enable more standards conformance for MSVC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -773,6 +773,10 @@ else:
     # MSVC doesn't have clear C standard support, /std only covers C++.
     # We apply it to CCFLAGS (both C and C++ code) in case it impacts C features.
     env.Prepend(CCFLAGS=["/std:c++17"])
+    # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
+    # Note that this is still not complete conformance, as certain Windows-related headers
+    # don't compile under complete conformance.
+    env.Prepend(CCFLAGS=["/permissive-"])
 
 # Disable exception handling. Godot doesn't use exceptions anywhere, and this
 # saves around 20% of binary size and very significant build time (GH-80513).


### PR DESCRIPTION
I just ran into [a case](https://github.com/godotengine/godot/pull/92842#discussion_r1721677611) where code seemed to compile just fine for me locally with MSVC but then failed in the CI checks when compiling with GCC.

MSVC by default (due to backwards compatibility) has quite a bit of [non-conforming behavior](https://learn.microsoft.com/en-us/cpp/build/reference/zc-conformance?view=msvc-170) when it comes to the C++ standards, which can to some degree be disabled using the [`/permissive-`](https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170) option. They do technically enable this option by default when creating new projects in newer versions of Visual Studio, but on the command-line you have to be explicit about it (unless you use `/std:c++latest` or `/std:c++20`, in which case it's also implicit apparently).

This PR fixes this discrepancy with GCC (and presumably Clang) by adding the `/permissive-` option when compiling with MSVC.

Note that this doesn't make it completely conforming still, since there are parts of the Windows SDK (and possibly other core Windows-related APIs) that won't compile under full conformance, but I figured this should improve things at least. It does catch the error I ran into above.

I guess this is also technically a breaking change for anyone downstream relying on non-conformance. I'm not sure if that justifies adding a (default enabled) SCons option for this perhaps?