### PR TITLE
Add `String::remove_string` method for convenience

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -256,19 +256,19 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 		if (!resource_path.is_empty()) {
 			return p_path.replace("res:/", resource_path);
 		}
-		return p_path.replace("res://", "");
+		return p_path.remove_string("res://");
 	} else if (p_path.begins_with("uid://")) {
 		const String path = ResourceUID::uid_to_path(p_path);
 		if (!resource_path.is_empty()) {
 			return path.replace("res:/", resource_path);
 		}
-		return path.replace("res://", "");
+		return path.remove_string("res://");
 	} else if (p_path.begins_with("user://")) {
 		String data_dir = OS::get_singleton()->get_user_data_dir();
 		if (!data_dir.is_empty()) {
 			return p_path.replace("user:/", data_dir);
 		}
-		return p_path.replace("user://", "");
+		return p_path.remove_string("user://");
 	}
 
 	return p_path;

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -225,7 +225,7 @@ void RemoteDebuggerPeerTCP::_poll() {
 RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create(const String &p_uri) {
 	ERR_FAIL_COND_V(!p_uri.begins_with("tcp://"), nullptr);
 
-	String debug_host = p_uri.replace("tcp://", "");
+	String debug_host = p_uri.remove_string("tcp://");
 	uint16_t debug_port = 6007;
 
 	if (debug_host.contains_char(':')) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -271,7 +271,7 @@ String FileAccess::fix_path(const String &p_path) const {
 					if (!resource_path.is_empty()) {
 						return r_path.replace("res:/", resource_path);
 					}
-					return r_path.replace("res://", "");
+					return r_path.remove_string("res://");
 				}
 			}
 
@@ -282,7 +282,7 @@ String FileAccess::fix_path(const String &p_path) const {
 				if (!data_dir.is_empty()) {
 					return r_path.replace("user:/", data_dir);
 				}
-				return r_path.replace("user://", "");
+				return r_path.remove_string("user://");
 			}
 
 		} break;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2955,6 +2955,106 @@ String String::remove_char(char32_t p_char) const {
 	return new_string;
 }
 
