### PR TITLE
Fix typo in `Array` code example

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -243,7 +243,7 @@
 				var numbers = [1, 2, 3]
 				var extra = [4, 5, 6]
 				numbers.append_array(extra)
-				print(nums) # Prints [1, 2, 3, 4, 5, 6]
+				print(numbers) # Prints [1, 2, 3, 4, 5, 6]
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Just a small typo fix.
(sorry I did it in the wrong file first in [godot-docs](https://github.com/godotengine/godot-docs/pull/9799))