### PR TITLE
Fix copying a Node with a signal potentially resulting in an editor crash

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -452,7 +452,13 @@ void ConnectDialog::_update_ok_enabled() {
 }
 
 void ConnectDialog::_update_warning_label() {
-	Ref<Script> scr = source->get_node(dst_path)->get_script();
+	Node *dst = source->get_node(dst_path);
+	if (dst == nullptr) {
+		warning_label->set_visible(false);
+		return;
+	}
+
+	Ref<Script> scr = dst->get_script();
 	if (scr.is_null()) {
 		warning_label->set_visible(false);
 		return;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2985,7 +2985,11 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 				if (!target) {
 					continue;
 				}
+
 				NodePath ptarget = p_original->get_path_to(target);
+				if (ptarget.is_empty()) {
+					continue;
+				}
 
 				Node *copytarget = target;
 


### PR DESCRIPTION
Fixes #96318 in two ways.

First of all it fixes a potential segfault in `ConnectDialog` if the destination node does not exist, caused by a potential nullptr in `ConnectDialog::_update_warning_label`.

Second it avoids copying a signal with a node if the target path is empty, since this will be an invalid path and won't be persisted to disk regardless, which avoids creating the potential nullptr in the first instance.

- *Bugsquad edit*: Fixes (partially) #101854