### PR TITLE
Attempt applying RESET pose during import.

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3096,6 +3096,19 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		}
 	}
 
+	// Apply RESET animation before serializing.
+	if (_scene_import_type == "PackedScene") {
+		int scene_child_count = scene->get_child_count();
+		for (int i = 0; i < scene_child_count; i++) {
+			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(scene->get_child(i));
+			if (ap) {
+				if (ap->can_apply_reset()) {
+					ap->apply_reset();
+				}
+			}
+		}
+	}
+
 	if (post_import_script.is_valid()) {
 		post_import_script->init(p_source_file);
 		scene = post_import_script->post_import(scene);


### PR DESCRIPTION
This PR attempts to use and set the RESET pose so it becomes the default skeletal pose when serializing an imported scene. Now that #96196 has been merged, you might notice that if you instanced + set editable children on some models, after saving, certain rotation quaternions in the pose don't actually match the base model, meaning useless data gets written to the scene which instances it.

The reason this happens is that the imported scene by default ~~uses the rest pose as the default pose, but scenes will automatically call the RESET animation whenever saving a scene. Even when the rest and reset pose appear to be a 1:1 match, certain bones will still not match because of quantization (rests are stored as Transform3Ds, whereas poses are stored as seperate position/rotation/scale values).~~  (Edit: actually, this isn't always the case, the pose can actually just be whatever the model came in as, though using the rest pose is what is used when importing with retargeting. None of this invalidates the point however since the idea is to make the imported pose consistent with the special RESET pose which gets set everytime a scene is saved). Making the RESET pose the default pose when importing should resolve this discontinuity.