### PR TITLE
Add note on calling behavior to `MultiplayerSynchronizer`

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -75,12 +75,12 @@
 	<signals>
 		<signal name="delta_synchronized">
 			<description>
-				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated. This signal is only called when properties set to replicate "On Change" are synchronized.
+				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated. This signal is only emitted when properties set to replicate "On Change" are synchronized.
 			</description>
 		</signal>
 		<signal name="synchronized">
 			<description>
-				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated. This signal is only called when properties set to replicate "Always" are synchronized.
+				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated. This signal is only emitted when properties set to replicate "Always" are synchronized.
 			</description>
 		</signal>
 		<signal name="visibility_changed">

--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -75,12 +75,12 @@
 	<signals>
 		<signal name="delta_synchronized">
 			<description>
-				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated.
+				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated. This signal is only called when properties set to replicate "On Change" are synchronized.
 			</description>
 		</signal>
 		<signal name="synchronized">
 			<description>
-				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated.
+				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated. This signal is only called when properties set to replicate "Always" are synchronized.
 			</description>
 		</signal>
 		<signal name="visibility_changed">


### PR DESCRIPTION
added a note on calling behavior to the documentation in lieu of my own trouble with the signals related to the synchronizer and  issue https://github.com/godotengine/godot/issues/88587
