### PR TITLE
Better syntax highlighting for expression properties.

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1522,6 +1522,31 @@ void Expression::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_error_text"), &Expression::get_error_text);
 }
 
+void Expression::get_reserved_words(List<String> *p_words) {
+	static const char *_reserved_words[] = {
+		"in",
+		"null",
+		"true",
+		"false",
+		"PI",
+		"TAU",
+		"INF",
+		"NAN",
+		"not",
+		"or",
+		"and",
+		"self",
+		nullptr,
+	};
+
+	const char **w = _reserved_words;
+
+	while (*w) {
+		p_words->push_back(*w);
+		w++;
+	}
+}
+
 Expression::~Expression() {
 	if (nodes) {
 		memdelete(nodes);

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -264,5 +264,7 @@ public:
 	bool has_execute_failed() const;
 	String get_error_text() const;
 
+	static void get_reserved_words(List<String> *p_words);
+
 	~Expression();
 };

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -263,11 +263,6 @@ void EditorPropertyMultilineText::_text_changed() {
 void EditorPropertyMultilineText::_open_big_text() {
 	if (!big_text_dialog) {
 		big_text = memnew(TextEdit);
-		if (expression) {
-			big_text->set_syntax_highlighter(text->get_syntax_highlighter());
-			big_text->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("expression"), EditorStringName(EditorFonts)));
-			big_text->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("expression_size"), EditorStringName(EditorFonts)));
-		}
 		big_text->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyMultilineText::_big_text_changed));
 		big_text->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 		big_text_dialog = memnew(AcceptDialog);
@@ -298,28 +293,15 @@ void EditorPropertyMultilineText::_notification(int p_what) {
 			Ref<Texture2D> df = get_editor_theme_icon(SNAME("DistractionFree"));
 			open_big_text->set_button_icon(df);
 
-			Ref<Font> font;
-			int font_size;
-			if (expression) {
-				font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
-				font_size = get_theme_font_size(SNAME("expression_size"), EditorStringName(EditorFonts));
+			Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("TextEdit"));
+			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("TextEdit"));
 
-				text->add_theme_font_override(SceneStringName(font), font);
-				text->add_theme_font_size_override(SceneStringName(font_size), font_size);
-				if (big_text) {
-					big_text->add_theme_font_override(SceneStringName(font), font);
-					big_text->add_theme_font_size_override(SceneStringName(font_size), font_size);
-				}
-			} else {
-				font = get_theme_font(SceneStringName(font), SNAME("TextEdit"));
-				font_size = get_theme_font_size(SceneStringName(font_size), SNAME("TextEdit"));
-			}
 			text->set_custom_minimum_size(Vector2(0, font->get_height(font_size) * 6));
 		} break;
 	}
 }
 
-EditorPropertyMultilineText::EditorPropertyMultilineText(bool p_expression) {
+EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_theme_constant_override("separation", 0);
 	add_child(hb);
@@ -337,12 +319,46 @@ EditorPropertyMultilineText::EditorPropertyMultilineText(bool p_expression) {
 	hb->add_child(open_big_text);
 	big_text_dialog = nullptr;
 	big_text = nullptr;
-	if (p_expression) {
-		expression = true;
-		Ref<EditorStandardSyntaxHighlighter> highlighter;
-		highlighter.instantiate();
-		text->set_syntax_highlighter(highlighter);
+}
+
+/////////////////////////////////////////////////////////
+
+void EditorPropertyMultilineExpressionText::_open_big_text() {
+	if (big_text) {
+		big_text->set_syntax_highlighter(text->get_syntax_highlighter());
+		big_text->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("expression"), EditorStringName(EditorFonts)));
+		big_text->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("expression_size"), EditorStringName(EditorFonts)));
 	}
+}
+
+void EditorPropertyMultilineExpressionText::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_ENTER_TREE: {
+			Ref<Texture2D> df = get_editor_theme_icon(SNAME("DistractionFree"));
+			open_big_text->set_button_icon(df);
+
+			Ref<Font> font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
+			int font_size = get_theme_font_size(SNAME("expression_size"), EditorStringName(EditorFonts));
+
+			text->add_theme_font_override(SceneStringName(font), font);
+			text->add_theme_font_size_override(SceneStringName(font_size), font_size);
+			if (big_text) {
+				big_text->add_theme_font_override(SceneStringName(font), font);
+				big_text->add_theme_font_size_override(SceneStringName(font_size), font_size);
+			}
+
+			text->set_custom_minimum_size(Vector2(0, font->get_height(font_size) * 6));
+		} break;
+	}
+}
+
+EditorPropertyMultilineExpressionText::EditorPropertyMultilineExpressionText() {
+	Ref<EditorExpressionSyntaxHighlighter> highlighter;
+	highlighter.instantiate();
+	text->set_syntax_highlighter(highlighter);
+
+	open_big_text->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyMultilineExpressionText::_open_big_text));
 }
 
 ///////////////////// TEXT ENUM /////////////////////////
