### PR TITLE
Add a way to know when a TileMapLayer's cell is modified

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -22,6 +22,21 @@
 				[b]Note:[/b] If the properties of [param tile_data] object should change over time, use [method notify_runtime_tile_data_update] to notify the [TileMapLayer] it needs an update.
 			</description>
 		</method>
+		<method name="_update_cells" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="coords" type="Vector2i[]" />
+			<param index="1" name="forced_cleanup" type="bool" />
+			<description>
+				Called when this [TileMapLayer]'s cells need an internal update. This update may be caused from individual cells being modified or by a change in the [member tile_set] (causing all cells to be queued for an update). The first call to this function is always for initializing all the [TileMapLayer]'s cells. [param coords] contains the coordinates of all modified cells, roughly in the order they were modified. [param forced_cleanup] is [code]true[/code] when the [TileMapLayer]'s internals should be fully cleaned up. This is the case when:
+				- The layer is disabled;
+				- The layer is not visible;
+				- [member tile_set] is set to [code]null[/code];
+				- The node is removed from the tree;
+				- The node is freed.
+				Note that any internal update happening while one of these conditions is verified is considered to be a "cleanup". See also [method update_internals].
+				[b]Warning:[/b] Implementing this method may degrade the [TileMapLayer]'s performance.
+			</description>
+		</method>
 		<method name="_use_tile_data_runtime_update" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="coords" type="Vector2i" />

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -321,6 +321,7 @@ private:
 	bool _runtime_update_needs_all_cells_cleaned_up = false;
 	void _clear_runtime_update_tile_data();
 	void _clear_runtime_update_tile_data_for_cell(CellData &r_cell_data);
+	void _update_cells_callback(bool p_force_cleanup);
 
 	// Per-system methods.
 #ifdef DEBUG_ENABLED
@@ -462,6 +463,7 @@ public:
 	void notify_runtime_tile_data_update();
 	GDVIRTUAL1R(bool, _use_tile_data_runtime_update, Vector2i);
 	GDVIRTUAL2(_tile_data_runtime_update, Vector2i, TileData *);
+	GDVIRTUAL2(_update_cells, TypedArray<Vector2i>, bool);
 
 	// --- Shortcuts to methods defined in TileSet ---
 	Vector2i map_pattern(const Vector2i &p_position_in_tilemap, const Vector2i &p_coords_in_pattern, Ref<TileMapPattern> p_pattern);


### PR DESCRIPTION
Hi !

This PR adds a callback inside the `TileMapLayer` that gets called when cells are updated. This was discussed in godotengine/godot#96078, which was a previous attempt at implementing this feature.