### PR TITLE
Don't warn about use of non-static member identifiers in static functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5505,7 +5505,35 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 	if (p_in_local_scope) {
 		while (base_class != nullptr) {
 			if (base_class->has_member(name)) {
-				parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()));
+				GDScriptParser::ClassNode::Member member = base_class->get_member(name);
+				bool is_member_static = false;
+
+				switch (member.type) {
+					case GDScriptParser::ClassNode::Member::FUNCTION:
+						is_member_static = member.function->is_static;
+						break;
+
+					case GDScriptParser::ClassNode::Member::VARIABLE:
+						is_member_static = member.variable->is_static;
+						break;
+
+					// Can't be static.
+					case GDScriptParser::ClassNode::Member::UNDEFINED:
+					case GDScriptParser::ClassNode::Member::CLASS:
+					case GDScriptParser::ClassNode::Member::CONSTANT:
+					case GDScriptParser::ClassNode::Member::SIGNAL:
+					case GDScriptParser::ClassNode::Member::ENUM:
+					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+					case GDScriptParser::ClassNode::Member::GROUP:
+						break;
+				}
+
+				// Non-static members aren't accessible from within static
+				// functions. Thus, a warning is only useful if we're in a
+				// non-static context or the member is static.
+				if (!static_context || is_member_static) {
+					parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, member.get_type_name(), itos(member.get_line()));
+				}
 				return;
 			}
 			base_class = base_class->base_type.class_type;

--- a/modules/gdscript/tests/scripts/analyzer/features/non_static_member_identifiers_in_static_functions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/non_static_member_identifiers_in_static_functions.gd
@@ -1,0 +1,46 @@
+class_name NonStaticMemberIdentifiersInStaticFunctionsOuterClass
+
+var member1 = 1
+var member2 = 2
+var member3 = 3
+var member4 = 4
+var member5 = 5
+
+
+static func f(member1):
+	print(member1)
+
+	var member2 = 2
+	print(member2)
+
+	const member3 = 3
+	print(member3)
+
+	for member4 in 1:
+		print(member4)
+
+	match 1:
+		var member5:
+			print(member5)
+
+
+class InnerClass extends NonStaticMemberIdentifiersInStaticFunctionsOuterClass:
+	static func g(member1):
+		print(member1)
+
+		var member2 = 2
+		print(member2)
+
+		const member3 = 3
+		print(member3)
+
+		for member4 in 1:
+			print(member4)
+
+		match 1:
+			var member5:
+				print(member5)
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/non_static_member_identifiers_in_static_functions.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/non_static_member_identifiers_in_static_functions.out
@@ -1,0 +1,1 @@
+GDTEST_OK

