### PR TITLE
Allow `force_drag` on mouse press

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1797,13 +1797,15 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				}
 			}
 
+			bool was_dragging = gui.dragging;
+
 			bool stopped = gui.mouse_focus && gui.mouse_focus->can_process() && _gui_call_input(gui.mouse_focus, mb);
 			if (stopped) {
 				set_input_as_handled();
 			}
 
-			if (gui.dragging && mb->get_button_index() == MouseButton::LEFT) {
-				// Alternate drop use (when using force_drag(), as proposed by #5342).
+			if (was_dragging && gui.dragging && mb->get_button_index() == MouseButton::LEFT) {
+				// Alternate drop use (when using force_drag(), as proposed by #5351).
 				_perform_drop(gui.mouse_focus, pos);
 			}
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/95880

The code comment says it was for #5342 but it was actually for https://github.com/godotengine/godot/issues/5351

The use case of #5351 still works, using `_get_drag_data` to drag with mouse down and using a button's `_on_pressed` to drag with mouse up after clicking.

Added a test.