### PR TITLE
Fix Connect Signal Dialog control alignment

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -486,11 +486,6 @@ void ConnectDialog::_notification(int p_what) {
 				type_list->set_item_icon(i, get_editor_theme_icon(type_name));
 			}
 
-			Ref<StyleBox> style = get_theme_stylebox(CoreStringName(normal), "LineEdit")->duplicate();
-			if (style.is_valid()) {
-				style->set_content_margin(SIDE_TOP, style->get_content_margin(SIDE_TOP) + 1.0);
-				from_signal->add_theme_style_override(CoreStringName(normal), style);
-			}
 			method_search->set_right_icon(get_editor_theme_icon("Search"));
 			open_method_tree->set_icon(get_editor_theme_icon("Edit"));
 		} break;

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -865,7 +865,6 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		// CheckBox.
 		{
 			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
-			checkbox_style->set_content_margin_individual((p_config.increased_margin + 2) * EDSCALE, p_config.base_margin * EDSCALE, (p_config.increased_margin + 2) * EDSCALE, p_config.base_margin * EDSCALE);
 
 			p_theme->set_stylebox(CoreStringName(normal), "CheckBox", checkbox_style);
 			p_theme->set_stylebox(SceneStringName(pressed), "CheckBox", checkbox_style);
@@ -1165,9 +1164,6 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 	// LineEdit & TextEdit.
 	{
 		Ref<StyleBoxFlat> text_editor_style = p_config.button_style->duplicate();
-		// The original button_style style has an extra 1 pixel offset that makes LineEdits not align with Buttons,
-		// so this compensates for that.
-		text_editor_style->set_content_margin(SIDE_TOP, text_editor_style->get_content_margin(SIDE_TOP) - 1 * EDSCALE);
 
 		// Don't round the bottom corners to make the line look sharper.
 		text_editor_style->set_corner_radius(CORNER_BOTTOM_LEFT, 0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/96163

## First problem
First problem was that CheckButton and CheckBox didn't have same height. 
To solve this I changed CheckBox to use same stylebox as CheckButton, as it uses same margins as Button.  
Do you think this is the correct way or should CheckButton height be same as the current CheckBox, or add a style override for this dialog to the CheckBox?

## Second problem
Problem two was that LineEdit changed height in some situations. 
Believe it has to do if it had a Button in same row or not (This was true in other places too, if it has no "partner" height is 29 else 30).

Example:
![image](https://github.com/user-attachments/assets/1f535d26-faa2-42c6-b149-1b67f8cb0147)
![image](https://github.com/user-attachments/assets/04f7b01f-c796-47d5-b28f-6233d5ffeb29)


To fix this I removed -1 from LineEdit and TextEdit top margin.

```
// The original button_style style has an extra 1 pixel offset that makes LineEdits not align with Buttons,
// so this compensates for that.
```
Could not find any problems in other places after removing the -1 from top margin (maybe something has changed since then?), appreciate if anyone else can take a look too. There was however an extra +1 to the top margin of from_signal (top left LineEdit) in the connect signal dialog that made it 1px to big after removing -1 from the theme. So the +1 was also removed.

## Result

Before:
![csd_sizes](https://github.com/user-attachments/assets/30dfe429-33cb-4f8a-852d-d0931826698e)

After:
![csd_after](https://github.com/user-attachments/assets/06a2d7cd-f713-41cc-9589-42f534d399d0)


### Compact

Before:
![csd_compact_before](https://github.com/user-attachments/assets/3e9aab65-32aa-4a79-8375-703baebdaa07)

After:
![csd_compact_after](https://github.com/user-attachments/assets/57832fb3-5e0a-4d8a-9e54-286fbc769278)