### PR TITLE
Compatibility: Fix crash when initializing certain compressed layered textures

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1497,11 +1497,9 @@ void TextureStorage::_texture_set_data(RID p_texture, const Ref<Image> &p_image,
 			glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 			if (texture->target == GL_TEXTURE_2D_ARRAY) {
 				if (p_initialize) {
-					glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, i, internal_format, w, h, texture->layers, 0,
-							size * texture->layers, &read[ofs]);
-				} else {
-					glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, 0, 0, p_layer, w, h, 1, internal_format, size, &read[ofs]);
+					glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, i, internal_format, w, h, texture->layers, 0, size * texture->layers, nullptr);
 				}
+				glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, 0, 0, p_layer, w, h, 1, internal_format, size, &read[ofs]);
 			} else {
 				glCompressedTexImage2D(blit_target, i, internal_format, w, h, 0, size, &read[ofs]);
 			}


### PR DESCRIPTION
Fixes a crash that happens when loading large compressed textures on the Compatibility renderer.

The code would try to initialize the entire texture with all the layers while only having access to the first one. This meant that the engine would reach outside of the layer's boundaries and read garbage data. If the total texture size was large enough, it would try to access uninitialized memory and crash.