### PR TITLE
Safe `Camera::unproject_position()`

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -479,27 +479,82 @@ Vector<Vector3> Camera3D::get_near_plane_points() const {
 	return points;
 }
 
-Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
-	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
+bool Camera3D::safe_unproject_position(const Vector3 &p_pos, Point2 &r_result) const {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), false, "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
 	Projection cm = _get_camera_projection(_near);
 
+	// These are homogeneous coordinates.
+	// The 1.0 will later become w, the perspective divide.
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
 	p = cm.xform4(p);
 
-	// Prevent divide by zero.
-	// TODO: Investigate, this was causing NaNs.
-	ERR_FAIL_COND_V(p.d == 0, Point2());
+	// If p.d is zero, there is a potential divide by zero ahead.
+	// This can occur if the test point is exactly on the focal plane
+	// with a perspective camera matrix (i.e. behind the near plane).
 
+	// There are two possibilities here:
+	// Either the test point is exactly at the origin, in which case the unprojected
+	// point should theoretically be the center of the viewport, OR
+	// infinity distance from the center of the viewport.
+
+	// We should also handle the case where the test point is CLOSE
+	// to the focal plane.
+	// This can cause returned unprojected results near infinity.
+	// The epsilon chosen here must be small, but still allow for near planes quite close to zero.
+
+	// Here we return false and let the calling routine handle this error condition.
+	if (Math::abs(p.d) < CMP_EPSILON) {
+		// Establish the viewport center as our baseline
+		Point2 center = viewport_size * 0.5f;
+		r_result = center;
+
+		// The viewport size here is irrelevant, we just want a high number
+		// (representing infinity) but not actually close to infinity to prevent
+		// knock on bugs if later maths later does something with these values.
+		// Suffice is for them to be WAY off the main viewport.
+		const float SOME_HIGH_VALUE = 100000.0f;
+		if (p.normal.x > 0) {
+			r_result.x += SOME_HIGH_VALUE;
+		} else if (p.normal.x < 0) {
+			r_result.x -= SOME_HIGH_VALUE;
+		}
+
+		// +y is down in 2D viewport,
+		// whereas in 3D, +y is up, so we need to flip here.
+		if (p.normal.y > 0) {
+			r_result.y -= SOME_HIGH_VALUE;
+		} else if (p.normal.y < 0) {
+			r_result.y += SOME_HIGH_VALUE;
+		}
+
+		return false;
+	}
 	p.normal /= p.d;
 
-	Point2 res;
-	res.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;
-	res.y = (-p.normal.y * 0.5 + 0.5) * viewport_size.y;
+	r_result.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;
+	r_result.y = (-p.normal.y * 0.5 + 0.5) * viewport_size.y;
 
+	return true;
+}
+
+Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Point2(), "Camera is not inside scene.");
+
+	Point2 res;
+
+	// Unproject can fail if the test point is on the camera matrix focal plane
+	// with a perspective transform.
+	// In this case, the unprojected point is potentially at infinity from the viewport
+	// center.
+	if (!safe_unproject_position(p_pos, res)) {
+#ifdef DEV_ENABLED
+		WARN_PRINT_ONCE("Camera::unproject_position() unprojecting points on the focal plane is unreliable.");
+#endif
+	}
 	return res;
 }
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -483,27 +483,82 @@ Vector<Vector3> Camera3D::get_near_plane_points() const {
 	return points;
 }
 
-Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
-	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
+bool Camera3D::safe_unproject_position(const Vector3 &p_pos, Point2 &r_result) const {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), false, "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
 	Projection cm = _get_camera_projection(_near);
 
+	// These are homogeneous coordinates.
+	// The 1.0 will later become w, the perspective divide.
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
 	p = cm.xform4(p);
 
-	// Prevent divide by zero.
-	// TODO: Investigate, this was causing NaNs.
-	ERR_FAIL_COND_V(p.d == 0, Point2());
+	// If p.d is zero, there is a potential divide by zero ahead.
+	// This can occur if the test point is exactly on the focal plane
+	// with a perspective camera matrix (i.e. behind the near plane).
 
+	// There are two possibilities here:
+	// Either the test point is exactly at the origin, in which case the unprojected
+	// point should theoretically be the center of the viewport, OR
+	// infinity distance from the center of the viewport.
+
+	// We should also handle the case where the test point is CLOSE
+	// to the focal plane.
+	// This can cause returned unprojected results near infinity.
+	// The epsilon chosen here must be small, but still allow for near planes quite close to zero.
+
+	// Here we return false and let the calling routine handle this error condition.
+	if (Math::abs(p.d) < CMP_EPSILON) {
+		// Establish the viewport center as our baseline
+		Point2 center = viewport_size * 0.5f;
+		r_result = center;
+
+		// The viewport size here is irrelevant, we just want a high number
+		// (representing infinity) but not actually close to infinity to prevent
+		// knock on bugs if later math later does something with these values.
+		// Suffice is for them to be WAY off the main viewport.
+		const float SOME_HIGH_VALUE = 100000.0f;
+		if (p.normal.x > 0) {
+			r_result.x += SOME_HIGH_VALUE;
+		} else if (p.normal.x < 0) {
+			r_result.x -= SOME_HIGH_VALUE;
+		}
+
+		// +y is down in 2D viewport,
+		// whereas in 3D, +y is up, so we need to flip here.
+		if (p.normal.y > 0) {
+			r_result.y -= SOME_HIGH_VALUE;
+		} else if (p.normal.y < 0) {
+			r_result.y += SOME_HIGH_VALUE;
+		}
+
+		return false;
+	}
 	p.normal /= p.d;
 
