### PR TITLE
ufbx: Update to 0.14.3

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -894,7 +894,7 @@ number and run the script.
 ## ufbx
 
 - Upstream: https://github.com/ufbx/ufbx
-- Version: 0.14.0 (80ff790ab36507b99ec7e4ef55b9cfb076ce821b, 2024)
+- Version: 0.14.3 (19bdb7e7ef02eb914d5e7211a3685f50ee6d27e3, 2024)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/ufbx/ufbx.c
+++ b/thirdparty/ufbx/ufbx.c
@@ -570,7 +570,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 14, 0)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 14, 3)
 ufbx_abi_data_def const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);
@@ -7257,8 +7257,8 @@ typedef enum {
 } ufbxi_parse_state;
 
 typedef enum {
-	UFBXI_ARRAY_FLAG_RESULT       = 0x1, // < Alloacte the array from the result buffer
-	UFBXI_ARRAY_FLAG_TMP_BUF      = 0x2, // < Alloacte the array from the result buffer
+	UFBXI_ARRAY_FLAG_RESULT       = 0x1, // < Allocate the array from the result buffer
+	UFBXI_ARRAY_FLAG_TMP_BUF      = 0x2, // < Allocate the array from the result buffer
 	UFBXI_ARRAY_FLAG_PAD_BEGIN    = 0x4, // < Pad the begin of the array with 4 zero elements to guard from invalid -1 index accesses
 	UFBXI_ARRAY_FLAG_ACCURATE_F32 = 0x8, // < Must be parsed as bit-accurate 32-bit floats
 } ufbxi_array_flags;
@@ -21772,6 +21772,10 @@ ufbxi_noinline static ufbx_quat ufbxi_get_rotation(const ufbx_props *props, ufbx
 		ufbxi_mul_rotate_quat(&t, node->adjust_pre_rotation);
 	}
 
+	if (node->adjust_mirror_axis) {
+		ufbxi_mirror_rotation(&t.rotation, node->adjust_mirror_axis);
+	}
+
 	return t.rotation;
 }
 
@@ -24710,7 +24714,7 @@ static ufbxi_noinline const ufbx_prop *ufbxi_next_prop_slow(ufbxi_prop_iter *ite
 	const ufbx_prop_override *over = iter->over;
 	if (prop == iter->prop_end && over == iter->over_end) return NULL;
 
-	// We can use `UINT32_MAX` as a termianting key (aka prefix) as prop names must
+	// We can use `UINT32_MAX` as a terminating key (aka prefix) as prop names must
 	// be valid UTF-8 and the byte sequence "\xff\xff\xff\xff" is not valid.
 	uint32_t prop_key = prop != iter->prop_end ? prop->_internal_key : UINT32_MAX;
 	uint32_t over_key = over != iter->over_end ? over->_internal_key : UINT32_MAX;

--- a/thirdparty/ufbx/ufbx.h
+++ b/thirdparty/ufbx/ufbx.h
@@ -266,7 +266,7 @@ struct ufbx_converter { };
 // `ufbx_source_version` contains the version of the corresponding source file.
 // HINT: The version can be compared numerically to the result of `ufbx_pack_version()`,
 // for example `#if UFBX_VERSION >= ufbx_pack_version(0, 12, 0)`.
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 14, 0)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 14, 3)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types
@@ -2673,7 +2673,7 @@ UFBX_ENUM_TYPE(ufbx_texture_type, UFBX_TEXTURE_TYPE, UFBX_TEXTURE_SHADER);
 
 // Blend modes to combine layered textures with, compatible with common blend
 // mode definitions in many art programs. Simpler blend modes have equations
-// specified below where `src` is the layer to compososite over `dst`.
+// specified below where `src` is the layer to composite over `dst`.
 // See eg. https://www.w3.org/TR/2013/WD-compositing-1-20131010/#blendingseparable
 typedef enum ufbx_blend_mode UFBX_ENUM_REPR {
 	UFBX_BLEND_TRANSLUCENT,   // < `src` effects result alpha
@@ -5286,6 +5286,8 @@ typedef enum ufbx_transform_flags UFBX_FLAG_REPR {
 } ufbx_transform_flags;
 
 // Evaluate the animated transform of a node given a time.
+// The returned transform is the local transform of the node (ie. relative to the parent),
+// comparable to `ufbx_node.local_transform`.
 ufbx_abi ufbx_transform ufbx_evaluate_transform(const ufbx_anim *anim, const ufbx_node *node, double time);
 ufbx_abi ufbx_transform ufbx_evaluate_transform_flags(const ufbx_anim *anim, const ufbx_node *node, double time, uint32_t flags);
 


### PR DESCRIPTION
https://github.com/ufbx/ufbx/releases/tag/v0.14.3

**Changes from version 0.14.0 to version 0.14.1:**

- Documentation: Specify result of ufbx_evaluate_transform()

**Changes from version 0.14.1 to version 0.14.2:**

- Fix UFBX_VERSION not matching tagged version

**Changes from version 0.14.2 to version 0.14.3:**

- Fix transform evaluation rotation fast path mirroring
- Fixes some broken cases of baking animations when converting handedness
