### PR TITLE
Extract EditorMainScreen from EditorNode

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -34,6 +34,7 @@
 #include "core/templates/hash_set.h"
 #include "editor/editor_help.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -1191,7 +1192,7 @@ void ConnectionsDock::_go_to_method(TreeItem &p_item) {
 	}
 
 	if (scr.is_valid() && ScriptEditor::get_singleton()->script_goto_method(scr, cd.method)) {
-		EditorNode::get_singleton()->editor_select(EditorNode::EDITOR_SCRIPT);
+		EditorNode::get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 	}
 }
 
@@ -1199,7 +1200,7 @@ void ConnectionsDock::_handle_class_menu_option(int p_option) {
 	switch (p_option) {
 		case CLASS_MENU_OPEN_DOCS:
 			ScriptEditor::get_singleton()->goto_help("class:" + class_menu_doc_class_name);
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 			break;
 	}
 }
@@ -1229,7 +1230,7 @@ void ConnectionsDock::_handle_signal_menu_option(int p_option) {
 		} break;
 		case SIGNAL_MENU_OPEN_DOCS: {
 			ScriptEditor::get_singleton()->goto_help("class_signal:" + String(meta["class"]) + ":" + String(meta["name"]));
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 		} break;
 	}
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -39,6 +39,7 @@
 #include "core/string/string_builder.h"
 #include "core/version_generated.gen.h"
 #include "editor/doc_data_compressed.gen.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_property_name_processor.h"
@@ -2310,7 +2311,7 @@ void EditorHelp::_update_doc() {
 void EditorHelp::_request_help(const String &p_string) {
 	Error err = _goto_desc(p_string);
 	if (err == OK) {
-		EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+		EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 	}
 }
 
@@ -3605,7 +3606,7 @@ void EditorHelpBit::_update_labels() {
 }
 
 void EditorHelpBit::_go_to_help(const String &p_what) {
-	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+	EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 	ScriptEditor::get_singleton()->goto_help(p_what);
 	emit_signal(SNAME("request_hide"));
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/keyboard.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -201,7 +202,7 @@ void EditorHelpSearch::_confirmed() {
 	}
 
 	// Activate the script editor and emit the signal with the documentation link to display.
-	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+	EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 
 	emit_signal(SNAME("go_to_help"), item->get_metadata(0));
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -34,6 +34,7 @@
 #include "core/os/keyboard.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_settings.h"
@@ -1037,7 +1038,7 @@ void EditorProperty::menu_option(int p_option) {
 		} break;
 		case MENU_OPEN_DOCUMENTATION: {
 			ScriptEditor::get_singleton()->goto_help(doc_path);
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 		} break;
 	}
 }
@@ -1297,7 +1298,7 @@ void EditorInspectorCategory::_handle_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPEN_DOCS:
 			ScriptEditor::get_singleton()->goto_help("class:" + doc_class_name);
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 			break;
 	}
 }

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -33,6 +33,7 @@
 
 #include "editor/editor_command_palette.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_resource_preview.h"
