### PR TITLE
Add import tab `import_script/path` relative path support

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3058,6 +3058,10 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	progress.step(TTR("Running Custom Script..."), 2);
 
 	String post_import_script_path = p_options["import_script/path"];
+	if (post_import_script_path.is_relative_path()) {
+		post_import_script_path = p_source_file.get_base_dir().path_join(post_import_script_path);
+	}
+
 	Ref<EditorScenePostImport> post_import_script;
 
 	if (!post_import_script_path.is_empty()) {


### PR DESCRIPTION
This simple PR adds relative path support for the "import_script/path" property of the import tab. Useful for post-import scripts that are beside their import file.

![image](https://github.com/user-attachments/assets/9d470727-3cbf-44a6-b53d-a884cd06da05)
