### PR TITLE
Fix Windows importer issue with new file detection

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -559,11 +559,10 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 		return 0;
 	}
 
-	String file = p_file;
-	if (file.ends_with("/") && file != "/") {
+	String file = fix_path(p_file);
+	if (file.ends_with("\\") && file != "\\") {
 		file = file.substr(0, file.length() - 1);
 	}
-	file = fix_path(file);
 
 	struct _stat st;
 	int rv = _wstat((LPCWSTR)(file.utf16().get_data()), &st);


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/96397

The importer was not detecting new files in the root directory due to handling of trailing slashes.

Related to changes from https://github.com/godotengine/godot/pull/91902

Tested with the mrp from https://github.com/godotengine/godot/issues/91413