@@ -215,7 +216,7 @@ Control *EditorInterface::get_base_control() const {
 }
 
 VBoxContainer *EditorInterface::get_editor_main_screen() const {
-	return EditorNode::get_singleton()->get_main_screen_control();
+	return EditorNode::get_singleton()->get_editor_main_screen()->get_control();
 }
 
 ScriptEditor *EditorInterface::get_script_editor() const {
@@ -232,7 +233,7 @@ SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
 }
 
 void EditorInterface::set_main_screen_editor(const String &p_name) {
-	EditorNode::get_singleton()->select_editor_by_name(p_name);
+	EditorNode::get_singleton()->get_editor_main_screen()->select_by_name(p_name);
 }
 
 void EditorInterface::set_distraction_free_mode(bool p_enter) {

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -1,0 +1,291 @@
+/**************************************************************************/
+/*  editor_main_screen.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_main_screen.h"
+
+#include "core/io/config_file.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
+#include "editor/plugins/editor_plugin.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+
+void EditorMainScreen::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			if (EDITOR_3D < buttons.size() && buttons[EDITOR_3D]->is_visible()) {
+				// If the 3D editor is enabled, use this as the default.
+				select(EDITOR_3D);
+				return;
+			}
+
+			// Switch to the first main screen plugin that is enabled. Usually this is
+			// 2D, but may be subsequent ones if 2D is disabled in the feature profile.
+			for (int i = 0; i < buttons.size(); i++) {
+				Button *editor_button = buttons[i];
+				if (editor_button->is_visible()) {
+					select(i);
+					return;
+				}
+			}
+
+			select(-1);
+		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+			for (int i = 0; i < buttons.size(); i++) {
+				Button *tb = buttons[i];
+				EditorPlugin *p_editor = editor_table[i];
+				Ref<Texture2D> icon = p_editor->get_icon();
+
+				if (icon.is_valid()) {
+					tb->set_icon(icon);
+				} else if (has_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons))) {
+					tb->set_icon(get_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons)));
+				}
+			}
+		} break;
+	}
+}
+
+void EditorMainScreen::set_button_container(HBoxContainer *p_button_hb) {
+	button_hb = p_button_hb;
+}
+
+void EditorMainScreen::save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const {
+	int selected_main_editor_idx = -1;
+	for (int i = 0; i < buttons.size(); i++) {
+		if (buttons[i]->is_pressed()) {
+			selected_main_editor_idx = i;
+			break;
+		}
+	}
+	if (selected_main_editor_idx != -1) {
+		p_config_file->set_value(p_section, "selected_main_editor_idx", selected_main_editor_idx);
+	} else {
+		p_config_file->set_value(p_section, "selected_main_editor_idx", Variant());
+	}
+}
+
+void EditorMainScreen::load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section) {
+	int selected_main_editor_idx = p_config_file->get_value(p_section, "selected_main_editor_idx", -1);
+	if (selected_main_editor_idx >= 0 && selected_main_editor_idx < buttons.size()) {
+		callable_mp(this, &EditorMainScreen::select).call_deferred(selected_main_editor_idx);
+	}
+}
+
+void EditorMainScreen::set_button_enabled(int p_index, bool p_enabled) {
+	ERR_FAIL_INDEX(p_index, buttons.size());
+	buttons[p_index]->set_visible(p_enabled);
+	if (!p_enabled && buttons[p_index]->is_pressed()) {
+		select(EDITOR_2D);
+	}
+}
+
+bool EditorMainScreen::is_button_enabled(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, buttons.size(), false);
+	return buttons[p_index]->is_visible();
+}
+
+int EditorMainScreen::_get_current_main_editor() const {
+	for (int i = 0; i < editor_table.size(); i++) {
+		if (editor_table[i] == selected_plugin) {
+			return i;
+		}
+	}
+
+	return 0;
+}
+
+void EditorMainScreen::select_next() {
+	int editor = _get_current_main_editor();
+
+	do {
+		if (editor == editor_table.size() - 1) {
+			editor = 0;
+		} else {
+			editor++;
+		}
+	} while (!buttons[editor]->is_visible());
+
+	select(editor);
+}
+
+void EditorMainScreen::select_prev() {
+	int editor = _get_current_main_editor();
+
+	do {
+		if (editor == 0) {
+			editor = editor_table.size() - 1;
+		} else {
+			editor--;
+		}
+	} while (!buttons[editor]->is_visible());
+
+	select(editor);
+}
+
+void EditorMainScreen::select_by_name(const String &p_name) {
+	ERR_FAIL_COND(p_name.is_empty());
+
+	for (int i = 0; i < buttons.size(); i++) {
+		if (buttons[i]->get_text() == p_name) {
+			select(i);
+			return;
+		}
+	}
+
+	ERR_FAIL_MSG("The editor name '" + p_name + "' was not found.");
+}
+
+void EditorMainScreen::select(int p_index) {
+	if (EditorNode::get_singleton()->is_changing_scene()) {
+		return;
+	}
+
+	ERR_FAIL_INDEX(p_index, editor_table.size());
+
+	if (!buttons[p_index]->is_visible()) { // Button hidden, no editor.
+		return;
+	}
+
+	for (int i = 0; i < buttons.size(); i++) {
+		buttons[i]->set_pressed_no_signal(i == p_index);
+	}
+
+	EditorPlugin *new_editor = editor_table[p_index];
+	ERR_FAIL_NULL(new_editor);
+
+	if (selected_plugin == new_editor) {
+		return;
+	}
+
+	if (selected_plugin) {
+		selected_plugin->make_visible(false);
+	}
+
+	selected_plugin = new_editor;
+	selected_plugin->make_visible(true);
+	selected_plugin->selected_notify();
+
+	EditorData &editor_data = EditorNode::get_editor_data();
+	int plugin_count = editor_data.get_editor_plugin_count();
+	for (int i = 0; i < plugin_count; i++) {
+		editor_data.get_editor_plugin(i)->notify_main_screen_changed(selected_plugin->get_name());
+	}
+
+	EditorNode::get_singleton()->update_distraction_free_mode();
+}
+
+int EditorMainScreen::get_selected_index() const {
+	for (int i = 0; i < editor_table.size(); i++) {
+		if (selected_plugin == editor_table[i]) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+int EditorMainScreen::get_plugin_index(EditorPlugin *p_editor) const {
+	int screen = -1;
+	for (int i = 0; i < editor_table.size(); i++) {
+		if (p_editor == editor_table[i]) {
+			screen = i;
+			break;
+		}
+	}
+	return screen;
+}
+
+EditorPlugin *EditorMainScreen::get_selected_plugin() const {
+	return selected_plugin;
+}
+
+VBoxContainer *EditorMainScreen::get_control() const {
+	return main_screen_vbox;
+}
+
+void EditorMainScreen::add_main_plugin(EditorPlugin *p_editor) {
+	Button *tb = memnew(Button);
+	tb->set_toggle_mode(true);
+	tb->set_theme_type_variation("MainScreenButton");
+	tb->set_name(p_editor->get_name());
+	tb->set_text(p_editor->get_name());
+
+	Ref<Texture2D> icon = p_editor->get_icon();
+	if (icon.is_null() && has_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons))) {
+		icon = get_editor_theme_icon(p_editor->get_name());
+	}
+	if (icon.is_valid()) {
+		tb->set_icon(icon);
+		// Make sure the control is updated if the icon is reimported.
+		icon->connect_changed(callable_mp((Control *)tb, &Control::update_minimum_size));
+	}
+
+	tb->connect(SceneStringName(pressed), callable_mp(this, &EditorMainScreen::select).bind(buttons.size()));
+
+	buttons.push_back(tb);
+	button_hb->add_child(tb);
+	editor_table.push_back(p_editor);
+}
+
+void EditorMainScreen::remove_main_plugin(EditorPlugin *p_editor) {
+	// Remove the main editor button and update the bindings of
+	// all buttons behind it to point to the correct main window.
+	for (int i = buttons.size() - 1; i >= 0; i--) {
+		if (p_editor->get_name() == buttons[i]->get_text()) {
+			if (buttons[i]->is_pressed()) {
+				select(EDITOR_SCRIPT);
+			}
+
+			memdelete(buttons[i]);
+			buttons.remove_at(i);
+
+			break;
+		} else {
+			buttons[i]->disconnect(SceneStringName(pressed), callable_mp(this, &EditorMainScreen::select));
+			buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &EditorMainScreen::select).bind(i - 1));
+		}
+	}
+
+	if (selected_plugin == p_editor) {
+		selected_plugin = nullptr;
+	}
+
+	editor_table.erase(p_editor);
+}
+
+EditorMainScreen::EditorMainScreen() {
+	main_screen_vbox = memnew(VBoxContainer);
+	main_screen_vbox->set_name("MainScreen");
+	main_screen_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_screen_vbox->add_theme_constant_override("separation", 0);
+	add_child(main_screen_vbox);
+}

--- a/editor/editor_main_screen.h
+++ b/editor/editor_main_screen.h
@@ -1,0 +1,91 @@
+/**************************************************************************/
+/*  editor_main_screen.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_MAIN_SCREEN_H
+#define EDITOR_MAIN_SCREEN_H
+
+#include "scene/gui/panel_container.h"
+
+class Button;
+class ConfigFile;
+class EditorPlugin;
+class HBoxContainer;
+class VBoxContainer;
+
+class EditorMainScreen : public PanelContainer {
+	GDCLASS(EditorMainScreen, PanelContainer);
+
+public:
+	enum EditorTable {
+		EDITOR_2D = 0,
+		EDITOR_3D,
+		EDITOR_SCRIPT,
+		EDITOR_ASSETLIB,
+	};
+
+private:
+	VBoxContainer *main_screen_vbox = nullptr;
+	EditorPlugin *selected_plugin = nullptr;
+
+	HBoxContainer *button_hb = nullptr;
+	Vector<Button *> buttons;
+	Vector<EditorPlugin *> editor_table;
+
+	int _get_current_main_editor() const;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void set_button_container(HBoxContainer *p_button_hb);
+
+	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
+	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
+
+	void set_button_enabled(int p_index, bool p_enabled);
+	bool is_button_enabled(int p_index) const;
+
+	void select_next();
+	void select_prev();
+	void select_by_name(const String &p_name);
+	void select(int p_index);
+	int get_selected_index() const;
+	int get_plugin_index(EditorPlugin *p_editor) const;
+	EditorPlugin *get_selected_plugin() const;
+
+	VBoxContainer *get_control() const;
+
+	void add_main_plugin(EditorPlugin *p_editor);
+	void remove_main_plugin(EditorPlugin *p_editor);
+
+	EditorMainScreen();
+};
+
+#endif // EDITOR_MAIN_SCREEN_H

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -42,27 +42,17 @@ typedef void (*EditorPluginInitializeCallback)();
 typedef bool (*EditorBuildCallback)();
 
 class AcceptDialog;
-class CenterContainer;
-class CheckBox;
 class ColorPicker;
 class ConfirmationDialog;
 class Control;
 class FileDialog;
-class HBoxContainer;
-class HSplitContainer;
-class LinkButton;
 class MenuBar;
 class MenuButton;
-class Node2D;
 class OptionButton;
 class Panel;
 class PanelContainer;
-class PopupPanel;
 class RichTextLabel;
 class SubViewport;
-class TabBar;
-class TabContainer;
-class TextureRect;
 class TextureProgressBar;
 class Tree;
 class VBoxContainer;
@@ -83,44 +73,33 @@ class EditorCommandPalette;
 class EditorDockManager;
 class EditorExport;
 class EditorExportPreset;
-class EditorExtensionManager;
 class EditorFeatureProfileManager;
 class EditorFileDialog;
 class EditorFolding;
-class EditorInspector;
 class EditorLayoutsDialog;
 class EditorLog;
+class EditorMainScreen;
 class EditorNativeShaderSourceVisualizer;
 class EditorPluginList;
 class EditorQuickOpen;
-class EditorPropertyResource;
 class EditorResourcePreview;
 class EditorResourceConversionPlugin;
 class EditorRunBar;
-class EditorRunNative;
 class EditorSceneTabs;
 class EditorSelectionHistory;
 class EditorSettingsDialog;
 class EditorTitleBar;
-class EditorToaster;
-class EditorUndoRedoManager;
 class ExportTemplateManager;
 class FBXImporterManager;
 class FileSystemDock;
 class HistoryDock;
-class ImportDock;
-class NodeDock;
 class OrphanResourcesDialog;
-class PluginConfigDialog;
 class ProgressDialog;
 class ProjectExportDialog;
 class ProjectSettingsEditor;
-class RunSettingsDialog;
 class SceneImportSettingsDialog;
-class ScriptCreateDialog;
 class SurfaceUpgradeTool;
 class SurfaceUpgradeDialog;
-class WindowWrapper;
 
 struct EditorProgress {
 	String task;
@@ -135,13 +114,6 @@ class EditorNode : public Node {
 	GDCLASS(EditorNode, Node);
 
 public:
-	enum EditorTable {
-		EDITOR_2D = 0,
-		EDITOR_3D,
-		EDITOR_SCRIPT,
-		EDITOR_ASSETLIB
-	};
-
 	enum SceneNameCasing {
 		SCENE_NAME_CASING_AUTO,
 		SCENE_NAME_CASING_PASCAL_CASE,
@@ -286,7 +258,6 @@ private:
 	EditorExport *editor_export = nullptr;
 	EditorLog *log = nullptr;
 	EditorNativeShaderSourceVisualizer *native_shader_source_visualizer = nullptr;
-	EditorPlugin *editor_plugin_screen = nullptr;
 	EditorPluginList *editor_plugins_force_input_forwarding = nullptr;
 	EditorPluginList *editor_plugins_force_over = nullptr;
 	EditorPluginList *editor_plugins_over = nullptr;
@@ -308,7 +279,6 @@ private:
 	HashMap<ObjectID, HashSet<EditorPlugin *>> active_plugins;
 	bool is_main_screen_editing = false;
 
-	PanelContainer *scene_root_parent = nullptr;
 	Control *gui_base = nullptr;
 	VBoxContainer *main_vbox = nullptr;
 	OptionButton *renderer = nullptr;
@@ -349,7 +319,6 @@ private:
 	Control *right_menu_spacer = nullptr;
 	EditorTitleBar *title_bar = nullptr;
 	EditorRunBar *project_run_bar = nullptr;
-	VBoxContainer *main_screen_vbox = nullptr;
 	MenuBar *main_menu = nullptr;
 	PopupMenu *apple_menu = nullptr;
 	PopupMenu *file_menu = nullptr;
@@ -423,9 +392,7 @@ private:
 	String current_path;
 	MenuButton *update_spinner = nullptr;
 
-	HBoxContainer *main_editor_button_hb = nullptr;
-	Vector<Button *> main_editor_buttons;
-	Vector<EditorPlugin *> editor_table;
+	EditorMainScreen *editor_main_screen = nullptr;
 
 	AudioStreamPreviewGenerator *audio_preview_gen = nullptr;
 	ProgressDialog *progress_dialog = nullptr;
@@ -575,8 +542,6 @@ private:
 	void _sources_changed(bool p_exist);
 
 	void _node_renamed();
-	void _editor_select_next();
-	void _editor_select_prev();
 	void _save_editor_states(const String &p_file, int p_idx = -1);
 	void _load_editor_plugin_states_from_config(const Ref<ConfigFile> &p_config_file);
 	void _update_title();
@@ -649,8 +614,6 @@ private:
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
 
-	int _get_current_main_editor();
-
 	void _save_editor_layout();
 	void _load_editor_layout();
 
@@ -688,7 +651,6 @@ private:
 	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 
 	void _immediate_dialog_confirmed();
-	void _select_default_main_screen_plugin();
 
 	void _begin_first_scan();
 
@@ -707,9 +669,6 @@ public:
 	void init_plugins();
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
 
-	void editor_select(int p_which);
-	void set_visible_editor(EditorTable p_table) { editor_select(p_table); }
-
 	bool call_build();
 
 	// This is a very naive estimation, but we need something now. Will be reworked later.
@@ -724,6 +683,7 @@ public:
 	static EditorTitleBar *get_title_bar() { return singleton->title_bar; }
 	static VSplitContainer *get_top_split() { return singleton->top_split; }
 	static EditorBottomPanel *get_bottom_panel() { return singleton->bottom_panel; }
+	static EditorMainScreen *get_editor_main_screen() { return singleton->editor_main_screen; }
 
 	static String adjust_scene_name_casing(const String &p_root_name);
 	static String adjust_script_name_casing(const String &p_file_name, ScriptLanguage::ScriptNameCasing p_auto_casing);
@@ -755,7 +715,6 @@ public:
 
 	static void cleanup();
 
-	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
 	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
@@ -769,6 +728,7 @@ public:
 
 	void new_inherited_scene() { _menu_option_confirm(FILE_NEW_INHERITED_SCENE, false); }
 
+	void update_distraction_free_mode();
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
 
@@ -791,8 +751,6 @@ public:
 	void push_node_item(Node *p_node);
 	void hide_unused_editors(const Object *p_editing_owner = nullptr);
 
-	void select_editor_by_name(const String &p_name);
-
 	void open_request(const String &p_path);
 	void edit_foreign_resource(Ref<Resource> p_resource);
 
@@ -802,7 +760,6 @@ public:
 
 	bool is_changing_scene() const;
 
-	VBoxContainer *get_main_screen_control();
 	SubViewport *get_scene_root() { return scene_root; } // Root of the scene being edited.
 
 	void set_edited_scene(Node *p_scene);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -270,7 +270,7 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 	ERR_FAIL_COND_V(theme.is_null(), Ref<ImageTexture>());
-	if (EditorNode::get_singleton()->get_main_screen_control()->is_layout_rtl()) {
+	if (EditorNode::get_singleton()->get_gui_base()->is_layout_rtl()) {
 		return theme->get_icon(SNAME("PlayBackwards"), EditorStringName(EditorIcons));
 	} else {
 		return theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons));

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -30,6 +30,7 @@
 
 #include "inspector_dock.h"
 
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -97,7 +98,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		case OBJECT_REQUEST_HELP: {
 			if (current) {
-				EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+				EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 				emit_signal(SNAME("request_help"), current->get_class());
 			}
 		} break;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "core/io/stream_peer_tls.h"
 #include "core/os/keyboard.h"
 #include "core/version.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -1794,7 +1795,7 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(addon_library);
+	EditorNode::get_singleton()->get_editor_main_screen()->get_control()->add_child(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	addon_library->hide();
 }

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -5735,7 +5736,7 @@ void CanvasItemEditorPlugin::_notification(int p_what) {
 CanvasItemEditorPlugin::CanvasItemEditorPlugin() {
 	canvas_item_editor = memnew(CanvasItemEditor);
 	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(canvas_item_editor);
+	EditorNode::get_singleton()->get_editor_main_screen()->get_control()->add_child(canvas_item_editor);
 	canvas_item_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	canvas_item_editor->hide();
 }

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -208,7 +208,7 @@ void CPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 
 CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin() {
 	particles_editor = memnew(CPUParticles3DEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(particles_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -452,7 +452,7 @@ void GPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 
 GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin() {
 	particles_editor = memnew(GPUParticles3DEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(particles_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -689,7 +689,7 @@ void MeshInstance3DEditorPlugin::make_visible(bool p_visible) {
 
 MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin() {
 	mesh_editor = memnew(MeshInstance3DEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(mesh_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(mesh_editor);
 
 	mesh_editor->options->hide();
 }

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -308,7 +308,7 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 MeshLibraryEditorPlugin::MeshLibraryEditorPlugin() {
 	mesh_library_editor = memnew(MeshLibraryEditor);
 
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(mesh_library_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(mesh_library_editor);
 	mesh_library_editor->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	mesh_library_editor->set_end(Point2(0, 22));
 	mesh_library_editor->hide();

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -384,7 +384,7 @@ void MultiMeshEditorPlugin::make_visible(bool p_visible) {
 
 MultiMeshEditorPlugin::MultiMeshEditorPlugin() {
 	multimesh_editor = memnew(MultiMeshEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(multimesh_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(multimesh_editor);
 
 	multimesh_editor->options->hide();
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "core/math/projection.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -9376,7 +9377,7 @@ Vector<Node3D *> Node3DEditor::gizmo_bvh_frustum_query(const Vector<Plane> &p_fr
 Node3DEditorPlugin::Node3DEditorPlugin() {
 	spatial_editor = memnew(Node3DEditor);
 	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(spatial_editor);
+	EditorNode::get_singleton()->get_editor_main_screen()->get_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();
 }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -44,6 +44,7 @@
 #include "editor/editor_command_palette.h"
 #include "editor/editor_help_search.h"
 #include "editor/editor_interface.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_script.h"
@@ -4612,7 +4613,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	Ref<Shortcut> make_floating_shortcut = ED_SHORTCUT_AND_COMMAND("script_editor/make_floating", TTR("Make Floating"));
 	window_wrapper->set_wrapped_control(script_editor, make_floating_shortcut);
 
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(window_wrapper);
+	EditorNode::get_singleton()->get_editor_main_screen()->get_control()->add_child(window_wrapper);
 	window_wrapper->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	window_wrapper->hide();
 	window_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditorPlugin::_window_visibility_changed));

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -129,7 +129,7 @@ void Skeleton2DEditorPlugin::make_visible(bool p_visible) {
 
 Skeleton2DEditorPlugin::Skeleton2DEditorPlugin() {
 	sprite_editor = memnew(Skeleton2DEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(sprite_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -673,7 +673,7 @@ void Sprite2DEditorPlugin::make_visible(bool p_visible) {
 
 Sprite2DEditorPlugin::Sprite2DEditorPlugin() {
 	sprite_editor = memnew(Sprite2DEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(sprite_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -37,6 +37,7 @@
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_quick_open.h"
@@ -1197,7 +1198,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				ScriptEditor::get_singleton()->goto_help("class_name:" + class_name);
 			}
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 		} break;
 		case TOOL_AUTO_EXPAND: {
 			scene_tree->set_auto_expand_selected(!EDITOR_GET("docks/scene_tree/auto_expand_to_selected"), true);

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -541,7 +541,7 @@ EditorPluginCSG::EditorPluginCSG() {
 	Node3DEditor::get_singleton()->add_gizmo_plugin(gizmo_plugin);
 
 	csg_shape_editor = memnew(CSGShapeEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(csg_shape_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(csg_shape_editor);
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -34,6 +34,7 @@
 
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -958,7 +959,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	_update_selection_transform();
 	_update_paste_indicator();
 
-	spatial_editor = Object::cast_to<Node3DEditorPlugin>(EditorNode::get_singleton()->get_editor_plugin_screen());
+	spatial_editor = Object::cast_to<Node3DEditorPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_selected_plugin());
 
 	if (!node) {
 		set_process(false);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -41,6 +41,7 @@
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -165,7 +166,7 @@ bool godot_icall_Internal_ScriptEditorEdit(Resource *p_resource, int32_t p_line,
 }
 
 void godot_icall_Internal_EditorNodeShowScriptScreen() {
-	EditorNode::get_singleton()->editor_select(EditorNode::EDITOR_SCRIPT);
+	EditorNode::get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 }
 
 void godot_icall_Internal_EditorRunPlay() {

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -176,7 +176,7 @@ void NavigationMeshEditorPlugin::make_visible(bool p_visible) {
 
 NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 	navigation_mesh_editor = memnew(NavigationMeshEditor);
-	EditorNode::get_singleton()->get_main_screen_control()->add_child(navigation_mesh_editor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(navigation_mesh_editor);
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
 	navigation_mesh_editor->hide();
 	navigation_mesh_editor->bake_hbox->hide();


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/87760

Extracts all functionality related to the main screen from EditorNode.
Behavior should not change.

### Details

In `_get_main_scene_state()`, removed the `main_tab` key. I don't think it has been used since 081a236.
In `_set_main_scene_state()`, removed the `editor_index` key check. Only used between https://github.com/godotengine/godot/commit/334a81844ee9f6d780dbd3c34f15863173b43e03 and #11075 (less than a month during 3.0 dev).
The state in only actually saved and used in `_save_central_editor_layout_to_config()` and `_load_central_editor_layout_from_config()`. `_get/set_main_scene_state()` is just used for switching between 2D/3D when opening a scene or changing selection to match the node.

Removed `distraction_free->move_to_front();` from `EditorNode::add_editor_plugin` since it isn't needed. The distraction free button is already after everything else in the SceneTabs, and if it was needed it should be somewhere else.

`set_visible_editor()` and `editor_select()` did the same thing. They are now `EditorMainScreen::select()`.
Renamed `editor_plugin_screen` -> `selected_plugin`, and removed some other `editor_main` prefixes.

The `scene_root_parent` is now the `editor_main_screen`. It is not actually the parent of the scene root, and this way I don't need to add a new control to hold the vbox.
I could make the `editor_main_screen` actually be the vbox instead of being parent to it, and the `scene_root_parent` can be called `main_screen_parent`, if that is better.

Also removed unused forward declarations in EditorNode.
