### PR TITLE
Metal: Improve startup times by using concurrent shader compilation APIs

### DIFF
--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -50,8 +50,11 @@
 
 #import "metal_objects.h"
 
+#import "metal_utils.h"
 #import "pixel_formats.h"
 #import "rendering_device_driver_metal.h"
+
+#import <os/signpost.h>
 
 void MDCommandBuffer::begin() {
 	DEV_ASSERT(commandBuffer == nil);
@@ -850,7 +853,7 @@ void MDCommandBuffer::_end_blit() {
 	type = MDCommandBufferStateType::None;
 }
 
-MDComputeShader::MDComputeShader(CharString p_name, Vector<UniformSet> p_sets, id<MTLLibrary> p_kernel) :
+MDComputeShader::MDComputeShader(CharString p_name, Vector<UniformSet> p_sets, MDLibrary *p_kernel) :
 		MDShader(p_name, p_sets), kernel(p_kernel) {
 }
 
@@ -868,7 +871,7 @@ void MDComputeShader::encode_push_constant_data(VectorView<uint32_t> p_data, MDC
 	[enc setBytes:ptr length:length atIndex:push_constants.binding];
 }
 
-MDRenderShader::MDRenderShader(CharString p_name, Vector<UniformSet> p_sets, id<MTLLibrary> _Nonnull p_vert, id<MTLLibrary> _Nonnull p_frag) :
+MDRenderShader::MDRenderShader(CharString p_name, Vector<UniformSet> p_sets, MDLibrary *_Nonnull p_vert, MDLibrary *_Nonnull p_frag) :
 		MDShader(p_name, p_sets), vert(p_vert), frag(p_frag) {
 }
 
@@ -1378,3 +1381,204 @@ id<MTLDepthStencilState> MDResourceCache::get_depth_stencil_state(bool p_use_dep
 	}
 	return *val;
 }
