### PR TITLE
[Windows] Simplify ANGLE fallback list and remove ID checks.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2274,131 +2274,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		FORCE_ANGLE("ATI", "Radeon (TM) R9 M3");
 		FORCE_ANGLE("AMD", "Radeon (TM) R9 M3");
 
-		// Intel GPUs.
-		FORCE_ANGLE("0x8086", "0x0042"); // HD Graphics, Gen5, Clarkdale
-		FORCE_ANGLE("0x8086", "0x0046"); // HD Graphics, Gen5, Arrandale
-		FORCE_ANGLE("0x8086", "0x010A"); // HD Graphics, Gen6, Sandy Bridge
-		FORCE_ANGLE("Intel", "Intel HD Graphics 2000");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 2000");
-		FORCE_ANGLE("0x8086", "0x0102"); // HD Graphics 2000, Gen6, Sandy Bridge
-		FORCE_ANGLE("0x8086", "0x0116"); // HD Graphics 3000, Gen6, Sandy Bridge
-		FORCE_ANGLE("Intel", "Intel HD Graphics 3000");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 3000");
-		FORCE_ANGLE("0x8086", "0x0126"); // HD Graphics 3000, Gen6, Sandy Bridge
-		FORCE_ANGLE("Intel", "Intel HD Graphics P3000");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P3000");
-		FORCE_ANGLE("0x8086", "0x0112"); // HD Graphics P3000, Gen6, Sandy Bridge
-		FORCE_ANGLE("0x8086", "0x0122");
-		FORCE_ANGLE("0x8086", "0x015A"); // HD Graphics, Gen7, Ivy Bridge
-		FORCE_ANGLE("Intel", "Intel HD Graphics 2500");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 2500");
-		FORCE_ANGLE("0x8086", "0x0152"); // HD Graphics 2500, Gen7, Ivy Bridge
-		FORCE_ANGLE("Intel", "Intel HD Graphics 4000");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 4000");
-		FORCE_ANGLE("0x8086", "0x0162"); // HD Graphics 4000, Gen7, Ivy Bridge
-		FORCE_ANGLE("0x8086", "0x0166");
-		FORCE_ANGLE("Intel", "Intel HD Graphics P4000");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P4000");
-		FORCE_ANGLE("0x8086", "0x016A"); // HD Graphics P4000, Gen7, Ivy Bridge
+		// Intel GPUs (Gen7-Gen9.5 devices).
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics");
+		FORCE_ANGLE("Intel", "Intel HD Graphics");
 		FORCE_ANGLE("Intel", "Intel(R) Vallyview Graphics");
-		FORCE_ANGLE("0x8086", "0x0F30"); // Intel(R) Vallyview Graphics, Gen7, Vallyview
-		FORCE_ANGLE("0x8086", "0x0F31");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 4200");
-		FORCE_ANGLE("0x8086", "0x0A1E"); // Intel(R) HD Graphics 4200, Gen7.5, Haswell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 4400");
-		FORCE_ANGLE("0x8086", "0x0A16"); // Intel(R) HD Graphics 4400, Gen7.5, Haswell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 4600");
-		FORCE_ANGLE("0x8086", "0x0412"); // Intel(R) HD Graphics 4600, Gen7.5, Haswell
-		FORCE_ANGLE("0x8086", "0x0416");
-		FORCE_ANGLE("0x8086", "0x0426");
-		FORCE_ANGLE("0x8086", "0x0D12");
-		FORCE_ANGLE("0x8086", "0x0D16");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P4600/P4700");
-		FORCE_ANGLE("0x8086", "0x041A"); // Intel(R) HD Graphics P4600/P4700, Gen7.5, Haswell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 5000");
-		FORCE_ANGLE("0x8086", "0x0422"); // Intel(R) HD Graphics 5000, Gen7.5, Haswell
-		FORCE_ANGLE("0x8086", "0x042A");
-		FORCE_ANGLE("0x8086", "0x0A26");
 		FORCE_ANGLE("Intel", "Intel(R) Iris(TM) Graphics 5100");
