### PR TITLE
Fix PopupMenu horizontal margin in editor theme

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1131,12 +1131,13 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
 			p_theme->set_icon("search", "PopupMenu", p_theme->get_icon(SNAME("Search"), EditorStringName(EditorIcons)));
 
+			p_theme->set_constant("h_separation", "PopupMenu", 4 * EDSCALE);
 			int v_sep = (p_config.enable_touch_optimizations ? 12 : p_config.forced_even_separation) * EDSCALE;
 			p_theme->set_constant("v_separation", "PopupMenu", v_sep);
 			p_theme->set_constant("search_bar_separation", "PopupMenu", v_sep);
 			p_theme->set_constant("outline_size", "PopupMenu", 0);
-			p_theme->set_constant("item_start_padding", "PopupMenu", p_config.separation_margin);
-			p_theme->set_constant("item_end_padding", "PopupMenu", p_config.separation_margin);
+			p_theme->set_constant("item_start_padding", "PopupMenu", p_config.popup_margin);
+			p_theme->set_constant("item_end_padding", "PopupMenu", p_config.popup_margin);
 		}
 	}
 


### PR DESCRIPTION
Believe this should fix: https://github.com/godotengine/godot/issues/89697

| 4.2.2  | 4.3 | New
| ------------- | ------------- | ------------- |
|  ![a422](https://github.com/user-attachments/assets/8cdd0bc2-c1c0-468d-8dcc-96a0dfd0e769) | ![a433](https://github.com/user-attachments/assets/32d9a11c-fec0-4794-a1b2-0a041ceb0180)  | ![Screenshot_20240822_161355](https://github.com/user-attachments/assets/14b7e27a-62e6-4812-b81f-86ae1fe5b949) |
|  ![b422](https://github.com/user-attachments/assets/e8e4e2cc-8254-4d13-9cd4-c1daaaf57c39) | ![b433](https://github.com/user-attachments/assets/4ffdc1d4-6fb2-428f-ac82-f78bcb81eacc) | ![Screenshot_20240822_161403](https://github.com/user-attachments/assets/7b00a9a9-0fb0-437a-bd2e-5f6fb6b8f5e5) |

Also added EDSCALE to h_separation, as it didn't seem to match h_separation in OptionButton. Example with scale 150%

Before:
![Screenshot_20240822_155950](https://github.com/user-attachments/assets/7a51d031-978e-44a3-8f3e-4cba6109086f)

After:
![Screenshot_20240822_160709](https://github.com/user-attachments/assets/e035f471-c593-414a-bfa9-c25166adaeac)

