### PR TITLE
Enable Metal for macOS x86_64.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -222,7 +222,7 @@ opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver on supported p
 opts.Add(BoolVariable("vulkan", "Enable the vulkan rendering driver", True))
 opts.Add(BoolVariable("opengl3", "Enable the OpenGL/GLES3 rendering driver", True))
 opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver on supported platforms", False))
-opts.Add(BoolVariable("metal", "Enable the Metal rendering driver on supported platforms (Apple arm64 only)", False))
+opts.Add(BoolVariable("metal", "Enable the Metal rendering driver on supported platforms (Apple arm64/x86_64)", False))
 opts.Add(BoolVariable("openxr", "Enable the OpenXR driver", True))
 opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
 opts.Add(BoolVariable("disable_exceptions", "Force disabling exception handling code", True))

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -30,6 +30,10 @@
 
 #import "rendering_context_driver_metal.h"
 
+#if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000)
+#define MTLGPUFamilyMetal3 (MTLGPUFamily)5001
+#endif
+
 @protocol MTLDeviceEx <MTLDevice>
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED < 130300
 - (void)setShouldMaximizeConcurrentCompilation:(BOOL)v;
@@ -54,8 +58,11 @@ Error RenderingContextDriverMetal::initialize() {
 	device.workarounds = Workarounds();
 
 	MetalDeviceProperties props(metal_device);
-	int version = (int)props.features.highestFamily - (int)MTLGPUFamilyApple1 + 1;
-	device.name = vformat("%s (Apple%d)", metal_device.name.UTF8String, version);
+	if (props.features.highestFamily == MTLGPUFamilyMetal3) {
+		device.name = vformat("%s (Metal3)", metal_device.name.UTF8String);
+	} else {
+		device.name = vformat("%s (Apple%d)", metal_device.name.UTF8String, (int)props.features.highestFamily - (int)MTLGPUFamilyApple1 + 1);
+	}
 
 	return OK;
 }

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -240,10 +240,6 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 
-    if env["metal"] and env["arch"] != "arm64":
-        # Only supported on arm64, so skip it for x86_64 builds.
-        env["metal"] = False
-
     extra_frameworks = set()
 
     if env["metal"]:


### PR DESCRIPTION
This PR enables Metal for macOS x86_64.

Additionally, `rendering_context_driver_metal.mm` now logs the actual Metal GPU family, as the previously computed value was incorrect.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
