### PR TITLE
[Doc] Clarify `is_null` methods of `Callable` and `Signal`

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -203,7 +203,8 @@
 		<method name="is_null" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this [Callable] has no target to call the method on.
+				Returns [code]true[/code] if this [Callable] has no target to call the method on. Equivalent to [code]callable == Callable()[/code].
+				[b]Note:[/b] This is [i]not[/i] the same as [code]not is_valid()[/code] and using [code]not is_null()[/code] will [i]not[/i] guarantee that this callable can be called. Use [method is_valid] instead.
 			</description>
 		</method>
 		<method name="is_standard" qualifiers="const">

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -119,7 +119,7 @@
 		<method name="is_null" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the signal's name does not exist in its object, or the object is not valid.
+				Returns [code]true[/code] if this [Signal] has no object and the signal name is empty. Equivalent to [code]signal == Signal()[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The two methods are implemented as:
```cpp
	_FORCE_INLINE_ bool is_null() const {
		return method == StringName() && object == 0;
	}
```
```cpp
	_FORCE_INLINE_ bool is_null() const {
		return object.is_null() && name == StringName();
	}
```


* Closes: https://github.com/godotengine/godot-docs/issues/9831
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
