### PR TITLE
Fix `SceneTreeDock` invalid state after trying to remove internal Node

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2650,6 +2650,13 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 		}
 	}
 
+	if (!entire_scene) {
+		for (const Node *E : remove_list) {
+			// `move_child` + `get_index` doesn't really work for internal nodes.
+			ERR_FAIL_COND_MSG(E->get_internal_mode() != INTERNAL_MODE_DISABLED, "Trying to remove internal node, this is not supported.");
+		}
+	}
+
 	EditorNode::get_singleton()->hide_unused_editors(this);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -2662,10 +2669,6 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 		undo_redo->add_undo_method(scene_tree, "update_tree");
 		undo_redo->add_undo_reference(edited_scene);
 	} else {
-		for (const Node *E : remove_list) {
-			// `move_child` + `get_index` doesn't really work for internal nodes.
-			ERR_FAIL_COND_MSG(E->get_internal_mode() != INTERNAL_MODE_DISABLED, "Trying to remove internal node, this is not supported.");
-		}
 		if (delete_tracks_checkbox->is_pressed() || p_cut) {
 			remove_list.sort_custom<Node::Comparator>(); // Sort nodes to keep positions.
 			HashMap<Node *, NodePath> path_renames;


### PR DESCRIPTION
Fixes #95397.

Some checks preventing unsupported removal of internal nodes were in the middle of an already created UndoRedo action, potentially leaving it in an invalid state as the created action would not be committed properly. This PR ensures the UndoRedo action is created only after all such checks passed.

---

Note that to potentially allow the currently unsupported SceneTreeDock actions for internal nodes, we could maybe change `Node::get_index(bool p_include_internal = true)` to `Node::get_index(bool p_absolute = true)` and remove this check:
https://github.com/godotengine/godot/blob/622393c1156e6ee349a2636c28183021b1442cbc/scene/main/node.h#L506-L508

This way `get_index(false)` could be used on internal nodes (currently it can't) and would return the within-internal-group index, which `Node::move_child` expects as its argument. Hence it would probably allow to make the logic in SceneTreeDock work fine for internal nodes too.
But not sure if it makes sense at all. Currently e.g. after saving a scene containing an internal node with `owner` set to the edited scene root (so it would be visible in the SceneTreeDock), the internal state would not be saved and thus the node would become non-internal after reopening the scene anyway. Meaning serializing internal nodes would also need to be supported, and maybe more. Aka definitely not a simple-"fix".