### PR TITLE
[Core,Drivers,Main] Improve checks using De Morgan's laws

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2651,7 +2651,7 @@ Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_q
 	if (save_webp_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
-	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), ERR_INVALID_PARAMETER, "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
+	ERR_FAIL_COND_V_MSG(p_lossy && (0.0f > p_quality || p_quality > 1.0f), ERR_INVALID_PARAMETER, "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
 
 	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality);
 }
@@ -2660,7 +2660,7 @@ Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_qua
 	if (save_webp_buffer_func == nullptr) {
 		return Vector<uint8_t>();
 	}
-	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), Vector<uint8_t>(), "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
+	ERR_FAIL_COND_V_MSG(p_lossy && (0.0f > p_quality || p_quality > 1.0f), Vector<uint8_t>(), "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
 
 	return save_webp_buffer_func(Ref<Image>((Image *)this), p_lossy, p_quality);
 }

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -299,7 +299,7 @@ Vector3 AStar3D::get_closest_position_in_segment(const Vector3 &p_point) const {
 		points.lookup(E.key.first, from_point);
 		points.lookup(E.key.second, to_point);
 
-		if (!(from_point->enabled && to_point->enabled)) {
+		if (!from_point->enabled || !to_point->enabled) {
 			continue;
 		}
 

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -382,7 +382,7 @@ bool Color::html_is_valid(const String &p_color) {
 
 	// Check if the amount of hex digits is valid.
 	int len = color.length();
-	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
+	if (len != 3 && len != 4 && len != 6 && len != 8) {
 		return false;
 	}
 

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -146,7 +146,7 @@ public:
 		int preserved_count = 0;
 		Triangle *triangles_ptrw = triangles.ptrw();
 		for (int i = 0; i < triangles.size(); i++) {
-			if (!(triangles[i].points[0] >= point_count || triangles[i].points[1] >= point_count || triangles[i].points[2] >= point_count)) {
+			if (triangles[i].points[0] < point_count && triangles[i].points[1] < point_count && triangles[i].points[2] < point_count) {
 				triangles_ptrw[preserved_count] = triangles[i];
 				preserved_count++;
 			}

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -703,7 +703,7 @@ bool ClassDB::can_instantiate(const StringName &p_class) {
 		return false;
 	}
 #endif
-	return (!ti->disabled && ti->creation_func != nullptr && !(ti->gdextension && !ti->gdextension->create_instance));
+	return (!ti->disabled && ti->creation_func != nullptr && (!ti->gdextension || ti->gdextension->create_instance));
 }
 
 bool ClassDB::is_abstract(const StringName &p_class) {
@@ -738,7 +738,7 @@ bool ClassDB::is_virtual(const StringName &p_class) {
 		return false;
 	}
 #endif
-	return (!ti->disabled && ti->creation_func != nullptr && !(ti->gdextension && !ti->gdextension->create_instance) && ti->is_virtual);
+	return (!ti->disabled && ti->creation_func != nullptr && (!ti->gdextension || ti->gdextension->create_instance) && ti->is_virtual);
 }
 
 void ClassDB::_add_class2(const StringName &p_class, const StringName &p_inherits) {

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -777,12 +777,12 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-#define XOR_OP(m_a, m_b) (((m_a) || (m_b)) && !((m_a) && (m_b)))
+#define XOR_OP(m_a, m_b) (((m_a) || (m_b)) && (!(m_a) || !(m_b)))
 template <typename A, typename B>
 class OperatorEvaluatorXor {
 public:
 	_FORCE_INLINE_ static bool xor_op(const A &a, const B &b) {
-		return ((a) || (b)) && !((a) && (b));
+		return ((a) || (b)) && (!(a) || !(b));
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
 		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
@@ -1055,7 +1055,7 @@ _FORCE_INLINE_ static bool _operate_and(bool p_left, bool p_right) {
 }
 
 _FORCE_INLINE_ static bool _operate_xor(bool p_left, bool p_right) {
-	return (p_left || p_right) && !(p_left && p_right);
+	return (p_left || p_right) && (!p_left || !p_right);
 }
 
 _FORCE_INLINE_ static bool _operate_get_nil(const Variant *p_ptr) {

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1257,7 +1257,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandAnimationSlice *as = static_cast<const Item::CommandAnimationSlice *>(c);
 				double current_time = RSG::rasterizer->get_total_time();
 				double local_time = Math::fposmod(current_time - as->offset, as->animation_length);
-				skipping = !(local_time >= as->slice_begin && local_time < as->slice_end);
+				skipping = local_time < as->slice_begin || local_time >= as->slice_end;
 
 				RenderingServerDefault::redraw_request(); // animation visible means redraw request
 			} break;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -223,7 +223,7 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 	if (has_alpha || has_read_screen_alpha || p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test == GLES3::SceneShaderData::DEPTH_TEST_DISABLED) {
 		//material is only meant for alpha pass
 		flags |= GeometryInstanceSurface::FLAG_PASS_ALPHA;
-		if (p_material->shader_data->uses_depth_prepass_alpha && !(p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test == GLES3::SceneShaderData::DEPTH_TEST_DISABLED)) {
+		if (p_material->shader_data->uses_depth_prepass_alpha && p_material->shader_data->depth_draw != GLES3::SceneShaderData::DEPTH_DRAW_DISABLED && p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_DISABLED) {
 			flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
 			flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
 		}

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -698,7 +698,7 @@ void ShaderGLES3::_clear_version(Version *p_version) {
 
 void ShaderGLES3::_initialize_version(Version *p_version) {
 	ERR_FAIL_COND(p_version->variants.size() > 0);
-	bool use_cache = shader_cache_dir_valid && !(feedback_count > 0 && GLES3::Config::get_singleton()->disable_transform_feedback_shader_cache);
+	bool use_cache = shader_cache_dir_valid && (feedback_count <= 0 || !GLES3::Config::get_singleton()->disable_transform_feedback_shader_cache);
 	if (use_cache && _load_from_cache(p_version)) {
 		return;
 	}

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -3062,7 +3062,7 @@ bool SceneShaderData::casts_shadows() const {
 	bool has_base_alpha = (uses_alpha && !uses_alpha_clip) || has_read_screen_alpha;
 	bool has_alpha = has_base_alpha || uses_blend_alpha;
 
-	return !has_alpha || (uses_depth_prepass_alpha && !(depth_draw == DEPTH_DRAW_DISABLED || depth_test == DEPTH_TEST_DISABLED));
+	return !has_alpha || (uses_depth_prepass_alpha && depth_draw != DEPTH_DRAW_DISABLED && depth_test != DEPTH_TEST_DISABLED);
 }
 
 RS::ShaderNativeSourceCode SceneShaderData::get_native_source_code() const {

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -238,14 +238,14 @@ NetSocketPosix::NetError NetSocketPosix::_get_socket_error() const {
 #endif
 
 bool NetSocketPosix::_can_use_ip(const IPAddress &p_ip, const bool p_for_bind) const {
-	if (p_for_bind && !(p_ip.is_valid() || p_ip.is_wildcard())) {
+	if (p_for_bind && !p_ip.is_valid() && !p_ip.is_wildcard()) {
 		return false;
 	} else if (!p_for_bind && !p_ip.is_valid()) {
 		return false;
 	}
 	// Check if socket support this IP type.
 	IP::Type type = p_ip.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
-	return !(_ip_type != IP::TYPE_ANY && !p_ip.is_wildcard() && _ip_type != type);
+	return _ip_type == IP::TYPE_ANY || p_ip.is_wildcard() || _ip_type == type;
 }
 
 _FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IPAddress p_ip, String p_if_name, bool p_add) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3052,7 +3052,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 			id->set_agile_input_event_flushing(agile_input_event_flushing);
 
 			if (bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_touch_from_mouse", false)) &&
-					!(editor || project_manager)) {
+					!editor && !project_manager) {
 				if (!DisplayServer::get_singleton()->is_touchscreen_available()) {
 					//only if no touchscreen ui hint, set emulation
 					id->set_emulate_touch_from_mouse(true);


### PR DESCRIPTION
Reduces cognitive load and improves readability, and avoids potential errors when expanding or rewording these. Doing the inverse of the expression, especially for longer expressions, can be difficult and the inverse might not be obvious if someone doesn't know the laws

Done in parts for ease of review and will open PRs for other parts of the codebase if this gets approved 

The laws in question are:
* `!(a && b) <=> (!a || !b)`
* `!(a || b) <=> (!a && !b)`

Also applied comparison inversions:
* `!(a < b) <=> (a >= b)` and `!(a <= b) <=> (a > b)`
* `!(a > b) <=> (a <= b)` and `!(a >= b) <=> (a < b)`

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
