### PR TITLE
Fix some C# variable types In `AStar2D/3D` Class Reference

### DIFF
--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -169,7 +169,7 @@
 				astar.ConnectPoints(2, 3, false);
 				astar.ConnectPoints(4, 3, false);
 				astar.ConnectPoints(1, 4, false);
-				int[] res = astar.GetIdPath(1, 3); // Returns [1, 2, 3]
+				long[] res = astar.GetIdPath(1, 3); // Returns [1, 2, 3]
 				[/csharp]
 				[/codeblocks]
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
@@ -209,7 +209,7 @@
 				astar.ConnectPoints(1, 2, true);
 				astar.ConnectPoints(1, 3, true);
 
-				int[] neighbors = astar.GetPointConnections(1); // Returns [2, 3]
+				long[] neighbors = astar.GetPointConnections(1); // Returns [2, 3]
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -197,7 +197,7 @@
 				astar.ConnectPoints(2, 3, false);
 				astar.ConnectPoints(4, 3, false);
 				astar.ConnectPoints(1, 4, false);
-				int[] res = astar.GetIdPath(1, 3); // Returns [1, 2, 3]
+				long[] res = astar.GetIdPath(1, 3); // Returns [1, 2, 3]
 				[/csharp]
 				[/codeblocks]
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
@@ -236,7 +236,7 @@
 				astar.ConnectPoints(1, 2, true);
 				astar.ConnectPoints(1, 3, true);
 
-				int[] neighbors = astar.GetPointConnections(1); // Returns [2, 3]
+				long[] neighbors = astar.GetPointConnections(1); // Returns [2, 3]
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixed some C# example code where `long[]` should be used in place of `int[]` as described in https://github.com/godotengine/godot-docs/issues/9806

* *Bugsquad edit, fixes: https://github.com/godotengine/godot-docs/issues/9806*