### PR TITLE
Tweak line/column indication in GDScript/shader editor error messages

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -554,8 +554,7 @@ void ScriptTextEditor::_validate_script() {
 		}
 
 		if (errors.size() > 0) {
-			// TRANSLATORS: Script error pointing to a line and column number.
-			String error_text = vformat(TTR("Error at (%d, %d):"), errors.front()->get().line, errors.front()->get().column) + " " + errors.front()->get().message;
+			String error_text = vformat(TTR("Error at line %d, column %d:"), errors.front()->get().line, errors.front()->get().column) + " " + errors.front()->get().message;
 			code_editor->set_error(error_text);
 			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
 		}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -493,9 +493,9 @@ void ShaderTextEditor::_validate_script() {
 		int err_line = err_positions.front()->get().line;
 		if (err_positions.size() == 1) {
 			// Error in main file
-			err_text = "error(" + itos(err_line) + "): " + err_text;
+			err_text = "Error at line " + itos(err_line) + ": " + err_text;
 		} else {
-			err_text = "error(" + itos(err_line) + ") in include " + err_positions.back()->get().file.get_file() + ":" + itos(err_positions.back()->get().line) + ": " + err_text;
+			err_text = "Error at line " + itos(err_line) + " in include " + err_positions.back()->get().file.get_file() + ":" + itos(err_positions.back()->get().line) + ": " + err_text;
 			set_error_count(err_positions.size() - 1);
 		}
 
@@ -555,11 +555,11 @@ void ShaderTextEditor::_validate_script() {
 			if (include_positions.size() > 1) {
 				//error is in an include
 				err_line = include_positions[0].line;
-				err_text = "error(" + itos(err_line) + ") in include " + include_positions[include_positions.size() - 1].file + ":" + itos(include_positions[include_positions.size() - 1].line) + ": " + sl.get_error_text();
+				err_text = "Error at line " + itos(err_line) + " in include " + include_positions[include_positions.size() - 1].file + ":" + itos(include_positions[include_positions.size() - 1].line) + ": " + sl.get_error_text();
 				set_error_count(include_positions.size() - 1);
 			} else {
 				err_line = sl.get_error_line();
-				err_text = "error(" + itos(err_line) + "): " + sl.get_error_text();
+				err_text = "Error at line " + itos(err_line) + ": " + sl.get_error_text();
 				set_error_count(0);
 			}
 			set_error(err_text);
@@ -594,7 +594,7 @@ void ShaderTextEditor::_update_warning_panel() {
 	for (const ShaderWarning &w : warnings) {
 		if (warning_count == 0) {
 			if (saved_treat_warning_as_errors) {
-				String error_text = "error(" + itos(w.get_line()) + "): " + w.get_message() + " " + TTR("Warnings should be fixed to prevent errors.");
+				String error_text = "Error at line " + itos(w.get_line()) + ": " + w.get_message() + " " + TTR("Warnings should be fixed to prevent errors.");
 				set_error_pos(w.get_line() - 1, 0);
 				set_error(error_text);
 				get_text_editor()->set_line_background_color(w.get_line() - 1, marked_line_color);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6320,7 +6320,7 @@ void VisualShaderEditor::_update_preview() {
 			preview_text->set_line_background_color(err_line - 1, error_line_color);
 			error_panel->show();
 
-			error_label->set_text("error(" + file + ":" + itos(err_line) + "): " + error_pp);
+			error_label->set_text("Error in " + file + " at line " + itos(err_line) + ": " + error_pp);
 			shader_error = true;
 			return;
 		}
@@ -6335,10 +6335,10 @@ void VisualShaderEditor::_update_preview() {
 		if (include_positions.size() > 1) {
 			// Error is in an include.
 			err_line = include_positions[0].line;
-			err_text = "error(" + itos(err_line) + ") in include " + include_positions[include_positions.size() - 1].file + ":" + itos(include_positions[include_positions.size() - 1].line) + ": " + sl.get_error_text();
+			err_text = "Error at line " + itos(err_line) + " in include " + include_positions[include_positions.size() - 1].file + ":" + itos(include_positions[include_positions.size() - 1].line) + ": " + sl.get_error_text();
 		} else {
 			err_line = sl.get_error_line();
-			err_text = "error(" + itos(err_line) + "): " + sl.get_error_text();
+			err_text = "Error at line " + itos(err_line) + ": " + sl.get_error_text();
 		}
 
 		Color error_line_color = EDITOR_GET("text_editor/theme/highlighting/mark_color");


### PR DESCRIPTION
This makes the message easier to understand.

- See https://github.com/godotengine/godot-proposals/discussions/10467#discussioncomment-10384218.

## Preview

![Screenshot 2024-08-20 052214](https://github.com/user-attachments/assets/df38d6ea-b183-41aa-b150-6544c9cf18a0)