+String String::remove_string(const String &p_what) const {
+	if (p_what.is_empty() || is_empty()) {
+		return *this;
+	}
+
+	const int what_length = p_what.length();
+
+	int search_from = 0;
+	int result = 0;
+
+	LocalVector<int> found;
+
+	while ((result = find(p_what, search_from)) >= 0) {
+		found.push_back(result);
+		search_from = result + what_length;
+	}
+
+	if (found.is_empty()) {
+		return *this;
+	}
+
+	String new_string;
+
+	const int old_length = length();
+
+	new_string.resize_uninitialized(old_length - (found.size() * what_length) + 1);
+
+	char32_t *new_ptrw = new_string.ptrw();
+	const char32_t *old_ptr = ptr();
+
+	int last_pos = 0;
+
+	for (const int &pos : found) {
+		if (last_pos != pos) {
+			memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
+			new_ptrw += (pos - last_pos);
+		}
+		last_pos = pos + what_length;
+	}
+
+	if (last_pos != old_length) {
+		memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
+		new_ptrw += old_length - last_pos;
+	}
+
+	*new_ptrw = 0;
+
+	return new_string;
+}
+
+String String::remove_string(const char *p_what) const {
+	const int what_length = strlen(p_what);
+
+	if (what_length == 0 || is_empty()) {
+		return *this;
+	}
+
+	int search_from = 0;
+	int result = 0;
+
+	LocalVector<int> found;
+
+	while ((result = find(p_what, search_from)) >= 0) {
+		found.push_back(result);
+		search_from = result + what_length;
+	}
+
+	if (found.is_empty()) {
+		return *this;
+	}
+
+	String new_string;
+
+	const int old_length = length();
+
+	new_string.resize_uninitialized(old_length - (found.size() * what_length) + 1);
+
+	char32_t *new_ptrw = new_string.ptrw();
+	const char32_t *old_ptr = ptr();
+
+	int last_pos = 0;
+
+	for (const int &pos : found) {
+		if (last_pos != pos) {
+			memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
+			new_ptrw += (pos - last_pos);
+		}
+		last_pos = pos + what_length;
+	}
+
+	if (last_pos != old_length) {
+		memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
+		new_ptrw += old_length - last_pos;
+	}
+
+	*new_ptrw = 0;
+
+	return new_string;
+}
+
 template <class T>
 static String _remove_chars_common(const String &p_this, const T *p_chars, int p_chars_len) {
 	// Delegate if p_chars has a single element.

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -430,6 +430,8 @@ public:
 	String remove_char(char32_t p_what) const;
 	String remove_chars(const String &p_chars) const;
 	String remove_chars(const char *p_chars) const;
+	String remove_string(const String &p_what) const;
+	String remove_string(const char *p_what) const;
 	String pad_decimals(int p_digits) const;
 	String pad_zeros(int p_digits) const;
 	String trim_prefix(const String &p_prefix) const;

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -67,7 +67,7 @@ Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) 
 	path_src = p_path;
 	ERR_FAIL_COND_V_MSG(fd[0] >= 0 || fd[1] >= 0, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
-	path = String("/tmp/") + p_path.replace("pipe://", "").replace_char('/', '_');
+	path = String("/tmp/") + p_path.remove_string("pipe://").replace_char('/', '_');
 	const CharString path_utf8 = path.utf8();
 
 	struct stat st = {};

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -546,19 +546,19 @@ Dictionary OS_Unix::get_memory_info() const {
 	while (f.is_valid() && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
 		if (s.begins_with("MemTotal:")) {
-			Vector<String> stok = s.replace("MemTotal:", "").strip_edges().split(" ");
+			Vector<String> stok = s.remove_string("MemTotal:").strip_edges().split(" ");
 			if (stok.size() == 2) {
 				mtotal = stok[0].to_int() * 1024;
 			}
 		}
 		if (s.begins_with("MemFree:")) {
-			Vector<String> stok = s.replace("MemFree:", "").strip_edges().split(" ");
+			Vector<String> stok = s.remove_string("MemFree:").strip_edges().split(" ");
 			if (stok.size() == 2) {
 				mfree = stok[0].to_int() * 1024;
 			}
 		}
 		if (s.begins_with("SwapFree:")) {
-			Vector<String> stok = s.replace("SwapFree:", "").strip_edges().split(" ");
+			Vector<String> stok = s.remove_string("SwapFree:").strip_edges().split(" ");
 			if (stok.size() == 2) {
 				sfree = stok[0].to_int() * 1024;
 			}

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -60,7 +60,7 @@ Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flag
 	path_src = p_path;
 	ERR_FAIL_COND_V_MSG(fd[0] != nullptr || fd[1] != nullptr, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
-	path = String("\\\\.\\pipe\\LOCAL\\") + p_path.replace("pipe://", "").replace_char('/', '_');
+	path = String("\\\\.\\pipe\\LOCAL\\") + p_path.remove_string("pipe://").replace_char('/', '_');
 
 	HANDLE h = CreateFileW((LPCWSTR)path.utf16().get_data(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 	if (h == INVALID_HANDLE_VALUE) {

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1006,7 +1006,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 			continue;
 		}
 
-		String name = E.operator String().replace("AudioEffect", "");
+		String name = E.operator String().remove_string("AudioEffect");
 		effect_options->add_item(name);
 		effect_options->set_item_metadata(-1, E);
 	}

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -478,7 +478,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 			} else if (text == "/root") {
 				text = ".";
 			} else {
-				text = text.replace("/root/", "");
+				text = text.remove_string("/root/");
 				int slash = text.find_char('/');
 				if (slash < 0) {
 					text = ".";

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1915,7 +1915,7 @@ void EditorHelp::_update_doc() {
 				_push_code_font();
 
 				if (constant.value.begins_with("Color(") && constant.value.ends_with(")")) {
-					String stripped = constant.value.remove_char(' ').replace("Color(", "").remove_char(')');
+					String stripped = constant.value.remove_char(' ').remove_string("Color(").remove_char(')');
 					PackedFloat64Array color = stripped.split_floats(",");
 					if (color.size() >= 3) {
 						class_desc->push_color(Color(color[0], color[1], color[2]));
@@ -2534,10 +2534,10 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 	}
 
 	// Remove codeblocks (they would be printed otherwise).
-	bbcode = bbcode.replace("[codeblocks]\n", "");
-	bbcode = bbcode.replace("\n[/codeblocks]", "");
-	bbcode = bbcode.replace("[codeblocks]", "");
-	bbcode = bbcode.replace("[/codeblocks]", "");
+	bbcode = bbcode.remove_string("[codeblocks]\n");
+	bbcode = bbcode.remove_string("\n[/codeblocks]");
+	bbcode = bbcode.remove_string("[codeblocks]");
+	bbcode = bbcode.remove_string("[/codeblocks]");
 
 	// Remove `\n` here because `\n` is replaced by `\n\n` later.
 	// Will be compensated when parsing `[/codeblock]`.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4984,7 +4984,7 @@ void EditorNode::_update_recent_scenes() {
 		String path;
 		for (int i = 0; i < rc.size(); i++) {
 			path = rc[i];
-			recent_scenes->add_item(path.replace("res://", ""), i);
+			recent_scenes->add_item(path.remove_string("res://"), i);
 		}
 
 		recent_scenes->add_separator();

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -256,7 +256,7 @@ bool CodeSignCodeResources::add_nested_file(const String &p_root, const String &
 			Vector<String> rqs = rq.parse_requirements();
 			for (int j = 0; j < rqs.size(); j++) {
 				if (rqs[j].begins_with("designated => ")) {
-					req_string = rqs[j].replace("designated => ", "");
+					req_string = rqs[j].remove_string("designated => ");
 				}
 			}
 		}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -523,7 +523,7 @@ void EditorExportPlatform::_edit_files_with_filter(Ref<DirAccess> &da, const Vec
 	if (!cur_dir.ends_with("/")) {
 		cur_dir += "/";
 	}
-	String cur_dir_no_prefix = cur_dir.replace("res://", "");
+	String cur_dir_no_prefix = cur_dir.remove_string("res://");
 
 	Vector<String> dirs;
 	String f = da->get_next();

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -620,7 +620,7 @@ void EditorExportPlatformAppleEmbedded::_fix_config_file(const Ref<EditorExportP
 			strnew += lines[i].replace("$pbx_launch_screen_build_reference", value) + "\n";
 #ifndef DISABLE_DEPRECATED
 		} else if (lines[i].contains("$pbx_launch_image_usage_setting")) {
-			strnew += lines[i].replace("$pbx_launch_image_usage_setting", "") + "\n";
+			strnew += lines[i].remove_string("$pbx_launch_image_usage_setting") + "\n";
 #endif
 		} else if (lines[i].contains("$launch_screen_image_mode")) {
 			int image_scale_mode = p_preset->get("storyboard/image_scale_mode");
@@ -1290,7 +1290,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 		return ERR_FILE_NOT_FOUND;
 	}
 
-	String base_dir = p_asset.get_base_dir().replace("res://", "").replace(".godot/mono/temp/bin/", "");
+	String base_dir = p_asset.get_base_dir().remove_string("res://").remove_string(".godot/mono/temp/bin/");
 	String asset = p_asset.ends_with("/") ? p_asset.left(-1) : p_asset;
 	String destination_dir;
 	String destination;

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -51,7 +51,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 		if (l.begins_with("newmtl ")) {
 			//vertex
 
-			current_name = l.replace("newmtl", "").strip_edges();
+			current_name = l.remove_string("newmtl").strip_edges();
 			current.instantiate();
 			current->set_name(current_name);
 			material_map[current_name] = current;
@@ -119,7 +119,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			//normal
 			ERR_FAIL_COND_V(current.is_null(), ERR_FILE_CORRUPT);
 
-			String p = l.replace("map_Kd", "").replace_char('\\', '/').strip_edges();
+			String p = l.remove_string("map_Kd").replace_char('\\', '/').strip_edges();
 			String path;
 			if (p.is_absolute_path()) {
 				path = p;
@@ -139,7 +139,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			//normal
 			ERR_FAIL_COND_V(current.is_null(), ERR_FILE_CORRUPT);
 
-			String p = l.replace("map_Ks", "").replace_char('\\', '/').strip_edges();
+			String p = l.remove_string("map_Ks").replace_char('\\', '/').strip_edges();
 			String path;
 			if (p.is_absolute_path()) {
 				path = p;
@@ -159,7 +159,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			//normal
 			ERR_FAIL_COND_V(current.is_null(), ERR_FILE_CORRUPT);
 
-			String p = l.replace("map_Ns", "").replace_char('\\', '/').strip_edges();
+			String p = l.remove_string("map_Ns").replace_char('\\', '/').strip_edges();
 			String path;
 			if (p.is_absolute_path()) {
 				path = p;
@@ -178,7 +178,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			//normal
 			ERR_FAIL_COND_V(current.is_null(), ERR_FILE_CORRUPT);
 
-			String p = l.replace("map_bump", "").replace_char('\\', '/').strip_edges();
+			String p = l.remove_string("map_bump").replace_char('\\', '/').strip_edges();
 			String path = base_path.path_join(p);
 
 			Ref<Texture2D> texture = ResourceLoader::load(path);
@@ -480,7 +480,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 			}
 
 			if (l.begins_with("usemtl ")) {
-				current_material = l.replace("usemtl", "").strip_edges();
+				current_material = l.remove_string("usemtl").strip_edges();
 			}
 
 			if (l.begins_with("g ")) {
@@ -489,7 +489,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 		} else if (l.begins_with("mtllib ")) { //parse material
 
-			current_material_library = l.replace("mtllib", "").strip_edges();
+			current_material_library = l.remove_string("mtllib").strip_edges();
 			if (!material_map.has(current_material_library)) {
 				HashMap<String, Ref<StandardMaterial3D>> lib;
 				String lib_path = current_material_library;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -440,7 +440,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	String end = p_what.substr(what.length());
 
 	if (what.containsn("$" + p_str)) { // Blender and other stuff.
-		return what.replace("$" + p_str, "") + end;
+		return what.remove_string("$" + p_str) + end;
 	}
 	if (what.to_lower().ends_with("-" + p_str)) { //collada only supports "_" and "-" besides letters
 		return what.substr(0, what.length() - (p_str.length() + 1)) + end;

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -1990,7 +1990,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
 				if (builtin) {
-					line = line.substr(0, start) + "await " + parts[0] + "." + parts[1].replace("\\\"", "").replace("\\'", "").remove_char(' ') + line.substr(end + start);
+					line = line.substr(0, start) + "await " + parts[0] + "." + parts[1].remove_string("\\\"").remove_string("\\'").remove_char(' ') + line.substr(end + start);
 				} else {
 					line = line.substr(0, start) + "await " + parts[0] + "." + parts[1].remove_chars("\"' ") + line.substr(end + start);
 				}

--- a/editor/scene/rename_dialog.cpp
+++ b/editor/scene/rename_dialog.cpp
@@ -465,7 +465,7 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 		if (parent_node) {
 			if (node == root_node) {
 				// Can not substitute parent of root.
-				result = result.replace("${PARENT}", "");
+				result = result.remove_string("${PARENT}");
 			} else {
 				result = result.replace("${PARENT}", parent_node->get_name());
 			}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -794,7 +794,7 @@ void ScriptEditor::_update_recent_scripts() {
 	String path;
 	for (int i = 0; i < rc.size(); i++) {
 		path = rc[i];
-		recent_scripts->add_item(path.replace("res://", ""));
+		recent_scripts->add_item(path.remove_string("res://"));
 	}
 
 	recent_scripts->add_separator();
@@ -2291,7 +2291,7 @@ void ScriptEditor::_update_script_names() {
 	Vector<String> disambiguated_script_names;
 	Vector<String> full_script_paths;
 	for (int j = 0; j < sedata.size(); j++) {
-		String name = sedata[j].name.replace("(*)", "");
+		String name = sedata[j].name.remove_string("(*)");
 		ScriptListName script_display = (ScriptListName)(int)EDITOR_GET("text_editor/script_list/list_script_names_as");
 		switch (script_display) {
 			case DISPLAY_NAME: {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1255,7 +1255,7 @@ bool EditorSettings::_save_text_editor_theme(const String &p_file) {
 
 	for (const String &key : keys) {
 		if (key.begins_with("text_editor/theme/highlighting/") && key.contains("color")) {
-			cf->set_value(theme_section, key.replace("text_editor/theme/highlighting/", ""), ((Color)props[key].variant).to_html());
+			cf->set_value(theme_section, key.remove_string("text_editor/theme/highlighting/"), ((Color)props[key].variant).to_html());
 		}
 	}
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -91,21 +91,21 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 #endif
 
 	if (!type_hints) {
-		processed_template = processed_template.replace(": int", "")
-									 .replace(": Shader.Mode", "")
-									 .replace(": VisualShader.Type", "")
-									 .replace(": float", "")
-									 .replace(": String", "")
-									 .replace(": Array[String]", "")
-									 .replace(": Node", "")
-									 .replace(": CharFXTransform", "")
+		processed_template = processed_template.remove_string(": int")
+									 .remove_string(": Shader.Mode")
+									 .remove_string(": VisualShader.Type")
+									 .remove_string(": float")
+									 .remove_string(": String")
+									 .remove_string(": Array[String]")
+									 .remove_string(": Node")
+									 .remove_string(": CharFXTransform")
 									 .replace(":=", "=")
-									 .replace(" -> void", "")
-									 .replace(" -> bool", "")
-									 .replace(" -> int", "")
-									 .replace(" -> PortType", "")
-									 .replace(" -> String", "")
-									 .replace(" -> Object", "");
+									 .remove_string(" -> void")
+									 .remove_string(" -> bool")
+									 .remove_string(" -> int")
+									 .remove_string(" -> PortType")
+									 .remove_string(" -> String")
+									 .remove_string(" -> Object");
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -141,7 +141,7 @@ void EditorNetworkProfiler::refresh_replication_data() {
 
 		int cfg_idx = cfg_info.path.find("::");
 		if (cfg_info.path.begins_with("res://") && ResourceLoader::exists(cfg_info.path) && cfg_idx > 0) {
-			String res_idstr = cfg_info.path.substr(cfg_idx + 2).replace("SceneReplicationConfig_", "");
+			String res_idstr = cfg_info.path.substr(cfg_idx + 2).remove_string("SceneReplicationConfig_");
 			String scene_path = cfg_info.path.substr(0, cfg_idx);
 			node->set_text(2, vformat("%s (%s)", res_idstr, scene_path.get_file()));
 			node->add_button(2, theme_cache.instance_options_icon);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -792,7 +792,7 @@ int64_t TextServerAdvanced::_name_to_tag(const String &p_name) const {
 	}
 
 	// No readable name, use tag string.
-	return hb_tag_from_string(p_name.replace("custom_", "").ascii().get_data(), -1);
+	return hb_tag_from_string(p_name.remove_string("custom_").ascii().get_data(), -1);
 }
 
 Variant::Type TextServerAdvanced::_get_tag_type(int64_t p_tag) const {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -221,7 +221,7 @@ int64_t TextServerFallback::_name_to_tag(const String &p_name) const {
 	}
 
 	// No readable name, use tag string.
-	return ot_tag_from_string(p_name.replace("custom_", "").ascii().get_data(), -1);
+	return ot_tag_from_string(p_name.remove_string("custom_").ascii().get_data(), -1);
 }
 
 _FORCE_INLINE_ void ot_tag_to_string(int32_t p_tag, char *p_buf) {

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -233,7 +233,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 			// NOTE: This assumes all directories that start with "values-" are for localization.
 			continue;
 		}
-		String locale = file.replace("values-", "").replace("-r", "_");
+		String locale = file.remove_string("values-").replace("-r", "_");
 		String locale_directory = p_gradle_build_dir.path_join("res/" + file + "/godot_project_name_string.xml");
 		if (p_appnames.has(locale)) {
 			String locale_project_name = p_appnames[locale];

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2207,7 +2207,7 @@ void WaylandThread::_wl_data_device_on_drop(void *data, struct wl_data_device *w
 
 		msg->files = String::utf8((const char *)list_data.ptr(), list_data.size()).split("\r\n", false);
 		for (int i = 0; i < msg->files.size(); i++) {
-			msg->files.write[i] = msg->files[i].replace("file://", "").uri_file_decode();
+			msg->files.write[i] = msg->files[i].remove_string("file://").uri_file_decode();
 		}
 
 		wayland_thread->push_message(msg);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5488,7 +5488,7 @@ void DisplayServerX11::process_events() {
 					Vector<String> files = String((char *)p.data).split("\r\n", false);
 					XFree(p.data);
 					for (int i = 0; i < files.size(); i++) {
-						files.write[i] = files[i].replace("file://", "").uri_file_decode();
+						files.write[i] = files[i].remove_string("file://").uri_file_decode();
 					}
 
 					if (windows[window_id].drop_files_callback.is_valid()) {

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -131,13 +131,13 @@
 								if (str == "*.*") {
 									ut = UTTypeData;
 								} else {
-									ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+									ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.remove_string("*.").strip_edges().utf8().get_data()]];
 								}
 								if (ut) {
 									[type_filters addObject:ut];
 								}
 							} else {
-								[type_filters addObject:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+								[type_filters addObject:[NSString stringWithUTF8String:str.remove_string("*.").strip_edges().utf8().get_data()]];
 							}
 						}
 					}
@@ -185,13 +185,13 @@
 							if (str == "*.*") {
 								ut = UTTypeData;
 							} else {
-								ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+								ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.remove_string("*.").strip_edges().utf8().get_data()]];
 							}
 							if (ut) {
 								[type_filters addObject:ut];
 							}
 						} else {
-							[type_filters addObject:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+							[type_filters addObject:[NSString stringWithUTF8String:str.remove_string("*.").strip_edges().utf8().get_data()]];
 						}
 					}
 				}

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -166,7 +166,7 @@ Array TTS_Windows::get_voices() const {
 						if (w_name) {
 							voice_d["name"] = String::utf16((const char16_t *)w_name);
 						} else {
-							voice_d["name"] = voice_d["id"].operator String().replace("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech\\Voices\\Tokens\\", "");
+							voice_d["name"] = voice_d["id"].operator String().remove_string("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech\\Voices\\Tokens\\");
 						}
 						voice_d["language"] = String::utf16((const char16_t *)w_lang_code) + "_" + String::utf16((const char16_t *)w_reg_code);
 						list.push_back(voice_d);

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -307,7 +307,7 @@ const StringName *GeometryInstance3D::_instance_uniform_get_remap(const StringNa
 #endif // DISABLE_DEPRECATED
 		if (s.begins_with("instance_shader_parameters/")) {
 			StringName pname = StringName(s);
-			StringName name = s.replace("instance_shader_parameters/", "");
+			StringName name = s.remove_string("instance_shader_parameters/");
 			instance_shader_parameter_property_remap[pname] = name;
 			return instance_shader_parameter_property_remap.getptr(pname);
 		}

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -78,7 +78,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 			push_chunk = true;
 			chunk.code = l.replace_first("#CODE", String()).remove_char(':').strip_edges().to_upper();
 		} else if (l.begins_with("#include ")) {
-			String include_file = l.replace("#include ", "").strip_edges();
+			String include_file = l.remove_string("#include ").strip_edges();
 			if (include_file[0] == '"') {
 				int end_pos = include_file.find_char('"', 1);
 				if (end_pos >= 0) {

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -140,7 +140,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				if (line.strip_edges().begins_with("#include")) {
 					if (p_include_func) {
 						//process include
-						String include = line.replace("#include", "").strip_edges();
+						String include = line.remove_string("#include").strip_edges();
 						if (!include.begins_with("\"") || !include.ends_with("\"")) {
 							base_error = "Malformed #include syntax, expected #include \"<path>\", found instead: " + include;
 							break;

--- a/servers/rendering/shader_include_db.cpp
+++ b/servers/rendering/shader_include_db.cpp
@@ -77,7 +77,7 @@ String ShaderIncludeDB::parse_include_files(const String &p_code) {
 		const String &l = lines[i];
 
 		if (l.begins_with(include)) {
-			String include_file = l.replace(include, "").strip_edges();
+			String include_file = l.remove_string(include).strip_edges();
 			if (include_file[0] == '"') {
 				int end_pos = include_file.find_char('"', 1);
 				if (end_pos >= 0) {

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -702,7 +702,7 @@ _FORCE_INLINE_ int32_t ot_tag_from_string(const char *p_str, int p_len) {
 
 int64_t TextServer::name_to_tag(const String &p_name) const {
 	// No readable name, use tag string.
-	return ot_tag_from_string(p_name.replace("custom_", "").ascii().get_data(), -1);
+	return ot_tag_from_string(p_name.remove_string("custom_").ascii().get_data(), -1);
 }
 
 _FORCE_INLINE_ void ot_tag_to_string(int32_t p_tag, char *p_buf) {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -539,6 +539,13 @@ TEST_CASE("[String] remove_chars") {
 	CHECK(s.remove_chars(String("xy")) == "Banana");
 }
 
+TEST_CASE("[String] remove_string") {
+	String s = "Banana";
+	MULTICHECK_STRING_EQ(s, remove_string, "an", "Ba");
+	MULTICHECK_STRING_EQ(s, remove_string, "", "Banana");
+	MULTICHECK_STRING_EQ(s, remove_string, "x", "Banana");
+}
+
 TEST_CASE("[String] Number to string") {
 	CHECK(String::num(0) == "0.0"); // The method takes double, so always add zeros.
 	CHECK(String::num(0.0) == "0.0");


### PR DESCRIPTION
This is mainly for minor performance boosts and general convenience and communication of intent, compared to the two character based ones below, but knowing in advance that the replacement is empty still allows improving performance. But not labelling as `performance` for now without some tests showing it helps significantly.

Didn't add a `remove_strings` option as I think it's of limited usefulness (there's only really one place I can think of where it'd be of real use, in the GDScript code)

Leaving this unexposed for the time being but can bind it if desired

Split into three commits for ease of review

Edit: This does not markedly improve performance, but is still useful IMO

See also:
* https://github.com/godotengine/godot/pull/92475
* https://github.com/godotengine/godot/pull/92476
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
