### PR TITLE
[macOS] Fix Quick Open shortcut conflict

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5462,7 +5462,8 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
-	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KeyModifierMask::CMD_OR_CTRL | Key::P));
+	// Using Control even on macOS to avoid conflict with Quick Open shortcut.
+	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KeyModifierMask::CTRL | Key::P));
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();


### PR DESCRIPTION
Quick Open doesn't work if any camera is selected:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/11161b26-702a-4dc4-b6aa-76ee06723a77"><br>

This changes the shortcut for camera preview from <kbd>Cmd+P</kbd> to <kbd>Ctrl+P</kbd> to make sure the non-contextual Quick Open shortcut always works (like in VSCode and other apps)

Same exact issue as in https://github.com/godotengine/godot/pull/96179 and https://github.com/godotengine/godot/pull/93581