### PR TITLE
AudioStream(Playback)WAV: Use LocalVectors instead of pointers

### DIFF
--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -62,7 +62,7 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 		qoa_desc desc = {};
 		uint32_t data_ofs = 0;
 		uint32_t frame_len = 0;
-		int16_t *dec = nullptr;
+		LocalVector<int16_t> dec;
 		uint32_t dec_len = 0;
 		int64_t cache_pos = -1;
 		int16_t cache[2] = { 0, 0 };
@@ -137,7 +137,7 @@ private:
 	int loop_begin = 0;
 	int loop_end = 0;
 	int mix_rate = 44100;
-	void *data = nullptr;
+	LocalVector<uint8_t> data;
 	uint32_t data_bytes = 0;
 
 protected:


### PR DESCRIPTION
**This PR originally used `Vector`s, but were changed to `LocalVector`s on reduz's request.**
___

Changes the types of (`AudioStreamPlaybackWAV::qoa.dec` and `AudioStreamWAV::data`) to use Vectors instead of pointers. This was done with `AudioStreamMP3`'s `data` between versions 3.x and 4.x of Godot.

Only private variables and function structures were modified, without altering return type, therefore does not break compatibility.

Alongside #95463, this PR makes the `AudioStreamWAV` and `AudioStreamPlaybackWAV` classes free of direct `memalloc/free` calls, and consequently the only `memalloc/free` calls within the `/scene` directory.