### PR TITLE
[Tree] Fix error when removing child from `Tree`

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -178,6 +178,9 @@ private:
 			if (parent->first_child == this) {
 				parent->first_child = next;
 			}
+			if (parent->last_child == this) {
+				parent->last_child = prev;
+			}
 		}
 	}
 

--- a/tests/scene/test_tree.h
+++ b/tests/scene/test_tree.h
@@ -108,6 +108,30 @@ TEST_CASE("[SceneTree][Tree]") {
 		memdelete(tree);
 	}
 
+	// https://github.com/godotengine/godot/issues/96205
+	SUBCASE("[Tree] Get last item after removal.") {
+		Tree *tree = memnew(Tree);
+		TreeItem *root = tree->create_item();
+
+		TreeItem *child1 = tree->create_item(root);
+		TreeItem *child2 = tree->create_item(root);
+
+		CHECK_EQ(root->get_child_count(), 2);
+		CHECK_EQ(tree->get_last_item(), child2);
+
+		root->remove_child(child2);
+
+		CHECK_EQ(root->get_child_count(), 1);
+		CHECK_EQ(tree->get_last_item(), child1);
+
+		root->add_child(child2);
+
+		CHECK_EQ(root->get_child_count(), 2);
+		CHECK_EQ(tree->get_last_item(), child2);
+
+		memdelete(tree);
+	}
+
 	SUBCASE("[Tree] Previous and Next items.") {
 		Tree *tree = memnew(Tree);
 		TreeItem *root = tree->create_item();


### PR DESCRIPTION
New `last_child` member was not properly updated

Will see if I can add a unit test to catch this as well

* Fixes: https://github.com/godotengine/godot/issues/96205

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
