### PR TITLE
Add `pressed_tolerance` to `BaseButton`, to improve accessibility on touch displays

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -75,12 +75,30 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	if (mouse_motion.is_valid()) {
 		if (status.press_attempt) {
 			bool last_press_inside = status.pressing_inside;
+			bool redraw = false;
+
 			status.pressing_inside = has_point(mouse_motion->get_position());
 			if (last_press_inside != status.pressing_inside) {
+				redraw = true;
+			}
+
+			if (is_scrolling) {
+				Point2 diff = Input::get_singleton()->get_mouse_position() - drag_from;
+				if (Math::abs(diff.x) > pressed_tolerance || Math::abs(diff.y) > pressed_tolerance) {
+					status.press_attempt = false;
+					redraw = true;
+				}
+			}
+
+			if (redraw) {
 				queue_redraw();
 			}
 		}
 	}
+}
+
+float BaseButton::_calculate_pressed_tolerance() {
+	return Math::round(DisplayServer::get_singleton()->screen_get_dpi() / 50.0);
 }
 
 void BaseButton::_notification(int p_what) {
@@ -97,10 +115,18 @@ void BaseButton::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN:
 		case NOTIFICATION_SCROLL_BEGIN: {
-			if (status.press_attempt) {
-				status.press_attempt = false;
-				queue_redraw();
-			}
+			is_scrolling = true;
+			drag_from = Input::get_singleton()->get_mouse_position();
+		} break;
+
+		case NOTIFICATION_DRAG_END:
+		case NOTIFICATION_SCROLL_END: {
+			is_scrolling = false;
+			drag_from = Vector2();
+		} break;
+
+		case NOTIFICATION_WM_DPI_CHANGE: {
+			pressed_tolerance = _calculate_pressed_tolerance();
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
@@ -501,6 +527,7 @@ void BaseButton::_bind_methods() {
 
 BaseButton::BaseButton() {
 	set_focus_mode(FOCUS_ALL);
+	pressed_tolerance = _calculate_pressed_tolerance();
 }
 
 BaseButton::~BaseButton() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -54,6 +54,9 @@ private:
 	bool shortcut_feedback = true;
 	Ref<Shortcut> shortcut;
 	ObjectID shortcut_context;
+	bool is_scrolling = false;
+	Point2 drag_from;
+	float pressed_tolerance; // Calculated in constructor and NOTIFICATION_WM_DPI_CHANGE.
 
 	ActionMode action_mode = ACTION_MODE_BUTTON_RELEASE;
 	struct Status {
@@ -71,6 +74,7 @@ private:
 	void _unpress_group();
 	void _pressed();
 	void _toggled(bool p_pressed);
+	float _calculate_pressed_tolerance();
 
 	void on_action_event(Ref<InputEvent> p_event);
 


### PR DESCRIPTION
Fixes #95532
Fixes #93612

-----------------

Test project: [base_button_tests.zip](https://github.com/user-attachments/files/16681812/base_button_tests.zip)

Test on MacOs `pressed_tolerance = 2` -> `round(DPI / 50)`

https://github.com/user-attachments/assets/ef16c387-ba77-4729-ae7f-5f5bbd6aa339

