### PR TITLE
Fix crash when calling `OpenXRAPI::get_hand_tracker()` and hand-tracking is disabled

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1737,8 +1737,12 @@ void OpenXRAPI::cleanup_extension_wrappers() {
 
 XrHandTrackerEXT OpenXRAPI::get_hand_tracker(int p_hand_index) {
 	ERR_FAIL_INDEX_V(p_hand_index, OpenXRHandTrackingExtension::HandTrackedHands::OPENXR_MAX_TRACKED_HANDS, XR_NULL_HANDLE);
+
+	OpenXRHandTrackingExtension *hand_tracking = OpenXRHandTrackingExtension::get_singleton();
+	ERR_FAIL_NULL_V(hand_tracking, XR_NULL_HANDLE);
+
 	OpenXRHandTrackingExtension::HandTrackedHands hand = static_cast<OpenXRHandTrackingExtension::HandTrackedHands>(p_hand_index);
-	return OpenXRHandTrackingExtension::get_singleton()->get_hand_tracker(hand)->hand_tracker;
+	return hand_tracking->get_hand_tracker(hand)->hand_tracker;
 }
 
 Size2 OpenXRAPI::get_recommended_target_size() {


### PR DESCRIPTION
This function is exposed to GDExtension, and we're calling it in the [godot_openxr_vendors](https://github.com/GodotVR/godot_openxr_vendors) extension.

This is the source of a crash in the hand-tracking sample in that project, that we didn't notice because the change to having hand-tracking disabled by default came shortly before Godot 4.3-stable was released.

(I'll follow-up with some more fixes on the extension as well, to handle hand-tracking being disabled even more gracefully)