-	Point2 res;
-	res.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;
-	res.y = (-p.normal.y * 0.5 + 0.5) * viewport_size.y;
+	r_result.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;
+	r_result.y = (-p.normal.y * 0.5 + 0.5) * viewport_size.y;
 
+	return true;
+}
+
+Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Point2(), "Camera is not inside scene.");
+
+	Point2 res;
+
+	// Unproject can fail if the test point is on the camera matrix focal plane
+	// with a perspective transform.
+	// In this case, the unprojected point is potentially at infinity from the viewport
+	// center.
+	if (!safe_unproject_position(p_pos, res)) {
+#ifdef DEV_ENABLED
+		WARN_PRINT_ONCE("Camera::unproject_position() unprojecting points on the focal plane is unreliable.");
+#endif
+	}
 	return res;
 }
 

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -169,6 +169,7 @@ public:
 	virtual Vector3 project_ray_origin(const Point2 &p_pos) const;
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
+	bool safe_unproject_position(const Vector3 &p_pos, Point2 &r_result) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
 	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const;
 

--- a/tests/scene/test_camera_3d.cpp
+++ b/tests/scene/test_camera_3d.cpp
@@ -255,6 +255,26 @@ TEST_CASE("[SceneTree][Camera3D] Project/Unproject position") {
 			CHECK(test_camera->project_position(Vector2(300, 150), 0.5f).is_equal_approx(Vector3(Math::SQRT3 * 0.5f, -Math::SQRT3 * 0.25f, -0.5f)));
 			CHECK(test_camera->project_position(Vector2(300, 150), 1.0f).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 * 0.5f, -1.0f)));
 			CHECK(test_camera->project_position(Vector2(300, 150), test_camera->get_far()).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 * 0.5f, -1.0f) * test_camera->get_far()));
+
+			SUBCASE("Singularities at focal plane") {
+				Vector2 center = Vector2(200, 100);
+
+				// Division-by-zero at camera origin (0, 0, 0)
+				Vector2 origin_result = test_camera->unproject_position(Vector3(0.0f, 0.0f, 0.0f));
+				CHECK(origin_result == center);
+
+				// Point offset on focal plane: offset Up (+Y 3D) and Right (+X 3D)
+				// Maps to: Right (+2D X) and Up (-2D Y)
+				Vector2 right_up_result = test_camera->unproject_position(Vector3(0.1f, 0.1f, 0.0f));
+				CHECK(right_up_result.x > (center.x + 90000.0f));
+				CHECK(right_up_result.y < (center.y - 90000.0f));
+
+				// Point offset on focal plane: offset Down (-Y 3D) and Left (-X 3D)
+				// Maps to: Left (-2D X) and Down (+2D Y)
+				Vector2 left_down_result = test_camera->unproject_position(Vector3(-0.1f, -0.1f, 0.0f));
+				CHECK(left_down_result.x < (center.x - 90000.0f));
+				CHECK(left_down_result.y > (center.y + 90000.0f));
+			}
 		}
 	}
 


### PR DESCRIPTION
* Provides a `safe_unproject_position()` function that returns failure and prevents NaNs
* Wraps the new function from the old bound `unproject_position()` function
* Adds unit test

A problem occurs when the test position is on (or close to) the focal plane of a perspective camera matrix. Under these conditions, the perspective divide is 0, and the unprojected position is undefined (potentially infinite from the viewport centre).

This PR provides a safe version of unproject that detects this condition and returns false, and attempts to recover and provide a sensible result, while printing a warning once (in DEV builds).

We wrap this from the existing `unproject_position()` routine, providing more robust behaviour from the existing bound function, and preventing NaNs, while still returning a result that should process normally and give expected results.

4.x version of #96032
Fixes #96028 (for 4.x)

Bugsquad edit:
Fixes #121686


## Notes
* Prior to the `ERR_FAIL_COND`, `unproject_position()` had a major bug whereby it would return NaNs when fed some input data.
* We also deal with test points that are close to the focal plane with an epsilon. This is to prevent near infinite return values and math exceptions in calling code in rare situations.

## Orthographic projections
Works fine in standard orthographic projections (via `Projection::set_orthogonal()`) where w is a constant 1.0, and the fallback block doesn't run.

There is an exception though: where a user bypasses native camera and creates a custom oblique or sheared projection matrix, they could still end up with `p.d` near zero.

However, even in this case, the PR is still correct. The existing `unproject` function would result in NaN, and this safe version will prevent this problem.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
