### PR TITLE
Add support for infinite projection matrix

### DIFF
--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -133,8 +133,10 @@ enum class EulerOrder {
  */
 #ifdef REAL_T_IS_DOUBLE
 typedef double real_t;
+#define MAX_REAL_T 1.7976931348623157e+308
 #else
 typedef float real_t;
+#define MAX_REAL_T 3.40282347e+38F
 #endif
 
 #endif // MATH_DEFS_H

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -188,8 +188,14 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 					matrix[11] - matrix[10],
 					matrix[15] - matrix[14]);
 
-			new_plane.normal = -new_plane.normal;
-			new_plane.normalize();
+			if (new_plane.normal[0] == 0 && new_plane.normal[1] == 0 && new_plane.normal[2] == 0) {
+				new_plane.normal = Vector3(0, 0, -1);
+				new_plane.d = MAX_REAL_T;
+			} else {
+				new_plane.normal = -new_plane.normal;
+				new_plane.normalize();
+			}
+
 			return new_plane;
 		}
 		case PLANE_LEFT: {
@@ -408,6 +414,10 @@ real_t Projection::get_z_far() const {
 			matrix[11] - matrix[10],
 			matrix[15] - matrix[14]);
 
+	if (new_plane.normal[0] == 0 && new_plane.normal[1] == 0 && new_plane.normal[2] == 0) {
+		return MAX_REAL_T;
+	}
+
 	new_plane.normalize();
 
 	return new_plane.d;
@@ -459,7 +469,13 @@ Vector2 Projection::get_far_plane_half_extents() const {
 			matrix[7] - matrix[6],
 			matrix[11] - matrix[10],
 			-matrix[15] + matrix[14]);
-	far_plane.normalize();
+
+	if (far_plane.normal[0] == 0 && far_plane.normal[1] == 0 && far_plane.normal[2] == 0) {
+		far_plane.normal = Vector3(0, 0, 1);
+		far_plane.d = -MAX_REAL_T;
+	} else {
+		far_plane.normalize();
+	}
 
 	///////--- Right Plane ---///////
 	Plane right_plane = Plane(matrix[3] - matrix[0],
@@ -537,8 +553,13 @@ Vector<Plane> Projection::get_projection_planes(const Transform3D &p_transform) 
 			matrix[11] - matrix[10],
 			matrix[15] - matrix[14]);
 
-	new_plane.normal = -new_plane.normal;
-	new_plane.normalize();
+	if (new_plane.normal[0] == 0 && new_plane.normal[1] == 0 && new_plane.normal[2] == 0) {
+		new_plane.normal = Vector3(0, 0, -1);
+		new_plane.d = MAX_REAL_T;
+	} else {
+		new_plane.normal = -new_plane.normal;
+		new_plane.normalize();
+	}
 
 	planes.write[1] = p_transform.xform(new_plane);
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -453,9 +453,9 @@ void main() {
 // VERTEX LIGHTING
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 #ifdef USE_MULTIVIEW
-	vec3 view = -normalize(vertex_interp - eye_offset);
+	vec3 view = -normalize((vertex_interp - eye_offset) / abs(vertex_interp.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #else
-	vec3 view = -normalize(vertex_interp);
+	vec3 view = -normalize(vertex_interp / abs(vertex_interp.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #endif
 
 	diffuse_light_interp = vec4(0.0);
@@ -562,8 +562,8 @@ void main() {
 	//for dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges
 
 	vec3 vtx = vertex_interp;
-	float distance = length(vtx);
-	vtx = normalize(vtx);
+	float distance = length(vtx / abs(vertex_interp.z)) * abs(vertex_interp.z); // Dividing before taking length() prevents overflow when values exceed sqrt(MAX_FLOAT)
+	vtx /= distance;
 	vtx.xy /= 1.0 - vtx.z;
 	vtx.z = (distance / scene_data.z_far);
 	vtx.z = vtx.z * 2.0 - 1.0;
@@ -821,7 +821,7 @@ vec4 fog_process(vec3 vertex) {
 	if (scene_data_block.data.fog_sun_scatter > 0.001) {
 		vec4 sun_scatter = vec4(0.0);
 		float sun_total = 0.0;
-		vec3 view = normalize(vertex);
+		vec3 view = normalize(vertex / abs(vertex.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 
 		for (uint i = 0; i < scene_data_block.data.directional_light_count; i++) {
 			vec3 light_color = directional_lights.data[i].color * directional_lights.data[i].energy;
@@ -876,10 +876,10 @@ void main() {
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
-	vec3 view = -normalize(vertex_interp - eye_offset);
+	vec3 view = -normalize((vertex_interp - eye_offset) / abs(vertex_interp.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #else
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-	vec3 view = -normalize(vertex_interp);
+	vec3 view = -normalize(vertex_interp / abs(vertex_interp.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #endif
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
@@ -1001,9 +1001,9 @@ void main() {
 #ifdef LIGHT_VERTEX_USED
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
-	view = -normalize(vertex - eye_offset);
+	view = -normalize((vertex - eye_offset) / abs(vertex.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #else
-	view = -normalize(vertex);
+	view = -normalize(vertex / abs(vertex.z)); // Dividing before normalizing prevents overflow when values exceed sqrt(MAX_FLOAT)
 #endif //USE_MULTIVIEW
 #endif //LIGHT_VERTEX_USED
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10515.
Fixes #55070 

## What is it about ?
This PR ensures that :
- class `Projection` returns a well-formed far plane when the matrix has the form of an infinite projection
- the rendering pipeline works as expected when the camera far plane is very far away

Without this PR, when the projection matrix is infinite, `Projection` generate zero vectors for the far plane normal, and 0 as z-far distance. This raise errors at different places in the rendering logic (culling, shadow mapping, GI, fog ...) and ultimately prevents anything to be rendered.

With this PR, `Projection` returns z-far distance as `MAX_REAL_T` and the far plane's normal as `Vector3(0, 0, -1)` when the projection matrix has the form of an infinite projection.

## Why it does matter ?
Godot 4.3 brought [reverse z-buffer](https://github.com/godotengine/godot/pull/88328) which unlocks rendering with very far apart near and far planes, with very limited risks of z-fighting in normal conditions.
However, in practice the usage of very far apart near and far planes is still not supported because it makes rendering fail for the reason described above.

This PR ultimately untaps the potential of natively supporting very deep scenes in Godot, without having to workaround it with multiple nested/layered cameras. This is especially useful for terrain rendering and space simulations.

## Under which conditions is an infinite projection matrix generated ?
The infinite form of a projection matrix is obtained when zfar tends towards infinity.
Due to numerical precision limits, in practice it's enough that znear and zfar values are far apart enough to obtain an infinite projection matrix.
I experienced that beyond a difference of 1e7 ~ 1e8 between the near and far distances, the matrix is generated infinite.

The below collapsed sections show how Perspective, Frustum and Orthogonal projections react to far apart znear and zfar when constructed from camera attributes. In a nutshell :
- For Perspective and Frustum, `columns[2][2] = -1` and `columns[3][2] = -2 * p_z_near`
- For Orthogonal, `columns[3][2] = -1`

<details>

**<summary>Expand details</summary>**

### Perspective projection
From [`Projection::set_perspective()`](https://github.com/godotengine/godot/blob/c5ac5d230822a6a39551487acc52350da450c429/core/math/projection.cpp#L270C1-L275C20):
```c++
deltaZ = p_z_far - p_z_near; // becomes p_z_far
// [...]
columns[0][0] = cotangent / p_aspect;
columns[1][1] = cotangent;
columns[2][2] = -(p_z_far + p_z_near) / deltaZ; // becomes -1
columns[2][3] = -1;
columns[3][2] = -2 * p_z_near * p_z_far / deltaZ; // becomes -2 * p_z_near
```
### Frustum projection
From [`Projection::set_frustum()`](https://github.com/godotengine/godot/blob/c5ac5d230822a6a39551487acc52350da450c429/core/math/projection.cpp#L369C1-L393C13), rewritten for clarity:
```c++
columns[0][0] = 2 * p_near / (p_right - p_left);
columns[1][1] = 2 * p_near / (p_top - p_bottom);
columns[2][0] = (p_right + p_left) / (p_right - p_left);
columns[2][1] = (p_top + p_bottom) / (p_top - p_bottom);
columns[2][2] = -(p_far + p_near) / (p_far - p_near); // becomes -1
columns[2][3] = -1;
columns[3][2] = -2 * p_far * p_near / (p_far - p_near); // becomes -2 * p_z_near
```

### Orthogonal projection
From [`Projection::set_orthogonal()`](https://github.com/godotengine/godot/blob/c5ac5d230822a6a39551487acc52350da450c429/core/math/projection.cpp#L347C2-L353C22)
```c++
columns[0][0] = 2.0 / (p_right - p_left);
columns[1][1] = 2.0 / (p_top - p_bottom);
columns[2][2] = -2.0 / (p_zfar - p_znear); // becomes -2.0 / p_zfar
columns[3][0] = -((p_right + p_left) / (p_right - p_left));
columns[3][1] = -((p_top + p_bottom) / (p_top - p_bottom));
columns[3][2] = -((p_zfar + p_znear) / (p_zfar - p_znear)); // becomes -1
columns[3][3] = 1.0;
```

</details>

## Why an infinite Perspective and Frustum projection matrices breaks zfar and far plane extraction ?
User camera settings are transformed into a projection matrix stored in a `Projection` object.
When needed, the rendering server extracts back the frustum planes and distances from the `Projection` object.
This happens in one of these 4 functions :
- `Projection::get_projection_planes()`
- `Projection::get_projection_plane()`
- `Projection::get_z_far()`
- `Projection::get_far_plane_half_extents()`

When the projection matrix degenerates to its infinite form due to numerical precision effects, it becomes  mathematically impossible to extract the far plane normal and intercept from it. 
When performed by one of those functions, the calculation gives 0 (zero vector as the normal, and 0 intercept).
This is the relevant code excerpt taken from [`Projection::get_projection_plane()`](https://github.com/godotengine/godot/blob/c5ac5d230822a6a39551487acc52350da450c429/core/math/projection.cpp#L186C1-L193C21) and rewritten for clarity (the logic is the same for other functions) :
```c++
// This initializes a plane with a zero vector as its normal (first 3 arguments)
Plane new_plane = Plane(columns[0][3] - columns[0][2], // = 0 in all cases
		columns[1][3] - columns[1][2], // = 0 in all cases
		columns[2][3] - columns[2][2], // = 0 for infinite Perspective and Frustum projection
		columns[3][3] - columns[3][2]);

new_plane.normal = -new_plane.normal;
new_plane.normalize(); // returns a zero plane when the normal is a zero vector
return new_plane;
```
Orthogonal projections aren't affected because `columns[2][2] = -2.0 / (p_zfar - p_znear)` which becomes `-2.0 / p_zfar` when `z_far` is big, which is still a (small) finite value. This is under the assumption that `p_zfar` is not set to `INFINITY` by the user, which is currently not possible through the editor, but possible with code.

## TODOs
- [x]  Detect infinite projections and return correct far plane (normal = `Vector3(0, 0, -1)` and intercept = `MAX_REAL_T`)
- [x]  List usages of extracted zfar value and check whether `MAX_REAL_T` breaks any further logic
  - [x] Forward renderers (clustered and mobile)
  - [x] Compatibility renderer
  - [x] Sky
  - [x] GI
  - [x] Fog
  - [x] SS effects
  - [x] Debug effects
  - [x] Scene renderer
  - [x] Cluster builder
  - [x] Scene culling
  - [x] Raycast occlusion culling
  - [x] Light culler
  - [x] Scene renderer
- [ ] Fix any broken logic with zfar = `MAX_REAL_T`
  - [x] Forward renderers (clustered and mobile)
  - [ ] Compatibility renderer
- [ ] Write unit tests with infinite far planes
  - [ ] Camera3D
  - [ ] XRCamera3D
  - [ ] Plane
- [ ] Add other features using zfar / far plane (like GI and light culling) in the demo project

## Infinite zfar impact analysis

The following collapsed sections document the behaviors of the various impacted steps of the rendering pipeline **when the zfar value extracted from the projection matrix is `MAX_REAL_T`**.

:white_check_mark: means the behaviour is likely fine.
:warning: means there is likely a problem. Further investigation is needed.

Note that for now this assessment is only based code inspection.
Proper testing will be needed in all cases.

<details>

**<summary>Show detailed analysis</summary>**

### `RenderForwardClustered` (+ `RasterizerSceneGLES3`)

`RenderForwardClustered::_fill_render_list()`
`RasterizerSceneGLES3::_fill_render_list()`:
- :white_check_mark: All surfaces are set to [`depth_layer` 0](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L912). OK since `depth_layer` seems [not to be used as a sort key](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h#L420-L440)

### `RenderForwardClustered` and `RenderForwardClusteredMobile` (+ `RasterizerSceneGLES3`)

`RenderForwardClustered::_render_particle_collider_heightfield()`
`RenderForwardClusteredMobile::_render_particle_collider_heightfield()`
`RasterizerSceneGLES3::render_particle_collider_heightfield()`
- :warning: [`scene_data`](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L2748-L2749) has `z_far` == `MAX_REAL_T` which leads [the ubo](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp#L117-L118) to have `z_far` = `MAX_REAL_T` too

### `SkyRD` (+ `RasterizerSceneGLES3`)

`SkyRD::setup_sky()`:
- :white_check_mark:The [sky scene UBO](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/environment/sky.cpp#L1202-L1203) has `z_far` = `MAX_REAL_T`, which leads the [sky shader](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/environment/sky.glsl#L90-L91) to have `z_far` = `MAX_REAL_T`. This value is not used anywhere in the glsl file though.

`SkyRD::update_res_buffers()`
`SkyRD::draw_sky()`:
`RasterizerSceneGLES3::_draw_sky()`
- :white_check_mark: If the sky has a custom fov, [build an infinite perspective projection](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/environment/sky.cpp#L1449-L1456) with the custom fov. Otherwise use the camera's projection, which is infinite too

### `GI`

`GI::process_gi()`:
- :warning: GI shader gets `zfar` = `MAX_REAL_T` via the [push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/environment/gi.cpp#L3854). This makes [the glsl function `reconstruct_position()`](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/environment/gi.glsl#L176-L180) return `vec2(NaN)` in all cases, which makes [`process_gi()` run on NaN vertices](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/environment/gi.glsl#L719-L720), which likely gives `NaN` in the end too (not checked)

### `Fog`

`Fog::volumetric_fog_update()` : 
- :white_check_mark: For each fog volume : [Fog shader](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl#L51-L52) gets `zfar` = `MAX_REAL_T` [via the UBO](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/environment/fog.cpp#L555-L556) , but this value is not used anywhere in the glsl file

- :warning: The [Fog process shader](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl#L150-L155) gets `fog_frustum_size_begin` = `fog_frustum_size_end` = `frustum_near_size` as well as `zfar` = `MAX_REAL_T` [via the UBO](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/environment/fog.cpp#L996-L1014). I haven't checked the effets yet but it's lilkely the fog is not rendered correctly

### `SSEffects`

`SSEffects::downsample_depth()` :
- :white_check_mark: The downsampling shader gets `zfar` = `MAX_REAL_T` [via the push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/ss_effects.cpp#L499-L502) only in Orthogonal mode, which is not affected by the infinite matrix issue

`SSEffects::screen_space_indirect_lighting` :
- :warning: The ssil shader gets `zfar` = `MAX_REAL_T` [via push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/ss_effects.cpp#L696-L697) which makes all reprojected samples in last frame's coordinates [lie on the near plane](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/ssil.glsl#L204-L211). I'm not sure what are the impacts for now.

`SSEffects::screen_space_reflection` :
- :warning: The ssr scale shader gets `camera_z_far` = `MAX_REAL_T` [via push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/ss_effects.cpp#L1429) which generates `NaN`s in depth values in two places ([1](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_scale.glsl#L76-L80) [2](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_scale.glsl#L100-L104)). Impacts not checked, but probably not good

- :warning: The ssr shader gets `camera_z_far` = `MAX_REAL_T` [via push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/ss_effects.cpp#L1467-L1468) which generates [infinite ray ends](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl#L105-L106) and [`NaN` depths](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl#L179-L180). Impacts not checked, but probably not good

`SSEffects::sub_surface_scattering` :
- :warning: The sss shader gets `camera_z_far` = `MAX_REAL_T` [via push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/ss_effects.cpp#L1644-L1645) which generates [`NaN`s in depth values](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl#L154-L160). Impacts not checked, but probably not good

### `DebugEffects`

`DebugEffects::draw_shadow_frustum()`:
- :warning: [Projections of all shadow splits](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/effects/debug_effects.cpp#L214-L251) likely have both near and far set as `MAX_REAL_T`. Impacts not checked, but probably not good

### `RendererSceneRenderRD` (+ `RasterizerSceneGLES3`)

`RendererSceneRenderRD::render_scene()`
`RasterizerSceneGLES3::render_scene()`:
- :warning: [`RenderSceneDataRD` UBO](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp#L1154-L1155) has `zfar` = `MAX_REAL_T` which has several effects in the scene shader : [fog mip level](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl#L1035-L1036) is always 1, [multiview cluster](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl#L1386-L1387) is always 0, and [interpolated vertex for dual paraboloid](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl#L491-L493) always lies on the near plane

`RendererSceneRenderRD::render_scene()`
- :warning: [FSR2](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L2371) might emit warnings as it implements infinite far with the [maximum representable float](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/thirdparty/amd-fsr2/ffx_fsr2.cpp#L324-L328) instead of infinity
- :white_check_mark: [`TAA::process()`](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L2393-L2394) and `TAA::resolve()` take z-depth and z-near as parameters but aren't used in the functions bodies

### `ClusterBuilderRD`

`ClusterBuilderRD::begin()`:
- :white_check_mark: `ClusterBuilderRD::add_box()` and `ClusterBuilderRD::add_light()` : render elements never touch the far plane
- :warning: The [`state_uniform buffer`](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/cluster_builder_rd.cpp#L436-L445) gets `inv_z = 0`, which makes the z cluster be always 0 in the [cluster_render shader](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/cluster_render.glsl#L159-L165)
- :warning: The debug shader gets `zfar` == `MAX_REAL_T` through [push constants](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/cluster_builder_rd.cpp#L539-L540) which generates `NaN` depth calculation and likely make it [output a solid color](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_rd/shaders/cluster_debug.glsl#L83-L114)

### `RendererSceneCull`

`RendererSceneCull::_light_instance_setup_directional_shadow()`:
- :warning: [Projections of all shadow splits](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_scene_cull.cpp#L2288-L2318) but the last one have both near and far set as camera znear. Impacts not checked, but probably not good. Probably what causes #81877 

`RendererSceneCull::_light_instance_update_shadow()`:
- :white_check_mark: [Convex queries](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_scene_cull.cpp#L2671-L2672) should work correctly with infinite far plane

`RendererSceneCull::_scene_cull()`:
- :white_check_mark: [frustum culling](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/servers/rendering/renderer_scene_cull.cpp#L2945-L2946) should work correctly with infinite far plane.

### `RaycastOcclusionCull::RaycastHZBuffer`

`RaycastOcclusionCull::RaycastHZBuffer::update_camera_rays()`:
- :warning: [Camera rays](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/modules/raycast/raycast_occlusion_cull.cpp#L159-L160) get `zfar` = `MAX_REAL_T`. Might have impacts on Embree logic
- :warning: [Mips](https://github.com/godotengine/godot/blob/7e99e939870fc149e42d2a76b764072f550f4b82/modules/raycast/raycast_occlusion_cull.cpp#L184-L194) are all set to `MAX_REAL_T` too

### `RenderingLightCuller`

`RenderingLightCuller::_add_light_camera_planes`
`RenderingLightCuller::add_light_camera_planes_directional`
`RenderingLightCuller::cull_regular_light`:
- :white_check_mark: Far plane has infinite intercept. Light culling should be performed correctly anyway

### `RendererSceneRender::CameraData`

`RendererSceneRender::CameraData::set_multiview_camera()`:
- :white_check_mark: The combined projection matrix should be fine with infinite far

</details>

## Test project
[PR95944.zip](https://github.com/user-attachments/files/16716771/PR95944.zip)

Camera has near = 0.05 and far ~= 1e20, perspective projection.
Pink sphere is at z ~= -1e20
Blue sphere is at z = -1e15
Green sphere is at z = -1e10
Orange sphere is at z = -1e5
Black sphere is at z = -1

**Without this PR :**

![image](https://github.com/user-attachments/assets/bb6cedaa-3557-450b-bc83-87feb9197524)

**With this PR :**

![image](https://github.com/user-attachments/assets/b233a8f3-7587-474c-8b0d-71f39d67a156)