### PR TITLE
`MovieWriter` extension support

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3348,14 +3348,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 			rendering_server->set_print_gpu_profile(true);
 		}
 
-		if (Engine::get_singleton()->get_write_movie_path() != String()) {
-			movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
-			if (movie_writer == nullptr) {
-				ERR_PRINT("Can't find movie writer for file type, aborting: " + Engine::get_singleton()->get_write_movie_path());
-				Engine::get_singleton()->set_write_movie_path(String());
-			}
-		}
-
 		OS::get_singleton()->benchmark_end_measure("Servers", "Rendering");
 	}
 
@@ -3579,6 +3571,16 @@ Error Main::setup2(bool p_show_boot_logo) {
 		GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
 
 		OS::get_singleton()->benchmark_end_measure("Scene", "Modules and Extensions");
+
+		// We need to initialize the movie writer here in case
+		// one of the user-provided GDExtensions subclasses MovieWriter.
+		if (Engine::get_singleton()->get_write_movie_path() != String()) {
+			movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
+			if (movie_writer == nullptr) {
+				ERR_PRINT("Can't find movie writer for file type, aborting: " + Engine::get_singleton()->get_write_movie_path());
+				Engine::get_singleton()->set_write_movie_path(String());
+			}
+		}
 	}
 
 	PackedStringArray extensions;


### PR DESCRIPTION
Fixes #96055 , MPR is fixed by this PR.

In `setup2` the setup sequence for the `MovieWriter` runs before any user provided subclasses of `MovieWriter` can be inserted into the lookup table. We can't instance `MovieWriter` prior to this point because, to my knowledge, it must be instanced during scene loading. Moving the writer directly after scene gdextension initialization fixes this, but I'm unsure if it's a clean solution or if the writer is selected directly after the render server is initialized for any specific reason. 