### PR TITLE
Abort execution if MovieWriter can't write file or find a valid extension

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2761,6 +2761,16 @@ Error Main::setup2(bool p_show_boot_logo) {
 		OS::get_singleton()->benchmark_end_measure("Servers", "Modules and Extensions");
 	}
 
+	// Perform this check before initializing the rest of the servers to avoid a crash on failure.
+	if (Engine::get_singleton()->get_write_movie_path() != String()) {
+		movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
+		if (movie_writer == nullptr) {
+			ERR_PRINT(vformat("Can't find MovieWriter for file type, aborting.\nCheck if the specified file path has a valid extension: %s", Engine::get_singleton()->get_write_movie_path()));
+			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
+			return FAILED;
+		}
+	}
+
 	/* Initialize Input */
 
 	{
@@ -2945,14 +2955,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 		if (profile_gpu || (!editor && bool(GLOBAL_GET("debug/settings/stdout/print_gpu_profile")))) {
 			rendering_server->set_print_gpu_profile(true);
-		}
-
-		if (Engine::get_singleton()->get_write_movie_path() != String()) {
-			movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
-			if (movie_writer == nullptr) {
-				ERR_PRINT("Can't find movie writer for file type, aborting: " + Engine::get_singleton()->get_write_movie_path());
-				Engine::get_singleton()->set_write_movie_path(String());
-			}
 		}
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Rendering");


### PR DESCRIPTION
This avoids having the engine run without any movie recording if it was requested on the command line.

It might be worth displaying a GUI alert using `OS::get_singleton()->alert()` (so you can see those errors when running a project without a visible terminal), but this is a blocking operation that can be problematic in automation scenarios. Maybe we should have a CLI argument to ignore `alert()`s (regardless of `--headless`).

- This closes https://github.com/godotengine/godot-proposals/issues/10505.

## Preview

### Invalid extension (not registered by any MovieWriter)

There's a warning about ObjectDB instances that is also present with the other abort situation in `setup2()` (when you have `._sc_` in a project folder and an editor binary in the same folder).

I don't know how to fix the GDExtension error while ensuring GDExtensions are initialized at this point, since they can define additional MovieWriters.

```
$ godot --write-movie /test
Godot Engine v4.4.dev.custom_build.4f7bd2b0b (2024-08-20 16:51:25 UTC) - https://godotengine.org
ERROR: Can't find MovieWriter for file type, aborting.
Check if the specified file path has a valid extension: /test
   at: setup2 (main/main.cpp:2768)
ERROR: Condition "int32_t(p_level) != level" is true.
   at: deinitialize_extensions (./core/extension/gdextension_manager.cpp:191)
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (./core/object/object.cpp:2288)
```

### Valid extension, but path is not writable

Unfortunately, this one does not exit cleanly yet. MovieWriter doesn't inherit SceneTree, so there's no `quit()` to call.

```
$ godot --write-movie /non_writable.avi
Godot Engine v4.4.dev.custom_build.4f7bd2b0b (2024-08-20 16:51:25 UTC) - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 555.58.02 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce RTX 4090

Project is missing: [...]
Movie Maker mode enabled, recording movie at 60 FPS...
ERROR: Condition "f.is_null()" is true. Returning: ERR_CANT_OPEN
   at: write_begin (servers/movie_writer/movie_writer_mjpeg.cpp:63)
ERROR: Couldn't begin writing files for Movie Maker mode, aborting.
Check if the specified file path is valid and has write permissions: /non_writable.avi
   at: begin (servers/movie_writer/movie_writer.cpp:130)
ERROR: BUG: Unreferenced static string to 0: current_animation_changed
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: text_set
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: lines_edited_from
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: autoshrink_changed
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: interface_added
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: ProgressDialog
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: size_changed
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: QuickSettingsDialog
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: SceneReplicationInterface
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: EditorTitleBar
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: EditorTheme
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: bus_renamed
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: bus_layout_changed
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: node_changed
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: SceneCacheInterface
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: ThemeContext
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: ProjectDialog
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: EngineUpdateLabel
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: menu_changed
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: EditorAssetLibrary
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: DependencyRemoveDialog
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: ProjectListItemControl
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: SceneRPCInterface
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: animation_player_changed
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: fallback_changed
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: animation_libraries_updated
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: mixer_applied
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: mixer_updated
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: animation_list_changed
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: caches_cleared
   at: unref (./core/string/string_name.cpp:118)
ERROR: BUG: Unreferenced static string to 0: cell_selected
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: SplitContainerDragger
   at: unref (./core/string/string_name.cpp:120)
ERROR: BUG: Unreferenced static string to 0: child_order_changed
   at: unref (./core/string/string_name.cpp:120)
ERROR: Pages in use exist at exit in PagedAllocator: N7Variant5Pools11BucketLargeE
   at: ~PagedAllocator (./core/templates/paged_allocator.h:170)
ERROR: Pages in use exist at exit in PagedAllocator: N7Variant5Pools12BucketMediumE
   at: ~PagedAllocator (./core/templates/paged_allocator.h:170)
ERROR: Pages in use exist at exit in PagedAllocator: N7Variant5Pools11BucketSmallE
   at: ~PagedAllocator (./core/templates/paged_allocator.h:170)
ERROR: Profiler not registered: multiplayer:bandwidth
   at: unregister_profiler (./core/debugger/engine_debugger.cpp:54)
ERROR: Profiler not registered: multiplayer:rpc
   at: unregister_profiler (./core/debugger/engine_debugger.cpp:54)
ERROR: Profiler not registered: multiplayer:replication
   at: unregister_profiler (./core/debugger/engine_debugger.cpp:54)
```

### Valid extension, but path is not writable after a certain frame

This will most likely occur when running out of space, or when the folder was moved or removed while frames are being written.

*TODO: Not tested yet.*