+
+static const char *SHADER_STAGE_NAMES[] = {
+	[RD::SHADER_STAGE_VERTEX] = "vert",
+	[RD::SHADER_STAGE_FRAGMENT] = "frag",
+	[RD::SHADER_STAGE_TESSELATION_CONTROL] = "tess_ctrl",
+	[RD::SHADER_STAGE_TESSELATION_EVALUATION] = "tess_eval",
+	[RD::SHADER_STAGE_COMPUTE] = "comp",
+};
+
+void ShaderCacheEntry::notify_free() const {
+	owner.shader_cache_free_entry(key);
+}
+
+@interface MDLibrary ()
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry;
+- (ShaderCacheEntry *)entry;
+@end
+
+@interface MDLazyLibrary : MDLibrary {
+	id<MTLLibrary> _library;
+	NSError *_error;
+	std::shared_mutex _mu;
+	bool _loaded;
+	id<MTLDevice> _device;
+	NSString *_source;
+	MTLCompileOptions *_options;
+}
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry
+							device:(id<MTLDevice>)device
+							source:(NSString *)source
+						   options:(MTLCompileOptions *)options;
+@end
+
+@interface MDImmediateLibrary : MDLibrary {
+	id<MTLLibrary> _library;
+	NSError *_error;
+	std::mutex _cv_mutex;
+	std::condition_variable _cv;
+	std::atomic<bool> _complete;
+	bool _ready;
+}
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry
+							device:(id<MTLDevice>)device
+							source:(NSString *)source
+						   options:(MTLCompileOptions *)options;
+@end
+
+@implementation MDLibrary {
+	ShaderCacheEntry *_entry;
+}
+
++ (instancetype)newLibraryWithCacheEntry:(ShaderCacheEntry *)entry
+								  device:(id<MTLDevice>)device
+								  source:(NSString *)source
+								 options:(MTLCompileOptions *)options
+								strategy:(ShaderLoadStrategy)strategy {
+	switch (strategy) {
+		case ShaderLoadStrategy::DEFAULT:
+			[[fallthrough]];
+		default:
+			return [[MDImmediateLibrary alloc] initWithCacheEntry:entry device:device source:source options:options];
+		case ShaderLoadStrategy::LAZY:
+			return [[MDLazyLibrary alloc] initWithCacheEntry:entry device:device source:source options:options];
+	}
+}
+
+- (ShaderCacheEntry *)entry {
+	return _entry;
+}
+
+- (id<MTLLibrary>)library {
+	CRASH_NOW_MSG("Not implemented");
+	return nil;
+}
+
+- (NSError *)error {
+	CRASH_NOW_MSG("Not implemented");
+	return nil;
+}
+
+- (void)setLabel:(NSString *)label {
+}
+
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry {
+	self = [super init];
+	_entry = entry;
+	_entry->library = self;
+	return self;
+}
+
+- (void)dealloc {
+	_entry->notify_free();
+}
+
+@end
+
+@implementation MDImmediateLibrary
+
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry
+							device:(id<MTLDevice>)device
+							source:(NSString *)source
+						   options:(MTLCompileOptions *)options {
+	self = [super initWithCacheEntry:entry];
+	_complete = false;
+	_ready = false;
+
+	__block os_signpost_id_t compile_id = (os_signpost_id_t)(uintptr_t)self;
+	os_signpost_interval_begin(LOG_INTERVALS, compile_id, "shader_compile",
+			"shader_name=%{public}s stage=%{public}s hash=%{public}s",
+			entry->name.get_data(), SHADER_STAGE_NAMES[entry->stage], entry->short_sha.get_data());
+
+	[device newLibraryWithSource:source
+						 options:options
+			   completionHandler:^(id<MTLLibrary> library, NSError *error) {
+				   os_signpost_interval_end(LOG_INTERVALS, compile_id, "shader_compile");
+				   self->_library = library;
+				   self->_error = error;
+				   if (error) {
+					   ERR_PRINT(String(U"Error compiling shader %s: %s").format(entry->name.get_data(), error.localizedDescription.UTF8String));
+				   }
+
+				   {
+					   std::lock_guard<std::mutex> lock(self->_cv_mutex);
+					   _ready = true;
+				   }
+				   _cv.notify_all();
+				   _complete = true;
+			   }];
+	return self;
+}
+
+- (id<MTLLibrary>)library {
+	if (!_complete) {
+		std::unique_lock<std::mutex> lock(_cv_mutex);
+		_cv.wait(lock, [&] { return _ready; });
+	}
+	return _library;
+}
+
+- (NSError *)error {
+	if (!_complete) {
+		std::unique_lock<std::mutex> lock(_cv_mutex);
+		_cv.wait(lock, [&] { return _ready; });
+	}
+	return _error;
+}
+
+@end
+
+@implementation MDLazyLibrary
+- (instancetype)initWithCacheEntry:(ShaderCacheEntry *)entry
+							device:(id<MTLDevice>)device
+							source:(NSString *)source
+						   options:(MTLCompileOptions *)options {
+	self = [super initWithCacheEntry:entry];
+	_device = device;
+	_source = source;
+	_options = options;
+
+	return self;
+}
+
+- (void)load {
+	{
+		std::shared_lock<std::shared_mutex> lock(_mu);
+		if (_loaded) {
+			return;
+		}
+	}
+
+	std::unique_lock<std::shared_mutex> lock(_mu);
+	if (_loaded) {
+		return;
+	}
+
+	ShaderCacheEntry *entry = [self entry];
+
+	__block os_signpost_id_t compile_id = (os_signpost_id_t)(uintptr_t)self;
+	os_signpost_interval_begin(LOG_INTERVALS, compile_id, "shader_compile",
+			"shader_name=%{public}s stage=%{public}s hash=%{public}s",
+			entry->name.get_data(), SHADER_STAGE_NAMES[entry->stage], entry->short_sha.get_data());
+	NSError *error;
+	_library = [_device newLibraryWithSource:_source options:_options error:&error];
+	os_signpost_interval_end(LOG_INTERVALS, compile_id, "shader_compile");
+	_device = nil;
+	_source = nil;
+	_options = nil;
+	_loaded = true;
+}
+
+- (id<MTLLibrary>)library {
+	[self load];
+	return _library;
+}
+
+- (NSError *)error {
+	[self load];
+	return _error;
+}
+
+@end

--- a/drivers/metal/metal_utils.h
+++ b/drivers/metal/metal_utils.h
@@ -31,6 +31,8 @@
 #ifndef METAL_UTILS_H
 #define METAL_UTILS_H
 
