### PR TITLE
Use InputMap actions consistently across all LineEdit's that filter an underlying Tree or ItemList.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7178,24 +7178,6 @@ void AnimationTrackEditor::_pick_track_select_recursive(TreeItem *p_item, const 
 	}
 }
 
-void AnimationTrackEditor::_pick_track_filter_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				pick_track->get_scene_tree()->get_scene_tree()->gui_input(k);
-				pick_track->get_filter_line_edit()->accept_event();
-			} break;
-			default:
-				break;
-		}
-	}
-}
-
 AnimationTrackEditor::AnimationTrackEditor() {
 	main_panel = memnew(PanelContainer);
 	main_panel->set_focus_mode(FOCUS_ALL); // Allow panel to have focus so that shortcuts work as expected.
@@ -7413,11 +7395,9 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	pick_track = memnew(SceneTreeDialog);
 	add_child(pick_track);
-	pick_track->register_text_enter(pick_track->get_filter_line_edit());
 	pick_track->set_title(TTR("Pick a node to animate:"));
 	pick_track->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_node_selected));
 	pick_track->get_filter_line_edit()->connect(SceneStringName(text_changed), callable_mp(this, &AnimationTrackEditor::_pick_track_filter_text_changed));
-	pick_track->get_filter_line_edit()->connect(SceneStringName(gui_input), callable_mp(this, &AnimationTrackEditor::_pick_track_filter_input));
 
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -649,7 +649,6 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _pick_track_filter_text_changed(const String &p_newtext);
 	void _pick_track_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
-	void _pick_track_filter_input(const Ref<InputEvent> &p_ie);
 
 	double snap_unit;
 	void _update_snap_unit();

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -425,26 +425,19 @@ void CreateDialog::_text_changed(const String &p_newtext) {
 	_update_search();
 }
 
-void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid() && k->is_pressed()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
-				search_box->accept_event();
-			} break;
-			case Key::SPACE: {
-				TreeItem *ti = search_options->get_selected();
-				if (ti) {
-					ti->set_collapsed(!ti->is_collapsed());
-				}
-				search_box->accept_event();
-			} break;
-			default:
-				break;
+void CreateDialog::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			search_options->gui_input(key);
+			search_box->accept_event();
+		} else if (key->is_action_pressed("ui_select", true)) {
+			TreeItem *ti = search_options->get_selected();
+			if (ti) {
+				ti->set_collapsed(!ti->is_collapsed());
+			}
+			search_box->accept_event();
 		}
 	}
 }

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -77,7 +77,7 @@ class CreateDialog : public ConfirmationDialog {
 	void _fill_type_list();
 	void _cleanup();
 
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _text_changed(const String &p_newtext);
 	void select_type(const String &p_type, bool p_center_on_item = true);
 	void _item_selected();

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -183,18 +183,13 @@ void EditorCommandPalette::_notification(int p_what) {
 	}
 }
 
-void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
-			} break;
-			default:
-				break;
+void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			search_options->gui_input(key);
+			command_search_box->accept_event();
 		}
 	}
 }

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -80,7 +80,7 @@ class EditorCommandPalette : public ConfirmationDialog {
 
 	void _update_command_search(const String &search_text);
 	float _score_path(const String &p_search, const String &p_path);
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _confirmed();
 	void _add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text = "None");
 	void _save_history() const;

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -169,19 +169,12 @@ void EditorHelpSearch::_update_results() {
 }
 
 void EditorHelpSearch::_search_box_gui_input(const Ref<InputEvent> &p_event) {
-	// Redirect up and down navigational key events to the results list.
+	// Redirect navigational key events to the tree.
 	Ref<InputEventKey> key = p_event;
 	if (key.is_valid()) {
-		switch (key->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				results_tree->gui_input(key);
-				search_box->accept_event();
-			} break;
-			default:
-				break;
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			results_tree->gui_input(key);
+			search_box->accept_event();
 		}
 	}
 }

--- a/editor/editor_quick_open.cpp
+++ b/editor/editor_quick_open.cpp
@@ -202,36 +202,30 @@ void EditorQuickOpen::_text_changed(const String &p_newtext) {
 	_update_search();
 }
 
