### PR TITLE
Autocompletion: Reintroduce enum options on assignment

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2112,7 +2112,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 	// Look in blocks first.
 	int last_assign_line = -1;
 	const GDScriptParser::ExpressionNode *last_assigned_expression = nullptr;
-	GDScriptParser::DataType id_type;
+	GDScriptCompletionIdentifier id_type;
 	GDScriptParser::SuiteNode *suite = p_context.current_suite;
 	bool is_function_parameter = false;
 
@@ -2134,7 +2134,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 	if (can_be_local && suite && suite->has_local(p_identifier->name)) {
 		const GDScriptParser::SuiteNode::Local &local = suite->get_local(p_identifier->name);
 
-		id_type = local.get_datatype();
+		id_type.type = local.get_datatype();
 
 		// Check initializer as the first assignment.
 		switch (local.type) {
@@ -2172,7 +2172,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 			base.type.is_meta_type = p_context.current_function && p_context.current_function->is_static;
 
 			if (_guess_identifier_type_from_base(p_context, base, p_identifier->name, base_identifier)) {
-				id_type = base_identifier.type;
+				id_type = base_identifier;
 			}
 		}
 	}
@@ -2212,7 +2212,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 				c.current_line = type_test->operand->start_line;
 				c.current_suite = suite;
 				if (type_test->test_datatype.is_hard_type()) {
-					id_type = type_test->test_datatype;
+					id_type.type = type_test->test_datatype;
 					if (last_assign_line < c.current_line) {
 						// Override last assignment.
 						last_assign_line = c.current_line;
@@ -2230,10 +2230,10 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 		c.current_line = last_assign_line;
 		GDScriptCompletionIdentifier assigned_type;
 		if (_guess_expression_type(c, last_assigned_expression, assigned_type)) {
-			if (id_type.is_set() && assigned_type.type.is_set() && !GDScriptAnalyzer::check_type_compatibility(id_type, assigned_type.type)) {
+			if (id_type.type.is_set() && assigned_type.type.is_set() && !GDScriptAnalyzer::check_type_compatibility(id_type.type, assigned_type.type)) {
 				// The assigned type is incompatible. The annotated type takes priority.
+				r_type = id_type;
 				r_type.assigned_expression = last_assigned_expression;
-				r_type.type = id_type;
 			} else {
 				r_type = assigned_type;
 			}
@@ -2251,8 +2251,8 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 						GDScriptParser::FunctionNode *parent_function = base_type.class_type->get_member(p_context.current_function->identifier->name).function;
 						if (parent_function->parameters_indices.has(p_identifier->name)) {
 							const GDScriptParser::ParameterNode *parameter = parent_function->parameters[parent_function->parameters_indices[p_identifier->name]];
-							if ((!id_type.is_set() || id_type.is_variant()) && parameter->get_datatype().is_hard_type()) {
-								id_type = parameter->get_datatype();
+							if ((!id_type.type.is_set() || id_type.type.is_variant()) && parameter->get_datatype().is_hard_type()) {
+								id_type.type = parameter->get_datatype();
 							}
 							if (parameter->initializer) {
 								GDScriptParser::CompletionContext c = p_context;
@@ -2268,7 +2268,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 					base_type = base_type.class_type->base_type;
 					break;
 				case GDScriptParser::DataType::NATIVE: {
-					if (id_type.is_set() && !id_type.is_variant()) {
+					if (id_type.type.is_set() && !id_type.type.is_variant()) {
 						base_type = GDScriptParser::DataType();
 						break;
 					}
@@ -2289,8 +2289,8 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 		}
 	}
 
-	if (id_type.is_set() && !id_type.is_variant()) {
-		r_type.type = id_type;
+	if (id_type.type.is_set() && !id_type.type.is_variant()) {
+		r_type = id_type;
 		return true;
 	}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1455,8 +1455,11 @@ private:
 	}
 	void apply_pending_warnings();
 #endif
-	void make_completion_context(CompletionType p_type, Node *p_node, int p_argument = -1);
-	void make_completion_context(CompletionType p_type, Variant::Type p_builtin_type);
+	// Setting p_force to false will prevent the completion context from being update if a context was already set before.
+	// This should only be done when we push context before we consumed any tokens for the corresponding structure.
+	// See parse_precedence for an example.
+	void make_completion_context(CompletionType p_type, Node *p_node, int p_argument = -1, bool p_force = true);
+	void make_completion_context(CompletionType p_type, Variant::Type p_builtin_type, bool p_force = true);
 	// In some cases it might become necessary to alter the completion context after parsing a subexpression.
 	// For example to not override COMPLETE_CALL_ARGUMENTS with COMPLETION_NONE from string literals.
 	void override_completion_context(const Node *p_for_node, CompletionType p_type, Node *p_node, int p_argument = -1);

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "new"},
+    {"display": "SIZE_EXPAND"},
+    {"display": "SIZE_EXPAND_FILL"},
+    {"display": "SIZE_FILL"},
+    {"display": "SIZE_SHRINK_BEGIN"},
+    {"display": "SIZE_SHRINK_CENTER"},
+    {"display": "SIZE_SHRINK_END"},
+]
+exclude=[
+    {"display": "Control.SIZE_EXPAND"},
+    {"display": "Control.SIZE_EXPAND_FILL"},
+    {"display": "Control.SIZE_FILL"},
+    {"display": "Control.SIZE_SHRINK_BEGIN"},
+    {"display": "Control.SIZE_SHRINK_CENTER"},
+    {"display": "Control.SIZE_SHRINK_END"},
+    {"display": "contro_var"}
+]

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.gd
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.gd
@@ -1,0 +1,7 @@
+extends Control
+
+var contro_var
+
+func _ready():
+    size_flags_horizontal = Control.➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "new"},
+    {"display": "SIZE_EXPAND"},
+    {"display": "SIZE_EXPAND_FILL"},
+    {"display": "SIZE_FILL"},
+    {"display": "SIZE_SHRINK_BEGIN"},
+    {"display": "SIZE_SHRINK_CENTER"},
+    {"display": "SIZE_SHRINK_END"},
+]
+exclude=[
+    {"display": "Control.SIZE_EXPAND"},
+    {"display": "Control.SIZE_EXPAND_FILL"},
+    {"display": "Control.SIZE_FILL"},
+    {"display": "Control.SIZE_SHRINK_BEGIN"},
+    {"display": "Control.SIZE_SHRINK_CENTER"},
+    {"display": "Control.SIZE_SHRINK_END"},
+    {"display": "contro_var"}
+]

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.gd
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.gd
@@ -1,0 +1,7 @@
+extends Control
+
+var contro_var
+
+func _ready():
+    size_flags_horizontal = Control.SIZE➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_identifier.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_identifier.cfg
@@ -1,0 +1,12 @@
+[output]
+include=[
+    {"display": "Control.SIZE_EXPAND"},
+    {"display": "Control.SIZE_EXPAND_FILL"},
+    {"display": "Control.SIZE_FILL"},
+    {"display": "Control.SIZE_SHRINK_BEGIN"},
+    {"display": "Control.SIZE_SHRINK_CENTER"},
+    {"display": "Control.SIZE_SHRINK_END"},
+]
+exclude=[
+    {"display": "contro_var"}
+]

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_identifier.gd
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_identifier.gd
@@ -1,0 +1,7 @@
+extends Control
+
+var contro_var
+
+func _ready():
+    size_flags_horizontal = Con➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_no_identifier.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_no_identifier.cfg
@@ -1,0 +1,12 @@
+[output]
+include=[
+    {"display": "Control.SIZE_EXPAND"},
+    {"display": "Control.SIZE_EXPAND_FILL"},
+    {"display": "Control.SIZE_FILL"},
+    {"display": "Control.SIZE_SHRINK_BEGIN"},
+    {"display": "Control.SIZE_SHRINK_CENTER"},
+    {"display": "Control.SIZE_SHRINK_END"},
+]
+exclude=[
+    {"display": "contro_var"}
+]

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_no_identifier.gd
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_no_identifier.gd
@@ -1,0 +1,7 @@
+extends Control
+
+var contro_var
+
+func _ready():
+    size_flags_horizontal = ➡
+    pass


### PR DESCRIPTION
> [!IMPORTANT]
> Since on `master` #96213 was caused by overlapping issues from #85224 and #94082 this PR can not be cherry-picked

Fixes #96213
Fixes #95986

- Fixes an oversight in #85224: The information needed for the enum suggestions when assigning are not contained within the datatype but the `CompletionIdentifier` so we can't just store and return the completion identifiers datatype
- Reintroduces the `p_force` parameter which I removed in #94082, in investigating those issues I found out why we need it :partying_face: (I added a comment in case the question comes up again). Luckily my assumptions from #94082 that it should be true almost always still holds, so I changed the default value accordingly. In the very specific case that we try to push a context but haven't consumed any tokens for the structure, that this context relates to, we don't want to override an existing context.
- Hacks a forcefully pushed completion context for COMPLETION_IDENTIFIER into `parse_precedence` the fact that all identifiers were never pushed with `p_force` caused some issues before. Now if an identifier is actually consumed the context is pushed with `p_force`, and can be overridden in specific contexts (e.g. in an assignment)
- Fixes an oversight in #94082 which allowed to override completion contexts which didn't have a node from everywhere. Now a context without node can't be overridden at all since the node acts as check that a completion context only gets overridden from a relevant position.
- Adds tests for #96213
- I already had tests for #95986 on a separate branch which test call hints in general. I didn't cherry pick them over but they will be coming eventually.

> Admittedly this is getting to the same grade of hackiness that we had before, but as long as the number of open issues decreases I'll still count it as a win :grimacing:
