### PR TITLE
[3.x] Physics Interpolation - warnings for misuse in 2D

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -125,7 +125,7 @@ void _err_flush_stdout() {
 // Prevent error spam by limiting the warnings to a certain frequency.
 void _physics_interpolation_warning(const char *p_function, const char *p_file, int p_line, ObjectID p_id, const char *p_warn_string) {
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-	const uint32_t warn_max = 2048;
+	const uint32_t warn_max = 256;
 	const uint32_t warn_timeout_seconds = 15;
 
 	static uint32_t warn_count = warn_max;
@@ -139,10 +139,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 
 	if (!warn_count) {
 		time_now = OS::get_singleton()->get_ticks_msec() / 1000;
-	}
-
-	if ((warn_count == 0) && (time_now >= warn_timeout)) {
 		warn_count = warn_max;
+
+		if (time_now < warn_timeout) {
+			return;
+		}
+
 		warn_timeout = time_now + warn_timeout_seconds;
 
 		if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
@@ -166,5 +168,6 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 			}
 		}
 	}
+
 #endif
 }

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -308,6 +308,10 @@ void Camera2D::_notification(int p_what) {
 				_ensure_update_interpolation_data();
 				if (Engine::get_singleton()->is_in_physics_frame()) {
 					_interpolation_data.xform_curr = get_camera_transform();
+				} else {
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+					PHYSICS_INTERPOLATION_NODE_WARNING(get_instance_id(), "Interpolated Camera2D transformed from outside physics process");
+#endif
 				}
 			}
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -958,6 +958,12 @@ void VisualServerCanvas::canvas_item_set_transform(RID p_item, const Transform2D
 		} else {
 			DEV_ASSERT(_interpolation_data.canvas_item_transform_update_list_curr->size());
 		}
+
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+		if (!Engine::get_singleton()->is_in_physics_frame()) {
+			PHYSICS_INTERPOLATION_WARNING("Interpolated CanvasItem set_transform called from outside physics process");
+		}
+#endif
 	}
 
 	canvas_item->xform_curr = p_transform;


### PR DESCRIPTION
Warn when moving canvas items and cameras outside physics tick.

## Notes
* Counterpart to 3D physics interpolation warnings.
* Setting transform of interpolated canvas items and cameras is *usually* user error when done outside the physics tick.
* Bumped up the frequency of the warnings very slightly (once the counter elapses, checks every 15 seconds, so there are some warnings, but not overly intrusive).
* Can be ported to 4.x.

## Discussion
Noticed in #95869 that users are still liable to make mistakes using interpolation, the warnings help indicate where they are doing things incorrectly, so they can research solution.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
