### PR TITLE
Implement intersect_ray_multiple to provide all collisions during a raycast

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -57,21 +57,6 @@
 				[b]Note:[/b] [ConcavePolygonShape2D]s and [CollisionPolygon2D]s in [code]Segments[/code] build mode are not solid shapes. Therefore, they will not be detected.
 			</description>
 		</method>
-		<method name="intersect_ray_multiple">
-			<return type="Dictionary" />
-			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
-			<description>
-				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
-				[code]collider[/code]: The colliding object.
-				[code]collider_id[/code]: The colliding object's ID.
-				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
-				[code]position[/code]: The intersection point.
-				[code]rid[/code]: The intersecting object's [RID].
-				[code]shape[/code]: The shape index of the colliding shape.
-				If the ray did not intersect anything, then an empty array is returned instead.
-				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
-			</description>
-		</method>
 		<method name="intersect_ray">
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
@@ -84,6 +69,21 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
+			</description>
+		</method>
+		<method name="intersect_ray_multiple">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
+			<description>
+				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty array is returned instead.
+				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -57,6 +57,21 @@
 				[b]Note:[/b] [ConcavePolygonShape2D]s and [CollisionPolygon2D]s in [code]Segments[/code] build mode are not solid shapes. Therefore, they will not be detected.
 			</description>
 		</method>
+		<method name="intersect_ray_multiple">
+			<return type="Dictionary" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
+			<description>
+				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty array is returned instead.
+				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
+			</description>
+		</method>
 		<method name="intersect_ray">
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -51,18 +51,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_ray_multiple" qualifiers="virtual">
-			<return type="bool" />
-			<param index="0" name="from" type="Vector2" />
-			<param index="1" name="to" type="Vector2" />
-			<param index="2" name="collision_mask" type="int" />
-			<param index="3" name="collide_with_bodies" type="bool" />
-			<param index="4" name="collide_with_areas" type="bool" />
-			<param index="5" name="hit_from_inside" type="bool" />
-			<param index="6" name="result" type="Vector&lt;PhysicsServer2DExtensionRayResult&gt;*" />
-			<description>
-			</description>
-		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector2" />
@@ -72,6 +60,18 @@
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="hit_from_inside" type="bool" />
 			<param index="6" name="result" type="PhysicsServer2DExtensionRayResult*" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="from" type="Vector2" />
+			<param index="1" name="to" type="Vector2" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="results" type="PhysicsServer2DExtensionMultiRayResult*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -59,7 +59,7 @@
 			<param index="3" name="collide_with_bodies" type="bool" />
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="hit_from_inside" type="bool" />
-			<param index="6" name="result" type="Vector<PhysicsServer2DExtensionRayResult>*" />
+			<param index="6" name="result" type="Vector&lt;PhysicsServer2DExtensionRayResult&gt;*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -51,6 +51,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="from" type="Vector2" />
+			<param index="1" name="to" type="Vector2" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="result" type="Vector<PhysicsServer2DExtensionRayResult>*" />
+			<description>
+			</description>
+		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector2" />

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -71,7 +71,7 @@
 				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				If the ray did not intersect anything, then an empty dictionary is returned instead.
+				If the ray did not intersect anything, then an empty array is returned instead.
 				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -58,6 +58,23 @@
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
 		</method>
+		<method name="intersect_ray_multiple">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
+			<description>
+				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters3D]. The returned object is an array of dictionaries with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]face_index[/code]: The face index at the intersection point.
+				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty dictionary is returned instead.
+				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
+			</description>
+		</method>
 		<method name="intersect_ray">
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -58,6 +58,22 @@
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
 		</method>
+		<method name="intersect_ray">
+			<return type="Dictionary" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
+			<description>
+				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters3D]. The returned object is a dictionary with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]face_index[/code]: The face index at the intersection point.
+				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty dictionary is returned instead.
+			</description>
+		</method>
 		<method name="intersect_ray_multiple">
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
@@ -73,22 +89,6 @@
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
 				[b]Note:[/b] The result will contain only the closest collision for each unique collision body. It does *not* report all surface collisions of all bodies.
