### PR TITLE
Only reset the tooltip timer when the mouse has actually moved

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1933,7 +1933,12 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					}
 				}
 
-				if (!is_tooltip_shown && over->can_process()) {
+				// If the tooltip timer isn't running, start it.
+				// Otherwise, only reset the timer if the mouse has moved more than 5 pixels.
+				if (!is_tooltip_shown && over->can_process() &&
+						(gui.tooltip_timer.is_null() ||
+								Math::is_zero_approx(gui.tooltip_timer->get_time_left()) ||
+								mm->get_relative().length() > 5.0)) {
 					if (gui.tooltip_timer.is_valid()) {
 						gui.tooltip_timer->release_connections();
 						gui.tooltip_timer = Ref<SceneTreeTimer>();


### PR DESCRIPTION
`InputEventMouseMotion` isn't guaranteed to fire only on actual mouse movement. It's not uncommon for the underlying OS motion event to be sent either by the OS itself or another application even though the mouse hasn't moved.  Godot will generate such zero-motion `InputEventMouseMotion` events itself for things like cursor shape changes.

This fixes #95845. There's a chance this could also fix #94189.
