### PR TITLE
[Windows] ANGLE fallback, use ID checks only for specific device names.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2043,6 +2043,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		BLOCK_DEVICE("AMD", "Radeon (TM) R9 M3");
 
 		// Intel GPUs.
+		BLOCK_DEVICE("Intel", "__ID_CHECK__:Intel(R) HD Graphics"); // Enable device ID checks for drivers using generic "Intel(R) HD Graphics" as name.
+		BLOCK_DEVICE("Intel", "__ID_CHECK__:Intel HD Graphics"); // Enable device ID checks for drivers using generic "Intel HD Graphics" as name.
 		BLOCK_DEVICE("0x8086", "0x0042"); // HD Graphics, Gen5, Clarkdale
 		BLOCK_DEVICE("0x8086", "0x0046"); // HD Graphics, Gen5, Arrandale
 		BLOCK_DEVICE("0x8086", "0x010A"); // HD Graphics, Gen6, Sandy Bridge

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6178,13 +6178,20 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 		bool force_angle = false;
 
-		Vector2i device_id = _get_device_ids(gl_info["name"]);
+		Vector2i device_id;
 		Array device_list = GLOBAL_GET("rendering/gl_compatibility/force_angle_on_devices");
 		for (int i = 0; i < device_list.size(); i++) {
 			const Dictionary &device = device_list[i];
 			if (device.has("vendor") && device.has("name")) {
 				const String &vendor = device["vendor"];
 				const String &name = device["name"];
+				if (device_id == Vector2i() && gl_info["vendor"].operator String().to_upper().contains(vendor.to_upper()) && name.to_upper().begins_with("__ID_CHECK__:")) {
+					const String &real_name = name.get_slice(":", 1);
+					if (real_name == "*" || gl_info["name"].operator String().to_upper() == real_name.to_upper()) {
+						// Load device IDs.
+						device_id = _get_device_ids(gl_info["name"]);
+					}
+				}
 				if (device_id != Vector2i() && vendor.begins_with("0x") && name.begins_with("0x") && device_id.x == vendor.lstrip("0x").hex_to_int() && device_id.y == name.lstrip("0x").hex_to_int()) {
 					// Check vendor/device IDs.
 					force_angle = true;


### PR DESCRIPTION
Might help with https://github.com/godotengine/godot/issues/95772

Skips device ID enumeration in device name is not in list (`Intel(R) HD Graphics` or `Intel HD Graphics`).