-			</description>
-		</method>
-		<method name="intersect_ray">
-			<return type="Dictionary" />
-			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
-			<description>
-				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters3D]. The returned object is a dictionary with the following fields:
-				[code]collider[/code]: The colliding object.
-				[code]collider_id[/code]: The colliding object's ID.
-				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
-				[code]position[/code]: The intersection point.
-				[code]face_index[/code]: The face index at the intersection point.
-				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
-				[code]rid[/code]: The intersecting object's [RID].
-				[code]shape[/code]: The shape index of the colliding shape.
-				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -58,6 +58,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="from" type="Vector3" />
+			<param index="1" name="to" type="Vector3" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="hit_back_faces" type="bool" />
+			<param index="7" name="pick_ray" type="bool" />
+			<param index="8" name="result" type="Vector<PhysicsServer3DExtensionRayResult>*" />
+			<description>
+			</description>
+		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector3" />

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -68,7 +68,7 @@
 			<param index="5" name="hit_from_inside" type="bool" />
 			<param index="6" name="hit_back_faces" type="bool" />
 			<param index="7" name="pick_ray" type="bool" />
-			<param index="8" name="result" type="Vector<PhysicsServer3DExtensionRayResult>*" />
+			<param index="8" name="result" type="Vector&lt;PhysicsServer3DExtensionRayResult&gt;*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -58,20 +58,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_ray_multiple" qualifiers="virtual">
-			<return type="bool" />
-			<param index="0" name="from" type="Vector3" />
-			<param index="1" name="to" type="Vector3" />
-			<param index="2" name="collision_mask" type="int" />
-			<param index="3" name="collide_with_bodies" type="bool" />
-			<param index="4" name="collide_with_areas" type="bool" />
-			<param index="5" name="hit_from_inside" type="bool" />
-			<param index="6" name="hit_back_faces" type="bool" />
-			<param index="7" name="pick_ray" type="bool" />
-			<param index="8" name="result" type="Vector&lt;PhysicsServer3DExtensionRayResult&gt;*" />
-			<description>
-			</description>
-		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector3" />
@@ -83,6 +69,20 @@
 			<param index="6" name="hit_back_faces" type="bool" />
 			<param index="7" name="pick_ray" type="bool" />
 			<param index="8" name="result" type="PhysicsServer3DExtensionRayResult*" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="from" type="Vector3" />
+			<param index="1" name="to" type="Vector3" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="hit_back_faces" type="bool" />
+			<param index="7" name="pick_ray" type="bool" />
+			<param index="8" name="results" type="PhysicsServer3DExtensionMultiRayResult*" />
 			<description>
 			</description>
 		</method>

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -39,6 +39,7 @@ thread_local const HashSet<RID> *PhysicsDirectSpaceState2DExtension::exclude = n
 void PhysicsDirectSpaceState2DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query);
 
+	GDVIRTUAL_BIND(_intersect_ray_multiple, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "results");
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "result");
 	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result", "max_results");

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -110,10 +110,12 @@ public:
 	PhysicsDirectBodyState2DExtension();
 };
 
+typedef Vector<PhysicsDirectSpaceState2D::RayResult> PhysicsServer2DExtensionMultiRayResult;
 typedef PhysicsDirectSpaceState2D::RayResult PhysicsServer2DExtensionRayResult;
 typedef PhysicsDirectSpaceState2D::ShapeResult PhysicsServer2DExtensionShapeResult;
 typedef PhysicsDirectSpaceState2D::ShapeRestInfo PhysicsServer2DExtensionShapeRestInfo;
 
