### PR TITLE
Fix importer preview for models with scaled armatures.

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -464,14 +464,8 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 		mesh_node->add_child(collider_view, true);
 		collider_view->set_owner(mesh_node);
 
-		Transform3D accum_xform;
-		Node3D *base = mesh_node;
-		while (base) {
-			accum_xform = base->get_transform() * accum_xform;
-			base = Object::cast_to<Node3D>(base->get_parent());
-		}
+		AABB aabb = mesh_node->get_aabb();
 
-		AABB aabb = accum_xform.xform(mesh_node->get_mesh()->get_aabb());
 		if (first_aabb) {
 			contents_aabb = aabb;
 			first_aabb = false;


### PR DESCRIPTION
Attempt to fix a bug with imported scenes with skinned meshes where the armature is scaled up or down. It does this by invoking the get_aabb function on mesh instance rather than the mesh itself with the node's global transform applied seperately so that full scaling is taken into account. This AABB is then used to calculate the optimal camera distance and frustum for the overall scene preview.
Before:
![godot windows editor dev x86_64_qI6HyFeWeh](https://github.com/user-attachments/assets/08474c89-4a6a-4a5c-9f38-aa26c6d84b66)
After:
![godot windows editor dev x86_64_ATra2byjPv](https://github.com/user-attachments/assets/e7b9420b-4177-4cc7-b248-21cdbdce937f)
[xbot_scaled.zip](https://github.com/user-attachments/files/16740220/xbot_scaled.zip)
