### PR TITLE
Make `Node.is_processing()` more descriptive about the behavior.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -644,6 +644,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if physics processing is enabled (see [method set_physics_process]).
+				[b]Note:[/b] This is also false when [method _physics_process] is not overridden (unless manually set by [method set_physics_process]). See also [method can_process].
 			</description>
 		</method>
 		<method name="is_physics_processing_internal" qualifiers="const">
@@ -656,6 +657,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if processing is enabled (see [method set_process]).
+				[b]Note:[/b] This is also false when [method _process] is not overridden (unless manually set by [method set_process]). See also [method can_process].
 			</description>
 		</method>
 		<method name="is_processing_input" qualifiers="const">


### PR DESCRIPTION
Makes it more clear as to whether use can_process or is_processing.