### PR TITLE
Expose `AudioStreamPlaybackInteractive::get_current_clip_index()`.

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1011,6 +1011,10 @@ void AudioStreamPlaybackInteractive::switch_to_clip(int p_index) {
 	switch_request = p_index;
 }
 
+int AudioStreamPlaybackInteractive::get_current_clip_index() const {
+	return playback_current;
+}
+
 int AudioStreamPlaybackInteractive::get_loop_count() const {
 	return 0; // Looping not supported
 }
@@ -1026,4 +1030,5 @@ bool AudioStreamPlaybackInteractive::is_playing() const {
 void AudioStreamPlaybackInteractive::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("switch_to_clip_by_name", "clip_name"), &AudioStreamPlaybackInteractive::switch_to_clip_by_name);
 	ClassDB::bind_method(D_METHOD("switch_to_clip", "clip_index"), &AudioStreamPlaybackInteractive::switch_to_clip);
+	ClassDB::bind_method(D_METHOD("get_current_clip_index"), &AudioStreamPlaybackInteractive::get_current_clip_index);
 }

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -259,6 +259,7 @@ public:
 
 	void switch_to_clip_by_name(const StringName &p_name);
 	void switch_to_clip(int p_index);
+	int get_current_clip_index() const;
 
 	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;
 	virtual Variant get_parameter(const StringName &p_name) const override;

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
@@ -9,6 +9,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_current_clip_index" qualifiers="const">
+			<return type="int" />
+			<description>
+				Return the index of the currently playing clip. You can use this to get the name of the currently playing clip with [method AudioStreamInteractive.get_clip_name].
+				[b]Example:[/b] Get the currently playing clip name from inside an [AudioStreamPlayer] node.
+				[codeblocks]
+				[gdscript]
+				var playing_clip_name = stream.get_clip_name(get_stream_playback().get_current_clip_index())
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="switch_to_clip">
 			<return type="void" />
 			<param index="0" name="clip_index" type="int" />


### PR DESCRIPTION
Closes godotengine/godot-proposals#10494

Add a way to get what is the currently playing clip from AudioStreamPlaybackInteractive.
Exposes `get_current_clip_index()`