### PR TITLE
Add `Button.text_offset` property

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -71,6 +71,9 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
+		<member name="text_offset" type="Vector2" setter="set_text_offset" getter="get_text_offset" default="&quot;&quot;">
+			Offset for the button's text, in pixels. Useful for fonts that appear visually off-center or for making the text feel more responsive.
+		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
 			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -463,6 +463,8 @@ void Button::_notification(int p_what) {
 					text_ofs.y += custom_element_size.height - drawable_size_remained.height; // Offset by the icon's height.
 				}
 
+				text_ofs += text_offset;
+
 				Color font_outline_color = theme_cache.font_outline_color;
 				int outline_size = theme_cache.outline_size;
 				if (outline_size > 0 && font_outline_color.a > 0.0f) {
@@ -636,6 +638,17 @@ Control::TextDirection Button::get_text_direction() const {
 	return text_direction;
 }
 
+void Button::set_text_offset(Vector2 p_offset) {
+	if (text_offset != p_offset) {
+		text_offset = p_offset;
+		queue_redraw();
+	}
+}
+
+Vector2 Button::get_text_offset() const {
+	return text_offset;
+}
+
 void Button::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
@@ -766,6 +779,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_autowrap_mode"), &Button::get_autowrap_mode);
 	ClassDB::bind_method(D_METHOD("set_text_direction", "direction"), &Button::set_text_direction);
 	ClassDB::bind_method(D_METHOD("get_text_direction"), &Button::get_text_direction);
+	ClassDB::bind_method(D_METHOD("set_text_offset", "offset"), &Button::set_text_offset);
+	ClassDB::bind_method(D_METHOD("get_text_offset"), &Button::get_text_offset);
 	ClassDB::bind_method(D_METHOD("set_language", "language"), &Button::set_language);
 	ClassDB::bind_method(D_METHOD("get_language"), &Button::get_language);
 	ClassDB::bind_method(D_METHOD("set_button_icon", "texture"), &Button::set_icon);
@@ -788,6 +803,7 @@ void Button::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 
 	ADD_GROUP("Text Behavior", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "text_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_text_offset", "get_text_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_text_alignment", "get_text_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -51,6 +51,7 @@ private:
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
 	bool clip_text = false;
+	Vector2 text_offset;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
@@ -142,6 +143,9 @@ public:
 
 	void set_expand_icon(bool p_enabled);
 	bool is_expand_icon() const;
+
+	void set_text_offset(Vector2 p_offset);
+	Vector2 get_text_offset() const;
 
 	void set_flat(bool p_enabled);
 	bool is_flat() const;


### PR DESCRIPTION
In certain fonts, the text within buttons appears too low, and often has to be worked around by adding a child Label node, as changing the content margins can make the button excessively large. I believe this is unnecessary, so I decided to add a new property to the Button node, `text_offset`.

It can be used to adjust the position of the text:

https://github.com/user-attachments/assets/75084e89-97eb-4f48-afcb-403c1fd1e2b0

...Or to make it respond to actions:

https://github.com/user-attachments/assets/494710bd-582d-4dc5-8673-276788079d74

```gdscript
extends Button


func _on_pressed() -> void:
	_shake_text()

func _shake_text() -> void:
	for i in range(64):
		await get_tree().create_timer(1.0/60).timeout
		text_offset = Vector2(randf_range(-5, 5), randf_range(-15, -5))
```

Tested on the latest `master` branch.

P.S. This is my first experience with C++, so feel free to correct me if my code doesn't meet the criteria.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10503*