### PR TITLE
Core: Fix unreachable code

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -712,8 +712,9 @@ Variant PlaceHolderScriptInstance::callp(const StringName &p_method, const Varia
 	} else {
 		return String("Attempt to call a method on a placeholder instance. Probably a bug, please report.");
 	}
-#endif
+#else
 	return Variant();
+#endif // TOOLS_ENABLED
 }
 
 void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, const HashMap<StringName, Variant> &p_values) {


### PR DESCRIPTION
Fixes a regression introduced by #94511 which made a section of unreachable code, causing build failure on MSVC w/ warnings-as-errors + extra warnings enabled