### PR TITLE
Fix incorrect parameters for layered textures in VRAM texture memory profiler

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1389,8 +1389,22 @@ void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
 		tinfo.format = t->format;
 		tinfo.width = t->alloc_width;
 		tinfo.height = t->alloc_height;
-		tinfo.depth = t->depth;
 		tinfo.bytes = t->total_data_size;
+
+		switch (t->type) {
+			case Texture::TYPE_3D:
+				tinfo.depth = t->depth;
+				break;
+
+			case Texture::TYPE_LAYERED:
+				tinfo.depth = t->layers;
+				break;
+
+			default:
+				tinfo.depth = 0;
+				break;
+		}
+
 		r_info->push_back(tinfo);
 	}
 }
@@ -1521,7 +1535,11 @@ void TextureStorage::_texture_set_data(RID p_texture, const Ref<Image> &p_image,
 		h = MAX(1, h >> 1);
 	}
 
-	texture->total_data_size = tsize;
+	if (texture->target == GL_TEXTURE_CUBE_MAP || texture->target == GL_TEXTURE_2D_ARRAY) {
+		texture->total_data_size = tsize * texture->layers;
+	} else {
+		texture->total_data_size = tsize;
+	}
 
 	texture->stored_cube_sides |= (1 << p_layer);
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1470,8 +1470,24 @@ void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
 		tinfo.format = t->format;
 		tinfo.width = t->width;
 		tinfo.height = t->height;
-		tinfo.depth = t->depth;
-		tinfo.bytes = Image::get_image_data_size(t->width, t->height, t->format, t->mipmaps);
+		tinfo.bytes = Image::get_image_data_size(t->width, t->height, t->format, t->mipmaps > 1);
+
+		switch (t->type) {
+			case TextureType::TYPE_3D:
+				tinfo.depth = t->depth;
+				tinfo.bytes *= t->depth;
+				break;
+
+			case TextureType::TYPE_LAYERED:
+				tinfo.depth = t->layers;
+				tinfo.bytes *= t->layers;
+				break;
+
+			default:
+				tinfo.depth = 0;
+				break;
+		}
+
 		r_info->push_back(tinfo);
 	}
 }

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -176,7 +176,7 @@ public:
 		uint32_t height;
 		uint32_t depth;
 		Image::Format format;
-		int bytes;
+		int64_t bytes;
 		String path;
 	};
 


### PR DESCRIPTION
The texture memory profiler used to incorrectly assume the texture's depth to also be its layer count, which caused invalid memory size estimations. Additionally, RD-based renderers would always assume a texture had mipmaps due to incorrect logic for checking their count.

Before:
![bb](https://github.com/user-attachments/assets/88be15b3-6cbd-4c68-84b3-f8358b357d65)

After:
![aa](https://github.com/user-attachments/assets/dfe7653d-a640-4be7-88f6-ac61beeebb1a)
