### PR TITLE
Keep looking when a preview plugin returns an empty image.

### DIFF
--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -23,7 +23,7 @@
 			<param index="2" name="metadata" type="Dictionary" />
 			<description>
 				Generate a preview from a given resource with the specified size. This must always be implemented.
-				Returning an empty texture is an OK way to fail and let another generator take care.
+				Returning [code]null[/code] is an OK way to fail and let another generator take care.
 				Care must be taken because this function is always called from a thread (not the main thread).
 				[param metadata] dictionary can be modified to store file-specific metadata that can be used in [method EditorResourceTooltipPlugin._make_tooltip_for_path] (like image size, sample length etc.).
 			</description>
@@ -35,7 +35,7 @@
 			<param index="2" name="metadata" type="Dictionary" />
 			<description>
 				Generate a preview directly from a path with the specified size. Implementing this is optional, as default code will load and call [method _generate].
-				Returning an empty texture is an OK way to fail and let another generator take care.
+				Returning [code]null[/code] is an OK way to fail and let another generator take care.
 				Care must be taken because this function is always called from a thread (not the main thread).
 				[param metadata] dictionary can be modified to store file-specific metadata that can be used in [method EditorResourceTooltipPlugin._make_tooltip_for_path] (like image size, sample length etc.).
 			</description>

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -221,7 +221,9 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			r_small_texture->set_image(small_image);
 		}
 
-		break;
+		if (generated.is_valid()) {
+			break;
+		}
 	}
 
 	if (!p_item.resource.is_valid()) {


### PR DESCRIPTION
The documentation for EditorResourcePreviewGenerator::_generate says that "Returning an empty texture is an OK way to fail and let another generator take care."

This patch enables that behavior.
