### PR TITLE
Metal: Enable for betsy and lightmapper modules in compatibility mode

### DIFF
--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -33,22 +33,36 @@
 
 #ifdef METAL_ENABLED
 
-#import "rendering_device_driver_metal.h"
-
 #import "servers/rendering/rendering_context_driver.h"
+#import "servers/rendering/rendering_device_driver.h"
 
 #import <CoreGraphics/CGGeometry.h>
+
+#ifdef __OBJC__
+#import "metal_objects.h"
+
 #import <Metal/Metal.h>
 #import <QuartzCore/CALayer.h>
 
 @class CAMetalLayer;
 @protocol CAMetalDrawable;
+#else
+typedef enum MTLPixelFormat {
+	MTLPixelFormatBGRA8Unorm = 80,
+} MTLPixelFormat;
+class MDCommandBuffer;
+#endif
+
 class PixelFormats;
 class MDResourceCache;
 
 class API_AVAILABLE(macos(11.0), ios(14.0)) RenderingContextDriverMetal : public RenderingContextDriver {
 protected:
-	id<MTLDevice> metal_device = nil;
+#ifdef __OBJC__
+	id<MTLDevice> metal_device = nullptr;
+#else
+	void *metal_device = nullptr;
+#endif
 	Device device; // There is only one device on Apple Silicon.
 
 public:
@@ -73,12 +87,20 @@ public:
 
 	// Platform-specific data for the Windows embedded in this driver.
 	struct WindowPlatformData {
+#ifdef __OBJC__
 		CAMetalLayer *__unsafe_unretained layer;
+#else
+		void *layer;
+#endif
 	};
 
-	class Surface {
+	class API_AVAILABLE(macos(11.0), ios(14.0)) Surface {
 	protected:
+#ifdef __OBJC__
 		id<MTLDevice> device;
+#else
+		void *device;
+#endif
 
 	public:
 		uint32_t width = 0;
@@ -86,8 +108,15 @@ public:
 		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
 		bool needs_resize = false;
 
-		Surface(id<MTLDevice> p_device) :
-				device(p_device) {}
+		Surface(
+#ifdef __OBJC__
+				id<MTLDevice> p_device
+#else
+				void *p_device
+#endif
+				) :
+				device(p_device) {
+		}
 		virtual ~Surface() = default;
 
 		MTLPixelFormat get_pixel_format() const { return MTLPixelFormatBGRA8Unorm; }
@@ -96,104 +125,14 @@ public:
 		virtual void present(MDCommandBuffer *p_cmd_buffer) = 0;
 	};
 
-	class SurfaceLayer : public Surface {
-		CAMetalLayer *__unsafe_unretained layer = nil;
-		LocalVector<MDFrameBuffer> frame_buffers;
-		LocalVector<id<MTLDrawable>> drawables;
-		uint32_t rear = -1;
-		uint32_t front = 0;
-		uint32_t count = 0;
-
-	public:
-		SurfaceLayer(CAMetalLayer *p_layer, id<MTLDevice> p_device) :
-				Surface(p_device), layer(p_layer) {
-			layer.allowsNextDrawableTimeout = YES;
-			layer.framebufferOnly = YES;
-			layer.opaque = OS::get_singleton()->is_layered_allowed() ? NO : YES;
-			layer.pixelFormat = get_pixel_format();
-			layer.device = p_device;
-		}
-
-		~SurfaceLayer() override {
-			layer = nil;
-		}
-
-		Error resize(uint32_t p_desired_framebuffer_count) override final {
-			if (width == 0 || height == 0) {
-				// Very likely the window is minimized, don't create a swap chain.
-				return ERR_SKIP;
-			}
-
-			CGSize drawableSize = CGSizeMake(width, height);
-			CGSize current = layer.drawableSize;
-			if (!CGSizeEqualToSize(current, drawableSize)) {
-				layer.drawableSize = drawableSize;
-			}
-
-			// Metal supports a maximum of 3 drawables.
-			p_desired_framebuffer_count = MIN(3U, p_desired_framebuffer_count);
-			layer.maximumDrawableCount = p_desired_framebuffer_count;
-
-#if TARGET_OS_OSX
-			// Display sync is only supported on macOS.
-			switch (vsync_mode) {
-				case DisplayServer::VSYNC_MAILBOX:
-				case DisplayServer::VSYNC_ADAPTIVE:
-				case DisplayServer::VSYNC_ENABLED:
-					layer.displaySyncEnabled = YES;
-					break;
-				case DisplayServer::VSYNC_DISABLED:
-					layer.displaySyncEnabled = NO;
-					break;
-			}
+#ifdef __OBJC__
+	id<MTLDevice>
+#else
+	void *
 #endif
-			drawables.resize(p_desired_framebuffer_count);
-			frame_buffers.resize(p_desired_framebuffer_count);
-			for (uint32_t i = 0; i < p_desired_framebuffer_count; i++) {
-				// Reserve space for the drawable texture.
-				frame_buffers[i].textures.resize(1);
-			}
-
-			return OK;
-		}
-
-		RDD::FramebufferID acquire_next_frame_buffer() override final {
-			if (count == frame_buffers.size()) {
-				return RDD::FramebufferID();
-			}
-
-			rear = (rear + 1) % frame_buffers.size();
-			count++;
-
-			MDFrameBuffer &frame_buffer = frame_buffers[rear];
-			frame_buffer.size = Size2i(width, height);
-
-			id<CAMetalDrawable> drawable = layer.nextDrawable;
-			ERR_FAIL_NULL_V_MSG(drawable, RDD::FramebufferID(), "no drawable available");
-			drawables[rear] = drawable;
-			frame_buffer.textures.write[0] = drawable.texture;
-
-			return RDD::FramebufferID(&frame_buffer);
-		}
-
-		void present(MDCommandBuffer *p_cmd_buffer) override final {
-			if (count == 0) {
-				return;
-			}
-
-			// Release texture and drawable.
-			frame_buffers[front].textures.write[0] = nil;
-			id<MTLDrawable> drawable = drawables[front];
-			drawables[front] = nil;
-
-			count--;
-			front = (front + 1) % frame_buffers.size();
-
-			[p_cmd_buffer->get_command_buffer() presentDrawable:drawable];
-		}
-	};
-
-	id<MTLDevice> get_metal_device() const { return metal_device; }
+	get_metal_device() const {
+		return metal_device;
+	}
 
 #pragma mark - Initialization
 

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -36,6 +36,9 @@
 #if defined(VULKAN_ENABLED)
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 #endif
+#if defined(METAL_ENABLED)
+#include "drivers/metal/rendering_context_driver_metal.h"
+#endif
 
 #include "bc6h.glsl.gen.h"
 
@@ -66,9 +69,15 @@ Error _compress_betsy(BetsyFormat p_format, Image *r_img) {
 
 	if (rd == nullptr) {
 #if defined(RD_ENABLED)
-#if defined(VULKAN_ENABLED)
-		rcd = memnew(RenderingContextDriverVulkan);
+#if defined(METAL_ENABLED)
+		rcd = memnew(RenderingContextDriverMetal);
 		rd = memnew(RenderingDevice);
+#endif
+#if defined(VULKAN_ENABLED)
+		if (rcd == nullptr) {
+			rcd = memnew(RenderingContextDriverVulkan);
+			rd = memnew(RenderingDevice);
+		}
 #endif
 #endif
 		if (rcd != nullptr && rd != nullptr) {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -44,6 +44,9 @@
 #if defined(VULKAN_ENABLED)
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 #endif
+#if defined(METAL_ENABLED)
+#include "drivers/metal/rendering_context_driver_metal.h"
+#endif
 
 //uncomment this if you want to see textures from all the process saved
 //#define DEBUG_TEXTURES
@@ -1043,9 +1046,15 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	RenderingDevice *rd = RenderingServer::get_singleton()->create_local_rendering_device();
 	if (rd == nullptr) {
 #if defined(RD_ENABLED)
-#if defined(VULKAN_ENABLED)
-		rcd = memnew(RenderingContextDriverVulkan);
+#if defined(METAL_ENABLED)
+		rcd = memnew(RenderingContextDriverMetal);
 		rd = memnew(RenderingDevice);
+#endif
+#if defined(VULKAN_ENABLED)
+		if (rcd == nullptr) {
+			rcd = memnew(RenderingContextDriverVulkan);
+			rd = memnew(RenderingDevice);
+		}
 #endif
 #endif
 		if (rcd != nullptr && rd != nullptr) {

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -41,6 +41,9 @@
 #if defined(D3D12_ENABLED)
 #include "drivers/d3d12/rendering_context_driver_d3d12.h"
 #endif
+#if defined(METAL_ENABLED)
+#include "drivers/metal/rendering_context_driver_metal.h"
+#endif
 
 DisplayServer *DisplayServer::singleton = nullptr;
 
@@ -1230,6 +1233,15 @@ bool DisplayServer::can_create_rendering_device() {
 #ifdef D3D12_ENABLED
 	if (rcd == nullptr) {
 		rcd = memnew(RenderingContextDriverD3D12);
+	}
+#endif
+#ifdef METAL_ENABLED
+	if (rcd == nullptr) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
+		rcd = memnew(RenderingContextDriverMetal);
+#pragma clang diagnostic pop
 	}
 #endif
 


### PR DESCRIPTION
To support this, the `rendering_context_driver_metal.h` header was updated to recognise when it is included in non-Objective-C source files.