### PR TITLE
Fix `frames_mixed` overflow in `AudioStreamPlaybackMP3` and `AudioStreamPlaybackOggVorbis`

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -131,7 +131,7 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= mp3_stream->get_length()) {
+	if (p_time < 0 || p_time >= mp3_stream->get_length()) {
 		p_time = 0;
 	}
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -281,7 +281,7 @@ void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= vorbis_stream->get_length()) {
+	if (p_time < 0 || p_time >= vorbis_stream->get_length()) {
 		p_time = 0;
 	}
 


### PR DESCRIPTION
Done, based on this comment https://github.com/godotengine/godot/pull/89499#issuecomment-2002117944
Closes #89390
