### PR TITLE
Add a way to change and loop audio clips for `AudioStreamPlaylist`

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -128,6 +128,14 @@ bool AudioStreamPlaylist::has_loop() const {
 	return loop;
 }
 
+void AudioStreamPlaylist::set_loop_clip(bool p_loop) {
+	loop_clip = p_loop;
+}
+
+bool AudioStreamPlaylist::has_loop_clip() const {
+	return loop_clip;
+}
+
 void AudioStreamPlaylist::_validate_property(PropertyInfo &r_property) const {
 	String prop = r_property.name;
 	if (prop != "stream_count" && prop.begins_with("stream_")) {
@@ -155,9 +163,12 @@ void AudioStreamPlaylist::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_loop", "loop"), &AudioStreamPlaylist::set_loop);
 	ClassDB::bind_method(D_METHOD("has_loop"), &AudioStreamPlaylist::has_loop);
+	ClassDB::bind_method(D_METHOD("set_loop_clip", "loop"), &AudioStreamPlaylist::set_loop_clip);
+	ClassDB::bind_method(D_METHOD("has_loop_clip"), &AudioStreamPlaylist::has_loop_clip);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shuffle"), "set_shuffle", "get_shuffle");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop_clip"), "set_loop_clip", "has_loop_clip");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fade_time", PROPERTY_HINT_RANGE, "0,1,0.01,suffix:s"), "set_fade_time", "get_fade_time");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stream_count", PROPERTY_HINT_RANGE, "0," + itos(MAX_STREAMS), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Streams,stream_,unfoldable,page_size=999,add_button_text=" + String(RTR("Add Stream"))), "set_stream_count", "get_stream_count");
@@ -280,11 +291,21 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 		for (int i = 0; i < to_mix; i++) {
 			*p_buffer = mix_buffer[i];
 			stream_todo -= time_dec;
-			if (stream_todo < 0) {
+			if (stream_todo < 0 || next_stream != -1) {
 				//find next stream.
 				int prev = play_order[play_index];
 
 				for (int j = 0; j < playlist->stream_count; j++) {
+					if (next_stream != -1) {
+						// Manually changed streams, exit
+						play_index = next_stream;
+						next_stream = -1;
+						break;
+					}
+					if (playlist->has_loop_clip()) {
+						// Don't advance if looping audio clip, exit
+						break;
+					}
 					play_index++;
 					if (play_index >= playlist->stream_count) {
 						// No loop, exit.
@@ -390,6 +411,41 @@ bool AudioStreamPlaybackPlaylist::is_playing() const {
 	return active;
 }
 
+void AudioStreamPlaybackPlaylist::change_clip(int stream_index) {
+	ERR_FAIL_INDEX(stream_index, playlist->stream_count);
+	next_stream = stream_index;
+}
+
+void AudioStreamPlaybackPlaylist::next_clip() {
+	next_stream = play_index + 1;
+
+	if (next_stream >= playlist->stream_count) {
+		if (!playlist->loop) {
+			// If playlist doesn't loop, don't change clips
+			next_stream = -1;
+		} else {
+			next_stream = 0;
+		}
+	}
+}
+
+void AudioStreamPlaybackPlaylist::previous_clip() {
+	next_stream = play_index - 1;
+
+	if (next_stream < 0) {
+		if (!playlist->loop) {
+			// If playlist doesn't loop, don't change clips
+			next_stream = -1;
+		} else {
+			next_stream = playlist->stream_count - 1;
+		}
+	}
+}
+
+int AudioStreamPlaybackPlaylist::get_current_clip_index() {
+	return play_order[play_index];
+}
+
 void AudioStreamPlaybackPlaylist::_update_playback_instances() {
 	stop();
 
@@ -400,4 +456,11 @@ void AudioStreamPlaybackPlaylist::_update_playback_instances() {
 			playback[i].unref();
 		}
 	}
+}
+
+void AudioStreamPlaybackPlaylist::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("change_clip", "clip_index"), &AudioStreamPlaybackPlaylist::change_clip);
+	ClassDB::bind_method(D_METHOD("next_clip"), &AudioStreamPlaybackPlaylist::next_clip);
+	ClassDB::bind_method(D_METHOD("previous_clip"), &AudioStreamPlaybackPlaylist::previous_clip);
+	ClassDB::bind_method(D_METHOD("get_current_clip_index"), &AudioStreamPlaybackPlaylist::get_current_clip_index);
 }

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -48,6 +48,7 @@ private:
 
 	bool shuffle = false;
 	bool loop = true;
+	bool loop_clip = false;
 	double fade_time = 0.3;
 
 	int stream_count = 0;
@@ -64,6 +65,8 @@ public:
 	bool get_shuffle() const;
 	void set_loop(bool p_loop);
 	virtual bool has_loop() const override;
+	void set_loop_clip(bool p_loop);
+	bool has_loop_clip() const;
 	void set_list_stream(int p_stream_index, Ref<AudioStream> p_stream);
 	Ref<AudioStream> get_list_stream(int p_stream_index) const;
 
@@ -99,6 +102,7 @@ private:
 	double fade_volume = 1.0;
 	int play_index = 0;
 	double offset = 0.0;
+	int next_stream = -1;
 
 	int loop_count = 0;
 
@@ -107,6 +111,9 @@ private:
 	void _update_order();
 
 	void _update_playback_instances();
+
+protected:
+	static void _bind_methods();
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;
@@ -118,6 +125,11 @@ public:
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	virtual void tag_used_streams() override;
+
+	int get_current_clip_index();
+	void change_clip(int clip_index);
+	void next_clip();
+	void previous_clip();
 
 	~AudioStreamPlaybackPlaylist();
 };

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
@@ -7,4 +7,33 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="change_clip">
+			<return type="void" />
+			<param index="0" name="clip_index" type="int" />
+			<description>
+				Changes to a specific clip within the playlist (by index). Sends an error to the console if [param clip_index] is out of bounds.
+			</description>
+		</method>
+		<method name="get_current_clip_index">
+			<return type="int" />
+			<description>
+				Get the currently playing audio clip index.
+			</description>
+		</method>
+		<method name="next_clip">
+			<return type="void" />
+			<description>
+				Play the next clip. The next random clip is played if [member AudioStreamPlaylist.shuffle] is enabled.
+				If [member AudioStreamPlaylist.loop] is disabled and is the last already, nothing will happen.
+			</description>
+		</method>
+		<method name="previous_clip">
+			<return type="void" />
+			<description>
+				Play the previous clip. The previous random clip is played if [member AudioStreamPlaylist.shuffle] is enabled.
+				If [member AudioStreamPlaylist.loop] is disabled and is the first already, nothing will happen.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
@@ -37,6 +37,9 @@
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="true">
 			If [code]true[/code], the playlist will loop, otherwise the playlist will end when the last stream is finished.
 		</member>
+		<member name="loop_clip" type="bool" setter="set_loop_clip" getter="has_loop_clip" default="false">
+			If [code]true[/code], the audio clip will loop, otherwise when the clip ends, the next one is played. The audio file loop import setting is not used inside the playlist.
+		</member>
 		<member name="shuffle" type="bool" setter="set_shuffle" getter="get_shuffle" default="false">
 			If [code]true[/code], the playlist will shuffle each time playback starts and each time it loops.
 		</member>


### PR DESCRIPTION
Closes godotengine/godot-proposals#10508

Adds several important features AudioStreamPlaylist is currently missing.

Playlist enhancements:
- Can manually change the playlist song with `change_clip(index)`
- Can skip or return to the previous song on the playlist (`next_clip()`, `previous_clip()`. Uses the shuffled list if the playlist is shuffled.
- Can get the index of the currently playing clip of the playlist with `get_current_clip_index()`.
- Add option to make looping songs inside the playlist. Will keep repeating the same clip until ~~`loop_song`~~ `loop_clip` property is disabled. (Because the clip's own looping property does not affect how clips are played in playlists)