### PR TITLE
OpenXR: Check correct status bit for hand tracking

### DIFF
--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -297,7 +297,7 @@ void OpenXRHandTrackingExtension::on_process() {
 					godot_tracker->set_hand_joint_radius((XRHandTracker::HandJoint)joint, location.radius);
 
 					if (joint == XR_HAND_JOINT_PALM_EXT) {
-						if (location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) {
+						if (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) {
 							XrHandTrackingDataSourceStateEXT &data_source = hand_trackers[i].data_source;
 
 							XRHandTracker::HandTrackingSource source = XRHandTracker::HAND_TRACKING_SOURCE_UNKNOWN;


### PR DESCRIPTION
In OpenXR the VALID bit informs us that that pose data is valid and usable. The TRACKING bit further informs us if the data is up to date or if we're dealing with inferred/calculated or otherwise manipulated data.

We were being too strict here resulting in data not being updated on some devices even though data was available.
In other places in the module, including in other places in hand tracking, we were checking the correct bit, just not here.