### PR TITLE
Fix GLES3 crash with Mesh surface with exactly 65536 vertices

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -301,7 +301,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 			Vector<uint8_t> ir = new_surface.index_data;
 			wr = wf_indices.ptrw();
 
-			if (new_surface.vertex_count < (1 << 16)) {
+			if (new_surface.vertex_count <= 65536) {
 				// Read 16 bit indices.
 				const uint16_t *src_idx = (const uint16_t *)ir.ptr();
 				for (uint32_t i = 0; i + 5 < wf_index_count; i += 6) {


### PR DESCRIPTION
One line fix for bug in GLES3 driver that can crash when a mesh has exactly 65536 vertices, because the wireframe generation code doesn't use the right buffer index size in unpacking, causing an out-of-bounds read.

See https://github.com/godotengine/godot/issues/95837 for minimal example project.

*Bugsquad edit:*
- Fixes #95837