### PR TITLE
ResourceImporterWAV: Fix memory leak on QOA import

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -517,16 +517,19 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	Vector<uint8_t> dst_data;
 	if (compression == 2) {
 		dst_format = AudioStreamWAV::FORMAT_QOA;
-		qoa_desc desc = { 0, 0, 0, { { { 0 }, { 0 } } } };
+		qoa_desc desc = {};
 		uint32_t qoa_len = 0;
 
 		desc.samplerate = rate;
 		desc.samples = frames;
 		desc.channels = format_channels;
 
-		void *encoded = qoa_encode((short *)pcm_data.ptrw(), &desc, &qoa_len);
-		dst_data.resize(qoa_len);
-		memcpy(dst_data.ptrw(), encoded, qoa_len);
+		void *encoded = qoa_encode((short *)pcm_data.ptr(), &desc, &qoa_len);
+		if (encoded) {
+			dst_data.resize(qoa_len);
+			memcpy(dst_data.ptrw(), encoded, qoa_len);
+			QOA_FREE(encoded);
+		}
 	} else {
 		dst_data = pcm_data;
 	}

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -692,8 +692,8 @@ Collection of single-file libraries used in Godot components.
   * License: MIT
 - `qoa.h`
   * Upstream: https://github.com/phoboslab/qoa
-  * Version: git (5c2a86d615661f34636cf179abf4fa278d3257e0, 2024)
-  * Modifications: Inlined functions, patched uninitialized variables and untyped mallocs.
+  * Version: git (e0c69447d4d3945c3c92ac1751e4cdc9803a8303, 2024)
+  * Modifications: Added a few modifiers to comply with C++ nature.
   * License: MIT
 - `r128.{c,h}`
   * Upstream: https://github.com/fahickman/r128

--- a/thirdparty/misc/patches/qoa-min-fix.patch
+++ b/thirdparty/misc/patches/qoa-min-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/qoa.h b/qoa.h
-index 592082933a..c890b88bd6 100644
+index cfed266bef..23612bb0bf 100644
 --- a/qoa.h
 +++ b/qoa.h
 @@ -140,14 +140,14 @@ typedef struct {
@@ -24,19 +24,15 @@ index 592082933a..c890b88bd6 100644
  
  #ifndef QOA_NO_STDIO
  
-@@ -394,9 +394,9 @@ unsigned int qoa_encode_frame(const short *sample_data, qoa_desc *qoa, unsigned
- 			#ifdef QOA_RECORD_TOTAL_ERROR
+@@ -395,7 +395,7 @@ unsigned int qoa_encode_frame(const short *sample_data, qoa_desc *qoa, unsigned
  				qoa_uint64_t best_error = -1;
  			#endif
--			qoa_uint64_t best_slice;
+ 			qoa_uint64_t best_slice = 0;
 -			qoa_lms_t best_lms;
--			int best_scalefactor;
-+			qoa_uint64_t best_slice = -1;
-+			qoa_lms_t best_lms = {{-1, -1, -1, -1}, {-1, -1, -1, -1}};
-+			int best_scalefactor = -1;
++			qoa_lms_t best_lms = {};
+ 			int best_scalefactor = 0;
  
  			for (int sfi = 0; sfi < 16; sfi++) {
- 				/* There is a strong correlation between the scalefactors of
 @@ -500,7 +500,7 @@ void *qoa_encode(const short *sample_data, qoa_desc *qoa, unsigned int *out_len)
  		num_frames * QOA_LMS_LEN * 4 * qoa->channels + /* 4 * 4 bytes lms state per channel */
  		num_slices * 8 * qoa->channels;                /* 8 byte slices */

--- a/thirdparty/misc/qoa.h
+++ b/thirdparty/misc/qoa.h
@@ -394,9 +394,9 @@ unsigned int qoa_encode_frame(const short *sample_data, qoa_desc *qoa, unsigned 
 			#ifdef QOA_RECORD_TOTAL_ERROR
 				qoa_uint64_t best_error = -1;
 			#endif
-			qoa_uint64_t best_slice = -1;
-			qoa_lms_t best_lms = {{-1, -1, -1, -1}, {-1, -1, -1, -1}};
-			int best_scalefactor = -1;
+			qoa_uint64_t best_slice = 0;
+			qoa_lms_t best_lms = {};
+			int best_scalefactor = 0;
 
 			for (int sfi = 0; sfi < 16; sfi++) {
 				/* There is a strong correlation between the scalefactors of


### PR DESCRIPTION
`qoa_encode` allocates memory using `malloc`, then returns its pointer. When I was implementing this initially, I tried to use `memfree` (because I thought using it instead of `free` was just a Godot convention), but it would always return an invalid pointer, so I though it was unnecessary until recently.

I continuously reimported a 1h21min WAV file as QOA, and the memory usage would increase by around 1.5-2GB every time.

I didn't like the idea of using direct `malloc` of `free` + variants directly into Godot code, but seems it was the best solution.

Also took the opportunity to sync with upstream.