### PR TITLE
Fix Path2D editor not updating gizmos on selection in scene tree

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -468,6 +468,8 @@ void Path2DEditor::edit(Node *p_path2d) {
 		}
 		node = nullptr;
 	}
+
+	canvas_item_editor->update_viewport();
 }
 
 void Path2DEditor::_bind_methods() {
@@ -718,7 +720,6 @@ bool Path2DEditorPlugin::handles(Object *p_object) const {
 void Path2DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		path2d_editor->show();
-
 	} else {
 		path2d_editor->hide();
 		path2d_editor->edit(nullptr);


### PR DESCRIPTION
Fixes #96392

You still need to release LMB before it updates, but the same goes for other editors, like the Polygon2D editor.

Is there even a reason for `_handles` and `_edit` to be called on mouse up after clicking a tree node, instead of on mouse down?
When selecting multiple nodes by holding `CTRL`, each additional node will be selected (and inspector updated etc.) on mouse down, but this is not the case for single selections.

**Edit:** Right, I just remembered that the delayed mouse up selection is needed for dragging nodes into the inspector.