### PR TITLE
SCons: Add "education" build that disables online features (asset library, update checker)

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -587,6 +587,7 @@ String ExportTemplateManager::_get_selected_mirror() const {
 }
 
 void ExportTemplateManager::_mirror_options_button_cbk(int p_id) {
+#ifdef EDITOR_CALL_HOME_ENABLED
 	switch (p_id) {
 		case VISIT_WEB_MIRROR: {
 			String mirror_url = _get_selected_mirror();
@@ -608,6 +609,7 @@ void ExportTemplateManager::_mirror_options_button_cbk(int p_id) {
 			DisplayServer::get_singleton()->clipboard_set(mirror_url);
 		} break;
 	}
+#endif
 }
 
 void ExportTemplateManager::_installed_table_button_cbk(Object *p_item, int p_column, int p_id, MouseButton p_button) {
@@ -814,7 +816,9 @@ void ExportTemplateManager::_notification(int p_what) {
 			current_missing_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			current_installed_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
 
+#ifdef EDITOR_CALL_HOME_ENABLED
 			mirror_options_button->set_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
+#endif
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -864,6 +868,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	set_hide_on_ok(false);
 	set_ok_button_text(TTR("Close"));
 
+#ifdef EDITOR_CALL_HOME_ENABLED
 	// Downloadable export templates are only available for stable and official alpha/beta/RC builds
 	// (which always have a number following their status, e.g. "alpha1").
 	// Therefore, don't display download-related features when using a development version
@@ -873,6 +878,9 @@ ExportTemplateManager::ExportTemplateManager() {
 			String(VERSION_STATUS) != String("alpha") &&
 			String(VERSION_STATUS) != String("beta") &&
 			String(VERSION_STATUS) != String("rc");
+#else
+	downloads_available = false;
+#endif
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
@@ -947,6 +955,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	HBoxContainer *download_install_hb = memnew(HBoxContainer);
 	install_options_vb->add_child(download_install_hb);
 
+#ifdef EDITOR_CALL_HOME_ENABLED
 	Label *mirrors_label = memnew(Label);
 	mirrors_label->set_text(TTR("Download from:"));
 	download_install_hb->add_child(mirrors_label);
@@ -985,6 +994,7 @@ ExportTemplateManager::ExportTemplateManager() {
 		download_current_button->set_disabled(true);
 		download_current_button->set_tooltip_text(TTR("Official export templates aren't available for development builds."));
 	}
+#endif
 
 	HBoxContainer *install_file_hb = memnew(HBoxContainer);
 	install_file_hb->set_alignment(BoxContainer::ALIGNMENT_END);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1774,12 +1774,10 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 ///////
 
 bool AssetLibraryEditorPlugin::is_available() {
-#ifdef WEB_ENABLED
-	// Asset Library can't work on Web editor for now as most assets are sourced
-	// directly from GitHub which does not set CORS.
-	return false;
-#else
+#ifdef ASSET_LIBRARY_ENABLED
 	return StreamPeerTLS::is_available();
+#else
+	return false;
 #endif
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1390,6 +1390,7 @@ ProjectManager::ProjectManager() {
 		}
 	}
 
+#ifdef ASSET_LIBRARY_ENABLED
 	// Asset library view.
 	if (AssetLibraryEditorPlugin::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
@@ -1403,6 +1404,7 @@ ProjectManager::ProjectManager() {
 		asset_library_toggle->set_disabled(true);
 		asset_library_toggle->set_tooltip_text(TTR("Asset Library not available (due to using Web editor, or because SSL support disabled)."));
 	}
+#endif
 
 	// Footer bar.
 	{

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -114,6 +114,12 @@ def configure(env: "SConsEnvironment"):
         print("Note: Forcing `initial_memory=64` as it is required for the web editor.")
         env["initial_memory"] = 64
 
+    # Asset Library can't work on Web editor for now as most assets are sourced
+    # directly from GitHub which does not set CORS.
+    if env.editor_build and env["asset_library"]:
+        print_warning("`platform=web target=editor` build requires `asset_library=no`, disabling the asset library.")
+        env["asset_library"] = False
+
     env.Append(LINKFLAGS=["-sINITIAL_MEMORY=%sMB" % env["initial_memory"]])
 
     ## Copy env variables.
@@ -233,7 +239,7 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-sEXPORTED_FUNCTIONS=['__emscripten_thread_crashed','_main']"])
 
     elif env["proxy_to_pthread"]:
-        print_warning('"threads=no" support requires "proxy_to_pthread=no", disabling proxy to pthread.')
+        print_warning("`threads=no` support requires `proxy_to_pthread=no`, disabling proxy to pthread.")
         env["proxy_to_pthread"] = False
 
     if env["lto"] != "none":


### PR DESCRIPTION
> The goal is to have separate official education builds. The challenge is that many school districts (especially in the US) have extremely restrictive rules around using software, particularly software that collects student data. Right now, many schools are blocked from using Godot because we have the potential to collect the student's IP address (through the asset library or version checker). Those schools want us to provide very extreme warranties about how that data is handled, which obviously we can't agree to. As a result, teachers and students at those schools can't use Godot. An alternative is for us to provide them with a version that collects no data whatsoever. Setting an environment variable does not achieve that and, in fact, exposes us to legal liability.
— @clayjohn 

This PR:
- adds the education build (`education=no|yes`), which adds a new module version string and sets `editor_call_home=no` **if** `education=yes` and `target=editor`.
- adds the "editor can call home" flag (`editor_can_call_home=no|yes` and `-DEDITOR_CALL_HOME_ENABLED`), which sets `asset_library=no`, `engine_update_check=no`, and `steamapi=no` **if** `education=yes` and `target=editor`
- adds the asset library build flag (`asset_library=no|yes` and `-DASSET_LIBRARY_ENABLED`), which controls if the Asset Library is built or not.

<img width="250" alt="Capture d’écran, le 2024-08-20 à 15 36 55" src="https://github.com/user-attachments/assets/61de0b46-e0fd-4653-8474-bdc8543fd0d7">
