### PR TITLE
Improve error message when loading non-PNG splash image

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3307,7 +3307,8 @@ void Main::setup_boot_logo() {
 				boot_logo.instantiate();
 				Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
 				if (load_err) {
-					ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
+					String msg = (boot_logo_path.ends_with(".png") ? "" : "The only supported format is PNG.");
+					ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + +"'. " + msg + " Loading default splash.");
 				}
 			}
 		} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96177

Are there any other places that needs check? 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