+GDVIRTUAL_NATIVE_PTR(PhysicsServer2DExtensionMultiRayResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer2DExtensionRayResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer2DExtensionShapeResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer2DExtensionShapeRestInfo)
@@ -127,7 +129,7 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
-	GDVIRTUAL7R(bool, _intersect_ray_multiple, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<Vector<PhysicsServer2DExtensionRayResult>>)
+	GDVIRTUAL7R(bool, _intersect_ray_multiple, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionMultiRayResult>)
 	GDVIRTUAL7R(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
 	GDVIRTUAL7R(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
 	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -127,6 +127,7 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
+	GDVIRTUAL7R(bool, _intersect_ray_multiple, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<Vector<PhysicsServer2DExtensionRayResult>>)
 	GDVIRTUAL7R(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
 	GDVIRTUAL7R(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
 	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
@@ -135,6 +136,13 @@ protected:
 	GDVIRTUAL8R(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
 
 public:
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_intersect_ray_multiple, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, &r_results, ret);
+		exclude = nullptr;
+		return ret;
+	}
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -39,6 +39,7 @@ thread_local const HashSet<RID> *PhysicsDirectSpaceState3DExtension::exclude = n
 void PhysicsDirectSpaceState3DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query);
 
+	GDVIRTUAL_BIND(_intersect_ray_multiple, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "results");
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "result");
 	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result_count", "max_results");

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -112,10 +112,12 @@ public:
 	PhysicsDirectBodyState3DExtension();
 };
 
