### PR TITLE
Fix script overwriting with external editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2711,9 +2711,11 @@ void ScriptEditor::apply_scripts() const {
 }
 
 void ScriptEditor::reload_scripts(bool p_refresh_only) {
-	if (external_editor_active) {
-		return;
-	}
+	// Call deferred to make sure it runs on the main thread.
+	callable_mp(this, &ScriptEditor::_reload_scripts).call_deferred(p_refresh_only);
+}
+
+void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!se) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -436,6 +436,7 @@ class ScriptEditor : public PanelContainer {
 	void _file_removed(const String &p_file);
 	void _autosave_scripts();
 	void _update_autosave_timer();
+	void _reload_scripts(bool p_refresh_only = false);
 
 	void _update_members_overview_visibility();
 	void _update_members_overview();


### PR DESCRIPTION
- fixes #88399
- fixes #91314
- fixes #82266
- alternative to #95969
- related https://github.com/godotengine/godot/pull/82956
- related https://github.com/godotengine/godot/issues/71016

#82956 does not fix the crash in #71016 if the external editor setting is turned off.
Basically this undoes https://github.com/godotengine/godot/pull/82956 and has an alternate fix for https://github.com/godotengine/godot/issues/71016.

#71016 happens because `ScriptEditor::_reload_scripts` it is called from a thread, and it is not safe to do so.
`ERR_MAIN_THREAD_GUARD` won't work here since `GDScriptLanguageServer::thread_main` sets `set_current_thread_safe_for_nodes` to `true`, even though its not really thread safe.

For instance, the crash is potentially caused by `GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl` being called from `TextEdit`'s draw in the main thread, while `ScriptEditor::reload_scripts` calls  `ScriptTextEditor::reload_text()`, `ScriptTextEditor::_validate_script()`, then `GDScriptSyntaxHighlighter::_update_cache`, which changes things while it is trying to be drawn.