@@ -3890,7 +3906,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyMultilineText *editor = memnew(EditorPropertyMultilineText);
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_EXPRESSION) {
-				EditorPropertyMultilineText *editor = memnew(EditorPropertyMultilineText(true));
+				EditorPropertyMultilineText *editor = memnew(EditorPropertyMultilineExpressionText());
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_TYPE_STRING) {
 				EditorPropertyClassName *editor = memnew(EditorPropertyClassName);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -113,6 +113,8 @@ public:
 
 class EditorPropertyMultilineText : public EditorProperty {
 	GDCLASS(EditorPropertyMultilineText, EditorProperty);
+
+protected:
 	TextEdit *text = nullptr;
 
 	AcceptDialog *big_text_dialog = nullptr;
@@ -122,15 +124,24 @@ class EditorPropertyMultilineText : public EditorProperty {
 	void _big_text_changed();
 	void _text_changed();
 	void _open_big_text();
-	bool expression = false;
 
-protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
 
 public:
 	virtual void update_property() override;
-	EditorPropertyMultilineText(bool p_expression = false);
+	EditorPropertyMultilineText();
+};
+
+class EditorPropertyMultilineExpressionText : public EditorPropertyMultilineText {
+	GDCLASS(EditorPropertyMultilineExpressionText, EditorPropertyMultilineText);
+
+protected:
+	void _open_big_text();
+	void _notification(int p_what);
+
+public:
+	EditorPropertyMultilineExpressionText();
 };
 
 class EditorPropertyTextEnum : public EditorProperty {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -36,6 +36,7 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
+#include "core/math/expression.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
@@ -108,6 +109,34 @@ void EditorSyntaxHighlighter::_bind_methods() {
 	GDVIRTUAL_BIND(_get_name)
 	GDVIRTUAL_BIND(_get_supported_languages)
 	GDVIRTUAL_BIND(_create)
+}
+
+////
+
+void EditorExpressionSyntaxHighlighter::_update_cache() {
+	highlighter->set_text_edit(text_edit);
+	highlighter->clear_keyword_colors();
+	highlighter->clear_member_keyword_colors();
+	highlighter->clear_color_regions();
+
+	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/function_color"));
+	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+	highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/member_variable_color"));
+
+	/* Reserved words. */
+	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	List<String> keywords;
+	Expression::get_reserved_words(&keywords);
+	for (const String &E : keywords) {
+		highlighter->add_keyword_color(E, keyword_color);
+	}
+}
+
+Ref<EditorSyntaxHighlighter> EditorExpressionSyntaxHighlighter::_create() const {
+	Ref<EditorExpressionSyntaxHighlighter> syntax_highlighter;
+	syntax_highlighter.instantiate();
+	return syntax_highlighter;
 }
 
 ////

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -73,6 +73,23 @@ public:
 	virtual Ref<EditorSyntaxHighlighter> _create() const;
 };
 
+class EditorExpressionSyntaxHighlighter : public EditorSyntaxHighlighter {
+	GDCLASS(EditorExpressionSyntaxHighlighter, EditorSyntaxHighlighter)
+
+private:
+	Ref<CodeHighlighter> highlighter;
+
+public:
+	virtual void _update_cache() override;
+	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override { return highlighter->get_line_syntax_highlighting(p_line); }
+
+	virtual String _get_name() const override { return TTR("Expression"); }
+
+	virtual Ref<EditorSyntaxHighlighter> _create() const override;
+
+	EditorExpressionSyntaxHighlighter() { highlighter.instantiate(); }
+};
+
 class EditorStandardSyntaxHighlighter : public EditorSyntaxHighlighter {
 	GDCLASS(EditorStandardSyntaxHighlighter, EditorSyntaxHighlighter)
 


### PR DESCRIPTION
First incremental improvement for displaying expressions in the inspector. Rather than using the generic script highlighting template, it now uses its own highlighter with the reserved keywords unique to expressions. It has also been refactored in such a way which will hopefully also facilitate more usability features in the future.

Old:
![godot windows editor dev x86_64_JAtKs97TXT](https://github.com/user-attachments/assets/513d3c05-5a15-4398-863a-13db8c51ced0)

New:
![godot windows editor dev x86_64_hZsAQp9yeo](https://github.com/user-attachments/assets/241cdb7d-1766-4d53-b58f-7f37687be918)