### PR TITLE
[macOS] Disable macOS window auto resizing logic when moving between the screens.

### DIFF
--- a/platform/macos/godot_window.mm
+++ b/platform/macos/godot_window.mm
@@ -79,4 +79,9 @@
 	return !wd.no_focus && !wd.is_popup;
 }
 
+- (id)_setFrame:(NSRect)rect fromAdjustmentToScreen:(NSScreen *)screen anchorIfNeeded:(void *)anchor animate:(int)animate {
+	// Override private NSWindow method to disable macOS window auto resizing logic when moving between the screens.
+	return nil;
+}
+
 @end


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95987, seems like OS bug, so I'm not sure if we should try to fix it at all,