### PR TITLE
Fix missing project date showing the unix epoch

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -760,7 +760,7 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->set_tags(item.tags, this);
 	hb->set_unsupported_features(item.unsupported_features.duplicate());
 	hb->set_project_version(item.project_version);
-	hb->set_last_edited_info(Time::get_singleton()->get_datetime_string_from_unix_time(item.last_edited, true));
+	hb->set_last_edited_info(!item.missing ? Time::get_singleton()->get_datetime_string_from_unix_time(item.last_edited, true) : TTR("Missing Date"));
 
 	hb->set_is_favorite(item.favorite);
 	hb->set_is_missing(item.missing);


### PR DESCRIPTION
Before:

![m](https://github.com/user-attachments/assets/74de3ab3-1988-44bd-9630-3b60692f2f38)

After:

![p](https://github.com/user-attachments/assets/fb9a6998-85c0-4599-902e-4ad342c0d7af)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/96274*