### PR TITLE
Fix Node `duplicate` mapping of child properties.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2951,10 +2951,11 @@ void Node::_duplicate_properties(const Node *p_root, const Node *p_original, Nod
 		}
 	}
 
-	for (int i = 0; i < p_original->get_child_count(); i++) {
+	for (int i = 0; i < p_copy->get_child_count(); i++) {
 		Node *copy_child = p_copy->get_child(i);
 		ERR_FAIL_NULL_MSG(copy_child, "Child node disappeared while duplicating.");
-		_duplicate_properties(p_root, p_original->get_child(i), copy_child, p_flags);
+		NodePath child_path = p_copy->get_path_to(copy_child);
+		_duplicate_properties(p_root, p_original->get_node(child_path), copy_child, p_flags);
 	}
 }
 


### PR DESCRIPTION
In Godot 4.3, the way the `duplicate` function copied properties was changed. This results in many error messages when any Node with internal nodes as children is duplicated, as there is not a one-to-one correspondence between the original and copied children indices. Instead, Node paths need to be used, as they are when duplicating signals. This commit fixes the log spam when duplicating Nodes with internal children by finding the correct corresponding child to copy properties to.

Fixes #92880 . Please cherrypick to 4.3 if possible.


P.S. this is my first pull request, please let me know if any of the metadata is incorrect.