### PR TITLE
Fix animation timeline resize widget allowing invalid internal values

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1855,6 +1855,8 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (dragging_hsize) {
 			int ofs = mm->get_position().x - dragging_hsize_from;
 			name_limit = dragging_hsize_at + ofs;
+			// Make sure name_limit is clamped to the range that UI allows.
+			name_limit = get_name_limit();
 			queue_redraw();
 			emit_signal(SNAME("name_limit_changed"));
 			play_position->queue_redraw();


### PR DESCRIPTION
This fixes a simple bug where dragging the resize widget out of bounds and then releasing the mouse button would put it into an invalid range that breaks the intended behaviour for it:

Before:

https://github.com/user-attachments/assets/e741845d-c437-4e9c-b176-1ba93a6aac3b

After:

https://github.com/user-attachments/assets/f16da9fe-6922-4c6b-a9bd-65de568da3b8

Note: Could be better to add a `set_name_limit()` method and move the clamping logic there, but `get_name_limit()` is used in 40 different places so I went with a smaller possible change to make sure it doesn't break anything in some obscure way