### PR TITLE
Fix FBX runtime import

### DIFF
--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -39,6 +39,8 @@ module_obj = []
 env_fbx.add_source_files(module_obj, "*.cpp")
 env_fbx.add_source_files(module_obj, "structures/*.cpp")
 
+SConscript("extensions/SCsub")
+
 if env.editor_build:
     env_fbx.add_source_files(module_obj, "editor/*.cpp")
 

--- a/modules/fbx/config.py
+++ b/modules/fbx/config.py
@@ -12,6 +12,7 @@ def get_doc_classes():
         "EditorSceneFormatImporterFBX2GLTF",
         "EditorSceneFormatImporterUFBX",
         "FBXDocument",
+        "FBXDocumentExtensionConvertImporterMesh",
         "FBXState",
     ]
 

--- a/modules/fbx/doc_classes/FBXDocumentExtensionConvertImporterMesh.xml
+++ b/modules/fbx/doc_classes/FBXDocumentExtensionConvertImporterMesh.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="FBXDocumentExtensionConvertImporterMesh" inherits="GLTFDocumentExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A class that converts [ImporterMesh] into [MeshInstance3D] for the FBX runtime loader.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
+	</tutorials>
+</class>

--- a/modules/fbx/extensions/SCsub
+++ b/modules/fbx/extensions/SCsub
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_gltf = env_modules.Clone()
+
+# Godot source files
+
+env_gltf.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/fbx/extensions/fbx_document_extension_convert_importer_mesh.cpp
+++ b/modules/fbx/extensions/fbx_document_extension_convert_importer_mesh.cpp
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*  fbx_document_extension_convert_importer_mesh.cpp                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "fbx_document_extension_convert_importer_mesh.h"
+
+#include "scene/3d/importer_mesh_instance_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/resources/3d/importer_mesh.h"
+
+void FBXDocumentExtensionConvertImporterMesh::_copy_meta(Object *p_src_object, Object *p_dst_object) {
+	List<StringName> meta_list;
+	p_src_object->get_meta_list(&meta_list);
+	for (const StringName &meta_key : meta_list) {
+		Variant meta_value = p_src_object->get_meta(meta_key);
+		p_dst_object->set_meta(meta_key, meta_value);
+	}
+}
+
+Error FBXDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_state, Node *p_root) {
+	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	List<Node *> queue;
+	queue.push_back(p_root);
+	List<Node *> delete_queue;
+	while (!queue.is_empty()) {
+		List<Node *>::Element *E = queue.front();
+		Node *node = E->get();
+		ImporterMeshInstance3D *importer_mesh_3d = Object::cast_to<ImporterMeshInstance3D>(node);
+		if (importer_mesh_3d) {
+			Ref<ImporterMesh> mesh = importer_mesh_3d->get_mesh();
+			if (mesh.is_valid()) {
+				MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
+				Ref<ArrayMesh> array_mesh = mesh->get_mesh();
+				mesh_instance_node_3d->set_name(node->get_name());
+				mesh_instance_node_3d->set_transform(importer_mesh_3d->get_transform());
+				mesh_instance_node_3d->set_mesh(array_mesh);
+				mesh_instance_node_3d->set_skin(importer_mesh_3d->get_skin());
+				mesh_instance_node_3d->set_skeleton_path(importer_mesh_3d->get_skeleton_path());
+				node->replace_by(mesh_instance_node_3d);
+				_copy_meta(importer_mesh_3d, mesh_instance_node_3d);
+				_copy_meta(mesh.ptr(), array_mesh.ptr());
+				delete_queue.push_back(node);
+				node = mesh_instance_node_3d;
+			} else {
+				WARN_PRINT("FBX: ImporterMeshInstance3D does not have a valid mesh. This should not happen. Continuing anyway.");
+			}
+		}
+		int child_count = node->get_child_count();
+		for (int i = 0; i < child_count; i++) {
+			queue.push_back(node->get_child(i));
+		}
+		queue.pop_front();
+	}
+	while (!delete_queue.is_empty()) {
+		List<Node *>::Element *E = delete_queue.front();
+		Node *node = E->get();
+		memdelete(node);
+		delete_queue.pop_front();
+	}
+	return OK;
+}

--- a/modules/fbx/extensions/fbx_document_extension_convert_importer_mesh.h
+++ b/modules/fbx/extensions/fbx_document_extension_convert_importer_mesh.h
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  fbx_document_extension_convert_importer_mesh.h                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef FBX_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H
+#define FBX_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H
+
+#include "modules/gltf/extensions/gltf_document_extension.h"
+#include "modules/gltf/gltf_defines.h"
+
+class FBXDocumentExtensionConvertImporterMesh : public GLTFDocumentExtension {
+	GDCLASS(FBXDocumentExtensionConvertImporterMesh, GLTFDocumentExtension);
+
+protected:
+	static void _copy_meta(Object *p_src_object, Object *p_dst_object);
+
+public:
+	Error import_post(Ref<GLTFState> p_state, Node *p_root) override;
+};
+
+#endif // FBX_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -2109,6 +2109,15 @@ Error FBXDocument::_parse(Ref<FBXState> p_state, String p_path, Ref<FileAccess> 
 		WARN_PRINT(vformat("FBX: ignored %d further ufbx warnings", ignored_warning_count));
 	}
 
