### PR TITLE
Antialias direct light samples in LightmapperRD

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1584,9 +1584,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 #endif
 
 	/* SECONDARY (indirect) LIGHT PASS(ES) */
-	if (p_step_function) {
-		p_step_function(0.6, RTR("Integrate indirect lighting"), p_bake_userdata, true);
-	}
 
 	if (p_bounces > 0) {
 		Vector<RD::Uniform> uniforms;
@@ -1649,6 +1646,10 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 		rd->submit();
 		rd->sync();
+
+		if (p_step_function) {
+			p_step_function(0.6, RTR("Integrate indirect lighting"), p_bake_userdata, true);
+		}
 
 		int count = 0;
 		for (int s = 0; s < atlas_slices; s++) {


### PR DESCRIPTION
Implements: https://github.com/godotengine/godot-proposals/issues/10489

While reviewing the [bicubic sampling PR](https://github.com/godotengine/godot/pull/89919) I noticed that static shadows look much worse in 4.x compared 3.x.

As it turns out, the reason the shadows looked better in 3.x was that OIDN was doing some anti-aliasing of the final texture that reduced the aliasing that was visible. When we switched to JNLM, we lost that antialising, so our static shadows appear very aliased at low resolutions.

This PR improves static shadows in two ways:
1. Adds antialising so that they look much smoother, with bicubic sampling, low resolution lightmaps are now feasible
2. Uses a Vogel disk instead of a non-uniform disk for doing light samples. This both reduces noise and is more accurate. We should have been using a uniform disk all along. 

I have tested this with all combinations of:
1. Static / Dynamic / Disabled lightmap mode
2. DirectionalLight3D, Omnilight3D, and SpotLight3D
3. Blur (0 and 1)
4. Light size (0 and non zero)

| Before | Before  + bicubic | After | After + bicubic |
| - | - | - | - |
| ![Screenshot from 2024-08-18 19-48-09](https://github.com/user-attachments/assets/1a19ed04-c28c-4ace-b724-c834bab1f16d) | ![Screenshot from 2024-08-18 19-48-24](https://github.com/user-attachments/assets/aac34e2f-52f4-4547-8018-85b15cd1b769) | ![Screenshot from 2024-08-18 19-11-57](https://github.com/user-attachments/assets/855bac43-3d8f-4e41-9b73-a2586378391e) |![Screenshot from 2024-08-18 19-47-50](https://github.com/user-attachments/assets/1778191d-66fb-461c-9ce1-2fcfbdab41b7) |

<details>
  <summary>Images: </summary>

| Before | After | After + bicubic |
| - | - | - |
| ![Screenshot from 2024-08-19 11-38-01](https://github.com/user-attachments/assets/a5876fe1-1852-4d85-86d6-b66fdd034fbd) | ![Screenshot from 2024-08-19 11-37-33](https://github.com/user-attachments/assets/24afed69-3d35-4108-836f-6d64314ed220) | ![image](https://github.com/user-attachments/assets/723766cc-355a-457c-b228-bf76e7c2f1a4) |
Note, in the _after_ images there is some slight bleeding (above the opening on the left where the ladder thing connects). This is caused by incorrect normals in the source mesh.
</details>

