### PR TITLE
[3.x] Fix random multithreaded crash that happens when setting the audio stream on a AudioStreamRandomPitch stream.

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -231,12 +231,14 @@ AudioStreamPlaybackMicrophone::AudioStreamPlaybackMicrophone() {
 ////////////////////////////////
 
 void AudioStreamRandomPitch::set_audio_stream(const Ref<AudioStream> &p_audio_stream) {
+	AudioServer::get_singleton()->lock();
 	audio_stream = p_audio_stream;
 	if (audio_stream.is_valid()) {
 		for (Set<AudioStreamPlaybackRandomPitch *>::Element *E = playbacks.front(); E; E = E->next()) {
 			E->get()->playback = audio_stream->instance_playback();
 		}
 	}
+	AudioServer::get_singleton()->unlock();
 }
 
 Ref<AudioStream> AudioStreamRandomPitch::get_audio_stream() const {


### PR DESCRIPTION
This was originally a pull request in master here: https://github.com/godotengine/godot/pull/55043

But the way audio is handled has changed and is no longer relevant to 4.x, so this is a 3.x specific fix for https://github.com/godotengine/godot/issues/54866
