### PR TITLE
Add `is_internal` property to scripts to hide objects from create dialog

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -172,6 +172,7 @@ void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
+	ClassDB::bind_method(D_METHOD("is_internal"), &Script::is_internal);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -161,6 +161,7 @@ public:
 	virtual bool is_tool() const = 0;
 	virtual bool is_valid() const = 0;
 	virtual bool is_abstract() const = 0;
+	virtual bool is_internal() const = 0;
 
 	virtual ScriptLanguage *get_language() const = 0;
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -62,6 +62,7 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_method_info, "method");
 
 	GDVIRTUAL_BIND(_is_tool);
+	GDVIRTUAL_BIND(_is_internal);
 	GDVIRTUAL_BIND(_is_valid);
 	GDVIRTUAL_BIND(_is_abstract);
 	GDVIRTUAL_BIND(_get_language);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -123,6 +123,7 @@ public:
 
 	EXBIND0RC(bool, is_tool)
 	EXBIND0RC(bool, is_valid)
+	EXBIND0RC(bool, is_internal)
 
 	virtual bool is_abstract() const override {
 		bool abst;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -241,6 +241,11 @@ void CreateDialog::_add_type(const StringName &p_type, TypeCategory p_type_categ
 			}
 			ERR_FAIL_COND(scr.is_null());
 
+			bool show_internal = EDITOR_GET("interface/editor/show_internal_matches_in_create_dialog");
+			if (!show_internal && scr->is_internal()) {
+				return;
+			}
+
 			Ref<Script> base = scr->get_base_script();
 			if (base.is_null()) {
 				// Must be a native base type.
@@ -281,6 +286,7 @@ void CreateDialog::_add_type(const StringName &p_type, TypeCategory p_type_categ
 void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category) {
 	bool script_type = ScriptServer::is_global_class(p_type);
 	bool is_abstract = false;
+	bool is_internal = false;
 	if (p_type_category == TypeCategory::CPP_TYPE) {
 		r_item->set_text(0, p_type);
 	} else if (p_type_category == TypeCategory::PATH_TYPE) {
@@ -294,6 +300,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
 		ERR_FAIL_COND(!scr.is_valid());
 		is_abstract = scr->is_abstract();
+		is_internal = scr->is_internal();
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);
 		r_item->set_text(0, p_type);
@@ -319,6 +326,10 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		r_item->add_button(0, get_editor_theme_icon("StatusError"), 0, false, TTR("This class is marked as deprecated."));
 	} else if (is_experimental) {
 		r_item->add_button(0, get_editor_theme_icon("NodeWarning"), 0, false, TTR("This class is marked as experimental."));
+	}
+
+	if (is_internal) {
+		r_item->add_button(0, get_editor_theme_icon("EditInternal"), 0, false, TTR("This class is marked for internal use only."));
 	}
 
 	if (!search_box->get_text().is_empty()) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -478,6 +478,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/show_internal_matches_in_create_dialog", false, "")
 
 	// Inspector
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1928,6 +1928,7 @@ struct _ScriptEditorItemData {
 	String sort_key;
 	Ref<Texture2D> icon;
 	bool tool = false;
+	bool internal = false;
 	int index = 0;
 	String tooltip;
 	bool used = false;
@@ -2146,6 +2147,7 @@ void ScriptEditor::_update_script_names() {
 			sd.ref = se;
 			if (scr.is_valid()) {
 				sd.tool = scr->is_tool();
+				sd.internal = scr->is_internal();
 			}
 
 			switch (sort_by) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -63,6 +63,7 @@ class GDScript : public Script {
 	bool tool = false;
 	bool valid = false;
 	bool reloading = false;
+	bool internal = false;
 
 	struct MemberInfo {
 		int index = 0;
@@ -268,6 +269,7 @@ public:
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;
 
 	bool is_tool() const override { return tool; }
+	bool is_internal() const override { return internal; }
 	Ref<GDScript> get_base() const;
 
 	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2686,6 +2686,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->clearing = false;
 
 	p_script->tool = parser->is_tool();
+	p_script->internal = parser->is_internal();
 
 	if (p_script->local_name != StringName()) {
 		if (ClassDB::class_exists(p_script->local_name) && ClassDB::is_class_exposed(p_script->local_name)) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -97,6 +97,7 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@tool"), AnnotationInfo::SCRIPT, &GDScriptParser::tool_annotation);
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
+		register_annotation(MethodInfo("@internal"), AnnotationInfo::SCRIPT, &GDScriptParser::internal_annotation);
 
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
@@ -4128,6 +4129,17 @@ bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node
 	return true;
 }
 
+bool GDScriptParser::internal_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+#ifdef DEBUG_ENABLED
+	if (_is_internal) {
+		push_error(R"("@internal" annotation can only be used once.)", p_annotation);
+		return false;
+	}
+#endif
+	_is_internal = true;
+	return true;
+}
+
 static String _get_annotation_error_string(const StringName &p_annotation_name, const Vector<Variant::Type> &p_expected_types, const GDScriptParser::DataType &p_provided_type) {
 	Vector<String> types;
 	for (int i = 0; i < p_expected_types.size(); i++) {
@@ -5824,6 +5836,9 @@ void GDScriptParser::TreePrinter::print_while(WhileNode *p_while) {
 void GDScriptParser::TreePrinter::print_tree(const GDScriptParser &p_parser) {
 	ERR_FAIL_NULL_MSG(p_parser.get_tree(), "Parse the code before printing the parse tree.");
 
+	if (p_parser.is_internal()) {
+		push_line("@internal");
+	}
 	if (p_parser.is_tool()) {
 		push_line("@tool");
 	}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -743,6 +743,7 @@ public:
 		ClassNode *outer = nullptr;
 		bool extends_used = false;
 		bool onready_used = false;
+		bool internal_used = false;
 		bool has_static_data = false;
 		bool annotated_static_unload = false;
 		String extends_path;
@@ -1327,6 +1328,7 @@ private:
 	friend class GDScriptParserRef;
 
 	bool _is_tool = false;
+	bool _is_internal = false;
 	String script_path;
 	bool for_completion = false;
 	bool parse_body = true;
@@ -1496,6 +1498,7 @@ private:
 	bool tool_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool internal_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
@@ -1565,6 +1568,7 @@ public:
 	Error parse_binary(const Vector<uint8_t> &p_binary, const String &p_script_path);
 	ClassNode *get_tree() const { return head; }
 	bool is_tool() const { return _is_tool; }
+	bool is_internal() const { return _is_internal; }
 	Ref<GDScriptParserRef> get_depended_parser_for(const String &p_path);
 	const HashMap<String, Ref<GDScriptParserRef>> &get_depended_parsers();
 	ClassNode *find_class(const String &p_qualified_name) const;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -79,6 +79,11 @@ public:
 		bool is_tool = false;
 
 		/**
+		 * Script is marked for internal use only.
+		 */
+		bool is_internal = false;
+
+		/**
 		 * Script is marked as global class and will be registered in the editor.
 		 * Registered classes can be created using certain editor dialogs and
 		 * can be referenced by name from other languages that support the feature.
@@ -261,6 +266,9 @@ public:
 
 	bool is_tool() const override {
 		return type_info.is_tool;
+	}
+	bool is_internal() const override {
+		return type_info.is_internal;
 	}
 	bool is_valid() const override {
 		return valid;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/InternalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/InternalAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class InternalAttribute : Attribute { }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -737,6 +737,7 @@ namespace Godot.Bridge
             godot_string className = Marshaling.ConvertStringToNative(typeName);
 
             bool isTool = scriptType.IsDefined(typeof(ToolAttribute), inherit: false);
+            bool isInternal = scriptType.IsDefined(typeof(InternalAttribute), inherit: false);
 
             // If the type is nested and the parent type is a tool script,
             // consider the nested type a tool script as well.
@@ -762,6 +763,7 @@ namespace Godot.Bridge
             outTypeInfo->ClassName = className;
             outTypeInfo->IconPath = iconPath;
             outTypeInfo->IsTool = isTool.ToGodotBool();
+            outTypeInfo->IsInternal = isInternal.ToGodotBool();
             outTypeInfo->IsGlobalClass = isGlobalClass.ToGodotBool();
             outTypeInfo->IsAbstract = scriptType.IsAbstract.ToGodotBool();
             outTypeInfo->IsGenericTypeDefinition = scriptType.IsGenericTypeDefinition.ToGodotBool();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -111,6 +111,7 @@ namespace Godot.NativeInterop
         private godot_string _className;
         private godot_string _iconPath;
         private godot_bool _isTool;
+        private godot_bool _isInternal;
         private godot_bool _isGlobalClass;
         private godot_bool _isAbstract;
         private godot_bool _isConstructedGenericType;
@@ -132,6 +133,12 @@ namespace Godot.NativeInterop
         {
             readonly get => _isTool;
             set => _isTool = value;
+        }
+
+        public godot_bool IsInternal
+        {
+            readonly get => _isInternal;
+            set => _isInternal = value;
         }
 
         public godot_bool IsGlobalClass


### PR DESCRIPTION
This PR adds:
- an `is_internal` value to scripts
- an `@internal` annotation for GDScript

This PR aims to let plugin developers a way to differentiate their internal plugin classes from the ones they intend to expose. _Note: This is not related to GDScript namespacing._

<details>
<summary>Editor settings</summary>
<img width="919" alt="Capture d’écran, le 2024-08-19 à 10 45 07" src="https://github.com/user-attachments/assets/2d45deb3-1749-4629-8e12-4151cf4f01e3">
</details>

| Show internal disabled | Show internal enabled |
| --- | --- |
| <img width="925" alt="Capture d’écran, le 2024-08-19 à 11 13 29" src="https://github.com/user-attachments/assets/c5a47939-635d-4fe5-b9f5-1ee83697e1c6"> | <img width="922" alt="Capture d’écran, le 2024-08-19 à 11 13 48" src="https://github.com/user-attachments/assets/e03ab910-5d93-4cce-b7ad-f2ef0f0bf882"> |
