### PR TITLE
Prevent empty post-import script paths throwing errors.

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3058,13 +3058,13 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	progress.step(TTR("Running Custom Script..."), 2);
 
 	String post_import_script_path = p_options["import_script/path"];
-	if (post_import_script_path.is_relative_path()) {
-		post_import_script_path = p_source_file.get_base_dir().path_join(post_import_script_path);
-	}
 
 	Ref<EditorScenePostImport> post_import_script;
 
 	if (!post_import_script_path.is_empty()) {
+		if (post_import_script_path.is_relative_path()) {
+			post_import_script_path = p_source_file.get_base_dir().path_join(post_import_script_path);
+		}
 		Ref<Script> scr = ResourceLoader::load(post_import_script_path);
 		if (!scr.is_valid()) {
 			EditorNode::add_io_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);


### PR DESCRIPTION
Fixes error being thrown when the post-import script path is empty. This was caused by an oversight in #96079 since is_relative_path doesn't appear to check if a path is actually empty, and will consider an empty path relative, pointing the post import script to its containing directory.