### PR TITLE
Deprecate `set_min_buttons_width_from_icons`

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -98,12 +98,12 @@
 			Vertical separation between the up and down buttons.
 		</theme_item>
 		<theme_item name="buttons_width" data_type="constant" type="int" default="16">
-			Width of the up and down buttons. If smaller than any icon set on the buttons, the respective icon may overlap neighboring elements, unless [theme_item set_min_buttons_width_from_icons] is different than [code]0[/code].
+			Width of the up and down buttons. If smaller than any icon set on the buttons, the respective icon may overlap neighboring elements. If smaller than [code]0[/code], the width is automatically adjusted from the icon size.
 		</theme_item>
 		<theme_item name="field_and_buttons_separation" data_type="constant" type="int" default="2">
 			Width of the horizontal separation between the text input field ([LineEdit]) and the buttons.
 		</theme_item>
-		<theme_item name="set_min_buttons_width_from_icons" data_type="constant" type="int" default="1">
+		<theme_item name="set_min_buttons_width_from_icons" data_type="constant" type="int" default="1" deprecated="This property exists only for compatibility with older themes. Setting [theme_item buttons_width] to a negative value has the same effect.">
 			If not [code]0[/code], the minimum button width corresponds to the widest of all icons set on those buttons, even if [theme_item buttons_width] is smaller.
 		</theme_item>
 		<theme_item name="down" data_type="icon" type="Texture2D">

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1507,7 +1507,9 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_constant("buttons_vertical_separation", "SpinBox", 0);
 		p_theme->set_constant("field_and_buttons_separation", "SpinBox", 2);
 		p_theme->set_constant("buttons_width", "SpinBox", 16);
+#ifndef DISABLE_DEPRECATED
 		p_theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
+#endif
 	}
 
 	// ProgressBar.

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -287,7 +287,12 @@ inline void SpinBox::_compute_sizes() {
 	int buttons_block_wanted_width = theme_cache.buttons_width + theme_cache.field_and_buttons_separation;
 	int buttons_block_icon_enforced_width = _get_widest_button_icon_width() + theme_cache.field_and_buttons_separation;
 
-	int w = theme_cache.set_min_buttons_width_from_icons != 0 ? MAX(buttons_block_icon_enforced_width, buttons_block_wanted_width) : buttons_block_wanted_width;
+#ifndef DISABLE_DEPRECATED
+	const bool min_width_from_icons = theme_cache.set_min_buttons_width_from_icons || (theme_cache.buttons_width < 0);
+#else
+	const bool min_width_from_icons = theme_cache.buttons_width < 0;
+#endif
+	int w = min_width_from_icons != 0 ? MAX(buttons_block_icon_enforced_width, buttons_block_wanted_width) : buttons_block_wanted_width;
 
 	if (w != sizing_cache.buttons_block_width) {
 		line_edit->set_offset(SIDE_LEFT, 0);
@@ -551,7 +556,9 @@ void SpinBox::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, buttons_vertical_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, field_and_buttons_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, buttons_width);
+#ifndef DISABLE_DEPRECATED
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, set_min_buttons_width_from_icons);
+#endif
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, updown_icon, "updown");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, up_icon, "up");

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -127,8 +127,9 @@ class SpinBox : public Range {
 		int buttons_vertical_separation = 0;
 		int field_and_buttons_separation = 0;
 		int buttons_width = 0;
-		int set_min_buttons_width_from_icons = 0;
-
+#ifndef DISABLE_DEPRECATED
+		bool set_min_buttons_width_from_icons = false;
+#endif
 	} theme_cache;
 
 	void _mouse_exited();

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -648,7 +648,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("buttons_vertical_separation", "SpinBox", 0);
 	theme->set_constant("field_and_buttons_separation", "SpinBox", 2);
 	theme->set_constant("buttons_width", "SpinBox", 16);
+#ifndef DISABLE_DEPRECATED
 	theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
+#endif
 
 	// ScrollContainer
 


### PR DESCRIPTION
As noted in https://github.com/godotengine/godot/pull/89265#issuecomment-2241788906, the new `set_min_buttons_width_from_icons` is redundant and only added for compatibility with existing themes. This PR deprecates it and makes `icon_width` behave like `set_min_buttons_width_from_icons` when the value is less than 0.
Although seems like theme items don't support deprecated messages .-.

To remove `set_min_buttons_width_from_icons` in the future, we'll need to adjust SpinBox icons to have proper width.