-		FORCE_ANGLE("0x8086", "0x0A22"); // Intel(R) Iris(TM) Graphics 5100, Gen7.5, Haswell
-		FORCE_ANGLE("0x8086", "0x0A2A");
-		FORCE_ANGLE("0x8086", "0x0A2B");
-		FORCE_ANGLE("0x8086", "0x0A2E");
 		FORCE_ANGLE("Intel", "Intel(R) Iris(TM) Pro Graphics 5200");
-		FORCE_ANGLE("0x8086", "0x0D22"); // Intel(R) Iris(TM) Pro Graphics 5200, Gen7.5, Haswell
-		FORCE_ANGLE("0x8086", "0x0D26");
-		FORCE_ANGLE("0x8086", "0x0D2A");
-		FORCE_ANGLE("0x8086", "0x0D2B");
-		FORCE_ANGLE("0x8086", "0x0D2E");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 400");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 405");
-		FORCE_ANGLE("0x8086", "0x22B0"); // Intel(R) HD Graphics, Gen8, Cherryview Braswell
-		FORCE_ANGLE("0x8086", "0x22B1");
-		FORCE_ANGLE("0x8086", "0x22B2");
-		FORCE_ANGLE("0x8086", "0x22B3");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 5300");
-		FORCE_ANGLE("0x8086", "0x161E"); // Intel(R) HD Graphics 5300, Gen8, Broadwell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 5500");
-		FORCE_ANGLE("0x8086", "0x1616"); // Intel(R) HD Graphics 5500, Gen8, Broadwell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 5600");
-		FORCE_ANGLE("0x8086", "0x1612"); // Intel(R) HD Graphics 5600, Gen8, Broadwell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 6000");
-		FORCE_ANGLE("0x8086", "0x1626"); // Intel(R) HD Graphics 6000, Gen8, Broadwell
 		FORCE_ANGLE("Intel", "Intel(R) Iris(TM) Graphics 6100");
-		FORCE_ANGLE("0x8086", "0x162B"); // Intel(R) Iris(TM) Graphics 6100, Gen8, Broadwell
 		FORCE_ANGLE("Intel", "Intel(R) Iris(TM) Pro Graphics 6200");
-		FORCE_ANGLE("0x8086", "0x1622"); // Intel(R) Iris(TM) Pro Graphics 6200, Gen8, Broadwell
 		FORCE_ANGLE("Intel", "Intel(R) Iris(TM) Pro Graphics P6300");
-		FORCE_ANGLE("0x8086", "0x162A"); // Intel(R) Iris(TM) Pro Graphics P6300, Gen8, Broadwell
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 500");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 505");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 510");
-		FORCE_ANGLE("0x8086", "0x1902"); // Intel(R) HD Graphics 510, Gen9, Skylake
-		FORCE_ANGLE("0x8086", "0x1906");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 520");
-		FORCE_ANGLE("0x8086", "0x1916"); // Intel(R) HD Graphics 520, Gen9, Skylake
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 530");
-		FORCE_ANGLE("0x8086", "0x1912"); // Intel(R) HD Graphics 530, Gen9, Skylake
-		FORCE_ANGLE("0x8086", "0x191B");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P530");
-		FORCE_ANGLE("0x8086", "0x191D"); // Intel(R) HD Graphics P530, Gen9, Skylake
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 515");
-		FORCE_ANGLE("0x8086", "0x191E"); // Intel(R) HD Graphics 515, Gen9, Skylake
 		FORCE_ANGLE("Intel", "Intel(R) Iris Graphics 540");
