### PR TITLE
Properly mute `-Wundefined-var-template` Clang warning in SafeBinaryMutex

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -861,7 +861,7 @@ else:  # GCC, Clang
             if cc_version_major >= 11:  # Broke on MethodBind templates before GCC 11.
                 env.Append(CCFLAGS=["-Wlogical-op"])
         elif methods.using_clang(env) or methods.using_emcc(env):
-            env.Append(CCFLAGS=["-Wimplicit-fallthrough", "-Wno-undefined-var-template"])
+            env.Append(CCFLAGS=["-Wimplicit-fallthrough"])
     elif env["warnings"] == "all":
         env.Append(CCFLAGS=["-Wall"] + common_warnings)
     elif env["warnings"] == "moderate":

--- a/core/os/safe_binary_mutex.h
+++ b/core/os/safe_binary_mutex.h
@@ -37,6 +37,11 @@
 
 #ifdef THREADS_ENABLED
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-var-template"
+#endif
+
 // A very special kind of mutex, used in scenarios where these
 // requirements hold at the same time:
 // - Must be used with a condition variable (only binary mutexes are suitable).
@@ -104,6 +109,10 @@ public:
 		mutex.unlock();
 	}
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #else // No threads.
 


### PR DESCRIPTION
Fixup of #94169, hopefully addressing this: https://github.com/godotengine/godot/pull/94169#issuecomment-2309753103