### PR TITLE
MP3: Use heap for big struct when setting data

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -224,15 +224,19 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 	int src_data_len = p_data.size();
 	const uint8_t *src_datar = p_data.ptr();
 
-	mp3dec_ex_t mp3d;
-	int err = mp3dec_ex_open_buf(&mp3d, src_datar, src_data_len, MP3D_SEEK_TO_SAMPLE);
-	ERR_FAIL_COND_MSG(err || mp3d.info.hz == 0, "Failed to decode mp3 file. Make sure it is a valid mp3 audio file.");
+	mp3dec_ex_t *mp3d = memnew(mp3dec_ex_t);
+	int err = mp3dec_ex_open_buf(mp3d, src_datar, src_data_len, MP3D_SEEK_TO_SAMPLE);
+	if (err || mp3d->info.hz == 0) {
+		memdelete(mp3d);
+		ERR_FAIL_MSG("Failed to decode mp3 file. Make sure it is a valid mp3 audio file.");
+	}
 
-	channels = mp3d.info.channels;
-	sample_rate = mp3d.info.hz;
-	length = float(mp3d.samples) / (sample_rate * float(channels));
+	channels = mp3d->info.channels;
+	sample_rate = mp3d->info.hz;
+	length = float(mp3d->samples) / (sample_rate * float(channels));
 
-	mp3dec_ex_close(&mp3d);
+	mp3dec_ex_close(mp3d);
+	memdelete(mp3d);
 
 	clear_data();
 


### PR DESCRIPTION
`mp3dec_ex_t` has a size of 16,064 bytes, not a good idea to declare it on stack.

I think this explains the purpose of this PR. Even if the chances of a problem happening are quite low, I believe it should be prevented.