### PR TITLE
Remove deprecated method `Window::move_to_foreground()`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -359,12 +359,6 @@
 				Centers a native window on the current screen and an embedded window on its embedder [Viewport].
 			</description>
 		</method>
-		<method name="move_to_foreground" deprecated="Use [method Window.grab_focus] instead.">
-			<return type="void" />
-			<description>
-				Causes the window to grab focus, allowing it to receive user input.
-			</description>
-		</method>
 		<method name="popup">
 			<return type="void" />
 			<param index="0" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -554,13 +554,6 @@ void Window::request_attention() {
 	}
 }
 
-#ifndef DISABLE_DEPRECATED
-void Window::move_to_foreground() {
-	WARN_DEPRECATED_MSG(R"*(The "move_to_foreground()" method is deprecated, use "grab_focus()" instead.)*");
-	grab_focus();
-}
-#endif // DISABLE_DEPRECATED
-
 bool Window::can_draw() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	if (!is_inside_tree()) {
@@ -2837,10 +2830,6 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_maximize_allowed"), &Window::is_maximize_allowed);
 
 	ClassDB::bind_method(D_METHOD("request_attention"), &Window::request_attention);
-
-#ifndef DISABLE_DEPRECATED
-	ClassDB::bind_method(D_METHOD("move_to_foreground"), &Window::move_to_foreground);
-#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &Window::set_visible);
 	ClassDB::bind_method(D_METHOD("is_visible"), &Window::is_visible);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -308,9 +308,6 @@ public:
 	bool is_maximize_allowed() const;
 
 	void request_attention();
-#ifndef DISABLE_DEPRECATED
-	void move_to_foreground();
-#endif // DISABLE_DEPRECATED
 
 	virtual void set_visible(bool p_visible);
 	bool is_visible() const;


### PR DESCRIPTION
- Follow-up of #83014, self-explanatory.
- This PR can be merged as soon as the time is deemed right.
