### PR TITLE
[3.x] Fix MSBuild logger exception thrown when processing a warning or an error with no associated file

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
@@ -88,7 +88,7 @@ namespace GodotTools.BuildLogger
 
             WriteLine(line);
 
-            string errorLine = $@"error,{e.File.CsvEscape()},{e.LineNumber},{e.ColumnNumber}," +
+            string errorLine = $@"error,{e.File?.CsvEscape() ?? string.Empty},{e.LineNumber},{e.ColumnNumber}," +
                                $"{e.Code?.CsvEscape() ?? string.Empty},{e.Message.CsvEscape()}," +
                                $"{e.ProjectFile?.CsvEscape() ?? string.Empty}";
             _issuesStreamWriter.WriteLine(errorLine);
@@ -103,7 +103,7 @@ namespace GodotTools.BuildLogger
 
             WriteLine(line);
 
-            string warningLine = $@"warning,{e.File.CsvEscape()},{e.LineNumber},{e.ColumnNumber}," +
+            string warningLine = $@"warning,{e.File?.CsvEscape() ?? string.Empty},{e.LineNumber},{e.ColumnNumber}," +
                                  $"{e.Code?.CsvEscape() ?? string.Empty},{e.Message.CsvEscape()}," +
                                  $"{e.ProjectFile?.CsvEscape() ?? string.Empty}";
             _issuesStreamWriter.WriteLine(warningLine);


### PR DESCRIPTION
I was trying to get [Fody](https://github.com/Fody/Home/) (specifically [PropertyChanged.Fody](https://github.com/Fody/PropertyChanged)) to work with my project. When the Fody package would throw an error or a warning the logger would encounter an exception and fail the build. Actually, the build would succeed, but editor would throw an error. Pressing build again would find that all files have been generated and launch the program normally. You can imagine how insane that made me feel.

The issue was that the warning/error parsing code did not account for the possibility of the `BuildErrorEventArgs.File` field being null. I also found that `BuildOutputView` would crash the entire editor when clicking on any entry without a related file, so I fixed that too (changing one `&&` to `||` did the trick). I couldn't get the debugger to work with the C# glue, so I added a few extra null-checks just in case there are other edge cases I missed.


Side note: In case someone finds this by googling `"Fody" + "Godot"`, the way I was able to get it to work was by enabling the addons inside a `<WeaverConfiguration><Weavers><Weavers /><WeaverConfiguration />` tag directly in the `.csproj` file. Don't bother with a `FodyWeavers.xml` file, it will only bring you confusion and pain. Also remember to set `PrivateAssets` to `all` for all NuGet packages (including Fody itself) like this:

```xml
<PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
  <PrivateAssets>all</PrivateAssets>
</PackageReference>
```