### PR TITLE
[macOS] Change breakpoint shortcuts to avoid conflicts

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2545,8 +2545,9 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT_OVERRIDE("script_text_editor/toggle_breakpoint", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);
 
 	ED_SHORTCUT("script_text_editor/remove_all_breakpoints", TTR("Remove All Breakpoints"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::F9);
-	ED_SHORTCUT("script_text_editor/goto_next_breakpoint", TTR("Go to Next Breakpoint"), KeyModifierMask::CMD_OR_CTRL | Key::PERIOD);
-	ED_SHORTCUT("script_text_editor/goto_previous_breakpoint", TTR("Go to Previous Breakpoint"), KeyModifierMask::CMD_OR_CTRL | Key::COMMA);
+	// Using Control for these shortcuts even on macOS because Command+Comma is taken for opening Editor Settings.
+	ED_SHORTCUT("script_text_editor/goto_next_breakpoint", TTR("Go to Next Breakpoint"), KeyModifierMask::CTRL | Key::PERIOD);
+	ED_SHORTCUT("script_text_editor/goto_previous_breakpoint", TTR("Go to Previous Breakpoint"), KeyModifierMask::CTRL | Key::COMMA);
 
 	ScriptEditor::register_create_script_editor_function(create_editor);
 }


### PR DESCRIPTION
Fixes this issue:

https://github.com/godotengine/godot/issues/23548#issuecomment-669946038

Changes:

- Go To Previous Breakpoint: `Command+Comma` -> `Control+Comma`
- Go To Next Breakpoint: `Command+Period` -> `Control+Period`

Making `Command+Comma` work reliably for Settings is important because it's the standard shortcut to open them in all macOS apps. Using Ctrl for the breakpoint shortcuts seems like the best option because that's how these kinds of cross-platform conflicts are usually handled (i.e in Godot [Ctrl+R is used to restart particle emission](https://github.com/godotengine/godot/pull/93581)) 

Edit: Also added a comment like in https://github.com/godotengine/godot/pull/93581 explaining that not using Command on mac is intentional