+#import <os/log.h>
+
 #pragma mark - Boolean flags
 
 namespace flags {
@@ -77,5 +79,23 @@ static constexpr uint64_t round_up_to_alignment(uint64_t p_value, uint64_t p_ali
 
 	return aligned_value;
 }
+
+class Defer {
+public:
+	Defer(std::function<void()> func) :
+			func_(func) {}
+	~Defer() { func_(); }
+
+private:
+	std::function<void()> func_;
+};
+
+#define CONCAT_INTERNAL(x, y) x##y
+#define CONCAT(x, y) CONCAT_INTERNAL(x, y)
+#define DEFER const Defer &CONCAT(defer__, __LINE__) = Defer
+
+extern os_log_t LOG_DRIVER;
+// Used for dynamic tracing.
+extern os_log_t LOG_INTERVALS;
 
 #endif // METAL_UTILS_H

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -48,6 +48,8 @@
 class RenderingContextDriverMetal;
 
 class API_AVAILABLE(macos(11.0), ios(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {
+	friend struct ShaderCacheEntry;
+
 	template <typename T>
 	using Result = std::variant<T, Error>;
 
@@ -76,6 +78,19 @@ class API_AVAILABLE(macos(11.0), ios(14.0)) RenderingDeviceDriverMetal : public 
 
 	Error _create_device();
 	Error _check_capabilities();
+
+#pragma mark - Shader Cache
+
+	ShaderLoadStrategy _shader_load_strategy = ShaderLoadStrategy::DEFAULT;
+
+	/**
+	 * The shader cache is a map of hashes of the Metal source to shader cache entries.
+	 *
+	 * To prevent unbounded growth of the cache, cache entries are automatically freed when
+	 * there are no more references to the MDLibrary associated with the cache entry.
+	 */
+	HashMap<SHA256Digest, ShaderCacheEntry *, HashableHasher<SHA256Digest>> _shader_cache;
+	void shader_cache_free_entry(const SHA256Digest &key);
 
 public:
 	Error initialize(uint32_t p_device_index, uint32_t p_frame_count) override final;
@@ -270,7 +285,7 @@ public:
 #pragma mark Pipeline
 
 private:
-	Result<id<MTLFunction>> _create_function(id<MTLLibrary> p_library, NSString *p_name, VectorView<PipelineSpecializationConstant> &p_specialization_constants);
+	Result<id<MTLFunction>> _create_function(MDLibrary *p_library, NSString *p_name, VectorView<PipelineSpecializationConstant> &p_specialization_constants);
 
 public:
 	virtual void pipeline_free(PipelineID p_pipeline_id) override final;


### PR DESCRIPTION
This PR dramatically reduces startup times for Godot when Metal shaders must be recompiled. 

The two primary changes are:

- Only schedule one `MTLLibrary` compilation request per unique shader source
- Use the [concurrent `MTLLibrary` creation API](https://developer.apple.com/documentation/metal/mtldevice/1433351-newlibrarywithsource?language=objc), to allow multiple compilation requests to run in the background

> [!NOTE]
>
> The number of concurrent compilation requests is managed by the OS, and is enabled in Godot by enabling the [`shouldMaximizeConcurrentCompilation`](https://developer.apple.com/documentation/metal/mtldevice/4133938-shouldmaximizeconcurrentcompilat?language=objc) property.

I ran the Bistro demo, which is a great stress test, and cleared the _entire_ Metal shader cache. My hardware is a MacBook Pro M1 Max. For comparison, starting MoltenVK under these conditions takes about 48 seconds for the UI to become responsive.

| Before | After |
| :---- | :---- |
| 2m:30s | 30s |

Relaunching after cache is warmed is about 8-9 seconds.


## Testing

I tested absolute worst-case scenarios, by removing the entire Metal shader cache for Godot. Normally, various restarts of Godot would compile core shaders, such as for the editor, so that the impact of launching the Bistro demo in the editor is not as bad.

You can find the OS Metal shader cache using the following command

```sh
ls `getconf DARWIN_USER_CACHE_DIR`/org.godotengine.godot
```

which might look similar to the following:

```
total 0
drwxr-xr-x@ 8 stuartcarnie  staff  256 27 Dec  2023 com.apple.gpuarchiver
drwxr-xr-x@ 7 stuartcarnie  staff  224 18 Jul 06:21 com.apple.metal
drwxr-xr-x@ 3 stuartcarnie  staff   96 10 Mar  2023 com.apple.metalfe
```

And to clear the cache, remove all those directories:

```sh
rm -rf `getconf DARWIN_USER_CACHE_DIR`/*
```

### Before

Launching the current version of Godot with Metal, and after adding some instrumentation that can be visualised in Instruments, we can see all the compilation is serial:

![CleanShot 2024-08-25 at 08 14 14@2x](https://github.com/user-attachments/assets/bc9f0e9a-f395-444b-9789-5eb1facba563)

It takes about 2m:30s for the UI to become responsive.

### After

Clearing the cache and running with the improvements, UI is responsive at around 30s. The following chart shows that shader compilation is now concurrent.

![CleanShot 2024-08-25 at 08 26 16@2x](https://github.com/user-attachments/assets/d75018e7-f3b0-46ea-a6ee-5e17de8abc22)

Take note of the section summary, for the **shader_compile** statistics, that indicate **936** unique shaders were compiled.

It turns out that only 250 shaders (26%) of the requested shaders are used by the editor. I implemented an alternative caching strategy that only compiles the shader when creating a pipeline to validate this:

![CleanShot 2024-08-25 at 08 30 02@2x](https://github.com/user-attachments/assets/61765dde-4e23-4183-bd86-bdbed1611772)

This strategy can be tested by specifying the following environment variable when launching Godot:

```
GODOT_MTL_SHADER_LOAD_STRATEGY=lazy
```
 
> [!IMPORTANT]
>
> I expect this strategy will be better if Godot introduces concurrent pipeline creation / compilation