### PR TITLE
Check for null native value before creating a new empty C# StringName during interop.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -52,7 +52,7 @@ namespace Godot
 
         // Explicit name to make it very clear
         internal static StringName CreateTakingOwnershipOfDisposableValue(godot_string_name nativeValueToOwn)
-            => new StringName(nativeValueToOwn);
+            => nativeValueToOwn.IsAllocated ? new StringName(nativeValueToOwn) : null;
 
         /// <summary>
         /// Constructs an empty <see cref="StringName"/>.


### PR DESCRIPTION
Fixes #96051 
Please see that Issue for context. If this behavior is intended, please close this request.