### PR TITLE
Use correct lightmap coefficients to ensure that the directional lightmap mode looks correct

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1729,16 +1729,10 @@ void main() {
 
 		vec3 n = normalize(lightmap_normal_xform * normal);
 
-		ambient_light += lm_light_l0 * 0.282095f;
-		ambient_light += lm_light_l1n1 * 0.32573 * n.y * lightmap_exposure_normalization;
-		ambient_light += lm_light_l1_0 * 0.32573 * n.z * lightmap_exposure_normalization;
-		ambient_light += lm_light_l1p1 * 0.32573 * n.x * lightmap_exposure_normalization;
-		if (metallic > 0.01) { // Since the more direct bounced light is lost, we can kind of fake it with this trick.
-			vec3 r = reflect(normalize(-vertex), normal);
-			specular_light += lm_light_l1n1 * 0.32573 * r.y * lightmap_exposure_normalization;
-			specular_light += lm_light_l1_0 * 0.32573 * r.z * lightmap_exposure_normalization;
-			specular_light += lm_light_l1p1 * 0.32573 * r.x * lightmap_exposure_normalization;
-		}
+		ambient_light += lm_light_l0 * lightmap_exposure_normalization;
+		ambient_light += lm_light_l1n1 * n.y * lightmap_exposure_normalization;
+		ambient_light += lm_light_l1_0 * n.z * lightmap_exposure_normalization;
+		ambient_light += lm_light_l1p1 * n.x * lightmap_exposure_normalization;
 #else
 		ambient_light += textureLod(lightmap_textures, uvw, 0.0).rgb * lightmap_exposure_normalization;
 #endif

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -915,7 +915,7 @@ LightmapperRD::BakeError LightmapperRD::_denoise_oidn(RenderingDevice *p_rd, RID
 	return BAKE_OK;
 }
 
-LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, int p_denoiser_range, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function) {
+LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, int p_denoiser_range, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function, void *p_bake_userdata) {
 	RID denoise_params_buffer = p_rd->uniform_buffer_create(sizeof(DenoiseParams));
 	DenoiseParams denoise_params;
 	denoise_params.spatial_bandwidth = 5.0f;
@@ -977,6 +977,11 @@ LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDSh
 				p_rd->submit();
 				p_rd->sync();
 			}
+		}
+		if (p_step_function) {
+			int percent = (s + 1) * 100 / p_atlas_slices;
+			float p = float(s) / p_atlas_slices * 0.1;
+			p_step_function(0.8 + p, vformat(RTR("Denoising %d%%"), percent), p_bake_userdata, false);
 		}
 	}
 
@@ -1581,6 +1586,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		Ref<Image> img = Image::create_from_data(atlas_size.width, atlas_size.height, false, Image::FORMAT_RGBAH, s);
 		img->save_exr("res://2_light_primary_" + itos(i) + ".exr", false);
 	}
+
+	if (p_bake_sh) {
+		for (int i = 0; i < atlas_slices * 4; i++) {
+			Vector<uint8_t> s = rd->texture_get_data(light_accum_tex, i);
+			Ref<Image> img = Image::create_from_data(atlas_size.width, atlas_size.height, false, Image::FORMAT_RGBAH, s);
+			img->save_exr("res://2_light_primary_accum_" + itos(i) + ".exr", false);
+		}
+	}
 #endif
 
 	/* SECONDARY (indirect) LIGHT PASS(ES) */
