### PR TITLE
Metal: Minor improvements to shader cache

### DIFF
--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -506,10 +506,10 @@ enum class ShaderLoadStrategy {
 	LAZY,
 };
 
-/**
- * A Metal shader library.
- */
-@interface MDLibrary : NSObject
+/// A Metal shader library.
+@interface MDLibrary : NSObject {
+	ShaderCacheEntry *_entry;
+};
 - (id<MTLLibrary>)library;
 - (NSError *)error;
 - (void)setLabel:(NSString *)label;
@@ -536,6 +536,10 @@ struct SHA256Digest {
 	SHA256Digest(const char *p_data, size_t p_length) {
 		CC_SHA256(p_data, (CC_LONG)p_length, data);
 	}
+
+	_FORCE_INLINE_ uint32_t short_sha() const {
+		return __builtin_bswap32(*(uint32_t *)&data[0]);
+	}
 };
 
 template <>
@@ -545,22 +549,18 @@ struct HashMapComparatorDefault<SHA256Digest> {
 	}
 };
 
-/**
- * A cache entry for a Metal shader library.
- */
+/// A cache entry for a Metal shader library.
 struct ShaderCacheEntry {
 	RenderingDeviceDriverMetal &owner;
+	/// A hash of the Metal shader source code.
 	SHA256Digest key;
 	CharString name;
-	CharString short_sha;
 	RD::ShaderStage stage = RD::SHADER_STAGE_VERTEX;
-	/**
-	 * This reference must be weak, to ensure that when the last strong reference to the library
-	 * is released, the cache entry is freed.
-	 */
+	/// This reference must be weak, to ensure that when the last strong reference to the library
+	/// is released, the cache entry is freed.
 	MDLibrary *__weak library = nil;
 
-	/** Notify the cache that this entry is no longer needed. */
+	/// Notify the cache that this entry is no longer needed.
 	void notify_free() const;
 
 	ShaderCacheEntry(RenderingDeviceDriverMetal &p_owner, SHA256Digest p_key) :

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -72,8 +72,8 @@ os_log_t LOG_DRIVER;
 os_log_t LOG_INTERVALS;
 
 __attribute__((constructor)) static void InitializeLogging(void) {
-	LOG_DRIVER = os_log_create("org.stuartcarnie.godot.metal", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
-	LOG_INTERVALS = os_log_create("org.stuartcarnie.godot.metal", "events");
+	LOG_DRIVER = os_log_create("org.godotengine.godot.metal", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+	LOG_INTERVALS = os_log_create("org.godotengine.godot.metal", "events");
 }
 
 /*****************/
@@ -2323,8 +2323,6 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_bytecode(const Vect
 
 		ShaderCacheEntry *cd = memnew(ShaderCacheEntry(*this, key));
 		cd->name = binary_data.shader_name;
-		String sha_hex = String::hex_encode_buffer(key.data, CC_SHA256_DIGEST_LENGTH);
-		cd->short_sha = sha_hex.substr(0, 8).utf8();
 		cd->stage = shader_data.stage;
 
 		MDLibrary *library = [MDLibrary newLibraryWithCacheEntry:cd


### PR DESCRIPTION
This PR is just some minor improvements to #96052 to remove an unnecessary allocation and reduce the size of the cache entry. I've also renamed the tracing subsystem name from `org.stuartcarnie` to `org.godotengine` for the Metal driver. 