### PR TITLE
Fix mouse move over an unfocused window

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4692,9 +4692,12 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
-			DisplayServer::WindowID receiving_window_id = _get_focused_window_or_popup();
-			if (receiving_window_id == INVALID_WINDOW_ID) {
-				receiving_window_id = window_id;
+			DisplayServer::WindowID receiving_window_id = window_id;
+			if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED || mouse_mode == MOUSE_MODE_CONFINED_HIDDEN) {
+				receiving_window_id = _get_focused_window_or_popup();
+				if (receiving_window_id == INVALID_WINDOW_ID) {
+					receiving_window_id = window_id;
+				}
 			}
 
 			const BitField<WinKeyModifierMask> &mods = _get_mods();


### PR DESCRIPTION
- Fixes #95754
- Fixes #96612

This issue seems a regression from #65496 where the mouse move event is always sent to the focused windows. It's ok the send the mouse movement to the focused window when it's captured by it, but not always.

Adding a condition to call `_get_focused_window_or_popup` only when the mouse mode is MOUSE_MODE_CAPTURED, MOUSE_MODE_CONFINED or MOUSE_MODE_CONFINED_HIDDEN fixed the problem.

I don't fully understand why the same problem does not occur on Linux or Mac. I cannot test on Mac, but on Linux, the problem is different, it's the button release event that is not sent to the unfocused window. But #95044 fixes this problem on Linux.

I retested the Color picker, the number slider in the inspector and the environment settings.

Edited: Added #96612 as a fixed issue
