### PR TITLE
GDExtension: Show warning on missing PDB file, rather than error

### DIFF
--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -155,7 +155,11 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 	} else if (!FileAccess::exists(copy_pdb_path)) {
 		copy_pdb_path = dll_base_dir.path_join(copy_pdb_path.get_file());
 	}
-	ERR_FAIL_COND_V_MSG(!FileAccess::exists(copy_pdb_path), FAILED, vformat("File '%s' does not exist.", copy_pdb_path));
+	if (!FileAccess::exists(copy_pdb_path)) {
+		// The PDB file may be distributed separately on purpose, so we don't consider this an error.
+		WARN_VERBOSE(vformat("PDB file '%s' for library '%s' was not found, skipping copy/rename.", copy_pdb_path, p_dll_path));
+		return ERR_SKIP;
+	}
 
 	String new_pdb_base_name = p_dll_path.get_file().get_basename() + "_";
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96350

Marking as a draft for now, because I haven't had a chance to test it yet (since Windows isn't my main development platform).