### PR TITLE
Make `ThemeTypeDialog` List navigatable when the `LineEdit` has focus

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2174,8 +2174,26 @@ void ThemeTypeDialog::_add_type_filter_cbk(const String &p_value) {
 	_update_add_type_options(p_value);
 }
 
+void ThemeTypeDialog::_type_filter_input(const Ref<InputEvent> &p_ie) {
+	Ref<InputEventKey> k = p_ie;
+	if (k.is_valid() && k->is_pressed()) {
+		switch (k->get_keycode()) {
+			case Key::UP:
+			case Key::DOWN:
+			case Key::PAGEUP:
+			case Key::PAGEDOWN: {
+				add_type_options->gui_input(k);
+				add_type_filter->accept_event();
+			} break;
+			default:
+				break;
+		}
+	}
+}
+
 void ThemeTypeDialog::_add_type_options_cbk(int p_index) {
 	add_type_filter->set_text(add_type_options->get_item_text(p_index));
+	add_type_filter->set_caret_column(add_type_filter->get_text().length());
 }
 
 void ThemeTypeDialog::_add_type_dialog_entered(const String &p_value) {
@@ -2245,6 +2263,7 @@ ThemeTypeDialog::ThemeTypeDialog() {
 	add_type_vb->add_child(add_type_filter);
 	add_type_filter->connect(SceneStringName(text_changed), callable_mp(this, &ThemeTypeDialog::_add_type_filter_cbk));
 	add_type_filter->connect("text_submitted", callable_mp(this, &ThemeTypeDialog::_add_type_dialog_entered));
+	add_type_filter->connect(SceneStringName(gui_input), callable_mp(this, &ThemeTypeDialog::_type_filter_input));
 
 	Label *add_type_options_label = memnew(Label);
 	add_type_options_label->set_text(TTR("Available Node-based types:"));

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -303,6 +303,7 @@ class ThemeTypeDialog : public ConfirmationDialog {
 	void _update_add_type_options(const String &p_filter = "");
 
 	void _add_type_filter_cbk(const String &p_value);
+	void _type_filter_input(const Ref<InputEvent> &p_ie);
 	void _add_type_options_cbk(int p_index);
 	void _add_type_dialog_entered(const String &p_value);
 	void _add_type_dialog_activated(int p_index);


### PR DESCRIPTION
Fixes: #96211

This makes the `ThemeTypeDialog` navigatable while the filter `LineEdit` has focus in the same way it is done for the `CreateDialog`:

https://github.com/godotengine/godot/blob/master/editor/create_dialog.cpp#L428

https://github.com/user-attachments/assets/b68a9b4b-82bd-4f1d-9fce-d28e69cccffc
