### PR TITLE
[Windows] Fix `OS.open_dynamic_library`

### DIFF
--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -260,7 +260,7 @@ bool get_dotnet_self_registered_dir(String &r_dotnet_root) {
 		return false;
 	}
 
-	r_dotnet_root = String::utf16((const char16_t *)buffer.ptr());
+	r_dotnet_root = String::utf16((const char16_t *)buffer.ptr()).replace("\\", "/");
 	RegCloseKey(hkey);
 	return true;
 #else

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -430,13 +430,13 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	bool has_dll_directory_api = ((add_dll_directory != nullptr) && (remove_dll_directory != nullptr));
 	DLL_DIRECTORY_COOKIE cookie = nullptr;
 
-	String dll_dir = ProjectSettings::get_singleton()->globalize_path(load_path.get_base_dir());
-	String wpath = fix_path(dll_dir);
+	String dll_path = fix_path(load_path);
+	String dll_dir = fix_path(ProjectSettings::get_singleton()->globalize_path(load_path.get_base_dir()));
 	if (p_data != nullptr && p_data->also_set_library_path && has_dll_directory_api) {
-		cookie = add_dll_directory((LPCWSTR)(wpath.get_base_dir().utf16().get_data()));
+		cookie = add_dll_directory((LPCWSTR)(dll_dir.utf16().get_data()));
 	}
 
-	p_library_handle = (void *)LoadLibraryExW((LPCWSTR)(wpath.utf16().get_data()), nullptr, (p_data != nullptr && p_data->also_set_library_path && has_dll_directory_api) ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
+	p_library_handle = (void *)LoadLibraryExW((LPCWSTR)(dll_path.utf16().get_data()), nullptr, (p_data != nullptr && p_data->also_set_library_path && has_dll_directory_api) ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
 	if (!p_library_handle) {
 		if (p_data != nullptr && p_data->generate_temp_files) {
 			DirAccess::remove_absolute(load_path);
@@ -447,7 +447,7 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 
 		HashSet<String> checked_libs;
 		HashSet<String> missing_libs;
-		debug_dynamic_library_check_dependencies(wpath, checked_libs, missing_libs);
+		debug_dynamic_library_check_dependencies(dll_path, checked_libs, missing_libs);
 		if (!missing_libs.is_empty()) {
 			String missing;
 			for (const String &E : missing_libs) {


### PR DESCRIPTION
Fixes incorrect rebase of https://github.com/godotengine/godot/pull/91902 after https://github.com/godotengine/godot/pull/96192 (dll directory was used instead of name).

Fixed https://github.com/godotengine/godot/issues/96231