### PR TITLE
[Windows] Move `__REQUIRED_RPCNDR_H_VERSION__` to the header.

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -136,7 +136,6 @@ if env.msvc:
     ]
 else:
     extra_defines += [
-        ("__REQUIRED_RPCNDR_H_VERSION__", 475),
         "HAVE_STRUCT_TIMESPEC",
     ]
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -36,6 +36,11 @@
 #include "core/templates/self_list.h"
 #include "servers/rendering/rendering_device_driver.h"
 
+#ifndef _MSC_VER
+// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
+#define __REQUIRED_RPCNDR_H_VERSION__ 475
+#endif
+
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96060