-void EditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
-				search_box->accept_event();
+void EditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			search_options->gui_input(key);
+			search_box->accept_event();
 
-				if (allow_multi_select) {
-					TreeItem *root = search_options->get_root();
-					if (!root->get_first_child()) {
-						break;
-					}
-
-					TreeItem *current = search_options->get_selected();
-					TreeItem *item = search_options->get_next_selected(root);
-					while (item) {
-						item->deselect(0);
-						item = search_options->get_next_selected(item);
-					}
-
-					current->select(0);
-					current->set_as_cursor(0);
+			if (allow_multi_select) {
+				TreeItem *root = search_options->get_root();
+				if (!root->get_first_child()) {
+					return;
 				}
-			} break;
-			default:
-				break;
+
+				TreeItem *current = search_options->get_selected();
+				TreeItem *item = search_options->get_next_selected(root);
+				while (item) {
+					item->deselect(0);
+					item = search_options->get_next_selected(item);
+				}
+
+				current->select(0);
+				current->set_as_cursor(0);
+			}
 		}
 	}
 }

--- a/editor/editor_quick_open.h
+++ b/editor/editor_quick_open.h
@@ -69,7 +69,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 	virtual void cancel_pressed() override;
 	void _cleanup();
 
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _text_changed(const String &p_newtext);
 
 protected:

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1744,6 +1744,17 @@ void SceneTreeDialog::_filter_changed(const String &p_filter) {
 	tree->set_filter(p_filter);
 }
 
