### PR TITLE
Add universal sign support for index macros

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -113,6 +113,37 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 // Index out of bounds error macros.
 // These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
 
+/**
+ * Internal index out of bounds check.
+ * WARNING: Do not use this macro directly.
+ *
+ * This macro accepts signed and unsigned integers, even mismatched a pair.
+ * Returns a boolean.
+ */
+#define ___gd_is_index_out_of_bounds(m_index, m_size)                                                    \
+	[](auto ___p_index, auto ___p_size) -> bool {                                                        \
+		using ___GDIndex = std::decay_t<decltype(___p_index)>;                                           \
+		using ___GDSize = std::decay_t<decltype(___p_size)>;                                             \
+		using ___GDSignedIndex = std::make_signed_t<___GDIndex>;                                         \
+		using ___GDSignedSize = std::make_signed_t<___GDSize>;                                           \
+		using ___GDUnsignedIndex = std::make_unsigned_t<___GDIndex>;                                     \
+		using ___GDUnsignedSize = std::make_unsigned_t<___GDSize>;                                       \
+		if (___p_size == 0) {                                                                            \
+			return true;                                                                                 \
+		}                                                                                                \
+		if constexpr (std::is_signed_v<___GDIndex>) {                                                    \
+			if (static_cast<___GDSignedIndex>(___p_index) < 0) {                                         \
+				return true;                                                                             \
+			}                                                                                            \
+		}                                                                                                \
+		if constexpr (std::is_signed_v<___GDSize>) {                                                     \
+			if (static_cast<___GDSignedSize>(___p_size) < 0) {                                           \
+				return true;                                                                             \
+			}                                                                                            \
+		}                                                                                                \
+		return static_cast<___GDUnsignedIndex>(___p_index) >= static_cast<___GDUnsignedSize>(___p_size); \
+	}(m_index, m_size)
+
 // Integer index out of bounds error macros.
 
 /**
@@ -123,7 +154,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns.
  */
 #define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                              \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return;                                                                                                 \
 	} else                                                                                                      \
@@ -134,7 +165,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                     \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return;                                                                                                        \
 	} else                                                                                                             \
@@ -144,7 +175,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                           \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return;                                                                                                              \
 	} else                                                                                                                   \
@@ -158,7 +189,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                              \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return m_retval;                                                                                        \
 	} else                                                                                                      \
@@ -169,7 +200,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                     \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return m_retval;                                                                                               \
 	} else                                                                                                             \
@@ -179,7 +210,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                           \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return m_retval;                                                                                                     \
 	} else                                                                                                                   \
@@ -194,7 +225,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the application crashes.
  */
 #define CRASH_BAD_INDEX(m_index, m_size)                                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                      \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                               \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
 		_err_flush_stdout();                                                                                                     \
 		GENERATE_TRAP();                                                                                                         \
