### PR TITLE
OpenXR: Support composition layers based on Android surfaces

### DIFF
--- a/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_android_surface">
+			<return type="JavaObject" />
+			<description>
+				Returns a [JavaObject] representing an [code]android.view.Surface[/code] if [member use_android_surface] is enabled and OpenXR has created the surface. Otherwise, this will return [code]null[/code].
+				[b]Note:[/b] The surface can only be created during an active OpenXR session. So, if [member use_android_surface] is enabled outside of an OpenXR session, it won't be created until a new session fully starts.
+			</description>
+		</method>
 		<method name="intersects_ray" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="origin" type="Vector3" />
@@ -32,6 +39,9 @@
 			Enables the blending the layer using its alpha channel.
 			Can be combined with [member Viewport.transparent_bg] to give the layer a transparent background.
 		</member>
+		<member name="android_surface_size" type="Vector2i" setter="set_android_surface_size" getter="get_android_surface_size" default="Vector2i(1024, 1024)">
+			The size of the Android surface to create if [member use_android_surface] is enabled.
+		</member>
 		<member name="enable_hole_punch" type="bool" setter="set_enable_hole_punch" getter="get_enable_hole_punch" default="false">
 			Enables a technique called "hole punching", which allows putting the composition layer behind the main projection layer (i.e. setting [member sort_order] to a negative value) while "punching a hole" through everything rendered by Godot so that the layer is still visible.
 			This can be used to create the illusion that the composition layer exists in the same 3D space as everything rendered by Godot, allowing objects to appear to pass both behind or in front of the composition layer.
@@ -42,6 +52,11 @@
 		<member name="sort_order" type="int" setter="set_sort_order" getter="get_sort_order" default="1">
 			The sort order for this composition layer. Higher numbers will be shown in front of lower numbers.
 			[b]Note:[/b] This will have no effect if a fallback mesh is being used.
+		</member>
+		<member name="use_android_surface" type="bool" setter="set_use_android_surface" getter="get_use_android_surface" default="false">
+			If enabled, an Android surface will be created (with the dimensions from [member android_surface_size]) which will provide the 2D content for the composition layer, rather than using [member layer_viewport].
+			See [method get_android_surface] for information about how to get the surface so that your application can draw to it.
+			[b]Note:[/b] This will only work in Android builds.
 		</member>
 	</members>
 </class>

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -35,6 +35,7 @@
 
 #include "scene/3d/node_3d.h"
 
+class JavaObject;
 class MeshInstance3D;
 class Mesh;
 class OpenXRAPI;
@@ -45,7 +46,12 @@ class SubViewport;
 class OpenXRCompositionLayer : public Node3D {
 	GDCLASS(OpenXRCompositionLayer, Node3D);
 
+	XrCompositionLayerBaseHeader *composition_layer_base_header = nullptr;
+	OpenXRViewportCompositionLayerProvider *openxr_layer_provider = nullptr;
+
 	SubViewport *layer_viewport = nullptr;
+	bool use_android_surface = false;
+	Size2i android_surface_size = Size2i(1024, 1024);
 	bool enable_hole_punch = false;
 	MeshInstance3D *fallback = nullptr;
 	bool should_update_fallback_mesh = false;
@@ -58,10 +64,12 @@ class OpenXRCompositionLayer : public Node3D {
 	void _reset_fallback_material();
 	void _remove_fallback_node();
 
+	void _setup_composition_layer_provider();
+	void _clear_composition_layer_provider();
+
 protected:
 	OpenXRAPI *openxr_api = nullptr;
 	OpenXRCompositionLayerExtension *composition_layer_extension = nullptr;
-	OpenXRViewportCompositionLayerProvider *openxr_layer_provider = nullptr;
 
 	static void _bind_methods();
 
@@ -69,6 +77,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_property_list) const;
 	bool _get(const StringName &p_property, Variant &r_value) const;
 	bool _set(const StringName &p_property, const Variant &p_value);
+	void _validate_property(PropertyInfo &p_property) const;
 
 	virtual void _on_openxr_session_begun();
 	virtual void _on_openxr_session_stopping();
@@ -82,9 +91,17 @@ protected:
 	static Vector<OpenXRCompositionLayer *> composition_layer_nodes;
 	bool is_viewport_in_use(SubViewport *p_viewport);
 
+	OpenXRCompositionLayer(XrCompositionLayerBaseHeader *p_composition_layer);
+
 public:
 	void set_layer_viewport(SubViewport *p_viewport);
 	SubViewport *get_layer_viewport() const;
+
+	void set_use_android_surface(bool p_use_android_surface);
+	bool get_use_android_surface() const;
+
+	void set_android_surface_size(Size2i p_size);
+	Size2i get_android_surface_size() const;
 
 	void set_enable_hole_punch(bool p_enable);
 	bool get_enable_hole_punch() const;
@@ -95,13 +112,13 @@ public:
 	void set_alpha_blend(bool p_alpha_blend);
 	bool get_alpha_blend() const;
 
+	Ref<JavaObject> get_android_surface();
 	bool is_natively_supported() const;
 
 	virtual PackedStringArray get_configuration_warnings() const override;
 
 	virtual Vector2 intersects_ray(const Vector3 &p_origin, const Vector3 &p_direction) const;
 
-	OpenXRCompositionLayer();
 	~OpenXRCompositionLayer();
 };
 

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
@@ -38,20 +38,8 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/mesh.h"
 
