### PR TITLE
Enable fallback from ANGLE to native and improve ANGLE error messages.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2526,8 +2526,8 @@
 			[b]Note:[/b] This setting is implemented only on Linux/X11.
 		</member>
 		<member name="rendering/gl_compatibility/fallback_to_native" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the compatibility renderer will fall back to native OpenGL if ANGLE over Metal is not supported.
-			[b]Note:[/b] This setting is implemented only on macOS.
+			If [code]true[/code], the compatibility renderer will fall back to native OpenGL if ANGLE is not supported, or ANGLE dynamic libraries aren't found.
+			[b]Note:[/b] This setting is implemented on macOS and Windows.
 		</member>
 		<member name="rendering/gl_compatibility/force_angle_on_devices" type="Array" setter="" getter="">
 			An [Array] of devices which should always use the ANGLE renderer.

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -357,7 +357,7 @@ Error EGLManager::initialize(void *p_native_display) {
 	// have to temporarily get a proper display and reload EGL once again to
 	// initialize everything else.
 	if (!gladLoaderLoadEGL(EGL_NO_DISPLAY)) {
-		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Can't load EGL.");
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Can't load EGL dynamic library.");
 	}
 
 	EGLDisplay tmp_display = EGL_NO_DISPLAY;
@@ -387,7 +387,7 @@ Error EGLManager::initialize(void *p_native_display) {
 	int version = gladLoaderLoadEGL(tmp_display);
 	if (!version) {
 		eglTerminate(tmp_display);
-		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Can't load EGL.");
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Can't load EGL dynamic library.");
 	}
 
 	int major = GLAD_VERSION_MAJOR(version);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3609,7 +3609,11 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 			gl_manager_angle = nullptr;
 			bool fallback = GLOBAL_GET("rendering/gl_compatibility/fallback_to_native");
 			if (fallback) {
-				WARN_PRINT("Your video card drivers seem not to support the required Metal version, switching to native OpenGL.");
+#ifdef EGL_STATIC
+				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE, switching to native OpenGL.");
+#else
+				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE or ANGLE dynamic libraries (libEGL.dylib and libGLESv2.dylib) are missing, switching to native OpenGL.");
+#endif
 				rendering_driver = "opengl3";
 			} else {
 				r_error = ERR_UNAVAILABLE;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95925

- Adds fallback from ANGLE to native.
- Adds some extra information to the error/warning messages.