### PR TITLE
Add Instance Placeholder validation check.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1236,6 +1236,10 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
+			if (!_validate_no_foreign()) {
+				break;
+			}
+
 			List<Node *> selection = editor_selection->get_selected_node_list();
 			List<Node *>::Element *e = selection.front();
 			if (e) {


### PR DESCRIPTION
The toggle to designate an instance as a placeholder is not saved on nodes which are editable children of another or instance or nodes inherited from another scene. This PR simply prevents the user from toggling the placeholder flag on nodes where this is not allowed.