### PR TITLE
GDScript: Fix missing error when returning a non-void function from a void function

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2395,6 +2395,7 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 		if (is_void_function) {
 			p_return->void_return = true;
 			const GDScriptParser::DataType &return_type = p_return->return_value->datatype;
+			bool is_hard_non_void_return = return_type.is_hard_type() && !(return_type.kind == GDScriptParser::DataType::BUILTIN && return_type.builtin_type == Variant::NIL);
 			if (is_call && !return_type.is_hard_type()) {
 				String function_name = parser->current_function->identifier ? parser->current_function->identifier->name.operator String() : String("<anonymous function>");
 				String called_function_name = static_cast<GDScriptParser::CallNode *>(p_return->return_value)->function_name.operator String();
@@ -2402,7 +2403,7 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 				parser->push_warning(p_return, GDScriptWarning::UNSAFE_VOID_RETURN, function_name, called_function_name);
 #endif
 				mark_node_unsafe(p_return);
-			} else if (!is_call) {
+			} else if (!is_call || is_hard_non_void_return) {
 				push_error("A void function cannot return a value.", p_return);
 			}
 			result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;


### PR DESCRIPTION
Fixes #95300. The error message when returning a value from a void function would trigger when returning a variable, but not when directly returning the result of a function.
