### PR TITLE
Disable text trimming in SceneTreeEditor

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -216,6 +216,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	TreeItem *item = tree->create_item(p_parent);
 
 	item->set_text(0, p_node->get_name());
+	item->set_text_overrun_behavior(0, TextServer::OVERRUN_NO_TRIMMING);
 	if (can_rename && !part_of_subscene) {
 		item->set_editable(0, true);
 	}


### PR DESCRIPTION
Tree will trim text by default, making it impossible to scroll horizontally. Interestingly, both trimming and horizontal scroll are enabled by default, and they are mutually exclusive. Maybe we should reconsider the default, but it breaks compatibility.

This PR changes the overrun behavior in scene tree. It does not cause text overlapping with buttons, the text is clipped separately from global trimming.

https://github.com/user-attachments/assets/e22f8aa0-3efc-496d-ab2e-9587d93740f1

Maybe the same should be done for file dock, but the problem is less prominent there from my experience.