### PR TITLE
Metal: Use correct operator to ensure specialization constants are sorted

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -3112,7 +3112,7 @@ RenderingDeviceDriverMetal::Result<id<MTLFunction>> RenderingDeviceDriverMetal::
 	NSArray<MTLFunctionConstant *> *constants = function.functionConstantsDictionary.allValues;
 	bool is_sorted = true;
 	for (uint32_t i = 1; i < constants.count; i++) {
-		if (constants[i - 1].index < constants[i].index) {
+		if (constants[i - 1].index > constants[i].index) {
 			is_sorted = false;
 			break;
 		}


### PR DESCRIPTION
Closes #96077

Resolves rendering issues for SDFGI when selecting half resolution. The issue was due to using the wrong operator to determine if the specialisation constants from a MTLFunction are sorted. This resulted in the wrong value for the constants and therefore the shader was in an invalid state.