### PR TITLE
Revert scaled armature advanced importer preview fix.

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -464,7 +464,14 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 		mesh_node->add_child(collider_view, true);
 		collider_view->set_owner(mesh_node);
 
-		AABB aabb = mesh_node->get_aabb();
+		Transform3D accum_xform;
+		Node3D *base = mesh_node;
+		while (base) {
+			accum_xform = base->get_transform() * accum_xform;
+			base = Object::cast_to<Node3D>(base->get_parent());
+		}
+
+		AABB aabb = accum_xform.xform(mesh_node->get_mesh()->get_aabb());
 
 		if (first_aabb) {
 			contents_aabb = aabb;


### PR DESCRIPTION
Reverts 06709e68657ad6595c8ae8603d17b62ec984539d
This was not actually the correct way to fix this, get_aabb does not actually do what I thought it did. The actual way would appear to be to do what the renderer itself does when calculating a visibility bounding box for a mesh instance, and use the skeleton itself to recalculate the bounding box.

While this does not fully implement this, this PR #96094 contains code which allows the skeleton's preview mesh to be factored into the scene's bounding box calculation which should result in a much more accurate scale and should solve the vast majority of cases like the one given in the previous PR's example.