### PR TITLE
Expose `RenderingServer.canvas_item_attach_skeleton`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -412,6 +412,14 @@
 				[b]Note:[/b] [param count] is unused and can be left unspecified.
 			</description>
 		</method>
+		<method name="canvas_item_attach_skeleton">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="skeleton" type="RID" />
+			<description>
+				Attaches a skeleton to the [CanvasItem]. Removes the previous skeleton.
+			</description>
+		</method>
 		<method name="canvas_item_clear">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3263,6 +3263,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_copy_to_backbuffer", "item", "enabled", "rect"), &RenderingServer::canvas_item_set_copy_to_backbuffer);
+	ClassDB::bind_method(D_METHOD("canvas_item_attach_skeleton", "item", "skeleton"), &RenderingServer::canvas_item_attach_skeleton);
 
 	ClassDB::bind_method(D_METHOD("canvas_item_clear", "item"), &RenderingServer::canvas_item_clear);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_draw_index", "item", "index"), &RenderingServer::canvas_item_set_draw_index);


### PR DESCRIPTION
Exposes the function 'RenderingServer.canvas_item_attach_skeleton'. The function is used internally by Polygon2D. Exposing it allows bypassing the Polygon2D and creating 2D-meshes that use skeletons directly (which I need for a custom importer of 2D meshes/skeletons that have blend-shapes; not supported by polygons). Did some basic testing and seems to work without issue, but second eyes would be welcome: e.g. is there a reason the function wasn't exposed?