### PR TITLE
MP3: Remove unnecessary memory allocation

### DIFF
--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -49,7 +49,7 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 
 	bool looping_override = false;
 	bool looping = false;
-	mp3dec_ex_t *mp3d = nullptr;
+	mp3dec_ex_t mp3d = {};
 	uint32_t frames_mixed = 0;
 	bool active = false;
 	int loops = 0;


### PR DESCRIPTION
The MP3 description has a fixed size, therefore no need to use a pointer for it.

The entirety of `AudioStreamPlaybackMP3` is instantiated on the heap anyway, so there's no risk of overflows (`mp3dec_ex_t` has a size of 16,064 bytes for reference). 