### PR TITLE
Fix AudioStreamPlaylist not fading when switching streams

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -280,10 +280,11 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 		for (int i = 0; i < to_mix; i++) {
 			*p_buffer = mix_buffer[i];
 			stream_todo -= time_dec;
-			if (stream_todo < 0) {
-				//find next stream.
+
+			if (stream_todo - playlist->fade_time < 0) {
 				int prev = play_order[play_index];
 
+				// Find next stream.
 				for (int j = 0; j < playlist->stream_count; j++) {
 					play_index++;
 					if (play_index >= playlist->stream_count) {
@@ -341,7 +342,6 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 					playback[idx]->mix(mix_buffer + i, 1.0, to_mix - i); // Fill rest of mix buffer
 				}
 
-				// Update fade todo.
 				double bpm = playlist->audio_streams[idx]->get_bpm();
 				int beat_count = playlist->audio_streams[idx]->get_beat_count();
 
@@ -352,9 +352,12 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 				}
 			}
 
+			// Cross-fade
 			if (fade_index != -1) {
+				*p_buffer *= (1 - fade_volume);
 				*p_buffer += fade_buffer[i] * fade_volume;
 				fade_volume -= fade_dec;
+
 				if (fade_volume <= 0.0) {
 					playback[fade_index]->stop();
 					fade_index = -1;


### PR DESCRIPTION
- Fixes #95879

The current implementation of `AudioStreamPlaylist` starts fading the stream when the stream _ends_, and documentation for `fade_time` states:

> Streams are expected to have an extra bit of audio after the end to help with fading.

This is not very clear, but that means you have to configure the BPM and beat count of the stream to make it shorter than the total length.

In this PR the fading instead starts before the stream ends (offset by `fade_time`). Currently it does a cross-fade, as that was easiest to implement with least changes. Having a different fade mode available, like `FADE_OUT` in `AudioStreamInteractive`, would probably be desirable though.

The current max fade time being 1 second also feels a little limiting, but I'm not sure what a good max time would be.

