### PR TITLE
Fix TileSet Scattering setting vanishing when changing tools

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -86,8 +86,7 @@ void TileMapLayerEditorTilesPlugin::_update_toolbar() {
 		transform_toolbar->show();
 		tools_settings_vsep_2->show();
 		random_tile_toggle->show();
-		scatter_label->show();
-		scatter_spinbox->show();
+		scatter_controls_container->set_visible(random_tile_toggle->is_pressed());
 	} else {
 		tools_settings_vsep->show();
 		picker_button->show();
@@ -96,8 +95,7 @@ void TileMapLayerEditorTilesPlugin::_update_toolbar() {
 		tools_settings_vsep_2->show();
 		bucket_contiguous_checkbox->show();
 		random_tile_toggle->show();
-		scatter_label->show();
-		scatter_spinbox->show();
+		scatter_controls_container->set_visible(random_tile_toggle->is_pressed());
 	}
 }
 


### PR DESCRIPTION
Fixes #96278 by showing the container Control for the Scattering controls in the TileSet Editor, only when the 'Place Random Tile' toggle is pressed.

It may be preferable to merge the else if and else blocks in this code (Lines 82-99), and use a similar `set_visible` call for `bucket_contiguous_checkbox` to reduce code duplication in this section and avoid potential discrepancies between the two cases in the future.