### PR TITLE
Fix C# example for GodotObject#_GetPropertyList

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -136,7 +136,7 @@
 				        }
 				    }
 
-				    private List&lt;int&gt; _numbers = new();
+				    private Godot.Collections.Array&lt;int&gt; _numbers = new();
 
 				    public override Godot.Collections.Array&lt;Godot.Collections.Dictionary&gt; _GetPropertyList()
 				    {


### PR DESCRIPTION
Documentation uses a wrong type (`System.Collections.Generic.List` instead of `Godot.Collections.Array`), causing the snippet to not compile.