+typedef Vector<PhysicsDirectSpaceState3D::RayResult> PhysicsServer3DExtensionMultiRayResult;
 typedef PhysicsDirectSpaceState3D::RayResult PhysicsServer3DExtensionRayResult;
 typedef PhysicsDirectSpaceState3D::ShapeResult PhysicsServer3DExtensionShapeResult;
 typedef PhysicsDirectSpaceState3D::ShapeRestInfo PhysicsServer3DExtensionShapeRestInfo;
 
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionMultiRayResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionRayResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeRestInfo)
@@ -129,7 +131,7 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
-	GDVIRTUAL9R(bool, _intersect_ray_multiple, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<Vector<PhysicsServer3DExtensionRayResult>>)
+	GDVIRTUAL9R(bool, _intersect_ray_multiple, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionMultiRayResult>)
 	GDVIRTUAL9R(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
 	GDVIRTUAL6R(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -129,6 +129,7 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
+	GDVIRTUAL9R(bool, _intersect_ray_multiple, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<Vector<PhysicsServer3DExtensionRayResult>>)
 	GDVIRTUAL9R(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
 	GDVIRTUAL6R(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
@@ -138,6 +139,13 @@ protected:
 	GDVIRTUAL2RC(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
 
 public:
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_intersect_ray_multiple, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_results, ret);
+		exclude = nullptr;
+		return ret;
+	}
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -115,7 +115,7 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 }
 
 // Helper for setting a singular ray result in the vector.
-_FORCE_INLINE_ static void _set_multiple_ray_result(const Vector<PhysicsDirectSpaceState2D::RayResult> &r_results,
+_FORCE_INLINE_ static void _set_multiple_ray_result(Vector<PhysicsDirectSpaceState2D::RayResult> &r_results,
 													const int &idx, const Vector2 &position, const Vector2 &normal,
 													const GodotCollisionObject2D *col_obj,
 													const int &shape){
@@ -126,7 +126,7 @@ _FORCE_INLINE_ static void _set_multiple_ray_result(const Vector<PhysicsDirectSp
 		collider = ObjectDB::get_instance(collider_id);
 	}
 
-	PhysicsDirectSpaceState2D::RayResult r_result = r_results.get(idx);
+	PhysicsDirectSpaceState2D::RayResult &r_result = r_results.ptrw()[idx];
 	r_result.position = position;
 	r_result.normal = normal;
 	r_result.shape = shape;
@@ -149,8 +149,6 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters 
 	//todo, create another array that references results, compute AABBs and check closest point to ray origin, sort, and stop evaluating results when beyond first collision
 
 	Vector2 res_normal;
-	const GodotCollisionObject2D *res_obj = nullptr;
-	real_t min_d = 1e10;
 
 	r_results.resize(amount);
 	int n_collisions = 0;
@@ -212,17 +210,18 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 		return false;
 	}
 
-	// Find closest collision point
-	Vector2 normal;
-	Vector2 shape_point;
+	// Find closest collision point - Need to base off distance sqr since we lost info on local normal
 	real_t ld;
-	real_t min_d = 1e10;
+	Vector2 shape_point;
+	Vector2 delta;
+	real_t min_d = -1.0f;
 	int min_idx = 0;
-	for (int i = 0; i < multi_result.size(); i++) {
-		normal = multi_result.get(i).normal;
+	int n_collisions = multi_result.size();
+	for (int i = 0; i < n_collisions; i++) {
 		shape_point = multi_result.get(i).position;
-		ld = normal.dot(shape_point);
-		if (ld < min_d) {
+		delta = shape_point - p_parameters.from;
+		ld = delta.length_squared();
+		if (min_d < 0.0 || ld < min_d) {
 			min_d = ld;
 			min_idx = i;
 		}

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -114,7 +114,28 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 	return cc;
 }
 
-bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
+// Helper for setting a singular ray result in the vector.
+_FORCE_INLINE_ static void _set_multiple_ray_result(const Vector<PhysicsDirectSpaceState2D::RayResult> &r_results,
+													const int &idx, const Vector2 &position, const Vector2 &normal,
+													const GodotCollisionObject2D *col_obj,
+													const int &shape){
+	ERR_FAIL_INDEX(idx, r_results.size());
+	ObjectID collider_id = col_obj->get_instance_id();
+	Object *collider = nullptr;
+	if (collider_id.is_valid()) {
+		collider = ObjectDB::get_instance(collider_id);
+	}
+
+	PhysicsDirectSpaceState2D::RayResult r_result = r_results.get(idx);
+	r_result.position = position;
+	r_result.normal = normal;
+	r_result.shape = shape;
+	r_result.collider_id = collider_id;
+	r_result.rid = col_obj->get_self();
+	r_result.collider = collider;
+}
+
+bool GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results){
 	ERR_FAIL_COND_V(space->locked, false);
 
 	Vector2 begin, end;
@@ -127,12 +148,12 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 
 	//todo, create another array that references results, compute AABBs and check closest point to ray origin, sort, and stop evaluating results when beyond first collision
 
-	bool collided = false;
-	Vector2 res_point, res_normal;
-	int res_shape = -1;
+	Vector2 res_normal;
 	const GodotCollisionObject2D *res_obj = nullptr;
 	real_t min_d = 1e10;
 
+	r_results.resize(amount);
+	int n_collisions = 0;
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
@@ -157,13 +178,9 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 		if (shape->contains_point(local_from)) {
 			if (p_parameters.hit_from_inside) {
 				// Hit shape at starting point.
-				min_d = 0;
-				res_point = begin;
-				res_normal = Vector2();
-				res_shape = shape_idx;
-				res_obj = col_obj;
-				collided = true;
-				break;
+				_set_multiple_ray_result(r_results, n_collisions, begin, Vector2(), col_obj, shape_idx);
+				n_collisions += 1;
+				continue;
 			} else {
 				// Ignore shape when starting inside.
 				continue;
@@ -171,36 +188,46 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 		}
 
 		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
+			ERR_FAIL_NULL_V(col_obj, false); // Shouldn't happen but silences warning.
 			Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 			shape_point = xform.xform(shape_point);
-
-			real_t ld = normal.dot(shape_point);
-
-			if (ld < min_d) {
-				min_d = ld;
-				res_point = shape_point;
-				res_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
-				res_shape = shape_idx;
-				res_obj = col_obj;
-				collided = true;
-			}
+			res_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
+			_set_multiple_ray_result(r_results, n_collisions, shape_point, res_normal, col_obj, shape_idx);
+			n_collisions += 1;
 		}
 	}
 
-	if (!collided) {
+	// Reduce size of r_results to n_collisions so invalid data is not propagated
+	r_results.resize(n_collisions);
+	return n_collisions > 0;
+}
+
+bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
+	ERR_FAIL_COND_V(space->locked, false);
+
+	Vector<RayResult> multi_result;
+	bool res = intersect_ray_multiple(p_parameters, multi_result);
+	
+	if(!res){
 		return false;
 	}
-	ERR_FAIL_NULL_V(res_obj, false); // Shouldn't happen but silences warning.
 
-	r_result.collider_id = res_obj->get_instance_id();
-	if (r_result.collider_id.is_valid()) {
-		r_result.collider = ObjectDB::get_instance(r_result.collider_id);
+	// Find closest collision point
+	Vector2 normal;
+	Vector2 shape_point;
+	real_t ld;
+	real_t min_d = 1e10;
+	int min_idx = 0;
+	for (int i = 0; i < multi_result.size(); i++) {
+		normal = multi_result.get(i).normal;
+		shape_point = multi_result.get(i).position;
+		ld = normal.dot(shape_point);
+		if (ld < min_d) {
+			min_d = ld;
+			min_idx = i;
+		}
 	}
-	r_result.normal = res_normal;
-	r_result.position = res_point;
-	r_result.rid = res_obj->get_self();
-	r_result.shape = res_shape;
-
+	r_result = multi_result.get(min_idx);
 	return true;
 }
 

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -195,7 +195,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters 
 		}
 	}
 
-	// Reduce size of r_results to n_collisions so invalid data is not propagated
+	// Reduce size of r_results to n_collisions so invalid data is not propagated.
 	r_results.resize(n_collisions);
 	return n_collisions > 0;
 }
@@ -210,7 +210,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 		return false;
 	}
 
