### PR TITLE
Fix `Array.sort_custom` example code

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -728,7 +728,7 @@
 				    print(my_items) # Prints [["Rice", 4], ["Tomato", 5], ["Apple", 9]]
 
 				    # Sort descending, using a lambda function.
-				    my_items.sort_custom(func(a, b): return a[0] &gt; b[0])
+				    my_items.sort_custom(func(a, b): return a[1] &gt; b[1])
 				    print(my_items) # Prints [["Apple", 9], ["Tomato", 5], ["Rice", 4]]
 				[/codeblock]
 				It may also be necessary to use this method to sort strings by natural order, with [method String.naturalnocasecmp_to], as in the following example:


### PR DESCRIPTION
`Array.sort_custom` descending sort example was comparing index 0, but had expected result based on comparing index 1.  Updated to use index 1 consistently.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
