### PR TITLE
WorkerThreadPool: Fix end-of-yield logic potentially leading to deadlocks

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -461,7 +461,10 @@ void WorkerThreadPool::_wait_collaboratively(ThreadData *p_caller_pool_thread, T
 			p_caller_pool_thread->signaled = false;
 
 			if (IS_WAIT_OVER) {
-				p_caller_pool_thread->yield_is_over = false;
+				if (unlikely(p_task == ThreadData::YIELDING)) {
+					p_caller_pool_thread->yield_is_over = false;
+				}
+
 				if (!exit_threads && was_signaled) {
 					// This thread was awaken for some additional reason, but it's about to exit.
 					// Let's find out what may be pending and forward the requests.


### PR DESCRIPTION
Without this, certain situations with much thread interactions can deadlock. The specific case I run into was multi-threaded resource loading from the editor with progress dialog running iterations and also separate-threaded physics.

If the flag was unconditionanlly reset, this could happen:
- A worker thread (A) is used by a server.
- Thread A starts yielding.
- Thread A is awaken to start processing a task.
- Thrad B triggers end-of-yield on thread A so **the relevant flag is set**.
- Thread A ends processing its current task and **clears the flag**.
- Thread A goes back to yielding without a chance of seeing the flag set so it keeps waiting forever.