-	// Find closest collision point - Need to base off distance sqr since we lost info on local normal
+	// Find closest collision point - Need to base off distance sqr since we lost info on local normal.
 	real_t ld;
 	Vector2 shape_point;
 	Vector2 delta;

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -116,9 +116,9 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 
 // Helper for setting a singular ray result in the vector.
 _FORCE_INLINE_ static void _set_multiple_ray_result(Vector<PhysicsDirectSpaceState2D::RayResult> &r_results,
-													const int &idx, const Vector2 &position, const Vector2 &normal,
-													const GodotCollisionObject2D *col_obj,
-													const int &shape){
+		const int &idx, const Vector2 &position, const Vector2 &normal,
+		const GodotCollisionObject2D *col_obj,
+		const int &shape) {
 	ERR_FAIL_INDEX(idx, r_results.size());
 	ObjectID collider_id = col_obj->get_instance_id();
 	Object *collider = nullptr;
@@ -135,7 +135,7 @@ _FORCE_INLINE_ static void _set_multiple_ray_result(Vector<PhysicsDirectSpaceSta
 	r_result.collider = collider;
 }
 
-bool GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results){
+bool GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) {
 	ERR_FAIL_COND_V(space->locked, false);
 
 	Vector2 begin, end;
@@ -205,8 +205,8 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 
 	Vector<RayResult> multi_result;
 	bool res = intersect_ray_multiple(p_parameters, multi_result);
-	
-	if(!res){
+
+	if (!res) {
 		return false;
 	}
 

--- a/servers/physics_2d/godot_space_2d.h
+++ b/servers/physics_2d/godot_space_2d.h
@@ -50,6 +50,7 @@ public:
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) override;

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -202,13 +202,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 			min_idx = i;
 		}
 	}
-	r_result.collider_id = multi_result.collider_ids.get(min_idx);
-	r_result.collider = multi_result.colliders.get(min_idx);
-	r_result.normal = multi_result.normals.get(min_idx);
-	r_result.face_index = multi_result.face_indexes.get(min_idx);
-	r_result.position = multi_result.positions.get(min_idx);
-	r_result.rid = multi_result.rids.get(min_idx);
-	r_result.shape = multi_result.shapes.get(min_idx);
+	ray_result_from_multiple(multi_result, r_result, min_idx);
 	return true;
 }
 

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -107,28 +107,27 @@ int GodotPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_par
 
 // Helper for setting a singular ray result in the vector.
 _FORCE_INLINE_ static void _set_multiple_ray_result(Vector<PhysicsDirectSpaceState3D::RayResult> &r_results,
-													const int &idx, const Vector3 &position, const Vector3 &normal,
-													const GodotCollisionObject3D *col_obj,
-													const int &shape, const int &face_index){
-		
-		ERR_FAIL_INDEX(idx, r_results.size());
-		ObjectID collider_id = col_obj->get_instance_id();
-		Object *collider = nullptr;
-		if (collider_id.is_valid()) {
-			collider = ObjectDB::get_instance(collider_id);
-		}
-
-		PhysicsDirectSpaceState3D::RayResult &r_result = r_results.ptrw()[idx];
-		r_result.position = position;
-		r_result.normal = normal;
-		r_result.shape = shape;
-		r_result.face_index = face_index;
-		r_result.collider_id = collider_id;
-		r_result.rid = col_obj->get_self();
-		r_result.collider = collider;
+		const int &idx, const Vector3 &position, const Vector3 &normal,
+		const GodotCollisionObject3D *col_obj,
+		const int &shape, const int &face_index) {
+	ERR_FAIL_INDEX(idx, r_results.size());
+	ObjectID collider_id = col_obj->get_instance_id();
+	Object *collider = nullptr;
+	if (collider_id.is_valid()) {
+		collider = ObjectDB::get_instance(collider_id);
 	}
 
-bool GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results){
+	PhysicsDirectSpaceState3D::RayResult &r_result = r_results.ptrw()[idx];
+	r_result.position = position;
+	r_result.normal = normal;
+	r_result.shape = shape;
+	r_result.face_index = face_index;
+	r_result.collider_id = collider_id;
+	r_result.rid = col_obj->get_self();
+	r_result.collider = collider;
+}
+
+bool GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) {
 	ERR_FAIL_COND_V(space->locked, false);
 
 	Vector3 begin, end;
@@ -203,7 +202,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 
 	Vector<RayResult> multi_result;
 	bool res = intersect_ray_multiple(p_parameters, multi_result);
-	if (!res){
+	if (!res) {
 		return false;
 	}
 

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -193,7 +193,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters 
 		}
 	}
 
