### PR TITLE
[.NET] Generate `ReadOnlySpan<T>` Overloads for GodotSharp APIs

### DIFF
--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -265,6 +265,7 @@ class BindingsGenerator {
 		bool is_singleton = false;
 		bool is_singleton_instance = false;
 		bool is_ref_counted = false;
+		bool is_span_compatible = false;
 
 		/**
 		 * Class is a singleton, but can't be declared as a static class as that would
@@ -840,7 +841,7 @@ class BindingsGenerator {
 	Error _generate_cs_type(const TypeInterface &itype, const String &p_output_file);
 
 	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuilder &p_output);
-	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output);
+	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output, bool p_use_span);
 	Error _generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output);
 
 	Error _generate_cs_native_calls(const InternalCall &p_icall, StringBuilder &r_output);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -394,7 +394,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
+        public static godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
+        {
+            return ConvertSystemArrayToNativePackedByteArray((ReadOnlySpan<byte>)p_array);
+        }
+
+        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(ReadOnlySpan<byte> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_byte_array();
@@ -417,7 +422,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
+        public static godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
+        {
+            return ConvertSystemArrayToNativePackedInt32Array((ReadOnlySpan<int>)p_array);
+        }
+
+        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(ReadOnlySpan<int> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int32_array();
@@ -440,7 +450,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
+        public static godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
+        {
+            return ConvertSystemArrayToNativePackedInt64Array((ReadOnlySpan<long>)p_array);
+        }
+
+        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(ReadOnlySpan<long> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int64_array();
@@ -463,8 +478,13 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        public static godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(Span<float> p_array)
+        {
+            return ConvertSystemArrayToNativePackedFloat32Array((ReadOnlySpan<float>)p_array);
+        }
+
         public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
-            Span<float> p_array)
+            ReadOnlySpan<float> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float32_array();
@@ -487,8 +507,13 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        public static godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(Span<double> p_array)
+        {
+            return ConvertSystemArrayToNativePackedFloat64Array((ReadOnlySpan<double>)p_array);
+        }
+
         public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
-            Span<double> p_array)
+            ReadOnlySpan<double> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float64_array();
@@ -511,6 +536,11 @@ namespace Godot.NativeInterop
         }
 
         public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
+        {
+            return ConvertSystemArrayToNativePackedStringArray((ReadOnlySpan<string>)p_array);
+        }
+
+        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(ReadOnlySpan<string> p_array)
         {
             godot_packed_string_array dest = new godot_packed_string_array();
 
@@ -544,8 +574,13 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        public static godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(Span<Vector2> p_array)
+        {
+            return ConvertSystemArrayToNativePackedVector2Array((ReadOnlySpan<Vector2>)p_array);
+        }
+
         public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
-            Span<Vector2> p_array)
+            ReadOnlySpan<Vector2> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector2_array();
@@ -568,8 +603,13 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        public static godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(Span<Vector3> p_array)
+        {
+            return ConvertSystemArrayToNativePackedVector3Array((ReadOnlySpan<Vector3>)p_array);
+        }
+
         public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
-            Span<Vector3> p_array)
+            ReadOnlySpan<Vector3> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector3_array();
@@ -592,8 +632,13 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        public static godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(Span<Vector4> p_array)
+        {
+            return ConvertSystemArrayToNativePackedVector4Array((ReadOnlySpan<Vector4>)p_array);
+        }
+
         public static unsafe godot_packed_vector4_array ConvertSystemArrayToNativePackedVector4Array(
-            Span<Vector4> p_array)
+            ReadOnlySpan<Vector4> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector4_array();
@@ -616,7 +661,12 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
+        public static godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
+        {
+            return ConvertSystemArrayToNativePackedColorArray((ReadOnlySpan<Color>)p_array);
+        }
+
+        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(ReadOnlySpan<Color> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_color_array();


### PR DESCRIPTION
By adding `ReadOnlySpan<T>` API overloads, this PR aims to make the overall GodotSharp API more flexible by addressing the need for a dedicated data transaction `T[]` when making API calls.

Using the example from [this proposal](https://github.com/godotengine/godot-proposals/issues/9083), the original `RenderingServer.MultimeshSetBuffer`
```csharp
public static void MultimeshSetBuffer(Rid multimesh, float[] buffer)
```
will have an additional overload that takes `ReadOnlySpan<float>`:
```csharp
public static void MultimeshSetBuffer(Rid multimesh, ReadOnlySpan<float> buffer)
```


_Bugsquad edit:_
- Closes https://github.com/godotengine/godot-proposals/issues/10012.