### PR TITLE
LightmapGI: Fix shader data alignment after #89919

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -96,7 +96,7 @@ struct Lightmap {
 	mat3 normal_xform;
 	vec2 light_texture_size;
 	float exposure_normalization;
-	vec2 pad;
+	float pad;
 };
 
 layout(set = 0, binding = 7, std140) restrict readonly buffer Lightmaps {


### PR DESCRIPTION
Fixes shader data alignment after the bicubic sampling PR (whoops)