### PR TITLE
Fix Tweeners to emit `finished()` when underlying object is deleted

### DIFF
--- a/doc/classes/PropertyTweener.xml
+++ b/doc/classes/PropertyTweener.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[PropertyTweener] is used to interpolate a property in an object. See [method Tween.tween_property] for more usage information.
+		The tweener will finish automatically if the target object is freed.
 		[b]Note:[/b] [method Tween.tween_property] is the only correct way to create [PropertyTweener]. Any [PropertyTweener] created manually will not function correctly.
 	</description>
 	<tutorials>

--- a/doc/classes/Tweener.xml
+++ b/doc/classes/Tweener.xml
@@ -11,7 +11,7 @@
 	<signals>
 		<signal name="finished">
 			<description>
-				Emitted when the [Tweener] has just finished its job.
+				Emitted when the [Tweener] has just finished its job or became invalid (e.g. due to a freed object).
 			</description>
 		</signal>
 	</signals>

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -579,6 +579,7 @@ bool PropertyTweener::step(double &r_delta) {
 
 	Object *target_instance = ObjectDB::get_instance(target);
 	if (!target_instance) {
+		_finish();
 		return false;
 	}
 	elapsed_time += r_delta;
@@ -706,6 +707,7 @@ bool CallbackTweener::step(double &r_delta) {
 	}
 
 	if (!callback.is_valid()) {
+		_finish();
 		return false;
 	}
 
@@ -770,6 +772,7 @@ bool MethodTweener::step(double &r_delta) {
 	}
 
 	if (!callback.is_valid()) {
+		_finish();
 		return false;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/10575