### PR TITLE
Document that `Node.duplicate` also duplicates its children.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -255,7 +255,7 @@
 			<return type="Node" />
 			<param index="0" name="flags" type="int" default="15" />
 			<description>
-				Duplicates the node, returning a new node with all of its properties, signals and groups copied from the original. The behavior can be tweaked through the [param flags] (see [enum DuplicateFlags]).
+				Duplicates the node, returning a new node with all of its properties, signals, groups, and children copied from the original. The behavior can be tweaked through the [param flags] (see [enum DuplicateFlags]).
 				[b]Note:[/b] For nodes with a [Script] attached, if [method Object._init] has been defined with required parameters, the duplicated node will not have a [Script].
 			</description>
 		</method>


### PR DESCRIPTION
The documentation of Node.duplicate does not mention that the Node's subtree is duplicated, as well. (see https://github.com/godotengine/godot/issues/95895)

"[...] children copied from the original." implies that their copies are already attached to the new node, so I think this is really all the additional info required.