### PR TITLE
Use `MutexLock` in more places

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -144,9 +144,8 @@ void RemoteDebuggerPeerTCP::_read_in() {
 			Error err = decode_variant(var, buf, in_pos, &read);
 			ERR_CONTINUE(read != in_pos || err != OK);
 			ERR_CONTINUE_MSG(var.get_type() != Variant::ARRAY, "Malformed packet received, not an Array.");
-			mutex.lock();
+			MutexLock lock(mutex);
 			in_queue.push_back(var);
-			mutex.unlock();
 		}
 	}
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1904,7 +1904,7 @@ void Object::set_instance_binding(void *p_token, void *p_binding, const GDExtens
 
 void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
 	void *binding = nullptr;
-	_instance_binding_mutex.lock();
+	MutexLock instance_binding_lock(_instance_binding_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (_instance_bindings[i].token == p_token) {
 			binding = _instance_bindings[i].binding;
@@ -1935,14 +1935,12 @@ void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindi
 		_instance_binding_count++;
 	}
 
-	_instance_binding_mutex.unlock();
-
 	return binding;
 }
 
 bool Object::has_instance_binding(void *p_token) {
 	bool found = false;
-	_instance_binding_mutex.lock();
+	MutexLock instance_binding_lock(_instance_binding_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (_instance_bindings[i].token == p_token) {
 			found = true;
@@ -1950,14 +1948,12 @@ bool Object::has_instance_binding(void *p_token) {
 		}
 	}
 
-	_instance_binding_mutex.unlock();
-
 	return found;
 }
 
 void Object::free_instance_binding(void *p_token) {
 	bool found = false;
-	_instance_binding_mutex.lock();
+	MutexLock instance_binding_lock(_instance_binding_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (!found && _instance_bindings[i].token == p_token) {
 			if (_instance_bindings[i].free_callback) {
@@ -1976,7 +1972,6 @@ void Object::free_instance_binding(void *p_token) {
 	if (found) {
 		_instance_binding_count--;
 	}
-	_instance_binding_mutex.unlock();
 }
 
 #ifdef TOOLS_ENABLED

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -667,7 +667,7 @@ protected:
 	_FORCE_INLINE_ bool _instance_binding_reference(bool p_reference) {
 		bool can_die = true;
 		if (_instance_bindings) {
-			_instance_binding_mutex.lock();
+			MutexLock instance_binding_lock(_instance_binding_mutex);
 			for (uint32_t i = 0; i < _instance_binding_count; i++) {
 				if (_instance_bindings[i].reference_callback) {
 					if (!_instance_bindings[i].reference_callback(_instance_bindings[i].token, _instance_bindings[i].binding, p_reference)) {
@@ -675,7 +675,6 @@ protected:
 					}
 				}
 			}
-			_instance_binding_mutex.unlock();
 		}
 		return can_die;
 	}

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -191,11 +191,10 @@ StringName::StringName(const StringName &p_name) {
 }
 
 void StringName::assign_static_unique_class_name(StringName *ptr, const char *p_name) {
-	mutex.lock();
+	MutexLock lock(mutex);
 	if (*ptr == StringName()) {
 		*ptr = StringName(p_name, true);
 	}
-	mutex.unlock();
 }
 
 StringName::StringName(const char *p_name, bool p_static) {

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1855,25 +1855,26 @@ void EditorFileSystem::_update_script_classes() {
 		return;
 	}
 
-	update_script_mutex.lock();
+	{
+		MutexLock update_script_lock(update_script_mutex);
 
-	EditorProgress *ep = nullptr;
-	if (update_script_paths.size() > 1) {
-		ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size()));
-	}
-
-	int step_count = 0;
-	for (const KeyValue<String, ScriptInfo> &E : update_script_paths) {
-		_register_global_class_script(E.key, E.key, E.value.type, E.value.script_class_name, E.value.script_class_extends, E.value.script_class_icon_path);
-		if (ep) {
-			ep->step(E.value.script_class_name, step_count++, false);
+		EditorProgress *ep = nullptr;
+		if (update_script_paths.size() > 1) {
+			ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size()));
 		}
+
+		int step_count = 0;
+		for (const KeyValue<String, ScriptInfo> &E : update_script_paths) {
+			_register_global_class_script(E.key, E.key, E.value.type, E.value.script_class_name, E.value.script_class_extends, E.value.script_class_icon_path);
+			if (ep) {
+				ep->step(E.value.script_class_name, step_count++, false);
+			}
+		}
+
+		memdelete_notnull(ep);
+
+		update_script_paths.clear();
 	}
-
-	memdelete_notnull(ep);
-
-	update_script_paths.clear();
-	update_script_mutex.unlock();
 
 	ScriptServer::save_global_classes();
 	EditorNode::get_editor_data().script_class_save_icon_paths();
@@ -1894,7 +1895,7 @@ void EditorFileSystem::_update_script_documentation() {
 		return;
 	}
 
-	update_script_mutex.lock();
+	MutexLock update_script_lock(update_script_mutex);
 
 	EditorProgress *ep = nullptr;
 	if (update_script_paths_documentation.size() > 1) {
@@ -1933,7 +1934,6 @@ void EditorFileSystem::_update_script_documentation() {
 	memdelete_notnull(ep);
 
 	update_script_paths_documentation.clear();
-	update_script_mutex.unlock();
 }
 
 void EditorFileSystem::_process_update_pending() {
@@ -1945,7 +1945,7 @@ void EditorFileSystem::_process_update_pending() {
 }
 
 void EditorFileSystem::_queue_update_script_class(const String &p_path, const String &p_type, const String &p_script_class_name, const String &p_script_class_extends, const String &p_script_class_icon_path) {
-	update_script_mutex.lock();
+	MutexLock update_script_lock(update_script_mutex);
 
 	ScriptInfo si;
 	si.type = p_type;
@@ -1955,8 +1955,6 @@ void EditorFileSystem::_queue_update_script_class(const String &p_path, const St
 	update_script_paths.insert(p_path, si);
 
 	update_script_paths_documentation.insert(p_path);
-
-	update_script_mutex.unlock();
 }
 
 void EditorFileSystem::_update_scene_groups() {
@@ -1970,31 +1968,32 @@ void EditorFileSystem::_update_scene_groups() {
 	}
 	int step_count = 0;
 
-	update_scene_mutex.lock();
-	for (const String &path : update_scene_paths) {
-		ProjectSettings::get_singleton()->remove_scene_groups_cache(path);
+	{
+		MutexLock update_scene_lock(update_scene_mutex);
+		for (const String &path : update_scene_paths) {
+			ProjectSettings::get_singleton()->remove_scene_groups_cache(path);
 
-		int index = -1;
-		EditorFileSystemDirectory *efd = find_file(path, &index);
+			int index = -1;
+			EditorFileSystemDirectory *efd = find_file(path, &index);
 
-		if (!efd || index < 0) {
-			// The file was removed.
-			continue;
+			if (!efd || index < 0) {
+				// The file was removed.
+				continue;
+			}
+
+			const HashSet<StringName> scene_groups = PackedScene::get_scene_groups(path);
+			if (!scene_groups.is_empty()) {
+				ProjectSettings::get_singleton()->add_scene_groups_cache(path, scene_groups);
+			}
+
+			if (ep) {
+				ep->step(efd->files[index]->file, step_count++, false);
+			}
 		}
 
-		const HashSet<StringName> scene_groups = PackedScene::get_scene_groups(path);
-		if (!scene_groups.is_empty()) {
-			ProjectSettings::get_singleton()->add_scene_groups_cache(path, scene_groups);
-		}
-
-		if (ep) {
-			ep->step(efd->files[index]->file, step_count++, false);
-		}
+		memdelete_notnull(ep);
+		update_scene_paths.clear();
 	}
-
-	memdelete_notnull(ep);
-	update_scene_paths.clear();
-	update_scene_mutex.unlock();
 
 	ProjectSettings::get_singleton()->save_scene_groups_cache();
 }
@@ -2009,9 +2008,8 @@ void EditorFileSystem::_update_pending_scene_groups() {
 }
 
 void EditorFileSystem::_queue_update_scene_groups(const String &p_path) {
-	update_scene_mutex.lock();
+	MutexLock update_scene_lock(update_scene_mutex);
 	update_scene_paths.insert(p_path);
-	update_scene_mutex.unlock();
 }
 
 void EditorFileSystem::_get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet<String> &r_list) {

--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -87,57 +87,55 @@ void NavMeshGenerator2D::sync() {
 		return;
 	}
 
-	baking_navmesh_mutex.lock();
-	generator_task_mutex.lock();
+	MutexLock baking_navmesh_lock(baking_navmesh_mutex);
+	{
+		MutexLock generator_task_lock(generator_task_mutex);
 
-	LocalVector<WorkerThreadPool::TaskID> finished_task_ids;
+		LocalVector<WorkerThreadPool::TaskID> finished_task_ids;
 
-	for (KeyValue<WorkerThreadPool::TaskID, NavMeshGeneratorTask2D *> &E : generator_tasks) {
-		if (WorkerThreadPool::get_singleton()->is_task_completed(E.key)) {
-			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
-			finished_task_ids.push_back(E.key);
+		for (KeyValue<WorkerThreadPool::TaskID, NavMeshGeneratorTask2D *> &E : generator_tasks) {
+			if (WorkerThreadPool::get_singleton()->is_task_completed(E.key)) {
+				WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+				finished_task_ids.push_back(E.key);
 
-			NavMeshGeneratorTask2D *generator_task = E.value;
-			DEV_ASSERT(generator_task->status == NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
+				NavMeshGeneratorTask2D *generator_task = E.value;
+				DEV_ASSERT(generator_task->status == NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
 
-			baking_navmeshes.erase(generator_task->navigation_mesh);
-			if (generator_task->callback.is_valid()) {
-				generator_emit_callback(generator_task->callback);
+				baking_navmeshes.erase(generator_task->navigation_mesh);
+				if (generator_task->callback.is_valid()) {
+					generator_emit_callback(generator_task->callback);
+				}
+				memdelete(generator_task);
 			}
-			memdelete(generator_task);
+		}
+
+		for (WorkerThreadPool::TaskID finished_task_id : finished_task_ids) {
+			generator_tasks.erase(finished_task_id);
 		}
 	}
-
-	for (WorkerThreadPool::TaskID finished_task_id : finished_task_ids) {
-		generator_tasks.erase(finished_task_id);
-	}
-
-	generator_task_mutex.unlock();
-	baking_navmesh_mutex.unlock();
 }
 
 void NavMeshGenerator2D::cleanup() {
-	baking_navmesh_mutex.lock();
-	generator_task_mutex.lock();
+	MutexLock baking_navmesh_lock(baking_navmesh_mutex);
+	{
+		MutexLock generator_task_lock(generator_task_mutex);
 
-	baking_navmeshes.clear();
+		baking_navmeshes.clear();
 
-	for (KeyValue<WorkerThreadPool::TaskID, NavMeshGeneratorTask2D *> &E : generator_tasks) {
-		WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
-		NavMeshGeneratorTask2D *generator_task = E.value;
-		memdelete(generator_task);
+		for (KeyValue<WorkerThreadPool::TaskID, NavMeshGeneratorTask2D *> &E : generator_tasks) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+			NavMeshGeneratorTask2D *generator_task = E.value;
+			memdelete(generator_task);
+		}
+		generator_tasks.clear();
+
+		generator_rid_rwlock.write_lock();
+		for (NavMeshGeometryParser2D *parser : generator_parsers) {
+			generator_parser_owner.free(parser->self);
+		}
+		generator_parsers.clear();
+		generator_rid_rwlock.write_unlock();
 	}
-	generator_tasks.clear();
-
-	generator_rid_rwlock.write_lock();
-	for (NavMeshGeometryParser2D *parser : generator_parsers) {
-		generator_parser_owner.free(parser->self);
-	}
-	generator_parsers.clear();
-	generator_rid_rwlock.write_unlock();
-
-	generator_task_mutex.unlock();
-	baking_navmesh_mutex.unlock();
 }
 
 void NavMeshGenerator2D::finish() {
@@ -212,7 +210,7 @@ void NavMeshGenerator2D::bake_from_source_geometry_data_async(Ref<NavigationPoly
 	baking_navmeshes.insert(p_navigation_mesh);
 	baking_navmesh_mutex.unlock();
 
-	generator_task_mutex.lock();
+	MutexLock generator_task_lock(generator_task_mutex);
 	NavMeshGeneratorTask2D *generator_task = memnew(NavMeshGeneratorTask2D);
 	generator_task->navigation_mesh = p_navigation_mesh;
 	generator_task->source_geometry_data = p_source_geometry_data;
@@ -220,14 +218,11 @@ void NavMeshGenerator2D::bake_from_source_geometry_data_async(Ref<NavigationPoly
 	generator_task->status = NavMeshGeneratorTask2D::TaskStatus::BAKING_STARTED;
 	generator_task->thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMeshGenerator2D::generator_thread_bake, generator_task, NavMeshGenerator2D::baking_use_high_priority_threads, "NavMeshGeneratorBake2D");
 	generator_tasks.insert(generator_task->thread_task_id, generator_task);
-	generator_task_mutex.unlock();
 }
 
 bool NavMeshGenerator2D::is_baking(Ref<NavigationPolygon> p_navigation_polygon) {
-	baking_navmesh_mutex.lock();
-	bool baking = baking_navmeshes.has(p_navigation_polygon);
-	baking_navmesh_mutex.unlock();
-	return baking;
+	MutexLock baking_navmesh_lock(baking_navmesh_mutex);
+	return baking_navmeshes.has(p_navigation_polygon);
 }
 
 void NavMeshGenerator2D::generator_thread_bake(void *p_arg) {

--- a/scene/resources/3d/fog_material.cpp
+++ b/scene/resources/3d/fog_material.cpp
@@ -138,7 +138,7 @@ void FogMaterial::cleanup_shader() {
 }
 
 void FogMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock shader_lock(shader_mutex);
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
@@ -165,7 +165,6 @@ void fog() {
 }
 )");
 	}
-	shader_mutex.unlock();
 }
 
 FogMaterial::FogMaterial() {

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -269,7 +269,7 @@ void ProceduralSkyMaterial::cleanup_shader() {
 }
 
 void ProceduralSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock shader_lock(shader_mutex);
 	if (shader_cache[0].is_null()) {
 		for (int i = 0; i < 2; i++) {
 			shader_cache[i] = RS::get_singleton()->shader_create();
@@ -354,7 +354,6 @@ void sky() {
 																		  i ? "render_mode use_debanding;" : ""));
 		}
 	}
-	shader_mutex.unlock();
 }
 
 ProceduralSkyMaterial::ProceduralSkyMaterial() {
@@ -463,7 +462,7 @@ void PanoramaSkyMaterial::cleanup_shader() {
 }
 
 void PanoramaSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock shader_lock(shader_mutex);
 	if (shader_cache[0].is_null()) {
 		for (int i = 0; i < 2; i++) {
 			shader_cache[i] = RS::get_singleton()->shader_create();
@@ -484,8 +483,6 @@ void sky() {
 																		  i ? "filter_linear" : "filter_nearest"));
 		}
 	}
-
-	shader_mutex.unlock();
 }
 
 PanoramaSkyMaterial::PanoramaSkyMaterial() {
@@ -692,7 +689,7 @@ void PhysicalSkyMaterial::cleanup_shader() {
 }
 
 void PhysicalSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock shader_lock(shader_mutex);
 	if (shader_cache[0].is_null()) {
 		for (int i = 0; i < 2; i++) {
 			shader_cache[i] = RS::get_singleton()->shader_create();
@@ -785,8 +782,6 @@ void sky() {
 																		  i ? "render_mode use_debanding;" : ""));
 		}
 	}
-
-	shader_mutex.unlock();
 }
 
 PhysicalSkyMaterial::PhysicalSkyMaterial() {


### PR DESCRIPTION
This ensures more safe management of mutexes and makes forgetting to unlock it less likely, most of these cases are trivial though and don't depend on it for safety but I'd prefer to avoid using direct locking unless it's necessary to handle locking between methods etc. or in some cases where using it is just too cluttered

There are some cases which could benefit from a little more of this using the new `temp_unlock/relock` methods of `MutexLock` but kept things simple here
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