+	document_extensions.clear();
+	for (Ref<GLTFDocumentExtension> ext : all_document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		err = ext->import_preflight(p_state, p_state->json["extensionsUsed"]);
+		if (err == OK) {
+			document_extensions.push_back(ext);
+		}
+	}
+
 	err = _parse_fbx_state(p_state, p_path);
 	ERR_FAIL_COND_V(err != OK, err);
 
@@ -2137,6 +2146,27 @@ Node *FBXDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, bool
 			_import_animation(state, ap, i, p_trimming, p_remove_immutable_tracks);
 		}
 	}
+	for (KeyValue<GLTFNodeIndex, Node *> E : state->scene_nodes) {
+		ERR_CONTINUE(!E.value);
+		for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+			ERR_CONTINUE(ext.is_null());
+			Dictionary node_json;
+			if (state->json.has("nodes")) {
+				Array nodes = state->json["nodes"];
+				if (0 <= E.key && E.key < nodes.size()) {
+					node_json = nodes[E.key];
+				}
+			}
+			Ref<GLTFNode> gltf_node = state->nodes[E.key];
+			Error err = ext->import_node(p_state, gltf_node, node_json, E.value);
+			ERR_CONTINUE(err != OK);
+		}
+	}
+	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		Error err = ext->import_post(p_state, root);
+		ERR_CONTINUE(err != OK);
+	}
 	ERR_FAIL_NULL_V(root, nullptr);
 	return root;
 }
@@ -2155,12 +2185,11 @@ Error FBXDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pat
 	state->base_path = p_base_path.get_base_dir();
 	err = _parse(state, state->base_path, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
-	// TODO: 202040118 // fire
-	// for (Ref<GLTFDocumentExtension> ext : get_all_gltf_document_extensions()) {
-	// 	ERR_CONTINUE(ext.is_null());
-	// 	err = ext->import_post_parse(state);
-	// 	ERR_FAIL_COND_V(err != OK, err);
-	// }
+	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		err = ext->import_post_parse(state);
+		ERR_FAIL_COND_V(err != OK, err);
+	}
 	return OK;
 }
 
@@ -2254,12 +2283,11 @@ Error FBXDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint3
 	state->base_path = base_path;
 	err = _parse(p_state, base_path, file);
 	ERR_FAIL_COND_V(err != OK, err);
-	// TODO: 20240118 // fire
-	// for (Ref<GLTFDocumentExtension> ext : document_extensions) {
-	// 	ERR_CONTINUE(ext.is_null());
-	// 	err = ext->import_post_parse(p_state);
-	// 	ERR_FAIL_COND_V(err != OK, err);
-	// }
+	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		err = ext->import_post_parse(p_state);
+		ERR_FAIL_COND_V(err != OK, err);
+	}
 	return OK;
 }
 

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_types.h"
 
+#include "extensions/fbx_document_extension_convert_importer_mesh.h"
 #include "fbx_document.h"
 
 #ifdef TOOLS_ENABLED
@@ -54,10 +55,20 @@ static void _editor_init() {
 }
 #endif // TOOLS_ENABLED
 
+#define FBX_REGISTER_DOCUMENT_EXTENSION(m_doc_ext_class) \
+	Ref<m_doc_ext_class> extension_##m_doc_ext_class;    \
+	extension_##m_doc_ext_class.instantiate();           \
+	FBXDocument::register_gltf_document_extension(extension_##m_doc_ext_class);
+
 void initialize_fbx_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(FBXDocument);
+		GDREGISTER_CLASS(FBXDocumentExtensionConvertImporterMesh);
 		GDREGISTER_CLASS(FBXState);
+		bool is_editor = Engine::get_singleton()->is_editor_hint();
+		if (!is_editor) {
+			FBX_REGISTER_DOCUMENT_EXTENSION(FBXDocumentExtensionConvertImporterMesh);
+		}
 	}
 
 #ifdef TOOLS_ENABLED
@@ -83,6 +94,5 @@ void uninitialize_fbx_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-	// TODO: 20240118 // fire
-	// FBXDocument::unregister_all_gltf_document_extensions();
+	FBXDocument::unregister_all_gltf_document_extensions();
 }


### PR DESCRIPTION
fixes #96029
fixes #96043

ufbx can import fbx files in the editor but not at runtime


edit: 
now it fully supports loading at runtime and in editor
it fully supports document extensions
it loads textures perfectly knowing when to load with a resourceloader and when to load with a buffer
all tested animations, bones, textures, models, surfaces they all work now