### PR TITLE
Fix relative paths for global class icons in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -241,11 +241,17 @@ namespace Godot.Bridge
 
             if (outIconPath != null)
             {
-                var iconAttr = scriptType.GetCustomAttributes(inherit: false)
+                IconAttribute? iconAttr = scriptType.GetCustomAttributes(inherit: false)
                     .OfType<IconAttribute>()
                     .FirstOrDefault();
 
-                *outIconPath = Marshaling.ConvertStringToNative(iconAttr?.Path);
+                if (!string.IsNullOrEmpty(iconAttr?.Path))
+                {
+                    string iconPath = iconAttr.Path.IsAbsolutePath()
+                        ? iconAttr.Path.SimplifyPath()
+                        : scriptPathStr.GetBaseDir().PathJoin(iconAttr.Path).SimplifyPath();
+                    *outIconPath = Marshaling.ConvertStringToNative(iconPath);
+                }
             }
 
             if (outBaseType != null)


### PR DESCRIPTION
This PR simply re-implements the path logic we used to have on global class icons. It should probably be cherry-picked to 4.3 too.

- Resolves #95592
