### PR TITLE
CI: Add C compile step for `gdextension_interface.h`

### DIFF
--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -56,3 +56,13 @@ jobs:
           cd godot-cpp/test
           scons target=template_debug dev_build=yes
           cd ../..
+
+  gdextension-c-compile:
+    runs-on: "ubuntu-20.04"
+    name: "Check GDExtension header with a C compiler"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Run C compiler on gdextension_interface.h"
+        run: |
+          gcc -c core/extension/gdextension_interface.h


### PR DESCRIPTION
It has happened repeatedly that C++ code accidentally crept into the GDExtension C header, a notable example being use of the `bool` type, latest example being #96406. 


This change adds a CI step to check the header with a C-only compiler. I chose gcc without any flags, let me know if there's an invocation that would fit better. 

Also, I put it as a separate job next to _Godot CPP_; maybe there's a better place.

---

This CI will fail until #96406 is merged.