### PR TITLE
Implement dynamic scaling of the LineEdit right icon based on control size and scale factor

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -310,6 +310,9 @@
 			If [code]true[/code], the [LineEdit] doesn't display decoration.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="icon_expand_mode" type="int" setter="set_icon_expand_mode" getter="get_icon_expand_mode" enum="LineEdit.ExpandMode" default="0">
+			Define the scaling behavior of the [member right_icon].
+		</member>
 		<member name="keep_editing_on_text_submit" type="bool" setter="set_keep_editing_on_text_submit" getter="is_editing_kept_on_text_submit" default="false">
 			If [code]true[/code], the [LineEdit] will not exit edit mode when text is submitted by pressing [code]ui_text_submit[/code] action (by default: [kbd]Enter[/kbd] or [kbd]Kp Enter[/kbd]).
 		</member>
@@ -351,6 +354,9 @@
 		</member>
 		<member name="right_icon" type="Texture2D" setter="set_right_icon" getter="get_right_icon">
 			Sets the icon that will appear in the right end of the [LineEdit] if there's no [member text], or always, if [member clear_button_enabled] is set to [code]false[/code].
+		</member>
+		<member name="right_icon_scale" type="float" setter="set_right_icon_scale" getter="get_right_icon_scale" default="1.0">
+			Scale ratio of the icon when [member icon_expand_mode] is set to [constant EXPAND_MODE_FIT_TO_LINE_EDIT].
 		</member>
 		<member name="secret" type="bool" setter="set_secret" getter="is_secret" default="false">
 			If [code]true[/code], every character is replaced with the secret character (see [member secret_character]).
@@ -538,6 +544,15 @@
 		</constant>
 		<constant name="KEYBOARD_TYPE_URL" value="7" enum="VirtualKeyboardType">
 			Virtual keyboard with additional keys to assist with typing URLs.
+		</constant>
+		<constant name="EXPAND_MODE_ORIGINAL_SIZE" value="0" enum="ExpandMode">
+			Use the original size for the right icon.
+		</constant>
+		<constant name="EXPAND_MODE_FIT_TO_TEXT" value="1" enum="ExpandMode">
+			Scale the right icon's size to match the size of the text.
+		</constant>
+		<constant name="EXPAND_MODE_FIT_TO_LINE_EDIT" value="2" enum="ExpandMode">
+			Scale the right icon to fit the LineEdit.
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -83,6 +83,12 @@ public:
 		KEYBOARD_TYPE_URL
 	};
 
+	enum ExpandMode {
+		EXPAND_MODE_ORIGINAL_SIZE,
+		EXPAND_MODE_FIT_TO_TEXT,
+		EXPAND_MODE_FIT_TO_LINE_EDIT,
+	};
+
 private:
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
 
@@ -91,6 +97,7 @@ private:
 	bool editable = false;
 	bool pass = false;
 	bool text_changed_dirty = false;
+	ExpandMode icon_expand_mode = EXPAND_MODE_ORIGINAL_SIZE;
 
 	enum AltInputMode {
 		ALT_INPUT_NONE,
@@ -158,6 +165,7 @@ private:
 
 	Ref<Texture2D> right_icon;
 	bool flat = false;
+	float right_icon_scale = 1.0;
 
 	struct Selection {
 		int begin = 0;
@@ -264,6 +272,7 @@ private:
 	void _texture_changed();
 
 	void _edit(bool p_show_virtual_keyboard = true, bool p_hide_focus = false);
+	Point2 _get_right_icon_size(Ref<Texture2D> p_right_icon) const;
 
 protected:
 	bool _is_over_clear_button(const Point2 &p_pos) const;
@@ -430,6 +439,12 @@ public:
 	void set_right_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_right_icon();
 
+	void set_icon_expand_mode(ExpandMode p_mode);
+	ExpandMode get_icon_expand_mode() const;
+
+	void set_right_icon_scale(float p_scale);
+	float get_right_icon_scale() const;
+
 	void set_flat(bool p_enabled);
 	bool is_flat() const;
 
@@ -449,3 +464,4 @@ public:
 
 VARIANT_ENUM_CAST(LineEdit::MenuItems);
 VARIANT_ENUM_CAST(LineEdit::VirtualKeyboardType);
+VARIANT_ENUM_CAST(LineEdit::ExpandMode);


### PR DESCRIPTION
Close: https://github.com/godotengine/godot-proposals/issues/10493

The implementation allows the LineEdit node to scale the right icon to match the font size first. Then, when the `expand_icon` option is enabled, the icon will expand to the full height of the node. The scale of the icon can then be controlled using the scale factor.


https://github.com/user-attachments/assets/bed11cde-9424-4f0f-9d6a-d7145eb40dda


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