-	// Reduce size of r_results to n_collisions so invalid data is not propagated
+	// Reduce size of r_results to n_collisions so invalid data is not propagated.
 	r_results.resize(n_collisions);
 	return n_collisions > 0;
 }
@@ -207,7 +207,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 		return false;
 	}
 
-	// Find closest collision point - Need to base off distance sqr since we lost info on local normal
+	// Find closest collision point - Need to base off distance sqr since we lost info on local normal.
 	real_t ld;
 	Vector3 shape_point;
 	Vector3 delta;

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -140,10 +140,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters 
 	int amount = space->broadphase->cull_segment(begin, end, space->intersection_query_results, GodotSpace3D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
 	//todo, create another array that references results, compute AABBs and check closest point to ray origin, sort, and stop evaluating results when beyond first collision
 
-	bool collided = false;
-	Vector3 res_point, res_normal;
-	int res_face_index = -1;
-	int res_shape = -1;
+	Vector3 res_normal;
 	const GodotCollisionObject3D *res_obj = nullptr;
 	real_t min_d = 1e10;
 
@@ -207,15 +204,16 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 	ERR_FAIL_COND_V(space->locked, false);
 
 	Vector<RayResult> multi_result;
-	bool collided = intersect_ray_multiple(p_parameters, multi_result);
-	if (!collided){
+	bool res = intersect_ray_multiple(p_parameters, multi_result);
+	if (!res){
 		return false;
 	}
 
-	real_t min_d = 1e10;
+	// Find closest collision point
 	real_t ld;
 	Vector3 normal;
 	Vector3 shape_point;
+	real_t min_d = 1e10;
 	int min_idx = 0;
 	for (int i = 0; i < multi_result.size(); i++) {
 		normal = multi_result.get(i).normal;

--- a/servers/physics_3d/godot_space_3d.h
+++ b/servers/physics_3d/godot_space_3d.h
@@ -51,6 +51,7 @@ public:
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, MultipleRayResult &r_result) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;

--- a/servers/physics_3d/godot_space_3d.h
+++ b/servers/physics_3d/godot_space_3d.h
@@ -51,7 +51,7 @@ public:
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
-	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, MultipleRayResult &r_result) override;
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -329,6 +329,33 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_ray_multiple(const Ref<PhysicsRayQueryParameters2D> &p_ray_query) {
+	ERR_FAIL_COND_V(!p_ray_query.is_valid(), TypedArray<Dictionary>());
+
+	Vector<RayResult> results;
+	bool res = intersect_ray_multiple(p_ray_query->get_parameters(), results);
+	
+	if (!res) {
+		return TypedArray<Dictionary>();
+	}
+
+	TypedArray<Dictionary> r;
+	int rc = results.size();
+	r.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		RayResult result = results.get(i);
+		d["position"] = result.position;
+		d["normal"] = result.normal;
+		d["collider_id"] = result.collider_id;
+		d["collider"] = result.collider;
+		d["shape"] = result.shape;
+		d["rid"] = result.rid;
+	}
+	return r;
+
+}
+
 Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query) {
 	ERR_FAIL_COND_V(!p_ray_query.is_valid(), Dictionary());
 
@@ -454,6 +481,7 @@ PhysicsDirectSpaceState2D::PhysicsDirectSpaceState2D() {
 
 void PhysicsDirectSpaceState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_point, DEFVAL(32));
+	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters"), &PhysicsDirectSpaceState2D::_intersect_ray_multiple);
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState2D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState2D::_cast_motion);

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -334,7 +334,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_ray_multiple(const 
 
 	Vector<RayResult> results;
 	bool res = intersect_ray_multiple(p_ray_query->get_parameters(), results);
-	
+
 	if (!res) {
 		return TypedArray<Dictionary>();
 	}
@@ -353,7 +353,6 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_ray_multiple(const 
 		d["rid"] = result.rid;
 	}
 	return r;
-
 }
 
 Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query) {

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -117,6 +117,7 @@ class PhysicsShapeQueryParameters2D;
 class PhysicsDirectSpaceState2D : public Object {
 	GDCLASS(PhysicsDirectSpaceState2D, Object);
 
+	TypedArray<Dictionary> _intersect_ray_multiple(const Ref<PhysicsRayQueryParameters2D> &p_ray_query);
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
@@ -149,6 +150,7 @@ public:
 		int shape = 0;
 	};
 
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) = 0;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -355,6 +355,33 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 
 /////////////////////////////////////
 
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_ray_multiple(const Ref<PhysicsRayQueryParameters3D> &p_ray_query) {
+	ERR_FAIL_COND_V(!p_ray_query.is_valid(), TypedArray<Dictionary>());
+
+	Vector<RayResult> results;
+	bool res = intersect_ray_multiple(p_ray_query->get_parameters(), results);
+
+	if (!res) {
+		return TypedArray<Dictionary>();
+	}
+	
+	int rc = results.size();
+	TypedArray<Dictionary> r;
+	r.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		d["position"] = results.get(i).position;
+		d["normal"] = results.get(i).normal;
+		d["face_index"] = results.get(i).face_index;
+		d["collider_id"] = results.get(i).collider_id;
+		d["collider"] = results.get(i).collider;
+		d["shape"] = results.get(i).shape;
+		d["rid"] = results.get(i).rid;
+		r[i] = d;
+	}
+	return r;
+}
+
 Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query) {
 	ERR_FAIL_COND_V(!p_ray_query.is_valid(), Dictionary());
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -364,7 +364,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_ray_multiple(const 
 	if (!res) {
 		return TypedArray<Dictionary>();
 	}
-	
+
 	int rc = results.size();
 	TypedArray<Dictionary> r;
 	r.resize(rc);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -508,6 +508,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
+	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray_multiple);
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -160,7 +160,6 @@ public:
 		int face_index = -1;
 	};
 
