### PR TITLE
Fix missing `GDScriptParser` reference on completion context

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -260,6 +260,7 @@ void GDScriptParser::override_completion_context(const Node *p_for_node, Complet
 	context.current_line = tokenizer->get_cursor_line();
 	context.current_argument = p_argument;
 	context.node = p_node;
+	context.parser = this;
 	completion_context = context;
 }
 


### PR DESCRIPTION
Fixes #96239 

Adds missing reference of `GDScriptParser` to the `CompletionContext` created at `GDScriptParser::override_completion_context`