### PR TITLE
Remove confusing USER prefix from script-logged errors

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -84,11 +84,7 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 		err_details = p_code;
 	}
 
-	if (p_editor_notify) {
-		logf_error("%s: %s\n", err_type, err_details);
-	} else {
-		logf_error("USER %s: %s\n", err_type, err_details);
-	}
+	logf_error("%s: %s\n", err_type, err_details);
 	logf_error("   at: %s (%s:%i)\n", p_function, p_file, p_line);
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -52,10 +52,6 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
 	}
 
-	if (p_editor_notify) {
-		err_str += " (User)";
-	}
-
 	MessageType message_type = p_type == ERR_HANDLER_WARNING ? MSG_TYPE_WARNING : MSG_TYPE_ERROR;
 
 	if (!Thread::is_main_thread()) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -166,15 +166,9 @@ void OS_Windows::initialize_debugging() {
 static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = String::utf8(p_errorexp);
+		err_str = String::utf8(p_errorexp) + "\n";
 	} else {
-		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
-	}
-
-	if (p_editor_notify) {
-		err_str += " (User)\n";
-	} else {
-		err_str += "\n";
+		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error) + "\n";
 	}
 
 	OutputDebugStringW((LPCWSTR)err_str.utf16().ptr());


### PR DESCRIPTION
Removes the USER prefix prepended by certain logging functions when pushing an error manually from scripts, as per discussion in #96086. This prefix was only present in some places, and could be confusing as to the actual source of the error.

Fixes #96086 