### PR TITLE
SCons: Pass `/Zc:__cplusplus` in MSVC builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -791,6 +791,8 @@ else:
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.
     env.Prepend(CCFLAGS=["/permissive-"])
+    # Allow use of `__cplusplus` macro to determine C++ standard universally.
+    env.Prepend(CXXFLAGS=["/Zc:__cplusplus"])
 
 # Disable exception handling. Godot doesn't use exceptions anywhere, and this
 # saves around 20% of binary size and very significant build time (GH-80513).

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -44,6 +44,9 @@
 #include "core/error/error_list.h"
 #include <cstdint>
 
+// Ensure that C++ standard is at least C++17. If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
+static_assert(__cplusplus >= 201703L);
+
 // Turn argument to string constant:
 // https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html#Stringizing
 #ifndef _STR


### PR DESCRIPTION
- Related: #89660

Passing this C++ flag on MSVC will allow `__cplusplus` to function like it does on every sensible compiler: specifying the C++ Standard used. While a largely superfluous addition when we're locked to C++17 atm, I wanted to separate this from the C++20 PR because this macro *could* have potential ramifications on its own. Based off local testing, that doesn't seem to be the case, but I wanted to ensure this change was in as controlled of an environment as possible.