### PR TITLE
Fix no unsaved indicator Save As resource

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -175,6 +175,13 @@ void EditorResourcePicker::_file_quick_selected() {
 	_file_selected(quick_open->get_selected());
 }
 
+void EditorResourcePicker::_resource_saved(Object *p_resource) {
+	if (edited_resource.is_valid() && p_resource == edited_resource.ptr()) {
+		emit_signal(SNAME("resource_changed"), edited_resource);
+		_update_resource();
+	}
+}
+
 void EditorResourcePicker::_update_menu() {
 	_update_menu_items();
 
@@ -407,6 +414,10 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 		case OBJ_MENU_SAVE_AS: {
 			if (edited_resource.is_null()) {
 				return;
+			}
+			Callable resource_saved = callable_mp(this, &EditorResourcePicker::_resource_saved);
+			if (!EditorNode::get_singleton()->is_connected("resource_saved", resource_saved)) {
+				EditorNode::get_singleton()->connect("resource_saved", resource_saved);
 			}
 			EditorNode::get_singleton()->save_resource_as(edited_resource);
 		} break;
@@ -831,6 +842,13 @@ void EditorResourcePicker::_notification(int p_what) {
 			if (dropping) {
 				dropping = false;
 				assign_button->queue_redraw();
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			Callable resource_saved = callable_mp(this, &EditorResourcePicker::_resource_saved);
+			if (EditorNode::get_singleton()->is_connected("resource_saved", resource_saved)) {
+				EditorNode::get_singleton()->disconnect("resource_saved", resource_saved);
 			}
 		} break;
 	}

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -91,6 +91,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _file_quick_selected();
 	void _file_selected(const String &p_path);
 
+	void _resource_saved(Object *p_resource);
+
 	void _update_menu();
 	void _update_menu_items();
 	void _edit_menu_cbk(int p_which);


### PR DESCRIPTION
- Fixes #96087
- Fixes #44053

There was no unsaved indicator on the scene after using "Save As..." on an internal resource. That caused the issue where the user did not get a warning if he closed the scene after doing the "Save As..." option.

I added a connect to the `resource_saved` signal on the EditorNode to know when the resource was saved. The signal is only disconnected when the `EditorResourcePicker` exit the tree. I don't think it's possible that the `resource_saved` signal could be emitted for the `edited_resource` on `EditorResourcePicker` on which the "Save As..." was used without it to be removed from the tree.