### PR TITLE
GLTF: Only create MeshInstance3D when needed

### DIFF
--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -52,24 +52,24 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 	while (!queue.is_empty()) {
 		List<Node *>::Element *E = queue.front();
 		Node *node = E->get();
-		ImporterMeshInstance3D *mesh_3d = cast_to<ImporterMeshInstance3D>(node);
-		if (mesh_3d) {
-			MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
-			Ref<ImporterMesh> mesh = mesh_3d->get_mesh();
+		ImporterMeshInstance3D *importer_mesh_3d = Object::cast_to<ImporterMeshInstance3D>(node);
+		if (importer_mesh_3d) {
+			Ref<ImporterMesh> mesh = importer_mesh_3d->get_mesh();
 			if (mesh.is_valid()) {
+				MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
 				Ref<ArrayMesh> array_mesh = mesh->get_mesh();
 				mesh_instance_node_3d->set_name(node->get_name());
-				mesh_instance_node_3d->set_transform(mesh_3d->get_transform());
+				mesh_instance_node_3d->set_transform(importer_mesh_3d->get_transform());
 				mesh_instance_node_3d->set_mesh(array_mesh);
-				mesh_instance_node_3d->set_skin(mesh_3d->get_skin());
-				mesh_instance_node_3d->set_skeleton_path(mesh_3d->get_skeleton_path());
+				mesh_instance_node_3d->set_skin(importer_mesh_3d->get_skin());
+				mesh_instance_node_3d->set_skeleton_path(importer_mesh_3d->get_skeleton_path());
 				node->replace_by(mesh_instance_node_3d);
-				_copy_meta(mesh_3d, mesh_instance_node_3d);
+				_copy_meta(importer_mesh_3d, mesh_instance_node_3d);
 				_copy_meta(mesh.ptr(), array_mesh.ptr());
 				delete_queue.push_back(node);
 				node = mesh_instance_node_3d;
 			} else {
-				memdelete(mesh_instance_node_3d);
+				WARN_PRINT("glTF: ImporterMeshInstance3D does not have a valid mesh. This should not happen. Continuing anyway.");
 			}
 		}
 		int child_count = node->get_child_count();


### PR DESCRIPTION
@fire pointed out this suboptimal code to me. Right now the code creates a MeshInstance3D, then checks if a mesh is available, and if not it deletes it. This is silly, there's no need to create and then delete when we can instead just move the creation inside of the if statement.

We expect that if an ImporterMeshInstance3D does not have a valid mesh, that the ImporterMeshInstance3D should not have been created in the first place, and there is a problem at some earlier stage of the import process. So I added a warning in the place that there used to be a memdelete.

Also, I renamed the `ImporterMeshInstance3D *mesh_3d` local variable to `importer_mesh_3d` for clarity.