### PR TITLE
Scope inspector sections by category to avoid folding collisions

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2838,6 +2838,7 @@ void EditorInspector::update_tree() {
 	String subgroup;
 	String subgroup_base;
 	int section_depth = 0;
+	String category_label;
 	VBoxContainer *category_vbox = nullptr;
 
 	List<PropertyInfo> plist;
@@ -2926,7 +2927,6 @@ void EditorInspector::update_tree() {
 				continue; // Empty, ignore it.
 			}
 
-			String category_label;
 			String category_tooltip;
 			Ref<Texture> category_icon;
 
@@ -3192,7 +3192,7 @@ void EditorInspector::update_tree() {
 
 				Color c = sscolor;
 				c.a /= level;
-				section->setup(acc_path, label, object, c, use_folding, section_depth, level);
+				section->setup(category_label + "/" + acc_path, label, object, c, use_folding, section_depth, level);
 				section->set_tooltip_text(tooltip);
 
 				// Add editors at the start of a group.


### PR DESCRIPTION
Fixes #96341 by hoisting the `category_label` String out of the property loop when building the inspector and using it to scope inspector sections, so that sections from different groups with the same name no longer collide in the HashSet.

The `EditorInspectorSection::section` property only appears to be used for controlling the folding and unfolding of the sections, so changing how this property is set shouldn't break anything else as far as I can tell.

An alternative option would have been to add an additional property containing the category and change folding logic to use this, however this would also then need to be added to `EditorInspectorSection::setup` which seemed more likely to be a breaking change.