-
 	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, Vector<RayResult> &r_results) = 0;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -159,6 +159,58 @@ public:
 		int face_index = -1;
 	};
 
+	struct MultipleRayResult {
+		PackedVector3Array positions;
+		PackedVector3Array normals;
+		Vector<RID> rids;
+		Vector<ObjectID> collider_ids;
+		Vector<Object*> colliders;
+		PackedInt64Array shapes;
+		PackedInt64Array face_indexes;
+		int n_collisions = 0;
+	};
+
+	_FORCE_INLINE_ void resize_multiple_ray_result(MultipleRayResult &r_result, int amount){
+		r_result.positions.resize(amount);
+		r_result.normals.resize(amount);
+		r_result.rids.resize(amount);
+		r_result.collider_ids.resize(amount);
+		r_result.colliders.resize(amount);
+		r_result.shapes.resize(amount);
+		r_result.face_indexes.resize(amount);
+	}
+
+	_FORCE_INLINE_ void add_multiple_ray_result(MultipleRayResult &r_result, const Vector3 &position, const Vector3 &normal,
+						const GodotCollisionObject3D *col_obj,
+						const int &shape, const int &face_index){
+		ObjectID collider_id = col_obj->get_instance_id();
+		Object *collider = nullptr;
+		if (collider_id.is_valid()) {
+			collider = ObjectDB::get_instance(collider_id);
+		}
+
+		if (r_result.n_collisions < r_result.positions.size()){
+			r_result.positions.set(r_result.n_collisions, position);
+			r_result.normals.set(r_result.n_collisions, normal);
+			r_result.shapes.set(r_result.n_collisions, shape);
+			r_result.face_indexes.set(r_result.n_collisions, face_index);
+			r_result.collider_ids.set(r_result.n_collisions, collider_id);
+			r_result.rids.set(r_result.n_collisions, col_obj->get_self());
+			r_result.colliders.set(r_result.n_collisions, collider);
+		}
+		else{ // Slower due to allocating new space. Avoid if possible by using `resize_multiple_ray_result` first
+			r_result.positions.push_back(position);
+			r_result.normals.push_back(normal);
+			r_result.shapes.push_back(shape);
+			r_result.face_indexes.push_back(face_index);
+			r_result.collider_ids.push_back(collider_id);
+			r_result.rids.push_back(col_obj->get_self());
+			r_result.colliders.push_back(collider);
+		}
+		r_result.n_collisions += 1;
+	}
+
+	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, MultipleRayResult &r_result) = 0;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -210,6 +210,17 @@ public:
 		r_result.n_collisions += 1;
 	}
 
