### PR TITLE
Add default value to parameter of `MeshInstance3D.get_active_material()` and `get_surface_override_material()`

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -67,9 +67,9 @@
 		</method>
 		<method name="get_active_material" qualifiers="const">
 			<return type="Material" />
-			<param index="0" name="surface" type="int" />
+			<param index="0" name="surface" type="int" default="0" />
 			<description>
-				Returns the [Material] that will be used by the [Mesh] when drawing. This can return the [member GeometryInstance3D.material_override], the surface override [Material] defined in this [MeshInstance3D], or the surface [Material] defined in the [member mesh]. For example, if [member GeometryInstance3D.material_override] is used, all surfaces will return the override material.
+				Returns the [Material] for the specified [param surface] that will be used by the [Mesh] when drawing. This can return the [member GeometryInstance3D.material_override], the surface override [Material] defined in this [MeshInstance3D], or the surface [Material] defined in the [member mesh]. For example, if [member GeometryInstance3D.material_override] is used, all surfaces will return the override material.
 				Returns [code]null[/code] if no material is active, including when [member mesh] is [code]null[/code].
 			</description>
 		</method>
@@ -94,7 +94,7 @@
 		</method>
 		<method name="get_surface_override_material" qualifiers="const">
 			<return type="Material" />
-			<param index="0" name="surface" type="int" />
+			<param index="0" name="surface" type="int" default="0" />
 			<description>
 				Returns the override [Material] for the specified [param surface] of the [Mesh] resource. See also [method get_surface_override_material_count].
 				[b]Note:[/b] This returns the [Material] associated to the [MeshInstance3D]'s Surface Material Override properties, not the material within the [Mesh] resource. To get the material within the [Mesh] resource, use [method Mesh.surface_get_material] instead.

--- a/scene/3d/mesh_instance_3d.compat.inc
+++ b/scene/3d/mesh_instance_3d.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  mesh_instance_3d.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Ref<Material> MeshInstance3D::_get_surface_override_material_bind_compat_96342(int p_surface) const {
+	return get_surface_override_material(p_surface);
+}
+
+Ref<Material> MeshInstance3D::_get_active_material_bind_compat_96342(int p_surface) const {
+	return get_active_material(p_surface);
+}
+
+void MeshInstance3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_surface_override_material", "surface"), &MeshInstance3D::_get_surface_override_material_bind_compat_96342);
+	ClassDB::bind_compatibility_method(D_METHOD("get_active_material", "surface"), &MeshInstance3D::_get_active_material_bind_compat_96342);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "mesh_instance_3d.h"
+#include "mesh_instance_3d.compat.inc"
 
 #include "scene/3d/skeleton_3d.h"
 
@@ -895,8 +896,8 @@ void MeshInstance3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_surface_override_material_count"), &MeshInstance3D::get_surface_override_material_count);
 	ClassDB::bind_method(D_METHOD("set_surface_override_material", "surface", "material"), &MeshInstance3D::set_surface_override_material);
-	ClassDB::bind_method(D_METHOD("get_surface_override_material", "surface"), &MeshInstance3D::get_surface_override_material);
-	ClassDB::bind_method(D_METHOD("get_active_material", "surface"), &MeshInstance3D::get_active_material);
+	ClassDB::bind_method(D_METHOD("get_surface_override_material", "surface"), &MeshInstance3D::get_surface_override_material, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_active_material", "surface"), &MeshInstance3D::get_active_material, DEFVAL(0));
 
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("create_trimesh_collision"), &MeshInstance3D::create_trimesh_collision);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -69,6 +69,12 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
+#ifndef DISABLE_DEPRECATED
+	Ref<Material> _get_surface_override_material_bind_compat_96342(int p_surface) const;
+	Ref<Material> _get_active_material_bind_compat_96342(int p_surface) const;
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
@@ -88,8 +94,8 @@ public:
 
 	int get_surface_override_material_count() const;
 	void set_surface_override_material(int p_surface, const Ref<Material> &p_material);
-	Ref<Material> get_surface_override_material(int p_surface) const;
-	Ref<Material> get_active_material(int p_surface) const;
+	Ref<Material> get_surface_override_material(int p_surface = 0) const;
+	Ref<Material> get_active_material(int p_surface = 0) const;
 
 #ifndef PHYSICS_3D_DISABLED
 	Node *create_trimesh_collision_node();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/10597
Given default value of `0` to  `p_surface`
