### PR TITLE
Unix: Don't create world-writable files when safe save is enabled

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -97,7 +97,7 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 			last_error = ERR_FILE_CANT_OPEN;
 			return last_error;
 		}
-		fchmod(fd, 0666);
+		fchmod(fd, 0644);
 		path = String::utf8(cs.ptr());
 
 		f = fdopen(fd, mode_string);

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -65,7 +65,7 @@ Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) 
 	struct stat st = {};
 	int err = stat(path.utf8().get_data(), &st);
 	if (err) {
-		if (mkfifo(path.utf8().get_data(), 0666) != 0) {
+		if (mkfifo(path.utf8().get_data(), 0600) != 0) {
 			last_error = ERR_FILE_CANT_OPEN;
 			return last_error;
 		}


### PR DESCRIPTION
When the "filesystem/on_save/safe_save_on_backup_then_rename" option is enabled, files are created with 0666 permissions (-rw-rw-rw-) which is too loose. Use 0644 (-rw-r--r--) instead which is how the files would normally be created with the setting disabled and the system umask taken into account.

Note: Originally I was going to remove the fchmod() entirely and allow mkstemp() to set the permissions based on the umask but https://github.com/godotengine/godot/pull/79866#discussion_r1273040161 suggests that would break web builds. However, there should be no reason for files created by godot to ever be world-writable.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
