### PR TITLE
Add `get_supported_gltf_extensions` to GLTFDocument

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -63,6 +63,13 @@
 				The [param bake_fps] parameter overrides the bake_fps in [param state].
 			</description>
 		</method>
+		<method name="get_supported_gltf_extensions" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a list of all support glTF extensions, including extensions supported directly by the engine, and extensions supported by user plugins registering [GLTFDocumentExtension] classes.
+				[b]Note:[/b] If this method is run before a GLTFDocumentExtension is registered, its extensions won't be included in the list. Be sure to only run this method after all extensions are registered. If you run this when the engine starts, consider waiting a frame before calling this method to ensure all extensions are registered.
+			</description>
+		</method>
 		<method name="register_gltf_document_extension" qualifiers="static">
 			<return type="void" />
 			<param index="0" name="extension" type="GLTFDocumentExtension" />

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -92,6 +92,8 @@ public:
 	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
 	static Vector<Ref<GLTFDocumentExtension>> get_all_gltf_document_extensions();
+	static Vector<String> get_supported_gltf_extensions();
+	static HashSet<String> get_supported_gltf_extensions_hashset();
 
 	void set_naming_version(int p_version);
 	int get_naming_version() const;


### PR DESCRIPTION
This method returns a list of all support glTF extensions, including extensions supported directly by the engine, and extensions supported by user plugins registering [GLTFDocumentExtension](https://docs.godotengine.org/en/stable/classes/class_gltfdocumentextension.html) classes.

This was requested by @BastiaanOlij: "I have a need to communicate the list of extensions we support to an external system so that it can limit/extend the GLTF document it is going to provide to me."

Most of this logic already existed in `_parse_gltf_extensions`, but now it is exposed. I also sorted the output, since this method is not expected to be called often, and it makes the output more predictable and easier to read.

This PR will conflict with #93722 and #94165, but it will be very easy to rebase them. This PR should be merged first.

Example output when ran in an empty Godot project as of this PR:

`["EXT_texture_webp", "GODOT_single_root", "KHR_lights_punctual", "KHR_materials_emissive_strength", "KHR_materials_pbrSpecularGlossiness", "KHR_materials_unlit", "KHR_texture_basisu", "KHR_texture_transform", "OMI_collider", "OMI_physics_body", "OMI_physics_shape"]`

Example output when run in a project that provides additional extensions in plugins:

`["EXT_texture_webp", "GODOT_single_root", "KHR_lights_punctual", "KHR_materials_emissive_strength", "KHR_materials_pbrSpecularGlossiness", "KHR_materials_unlit", "KHR_texture_basisu", "KHR_texture_transform", "KHR_xmp_json_ld", "OMI_collider", "OMI_physics_body", "OMI_physics_joint", "OMI_physics_shape", "OMI_seat", "OMI_spawn_point", "OMI_vehicle_body", "OMI_vehicle_hover_thruster", "OMI_vehicle_thruster", "OMI_vehicle_wheel"]`