### PR TITLE
Docs: fix default value of `CharacterBody3D.up_direction`

### DIFF
--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -180,7 +180,7 @@
 		<member name="slide_on_ceiling" type="bool" setter="set_slide_on_ceiling_enabled" getter="is_slide_on_ceiling_enabled" default="true">
 			If [code]true[/code], during a jump against the ceiling, the body will slide, if [code]false[/code] it will be stopped and will fall vertically.
 		</member>
-		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3(0, 1, 0)">
+		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3.UP">
 			Vector pointing upwards, used to determine what is a wall and what is a floor (or a ceiling) when calling [method move_and_slide]. Defaults to [constant Vector3.UP]. As the vector will be normalized it can't be equal to [constant Vector3.ZERO], if you want all collisions to be reported as walls, consider using [constant MOTION_MODE_FLOATING] as [member motion_mode].
 		</member>
 		<member name="velocity" type="Vector3" setter="set_velocity" getter="get_velocity" default="Vector3(0, 0, 0)">


### PR DESCRIPTION
Fixes a misleading default value display in the docs page for `CharacterBody3D`.

The docs currently display the default value for `CharacterBody3D.up_direction` as `= Vector3(0, 1, 0)`. While this is *technically* accurate, this indicates that the default value is a mutable `Vector3`. This is not the case, as it's actually `= Vector3.UP`, which is a const and cannot be mutated. This can lead to trying to reassign its `x`, `y`, and `z` properties and encountering a runtime error they might not know the reason for.

This PR fixes this issue by properly clarifying the up direction to be a constant reference. As the description links to `Vector3.UP`, this should be sufficient for legibility.