### PR TITLE
Add Revert support to SkeletonEditor.

### DIFF
--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -130,9 +130,11 @@ void EditorPropertyVectorN::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			if (linked->is_visible()) {
-				const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
-				linked->set_pressed_no_signal(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
-				_update_ratio();
+				if (get_edited_object()) {
+					const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
+					linked->set_pressed_no_signal(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
+					_update_ratio();
+				}
 			}
 		} break;
 

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -96,6 +96,8 @@ public:
 class Skeleton3DEditor : public VBoxContainer {
 	GDCLASS(Skeleton3DEditor, VBoxContainer);
 
+	static void _bind_methods();
+
 	friend class Skeleton3DEditorPlugin;
 
 	enum SkeletonOption {
@@ -115,6 +117,10 @@ class Skeleton3DEditor : public VBoxContainer {
 	EditorInspectorPluginSkeleton *editor_plugin = nullptr;
 
 	Skeleton3D *skeleton = nullptr;
+
+	enum {
+		JOINT_BUTTON_REVERT = 0,
+	};
 
 	Tree *joint_tree = nullptr;
 	BoneTransformEditor *rest_editor = nullptr;
@@ -149,6 +155,7 @@ class Skeleton3DEditor : public VBoxContainer {
 	EditorFileDialog *file_export_lib = nullptr;
 
 	void update_joint_tree();
+	void update_all();
 
 	void create_editors();
 
@@ -189,6 +196,7 @@ class Skeleton3DEditor : public VBoxContainer {
 
 	void _joint_tree_selection_changed();
 	void _joint_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button);
+	void _joint_tree_button_clicked(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _update_properties();
 
 	void _subgizmo_selection_change();


### PR DESCRIPTION
Closes #88877

Another PR which is a byproduct of triage-ing #91211

https://github.com/user-attachments/assets/f740ad02-19c9-4003-b973-32453a77be67

This PR makes the bespoke custom SkeletonEditor property editors capable of reverting to their default values. This includes reverting individual bone transforms, enabling pose mode, and even reseting reparented or renamed bones. The makes the SkeletonEditor consistent with the broader behaviour of the Godot inspector. It also includes an optional link mode for the scale property like the regular Node3D scale property.

This should overall make manual editing of poses in Godot much more viable to the end user.