@@ -1803,7 +1816,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			} else {
 				// JNLM (built-in).
 				SWAP(light_accum_tex, light_accum_tex2);
-				error = _denoise(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, normal_tex, light_accum_tex, p_denoiser_strength, p_denoiser_range, atlas_size, atlas_slices, p_bake_sh, p_step_function);
+				error = _denoise(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, normal_tex, light_accum_tex, p_denoiser_strength, p_denoiser_range, atlas_size, atlas_slices, p_bake_sh, p_step_function, p_bake_userdata);
 			}
 			if (unlikely(error != BAKE_OK)) {
 				return error;

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -272,7 +272,7 @@ class LightmapperRD : public Lightmapper {
 	void _raster_geometry(RenderingDevice *rd, Size2i atlas_size, int atlas_slices, int grid_size, AABB bounds, float p_bias, Vector<int> slice_triangle_count, RID position_tex, RID unocclude_tex, RID normal_tex, RID raster_depth_buffer, RID rasterize_shader, RID raster_base_uniform);
 
 	BakeError _dilate(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices);
-	BakeError _denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, int p_denoiser_range, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function);
+	BakeError _denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, int p_denoiser_range, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function, void *p_bake_userdata);
 
 	Error _store_pfm(RenderingDevice *p_rd, RID p_atlas_tex, int p_index, const Size2i &p_atlas_size, const String &p_name);
 	Ref<Image> _read_pfm(const String &p_name);

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -588,15 +588,20 @@ void main() {
 			light_for_texture += light;
 
 #ifdef USE_SH_LIGHTMAPS
+			// These coefficients include the factored out SH evaluation, diffuse convolution, and final application, as well as the BRDF 1/PI and the spherical monte carlo factor.
+			// LO: 1/(2*sqrtPI) * 1/(2*sqrtPI) * PI * PI * 1/PI = 0.25
+			// L1: sqrt(3/(4*pi)) * sqrt(3/(4*pi)) * (PI*2/3) * (2 * PI) * 1/PI = 1.0
+			// Note: This only works because we aren't scaling, rotating, or combing harmonics, we are just directing applying them in the shader.
+
 			float c[4] = float[](
-					0.282095, //l0
-					0.488603 * light_dir.y, //l1n1
-					0.488603 * light_dir.z, //l1n0
-					0.488603 * light_dir.x //l1p1
+					0.25, //l0
+					light_dir.y, //l1n1
+					light_dir.z, //l1n0
+					light_dir.x //l1p1
 			);
 
 			for (uint j = 0; j < 4; j++) {
-				sh_accum[j].rgb += light * c[j] * 8.0;
+				sh_accum[j].rgb += light * c[j] * bake_params.exposure_normalization;
 			}
 #endif
 		}
