### PR TITLE
Consider search keywords in `CreateDialog`

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -46,6 +46,11 @@ class CreateDialog : public ConfirmationDialog {
 		OTHER_TYPE
 	};
 
+	struct TypeInfo {
+		StringName type_name;
+		PackedStringArray search_keywords;
+	};
+
 	LineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 
@@ -63,14 +68,14 @@ class CreateDialog : public ConfirmationDialog {
 	HashMap<String, TreeItem *> search_options_types;
 	HashMap<String, String> custom_type_parents;
 	HashMap<String, int> custom_type_indices;
-	List<StringName> type_list;
+	List<TypeInfo> type_info_list;
 	HashSet<StringName> type_blacklist;
 	HashSet<StringName> custom_type_blocklist;
 
 	void _update_search();
 	bool _should_hide_type(const StringName &p_type) const;
-	void _add_type(const StringName &p_type, TypeCategory p_type_category);
-	void _configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category);
+	void _add_type(const StringName &p_type, TypeCategory p_type_category, const String &p_match_keyword);
+	void _configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category, const String &p_match_keyword);
 	float _score_type(const String &p_type, const String &p_search) const;
 	bool _is_type_preferred(const String &p_type) const;
 	void _script_button_clicked(TreeItem *p_item, int p_column, int p_button_id, MouseButton p_mouse_button_index);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/10573

Uses the search keywords defined on the class in order to improve search.

This works for any uses of the `CreateDialog`, such as adding a new node or creating a new resource file.

![image](https://github.com/user-attachments/assets/38af3439-7d59-499d-947f-4d9f468b3196)

Similar to the docs search (F1), it only shows the suffix text if the name did not match the search text.

There is a weird bug when you search for whitespace, but this also was the case in 4.3 so unrelated to these changes.