### PR TITLE
Honor `pitch_scale` value before playing audio sample

### DIFF
--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -294,6 +294,7 @@ void AudioDriverWeb::start_sample_playback(const Ref<AudioSamplePlayback> &p_pla
 			itos(p_playback->stream->get_instance_id()).utf8().get_data(),
 			AudioServer::get_singleton()->get_bus_index(p_playback->bus),
 			p_playback->offset,
+			p_playback->pitch_scale,
 			volume_ptrw);
 }
 

--- a/platform/web/godot_audio.h
+++ b/platform/web/godot_audio.h
@@ -51,7 +51,7 @@ extern void godot_audio_input_stop();
 extern int godot_audio_sample_stream_is_registered(const char *p_stream_object_id);
 extern void godot_audio_sample_register_stream(const char *p_stream_object_id, float *p_frames_buf, int p_frames_total, const char *p_loop_mode, int p_loop_begin, int p_loop_end);
 extern void godot_audio_sample_unregister_stream(const char *p_stream_object_id);
-extern void godot_audio_sample_start(const char *p_playback_object_id, const char *p_stream_object_id, int p_bus_index, float p_offset, float *p_volume_ptr);
+extern void godot_audio_sample_start(const char *p_playback_object_id, const char *p_stream_object_id, int p_bus_index, float p_offset, float p_pitch_scale, float *p_volume_ptr);
 extern void godot_audio_sample_stop(const char *p_playback_object_id);
 extern void godot_audio_sample_set_pause(const char *p_playback_object_id, bool p_pause);
 extern int godot_audio_sample_is_active(const char *p_playback_object_id);

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -328,6 +328,7 @@ class SampleNodeBus {
  *   offset?: number
  *   playbackRate?: number
  *   startTime?: number
+ *   pitchScale?: number
  *   loopMode?: LoopMode
  *   volume?: Float32Array
  *   start?: boolean
@@ -438,7 +439,7 @@ class SampleNode {
 		/** @type {LoopMode} */
 		this.loopMode = options.loopMode ?? this.getSample().loopMode ?? 'disabled';
 		/** @type {number} */
-		this._pitchScale = 1;
+		this._pitchScale = options.pitchScale ?? 1;
 		/** @type {number} */
 		this._sourceStartTime = 0;
 		/** @type {Map<Bus, SampleNodeBus>} */
@@ -1648,13 +1649,14 @@ const _GodotAudio = {
 	},
 
 	godot_audio_sample_start__proxy: 'sync',
-	godot_audio_sample_start__sig: 'viiiii',
+	godot_audio_sample_start__sig: 'viiiifi',
 	/**
 	 * Starts a sample.
 	 * @param {number} playbackObjectIdStrPtr Playback object id pointer
 	 * @param {number} streamObjectIdStrPtr Stream object id pointer
 	 * @param {number} busIndex Bus index
 	 * @param {number} offset Sample offset
+	 * @param {number} pitchScale Pitch scale
 	 * @param {number} volumePtr Volume pointer
 	 * @returns {void}
 	 */
@@ -1663,6 +1665,7 @@ const _GodotAudio = {
 		streamObjectIdStrPtr,
 		busIndex,
 		offset,
+		pitchScale,
 		volumePtr
 	) {
 		/** @type {string} */
@@ -1671,11 +1674,12 @@ const _GodotAudio = {
 		const streamObjectId = GodotRuntime.parseString(streamObjectIdStrPtr);
 		/** @type {Float32Array} */
 		const volume = GodotRuntime.heapSub(HEAPF32, volumePtr, 8);
-		/** @type {SampleNodeConstructorOptions} */
+		/** @type {SampleNodeOptions} */
 		const startOptions = {
 			offset,
 			volume,
 			playbackRate: 1,
+			pitchScale,
 			start: true,
 		};
 		GodotAudio.start_sample(

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -152,6 +152,7 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 				Ref<AudioSamplePlayback> sample_playback;
 				sample_playback.instantiate();
 				sample_playback->stream = stream;
+				sample_playback->pitch_scale = pitch_scale;
 				stream_playback->set_sample_playback(sample_playback);
 			}
 		} else if (!stream->is_meta_stream()) {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -50,6 +50,7 @@ public:
 	Ref<AudioStream> stream;
 
 	float offset = 0.0f;
+	float pitch_scale = 1.0;
 	Vector<AudioFrame> volume_vector;
 	StringName bus;
 };


### PR DESCRIPTION
This PR makes it so that AudioStreamPlayers `pitch_scale` value is taken into account when playing the Web audio sample.

Fixes #95850