### PR TITLE
[Android] Check if `keyStore` path is empty

### DIFF
--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -36,7 +36,7 @@ ext {
     // Return the keystore file used for signing the release build.
     getGodotKeystoreFile = { ->
         def keyStore = System.getenv("GODOT_ANDROID_SIGN_KEYSTORE")
-        if (keyStore == null) {
+        if (keyStore == null || keyStore.isEmpty()) {
             return null
         }
         return file(keyStore)


### PR DESCRIPTION
In [godot-build-scripts](https://github.com/godotengine/godot-build-scripts), the default [`config.sh`](https://github.com/godotengine/godot-build-scripts/blob/c3d199c4d4be8c693d1e59150fb4d769cef341c5/config.sh.in#L79) sets `GODOT_ANDROID_SIGN_KEYSTORE` to an empty string but we were only checking if it's null.

Although, I'm not sure why this was being evaluated if I wasn't building the editor.