+void SceneTreeDialog::_on_filter_gui_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			tree->get_scene_tree()->gui_input(key);
+			filter->accept_event();
+		}
+	}
+}
+
 void SceneTreeDialog::_bind_methods() {
 	ClassDB::bind_method("_cancel", &SceneTreeDialog::_cancel);
 
@@ -1764,6 +1775,10 @@ SceneTreeDialog::SceneTreeDialog() {
 	filter->set_clear_button_enabled(true);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect(SceneStringName(text_changed), callable_mp(this, &SceneTreeDialog::_filter_changed));
+	filter->connect(SceneStringName(gui_input), callable_mp(this, &SceneTreeDialog::_on_filter_gui_input));
+
+	register_text_enter(filter);
+
 	filter_hbc->add_child(filter);
 
 	// Add 'Show All' button to HBoxContainer next to the filter, visible only when valid_types is defined.

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -195,6 +195,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 	void _cancel();
 	void _selected_changed();
 	void _filter_changed(const String &p_filter);
+	void _on_filter_gui_input(const Ref<InputEvent> &p_event);
 	void _show_all_nodes_changed(bool p_button_pressed);
 
 protected:

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -358,12 +358,14 @@ void ScriptEditorQuickOpen::_text_changed(const String &p_newtext) {
 	_update_search();
 }
 
-void ScriptEditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-
-	if (k.is_valid() && (k->get_keycode() == Key::UP || k->get_keycode() == Key::DOWN || k->get_keycode() == Key::PAGEUP || k->get_keycode() == Key::PAGEDOWN)) {
-		search_options->gui_input(k);
-		search_box->accept_event();
+void ScriptEditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			search_options->gui_input(key);
+			search_box->accept_event();
+		}
 	}
 }
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -131,7 +131,7 @@ class ScriptEditorQuickOpen : public ConfirmationDialog {
 
 	void _update_search();
 
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	Vector<String> functions;
 
 	void _confirmed();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2174,19 +2174,13 @@ void ThemeTypeDialog::_add_type_filter_cbk(const String &p_value) {
 	_update_add_type_options(p_value);
 }
 
-void ThemeTypeDialog::_type_filter_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid() && k->is_pressed()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				add_type_options->gui_input(k);
-				add_type_filter->accept_event();
-			} break;
-			default:
-				break;
+void ThemeTypeDialog::_type_filter_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the item list.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			add_type_options->gui_input(key);
+			add_type_filter->accept_event();
 		}
 	}
 }

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -303,7 +303,7 @@ class ThemeTypeDialog : public ConfirmationDialog {
 	void _update_add_type_options(const String &p_filter = "");
 
 	void _add_type_filter_cbk(const String &p_value);
-	void _type_filter_input(const Ref<InputEvent> &p_ie);
+	void _type_filter_input(const Ref<InputEvent> &p_event);
 	void _add_type_options_cbk(int p_index);
 	void _add_type_dialog_entered(const String &p_value);
 	void _add_type_dialog_activated(int p_index);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2148,6 +2148,7 @@ String VisualShaderEditor::_get_description(int p_idx) {
 
 void VisualShaderEditor::_update_options_menu() {
 	node_desc->set_text("");
+	highend_label->set_visible(false);
 	members_dialog->get_ok_button()->set_disabled(true);
 
 	members->clear();
@@ -2312,6 +2313,8 @@ void VisualShaderEditor::_update_options_menu() {
 			item->select(0);
 			node_desc->set_text(options[i].description);
 			is_first_item = false;
+
+			members_dialog->get_ok_button()->set_disabled(false);
 		}
 		switch (options[i].return_type) {
 			case VisualShaderNode::PORT_TYPE_SCALAR:
@@ -4924,7 +4927,7 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos, VisualShaderNod
 	Vector2 difference = (dialog_rect.get_end() - window_rect.get_end()).maxf(0);
 	members_dialog->set_position(members_dialog->get_position() - difference);
 
-	callable_mp((Control *)node_filter, &Control::grab_focus).call_deferred(); // Still not visible.
+	node_filter->grab_focus();
 	node_filter->select_all();
 }
 
@@ -4947,6 +4950,8 @@ void VisualShaderEditor::_show_add_varying_dialog() {
 	add_varying_dialog->set_position(graph->get_screen_position() + varying_button->get_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	add_varying_dialog->popup();
 
+	varying_name->grab_focus();
+
 	// Keep dialog within window bounds.
 	Rect2 window_rect = Rect2(DisplayServer::get_singleton()->window_get_position(), DisplayServer::get_singleton()->window_get_size());
 	Rect2 dialog_rect = Rect2(add_varying_dialog->get_position(), add_varying_dialog->get_size());
@@ -4958,6 +4963,8 @@ void VisualShaderEditor::_show_remove_varying_dialog() {
 	remove_varying_dialog->set_position(graph->get_screen_position() + varying_button->get_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	remove_varying_dialog->popup();
 
+	varyings->grab_focus();
+
 	// Keep dialog within window bounds.
 	Rect2 window_rect = Rect2(DisplayServer::get_singleton()->window_get_position(), DisplayServer::get_singleton()->window_get_size());
 	Rect2 dialog_rect = Rect2(remove_varying_dialog->get_position(), remove_varying_dialog->get_size());
@@ -4965,11 +4972,14 @@ void VisualShaderEditor::_show_remove_varying_dialog() {
 	remove_varying_dialog->set_position(remove_varying_dialog->get_position() - difference);
 }
 
-void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> ie = p_ie;
-	if (ie.is_valid() && (ie->get_keycode() == Key::UP || ie->get_keycode() == Key::DOWN || ie->get_keycode() == Key::ENTER || ie->get_keycode() == Key::KP_ENTER)) {
-		members->gui_input(ie);
-		node_filter->accept_event();
+void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			members->gui_input(key);
+			node_filter->accept_event();
+		}
 	}
 }
 
@@ -5700,9 +5710,6 @@ void VisualShaderEditor::_member_selected() {
 	}
 }
 
-void VisualShaderEditor::_member_unselected() {
-}
-
 void VisualShaderEditor::_member_create() {
 	TreeItem *item = members->get_selected();
 	if (item != nullptr && item->has_meta("id")) {
@@ -6092,7 +6099,6 @@ void VisualShaderEditor::_show_preview_text() {
 		} else {
 			code_preview_window->popup();
 		}
-		_preview_size_changed();
 
 		if (pending_update_preview) {
 			_update_preview();
@@ -6105,12 +6111,7 @@ void VisualShaderEditor::_show_preview_text() {
 
 void VisualShaderEditor::_preview_close_requested() {
 	code_preview_showed = false;
-	code_preview_window->hide();
 	code_preview_button->set_pressed(false);
-}
-
-void VisualShaderEditor::_preview_size_changed() {
-	code_preview_vbox->set_custom_minimum_size(code_preview_window->get_size());
 }
 
 static ShaderLanguage::DataType _visual_shader_editor_get_global_shader_uniform_type(const StringName &p_variable) {
@@ -6460,12 +6461,12 @@ VisualShaderEditor::VisualShaderEditor() {
 	// CODE PREVIEW
 	///////////////////////////////////////
 
-	code_preview_window = memnew(Window);
+	code_preview_window = memnew(AcceptDialog);
 	code_preview_window->set_title(TTR("Generated Shader Code"));
 	code_preview_window->set_visible(code_preview_showed);
-	code_preview_window->set_exclusive(true);
-	code_preview_window->connect("close_requested", callable_mp(this, &VisualShaderEditor::_preview_close_requested));
-	code_preview_window->connect("size_changed", callable_mp(this, &VisualShaderEditor::_preview_size_changed));
+	code_preview_window->set_ok_button_text(TTR("Close"));
+	code_preview_window->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_preview_close_requested));
+	code_preview_window->connect("canceled", callable_mp(this, &VisualShaderEditor::_preview_close_requested));
 	add_child(code_preview_window);
 
 	code_preview_vbox = memnew(VBoxContainer);
@@ -6612,7 +6613,6 @@ VisualShaderEditor::VisualShaderEditor() {
 	members->set_custom_minimum_size(Size2(180 * EDSCALE, 200 * EDSCALE));
 	members->connect("item_activated", callable_mp(this, &VisualShaderEditor::_member_create));
 	members->connect(SceneStringName(item_selected), callable_mp(this, &VisualShaderEditor::_member_selected));
-	members->connect("nothing_selected", callable_mp(this, &VisualShaderEditor::_member_unselected));
 
 	HBoxContainer *desc_hbox = memnew(HBoxContainer);
 	members_vb->add_child(desc_hbox);
@@ -6638,21 +6638,20 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	members_dialog = memnew(ConfirmationDialog);
 	members_dialog->set_title(TTR("Create Shader Node"));
-	members_dialog->set_exclusive(true);
 	members_dialog->add_child(members_vb);
 	members_dialog->set_ok_button_text(TTR("Create"));
-	members_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_member_create));
+	members_dialog->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_member_create));
 	members_dialog->get_ok_button()->set_disabled(true);
 	members_dialog->connect("canceled", callable_mp(this, &VisualShaderEditor::_member_cancel));
+	members_dialog->register_text_enter(node_filter);
 	add_child(members_dialog);
 
 	// add varyings dialog
 	{
 		add_varying_dialog = memnew(ConfirmationDialog);
 		add_varying_dialog->set_title(TTR("Create Shader Varying"));
-		add_varying_dialog->set_exclusive(true);
 		add_varying_dialog->set_ok_button_text(TTR("Create"));
-		add_varying_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_varying_create));
+		add_varying_dialog->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_varying_create));
 		add_varying_dialog->get_ok_button()->set_disabled(true);
 		add_child(add_varying_dialog);
 
@@ -6679,6 +6678,7 @@ VisualShaderEditor::VisualShaderEditor() {
 		varying_name->set_custom_minimum_size(Size2(150 * EDSCALE, 0));
 		varying_name->set_h_size_flags(SIZE_EXPAND_FILL);
 		varying_name->connect(SceneStringName(text_changed), callable_mp(this, &VisualShaderEditor::_varying_name_changed));
+		add_varying_dialog->register_text_enter(varying_name);
 
 		varying_mode = memnew(OptionButton);
 		hb->add_child(varying_mode);
@@ -6696,9 +6696,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	{
 		remove_varying_dialog = memnew(ConfirmationDialog);
 		remove_varying_dialog->set_title(TTR("Delete Shader Varying"));
-		remove_varying_dialog->set_exclusive(true);
 		remove_varying_dialog->set_ok_button_text(TTR("Delete"));
-		remove_varying_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_varying_deleted));
+		remove_varying_dialog->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_varying_deleted));
 		add_child(remove_varying_dialog);
 
 		VBoxContainer *vb = memnew(VBoxContainer);

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -230,7 +230,7 @@ class VisualShaderEditor : public ShaderEditor {
 
 	bool pending_update_preview = false;
 	bool shader_error = false;
-	Window *code_preview_window = nullptr;
+	AcceptDialog *code_preview_window = nullptr;
 	VBoxContainer *code_preview_vbox = nullptr;
 	CodeEdit *preview_text = nullptr;
 	Ref<CodeHighlighter> syntax_highlighter = nullptr;
@@ -576,9 +576,8 @@ class VisualShaderEditor : public ShaderEditor {
 	void _graph_gui_input(const Ref<InputEvent> &p_event);
 
 	void _member_filter_changed(const String &p_text);
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _member_selected();
-	void _member_unselected();
 	void _member_create();
 	void _member_cancel();
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -30,49 +30,38 @@
 
 #include "property_selector.h"
 
-#include "core/os/keyboard.h"
-#include "editor/doc_tools.h"
 #include "editor/editor_help.h"
 #include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/rich_text_label.h"
 #include "scene/gui/tree.h"
 
 void PropertySelector::_text_changed(const String &p_newtext) {
 	_update_search();
 }
 
-void PropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
+void PropertySelector::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the tree.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			search_options->gui_input(key);
+			search_box->accept_event();
 
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
-				search_box->accept_event();
+			TreeItem *root = search_options->get_root();
+			if (!root->get_first_child()) {
+				return;
+			}
 
-				TreeItem *root = search_options->get_root();
-				if (!root->get_first_child()) {
-					break;
-				}
+			TreeItem *current = search_options->get_selected();
 
-				TreeItem *current = search_options->get_selected();
+			TreeItem *item = search_options->get_next_selected(root);
+			while (item) {
+				item->deselect(0);
+				item = search_options->get_next_selected(item);
+			}
 
-				TreeItem *item = search_options->get_next_selected(root);
-				while (item) {
-					item->deselect(0);
-					item = search_options->get_next_selected(item);
-				}
-
-				current->select(0);
-
-			} break;
-			default:
-				break;
+			current->select(0);
 		}
 	}
 }
