### PR TITLE
[Windows] Suppress unnecessary `ar` messages

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -475,7 +475,7 @@ def use_windows_spawn_fix(self, platform=None):
     # got built correctly regardless the invocation strategy.
     # Furthermore, since SCons will rebuild the library from scratch when an object file
     # changes, no multiple versions of the same object file will be present.
-    self.Replace(ARFLAGS="q")
+    self.Replace(ARFLAGS="cq")
 
     def mySubProcess(cmdline, env):
         startupinfo = subprocess.STARTUPINFO()


### PR DESCRIPTION
Removes some useless `creating ***.a` waning messages cause by https://github.com/godotengine/godot/pull/94747, which enabled `stderr` print, and `ar` is sending these to `stderr` without `c` modifier.