### PR TITLE
Wayland: Use `wayland-egl-core.h` instead of `wayland-egl.h`

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -44,7 +44,7 @@
 #include <wayland-client-core.h>
 #include <wayland-cursor.h>
 #ifdef GLES3_ENABLED
-#include <wayland-egl.h>
+#include <wayland-egl-core.h>
 #endif
 #include <xkbcommon/xkbcommon.h>
 #endif // SOWRAP_ENABLED


### PR DESCRIPTION
-avoid use of transitive wayland include

-resolves https://github.com/godotengine/godot/issues/95830