### PR TITLE
Cleanup of raw `nullptr` checks with `Ref`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -675,7 +675,7 @@ GDExtensionInterfaceFunctionPtr GDExtension::get_interface_function(const String
 }
 
 Error GDExtension::open_library(const String &p_path, const Ref<GDExtensionLoader> &p_loader) {
-	ERR_FAIL_NULL_V_MSG(p_loader, FAILED, "Can't open GDExtension without a loader.");
+	ERR_FAIL_COND_V_MSG(p_loader.is_null(), FAILED, "Can't open GDExtension without a loader.");
 	loader = p_loader;
 
 	Error err = loader->open_library(p_path);

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -37,7 +37,7 @@
 #include <stdio.h>
 
 Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic) {
-	ERR_FAIL_COND_V_MSG(file != nullptr, ERR_ALREADY_IN_USE, "Can't open file while another file from path '" + file->get_path_absolute() + "' is open.");
+	ERR_FAIL_COND_V_MSG(file.is_valid(), ERR_ALREADY_IN_USE, "Can't open file while another file from path '" + file->get_path_absolute() + "' is open.");
 	ERR_FAIL_COND_V(p_key.size() != 32, ERR_INVALID_PARAMETER);
 
 	pos = 0;
@@ -162,7 +162,7 @@ void FileAccessEncrypted::_close() {
 }
 
 bool FileAccessEncrypted::is_open() const {
-	return file != nullptr;
+	return file.is_valid();
 }
 
 String FileAccessEncrypted::get_path() const {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4225,7 +4225,7 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 	result["root_mean_squared"] = INFINITY;
 	result["peak_snr"] = 0.0f;
 
-	ERR_FAIL_NULL_V(p_compared_image, result);
+	ERR_FAIL_COND_V(p_compared_image.is_null(), result);
 	Error err = OK;
 	Ref<Image> compared_image = duplicate(true);
 	if (compared_image->is_compressed()) {

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -814,7 +814,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 }
 
 PackedByteArray PList::save_asn1() const {
-	if (root == nullptr) {
+	if (root.is_null()) {
 		ERR_FAIL_V_MSG(PackedByteArray(), "PList: Invalid PList, no root node.");
 	}
 	size_t size = root->get_asn1_size(1);
@@ -848,7 +848,7 @@ PackedByteArray PList::save_asn1() const {
 }
 
 String PList::save_text() const {
-	if (root == nullptr) {
+	if (root.is_null()) {
 		ERR_FAIL_V_MSG(String(), "PList: Invalid PList, no root node.");
 	}
 

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -719,7 +719,7 @@ void AnimationBezierTrackEdit::set_root(Node *p_root) {
 
 void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 	is_filtered = p_filtered;
-	if (animation == nullptr) {
+	if (animation.is_null()) {
 		return;
 	}
 	String base_path = animation->track_get_path(selected_track);

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -140,7 +140,7 @@ Vector<String> EditorExportPlugin::get_ios_project_static_libs() const {
 }
 
 Variant EditorExportPlugin::get_option(const StringName &p_name) const {
-	ERR_FAIL_NULL_V(export_preset, Variant());
+	ERR_FAIL_COND_V(export_preset.is_null(), Variant());
 	return export_preset->get(p_name);
 }
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -446,7 +446,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 }
 
 static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r_shape_list, bool p_convex) {
-	ERR_FAIL_NULL_MSG(mesh, "Cannot generate shape list with null mesh value.");
+	ERR_FAIL_COND_MSG(mesh.is_null(), "Cannot generate shape list with null mesh value.");
 	if (!p_convex) {
 		Ref<ConcavePolygonShape3D> shape = mesh->create_trimesh_shape();
 		r_shape_list.push_back(shape);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -509,7 +509,7 @@ void DynamicFontImportSettingsDialog::_variation_add() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 	import_variation_data.instantiate();
 	import_variation_data->owner = this;
-	ERR_FAIL_NULL(import_variation_data);
+	ERR_FAIL_COND(import_variation_data.is_null());
 
 	for (List<ResourceImporter::ImportOption>::Element *E = options_variations.front(); E; E = E->next()) {
 		import_variation_data->defaults[E->get().option.name] = E->get().default_value;
@@ -529,7 +529,7 @@ void DynamicFontImportSettingsDialog::_variation_selected() {
 	TreeItem *vars_item = vars_list->get_selected();
 	if (vars_item) {
 		Ref<DynamicFontImportSettingsData> import_variation_data = vars_item->get_metadata(0);
-		ERR_FAIL_NULL(import_variation_data);
+		ERR_FAIL_COND(import_variation_data.is_null());
 
 		inspector_vars->edit(import_variation_data.ptr());
 		import_variation_data->notify_property_list_changed();
@@ -588,14 +588,14 @@ void DynamicFontImportSettingsDialog::_variations_validate() {
 	}
 	for (TreeItem *vars_item_a = vars_list_root->get_first_child(); vars_item_a; vars_item_a = vars_item_a->get_next()) {
 		Ref<DynamicFontImportSettingsData> import_variation_data_a = vars_item_a->get_metadata(0);
-		ERR_FAIL_NULL(import_variation_data_a);
+		ERR_FAIL_COND(import_variation_data_a.is_null());
 
 		for (TreeItem *vars_item_b = vars_list_root->get_first_child(); vars_item_b; vars_item_b = vars_item_b->get_next()) {
 			if (vars_item_b != vars_item_a) {
 				bool match = true;
 				for (const KeyValue<StringName, Variant> &E : import_variation_data_a->settings) {
 					Ref<DynamicFontImportSettingsData> import_variation_data_b = vars_item_b->get_metadata(0);
-					ERR_FAIL_NULL(import_variation_data_b);
+					ERR_FAIL_COND(import_variation_data_b.is_null());
 					match = match && (import_variation_data_b->settings[E.key] == E.value);
 				}
 				if (match) {
@@ -956,7 +956,7 @@ void DynamicFontImportSettingsDialog::_re_import() {
 	Array configurations;
 	for (TreeItem *vars_item = vars_list_root->get_first_child(); vars_item; vars_item = vars_item->get_next()) {
 		Ref<DynamicFontImportSettingsData> import_variation_data = vars_item->get_metadata(0);
-		ERR_FAIL_NULL(import_variation_data);
+		ERR_FAIL_COND(import_variation_data.is_null());
 
 		Dictionary preload_config;
 		preload_config["name"] = vars_item->get_text(0);
@@ -1107,7 +1107,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	inspector_general->edit(nullptr);
 
 	text_settings_data.instantiate();
-	ERR_FAIL_NULL(text_settings_data);
+	ERR_FAIL_COND(text_settings_data.is_null());
 
 	text_settings_data->owner = this;
 
@@ -1137,7 +1137,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 
 	Ref<ConfigFile> config;
 	config.instantiate();
-	ERR_FAIL_NULL(config);
+	ERR_FAIL_COND(config.is_null());
 
 	Error err = config->load(p_path + ".import");
 	print_verbose("Loading import settings:");
@@ -1169,7 +1169,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 
 					Ref<DynamicFontImportSettingsData> import_variation_data_custom;
 					import_variation_data_custom.instantiate();
-					ERR_FAIL_NULL(import_variation_data_custom);
+					ERR_FAIL_COND(import_variation_data_custom.is_null());
 
 					import_variation_data_custom->owner = this;
 					for (List<ResourceImporter::ImportOption>::Element *F = options_variations.front(); F; F = F->next()) {

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -510,7 +510,7 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 	}
 
 	bool can_compress_hdr = r_texture_import->hdr_compression > 0;
-	ERR_FAIL_NULL(r_texture_import->image);
+	ERR_FAIL_COND(r_texture_import->image.is_null());
 	bool is_hdr = (r_texture_import->image->get_format() >= Image::FORMAT_RF && r_texture_import->image->get_format() <= Image::FORMAT_RGBE9995);
 	ERR_FAIL_NULL(r_texture_import->slices);
 	// Can compress hdr, but hdr with alpha is not compressible.

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -171,7 +171,7 @@ void ImportDock::_add_keep_import_option(const String &p_importer_name) {
 void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_config) {
 	// Set the importer class to fetch the correct class in the XML class reference.
 	// This allows tooltips to display when hovering properties.
-	if (params->importer != nullptr) {
+	if (params->importer.is_valid()) {
 		// Null check to avoid crashing if the "Keep File (exported as is)" mode is selected.
 		import_opts->set_object_class(params->importer->get_class_name());
 	}

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -982,7 +982,7 @@ void EditorNode3DGizmoPlugin::create_handle_material(const String &p_name, bool 
 
 	handle_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	handle_material->set_flag(StandardMaterial3D::FLAG_USE_POINT_SIZE, true);
-	Ref<Texture2D> handle_t = p_icon != nullptr ? p_icon : EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Editor3DHandle"), EditorStringName(EditorIcons));
+	Ref<Texture2D> handle_t = p_icon.is_valid() ? p_icon : EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Editor3DHandle"), EditorStringName(EditorIcons));
 	handle_material->set_point_size(handle_t->get_width());
 	handle_material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, handle_t);
 	handle_material->set_albedo(Color(1, 1, 1));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4506,8 +4506,8 @@ bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path
 
 	Node *instantiated_scene = nullptr;
 
-	if (mesh != nullptr || scene != nullptr) {
-		if (mesh != nullptr) {
+	if (mesh.is_valid() || scene.is_valid()) {
+		if (mesh.is_valid()) {
 			MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
 			mesh_instance->set_mesh(mesh);
 
@@ -4538,7 +4538,7 @@ bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path
 		}
 	}
 
-	if (scene != nullptr) {
+	if (scene.is_valid()) {
 		instantiated_scene->set_scene_file_path(ProjectSettings::get_singleton()->localize_path(p_path));
 	}
 
@@ -9291,7 +9291,7 @@ struct _GizmoPluginNameComparator {
 };
 
 void Node3DEditor::add_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin) {
-	ERR_FAIL_NULL(p_plugin.ptr());
+	ERR_FAIL_COND(p_plugin.is_null());
 
 	gizmo_plugins_by_priority.push_back(p_plugin);
 	gizmo_plugins_by_priority.sort_custom<_GizmoPluginPriorityComparator>();

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -295,7 +295,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			Vector2 gpoint = mm->get_position();
 
 			Ref<Curve2D> curve = node->get_curve();
-			if (curve == nullptr) {
+			if (curve.is_null()) {
 				return true;
 			}
 			if (curve->get_point_count() < 2) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -510,7 +510,7 @@ void ScriptEditor::_set_execution(Ref<RefCounted> p_script, int p_line) {
 				continue;
 			}
 
-			if ((scr != nullptr && se->get_edited_resource() == p_script) || se->get_edited_resource()->get_path() == scr->get_path()) {
+			if ((scr.is_valid() && se->get_edited_resource() == p_script) || se->get_edited_resource()->get_path() == scr->get_path()) {
 				se->set_executing_line(p_line);
 			}
 		}
@@ -526,7 +526,7 @@ void ScriptEditor::_clear_execution(Ref<RefCounted> p_script) {
 				continue;
 			}
 
-			if ((scr != nullptr && se->get_edited_resource() == p_script) || se->get_edited_resource()->get_path() == scr->get_path()) {
+			if ((scr.is_valid() && se->get_edited_resource() == p_script) || se->get_edited_resource()->get_path() == scr->get_path()) {
 				se->clear_executing_line();
 			}
 		}
@@ -711,7 +711,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 		}
 
 		Ref<Script> scr = Object::cast_to<ScriptEditorBase>(c)->get_edited_resource();
-		if (scr != nullptr) {
+		if (scr.is_valid()) {
 			notify_script_changed(scr);
 		}
 
@@ -1017,7 +1017,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 		}
 
 		Ref<TextFile> text_file = scr;
-		if (text_file != nullptr) {
+		if (text_file.is_valid()) {
 			se->apply_code();
 			_save_text_file(text_file, text_file->get_path());
 			break;
@@ -1228,7 +1228,7 @@ Ref<Script> ScriptEditor::_get_current_script() {
 
 	if (current) {
 		Ref<Script> scr = current->get_edited_resource();
-		return scr != nullptr ? scr : nullptr;
+		return scr.is_valid() ? scr : nullptr;
 	} else {
 		return nullptr;
 	}
@@ -1420,7 +1420,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				Ref<TextFile> text_file = resource;
 				Ref<Script> scr = resource;
 
-				if (text_file != nullptr) {
+				if (text_file.is_valid()) {
 					file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 					file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 					file_dialog_option = FILE_SAVE_AS;
@@ -1449,7 +1449,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 			case FILE_TOOL_RELOAD_SOFT: {
 				Ref<Script> scr = current->get_edited_resource();
-				if (scr == nullptr || scr.is_null()) {
+				if (scr.is_null()) {
 					EditorNode::get_singleton()->show_warning(TTR("Can't obtain the script for reloading."));
 					break;
 				}
@@ -1463,7 +1463,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 			case FILE_RUN: {
 				Ref<Script> scr = current->get_edited_resource();
-				if (scr == nullptr || scr.is_null()) {
+				if (scr.is_null()) {
 					EditorToaster::get_singleton()->popup_str(TTR("Cannot run the edited file because it's not a script."), EditorToaster::SEVERITY_WARNING);
 					break;
 				}
@@ -1796,7 +1796,7 @@ void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 
 		if (se) {
 			Ref<Script> scr = se->get_edited_resource();
-			if (scr == nullptr || !scr.is_valid()) {
+			if (scr.is_null()) {
 				continue;
 			}
 
@@ -2500,7 +2500,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			continue;
 		}
 
-		if ((scr != nullptr && se->get_edited_resource() == p_resource) || se->get_edited_resource()->get_path() == p_resource->get_path()) {
+		if ((scr.is_valid() && se->get_edited_resource() == p_resource) || se->get_edited_resource()->get_path() == p_resource->get_path()) {
 			if (should_open) {
 				se->enable_editor(this);
 
@@ -2550,7 +2550,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 		PackedStringArray languages = highlighter->_get_supported_languages();
 		// If script try language, else use extension.
-		if (scr != nullptr) {
+		if (scr.is_valid()) {
 			if (languages.has(scr->get_language()->get_name())) {
 				se->set_syntax_highlighter(highlighter);
 				highlighter_set = true;
@@ -2660,7 +2660,7 @@ void ScriptEditor::save_current_script() {
 	Ref<TextFile> text_file = resource;
 	Ref<Script> scr = resource;
 
-	if (text_file != nullptr) {
+	if (text_file.is_valid()) {
 		current->apply_code();
 		_save_text_file(text_file, text_file->get_path());
 		return;
@@ -2711,7 +2711,7 @@ void ScriptEditor::save_all_scripts() {
 			Ref<TextFile> text_file = edited_res;
 			Ref<Script> scr = edited_res;
 
-			if (text_file != nullptr) {
+			if (text_file.is_valid()) {
 				_save_text_file(text_file, text_file->get_path());
 				continue;
 			}
@@ -2788,7 +2788,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 			}
 
 			Ref<JSON> json = edited_res;
-			if (json != nullptr) {
+			if (json.is_valid()) {
 				Ref<JSON> rel_json = ResourceLoader::load(json->get_path(), json->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 				ERR_CONTINUE(!rel_json.is_valid());
 				json->parse(rel_json->get_parsed_text(), true);
@@ -3338,7 +3338,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_separator();
 	if (se) {
 		Ref<Script> scr = se->get_edited_resource();
-		if (scr != nullptr) {
+		if (scr.is_valid()) {
 			if (!scr.is_null() && scr->is_tool()) {
 				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_TOOL_RELOAD_SOFT);
 				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_RUN);
@@ -3685,7 +3685,7 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 		seb->ensure_focus();
 
 		Ref<Script> scr = seb->get_edited_resource();
-		if (scr != nullptr) {
+		if (scr.is_valid()) {
 			notify_script_changed(scr);
 		}
 	}
@@ -3724,7 +3724,7 @@ Vector<Ref<Script>> ScriptEditor::get_open_scripts() const {
 		}
 
 		Ref<Script> scr = se->get_edited_resource();
-		if (scr != nullptr) {
+		if (scr.is_valid()) {
 			out_scripts.push_back(scr);
 		}
 	}

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -104,12 +104,12 @@ void TextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	edited_res = p_res;
 
 	Ref<TextFile> text_file = edited_res;
-	if (text_file != nullptr) {
+	if (text_file.is_valid()) {
 		code_editor->get_text_editor()->set_text(text_file->get_text());
 	}
 
 	Ref<JSON> json_file = edited_res;
-	if (json_file != nullptr) {
+	if (json_file.is_valid()) {
 		code_editor->get_text_editor()->set_text(json_file->get_parsed_text());
 	}
 
@@ -169,12 +169,12 @@ void TextEditor::reload_text() {
 	int v = te->get_v_scroll();
 
 	Ref<TextFile> text_file = edited_res;
-	if (text_file != nullptr) {
+	if (text_file.is_valid()) {
 		te->set_text(text_file->get_text());
 	}
 
 	Ref<JSON> json_file = edited_res;
-	if (json_file != nullptr) {
+	if (json_file.is_valid()) {
 		te->set_text(json_file->get_parsed_text());
 	}
 
@@ -194,7 +194,7 @@ void TextEditor::_validate_script() {
 	emit_signal(SNAME("edited_script_changed"));
 
 	Ref<JSON> json_file = edited_res;
-	if (json_file != nullptr) {
+	if (json_file.is_valid()) {
 		CodeEdit *te = code_editor->get_text_editor();
 
 		te->set_line_background_color(code_editor->get_error_pos().x, Color(0, 0, 0, 0));
@@ -245,12 +245,12 @@ void TextEditor::_bookmark_item_pressed(int p_idx) {
 
 void TextEditor::apply_code() {
 	Ref<TextFile> text_file = edited_res;
-	if (text_file != nullptr) {
+	if (text_file.is_valid()) {
 		text_file->set_text(code_editor->get_text_editor()->get_text());
 	}
 
 	Ref<JSON> json_file = edited_res;
-	if (json_file != nullptr) {
+	if (json_file.is_valid()) {
 		json_file->parse(code_editor->get_text_editor()->get_text(), true);
 	}
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -169,7 +169,7 @@ void EditorInspectorPluginTexture::parse_begin(Object *p_object) {
 		Ref<Image> image(Object::cast_to<Image>(p_object));
 		texture = ImageTexture::create_from_image(image);
 
-		ERR_FAIL_NULL_MSG(texture, "Failed to create the texture from an invalid image.");
+		ERR_FAIL_COND_MSG(texture.is_null(), "Failed to create the texture from an invalid image.");
 	}
 
 	add_custom_control(memnew(TexturePreview(texture, true)));

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3682,7 +3682,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (selection.size() == 1) {
 		bool is_external = (!selection.front()->get()->get_scene_file_path().is_empty());
 		if (is_external) {
-			bool is_inherited = selection.front()->get()->get_scene_inherited_state() != nullptr;
+			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
 			bool is_top_level = selection.front()->get()->get_owner() == nullptr;
 			if (is_inherited && is_top_level) {
 				menu->add_separator();

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -183,7 +183,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 
 		// If settings are comparable to the old theme, then just copy existing icons over.
 		// Otherwise, regenerate them.
-		bool keep_old_icons = (p_old_theme != nullptr && theme->get_generated_icons_hash() == p_old_theme->get_generated_icons_hash());
+		bool keep_old_icons = (p_old_theme.is_valid() && theme->get_generated_icons_hash() == p_old_theme->get_generated_icons_hash());
 		if (keep_old_icons) {
 			print_verbose("EditorTheme: Can keep old icons, copying.");
 			editor_copy_icons(theme, p_old_theme);

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -875,7 +875,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 						const int material = int(fbx_material->typed_id);
 						ERR_FAIL_INDEX_V(material, p_state->materials.size(), ERR_FILE_CORRUPT);
 						Ref<Material> mat3d = p_state->materials[material];
-						ERR_FAIL_NULL_V(mat3d, ERR_FILE_CORRUPT);
+						ERR_FAIL_COND_V(mat3d.is_null(), ERR_FILE_CORRUPT);
 
 						Ref<BaseMaterial3D> base_material = mat3d;
 						if (has_vertex_color && base_material.is_valid()) {
@@ -891,7 +891,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 						}
 						mat = mat3d;
 					}
-					ERR_FAIL_NULL_V(mat, ERR_FILE_CORRUPT);
+					ERR_FAIL_COND_V(mat.is_null(), ERR_FILE_CORRUPT);
 					mat_name = mat->get_name();
 				}
 				import_mesh->add_surface(primitive, array, morphs,
@@ -1056,7 +1056,7 @@ GLTFImageIndex FBXDocument::_parse_image_save_image(Ref<FBXState> p_state, const
 }
 
 Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_path) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 
 	const ufbx_scene *fbx_scene = p_state->scene.get();
 	for (int texture_i = 0; texture_i < static_cast<int>(fbx_scene->texture_files.count); texture_i++) {
@@ -2118,7 +2118,6 @@ Error FBXDocument::_parse(Ref<FBXState> p_state, String p_path, Ref<FileAccess> 
 Node *FBXDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, bool p_trimming, bool p_remove_immutable_tracks) {
 	Ref<FBXState> state = p_state;
 	ERR_FAIL_COND_V(state.is_null(), nullptr);
-	ERR_FAIL_NULL_V(state, nullptr);
 	ERR_FAIL_INDEX_V(0, state->root_nodes.size(), nullptr);
 	p_state->set_bake_fps(p_bake_fps);
 	GLTFNodeIndex fbx_root = state->root_nodes.write[0];
@@ -2246,7 +2245,7 @@ Error FBXDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint3
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);
-	ERR_FAIL_NULL_V(file, ERR_FILE_CANT_OPEN);
+	ERR_FAIL_COND_V(file.is_null(), ERR_FILE_CANT_OPEN);
 	String base_path = p_base_path;
 	if (base_path.is_empty()) {
 		base_path = p_path.get_base_dir();

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -150,7 +150,7 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 
 GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
 		function(p_function) {
-	ERR_FAIL_NULL(p_script.ptr());
+	ERR_FAIL_COND(p_script.is_null());
 	ERR_FAIL_NULL(p_function);
 	script = p_script;
 	captures = p_captures;
@@ -282,7 +282,7 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 
 GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
 		function(p_function) {
-	ERR_FAIL_NULL(p_self.ptr());
+	ERR_FAIL_COND(p_self.is_null());
 	ERR_FAIL_NULL(p_function);
 	reference = p_self;
 	object = p_self.ptr();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4795,9 +4795,9 @@ String GDScriptParser::DataType::to_string() const {
 			return class_type->fqcn;
 		case SCRIPT: {
 			if (is_meta_type) {
-				return script_type != nullptr ? script_type->get_class_name().operator String() : "";
+				return script_type.is_valid() ? script_type->get_class_name().operator String() : "";
 			}
-			String name = script_type != nullptr ? script_type->get_name() : "";
+			String name = script_type.is_valid() ? script_type->get_name() : "";
 			if (!name.is_empty()) {
 				return name;
 			}

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -196,7 +196,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 		ERR_FAIL_COND_V_MSG(!clients.has(latest_client_id), ret.to_json(),
 				vformat("GDScriptLanguageProtocol: Can't initialize invalid peer '%d'.", latest_client_id));
 		Ref<LSPeer> peer = clients.get(latest_client_id);
-		if (peer != nullptr) {
+		if (peer.is_valid()) {
 			String msg = Variant(request).to_json_string();
 			msg = format_output(msg);
 			(*peer)->res_queue.push_back(msg.utf8());
@@ -298,7 +298,7 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	}
 	ERR_FAIL_COND(!clients.has(p_client_id));
 	Ref<LSPeer> peer = clients.get(p_client_id);
-	ERR_FAIL_NULL(peer);
+	ERR_FAIL_COND(peer.is_null());
 
 	Dictionary message = make_notification(p_method, p_params);
 	String msg = Variant(message).to_json_string();
@@ -319,7 +319,7 @@ void GDScriptLanguageProtocol::request_client(const String &p_method, const Vari
 	}
 	ERR_FAIL_COND(!clients.has(p_client_id));
 	Ref<LSPeer> peer = clients.get(p_client_id);
-	ERR_FAIL_NULL(peer);
+	ERR_FAIL_COND(peer.is_null());
 
 	Dictionary message = make_request(p_method, p_params, next_server_id);
 	next_server_id++;

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -56,7 +56,7 @@ void GLTFDocumentExtension::_bind_methods() {
 
 // Import process.
 Error GLTFDocumentExtension::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_preflight, p_state, p_extensions, err);
 	return err;
@@ -69,16 +69,16 @@ Vector<String> GLTFDocumentExtension::get_supported_extensions() {
 }
 
 Error GLTFDocumentExtension::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_parse_node_extensions, p_state, p_gltf_node, p_extensions, err);
 	return err;
 }
 
 Error GLTFDocumentExtension::parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(r_image, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(r_image.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_parse_image_data, p_state, p_image_data, p_mime_type, r_image, err);
 	return err;
@@ -91,31 +91,31 @@ String GLTFDocumentExtension::get_image_file_extension() {
 }
 
 Error GLTFDocumentExtension::parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(r_gltf_texture, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(r_gltf_texture.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_parse_texture_json, p_state, p_texture_json, r_gltf_texture, err);
 	return err;
 }
 
 Node3D *GLTFDocumentExtension::generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) {
-	ERR_FAIL_NULL_V(p_state, nullptr);
-	ERR_FAIL_NULL_V(p_gltf_node, nullptr);
+	ERR_FAIL_COND_V(p_state.is_null(), nullptr);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), nullptr);
 	Node3D *ret_node = nullptr;
 	GDVIRTUAL_CALL(_generate_scene_node, p_state, p_gltf_node, p_scene_parent, ret_node);
 	return ret_node;
 }
 
 Error GLTFDocumentExtension::import_post_parse(Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_post_parse, p_state, err);
 	return err;
 }
 
 Error GLTFDocumentExtension::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_node, p_state, p_gltf_node, r_dict, p_node, err);
@@ -124,7 +124,7 @@ Error GLTFDocumentExtension::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 
 Error GLTFDocumentExtension::import_post(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_post, p_state, p_root, err);
 	return err;
@@ -139,14 +139,14 @@ Error GLTFDocumentExtension::export_preflight(Ref<GLTFState> p_state, Node *p_ro
 }
 
 void GLTFDocumentExtension::convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) {
-	ERR_FAIL_NULL(p_state);
-	ERR_FAIL_NULL(p_gltf_node);
+	ERR_FAIL_COND(p_state.is_null());
+	ERR_FAIL_COND(p_gltf_node.is_null());
 	ERR_FAIL_NULL(p_scene_node);
 	GDVIRTUAL_CALL(_convert_scene_node, p_state, p_gltf_node, p_scene_node);
 }
 
 Error GLTFDocumentExtension::export_preserialize(Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_export_preserialize, p_state, err);
 	return err;
@@ -160,38 +160,38 @@ Vector<String> GLTFDocumentExtension::get_saveable_image_formats() {
 
 PackedByteArray GLTFDocumentExtension::serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary p_image_dict, const String &p_image_format, float p_lossy_quality) {
 	PackedByteArray ret;
-	ERR_FAIL_NULL_V(p_state, ret);
-	ERR_FAIL_NULL_V(p_image, ret);
+	ERR_FAIL_COND_V(p_state.is_null(), ret);
+	ERR_FAIL_COND_V(p_image.is_null(), ret);
 	GDVIRTUAL_CALL(_serialize_image_to_bytes, p_state, p_image, p_image_dict, p_image_format, p_lossy_quality, ret);
 	return ret;
 }
 
 Error GLTFDocumentExtension::save_image_at_path(Ref<GLTFState> p_state, Ref<Image> p_image, const String &p_file_path, const String &p_image_format, float p_lossy_quality) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_image, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_image.is_null(), ERR_INVALID_PARAMETER);
 	Error ret = OK;
 	GDVIRTUAL_CALL(_save_image_at_path, p_state, p_image, p_file_path, p_image_format, p_lossy_quality, ret);
 	return ret;
 }
 
 Error GLTFDocumentExtension::serialize_texture_json(Ref<GLTFState> p_state, Dictionary p_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_gltf_texture, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_texture.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_serialize_texture_json, p_state, p_texture_json, p_gltf_texture, p_image_format, err);
 	return err;
 }
 
 Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, r_dict, p_node, err);
 	return err;
 }
 
 Error GLTFDocumentExtension::export_post(Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_export_post, p_state, err);
 	return err;

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -45,7 +45,7 @@ void GLTFDocumentExtensionConvertImporterMesh::_copy_meta(Object *p_src_object, 
 
 Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	List<Node *> queue;
 	queue.push_back(p_root);
 	List<Node *> delete_queue;

--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -229,7 +229,7 @@ Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_resource(const Ref<Shape3D> &p_shap
 }
 
 Ref<Shape3D> GLTFPhysicsShape::to_resource(bool p_cache_shapes) {
-	if (!p_cache_shapes || _shape_cache == nullptr) {
+	if (!p_cache_shapes || _shape_cache.is_null()) {
 		if (shape_type == "box") {
 			Ref<BoxShape3D> box;
 			box.instantiate();

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -299,8 +299,8 @@ Error GLTFDocument::_parse_json(const String &p_path, Ref<GLTFState> p_state) {
 }
 
 Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL_V(p_file, ERR_INVALID_PARAMETER);
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_file.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_file->get_position() != 0, ERR_FILE_CANT_READ);
 	uint32_t magic = p_file->get_32();
 	ERR_FAIL_COND_V(magic != 0x46546C67, ERR_FILE_UNRECOGNIZED); //glTF
@@ -3282,7 +3282,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 					const int material = p["material"];
 					ERR_FAIL_INDEX_V(material, p_state->materials.size(), ERR_FILE_CORRUPT);
 					Ref<Material> mat3d = p_state->materials[material];
-					ERR_FAIL_NULL_V(mat3d, ERR_FILE_CORRUPT);
+					ERR_FAIL_COND_V(mat3d.is_null(), ERR_FILE_CORRUPT);
 
 					Ref<BaseMaterial3D> base_material = mat3d;
 					if (has_vertex_color && base_material.is_valid()) {
@@ -3298,7 +3298,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 					}
 					mat = mat3d;
 				}
-				ERR_FAIL_NULL_V(mat, ERR_FILE_CORRUPT);
+				ERR_FAIL_COND_V(mat.is_null(), ERR_FILE_CORRUPT);
 				mat_name = mat->get_name();
 			}
 			import_mesh->add_surface(primitive, array, morphs,
@@ -3601,7 +3601,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 }
 
 Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_path) {
-	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	if (!p_state->json.has("images")) {
 		return OK;
 	}
@@ -6967,14 +6967,14 @@ Dictionary _serialize_texture_transform_uv(Vector2 p_offset, Vector2 p_scale) {
 }
 
 Dictionary GLTFDocument::_serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material) {
-	ERR_FAIL_NULL_V(p_material, Dictionary());
+	ERR_FAIL_COND_V(p_material.is_null(), Dictionary());
 	Vector3 offset = p_material->get_uv1_offset();
 	Vector3 scale = p_material->get_uv1_scale();
 	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
 }
 
 Dictionary GLTFDocument::_serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material) {
-	ERR_FAIL_NULL_V(p_material, Dictionary());
+	ERR_FAIL_COND_V(p_material.is_null(), Dictionary());
 	Vector3 offset = p_material->get_uv2_offset();
 	Vector3 scale = p_material->get_uv2_scale();
 	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
@@ -7345,7 +7345,7 @@ Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_se
 
 PackedByteArray GLTFDocument::generate_buffer(Ref<GLTFState> p_state) {
 	Ref<GLTFState> state = p_state;
-	ERR_FAIL_NULL_V(state, PackedByteArray());
+	ERR_FAIL_COND_V(state.is_null(), PackedByteArray());
 	// For buffers, set the state filename to an empty string, but
 	// don't touch the base path, in case the user set it manually.
 	state->filename = "";
@@ -7357,7 +7357,7 @@ PackedByteArray GLTFDocument::generate_buffer(Ref<GLTFState> p_state) {
 
 Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_path) {
 	Ref<GLTFState> state = p_state;
-	ERR_FAIL_NULL_V(state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(state.is_null(), ERR_INVALID_PARAMETER);
 	state->base_path = p_path.get_base_dir();
 	state->filename = p_path.get_file();
 	Error err = _serialize(state);
@@ -7373,7 +7373,7 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_
 
 Node *GLTFDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, bool p_trimming, bool p_remove_immutable_tracks) {
 	Ref<GLTFState> state = p_state;
-	ERR_FAIL_NULL_V(state, nullptr);
+	ERR_FAIL_COND_V(state.is_null(), nullptr);
 	ERR_FAIL_INDEX_V(0, state->root_nodes.size(), nullptr);
 	Error err = OK;
 	p_state->set_bake_fps(p_bake_fps);
@@ -7491,7 +7491,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);
-	ERR_FAIL_NULL_V(file, ERR_FILE_CANT_OPEN);
+	ERR_FAIL_COND_V(file.is_null(), ERR_FILE_CANT_OPEN);
 	String base_path = p_base_path;
 	if (base_path.is_empty()) {
 		base_path = p_path.get_base_dir();
@@ -7508,7 +7508,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint
 }
 
 Error GLTFDocument::_parse_gltf_extensions(Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL_V(p_state, ERR_PARSE_ERROR);
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_PARSE_ERROR);
 	if (p_state->json.has("extensionsUsed")) {
 		Vector<String> ext_array = p_state->json["extensionsUsed"];
 		p_state->extensions_used = ext_array;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2796,7 +2796,7 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 
 	if (GDMonoCache::godot_api_cache_updated) {
 		GDMonoCache::managed_callbacks.ScriptManagerBridge_GetOrCreateScriptBridgeForPath(&p_path, &scr);
-		ERR_FAIL_NULL_V_MSG(scr, Ref<Resource>(), "Could not create C# script '" + real_path + "'.");
+		ERR_FAIL_COND_V_MSG(scr.is_null(), Ref<Resource>(), "Could not create C# script '" + real_path + "'.");
 	} else {
 		scr = Ref<CSharpScript>(memnew(CSharpScript));
 	}

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -194,7 +194,7 @@ private:
 			if (!has_data) {
 				// 3. Extract the data to a temporary location to load from there.
 				Ref<DirAccess> da = DirAccess::create_for_path(packed_path);
-				ERR_FAIL_NULL(da);
+				ERR_FAIL_COND(da.is_null());
 				ERR_FAIL_COND(da->copy_dir(packed_path, data_dir_root) != OK);
 			}
 			api_assemblies_dir = data_dir_root;

--- a/modules/noise/tests/test_noise_texture_2d.h
+++ b/modules/noise/tests/test_noise_texture_2d.h
@@ -135,7 +135,7 @@ TEST_CASE("[NoiseTexture][SceneTree] Getter and setter") {
 	noise_texture->set_noise(noise);
 	CHECK(noise_texture->get_noise() == noise);
 	noise_texture->set_noise(nullptr);
-	CHECK(noise_texture->get_noise() == nullptr);
+	CHECK(noise_texture->get_noise().is_null());
 
 	noise_texture->set_width(8);
 	noise_texture->set_height(4);
@@ -190,7 +190,7 @@ TEST_CASE("[NoiseTexture][SceneTree] Getter and setter") {
 	noise_texture->set_color_ramp(gradient);
 	CHECK(noise_texture->get_color_ramp() == gradient);
 	noise_texture->set_color_ramp(nullptr);
-	CHECK(noise_texture->get_color_ramp() == nullptr);
+	CHECK(noise_texture->get_color_ramp().is_null());
 }
 
 TEST_CASE("[NoiseTexture2D][SceneTree] Generating a basic noise texture with mipmaps and color ramp modulation") {

--- a/modules/noise/tests/test_noise_texture_3d.h
+++ b/modules/noise/tests/test_noise_texture_3d.h
@@ -133,7 +133,7 @@ TEST_CASE("[NoiseTexture][SceneTree] Getter and setter") {
 	noise_texture->set_noise(noise);
 	CHECK(noise_texture->get_noise() == noise);
 	noise_texture->set_noise(nullptr);
-	CHECK(noise_texture->get_noise() == nullptr);
+	CHECK(noise_texture->get_noise().is_null());
 
 	noise_texture->set_width(8);
 	noise_texture->set_height(4);
@@ -174,7 +174,7 @@ TEST_CASE("[NoiseTexture][SceneTree] Getter and setter") {
 	noise_texture->set_color_ramp(gradient);
 	CHECK(noise_texture->get_color_ramp() == gradient);
 	noise_texture->set_color_ramp(nullptr);
-	CHECK(noise_texture->get_color_ramp() == nullptr);
+	CHECK(noise_texture->get_color_ramp().is_null());
 }
 
 TEST_CASE("[NoiseTexture3D][SceneTree] Generating a basic noise texture with mipmaps and color ramp modulation") {

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -80,32 +80,32 @@ TEST_CASE("[RegEx] Searching") {
 	REQUIRE(re.is_valid());
 
 	Ref<RegExMatch> match = re.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "ea");
 
 	match = re.search(s, 1, 2);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "e");
 	match = re.search(s, 2, 4);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "a");
 	match = re.search(s, 3, 5);
-	CHECK(match == nullptr);
+	CHECK(match.is_null());
 	match = re.search(s, 6, 2);
-	CHECK(match == nullptr);
+	CHECK(match.is_null());
 
 	const Array all_results = re.search_all(s);
 	CHECK(all_results.size() == 2);
 	match = all_results[0];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "ea");
 	match = all_results[1];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "i");
 
 	CHECK(re.compile(numerics) == OK);
 	CHECK(re.is_valid());
-	CHECK(re.search(s) == nullptr);
+	CHECK(re.search(s).is_null());
 	CHECK(re.search_all(s).size() == 0);
 }
 
@@ -168,7 +168,7 @@ TEST_CASE("[RegEx] Uninitialized use") {
 
 	RegEx re;
 	ERR_PRINT_OFF;
-	CHECK(re.search(s) == nullptr);
+	CHECK(re.search(s).is_null());
 	CHECK(re.search_all(s).size() == 0);
 	CHECK(re.sub(s, "") == "");
 	CHECK(re.get_group_count() == 0);
@@ -237,10 +237,10 @@ TEST_CASE("[RegEx] Invalid end position") {
 	const Array all_results = re.search_all(s, 0, 10);
 	CHECK(all_results.size() == 2);
 	match = all_results[0];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == String("o"));
 	match = all_results[1];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == String("o"));
 
 	CHECK(re.sub(s, "", true, 0, 10) == "Gdt");
@@ -251,7 +251,7 @@ TEST_CASE("[RegEx] Get match string list") {
 
 	RegEx re("(Go)(dot)");
 	Ref<RegExMatch> match = re.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	PackedStringArray result;
 	result.append("Godot");
 	result.append("Go");
@@ -265,14 +265,14 @@ TEST_CASE("[RegEx] Match start and end positions") {
 	RegEx re1("pattern");
 	REQUIRE(re1.is_valid());
 	Ref<RegExMatch> match = re1.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 6);
 	CHECK(match->get_end(0) == 13);
 
 	RegEx re2("(?<vowel>[aeiou])");
 	REQUIRE(re2.is_valid());
 	match = re2.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start("vowel") == 2);
 	CHECK(match->get_end("vowel") == 3);
 }
@@ -307,7 +307,7 @@ TEST_CASE("[RegEx] Simple lookahead") {
 	RegEx re("o(?=t)");
 	REQUIRE(re.is_valid());
 	Ref<RegExMatch> match = re.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 3);
 	CHECK(match->get_end(0) == 4);
 }
@@ -325,12 +325,12 @@ TEST_CASE("[RegEx] Lookahead groups empty matches") {
 	CHECK(all_results.size() == 2);
 
 	match = all_results[0];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == String(""));
 	CHECK(match->get_string(1) == String("12"));
 
 	match = all_results[1];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == String(""));
 	CHECK(match->get_string(1) == String("2"));
 }
@@ -341,7 +341,7 @@ TEST_CASE("[RegEx] Simple lookbehind") {
 	RegEx re("(?<=d)o");
 	REQUIRE(re.is_valid());
 	Ref<RegExMatch> match = re.search(s);
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 3);
 	CHECK(match->get_end(0) == 4);
 }
@@ -355,22 +355,22 @@ TEST_CASE("[RegEx] Simple lookbehind search all") {
 	CHECK(all_results.size() == 4);
 
 	Ref<RegExMatch> match = all_results[0];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 1);
 	CHECK(match->get_end(0) == 2);
 
 	match = all_results[1];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 3);
 	CHECK(match->get_end(0) == 4);
 
 	match = all_results[2];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 7);
 	CHECK(match->get_end(0) == 8);
 
 	match = all_results[3];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 9);
 	CHECK(match->get_end(0) == 10);
 }
@@ -386,7 +386,7 @@ TEST_CASE("[RegEx] Lookbehind groups empty matches") {
 	CHECK(all_results.size() == 3);
 
 	match = all_results[0];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 2);
 	CHECK(match->get_end(0) == 2);
 	CHECK(match->get_start(1) == 1);
@@ -395,7 +395,7 @@ TEST_CASE("[RegEx] Lookbehind groups empty matches") {
 	CHECK(match->get_string(1) == String("b"));
 
 	match = all_results[1];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 6);
 	CHECK(match->get_end(0) == 6);
 	CHECK(match->get_start(1) == 5);
@@ -404,7 +404,7 @@ TEST_CASE("[RegEx] Lookbehind groups empty matches") {
 	CHECK(match->get_string(1) == String("b"));
 
 	match = all_results[2];
-	REQUIRE(match != nullptr);
+	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 8);
 	CHECK(match->get_end(0) == 8);
 	CHECK(match->get_start(1) == 7);

--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -229,14 +229,14 @@ Ref<UPNPDevice> UPNP::get_device(int index) const {
 }
 
 void UPNP::add_device(Ref<UPNPDevice> device) {
-	ERR_FAIL_NULL(device);
+	ERR_FAIL_COND(device.is_null());
 
 	devices.push_back(device);
 }
 
 void UPNP::set_device(int index, Ref<UPNPDevice> device) {
 	ERR_FAIL_INDEX(index, devices.size());
-	ERR_FAIL_NULL(device);
+	ERR_FAIL_COND(device.is_null());
 
 	devices.set(index, device);
 }
@@ -257,7 +257,7 @@ Ref<UPNPDevice> UPNP::get_gateway() const {
 	for (int i = 0; i < devices.size(); i++) {
 		Ref<UPNPDevice> dev = get_device(i);
 
-		if (dev != nullptr && dev->is_valid_gateway()) {
+		if (dev.is_valid() && dev->is_valid_gateway()) {
 			return dev;
 		}
 	}
@@ -292,7 +292,7 @@ bool UPNP::is_discover_ipv6() const {
 String UPNP::query_external_address() const {
 	Ref<UPNPDevice> dev = get_gateway();
 
-	if (dev == nullptr) {
+	if (dev.is_null()) {
 		return "";
 	}
 
@@ -302,7 +302,7 @@ String UPNP::query_external_address() const {
 int UPNP::add_port_mapping(int port, int port_internal, String desc, String proto, int duration) const {
 	Ref<UPNPDevice> dev = get_gateway();
 
-	if (dev == nullptr) {
+	if (dev.is_null()) {
 		return UPNP_RESULT_NO_GATEWAY;
 	}
 
@@ -312,7 +312,7 @@ int UPNP::add_port_mapping(int port, int port_internal, String desc, String prot
 int UPNP::delete_port_mapping(int port, String proto) const {
 	Ref<UPNPDevice> dev = get_gateway();
 
-	if (dev == nullptr) {
+	if (dev.is_null()) {
 		return UPNP_RESULT_NO_GATEWAY;
 	}
 

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -48,7 +48,7 @@ Error ZIPPacker::close() {
 
 	Error err = zipClose(zf, nullptr) == ZIP_OK ? OK : FAILED;
 	if (err == OK) {
-		DEV_ASSERT(fa == nullptr);
+		DEV_ASSERT(fa.is_null());
 		zf = nullptr;
 	}
 

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -48,7 +48,7 @@ Error ZIPReader::close() {
 
 	Error err = unzClose(uzf) == UNZ_OK ? OK : FAILED;
 	if (err == OK) {
-		DEV_ASSERT(fa == nullptr);
+		DEV_ASSERT(fa.is_null());
 		uzf = nullptr;
 	}
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -463,7 +463,7 @@ void AnimatedSprite2D::play(const StringName &p_name, float p_custom_scale, bool
 		name = animation;
 	}
 
-	ERR_FAIL_NULL_MSG(frames, vformat("There is no animation with name '%s'.", name));
+	ERR_FAIL_COND_MSG(frames.is_null(), vformat("There is no animation with name '%s'.", name));
 	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(name), vformat("There is no animation with name '%s'.", name));
 
 	if (frames->get_frame_count(name) == 0) {
@@ -541,7 +541,7 @@ void AnimatedSprite2D::set_animation(const StringName &p_name) {
 
 	emit_signal(SceneStringName(animation_changed));
 
-	if (frames == nullptr) {
+	if (frames.is_null()) {
 		animation = StringName();
 		stop();
 		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -517,12 +517,12 @@ bool MeshInstance3D::_property_get_revert(const StringName &p_name, Variant &r_p
 
 Ref<ArrayMesh> MeshInstance3D::bake_mesh_from_current_blend_shape_mix(Ref<ArrayMesh> p_existing) {
 	Ref<ArrayMesh> source_mesh = get_mesh();
-	ERR_FAIL_NULL_V_MSG(source_mesh, Ref<ArrayMesh>(), "The source mesh must be a valid ArrayMesh.");
+	ERR_FAIL_COND_V_MSG(source_mesh.is_null(), Ref<ArrayMesh>(), "The source mesh must be a valid ArrayMesh.");
 
 	Ref<ArrayMesh> bake_mesh;
 
 	if (p_existing.is_valid()) {
-		ERR_FAIL_NULL_V_MSG(p_existing, Ref<ArrayMesh>(), "The existing mesh must be a valid ArrayMesh.");
+		ERR_FAIL_COND_V_MSG(p_existing.is_null(), Ref<ArrayMesh>(), "The existing mesh must be a valid ArrayMesh.");
 		ERR_FAIL_COND_V_MSG(source_mesh == p_existing, Ref<ArrayMesh>(), "The source mesh can not be the same mesh as the existing mesh.");
 
 		bake_mesh = p_existing;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -132,7 +132,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 
 	// Properly setup UVs for impostor textures (AtlasTexture).
 	Ref<AtlasTexture> atlas_tex = p_texture;
-	if (atlas_tex != nullptr) {
+	if (atlas_tex.is_valid()) {
 		src_tsize[0] = atlas_tex->get_atlas()->get_width();
 		src_tsize[1] = atlas_tex->get_atlas()->get_height();
 	}
@@ -1324,7 +1324,7 @@ void AnimatedSprite3D::play(const StringName &p_name, float p_custom_scale, bool
 		name = animation;
 	}
 
-	ERR_FAIL_NULL_MSG(frames, vformat("There is no animation with name '%s'.", name));
+	ERR_FAIL_COND_MSG(frames.is_null(), vformat("There is no animation with name '%s'.", name));
 	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(name), vformat("There is no animation with name '%s'.", name));
 
 	if (frames->get_frame_count(name) == 0) {
@@ -1402,7 +1402,7 @@ void AnimatedSprite3D::set_animation(const StringName &p_name) {
 
 	emit_signal(SceneStringName(animation_changed));
 
-	if (frames == nullptr) {
+	if (frames.is_null()) {
 		animation = StringName();
 		stop();
 		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
@@ -176,7 +176,7 @@ void NavigationMeshSourceGeometryData2D::add_obstruction_outline(const PackedVec
 }
 
 void NavigationMeshSourceGeometryData2D::merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry) {
-	ERR_FAIL_NULL(p_other_geometry);
+	ERR_FAIL_COND(p_other_geometry.is_null());
 
 	Vector<Vector<Vector2>> other_traversable_outlines;
 	Vector<Vector<Vector2>> other_obstruction_outlines;

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -223,7 +223,7 @@ void NavigationMeshSourceGeometryData3D::add_faces(const PackedVector3Array &p_f
 }
 
 void NavigationMeshSourceGeometryData3D::merge(const Ref<NavigationMeshSourceGeometryData3D> &p_other_geometry) {
-	ERR_FAIL_NULL(p_other_geometry);
+	ERR_FAIL_COND(p_other_geometry.is_null());
 
 	Vector<float> other_vertices;
 	Vector<int> other_indices;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -37,7 +37,7 @@
 #include "scene/main/scene_tree.h"
 
 void Material::set_next_pass(const Ref<Material> &p_pass) {
-	for (Ref<Material> pass_child = p_pass; pass_child != nullptr; pass_child = pass_child->get_next_pass()) {
+	for (Ref<Material> pass_child = p_pass; pass_child.is_valid(); pass_child = pass_child->get_next_pass()) {
 		ERR_FAIL_COND_MSG(pass_child == this, "Can't set as next_pass one of its parents to prevent crashes due to recursive loop.");
 	}
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -158,7 +158,7 @@ void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_gr
 #ifdef MODULE_REGEX_ENABLED
 				const RegEx pattern("/\\*\\*\\s([^*]|[\\r\\n]|(\\*+([^*/]|[\\r\\n])))*\\*+/\\s*uniform\\s+\\w+\\s+" + pi.name + "(?=[\\s:;=])");
 				Ref<RegExMatch> pattern_ref = pattern.search(code);
-				if (pattern_ref != nullptr) {
+				if (pattern_ref.is_valid()) {
 					RegExMatch *match = pattern_ref.ptr();
 					const RegEx pattern_tip("\\/\\*\\*([\\s\\S]*?)\\*/");
 					Ref<RegExMatch> pattern_tip_ref = pattern_tip.search(match->get_string(0));

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -792,7 +792,7 @@ void SurfaceTool::deindex() {
 }
 
 void SurfaceTool::_create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
-	ERR_FAIL_NULL_MSG(p_existing, "First argument in SurfaceTool::_create_list() must be a valid object of type Mesh");
+	ERR_FAIL_COND_MSG(p_existing.is_null(), "First argument in SurfaceTool::_create_list() must be a valid object of type Mesh");
 
 	Array arr = p_existing->surface_get_arrays(p_surface);
 	ERR_FAIL_COND(arr.size() != RS::ARRAY_MAX);
@@ -968,7 +968,7 @@ void SurfaceTool::create_from_triangle_arrays(const Array &p_arrays) {
 }
 
 void SurfaceTool::create_from(const Ref<Mesh> &p_existing, int p_surface) {
-	ERR_FAIL_NULL_MSG(p_existing, "First argument in SurfaceTool::create_from() must be a valid object of type Mesh");
+	ERR_FAIL_COND_MSG(p_existing.is_null(), "First argument in SurfaceTool::create_from() must be a valid object of type Mesh");
 
 	clear();
 	primitive = p_existing->surface_get_primitive_type(p_surface);
@@ -983,7 +983,7 @@ void SurfaceTool::create_from(const Ref<Mesh> &p_existing, int p_surface) {
 }
 
 void SurfaceTool::create_from_blend_shape(const Ref<Mesh> &p_existing, int p_surface, const String &p_blend_shape_name) {
-	ERR_FAIL_NULL_MSG(p_existing, "First argument in SurfaceTool::create_from_blend_shape() must be a valid object of type Mesh");
+	ERR_FAIL_COND_MSG(p_existing.is_null(), "First argument in SurfaceTool::create_from_blend_shape() must be a valid object of type Mesh");
 
 	clear();
 	primitive = p_existing->surface_get_primitive_type(p_surface);
@@ -1023,7 +1023,7 @@ void SurfaceTool::create_from_blend_shape(const Ref<Mesh> &p_existing, int p_sur
 }
 
 void SurfaceTool::append_from(const Ref<Mesh> &p_existing, int p_surface, const Transform3D &p_xform) {
-	ERR_FAIL_NULL_MSG(p_existing, "First argument in SurfaceTool::append_from() must be a valid object of type Mesh");
+	ERR_FAIL_COND_MSG(p_existing.is_null(), "First argument in SurfaceTool::append_from() must be a valid object of type Mesh");
 
 	if (vertex_array.size() == 0) {
 		primitive = p_existing->surface_get_primitive_type(p_surface);

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -149,7 +149,7 @@ Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 
 	ensure_thread_stopped();
 	bool is_currently_recording = false;
-	if (current_instance != nullptr) {
+	if (current_instance.is_valid()) {
 		is_currently_recording = current_instance->is_recording;
 	}
 	if (is_currently_recording) {
@@ -161,28 +161,28 @@ Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 }
 
 void AudioEffectRecord::ensure_thread_stopped() {
-	if (current_instance != nullptr) {
+	if (current_instance.is_valid()) {
 		current_instance->finish();
 	}
 }
 
 void AudioEffectRecord::set_recording_active(bool p_record) {
 	if (p_record) {
-		if (current_instance == nullptr) {
+		if (current_instance.is_null()) {
 			WARN_PRINT("Recording should not be set as active before Godot has initialized.");
 			return;
 		}
 		ensure_thread_stopped();
 		current_instance->init();
 	} else {
-		if (current_instance != nullptr) {
+		if (current_instance.is_valid()) {
 			current_instance->is_recording = false;
 		}
 	}
 }
 
 bool AudioEffectRecord::is_recording_active() const {
-	if (current_instance == nullptr) {
+	if (current_instance.is_null()) {
 		return false;
 	} else {
 		return current_instance->is_recording;

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -183,7 +183,7 @@ Transform3D XRServer::get_reference_frame() const {
 }
 
 void XRServer::center_on_hmd(RotationMode p_rotation_mode, bool p_keep_height) {
-	if (primary_interface == nullptr) {
+	if (primary_interface.is_null()) {
 		return;
 	}
 
@@ -235,7 +235,7 @@ void XRServer::_set_render_reference_frame(const Transform3D &p_reference_frame)
 
 Transform3D XRServer::get_hmd_transform() {
 	Transform3D hmd_transform;
-	if (primary_interface != nullptr) {
+	if (primary_interface.is_valid()) {
 		hmd_transform = primary_interface->get_camera_transform();
 	}
 	return hmd_transform;

--- a/tests/core/io/test_http_client.h
+++ b/tests/core/io/test_http_client.h
@@ -41,7 +41,7 @@ namespace TestHTTPClient {
 
 TEST_CASE("[HTTPClient] Instantiation") {
 	Ref<HTTPClient> client = HTTPClient::create();
-	CHECK_MESSAGE(client != nullptr, "A HTTP Client created should not be a null pointer");
+	CHECK_MESSAGE(client.is_valid(), "A HTTP Client created should not be a null pointer");
 }
 
 TEST_CASE("[HTTPClient] query_string_from_dict") {

--- a/tests/scene/test_path_2d.h
+++ b/tests/scene/test_path_2d.h
@@ -40,7 +40,7 @@ namespace TestPath2D {
 TEST_CASE("[SceneTree][Path2D] Initialization") {
 	SUBCASE("Path should be empty right after initialization") {
 		Path2D *test_path = memnew(Path2D);
-		CHECK(test_path->get_curve() == nullptr);
+		CHECK(test_path->get_curve().is_null());
 		memdelete(test_path);
 	}
 }

--- a/tests/scene/test_path_3d.h
+++ b/tests/scene/test_path_3d.h
@@ -40,7 +40,7 @@ namespace TestPath3D {
 TEST_CASE("[Path3D] Initialization") {
 	SUBCASE("Path should be empty right after initialization") {
 		Path3D *test_path = memnew(Path3D);
-		CHECK(test_path->get_curve() == nullptr);
+		CHECK(test_path->get_curve().is_null());
 		memdelete(test_path);
 	}
 }

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -609,7 +609,7 @@ TEST_CASE("[SceneTree][Primitive][TubeTrail] TubeTrail Primitive") {
 		CHECK(tube->get_sections() >= 0);
 		CHECK(tube->get_section_length() > 0);
 		CHECK(tube->get_section_rings() >= 0);
-		CHECK(tube->get_curve() == nullptr);
+		CHECK(tube->get_curve().is_null());
 		CHECK(tube->get_builtin_bind_pose_count() >= 0);
 	}
 
@@ -669,7 +669,7 @@ TEST_CASE("[SceneTree][Primitive][RibbonTrail] RibbonTrail Primitive") {
 		CHECK(ribbon->get_section_length() > 0);
 		CHECK(ribbon->get_section_segments() >= 0);
 		CHECK(ribbon->get_builtin_bind_pose_count() >= 0);
-		CHECK(ribbon->get_curve() == nullptr);
+		CHECK(ribbon->get_curve().is_null());
 		CHECK((ribbon->get_shape() == RibbonTrailMesh::SHAPE_CROSS ||
 				ribbon->get_shape() == RibbonTrailMesh::SHAPE_FLAT));
 	}
@@ -731,7 +731,7 @@ TEST_CASE("[SceneTree][Primitive][Text] Text Primitive") {
 				text->get_vertical_alignment() == VERTICAL_ALIGNMENT_TOP ||
 				text->get_vertical_alignment() == VERTICAL_ALIGNMENT_CENTER ||
 				text->get_vertical_alignment() == VERTICAL_ALIGNMENT_FILL));
-		CHECK(text->get_font() == nullptr);
+		CHECK(text->get_font().is_null());
 		CHECK(text->get_font_size() > 0);
 		CHECK(text->get_line_spacing() >= 0);
 		CHECK((text->get_autowrap_mode() == TextServer::AUTOWRAP_OFF ||


### PR DESCRIPTION
With optional second commit fully forbidding these comparisons, used to identify these cases, I'd say this should be integrated as we don't really permit checking against `nullptr` and it'd be good to simply enforce it, though the error messages can be a bit cryptic at times so leaving it open
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
