### PR TITLE
Add `JavaScriptBridge` buffer methods

### DIFF
--- a/doc/classes/JavaScriptBridge.xml
+++ b/doc/classes/JavaScriptBridge.xml
@@ -60,6 +60,20 @@
 				Returns an interface to a JavaScript object that can be used by scripts. The [param interface] must be a valid property of the JavaScript [code]window[/code]. The callback must accept a single [Array] argument, which will contain the JavaScript [code]arguments[/code]. See [JavaScriptObject] for usage.
 			</description>
 		</method>
+		<method name="is_js_buffer">
+			<return type="bool" />
+			<param index="0" name="javascript_object" type="JavaScriptObject" />
+			<description>
+				Returns [code]true[/code] if the given [param javascript_object] is of type [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer][code]ArrayBuffer[/code][/url], [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView][code]DataView[/code][/url], or one of the many [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray]typed array objects[/url].
+			</description>
+		</method>
+		<method name="js_buffer_to_packed_byte_array">
+			<return type="PackedByteArray" />
+			<param index="0" name="javascript_buffer" type="JavaScriptObject" />
+			<description>
+				Returns a copy of [param javascript_buffer]'s contents as a [PackedByteArray]. See also [method is_js_buffer].
+			</description>
+		</method>
 		<method name="pwa_needs_update" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -66,6 +66,8 @@ void JavaScriptBridge::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScriptBridge::eval, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_interface", "interface"), &JavaScriptBridge::get_interface);
 	ClassDB::bind_method(D_METHOD("create_callback", "callable"), &JavaScriptBridge::create_callback);
+	ClassDB::bind_method(D_METHOD("is_js_buffer", "javascript_object"), &JavaScriptBridge::is_js_buffer);
+	ClassDB::bind_method(D_METHOD("js_buffer_to_packed_byte_array", "javascript_buffer"), &JavaScriptBridge::js_buffer_to_packed_byte_array);
 	{
 		MethodInfo mi;
 		mi.name = "create_object";
@@ -91,6 +93,14 @@ Ref<JavaScriptObject> JavaScriptBridge::get_interface(const String &p_interface)
 
 Ref<JavaScriptObject> JavaScriptBridge::create_callback(const Callable &p_callable) {
 	return Ref<JavaScriptObject>();
+}
+
+bool JavaScriptBridge::is_js_buffer(Ref<JavaScriptObject> p_js_obj) {
+	return false;
+}
+
+PackedByteArray JavaScriptBridge::js_buffer_to_packed_byte_array(Ref<JavaScriptObject> p_js_obj) {
+	return PackedByteArray();
 }
 
 Variant JavaScriptBridge::_create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {

--- a/platform/web/api/javascript_bridge_singleton.h
+++ b/platform/web/api/javascript_bridge_singleton.h
@@ -57,6 +57,8 @@ public:
 	Variant eval(const String &p_code, bool p_use_global_exec_context = false);
 	Ref<JavaScriptObject> get_interface(const String &p_interface);
 	Ref<JavaScriptObject> create_callback(const Callable &p_callable);
+	bool is_js_buffer(Ref<JavaScriptObject> p_js_obj);
+	PackedByteArray js_buffer_to_packed_byte_array(Ref<JavaScriptObject> p_js_obj);
 	Variant _create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	void download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime = "application/octet-stream");
 	bool pwa_needs_update() const;

--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -127,6 +127,10 @@ const GodotJSWrapper = {
 			GodotRuntime.setHeapValue(p_exchange, id, 'i64');
 			return 24; // OBJECT
 		},
+
+		isBuffer: function (obj) {
+			return obj instanceof ArrayBuffer || ArrayBuffer.isView(obj);
+		},
 	},
 
 	godot_js_wrapper_interface_get__proxy: 'sync',
@@ -302,6 +306,34 @@ const GodotJSWrapper = {
 			GodotRuntime.error(`Error calling constructor ${name} with args:`, args, 'error:', e);
 			return -1;
 		}
+	},
+
+	godot_js_wrapper_object_is_buffer__proxy: 'sync',
+	godot_js_wrapper_object_is_buffer__sig: 'ii',
+	godot_js_wrapper_object_is_buffer: function (p_id) {
+		const obj = GodotJSWrapper.get_proxied_value(p_id);
+		return GodotJSWrapper.isBuffer(obj)
+			? 1
+			: 0;
+	},
+
+	godot_js_wrapper_object_transfer_buffer__proxy: 'sync',
+	godot_js_wrapper_object_transfer_buffer__sig: 'viiii',
+	godot_js_wrapper_object_transfer_buffer: function (p_id, p_byte_arr, p_byte_arr_write, p_callback) {
+		let obj = GodotJSWrapper.get_proxied_value(p_id);
+		if (!GodotJSWrapper.isBuffer(obj)) {
+			return;
+		}
+
+		if (ArrayBuffer.isView(obj) && !(obj instanceof Uint8Array)) {
+			obj = new Uint8Array(obj.buffer);
+		} else if (obj instanceof ArrayBuffer) {
+			obj = new Uint8Array(obj);
+		}
+
+		const resizePackedByteArrayAndOpenWrite = GodotRuntime.get_func(p_callback);
+		const bytesPtr = resizePackedByteArrayAndOpenWrite(p_byte_arr, p_byte_arr_write, obj.length);
+		HEAPU8.set(obj, bytesPtr);
 	},
 };
 


### PR DESCRIPTION
This PR adds `JavaScriptBridge.is_js_buffer()` and `JavaScriptBridge.js_buffer_to_packed_byte_array()`.

This lets users to easily convert JavaScript [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView), or one of the many [typed array objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) to Godot `PackedByteArray`.

This is especially helpful when computing or downloading something on the JavaScript side with the intent to transfer the contents to Godot.