### PR TITLE
WAV: Add missing break on `get_length()`

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -560,6 +560,7 @@ double AudioStreamWAV::get_length() const {
 			qoa_desc desc = { 0, 0, 0, { { { 0 }, { 0 } } } };
 			qoa_decode_header((uint8_t *)data + DATA_PAD, data_bytes, &desc);
 			len = desc.samples * desc.channels;
+			break;
 	}
 
 	if (stereo) {


### PR DESCRIPTION
Didn't notice because it worked fine before. It's best to add it regardless for code style and avoid possible bugs.