@@ -646,15 +651,20 @@ void main() {
 		vec3 light = trace_indirect_light(position, ray_dir, noise);
 
 #ifdef USE_SH_LIGHTMAPS
+		// These coefficients include the factored out SH evaluation, diffuse convolution, and final application, as well as the BRDF 1/PI and the spherical monte carlo factor.
+		// LO: 1/(2*sqrtPI) * 1/(2*sqrtPI) * PI * PI * 1/PI = 0.25
+		// L1: sqrt(3/(4*pi)) * sqrt(3/(4*pi)) * (PI*2/3) * (2 * PI) * 1/PI = 1.0
+		// Note: This only works because we aren't scaling, rotating, or combing harmonics, we are just directing applying them in the shader.
+
 		float c[4] = float[](
-				0.282095, //l0
-				0.488603 * ray_dir.y, //l1n1
-				0.488603 * ray_dir.z, //l1n0
-				0.488603 * ray_dir.x //l1p1
+				0.25, //l0
+				ray_dir.y, //l1n1
+				ray_dir.z, //l1n0
+				ray_dir.x //l1p1
 		);
 
 		for (uint j = 0; j < 4; j++) {
-			sh_accum[j].rgb += light * c[j] * 8.0;
+			sh_accum[j].rgb += light * c[j];
 		}
 #else
 		light_accum += light;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1450,16 +1450,10 @@ void fragment_shader(in SceneData scene_data) {
 			vec3 n = normalize(lightmaps.data[ofs].normal_xform * normal);
 			float en = lightmaps.data[ofs].exposure_normalization;
 
-			ambient_light += lm_light_l0 * 0.282095f * en;
-			ambient_light += lm_light_l1n1 * 0.32573 * n.y * en;
-			ambient_light += lm_light_l1_0 * 0.32573 * n.z * en;
-			ambient_light += lm_light_l1p1 * 0.32573 * n.x * en;
-			if (metallic > 0.01) { // since the more direct bounced light is lost, we can kind of fake it with this trick
-				vec3 r = reflect(normalize(-vertex), normal);
-				specular_light += lm_light_l1n1 * 0.32573 * r.y * en;
-				specular_light += lm_light_l1_0 * 0.32573 * r.z * en;
-				specular_light += lm_light_l1p1 * 0.32573 * r.x * en;
-			}
+			ambient_light += lm_light_l0 * en;
+			ambient_light += lm_light_l1n1 * n.y * en;
+			ambient_light += lm_light_l1_0 * n.z * en;
+			ambient_light += lm_light_l1p1 * n.x * en;
 
 		} else {
 			ambient_light += textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw, 0.0).rgb * lightmaps.data[ofs].exposure_normalization;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1210,17 +1210,10 @@ void main() {
 			vec3 n = normalize(lightmaps.data[ofs].normal_xform * normal);
 			float exposure_normalization = lightmaps.data[ofs].exposure_normalization;
 
-			ambient_light += lm_light_l0 * 0.282095f;
-			ambient_light += lm_light_l1n1 * 0.32573 * n.y * exposure_normalization;
-			ambient_light += lm_light_l1_0 * 0.32573 * n.z * exposure_normalization;
-			ambient_light += lm_light_l1p1 * 0.32573 * n.x * exposure_normalization;
-			if (metallic > 0.01) { // since the more direct bounced light is lost, we can kind of fake it with this trick
-				vec3 r = reflect(normalize(-vertex), normal);
-				specular_light += lm_light_l1n1 * 0.32573 * r.y * exposure_normalization;
-				specular_light += lm_light_l1_0 * 0.32573 * r.z * exposure_normalization;
-				specular_light += lm_light_l1p1 * 0.32573 * r.x * exposure_normalization;
-			}
-
+			ambient_light += lm_light_l0 * exposure_normalization;
+			ambient_light += lm_light_l1n1 * n.y * exposure_normalization;
+			ambient_light += lm_light_l1_0 * n.z * exposure_normalization;
+			ambient_light += lm_light_l1p1 * n.x * exposure_normalization;
 		} else {
 			ambient_light += textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw, 0.0).rgb * lightmaps.data[ofs].exposure_normalization;
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/88470
Fixes: https://github.com/godotengine/godot/issues/81556
Fixes: https://github.com/godotengine/godot/issues/85506
Might Fix: https://github.com/godotengine/godot/issues/95875

This PR includes a few niceties in the lightmapper as I found them useful when debugging originally. 

Ultimately, https://github.com/godotengine/godot/issues/88470 is caused by the brightness of directional lightmaps being too high. The additional contrast trips up the denoiser and results in it not being able to reduce the aliasing as much. 

This PR uses the correct coefficients which, surprisingly, cancel each other out. The coefficients have been wrong since this was first written. https://github.com/godotengine/godot/pull/61910 took a stab at fixing them and actually got quite close (the correct value would have been `2 * PI`, but 8 was used). This resulted in our lightmap code being subtly too bright. 

Now spherical harmonics are super complex, transforming them is a total pain. However, _if_ you are not transforming them and _if_ you only use the first two levels, you can basically factor out all the coefficients. Which is exactly what this PR does. Previously we half factored out the coefficients so it was impossible to understand what the magic numbers represented and why they were there. Now, everything is factored out so the runtime shader simply reads the final value. This is both easier to understand and faster to run. 

This PR also removes the metallic option from directional lightmap as it is guaranteed to return negative numbers in many cases. Our basic form of SH works really well for lightmaps because we can make the assumption that we will only every read from the top hemisphere (relative to the surface). When using the SH for specular we do a reflection over the normal and can easily read from the bottom hemisphere which is not guaranteed to contain valid numbers (in fact in most cases it will contain negative numbers). I don't think this code ever worked, so I am just removing it. There are other ways to derive specular from directional lightmaps and we can go with one of those in the future. 

Finally this PR also cleans up our use of exposure normalization by adding it in a few missed places. This should make things work better when using physical light units

_Omitting the normal map to make the difference more visible. Note the sharpness of the shadows and the change in overall brightness_
| before directional | before non directional | after directional|
| - | - | - |
| ![Screenshot from 2024-08-21 00-44-36](https://github.com/user-attachments/assets/951194b6-6628-4bf3-bb69-cc5a5118ef7f) | ![image](https://github.com/user-attachments/assets/6318342b-9e9f-4ed2-a8f9-5902630a7e56) | ![Screenshot from 2024-08-21 00-17-59](https://github.com/user-attachments/assets/3ddabcd3-1d23-44b9-abc7-be7d806991b2) |

CC @BlueCube3310 This should make things very straightforward if you want to apply the Frostbite Flux optimization to the L1 harmonics.
