### PR TITLE
[Android Editor] Update the options for launching the Play window in PiP mode

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -967,6 +967,7 @@
 			- [b]Auto (based on screen size)[/b] (default) will automatically choose how to launch the Play window based on the device and screen metrics. Defaults to [b]Same as Editor[/b] on phones and [b]Side-by-side with Editor[/b] on tablets.
 			- [b]Same as Editor[/b] will launch the Play window in the same window as the Editor.
 			- [b]Side-by-side with Editor[/b] will launch the Play window side-by-side with the Editor window.
+			- [b]Launch in PiP mode[/b] will launch the Play window directly in picture-in-picture (PiP) mode if PiP mode is supported and enabled. When maximized, the Play window will occupy the same window as the Editor.
 			[b]Note:[/b] Only available in the Android editor.
 		</member>
 		<member name="run/window_placement/play_window_pip_mode" type="int" setter="" getter="">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -824,7 +824,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/screen", -5, screen_hints)
 #endif
 	// Should match the ANDROID_WINDOW_* constants in 'platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt'
-	String android_window_hints = "Auto (based on screen size):0,Same as Editor:1,Side-by-side with Editor:2";
+	String android_window_hints = "Auto (based on screen size):0,Same as Editor:1,Side-by-side with Editor:2,Launch in PiP mode:3";
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/android_window", 0, android_window_hints)
 
 	int default_play_window_pip_mode = 0;

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/EditorWindowInfo.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/EditorWindowInfo.kt
@@ -48,7 +48,12 @@ enum class LaunchPolicy {
 	/**
 	 * Adjacent launches are enabled.
 	 */
-	ADJACENT
+	ADJACENT,
+
+	/**
+	 * Launches happen in the same window but start in PiP mode.
+	 */
+	SAME_AND_LAUNCH_IN_PIP_MODE
 }
 
 /**


### PR DESCRIPTION
Follow-up from https://github.com/godotengine/godot/pull/95700#issuecomment-2321751026

This PR adds a new mode to launch the Play window directly in picture-in-picture (PiP) mode.


https://github.com/user-attachments/assets/b5ce9310-7e10-4ffa-9dbe-7b555db4cb75





<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
