### PR TITLE
Metal: Bind index buffer with offset

### DIFF
--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -227,6 +227,7 @@ public:
 		id<MTLRenderCommandEncoder> encoder = nil;
 		id<MTLBuffer> __unsafe_unretained index_buffer = nil; // Buffer is owned by RDD.
 		MTLIndexType index_type = MTLIndexTypeUInt16;
+		uint32_t index_offset = 0;
 		LocalVector<id<MTLBuffer> __unsafe_unretained> vertex_buffers;
 		LocalVector<NSUInteger> vertex_offsets;
 		// clang-format off

--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -717,6 +717,7 @@ void MDCommandBuffer::render_bind_index_buffer(RDD::BufferID p_buffer, RDD::Inde
 
 	render.index_buffer = rid::get(p_buffer);
 	render.index_type = p_format == RDD::IndexBufferFormat::INDEX_BUFFER_FORMAT_UINT16 ? MTLIndexTypeUInt16 : MTLIndexTypeUInt32;
+	render.index_offset = p_offset;
 }
 
 void MDCommandBuffer::render_draw_indexed(uint32_t p_index_count,
@@ -729,13 +730,16 @@ void MDCommandBuffer::render_draw_indexed(uint32_t p_index_count,
 
 	id<MTLRenderCommandEncoder> enc = render.encoder;
 
+	uint32_t index_offset = render.index_offset;
+	index_offset += p_first_index * (render.index_type == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t));
+
 	[enc drawIndexedPrimitives:render.pipeline->raster_state.render_primitive
 					indexCount:p_index_count
 					 indexType:render.index_type
 				   indexBuffer:render.index_buffer
-			 indexBufferOffset:p_vertex_offset
+			 indexBufferOffset:index_offset
 				 instanceCount:p_instance_count
-					baseVertex:p_first_index
+					baseVertex:p_vertex_offset
 				  baseInstance:p_first_instance];
 }
 


### PR DESCRIPTION
Fixes #96348

Referring to the [Metal docs](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1515520-drawindexedprimitives?language=objc), `indexBufferOffset` is a byte offset, so `p_first_index` has to be converted.