@@ -313,7 +302,7 @@ void PropertySelector::_update_search() {
 		}
 	}
 
-	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
+	get_ok_button()->set_disabled(search_options->get_selected() == nullptr);
 }
 
 void PropertySelector::_confirmed() {
@@ -329,6 +318,8 @@ void PropertySelector::_item_selected() {
 	help_bit->set_custom_text(String(), String(), String());
 
 	TreeItem *item = search_options->get_selected();
+	get_ok_button()->set_disabled(item == nullptr);
+
 	if (!item) {
 		return;
 	}

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -45,7 +45,7 @@ class PropertySelector : public ConfirmationDialog {
 	Tree *search_options = nullptr;
 
 	void _text_changed(const String &p_newtext);
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _update_search();
 	void _confirmed();
 	void _item_selected();

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -815,13 +815,14 @@ void GridMapEditor::_text_changed(const String &p_text) {
 	update_palette();
 }
 
-void GridMapEditor::_sbox_input(const Ref<InputEvent> &p_ie) {
-	const Ref<InputEventKey> k = p_ie;
-
-	if (k.is_valid() && (k->get_keycode() == Key::UP || k->get_keycode() == Key::DOWN || k->get_keycode() == Key::PAGEUP || k->get_keycode() == Key::PAGEDOWN)) {
-		// Forward the key input to the ItemList so it can be scrolled
-		mesh_library_palette->gui_input(k);
-		search_box->accept_event();
+void GridMapEditor::_sbox_input(const Ref<InputEvent> &p_event) {
+	// Redirect navigational key events to the item list.
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid()) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+			mesh_library_palette->gui_input(key);
+			search_box->accept_event();
+		}
 	}
 }
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -199,7 +199,7 @@ class GridMapEditor : public VBoxContainer {
 	void _update_theme();
 
 	void _text_changed(const String &p_text);
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _mesh_library_palette_input(const Ref<InputEvent> &p_ie);
 
 	void _icon_size_changed(float p_value);

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -93,24 +93,6 @@ void ReplicationEditor::_pick_node_select_recursive(TreeItem *p_item, const Stri
 	}
 }
 
-void ReplicationEditor::_pick_node_filter_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				pick_node->get_scene_tree()->get_scene_tree()->gui_input(k);
-				pick_node->get_filter_line_edit()->accept_event();
-			} break;
-			default:
-				break;
-		}
-	}
-}
-
 void ReplicationEditor::_pick_node_selected(NodePath p_path) {
 	Node *root = current->get_node(current->get_root_path());
 	ERR_FAIL_NULL(root);
@@ -184,11 +166,9 @@ ReplicationEditor::ReplicationEditor() {
 
 	pick_node = memnew(SceneTreeDialog);
 	add_child(pick_node);
-	pick_node->register_text_enter(pick_node->get_filter_line_edit());
 	pick_node->set_title(TTR("Pick a node to synchronize:"));
 	pick_node->connect("selected", callable_mp(this, &ReplicationEditor::_pick_node_selected));
 	pick_node->get_filter_line_edit()->connect(SceneStringName(text_changed), callable_mp(this, &ReplicationEditor::_pick_node_filter_text_changed));
-	pick_node->get_filter_line_edit()->connect("gui_input", callable_mp(this, &ReplicationEditor::_pick_node_filter_input));
 
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -81,7 +81,6 @@ private:
 
 	void _pick_node_filter_text_changed(const String &p_newtext);
 	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
-	void _pick_node_filter_input(const Ref<InputEvent> &p_ie);
 	void _pick_node_selected(NodePath p_path);
 
 	void _pick_new_property();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/pull/96212#pullrequestreview-2268444862
Similiar to https://github.com/godotengine/godot/pull/43663

- Instead of checking for `Key::UP`, `Key::DOWN`, `Key::PAGEUP`, `Key::PAGEDOWN` etc., we rather check for the action like `ui_up` or `ui_down` etc..
- Also use AcceptDialog's `register_text_enter` functionality to consistently close a dialog when `ENTER` is pressed while the `LineEdit` has focus (instead of redirecting `ENTER` keys to e.g. the underlying `Tree`).
- Unify the `LineEdit` filter behavior for the `SceneTreeDialog` and corresponding usages.
- Improve OK Button disablement (something should be selected).

While at the `editor/plugins/visual_shader_editor_plugin.cpp`, found some related things I fixed while there:
- grab focus for corresponding control when the `varying` dialogs are shown
- shader code preview dialog always used the old size as minimum size, making the dialog bigger and bigger without the possibility to make the dialog smaller
- shader code preview dialog is an `AcceptDialog` now, which enables the same navigation as for other dialogs (press ENTER to confirm, ESCAPE to close, was the only dialog where this does not work)

Affected dialogs and how to test them (Navigate while the LineEdit has focus, press ENTER to confirm selection):
- `CreateDialog` (Create Node or Resource)
- `EditorCommandPalette` (CTRL+Shift+P)
- `EditorHelpSearch` (F1)
- `EditorQuickOpen` (CTRL+Shift+O)
- `GridMapEditor` (`GridMap with MeshLibrary`)
- `PropertySelector` (`MultiplayerSynchronizer` -> add property)
- `SceneTreeDialog` (`@export var abc: NodePath` -> Assign a Node, used in AnimationTrackEditor, ReplicationEditor)
- `ScriptEditorQuickOpen`  (edit `Script` -> CTRL+ALT+F)
- `ThemeTypeDialog` (edit `Theme `-> add type)
- `VisualShaderEditor`, including varying dialog and shader preview dialog (`Shader Editor`)