@@ -209,7 +240,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the application crashes.
  */
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                         \
+	if (unlikely(___gd_is_index_out_of_bounds(m_index, m_size))) {                                                                  \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
 		_err_flush_stdout();                                                                                                        \
 		GENERATE_TRAP();                                                                                                            \
@@ -219,6 +250,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 // Unsigned integer index out of bounds error macros.
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX` instead.
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG`.
  * Only use this macro if there is no sensible error message.
  *
@@ -233,6 +265,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX_MSG` instead.
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
@@ -244,6 +277,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX_EDMSG` instead.
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                \
@@ -254,6 +288,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX_V` instead.
  * Try using `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
  * Only use this macro if there is no sensible error message.
  *
@@ -268,6 +303,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX_V_MSG` instead.
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
@@ -279,6 +315,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `ERR_FAIL_INDEX_V_EDMSG` instead.
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
@@ -289,6 +326,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `CRASH_BAD_INDEX` instead.
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
  * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable, and
  * there is no sensible error message.
@@ -305,6 +343,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
+ * DEPRECATED: Use `CRASH_BAD_INDEX_MSG` instead.
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
  * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable.
  *

--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -61,7 +61,7 @@ public:
 	}
 
 	uint64_t move(uint64_t p_idx, uint64_t p_bin) {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_idx, array.size(), -1);
+		ERR_FAIL_INDEX_V(p_idx, array.size(), -1);
 
 		uint64_t current_bin = bin_limits.size() - 1;
 		while (p_idx > bin_limits[current_bin]) {
@@ -113,7 +113,7 @@ public:
 	}
 
 	void remove_at(uint64_t p_idx) {
-		ERR_FAIL_UNSIGNED_INDEX(p_idx, array.size());
+		ERR_FAIL_INDEX(p_idx, array.size());
 		uint64_t new_idx = move(p_idx, 0);
 		uint64_t swap_idx = array.size() - 1;
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -72,7 +72,7 @@ public:
 	}
 
 	void remove_at(U p_index) {
-		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
+		ERR_FAIL_INDEX(p_index, count);
 		count--;
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
@@ -170,11 +170,11 @@ public:
 		}
 	}
 	_FORCE_INLINE_ const T &operator[](U p_index) const {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		return data[p_index];
 	}
 	_FORCE_INLINE_ T &operator[](U p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		return data[p_index];
 	}
 
@@ -243,7 +243,7 @@ public:
 	}
 
 	void insert(U p_pos, T p_val) {
-		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);
+		ERR_FAIL_INDEX(p_pos, count + 1);
 		if (p_pos == count) {
 			push_back(p_val);
 		} else {

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -166,14 +166,14 @@ class PagedArray {
 
 public:
 	_FORCE_INLINE_ const T &operator[](uint64_t p_index) const {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		uint32_t page = p_index >> page_size_shift;
 		uint32_t offset = p_index & page_size_mask;
 
 		return page_data[page][offset];
 	}
 	_FORCE_INLINE_ T &operator[](uint64_t p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		uint32_t page = p_index >> page_size_shift;
 		uint32_t offset = p_index & page_size_mask;
 
@@ -230,7 +230,7 @@ public:
 	}
 
 	void remove_at_unordered(uint64_t p_index) {
-		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
+		ERR_FAIL_INDEX(p_index, count);
 		(*this)[p_index] = (*this)[count - 1];
 		pop_back();
 	}

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -120,7 +120,7 @@ public:
 	}
 	void free(const U &p_id) {
 		// should not be on free list already
-		ERR_FAIL_UNSIGNED_INDEX(p_id, list.size());
+		ERR_FAIL_INDEX(p_id, list.size());
 		freelist.push_back(p_id);
 		ERR_FAIL_COND_MSG(!_used_size, "_used_size has become out of sync, have you double freed an item?");
 		_used_size--;

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -827,52 +827,52 @@ public:
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadows_length(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].shadows.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_shadows_allocated(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].textures.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_subdivision(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].subdivision;
 	}
 
 	_FORCE_INLINE_ GLuint shadow_atlas_get_quadrant_shadow_texture(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].textures.size(), 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].textures.size(), 0);
 		return atlas->quadrants[p_quadrant].textures[p_shadow];
 	}
 
 	_FORCE_INLINE_ GLuint shadow_atlas_get_quadrant_shadow_fb(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].fbos.size(), 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].fbos.size(), 0);
 		return atlas->quadrants[p_quadrant].fbos[p_shadow];
 	}
 
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadow_size(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return (atlas->size >> 1) / atlas->quadrants[p_quadrant].subdivision;
 	}
 
 	_FORCE_INLINE_ bool shadow_atlas_get_quadrant_shadow_is_omni(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, false);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, false);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, (uint32_t)atlas->quadrants[p_quadrant].shadows.size(), false);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, false);
+		ERR_FAIL_INDEX_V(p_shadow, (uint32_t)atlas->quadrants[p_quadrant].shadows.size(), false);
 		return atlas->quadrants[p_quadrant].shadows[p_shadow].owner_is_omni;
 	}
 

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -471,7 +471,7 @@ RS::BlendShapeMode MeshStorage::mesh_get_blend_shape_mode(RID p_mesh) const {
 void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -486,7 +486,7 @@ void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, i
 void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -501,7 +501,7 @@ void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface
 void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -516,7 +516,7 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	mesh->surfaces[p_surface]->material = p_material;
 
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
@@ -526,7 +526,7 @@ void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_mat
 RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RID());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RID());
 
 	return mesh->surfaces[p_surface]->material;
 }
@@ -534,7 +534,7 @@ RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RS::SurfaceData());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RS::SurfaceData());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RS::SurfaceData());
 
 	Mesh::Surface &s = *mesh->surfaces[p_surface];
 
@@ -1569,7 +1569,7 @@ void MeshStorage::_multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool 
 	uint32_t region_index = p_index / MULTIMESH_DIRTY_REGION_SIZE;
 #ifdef DEBUG_ENABLED
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
-	ERR_FAIL_UNSIGNED_INDEX(region_index, data_cache_dirty_region_count); //bug
+	ERR_FAIL_INDEX(region_index, data_cache_dirty_region_count); //bug
 #endif
 	if (!multimesh->data_cache_dirty_regions[region_index]) {
 		multimesh->data_cache_dirty_regions[region_index] = true;

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -337,7 +337,7 @@ public:
 	_FORCE_INLINE_ void *mesh_get_surface(RID p_mesh, uint32_t p_surface_index) {
 		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_NULL_V(mesh, nullptr);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
+		ERR_FAIL_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
 
 		return mesh->surfaces[p_surface_index];
 	}
@@ -460,7 +460,7 @@ public:
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;
-		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
+		ERR_FAIL_INDEX(p_surface_index, mesh->surface_count);
 
 		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -373,17 +373,17 @@ uint64_t Utilities::get_captured_timestamps_frame() const {
 }
 
 uint64_t Utilities::get_captured_timestamp_gpu_time(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_result_values[p_index];
 }
 
 uint64_t Utilities::get_captured_timestamp_cpu_time(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_cpu_result_values[p_index];
 }
 
 String Utilities::get_captured_timestamp_name(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
 	return frames[frame].timestamp_result_names[p_index];
 }
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -422,33 +422,33 @@ uint32_t GodotSoftBody3D::get_node_count() const {
 }
 
 real_t GodotSoftBody3D::get_node_inv_mass(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), 0.0);
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), 0.0);
 	return nodes[p_node_index].im;
 }
 
 Vector3 GodotSoftBody3D::get_node_position(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].x;
 }
 
 Vector3 GodotSoftBody3D::get_node_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].v;
 }
 
 Vector3 GodotSoftBody3D::get_node_biased_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].bv;
 }
 
 void GodotSoftBody3D::apply_node_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
+	ERR_FAIL_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.v += p_impulse * node.im;
 }
 
 void GodotSoftBody3D::apply_node_bias_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
+	ERR_FAIL_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.bv += p_impulse * node.im;
 }
@@ -458,7 +458,7 @@ uint32_t GodotSoftBody3D::get_face_count() const {
 }
 
 void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1, Vector3 &r_point_2, Vector3 &r_point_3) const {
-	ERR_FAIL_UNSIGNED_INDEX(p_face_index, faces.size());
+	ERR_FAIL_INDEX(p_face_index, faces.size());
 	const Face &face = faces[p_face_index];
 	r_point_1 = face.n[0]->x;
 	r_point_2 = face.n[1]->x;
@@ -466,7 +466,7 @@ void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1,
 }
 
 Vector3 GodotSoftBody3D::get_face_normal(uint32_t p_face_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_face_index, faces.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_face_index, faces.size(), Vector3());
 	return faces[p_face_index].normal;
 }
 

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -249,9 +249,9 @@ PackedInt32Array AudioStreamInteractive::get_transition_list() const {
 void AudioStreamInteractive::add_transition(int p_from_clip, int p_to_clip, TransitionFromTime p_from_time, TransitionToTime p_to_time, FadeMode p_fade_mode, float p_fade_beats, bool p_use_filler_flip, int p_filler_clip, bool p_hold_previous) {
 	ERR_FAIL_COND(p_from_clip < CLIP_ANY || p_from_clip >= clip_count);
 	ERR_FAIL_COND(p_to_clip < CLIP_ANY || p_to_clip >= clip_count);
-	ERR_FAIL_UNSIGNED_INDEX(p_from_time, TRANSITION_FROM_TIME_MAX);
-	ERR_FAIL_UNSIGNED_INDEX(p_to_time, TRANSITION_TO_TIME_MAX);
-	ERR_FAIL_UNSIGNED_INDEX(p_fade_mode, FADE_MAX);
+	ERR_FAIL_INDEX(p_from_time, TRANSITION_FROM_TIME_MAX);
+	ERR_FAIL_INDEX(p_to_time, TRANSITION_TO_TIME_MAX);
+	ERR_FAIL_INDEX(p_fade_mode, FADE_MAX);
 
 	Transition tr;
 	tr.from_time = p_from_time;
@@ -353,8 +353,8 @@ static void _test_and_swap(T &p_elem, uint32_t p_a, uint32_t p_b) {
 }
 
 void AudioStreamInteractive::_inspector_array_swap_clip(uint32_t p_item_a, uint32_t p_item_b) {
-	ERR_FAIL_UNSIGNED_INDEX(p_item_a, (uint32_t)clip_count);
-	ERR_FAIL_UNSIGNED_INDEX(p_item_b, (uint32_t)clip_count);
+	ERR_FAIL_INDEX(p_item_a, clip_count);
+	ERR_FAIL_INDEX(p_item_b, clip_count);
 
 	for (int i = 0; i < clip_count; i++) {
 		_test_and_swap(clips[i].auto_advance_next_clip, p_item_a, p_item_b);

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -45,7 +45,7 @@ bool MultiplayerSpawner::_set(const StringName &p_name, const Variant &p_value) 
 		String ns = p_name;
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
-			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
+			ERR_FAIL_INDEX_V(index, spawnable_scenes.size(), false);
 			spawnable_scenes[index].path = ResourceUID::ensure_path(p_value);
 			return true;
 		}
@@ -61,7 +61,7 @@ bool MultiplayerSpawner::_get(const StringName &p_name, Variant &r_ret) const {
 		String ns = p_name;
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
-			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
+			ERR_FAIL_INDEX_V(index, spawnable_scenes.size(), false);
 			r_ret = ResourceUID::path_to_uid(spawnable_scenes[index].path);
 			return true;
 		}
@@ -296,7 +296,7 @@ const Variant MultiplayerSpawner::get_spawn_argument(const ObjectID &p_id) const
 
 Node *MultiplayerSpawner::instantiate_scene(int p_id) {
 	ERR_FAIL_COND_V_MSG(spawn_limit && spawn_limit <= tracked_nodes.size(), nullptr, "Spawn limit reached!");
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_id, spawnable_scenes.size(), nullptr);
+	ERR_FAIL_INDEX_V(p_id, spawnable_scenes.size(), nullptr);
 	SpawnableScene &sc = spawnable_scenes[p_id];
 	if (sc.cache.is_null()) {
 		sc.cache = ResourceLoader::load(sc.path);

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -336,7 +336,7 @@ Vector3 NavMap::get_random_point(uint32_t p_navigation_layers, bool p_uniformly)
 		RBMap<real_t, uint32_t>::Iterator E = accessible_regions_area_map.find_closest(random_accessible_regions_area_map);
 		ERR_FAIL_COND_V(!E, Vector3());
 		uint32_t random_region_index = E->value;
-		ERR_FAIL_UNSIGNED_INDEX_V(random_region_index, accessible_regions.size(), Vector3());
+		ERR_FAIL_INDEX_V(random_region_index, accessible_regions.size(), Vector3());
 
 		const NavRegion *random_region = accessible_regions[random_region_index];
 		ERR_FAIL_NULL_V(random_region, Vector3());

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -359,19 +359,19 @@ bool OpenXRHandTrackingExtension::get_active() {
 }
 
 const OpenXRHandTrackingExtension::HandTracker *OpenXRHandTrackingExtension::get_hand_tracker(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, nullptr);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, nullptr);
 
 	return &hand_trackers[p_hand];
 }
 
 XrHandJointsMotionRangeEXT OpenXRHandTrackingExtension::get_motion_range(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XR_HAND_JOINTS_MOTION_RANGE_MAX_ENUM_EXT);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XR_HAND_JOINTS_MOTION_RANGE_MAX_ENUM_EXT);
 
 	return hand_trackers[p_hand].motion_range;
 }
 
 OpenXRHandTrackingExtension::HandTrackedSource OpenXRHandTrackingExtension::get_hand_tracking_source(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, OPENXR_SOURCE_UNKNOWN);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, OPENXR_SOURCE_UNKNOWN);
 
 	if (hand_tracking_source_ext) {
 		if (!hand_trackers[p_hand].data_source.isActive) {
@@ -391,13 +391,13 @@ OpenXRHandTrackingExtension::HandTrackedSource OpenXRHandTrackingExtension::get_
 }
 
 void OpenXRHandTrackingExtension::set_motion_range(HandTrackedHands p_hand, XrHandJointsMotionRangeEXT p_motion_range) {
-	ERR_FAIL_UNSIGNED_INDEX(p_hand, OPENXR_MAX_TRACKED_HANDS);
+	ERR_FAIL_INDEX(p_hand, OPENXR_MAX_TRACKED_HANDS);
 	hand_trackers[p_hand].motion_range = p_motion_range;
 }
 
 XrSpaceLocationFlags OpenXRHandTrackingExtension::get_hand_joint_location_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceLocationFlags(0));
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceLocationFlags(0));
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceLocationFlags(0));
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceLocationFlags(0));
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return XrSpaceLocationFlags(0);
@@ -408,8 +408,8 @@ XrSpaceLocationFlags OpenXRHandTrackingExtension::get_hand_joint_location_flags(
 }
 
 Quaternion OpenXRHandTrackingExtension::get_hand_joint_rotation(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Quaternion());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Quaternion());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Quaternion());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Quaternion());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Quaternion();
@@ -420,8 +420,8 @@ Quaternion OpenXRHandTrackingExtension::get_hand_joint_rotation(HandTrackedHands
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_position(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();
@@ -432,8 +432,8 @@ Vector3 OpenXRHandTrackingExtension::get_hand_joint_position(HandTrackedHands p_
 }
 
 float OpenXRHandTrackingExtension::get_hand_joint_radius(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, 0.0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, 0.0);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, 0.0);
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, 0.0);
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return 0.0;
@@ -443,8 +443,8 @@ float OpenXRHandTrackingExtension::get_hand_joint_radius(HandTrackedHands p_hand
 }
 
 XrSpaceVelocityFlags OpenXRHandTrackingExtension::get_hand_joint_velocity_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceVelocityFlags(0));
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceVelocityFlags(0));
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceVelocityFlags(0));
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceVelocityFlags(0));
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return XrSpaceVelocityFlags(0);
@@ -455,8 +455,8 @@ XrSpaceVelocityFlags OpenXRHandTrackingExtension::get_hand_joint_velocity_flags(
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_linear_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();
@@ -467,8 +467,8 @@ Vector3 OpenXRHandTrackingExtension::get_hand_joint_linear_velocity(HandTrackedH
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_angular_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -171,7 +171,7 @@ RID OpenXRVisibilityMaskExtension::get_mesh() {
 
 void OpenXRVisibilityMaskExtension::_update_mesh_data(uint32_t p_view) {
 	if (available) {
-		ERR_FAIL_UNSIGNED_INDEX(p_view, 4);
+		ERR_FAIL_INDEX(p_view, 4);
 
 		OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 		ERR_FAIL_NULL(openxr_api);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2536,7 +2536,7 @@ int OpenXRAPI::get_foveation_level() const {
 }
 
 void OpenXRAPI::set_foveation_level(int p_foveation_level) {
-	ERR_FAIL_UNSIGNED_INDEX(p_foveation_level, 4);
+	ERR_FAIL_INDEX(p_foveation_level, 4);
 	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
 	if (fov_ext != nullptr && fov_ext->is_enabled()) {
 		XrFoveationLevelFB levels[] = { XR_FOVEATION_LEVEL_NONE_FB, XR_FOVEATION_LEVEL_LOW_FB, XR_FOVEATION_LEVEL_MEDIUM_FB, XR_FOVEATION_LEVEL_HIGH_FB };

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1003,7 +1003,7 @@ Transform3D OpenXRInterface::get_camera_transform() {
 Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Transform3D());
-	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
+	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
 
 	Transform3D t;
 	if (openxr_api && openxr_api->get_view_transform(p_view, t)) {
@@ -1023,7 +1023,7 @@ Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Trans
 
 Projection OpenXRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	Projection cm;
-	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
+	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
 
 	if (openxr_api) {
 		if (openxr_api->get_view_projection(p_view, p_z_near, p_z_far, cm)) {

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -222,7 +222,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 
 		int original_path_size = pdb_info.path.utf8().length();
 		// Double-check file bounds.
-		ERR_FAIL_UNSIGNED_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
+		ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
 
 		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
 		file->seek(pdb_info.address);

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -38,6 +38,8 @@
 
 #include "thirdparty/misc/polypartition.h"
 
+#include <cstdint>
+
 void CollisionPolygon2D::_build_polygon() {
 	collision_object->shape_owner_clear_shapes(owner_id);
 
@@ -58,19 +60,20 @@ void CollisionPolygon2D::_build_polygon() {
 		}
 
 	} else {
-		if (polygon.size() < 2) {
+		uint64_t polygon_size = polygon.size();
+		if (polygon_size < 2) {
 			return;
 		}
 
 		Ref<ConcavePolygonShape2D> concave = memnew(ConcavePolygonShape2D);
 
 		Vector<Vector2> segments;
-		segments.resize(polygon.size() * 2);
+		segments.resize(polygon_size * 2);
 		Vector2 *w = segments.ptrw();
 
-		for (int i = 0; i < polygon.size(); i++) {
+		for (uint64_t i = 0; i < polygon_size; i++) {
 			w[(i << 1) + 0] = polygon[i];
-			w[(i << 1) + 1] = polygon[(i + 1) % polygon.size()];
+			w[(i << 1) + 1] = polygon[(i + 1) % polygon_size];
 		}
 
 		concave->set_segments(segments);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1412,7 +1412,7 @@ uint32_t CanvasItem::get_visibility_layer() const {
 
 void CanvasItem::set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_enable) {
 	ERR_THREAD_GUARD;
-	ERR_FAIL_UNSIGNED_INDEX(p_visibility_layer, 32);
+	ERR_FAIL_INDEX(p_visibility_layer, 32);
 	if (p_enable) {
 		set_visibility_layer(visibility_layer | (1 << p_visibility_layer));
 	} else {
@@ -1422,7 +1422,7 @@ void CanvasItem::set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_en
 
 bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_visibility_layer, 32, false);
+	ERR_FAIL_INDEX_V(p_visibility_layer, 32, false);
 	return (visibility_layer & (1 << p_visibility_layer));
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3880,7 +3880,7 @@ uint32_t Viewport::get_canvas_cull_mask() const {
 
 void Viewport::set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_UNSIGNED_INDEX(p_layer, 32);
+	ERR_FAIL_INDEX(p_layer, 32);
 	if (p_enable) {
 		set_canvas_cull_mask(canvas_cull_mask | (1 << p_layer));
 	} else {
@@ -3890,7 +3890,7 @@ void Viewport::set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable) {
 
 bool Viewport::get_canvas_cull_mask_bit(uint32_t p_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, 32, false);
+	ERR_FAIL_INDEX_V(p_layer, 32, false);
 	return (canvas_cull_mask & (1 << p_layer));
 }
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -119,7 +119,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "compressed_track") {
 			int index = p_value;
 			ERR_FAIL_COND_V(!compression.enabled, false);
-			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)index, compression.bounds.size(), false);
+			ERR_FAIL_INDEX_V(index, compression.bounds.size(), false);
 			Track *t = tracks[track];
 			t->interpolation = INTERPOLATION_LINEAR; //only linear supported
 			switch (t->type) {
@@ -5290,7 +5290,7 @@ bool Animation::_blend_shape_interpolate_compressed(uint32_t p_compressed_track,
 template <uint32_t COMPONENTS>
 bool Animation::_fetch_compressed(uint32_t p_compressed_track, double p_time, Vector3i &r_current_value, double &r_current_time, Vector3i &r_next_value, double &r_next_time, uint32_t *key_index) const {
 	ERR_FAIL_COND_V(!compression.enabled, false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), false);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), false);
 	p_time = CLAMP(p_time, 0, length);
 	if (key_index) {
 		*key_index = 0;
@@ -5436,7 +5436,7 @@ bool Animation::_fetch_compressed(uint32_t p_compressed_track, double p_time, Ve
 template <uint32_t COMPONENTS>
 void Animation::_get_compressed_key_indices_in_range(uint32_t p_compressed_track, double p_time, double p_delta, List<int> *r_indices) const {
 	ERR_FAIL_COND(!compression.enabled);
-	ERR_FAIL_UNSIGNED_INDEX(p_compressed_track, compression.bounds.size());
+	ERR_FAIL_INDEX(p_compressed_track, compression.bounds.size());
 
 	double frame_to_sec = 1.0 / double(compression.fps);
 	uint32_t key_index = 0;
@@ -5517,7 +5517,7 @@ void Animation::_get_compressed_key_indices_in_range(uint32_t p_compressed_track
 
 int Animation::_get_compressed_key_count(uint32_t p_compressed_track) const {
 	ERR_FAIL_COND_V(!compression.enabled, -1);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), -1);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), -1);
 
 	int key_count = 0;
 
@@ -5553,7 +5553,7 @@ float Animation::_uncompress_blend_shape(const Vector3i &p_value) const {
 template <uint32_t COMPONENTS>
 bool Animation::_fetch_compressed_by_index(uint32_t p_compressed_track, int p_index, Vector3i &r_value, double &r_time) const {
 	ERR_FAIL_COND_V(!compression.enabled, false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), false);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), false);
 
 	for (const Compression::Page &page : compression.pages) {
 		const uint8_t *page_data = page.data.ptr();

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -318,14 +318,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 							// We cannot know if the referenced nodes exist yet, so instead of deferring, we write the NodePaths directly.
 
 							uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
-							ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
+							ERR_FAIL_INDEX_V(name_idx, sname_count, nullptr);
 
 							node->set(snames[name_idx], props[nprops[j].value], &valid);
 							continue;
 						}
 
 						uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
-						ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
+						ERR_FAIL_INDEX_V(name_idx, sname_count, nullptr);
 
 						DeferredNodePathProperties dnp;
 						dnp.value = props[nprops[j].value];

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -1083,14 +1083,14 @@ public:
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadow_size(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].shadows.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_subdivision(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].subdivision;
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -528,7 +528,7 @@ RS::BlendShapeMode MeshStorage::mesh_get_blend_shape_mode(RID p_mesh) const {
 void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->vertex_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -540,7 +540,7 @@ void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, i
 void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->attribute_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -552,7 +552,7 @@ void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface
 void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->skin_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -564,7 +564,7 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	mesh->surfaces[p_surface]->material = p_material;
 
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
@@ -574,7 +574,7 @@ void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_mat
 RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RID());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RID());
 
 	return mesh->surfaces[p_surface]->material;
 }
@@ -582,7 +582,7 @@ RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RS::SurfaceData());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RS::SurfaceData());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RS::SurfaceData());
 
 	Mesh::Surface &s = *mesh->surfaces[p_surface];
 
@@ -1639,7 +1639,7 @@ void MeshStorage::_multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool 
 	uint32_t region_index = p_index / MULTIMESH_DIRTY_REGION_SIZE;
 #ifdef DEBUG_ENABLED
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
-	ERR_FAIL_UNSIGNED_INDEX(region_index, data_cache_dirty_region_count); //bug
+	ERR_FAIL_INDEX(region_index, data_cache_dirty_region_count); //bug
 #endif
 	if (!multimesh->data_cache_dirty_regions[region_index]) {
 		multimesh->data_cache_dirty_regions[region_index] = true;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -411,7 +411,7 @@ public:
 	_FORCE_INLINE_ void *mesh_get_surface(RID p_mesh, uint32_t p_surface_index) {
 		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_NULL_V(mesh, nullptr);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
+		ERR_FAIL_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
 
 		return mesh->surfaces[p_surface_index];
 	}
@@ -519,7 +519,7 @@ public:
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;
-		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
+		ERR_FAIL_INDEX(p_surface_index, mesh->surface_count);
 
 		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -392,10 +392,10 @@ RID RenderSceneBuffersRD::get_texture_slice_view(const StringName &p_context, co
 	ERR_FAIL_COND_V(named_texture.texture.is_null(), RID());
 
 	// check if we're in bounds
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, named_texture.format.array_layers, RID());
+	ERR_FAIL_INDEX_V(p_layer, named_texture.format.array_layers, RID());
 	ERR_FAIL_COND_V(p_layers == 0, RID());
 	ERR_FAIL_COND_V(p_layer + p_layers > named_texture.format.array_layers, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, named_texture.format.mipmaps, RID());
+	ERR_FAIL_INDEX_V(p_mipmap, named_texture.format.mipmaps, RID());
 	ERR_FAIL_COND_V(p_mipmaps == 0, RID());
 	ERR_FAIL_COND_V(p_mipmap + p_mipmaps > named_texture.format.mipmaps, RID());
 
@@ -442,7 +442,7 @@ Size2i RenderSceneBuffersRD::get_texture_slice_size(const StringName &p_context,
 	ERR_FAIL_COND_V(named_texture.texture.is_null(), Size2i());
 
 	// check if we're in bounds
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, named_texture.format.mipmaps, Size2i());
+	ERR_FAIL_INDEX_V(p_mipmap, named_texture.format.mipmaps, Size2i());
 
 	// return our size
 	return named_texture.sizes[p_mipmap];

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -51,13 +51,13 @@ uint32_t RenderSceneDataRD::get_view_count() const {
 }
 
 Vector3 RenderSceneDataRD::get_view_eye_offset(uint32_t p_view) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_count, Vector3());
+	ERR_FAIL_INDEX_V(p_view, view_count, Vector3());
 
 	return view_eye_offset[p_view];
 }
 
 Projection RenderSceneDataRD::get_view_projection(uint32_t p_view) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_count, Projection());
+	ERR_FAIL_INDEX_V(p_view, view_count, Projection());
 
 	Projection correction;
 	correction.set_depth_correction(flip_y);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3624,7 +3624,7 @@ RID TextureStorage::render_target_get_rd_texture_slice(RID p_render_target, uint
 	if (rt->view_count == 1) {
 		return rt->color;
 	} else {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_layer, rt->view_count, RID());
+		ERR_FAIL_INDEX_V(p_layer, rt->view_count, RID());
 		if (rt->color_slices.size() == 0) {
 			for (uint32_t v = 0; v < rt->view_count; v++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->color, v, 0);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1070,9 +1070,9 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 
 	// Create view.
 
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, src_texture->mipmaps, RID());
+	ERR_FAIL_INDEX_V(p_mipmap, src_texture->mipmaps, RID());
 	ERR_FAIL_COND_V(p_mipmap + p_mipmaps > src_texture->mipmaps, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, src_texture->layers, RID());
+	ERR_FAIL_INDEX_V(p_layer, src_texture->layers, RID());
 
 	int slice_layers = 1;
 	if (p_layers != 0) {
@@ -6491,18 +6491,18 @@ uint64_t RenderingDevice::get_captured_timestamps_frame() const {
 
 uint64_t RenderingDevice::get_captured_timestamp_gpu_time(uint32_t p_index) const {
 	ERR_RENDER_THREAD_GUARD_V(0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return driver->timestamp_query_result_to_time(frames[frame].timestamp_result_values[p_index]);
 }
 
 uint64_t RenderingDevice::get_captured_timestamp_cpu_time(uint32_t p_index) const {
 	ERR_RENDER_THREAD_GUARD_V(0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_cpu_result_values[p_index];
 }
 
 String RenderingDevice::get_captured_timestamp_name(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
 	return frames[frame].timestamp_result_names[p_index];
 }
 

--- a/tests/core/error/test_error_macros.h
+++ b/tests/core/error/test_error_macros.h
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  test_error_macros.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_ERROR_MACROS_H
+#define TEST_ERROR_MACROS_H
+
+#include "core/error/error_macros.h"
+
+#include "tests/test_macros.h"
+
+#include <cstdint>
+
+TEST_CASE("[Error macros] ___gd_is_index_out_of_bounds macro returns expected values") {
+	// ===============
+	// Inbound checks.
+	// ===============
+	int in_a_index = 0;
+	int in_a_size = 5;
+	CHECK(___gd_is_index_out_of_bounds(in_a_index, in_a_size) == false);
+	int in_b_index = 343214;
+	int in_b_size = 943928;
+	CHECK(___gd_is_index_out_of_bounds(in_b_index, in_b_size) == false);
+	uint8_t in_c_index = 0;
+	uint16_t in_c_size = 1;
+	CHECK(___gd_is_index_out_of_bounds(in_c_index, in_c_size) == false);
+	uint32_t in_d_index = 343214;
+	uint64_t in_d_size = 943928;
+	CHECK(___gd_is_index_out_of_bounds(in_d_index, in_d_size) == false);
+	int in_e_index = 0;
+	unsigned int in_e_size = 1;
+	CHECK(___gd_is_index_out_of_bounds(in_e_index, in_e_size) == false);
+	unsigned int in_f_index = 0;
+	int in_f_size = 1;
+	CHECK(___gd_is_index_out_of_bounds(in_f_index, in_f_size) == false);
+
+	// =====================
+	// Out of bounds checks.
+	// =====================
+	// Size is 0.
+	int out_a_index = 0;
+	int out_a_size = 0;
+	CHECK(___gd_is_index_out_of_bounds(out_a_index, out_a_size) == true);
+	// Index is negative.
+	int out_b_index = -1;
+	int out_b_size = 1;
+	CHECK(___gd_is_index_out_of_bounds(out_b_index, out_b_size) == true);
+	// Size is negative.
+	int out_c_index = 1;
+	int out_c_size = -1;
+	CHECK(___gd_is_index_out_of_bounds(out_c_index, out_c_size) == true);
+	// Both are negative.
+	int out_d_index = -1;
+	int out_d_size = -1;
+	CHECK(___gd_is_index_out_of_bounds(out_d_index, out_d_size) == true);
+	// Index is bigger than size.
+	int out_e_index = 127;
+	int out_e_size = 126;
+	CHECK(___gd_is_index_out_of_bounds(out_e_index, out_e_size) == true);
+	// Index would be bigger than size if index was read as `uint8_t`.
+	int8_t out_f_index = -1;
+	uint8_t out_f_size = 1;
+	CHECK(___gd_is_index_out_of_bounds(out_f_index, out_f_size) == true);
+	// This would be alright if size was read as `uint8_t`.
+	uint8_t out_g_index = 1;
+	int8_t out_g_size = -1;
+	CHECK(___gd_is_index_out_of_bounds(out_g_index, out_g_size) == true);
+}
+
+#endif // TEST_ERROR_MACROS_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -38,6 +38,7 @@
 #endif // TOOLS_ENABLED
 
 #include "tests/core/config/test_project_settings.h"
+#include "tests/core/error/test_error_macros.h"
 #include "tests/core/input/test_input_event.h"
 #include "tests/core/input/test_input_event_key.h"
 #include "tests/core/input/test_input_event_mouse.h"


### PR DESCRIPTION
With this PR, `ERR_FAIL_INDEX`, `ERR_FAIL_INDEX_MSG`, `ERR_FAIL_INDEX_EDMSG`, `ERR_FAIL_INDEX_V`, `ERR_FAIL_INDEX_V_MSG`, `ERR_FAIL_INDEX_V_EDMSG`, `CRASH_BAD_INDEX`, and `CRASH_BAD_INDEX_MSG` now accept mismatched signed pair.

~~This PR removes also the `UNSIGNED_INDEX` macros, as they aren't needed anymore.~~
Edit: kept for compatibility reasons.

~~To test the PR, you can go see the implementation on the [Compiler Explorer (godbolt)](https://godbolt.org/z/j9nWs7T55)~~
~~Edit: new implementation: https://godbolt.org/z/cfbzf8876~~
Edit: bug in previous implementation, here's the fix: https://godbolt.org/z/db5aYc5bf

Supersedes #96302