### PR TITLE
Fix `StyleBoxFlat` rectangles skewing independently

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -300,8 +300,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 				const real_t x = radius * (real_t)cos((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.x;
 				const real_t y = radius * (real_t)sin((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.y;
-				const float x_skew = -skew.x * (y - ring_rect.get_center().y);
-				const float y_skew = -skew.y * (x - ring_rect.get_center().x);
+				const float x_skew = -skew.x * (y - style_rect.get_center().y);
+				const float y_skew = -skew.y * (x - style_rect.get_center().x);
 				verts.push_back(Vector2(x + x_skew, y + y_skew));
 				colors.push_back(color);
 			}


### PR DESCRIPTION
Fixes #96281.

The skewing for the subrectangles was calculated not relative to the center of the whole bigger rectangle as it should.

I'm not super familiar with the changed code, so not sure it's fully correct for all cases. But it only affects skewed StyleBoxFlats and as far as I've tested it works just fine (tried changing all properties). So I consider it a low risk change, thus viable for cherry-picking.

Before<br>(v4.3.stable.official [77dcf97d8])|After<br>(this PR)
-|-
![XwMcdEW3mC](https://github.com/user-attachments/assets/2b8c9447-6ec3-4ebc-aff3-4ec9f76b7e48)|![qPoQSn3NIO](https://github.com/user-attachments/assets/886fec5b-8d01-44ab-9438-8a90ad5abed4)
![Godot_v4 3-stable_win64_GsPQJxRZfT](https://github.com/user-attachments/assets/64f6a51f-361a-42ba-8034-49c31876c4f5)|![cJ1QvUOda4](https://github.com/user-attachments/assets/1d2db3c7-17dd-47fb-a939-c7c896c5c19f)
![E582s53qCz](https://github.com/user-attachments/assets/6a0ec7f6-3b6e-418d-ad32-1810350cd5f7)|![B0eROQgM4N](https://github.com/user-attachments/assets/2594dbb7-6fe9-41cb-9e0a-6d6538765e93)

