### PR TITLE
Fix loading GDExtensions in exported games

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -678,12 +678,10 @@ Error GDExtension::open_library(const String &p_path, const Ref<GDExtensionLoade
 	ERR_FAIL_NULL_V_MSG(p_loader, FAILED, "Can't open GDExtension without a loader.");
 	loader = p_loader;
 
-	String abs_path = ProjectSettings::get_singleton()->globalize_path(p_path);
+	Error err = loader->open_library(p_path);
 
-	Error err = loader->open_library(abs_path);
-
-	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, "GDExtension dynamic library not found: " + abs_path);
-	ERR_FAIL_COND_V_MSG(err != OK, err, "Can't open GDExtension dynamic library: " + abs_path);
+	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, "GDExtension dynamic library not found: " + p_path);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Can't open GDExtension dynamic library: " + p_path);
 
 	err = loader->initialize(&gdextension_get_proc_address, this, &initialization);
 


### PR DESCRIPTION
Fixes an issue introduced by PR https://github.com/godotengine/godot/pull/91166

In current `master`, GDExtensions will fail to load in exported projects. I noticed it first on Android, because you need to export in order to run on Android, but I've tested that this is the case for a desktop Linux export as well.

Basically, we're getting the absolute path a little earlier than we should, which works when running the unexported project from the editor, but doesn't when the `.gdextension` file is in the PCK file - we need to still use the `res://` path for loading that.

This PR fixes the issue in my testing on both Linux and Android!