### PR TITLE
[3.x] Cancel tooltips when the mouse leaves the window

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -408,6 +408,7 @@ void Viewport::_notification(int p_what) {
 			gui.mouse_in_window = false;
 			_drop_physics_mouseover();
 			_drop_mouse_over();
+			_gui_cancel_tooltip();
 			// When the mouse exits the window, we want to end mouse_over, but
 			// not mouse_focus, because, for example, we want to continue
 			// dragging a scrollbar even if the mouse has left the window.


### PR DESCRIPTION
This is a backport of 807431c49a6b33ecc88f8d4ebcb3b2f359591b1c to the 3.x branch.

This fixes #46737.

