### PR TITLE
Fix invalid `Skeleton3D` bone pose updates

### DIFF
--- a/scene/3d/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr_hand_modifier_3d.cpp
@@ -207,6 +207,11 @@ void XRHandModifier3D::_process_modification() {
 
 		// Apply previous relative transforms if they are stored.
 		for (int joint = 0; joint < XRHandTracker::HAND_JOINT_MAX; joint++) {
+			const int bone = joints[joint].bone;
+			if (bone == -1) {
+				continue;
+			}
+
 			if (bone_update == BONE_UPDATE_FULL) {
 				skeleton->set_bone_pose_position(joints[joint].bone, previous_relative_transforms[joint].origin);
 			}


### PR DESCRIPTION
The issue would cause log spams when trying to update the bone pose position or rotation with an invalid bone index.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