-OpenXRCompositionLayerCylinder::OpenXRCompositionLayerCylinder() {
-	composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		radius, // radius
-		central_angle, // centralAngle
-		aspect_ratio, // aspectRatio
-	};
-	openxr_layer_provider = memnew(OpenXRViewportCompositionLayerProvider((XrCompositionLayerBaseHeader *)&composition_layer));
+OpenXRCompositionLayerCylinder::OpenXRCompositionLayerCylinder() :
+		OpenXRCompositionLayer((XrCompositionLayerBaseHeader *)&composition_layer) {
 	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRCompositionLayerCylinder::update_transform));
 }
 

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.h
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.h
@@ -38,7 +38,18 @@
 class OpenXRCompositionLayerCylinder : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerCylinder, OpenXRCompositionLayer);
 
-	XrCompositionLayerCylinderKHR composition_layer;
+	XrCompositionLayerCylinderKHR composition_layer = {
+		XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR, // type
+		nullptr, // next
+		0, // layerFlags
+		XR_NULL_HANDLE, // space
+		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
+		{}, // subImage
+		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
+		1.0, // radius
+		Math_PI / 2.0, // centralAngle
+		1.0, // aspectRatio
+	};
 
 	float radius = 1.0;
 	float aspect_ratio = 1.0;

--- a/modules/openxr/scene/openxr_composition_layer_equirect.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.cpp
@@ -38,21 +38,8 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/mesh.h"
 
-OpenXRCompositionLayerEquirect::OpenXRCompositionLayerEquirect() {
-	composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		radius, // radius
-		central_horizontal_angle, // centralHorizontalAngle
-		upper_vertical_angle, // upperVerticalAngle
-		-lower_vertical_angle, // lowerVerticalAngle
-	};
-	openxr_layer_provider = memnew(OpenXRViewportCompositionLayerProvider((XrCompositionLayerBaseHeader *)&composition_layer));
+OpenXRCompositionLayerEquirect::OpenXRCompositionLayerEquirect() :
+		OpenXRCompositionLayer((XrCompositionLayerBaseHeader *)&composition_layer) {
 	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRCompositionLayerEquirect::update_transform));
 }
 

--- a/modules/openxr/scene/openxr_composition_layer_equirect.h
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.h
@@ -38,7 +38,19 @@
 class OpenXRCompositionLayerEquirect : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerEquirect, OpenXRCompositionLayer);
 
-	XrCompositionLayerEquirect2KHR composition_layer;
+	XrCompositionLayerEquirect2KHR composition_layer = {
+		XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR, // type
+		nullptr, // next
+		0, // layerFlags
+		XR_NULL_HANDLE, // space
+		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
+		{}, // subImage
+		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
+		1.0, // radius
+		Math_PI / 2.0, // centralHorizontalAngle
+		Math_PI / 4.0, // upperVerticalAngle
+		-Math_PI / 4.0, // lowerVerticalAngle
+	};
 
 	float radius = 1.0;
 	float central_horizontal_angle = Math_PI / 2.0;

--- a/modules/openxr/scene/openxr_composition_layer_quad.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_quad.cpp
@@ -38,18 +38,8 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/3d/primitive_meshes.h"
 
-OpenXRCompositionLayerQuad::OpenXRCompositionLayerQuad() {
-	composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_QUAD, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		{ (float)quad_size.x, (float)quad_size.y }, // size
-	};
-	openxr_layer_provider = memnew(OpenXRViewportCompositionLayerProvider((XrCompositionLayerBaseHeader *)&composition_layer));
+OpenXRCompositionLayerQuad::OpenXRCompositionLayerQuad() :
+		OpenXRCompositionLayer((XrCompositionLayerBaseHeader *)&composition_layer) {
 	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRCompositionLayerQuad::update_transform));
 }
 

--- a/modules/openxr/scene/openxr_composition_layer_quad.h
+++ b/modules/openxr/scene/openxr_composition_layer_quad.h
@@ -38,7 +38,16 @@
 class OpenXRCompositionLayerQuad : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerQuad, OpenXRCompositionLayer);
 
-	XrCompositionLayerQuad composition_layer;
+	XrCompositionLayerQuad composition_layer = {
+		XR_TYPE_COMPOSITION_LAYER_QUAD, // type
+		nullptr, // next
+		0, // layerFlags
+		XR_NULL_HANDLE, // space
+		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
+		{}, // subImage
+		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
+		{ 1.0, 1.0 }, // size
+	};
 
 	Size2 quad_size = Size2(1.0, 1.0);
 


### PR DESCRIPTION
This adds support for composition layers that get their 2D content from Android surfaces.

It depends on PR https://github.com/godotengine/godot/pull/96182 in order to allow GDScript to get the Android surface as a `JavaObject`, and then either directly interact with it via `JavaClassWrapper`, or, more likely, pass it to a `JNISingleton` registered by a custom Godot Android Plugin.

This could be used to, for example, play a video via Android libraries, and have the output displayed on a composition layer in XR.

You enable it by simply checking "Use Android Surface" on the `OpenXRCompositionLayer`, which will hide the "Viewport Layer" property, and show the "Android Surface Size" property:

![Selection_203](https://github.com/user-attachments/assets/00207f4e-6995-4a41-bacb-d912daa8011a)

Here's a GDScript example that simply fills the Android surface with red, which can be used to test that it's working:

```gdscript
func _process(delta):
	var android_surface = $OpenXRCompositionLayerQuad.get_android_surface()
	if android_surface:
		var color = JavaClassWrapper.wrap('android.graphics.Color')
		var canvas = android_surface.lockCanvas(null)
		if canvas != null:
			var red = color.rgb(1.0, 0.0, 0.0)
			canvas.drawColor(red)
		android_surface.unlockCanvasAndPost(canvas)
```

Again, in a real app you'd probably pass the surface to your Godot Android Plugin, but this is much easier to test. :-)

~~Marking as a DRAFT until PR https://github.com/godotengine/godot/pull/96182 is merged.~~