### PR TITLE
Fix dock width not respecting editor scale

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -509,7 +509,7 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 	}
 
 	for (int i = 0; i < hsplits.size(); i++) {
-		p_layout->set_value(p_section, "dock_hsplit_" + itos(i + 1), hsplits[i]->get_split_offset());
+		p_layout->set_value(p_section, "dock_hsplit_" + itos(i + 1), int(hsplits[i]->get_split_offset() / EDSCALE));
 	}
 
 	FileSystemDock::get_singleton()->save_layout_to_config(p_layout, p_section);
@@ -605,7 +605,7 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 			continue;
 		}
 		int ofs = p_layout->get_value(p_section, "dock_hsplit_" + itos(i + 1));
-		hsplits[i]->set_split_offset(ofs);
+		hsplits[i]->set_split_offset(ofs * EDSCALE);
 	}
 
 	FileSystemDock::get_singleton()->load_layout_from_config(p_layout, p_section);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7555,8 +7555,8 @@ EditorNode::EditorNode() {
 		default_layout->set_value(docks_section, "dock_split_" + itos(i + 1), 0);
 	}
 	default_layout->set_value(docks_section, "dock_hsplit_1", 0);
-	default_layout->set_value(docks_section, "dock_hsplit_2", 270 * EDSCALE);
-	default_layout->set_value(docks_section, "dock_hsplit_3", -270 * EDSCALE);
+	default_layout->set_value(docks_section, "dock_hsplit_2", 270);
+	default_layout->set_value(docks_section, "dock_hsplit_3", -270);
 	default_layout->set_value(docks_section, "dock_hsplit_4", 0);
 
 	_update_layouts_menu();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/96337

Dock manager was missing some `EDSCALE`s. This PR makes it store unscaled values in `editor_layout.cfg` so that correct values can be calculated for the current editor scale when config is loaded

Technically this "breaks compatibility" with the old config values, but considering all it'll do is make docks larger one time for HiDPI users who switch existing projects from 4.3 to 4.4, it's probably not a big deal