### PR TITLE
Add `String.is_valid_unicode_identifier()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1768,7 +1768,7 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 
 void Engine::register_singleton(const StringName &p_name, Object *p_object) {
 	ERR_FAIL_COND_MSG(has_singleton(p_name), "Singleton already registered: " + String(p_name));
-	ERR_FAIL_COND_MSG(!String(p_name).is_valid_identifier(), "Singleton name is not a valid identifier: " + p_name);
+	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), "Singleton name is not a valid identifier: " + p_name);
 	::Engine::Singleton s;
 	s.class_name = p_name;
 	s.name = p_name;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -355,7 +355,7 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	StringName parent_class_name = *reinterpret_cast<const StringName *>(p_parent_class_name);
-	ERR_FAIL_COND_MSG(!String(class_name).is_valid_identifier(), "Attempt to register extension class '" + class_name + "', which is not a valid class identifier.");
+	ERR_FAIL_COND_MSG(!String(class_name).is_valid_ascii_identifier(), "Attempt to register extension class '" + class_name + "', which is not a valid class identifier.");
 	ERR_FAIL_COND_MSG(ClassDB::class_exists(class_name), "Attempt to register extension class '" + class_name + "', which appears to be already registered.");
 
 	Extension *parent_extension = nullptr;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -997,7 +997,7 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (E) {
 		E->value = p_value;
 	} else {
-		ERR_FAIL_COND_MSG(!p_name.operator String().is_valid_identifier(), "Invalid metadata identifier: '" + p_name + "'.");
+		ERR_FAIL_COND_MSG(!p_name.operator String().is_valid_ascii_identifier(), "Invalid metadata identifier: '" + p_name + "'.");
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 
 		const String &sname = p_name;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4624,7 +4624,7 @@ bool String::is_absolute_path() const {
 	}
 }
 
-String String::validate_identifier() const {
+String String::validate_ascii_identifier() const {
 	if (is_empty()) {
 		return "_"; // Empty string is not a valid identifier;
 	}
@@ -4647,7 +4647,7 @@ String String::validate_identifier() const {
 	return result;
 }
 
-bool String::is_valid_identifier() const {
+bool String::is_valid_ascii_identifier() const {
 	int len = length();
 
 	if (len == 0) {
@@ -4666,6 +4666,26 @@ bool String::is_valid_identifier() const {
 		}
 	}
 
+	return true;
+}
+
+bool String::is_valid_unicode_identifier() const {
+	const char32_t *str = ptr();
+	int len = length();
+
+	if (len == 0) {
+		return false; // Empty string.
+	}
+
+	if (!is_unicode_identifier_start(str[0])) {
+		return false;
+	}
+
+	for (int i = 1; i < len; i++) {
+		if (!is_unicode_identifier_continue(str[i])) {
+			return false;
+		}
+	}
 	return true;
 }
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -459,16 +459,20 @@ public:
 	// node functions
 	static String get_invalid_node_name_characters(bool p_allow_internal = false);
 	String validate_node_name() const;
-	String validate_identifier() const;
+	String validate_ascii_identifier() const;
 	String validate_filename() const;
 
-	bool is_valid_identifier() const;
+	bool is_valid_ascii_identifier() const;
+	bool is_valid_unicode_identifier() const;
 	bool is_valid_int() const;
 	bool is_valid_float() const;
 	bool is_valid_hex_number(bool p_with_prefix) const;
 	bool is_valid_html_color() const;
 	bool is_valid_ip_address() const;
 	bool is_valid_filename() const;
+
+	// Use `is_valid_ascii_identifier()` instead. Kept for compatibility.
+	bool is_valid_identifier() const { return is_valid_ascii_identifier(); }
 
 	/**
 	 * The constructors must not depend on other overloads

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1724,6 +1724,8 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(validate_node_name, sarray(), varray());
 	bind_string_method(validate_filename, sarray(), varray());
 
+	bind_string_method(is_valid_ascii_identifier, sarray(), varray());
+	bind_string_method(is_valid_unicode_identifier, sarray(), varray());
 	bind_string_method(is_valid_identifier, sarray(), varray());
 	bind_string_method(is_valid_int, sarray(), varray());
 	bind_string_method(is_valid_float, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -451,6 +451,19 @@
 				Returns [code]true[/code] if all characters of this string can be found in [param text] in their original order, [b]ignoring case[/b].
 			</description>
 		</method>
+		<method name="is_valid_ascii_identifier" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this string is a valid ASCII identifier. A valid ASCII identifier may contain only letters, digits, and underscores ([code]_[/code]), and the first character may not be a digit.
+				[codeblock]
+				print("node_2d".is_valid_ascii_identifier())    # Prints true
+				print("TYPE_FLOAT".is_valid_ascii_identifier()) # Prints true
+				print("1st_method".is_valid_ascii_identifier()) # Prints false
+				print("MyMethod#2".is_valid_ascii_identifier()) # Prints false
+				[/codeblock]
+				See also [method is_valid_unicode_identifier].
+			</description>
+		</method>
 		<method name="is_valid_filename" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -490,7 +503,7 @@
 				Returns [code]true[/code] if this string is a valid color in hexadecimal HTML notation. The string must be a hexadecimal value (see [method is_valid_hex_number]) of either 3, 4, 6 or 8 digits, and may be prefixed by a hash sign ([code]#[/code]). Other HTML notations for colors, such as names or [code]hsl()[/code], are not considered valid. See also [method Color.html].
 			</description>
 		</method>
-		<method name="is_valid_identifier" qualifiers="const">
+		<method name="is_valid_identifier" qualifiers="const" deprecated="Use [method is_valid_ascii_identifier] instead.">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this string is a valid identifier. A valid identifier may contain only letters, digits and underscores ([code]_[/code]), and the first character may not be a digit.
@@ -519,6 +532,23 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this string represents a well-formatted IPv4 or IPv6 address. This method considers [url=https://en.wikipedia.org/wiki/Reserved_IP_addresses]reserved IP addresses[/url] such as [code]"0.0.0.0"[/code] and [code]"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"[/code] as valid.
+			</description>
+		</method>
+		<method name="is_valid_unicode_identifier" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this string is a valid Unicode identifier.
+				A valid Unicode identifier must begin with a Unicode character of class [code]XID_Start[/code] or [code]"_"[/code], and may contain Unicode characters of class [code]XID_Continue[/code] in the other positions.
+				[codeblock]
+				print("node_2d".is_valid_unicode_identifier())      # Prints true
+				print("1st_method".is_valid_unicode_identifier())   # Prints false
+				print("MyMethod#2".is_valid_unicode_identifier())   # Prints false
+				print("állóképesség".is_valid_unicode_identifier()) # Prints true
+				print("выносливость".is_valid_unicode_identifier()) # Prints true
+				print("体力".is_valid_unicode_identifier())         # Prints true
+				[/codeblock]
+				See also [method is_valid_ascii_identifier].
+				[b]Note:[/b] This method checks identifiers the same way as GDScript. See [method TextServer.is_valid_identifier] for more advanced checks.
 			</description>
 		</method>
 		<method name="join" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -420,6 +420,19 @@
 				Returns [code]true[/code] if all characters of this string can be found in [param text] in their original order, [b]ignoring case[/b].
 			</description>
 		</method>
+		<method name="is_valid_ascii_identifier" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this string is a valid ASCII identifier. A valid ASCII identifier may contain only letters, digits, and underscores ([code]_[/code]), and the first character may not be a digit.
+				[codeblock]
+				print("node_2d".is_valid_ascii_identifier())    # Prints true
+				print("TYPE_FLOAT".is_valid_ascii_identifier()) # Prints true
+				print("1st_method".is_valid_ascii_identifier()) # Prints false
+				print("MyMethod#2".is_valid_ascii_identifier()) # Prints false
+				[/codeblock]
+				See also [method is_valid_unicode_identifier].
+			</description>
+		</method>
 		<method name="is_valid_filename" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -459,7 +472,7 @@
 				Returns [code]true[/code] if this string is a valid color in hexadecimal HTML notation. The string must be a hexadecimal value (see [method is_valid_hex_number]) of either 3, 4, 6 or 8 digits, and may be prefixed by a hash sign ([code]#[/code]). Other HTML notations for colors, such as names or [code]hsl()[/code], are not considered valid. See also [method Color.html].
 			</description>
 		</method>
-		<method name="is_valid_identifier" qualifiers="const">
+		<method name="is_valid_identifier" qualifiers="const" deprecated="Use [method is_valid_ascii_identifier] instead.">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this string is a valid identifier. A valid identifier may contain only letters, digits and underscores ([code]_[/code]), and the first character may not be a digit.
@@ -488,6 +501,23 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this string represents a well-formatted IPv4 or IPv6 address. This method considers [url=https://en.wikipedia.org/wiki/Reserved_IP_addresses]reserved IP addresses[/url] such as [code]"0.0.0.0"[/code] and [code]"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"[/code] as valid.
+			</description>
+		</method>
+		<method name="is_valid_unicode_identifier" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this string is a valid Unicode identifier.
+				A valid Unicode identifier must begin with a Unicode character of class [code]XID_Start[/code] or [code]"_"[/code], and may contain Unicode characters of class [code]XID_Continue[/code] in the other positions.
+				[codeblock]
+				print("node_2d".is_valid_unicode_identifier())      # Prints true
+				print("1st_method".is_valid_unicode_identifier())   # Prints false
+				print("MyMethod#2".is_valid_unicode_identifier())   # Prints false
+				print("állóképesség".is_valid_unicode_identifier()) # Prints true
+				print("выносливость".is_valid_unicode_identifier()) # Prints true
+				print("体力".is_valid_unicode_identifier())         # Prints true
+				[/codeblock]
+				See also [method is_valid_ascii_identifier].
+				[b]Note:[/b] This method checks identifiers the same way as GDScript. See [method TextServer.is_valid_identifier] for more advanced checks.
 			</description>
 		</method>
 		<method name="join" qualifiers="const">

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -88,7 +88,7 @@ void EditorAutoloadSettings::_notification(int p_what) {
 }
 
 bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, String *r_error) {
-	if (!p_name.is_valid_identifier()) {
+	if (!p_name.is_valid_ascii_identifier()) {
 		if (r_error) {
 			*r_error = TTR("Invalid name.") + " ";
 			if (p_name.size() > 0 && p_name.left(1).is_numeric()) {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4270,7 +4270,7 @@ void EditorInspector::_check_meta_name() {
 
 	if (meta_name.is_empty()) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
-	} else if (!meta_name.is_valid_identifier()) {
+	} else if (!meta_name.is_valid_ascii_identifier()) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
 	} else if (object->has_meta(meta_name)) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1816,9 +1816,9 @@ static String _get_dropped_resource_line(const Ref<Resource> &p_resource, bool p
 	}
 
 	if (is_script) {
-		variable_name = variable_name.to_pascal_case().validate_identifier();
+		variable_name = variable_name.to_pascal_case().validate_ascii_identifier();
 	} else {
-		variable_name = variable_name.to_snake_case().to_upper().validate_identifier();
+		variable_name = variable_name.to_snake_case().to_upper().validate_ascii_identifier();
 	}
 	return vformat("const %s = preload(%s)", variable_name, _quote_drop_data(path));
 }
@@ -1932,13 +1932,13 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 					path = sn->get_path_to(node);
 				}
 				for (const String &segment : path.split("/")) {
-					if (!segment.is_valid_identifier()) {
+					if (!segment.is_valid_ascii_identifier()) {
 						path = _quote_drop_data(path);
 						break;
 					}
 				}
 
-				String variable_name = String(node->get_name()).to_snake_case().validate_identifier();
+				String variable_name = String(node->get_name()).to_snake_case().validate_ascii_identifier();
 				if (use_type) {
 					StringName class_name = node->get_class_name();
 					Ref<Script> node_script = node->get_script();
@@ -1975,7 +1975,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 				}
 
 				for (const String &segment : path.split("/")) {
-					if (!segment.is_valid_identifier()) {
+					if (!segment.is_valid_ascii_identifier()) {
 						path = _quote_drop_data(path);
 						break;
 					}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1590,7 +1590,7 @@ void VisualShaderEditor::clear_custom_types() {
 }
 
 void VisualShaderEditor::add_custom_type(const String &p_name, const String &p_type, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend) {
-	ERR_FAIL_COND(!p_name.is_valid_identifier());
+	ERR_FAIL_COND(!p_name.is_valid_ascii_identifier());
 	ERR_FAIL_COND(p_type.is_empty() && !p_script.is_valid());
 
 	for (int i = 0; i < add_options.size(); i++) {
@@ -5791,7 +5791,7 @@ void VisualShaderEditor::_varying_create() {
 }
 
 void VisualShaderEditor::_varying_name_changed(const String &p_name) {
-	if (!p_name.is_valid_identifier()) {
+	if (!p_name.is_valid_ascii_identifier()) {
 		varying_error_label->show();
 		varying_error_label->set_text(TTR("Invalid name for varying."));
 		add_varying_dialog->get_ok_button()->set_disabled(true);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -221,7 +221,7 @@ void ProjectSettingsEditor::_update_property_box() {
 
 		const Vector<String> names = name.split("/");
 		for (int i = 0; i < names.size(); i++) {
-			if (!names[i].is_valid_identifier()) {
+			if (!names[i].is_valid_ascii_identifier()) {
 				return;
 			}
 		}

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -100,7 +100,7 @@ static Vector<String> _get_hierarchy(const String &p_class_name) {
 	}
 
 	if (hierarchy.is_empty()) {
-		if (p_class_name.is_valid_identifier()) {
+		if (p_class_name.is_valid_ascii_identifier()) {
 			hierarchy.push_back(p_class_name);
 		}
 		hierarchy.push_back("Object");

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -349,7 +349,7 @@ String ShaderGlobalsEditor::_check_new_variable_name(const String &p_variable_na
 		return TTR("Name cannot be empty.");
 	}
 
-	if (!p_variable_name.is_valid_identifier()) {
+	if (!p_variable_name.is_valid_ascii_identifier()) {
 		return TTR("Name must be a valid identifier.");
 	}
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -97,8 +97,8 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)
-								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_identifier())
-								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_identifier())
+								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_ascii_identifier())
+								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_ascii_identifier())
 								 .replace("_TS_", _get_indentation());
 	scr->set_source_code(processed_template);
 	return scr;
@@ -3486,7 +3486,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					// is not a valid identifier.
 					bool path_needs_quote = false;
 					for (const String &part : opt.split("/")) {
-						if (!part.is_valid_identifier()) {
+						if (!part.is_valid_ascii_identifier()) {
 							path_needs_quote = true;
 							break;
 						}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -833,7 +833,7 @@ VisualShader::Type VisualShader::get_shader_type() const {
 }
 
 void VisualShader::add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) {
-	ERR_FAIL_COND(!p_name.is_valid_identifier());
+	ERR_FAIL_COND(!p_name.is_valid_ascii_identifier());
 	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
 	ERR_FAIL_INDEX((int)p_type, (int)VARYING_TYPE_MAX);
 	ERR_FAIL_COND(varyings.has(p_name));
@@ -4571,7 +4571,7 @@ String VisualShaderNodeGroupBase::get_outputs() const {
 }
 
 bool VisualShaderNodeGroupBase::is_valid_port_name(const String &p_name) const {
-	if (!p_name.is_valid_identifier()) {
+	if (!p_name.is_valid_ascii_identifier()) {
 		return false;
 	}
 	for (int i = 0; i < get_input_port_count(); i++) {

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -112,7 +112,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				}
 				Vector<String> slices = l.get_slice(";", 0).split("=");
 				String version = slices[0].strip_edges();
-				if (!version.is_valid_identifier()) {
+				if (!version.is_valid_ascii_identifier()) {
 					base_error = "Version names must be valid identifiers, found '" + version + "' instead.";
 					break;
 				}

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -173,7 +173,7 @@ String ShaderPreprocessor::Tokenizer::get_identifier(bool *r_is_cursor, bool p_s
 	}
 
 	String id = vector_to_string(text);
-	if (!id.is_valid_identifier()) {
+	if (!id.is_valid_ascii_identifier()) {
 		return "";
 	}
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -2165,23 +2165,7 @@ TypedArray<Dictionary> TextServer::_shaped_text_get_ellipsis_glyphs_wrapper(cons
 }
 
 bool TextServer::is_valid_identifier(const String &p_string) const {
-	const char32_t *str = p_string.ptr();
-	int len = p_string.length();
-
-	if (len == 0) {
-		return false; // Empty string.
-	}
-
-	if (!is_unicode_identifier_start(str[0])) {
-		return false;
-	}
-
-	for (int i = 1; i < len; i++) {
-		if (!is_unicode_identifier_continue(str[i])) {
-			return false;
-		}
-	}
-	return true;
+	return p_string.is_valid_unicode_identifier();
 }
 
 bool TextServer::is_valid_letter(uint64_t p_unicode) const {

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -603,7 +603,7 @@ void add_exposed_classes(Context &r_context) {
 
 			MethodData method;
 			method.name = method_info.name;
-			TEST_FAIL_COND(!String(method.name).is_valid_identifier(),
+			TEST_FAIL_COND(!String(method.name).is_valid_ascii_identifier(),
 					"Method name is not a valid identifier: '", exposed_class.name, ".", method.name, "'.");
 
 			if (method_info.flags & METHOD_FLAG_VIRTUAL) {
@@ -729,7 +729,7 @@ void add_exposed_classes(Context &r_context) {
 			const MethodInfo &method_info = signal_map.get(K.key);
 
 			signal.name = method_info.name;
-			TEST_FAIL_COND(!String(signal.name).is_valid_identifier(),
+			TEST_FAIL_COND(!String(signal.name).is_valid_ascii_identifier(),
 					"Signal name is not a valid identifier: '", exposed_class.name, ".", signal.name, "'.");
 
 			int i = 0;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1821,21 +1821,23 @@ TEST_CASE("[String] Join") {
 }
 
 TEST_CASE("[String] Is_*") {
-	static const char *data[12] = { "-30", "100", "10.1", "10,1", "1e2", "1e-2", "1e2e3", "0xAB", "AB", "Test1", "1Test", "Test*1" };
-	static bool isnum[12] = { true, true, true, false, false, false, false, false, false, false, false, false };
-	static bool isint[12] = { true, true, false, false, false, false, false, false, false, false, false, false };
-	static bool ishex[12] = { true, true, false, false, true, false, true, false, true, false, false, false };
-	static bool ishex_p[12] = { false, false, false, false, false, false, false, true, false, false, false, false };
-	static bool isflt[12] = { true, true, true, false, true, true, false, false, false, false, false, false };
-	static bool isid[12] = { false, false, false, false, false, false, false, false, true, true, false, false };
+	static const char *data[13] = { "-30", "100", "10.1", "10,1", "1e2", "1e-2", "1e2e3", "0xAB", "AB", "Test1", "1Test", "Test*1", "文字" };
+	static bool isnum[13] = { true, true, true, false, false, false, false, false, false, false, false, false, false };
+	static bool isint[13] = { true, true, false, false, false, false, false, false, false, false, false, false, false };
+	static bool ishex[13] = { true, true, false, false, true, false, true, false, true, false, false, false, false };
+	static bool ishex_p[13] = { false, false, false, false, false, false, false, true, false, false, false, false, false };
+	static bool isflt[13] = { true, true, true, false, true, true, false, false, false, false, false, false, false };
+	static bool isaid[13] = { false, false, false, false, false, false, false, false, true, true, false, false, false };
+	static bool isuid[13] = { false, false, false, false, false, false, false, false, true, true, false, false, true };
 	for (int i = 0; i < 12; i++) {
-		String s = String(data[i]);
+		String s = String::utf8(data[i]);
 		CHECK(s.is_numeric() == isnum[i]);
 		CHECK(s.is_valid_int() == isint[i]);
 		CHECK(s.is_valid_hex_number(false) == ishex[i]);
 		CHECK(s.is_valid_hex_number(true) == ishex_p[i]);
 		CHECK(s.is_valid_float() == isflt[i]);
-		CHECK(s.is_valid_identifier() == isid[i]);
+		CHECK(s.is_valid_ascii_identifier() == isaid[i]);
+		CHECK(s.is_valid_unicode_identifier() == isuid[i]);
 	}
 }
 
@@ -1863,16 +1865,16 @@ TEST_CASE("[String] validate_node_name") {
 
 TEST_CASE("[String] validate_identifier") {
 	String empty_string;
-	CHECK(empty_string.validate_identifier() == "_");
+	CHECK(empty_string.validate_ascii_identifier() == "_");
 
 	String numeric_only = "12345";
-	CHECK(numeric_only.validate_identifier() == "_12345");
+	CHECK(numeric_only.validate_ascii_identifier() == "_12345");
 
 	String name_with_spaces = "Name with spaces";
-	CHECK(name_with_spaces.validate_identifier() == "Name_with_spaces");
+	CHECK(name_with_spaces.validate_ascii_identifier() == "Name_with_spaces");
 
 	String name_with_invalid_chars = U"Invalid characters:@*#&世界";
-	CHECK(name_with_invalid_chars.validate_identifier() == "Invalid_characters_______");
+	CHECK(name_with_invalid_chars.validate_ascii_identifier() == "Invalid_characters_______");
 }
 
 TEST_CASE("[String] Variant indexed get") {


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/discussions/9851

Rationale:

- The old `is_valid_identifier()` is checking for traditional ASCII identifiers. Its name can be confusing because GDScript implements Unicode identifiers.
- There is currently no way to check according to GDScript's rule of Unicode identifiers. `TextServer.is_valid_identifier()` is close, but advanced text server adds extra conversions and rules. Text server extensions could potentially also change the rules.

This PR:

- Adds `is_valid_unicode_identifier()`: Basic unicode identifier checking, the same as how GDScript parses identifiers
- Adds `is_valid_ascii_identifier()` : Same as the old `is_valid_identifier()`
- Deprecates `is_valid_identifier()`
- Renames internal method `validate_identifier()` to `validate_ascii_identifier()`