### PR TITLE
Clean up Viewport's `forced_mouse_focus`

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -103,7 +103,6 @@ void EditorObjectSelector::_show_popup() {
 	sub_objects_menu->set_position(gp);
 	sub_objects_menu->set_size(Size2(size.width, 1));
 
-	sub_objects_menu->take_mouse_focus();
 	sub_objects_menu->popup();
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2592,14 +2592,6 @@ void PopupMenu::clear_autohide_areas() {
 	autohide_areas.clear();
 }
 
-void PopupMenu::take_mouse_focus() {
-	ERR_FAIL_COND(!is_inside_tree());
-
-	if (get_parent()) {
-		get_parent()->get_viewport()->pass_mouse_focus_to(this, control);
-	}
-}
-
 bool PopupMenu::_set(const StringName &p_name, const Variant &p_value) {
 	if (property_helper.property_set_value(p_name, p_value)) {
 		return true;

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -369,8 +369,6 @@ public:
 	virtual void popup(const Rect2i &p_bounds = Rect2i()) override;
 	virtual void set_visible(bool p_visible) override;
 
-	void take_mouse_focus();
-
 	PopupMenu();
 	~PopupMenu();
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -655,9 +655,7 @@ void Viewport::_notification(int p_what) {
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			_gui_cancel_tooltip();
 			_drop_physics_mouseover();
-			if (gui.mouse_focus && !gui.forced_mouse_focus) {
-				_drop_mouse_focus();
-			}
+			_drop_mouse_focus();
 			// When the window focus changes, we want to end mouse_focus, but
 			// not the mouse_over. Note: The OS will trigger a separate mouse
 			// exit event if the change in focus results in the mouse exiting
@@ -1831,7 +1829,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			// as the release will never be received otherwise.
 			if (gui.mouse_focus_mask.is_empty()) {
 				gui.mouse_focus = nullptr;
-				gui.forced_mouse_focus = false;
 			}
 
 			bool stopped = mouse_focus && mouse_focus->can_process() && _gui_call_input(mouse_focus, mb);
@@ -1860,7 +1857,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							gui.drag_data = control->get_drag_data(control->get_global_transform_with_canvas().affine_inverse().xform(mpos - gui.drag_accum));
 							if (gui.drag_data.get_type() != Variant::NIL) {
 								gui.mouse_focus = nullptr;
-								gui.forced_mouse_focus = false;
 								gui.mouse_focus_mask.clear();
 								break;
 							} else {
@@ -2398,7 +2394,6 @@ void Viewport::_gui_hide_control(Control *p_control) {
 void Viewport::_gui_remove_control(Control *p_control) {
 	if (gui.mouse_focus == p_control) {
 		gui.mouse_focus = nullptr;
-		gui.forced_mouse_focus = false;
 		gui.mouse_focus_mask.clear();
 	}
 	if (gui.key_focus == p_control) {
@@ -2564,8 +2559,11 @@ void Viewport::_drop_mouse_focus() {
 	Control *c = gui.mouse_focus;
 	BitField<MouseButtonMask> mask = gui.mouse_focus_mask;
 	gui.mouse_focus = nullptr;
-	gui.forced_mouse_focus = false;
 	gui.mouse_focus_mask.clear();
+
+	if (!c) {
+		return;
+	}
 
 	for (int i = 0; i < 3; i++) {
 		if ((int)mask & (1 << i)) {
@@ -3891,23 +3889,6 @@ Rect2i Viewport::subwindow_get_popup_safe_rect(Window *p_window) const {
 	// ERR_FAIL_COND_V(index == -1, Rect2i());
 
 	return gui.sub_windows[index].parent_safe_rect;
-}
-
-void Viewport::pass_mouse_focus_to(Viewport *p_viewport, Control *p_control) {
-	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_NULL(p_viewport);
-	ERR_FAIL_NULL(p_control);
-
-	if (gui.mouse_focus) {
-		p_viewport->gui.mouse_focus = p_control;
-		p_viewport->gui.mouse_focus_mask = gui.mouse_focus_mask;
-		p_viewport->gui.key_focus = p_control;
-		p_viewport->gui.forced_mouse_focus = true;
-
-		gui.mouse_focus = nullptr;
-		gui.forced_mouse_focus = false;
-		gui.mouse_focus_mask.clear();
-	}
 }
 
 void Viewport::set_sdf_oversize(SDFOversize p_sdf_oversize) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -349,7 +349,6 @@ private:
 	Ref<Texture2D> vrs_texture;
 
 	struct GUI {
-		bool forced_mouse_focus = false; //used for menu buttons
 		bool mouse_in_viewport = false;
 		bool key_event_accepted = false;
 		HashMap<int, ObjectID> touch_focus;
@@ -661,8 +660,6 @@ public:
 
 	Viewport *get_parent_viewport() const;
 	Window *get_base_window() const;
-
-	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
 
 	void set_canvas_cull_mask(uint32_t p_layers);
 	uint32_t get_canvas_cull_mask() const;


### PR DESCRIPTION
The `EditorObjectSelector::_show_popup` called `PopupMenu::take_mouse_focus`, which called `Viewport::pass_mouse_focus_to`, which did nothing because the `_show_popup` is only called on left mouse button release and there is no `mouse_focus` set when the mouse is released. Since that was the only usage these methods were removed.

`Viewport::pass_mouse_focus_to` is the only place that`gui.forced_mouse_focus` is set to true, so it is also removed.