### PR TITLE
Improve `DampedSpringJoint2D` documentation 

### DIFF
--- a/doc/classes/DampedSpringJoint2D.xml
+++ b/doc/classes/DampedSpringJoint2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A physics joint that connects two 2D physics bodies with a spring-like force. This resembles a spring that always wants to stretch to a given length.
+		The joint will connect to [member Joint2D.node_a] at the joint's global position, and will attach to [member Joint2D.node_b] at the point [member length] units away in the local +Y axis.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,13 +14,13 @@
 			The spring joint's damping ratio. A value between [code]0[/code] and [code]1[/code]. When the two bodies move into different directions the system tries to align them to the spring axis again. A high [member damping] value forces the attached bodies to align faster.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="50.0">
-			The spring joint's maximum length. The two attached bodies cannot stretch it past this value.
+			The spring joint's initial length. This, along with [member Node2D.rotation], defines where [member Joint2D.node_b] will be attached to.
 		</member>
 		<member name="rest_length" type="float" setter="set_rest_length" getter="get_rest_length" default="0.0">
-			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards this length.
+			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards its [member rest_length]. If set to 0, it will instead be set to [member length].
 		</member>
 		<member name="stiffness" type="float" setter="set_stiffness" getter="get_stiffness" default="20.0">
-			The higher the value, the less the bodies attached to the joint will deform it. The joint applies an opposing force to the bodies, the product of the stiffness multiplied by the size difference from its resting length.
+			The higher the value, the harder the spring joint will pull towards its [member rest_length]. The joint applies an opposing force to the bodies, the product of the [member stiffness] multiplied by the size difference from its resting length.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Added missing information on the usage of the DampedSpringJoint2D node, along with fixing false information about its length member. Also rewrote some sections for extra clarity.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
