### PR TITLE
Update `ScrollContainer` to use `float` scroll values

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -49,23 +49,23 @@
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 			Deadzone for touch scrolling. Lower deadzone makes the scrolling more sensitive.
 		</member>
-		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
+		<member name="scroll_horizontal" type="float" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			The current horizontal scroll value.
 			[b]Note:[/b] If you are setting this value in the [method Node._ready] function or earlier, it needs to be wrapped with [method Object.set_deferred], since scroll bar's [member Range.max_value] is not initialized yet.
 			[codeblock]
 			func _ready():
-			    set_deferred("scroll_horizontal", 600)
+			    set_deferred("scroll_horizontal", 600.0)
 			[/codeblock]
 		</member>
 		<member name="scroll_horizontal_custom_step" type="float" setter="set_horizontal_custom_step" getter="get_horizontal_custom_step" default="-1.0">
 			Overrides the [member ScrollBar.custom_step] used when clicking the internal scroll bar's horizontal increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
-		<member name="scroll_vertical" type="int" setter="set_v_scroll" getter="get_v_scroll" default="0">
+		<member name="scroll_vertical" type="float" setter="set_v_scroll" getter="get_v_scroll" default="0">
 			The current vertical scroll value.
 			[b]Note:[/b] Setting it early needs to be deferred, just like in [member scroll_horizontal].
 			[codeblock]
 			func _ready():
-			    set_deferred("scroll_vertical", 600)
+			    set_deferred("scroll_vertical", 600.0)
 			[/codeblock]
 		</member>
 		<member name="scroll_vertical_custom_step" type="float" setter="set_vertical_custom_step" getter="get_vertical_custom_step" default="-1.0">

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -454,21 +454,21 @@ void ScrollContainer::_scroll_moved(float) {
 	queue_sort();
 };
 
-void ScrollContainer::set_h_scroll(int p_pos) {
+void ScrollContainer::set_h_scroll(float p_pos) {
 	h_scroll->set_value(p_pos);
 	_cancel_drag();
 }
 
-int ScrollContainer::get_h_scroll() const {
+float ScrollContainer::get_h_scroll() const {
 	return h_scroll->get_value();
 }
 
-void ScrollContainer::set_v_scroll(int p_pos) {
+void ScrollContainer::set_v_scroll(float p_pos) {
 	v_scroll->set_value(p_pos);
 	_cancel_drag();
 }
 
-int ScrollContainer::get_v_scroll() const {
+float ScrollContainer::get_v_scroll() const {
 	return v_scroll->get_value();
 }
 
@@ -599,8 +599,8 @@ void ScrollContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "follow_focus"), "set_follow_focus", "is_following_focus");
 
 	ADD_GROUP("Scroll", "scroll_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal", PROPERTY_HINT_NONE, "suffix:px"), "set_h_scroll", "get_h_scroll");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_vertical", PROPERTY_HINT_NONE, "suffix:px"), "set_v_scroll", "get_v_scroll");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_horizontal", PROPERTY_HINT_NONE, "suffix:px"), "set_h_scroll", "get_h_scroll");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical", PROPERTY_HINT_NONE, "suffix:px"), "set_v_scroll", "get_v_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_horizontal_custom_step", PROPERTY_HINT_RANGE, "-1,4096,suffix:px"), "set_horizontal_custom_step", "get_horizontal_custom_step");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical_custom_step", PROPERTY_HINT_RANGE, "-1,4096,suffix:px"), "set_vertical_custom_step", "get_vertical_custom_step");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "horizontal_scroll_mode", PROPERTY_HINT_ENUM, "Disabled,Auto,Always Show,Never Show"), "set_horizontal_scroll_mode", "get_horizontal_scroll_mode");

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -91,11 +91,11 @@ protected:
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 
-	void set_h_scroll(int p_pos);
-	int get_h_scroll() const;
+	void set_h_scroll(float p_pos);
+	float get_h_scroll() const;
 
-	void set_v_scroll(int p_pos);
-	int get_v_scroll() const;
+	void set_v_scroll(float p_pos);
+	float get_v_scroll() const;
 
 	void set_horizontal_custom_step(float p_custom_step);
 	float get_horizontal_custom_step() const;


### PR DESCRIPTION
Implements proposal [#10544](https://github.com/godotengine/godot-proposals/issues/10544).

Changes `ScrollContainer` scroll values to floats, allowing smoother scrolling.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/10544*