-		FORCE_ANGLE("0x8086", "0x1926"); // Intel(R) Iris Graphics 540, Gen9, Skylake
-		FORCE_ANGLE("0x8086", "0x1927");
-		FORCE_ANGLE("Intel", "Intel(R) Iris Pro Graphics 580");
-		FORCE_ANGLE("0x8086", "0x193B"); // Intel(R) Iris Pro Graphics 580, Gen9, Skylake
-		FORCE_ANGLE("Intel", "Intel(R) Iris Pro Graphics P580");
-		FORCE_ANGLE("0x8086", "0x193D"); // Intel(R) Iris Pro Graphics P580, Gen9, Skylake
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 610");
-		FORCE_ANGLE("0x8086", "0x5902"); // Intel(R) HD Graphics 610, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x5906");
-		FORCE_ANGLE("0x8086", "0x5908");
-		FORCE_ANGLE("0x8086", "0x590A");
-		FORCE_ANGLE("0x8086", "0x590B");
-		FORCE_ANGLE("0x8086", "0x590E");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 615");
-		FORCE_ANGLE("0x8086", "0x5913"); // Intel(R) HD Graphics 615, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x5915");
-		FORCE_ANGLE("0x8086", "0x591E");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 620");
-		FORCE_ANGLE("0x8086", "0x5916"); // Intel(R) HD Graphics 620, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x5917");
-		FORCE_ANGLE("0x8086", "0x5921");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 630");
-		FORCE_ANGLE("0x8086", "0x5912"); // Intel(R) HD Graphics 630, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x591B");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 635");
-		FORCE_ANGLE("0x8086", "0x5923"); // Intel(R) HD Graphics 635, Gen9.5, Kaby Lake
 		FORCE_ANGLE("Intel", "Intel(R) Iris Plus Graphics 640");
-		FORCE_ANGLE("0x8086", "0x5926"); // Intel(R) Iris Plus Graphics 640, Gen9.5, Kaby Lake
 		FORCE_ANGLE("Intel", "Intel(R) Iris Plus Graphics 650");
-		FORCE_ANGLE("0x8086", "0x5927"); // Iris Plus Graphics 650, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x593B");
-		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P630");
-		FORCE_ANGLE("0x8086", "0x591A"); // Intel(R) HD Graphics P630, Gen9.5, Kaby Lake
-		FORCE_ANGLE("0x8086", "0x591D");
+		FORCE_ANGLE("Intel", "Intel(R) Iris Pro Graphics 580");
+		FORCE_ANGLE("Intel", "Intel(R) Iris Pro Graphics P580");
 
 #undef FORCE_ANGLE
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7162,21 +7162,27 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		bool force_angle = false;
 		gl_supported = gl_info["version"].operator int() >= 30003;
 
-		Vector2i device_id = _get_device_ids(gl_info["name"]);
+		Vector2i device_id = Vector2i(-1, -1);
 		Array device_list = GLOBAL_GET("rendering/gl_compatibility/force_angle_on_devices");
 		for (int i = 0; i < device_list.size(); i++) {
 			const Dictionary &device = device_list[i];
 			if (device.has("vendor") && device.has("name")) {
 				const String &vendor = device["vendor"];
 				const String &name = device["name"];
-				if (device_id != Vector2i() && vendor.begins_with("0x") && name.begins_with("0x") && device_id.x == vendor.lstrip("0x").hex_to_int() && device_id.y == name.lstrip("0x").hex_to_int()) {
-					// Check vendor/device IDs.
-					force_angle = true;
-					break;
-				} else if (gl_info["vendor"].operator String().to_upper().contains(vendor.to_upper()) && (name == "*" || gl_info["name"].operator String().to_upper().contains(name.to_upper()))) {
+				if (gl_info["vendor"].operator String().containsn(vendor) && (name == "*" || gl_info["name"].operator String().containsn(name))) {
 					// Check vendor/device names.
 					force_angle = true;
 					break;
+				} else if (vendor.begins_with("0x") && name.begins_with("0x")) {
+					if (device_id == Vector2i(-1, -1)) {
+						// Load device IDs.
+						device_id = _get_device_ids(gl_info["name"]);
+					}
+					if (device_id.x == vendor.lstrip("0x").hex_to_int() && device_id.y == name.lstrip("0x").hex_to_int()) {
+						// Check vendor/device IDs.
+						force_angle = true;
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Alternative option for https://github.com/godotengine/godot/pull/95852, will force ANGLE on more Gen9 / 9.5 devices, but removes all device ID checks and simplify fallback list.
