### PR TITLE
Add PopupMenu `id_mouse_entered/exited` signals

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -668,7 +668,7 @@
 		<signal name="id_mouse_entered">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emited when mouse enters menu item
+				Emitted when the mouse cursor enters an item's clickable area.
 			</description>
 		</signal>
 		<signal name="id_mouse_exited">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -665,13 +665,13 @@
 				[b]Note:[/b] If [param id] is negative (either explicitly or due to overflow), this will return the corresponding index instead.
 			</description>
 		</signal>
-		<signal name="id_mouse_enter">
+		<signal name="id_mouse_entered">
 			<param index="0" name="id" type="int" />
 			<description>
 				Emited when mouse enters menu item
 			</description>
 		</signal>
-		<signal name="id_mouse_exit">
+		<signal name="id_mouse_exited">
 			<param index="0" name="id" type="int" />
 			<description>
 				Emited when mouse exits menu item

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -665,6 +665,18 @@
 				[b]Note:[/b] If [param id] is negative (either explicitly or due to overflow), this will return the corresponding index instead.
 			</description>
 		</signal>
+		<signal name="id_mouse_enter">
+			<param index="0" name="id" type="int" />
+			<description>
+				Emited when mouse enters menu item
+			</description>
+		</signal>
+		<signal name="id_mouse_exit">
+			<param index="0" name="id" type="int" />
+			<description>
+				Emited when mouse exits menu item
+			</description>
+		</signal>
 		<signal name="index_pressed">
 			<param index="0" name="index" type="int" />
 			<description>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -674,7 +674,7 @@
 		<signal name="id_mouse_exited">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emited when mouse exits menu item
+				Emitted when the mouse cursor leaves an item's clickable area.
 			</description>
 		</signal>
 		<signal name="index_pressed">

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -710,7 +710,7 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 	if (id < 0) {
 		mouse_over = -1;
 		control->queue_redraw();
-		if (old_id>-1) {
+		if (old_id > -1) {
 			emit_signal(SNAME("id_mouse_exited"), old_id);
 		}
 		return;
@@ -724,7 +724,7 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 	if (over != mouse_over) {
 		mouse_over = over;
 		control->queue_redraw();
-		if (old_id>-1) {
+		if (old_id > -1) {
 			emit_signal(SNAME("id_mouse_exited"), old_id);
 		}
 		emit_signal(SNAME("id_mouse_entered"), mouse_over);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -704,7 +704,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 
 void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 	int over = _get_mouse_over(p_over);
-	int old_id = mouse_over
+	int old_id = mouse_over;
 	int id = (over < 0 || items[over].separator || items[over].disabled) ? -1 : (items[over].id >= 0 ? items[over].id : over);
 
 	if (id < 0) {
@@ -727,7 +727,7 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 		if (old_id>-1) {
 			emit_signal(SNAME("id_mouse_exited"), old_id);
 		}
-		emit_signal(SNAME("id_mouse_entered"), mouse_over)
+		emit_signal(SNAME("id_mouse_entered"), mouse_over);
 	}
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2778,6 +2778,8 @@ void PopupMenu::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("id_mouse_entered", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("id_mouse_exited", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("menu_changed"));
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -704,11 +704,15 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 
 void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 	int over = _get_mouse_over(p_over);
+	int old_id = mouse_over
 	int id = (over < 0 || items[over].separator || items[over].disabled) ? -1 : (items[over].id >= 0 ? items[over].id : over);
 
 	if (id < 0) {
 		mouse_over = -1;
 		control->queue_redraw();
+		if (old_id>-1) {
+			emit_signal(SNAME("id_mouse_exited"), old_id);
+		}
 		return;
 	}
 
@@ -720,6 +724,10 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 	if (over != mouse_over) {
 		mouse_over = over;
 		control->queue_redraw();
+		if (old_id>-1) {
+			emit_signal(SNAME("id_mouse_exited"), old_id);
+		}
+		emit_signal(SNAME("id_mouse_entered"), mouse_over)
 	}
 }
 


### PR DESCRIPTION
Adds signals to PopupMenu to emit once mouse enters/exits menu item, so events and sounds can be atached to user hovering over menu items

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/1977.*