### PR TITLE
ResourceLoader: Handle another case of user tokens

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -539,6 +539,11 @@ Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path,
 		if (!ignoring_cache && thread_load_tasks.has(local_path)) {
 			load_token = Ref<LoadToken>(thread_load_tasks[local_path].load_token);
 			if (load_token.is_valid()) {
+				if (p_for_user) {
+					// Load task exists, with no user tokens at the moment.
+					// Let's "attach" to it.
+					_load_threaded_request_setup_user_token(load_token.ptr(), p_path);
+				}
 				return load_token;
 			} else {
 				// The token is dying (reached 0 on another thread).


### PR DESCRIPTION
A case that df23858488098086da20c67d9fc62f7ffb3d528c failed to handle.

This fixes a case like this:
- User code starts loading resource A.
- The system starts loading resource B as it's a dependency of A.
- User code starts loading explicitly resource B.
- User code queries status or tries to retrieve the result of loading B. The resource loader will find no user tokens corresponding to that resource, so an error will be returned.