### PR TITLE
Fix `get_edited_resource` for `EditorSyntaxHighlighter` for a TextFile

### DIFF
--- a/doc/classes/EditorSyntaxHighlighter.xml
+++ b/doc/classes/EditorSyntaxHighlighter.xml
@@ -22,5 +22,11 @@
 				Virtual method which can be overridden to return the supported language names.
 			</description>
 		</method>
+		<method name="get_edited_resource">
+			<return type="RefCounted" />
+			<description>
+				Returns the associated [Resource].
+			</description>
+		</method>
 	</methods>
 </class>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -96,7 +96,7 @@ Ref<EditorSyntaxHighlighter> EditorSyntaxHighlighter::_create() const {
 }
 
 void EditorSyntaxHighlighter::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_get_edited_resource"), &EditorSyntaxHighlighter::_get_edited_resource);
+	ClassDB::bind_method(D_METHOD("get_edited_resource"), &EditorSyntaxHighlighter::_get_edited_resource);
 
 	GDVIRTUAL_BIND(_get_name)
 	GDVIRTUAL_BIND(_get_supported_languages)

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -55,6 +55,7 @@ void TextEditor::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlight
 	}
 
 	CodeEdit *te = code_editor->get_text_editor();
+	p_highlighter->_set_edited_resource(edited_res);
 	te->set_syntax_highlighter(p_highlighter);
 }
 


### PR DESCRIPTION
The call was being hidden due to the underscore prefix And the resource was never set in the TextEditor