### PR TITLE
GDScript: Add `@override` annotation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -694,18 +694,17 @@
 		<annotation name="@override">
 			<return type="void" />
 			<description>
-				Mark the following method to override the parent classes version of said method to allow for arguments for a builtin function to differ from parent to child
-				[codeblock]
-				class A:
-					func test(x: float): pass
+                Mark the following method to override the parent classes version of said method to allow for arguments for a builtin function to differ from parent to child
+                [codeblock]
+                class A:
+                    func test(x: float): pass
 
+                class B:
+                    extends A
 
-				class B:
-					extends A
-
-					@override
-					func test(x: String, y: String): pass
-				[/codeblock]
+                    @override
+                    func test(x: String, y: String): pass
+                [/codeblock]
 			</description>
 		</annotation>
 		<annotation name="@rpc">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -691,6 +691,23 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@override">
+			<return type="void" />
+			<description>
+				Mark the following method to override the parent classes version of said method to allow for arguments for a builtin function to differ from parent to child
+				[codeblock]
+				class A:
+					func test(x: float): pass
+
+
+				class B:
+					extends A
+
+					@override
+					func test(x: String, y: String): pass
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@rpc">
 			<return type="void" />
 			<param index="0" name="mode" type="String" default="&quot;authority&quot;" />

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1755,21 +1755,25 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 				}
 			}
 
-			int par_count_diff = p_function->parameters.size() - parameters_types.size();
-			valid = valid && par_count_diff >= 0;
-			valid = valid && default_value_count >= default_par_count + par_count_diff;
+			if (!p_function->is_override){
+				int par_count_diff = p_function->parameters.size() - parameters_types.size();
+				valid = valid && par_count_diff >= 0;
+				valid = valid && default_value_count >= default_par_count + par_count_diff;
+			}
 
 			if (valid) {
 				int i = 0;
-				for (const GDScriptParser::DataType &parent_par_type : parameters_types) {
-					// Check parameter type contravariance.
-					GDScriptParser::DataType current_par_type = p_function->parameters[i++]->get_datatype();
-					if (parent_par_type.is_variant() && parent_par_type.is_hard_type()) {
-						// `is_type_compatible()` returns `true` if one of the types is `Variant`.
-						// Don't allow narrowing a hard `Variant`.
-						valid = valid && current_par_type.is_variant();
-					} else {
-						valid = valid && is_type_compatible(current_par_type, parent_par_type);
+				if (!p_function->is_override) {
+					for (const GDScriptParser::DataType &parent_par_type : parameters_types) {
+						// Check parameter type contravariance.
+						GDScriptParser::DataType current_par_type = p_function->parameters[i++]->get_datatype();
+						if (parent_par_type.is_variant() && parent_par_type.is_hard_type()) {
+							// `is_type_compatible()` returns `true` if one of the types is `Variant`.
+							// Don't allow narrowing a hard `Variant`.
+							valid = valid && current_par_type.is_variant();
+						} else {
+							valid = valid && is_type_compatible(current_par_type, parent_par_type);
+						}
 					}
 				}
 			}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1755,7 +1755,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 				}
 			}
 
-			if (!p_function->is_override){
+			if (!p_function->is_override) {
 				int par_count_diff = p_function->parameters.size() - parameters_types.size();
 				valid = valid && par_count_diff >= 0;
 				valid = valid && default_value_count >= default_par_count + par_count_diff;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -98,6 +98,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 
+		register_annotation(MethodInfo("@override"), AnnotationInfo::FUNCTION, &GDScriptParser::override_annotation);
+
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
@@ -4132,6 +4134,19 @@ bool GDScriptParser::icon_annotation(AnnotationNode *p_annotation, Node *p_targe
 		class_node->simplified_icon_path = path;
 	}
 
+	return true;
+}
+
+bool GDScriptParser::override_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION, false, R"("@override" annotation can only be applied to functions.)");
+
+	FunctionNode *function = static_cast<FunctionNode *>(p_target);
+
+	if (function->is_override) {
+		push_error(R"("@override" annotation can only be used once per function.)", p_annotation);
+		return false;
+	}
+	function->is_override = true;
 	return true;
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -850,6 +850,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
+		bool is_override = false;
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
@@ -1498,6 +1499,7 @@ private:
 	bool tool_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool override_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);


### PR DESCRIPTION
added `@override` annotation allowing for the arguments in a function to be overridden by a child/extension of a class

* _Bugsquad edit:_ Closes godotengine/godot-proposals#10586.