### PR TITLE
AnimationNodeStateMachineTransition expression time input values.

### DIFF
--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -308,9 +308,9 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	AnimationNode::NodeTimeInfo process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
 	AnimationNode::NodeTimeInfo _process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
 
-	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
-	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only);
-	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
+	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition, double p_delta, double p_current_time) const;
+	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, double p_current_time, bool p_test_only);
+	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, double p_current_time) const;
 	Ref<AnimationNodeStateMachineTransition> _check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const;
 	bool _can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
 


### PR DESCRIPTION
This PR extends the AnimationNodeStateMachineTransition expression parser to apply the delta and current_time values as inputs. This allows the expression to evaluate these values as part of transition evaluation check and opens the possibility to allow animations which transition into other animations at explicit pre-defined intervals. This level of control may prove important for certain types of heavily animation-driven games.

In a practical sense, this allows the user to define 'windows' in an animation where can transition (for example, a sword swing may need to immediately transition into a hit or whiff depending on the game state, but is dependent upon particular intervals in the animation itself). In this example, a transition is checks for whether a speed value has exceeded a threshold every time the animation passes 3 seconds:

![godot windows editor dev x86_64_vUFlP1aMzG](https://github.com/user-attachments/assets/6b5fc15a-33ae-4415-81c4-1eae79e9c064)

Another stale alternative implementation I did is available here (https://github.com/godotengine/godot/pull/71299) which implements functionality to achieve the same goal, but extends the 'switch' property instead. I consider this PR to be a quick, dirty, and not especially user-friendly solution to this limitation due to its dependence on the expression parser which does not currently provide good user feedback. It may instead prove preferable to revive the earlier implementation instead. Leaving in draft for now until broader consensus is determined on how this functionality should be handled.