--- a/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_non_static_functions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_non_static_functions.gd
@@ -1,0 +1,46 @@
+class_name StaticMemberIdentifiersInNonStaticFunctionsOuterClass
+
+static var static1 = 1
+static var static2 = 2
+static var static3 = 3
+static var static4 = 4
+static var static5 = 5
+
+
+func f(static1):
+	print(static1)
+
+	var static2 = 2
+	print(static2)
+
+	const static3 = 3
+	print(static3)
+
+	for static4 in 1:
+		print(static4)
+
+	match 1:
+		var static5:
+			print(static5)
+
+
+class InnerClass extends StaticMemberIdentifiersInNonStaticFunctionsOuterClass:
+	func g(static1):
+		print(static1)
+
+		var static2 = 2
+		print(static2)
+
+		const static3 = 3
+		print(static3)
+
+		for static4 in 1:
+			print(static4)
+
+		match 1:
+			var static5:
+				print(static5)
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_non_static_functions.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_non_static_functions.out
@@ -1,0 +1,41 @@
+GDTEST_OK
+>> WARNING
+>> Line: 10
+>> SHADOWED_VARIABLE
+>> The local function parameter "static1" is shadowing an already-declared variable at line 3.
+>> WARNING
+>> Line: 13
+>> SHADOWED_VARIABLE
+>> The local variable "static2" is shadowing an already-declared variable at line 4.
+>> WARNING
+>> Line: 16
+>> SHADOWED_VARIABLE
+>> The local constant "static3" is shadowing an already-declared variable at line 5.
+>> WARNING
+>> Line: 19
+>> SHADOWED_VARIABLE
+>> The local "for" iterator variable "static4" is shadowing an already-declared variable at line 6.
+>> WARNING
+>> Line: 23
+>> SHADOWED_VARIABLE
+>> The local pattern bind "static5" is shadowing an already-declared variable at line 7.
+>> WARNING
+>> Line: 28
+>> SHADOWED_VARIABLE
+>> The local function parameter "static1" is shadowing an already-declared variable at line 3.
+>> WARNING
+>> Line: 31
+>> SHADOWED_VARIABLE
+>> The local variable "static2" is shadowing an already-declared variable at line 4.
+>> WARNING
+>> Line: 34
+>> SHADOWED_VARIABLE
+>> The local constant "static3" is shadowing an already-declared variable at line 5.
+>> WARNING
+>> Line: 37
+>> SHADOWED_VARIABLE
+>> The local "for" iterator variable "static4" is shadowing an already-declared variable at line 6.
+>> WARNING
+>> Line: 41
+>> SHADOWED_VARIABLE
+>> The local pattern bind "static5" is shadowing an already-declared variable at line 7.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_static_functions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_static_functions.gd
@@ -1,0 +1,46 @@
+class_name StaticMemberIdentifiersInStaticFunctionsOuterClass
+
+static var static1 = 1
+static var static2 = 2
+static var static3 = 3
+static var static4 = 4
+static var static5 = 5
+
+
+static func f(static1):
+	print(static1)
+
+	var static2 = 2
+	print(static2)
+
+	const static3 = 3
+	print(static3)
+
+	for static4 in 1:
+		print(static4)
+
+	match 1:
+		var static5:
+			print(static5)
+
+
+class InnerClass extends StaticMemberIdentifiersInStaticFunctionsOuterClass:
+	static func g(static1):
+		print(static1)
+
+		var static2 = 2
+		print(static2)
+
+		const static3 = 3
+		print(static3)
+
+		for static4 in 1:
+			print(static4)
+
+		match 1:
+			var static5:
+				print(static5)
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_static_functions.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/static_member_identifiers_in_static_functions.out
@@ -1,0 +1,41 @@
+GDTEST_OK
+>> WARNING
+>> Line: 10
+>> SHADOWED_VARIABLE
+>> The local function parameter "static1" is shadowing an already-declared variable at line 3.
+>> WARNING
+>> Line: 13
+>> SHADOWED_VARIABLE
+>> The local variable "static2" is shadowing an already-declared variable at line 4.
+>> WARNING
+>> Line: 16
+>> SHADOWED_VARIABLE
+>> The local constant "static3" is shadowing an already-declared variable at line 5.
+>> WARNING
+>> Line: 19
+>> SHADOWED_VARIABLE
+>> The local "for" iterator variable "static4" is shadowing an already-declared variable at line 6.
+>> WARNING
+>> Line: 23
+>> SHADOWED_VARIABLE
+>> The local pattern bind "static5" is shadowing an already-declared variable at line 7.
+>> WARNING
+>> Line: 28
+>> SHADOWED_VARIABLE
+>> The local function parameter "static1" is shadowing an already-declared variable at line 3.
+>> WARNING
+>> Line: 31
+>> SHADOWED_VARIABLE
+>> The local variable "static2" is shadowing an already-declared variable at line 4.
+>> WARNING
+>> Line: 34
+>> SHADOWED_VARIABLE
+>> The local constant "static3" is shadowing an already-declared variable at line 5.
+>> WARNING
+>> Line: 37
+>> SHADOWED_VARIABLE
+>> The local "for" iterator variable "static4" is shadowing an already-declared variable at line 6.
+>> WARNING
+>> Line: 41
+>> SHADOWED_VARIABLE
+>> The local pattern bind "static5" is shadowing an already-declared variable at line 7.


### PR DESCRIPTION
Fixes #63120.

To summarise the linked issue: non-static members aren't accessible from within static functions and thus can't be shadowed, however a warning is still emitted if an identifier within a static function is the same as a non-static member. For example, this occurs in factory functions:

```gdscript
class_name Person
extends Resource

@export var name: String

# Warning: The local function parameter "name" is shadowing an already-declared variable at line 4.
static func create(name: String) -> Person:
	var person := Person.new()
	person.name = name
	return person
```

This PR updates `GDScriptAnalyzer::is_shadowing` to omit the warning in this case. The warning is still emitted if an identifier within a static function is the same as that of another static member, or if an identifier within a non-static function is the same as any other member (static or non-static).