+	_FORCE_INLINE_ void ray_result_from_multiple(MultipleRayResult &multi_result, RayResult &r_result, int &multi_idx){
+		ERR_FAIL_COND_MSG(multi_idx < multi_result.n_collisions, "Out of bounds index for multi ray result");
+		r_result.collider_id = multi_result.collider_ids.get(multi_idx);
+		r_result.collider = multi_result.colliders.get(multi_idx);
+		r_result.normal = multi_result.normals.get(multi_idx);
+		r_result.face_index = multi_result.face_indexes.get(multi_idx);
+		r_result.position = multi_result.positions.get(multi_idx);
+		r_result.rid = multi_result.rids.get(multi_idx);
+		r_result.shape = multi_result.shapes.get(multi_idx);
+	}
+
 	virtual bool intersect_ray_multiple(const RayParameters &p_parameters, MultipleRayResult &r_result) = 0;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 


### PR DESCRIPTION
This is an alternative implementation of another PR to add this feature [PR91303](https://github.com/godotengine/godot/pull/91303) that implements the "intersect_ray_multiple" feature suggested in https://github.com/godotengine/godot-proposals/issues/9059 and https://github.com/godotengine/godot-proposals/issues/2616.

There are a few key differences between my implementation and ev1313 where I've tried to remain a bit more conservative in how much is changed:
* My implementation expects an empty `Vector<RayResult>` passed by reference into the`GodotPhysicsDirectSpaceState3D::intersect_ray_multiple` to allow the vector to be resized within this function. The vector is allocated internally in this function to yield all possible results from the `cull_segment` call. 
* My return from `intersect_ray_multiple` is a bool simply stating an object was hit. The number of collisions can be determined via the vector size.
* The vector size is reduced at the end of this function to ensure the vector is always sized to the number of collisions (cannot access an invalid RayResult struct).
* The closest collision point calculation has been moved to `GodotPhysicsDirectSpaceState3D::intersect_ray`. Methodology is changed as the function no longer has  local reference frames of hit objects. Instead it simply checks for the smallest squared distance between origin and collisions.
* No modifications have been made to the `PhysicsDirectSpaceState3D::RayResult` struct
* No modifications have been made to the `PhysicsDirectSpaceState3D::RayParameters` struct

There is one point of potential concern in both of our PRs. Raycasts are extremely common and games may have dozens or hundreds performed each tick. There is a performance question about allocation of a new Vector<RayResult> every time a raycast collision detection is asked (my method also has a size reduction). I don't know whether it's significant at all, but if it is a concern then a suggestion would be to have a private `Vector<RayResult>` initialized to the `GodotSpace3D::INTERSECTION_QUERY_MAX` value and modify this single vector. A result would provide a pointer to the vector and the number of collisions so the user can iterate on only valid collisions. My understanding is that simultaneous access of the space state is not allowed (can only be done on the physics thread) so race conditions wouldn't necessarily be a concern. I gladly welcome discussion or suggestions on this as I have little experience in the matter.