### PR TITLE
Add a zoom speed setting to the 2D editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -259,10 +259,13 @@
 			The color to use when drawing smart snapping lines in the 2D editor. The smart snapping lines will automatically display when moving 2D nodes if smart snapping is enabled in the Snapping Options menu at the top of the 2D editor viewport.
 		</member>
 		<member name="editors/2d/use_integer_zoom_by_default" type="bool" setter="" getter="">
-			If [code]true[/code], the 2D editor will snap to integer zoom values while not holding the [kbd]Alt[/kbd] key and powers of two while holding it. If [code]false[/code], this behavior is swapped.
+			If [code]true[/code], the 2D editor will snap to integer zoom values when not holding the [kbd]Alt[/kbd] key. If [code]false[/code], this behavior is swapped.
 		</member>
 		<member name="editors/2d/viewport_border_color" type="Color" setter="" getter="">
 			The color of the viewport border in the 2D editor. This border represents the viewport's size at the base resolution defined in the Project Settings. Objects placed outside this border will not be visible unless a [Camera2D] node is used, or unless the window is resized and the stretch mode is set to [code]disabled[/code].
+		</member>
+		<member name="editors/2d/zoom_speed_factor" type="float" setter="" getter="">
+			The factor to use when zooming in or out in the 2D editor. For example, [code]1.1[/code] will zoom in by 10% with every step. If set to [code]2.0[/code], zooming will only cycle through powers of two.
 		</member>
 		<member name="editors/3d/default_fov" type="float" setter="" getter="">
 			The default camera vertical field of view to use in the 3D editor (in degrees). The camera field of view can be adjusted on a per-scene basis using the [b]View[/b] menu at the top of the 3D editor. If a scene had its camera field of view adjusted using the [b]View[/b] menu, this setting is ignored in the scene in question. This setting is also ignored while a [Camera3D] node is being previewed in the editor.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -766,6 +766,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/bone_outline_size", 2.0, "0.01,8,0.01,or_greater")
 	_initial_set("editors/2d/viewport_border_color", Color(0.4, 0.4, 1.0, 0.4));
 	_initial_set("editors/2d/use_integer_zoom_by_default", false);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/zoom_speed_factor", 1.1, "1.01,2,0.01")
 
 	// Panning
 	// Enum should be in sync with ControlScheme in ViewPanner.

--- a/editor/gui/editor_zoom_widget.cpp
+++ b/editor/gui/editor_zoom_widget.cpp
@@ -141,22 +141,15 @@ void EditorZoomWidget::set_zoom_by_increments(int p_increment_count, bool p_inte
 			}
 		}
 	} else {
-		// Base increment factor defined as the twelveth root of two.
-		// This allows for a smooth geometric evolution of the zoom, with the advantage of
-		// visiting all integer power of two scale factors.
-		// Note: this is analogous to the 'semitone' interval in the music world
-		// In order to avoid numerical imprecisions, we compute and edit a zoom index
-		// with the following relation: zoom = 2 ^ (index / 12)
-
 		if (zoom < CMP_EPSILON || p_increment_count == 0) {
 			return;
 		}
 
-		// zoom = 2**(index/12) => log2(zoom) = index/12
-		float closest_zoom_index = Math::round(Math::log(zoom_noscale) * 12.f / Math::log(2.f));
-
-		float new_zoom_index = closest_zoom_index + p_increment_count;
-		float new_zoom = Math::pow(2.f, new_zoom_index / 12.f);
+		// Zoom is calculated as pow(zoom_factor, zoom_step).
+		// This ensures the zoom will always equal 100% when zoom_step is 0.
+		float zoom_factor = EDITOR_GET("editors/2d/zoom_speed_factor");
+		float current_zoom_step = Math::round(Math::log(zoom_noscale) / Math::log(zoom_factor));
+		float new_zoom = Math::pow(zoom_factor, current_zoom_step + p_increment_count);
 
 		// Restore Editor scale transformation.
 		new_zoom *= MAX(1, EDSCALE);


### PR DESCRIPTION
- Closes godotengine/godot-proposals#863
- Supersedes #43008 

The old zoom logic (introduced by #37073), used the [twelfth root of two](https://en.wikipedia.org/wiki/Twelfth_root_of_two) as the zoom factor (roughly equaling `1.06`). This had the advantage of visiting all power of two factors (e.g. 25%, 50%, 100%, 200%) which is good for pixel art, but led to quite slow zooming and had many intermediate values you had to scroll through to actually hit those nice values. After #48252 introduced shortcuts for this use case, and the Integer Zoom setting now exists, I don't see much use in preserving this constant zoom factor.

This PR instead lets the user configure the zoom factor to be between `1.01` and `2.0`. It will still be guaranteed to hit the 100% zoom value, but not any other specific values. **However**, when setting it to `2.0`, it will _only_ hit power of two factors, since it doubles or halves the value every time.

I set the default to `1.1`, in order to be slightly faster than the current zooming (and since it's a pretty number).

I additionally changed the tooltip for the Integer Zoom setting, since it wrongly stated that default zooming snaps to powers of two (insinuating that each zoom step would be a power of two, without any intermediate values). In any case, that would not be true after this PR, unless setting the factor to `2.0` as previously stated.