### PR TITLE
Fix Polygon2D UV editor error when opening grid settings

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1482,7 +1482,7 @@ Polygon2DEditor::Polygon2DEditor() {
 
 	grid_settings = memnew(AcceptDialog);
 	grid_settings->set_title(TTR("Configure Grid:"));
-	add_child(grid_settings);
+	uv_edit->add_child(grid_settings);
 	VBoxContainer *grid_settings_vb = memnew(VBoxContainer);
 	grid_settings->add_child(grid_settings_vb);
 


### PR DESCRIPTION
Fixes #96187

The grid settings window now gets added as a child to the UV editor window, instead of as a sibling. In addition to the error going away, you can no longer close the UV editor window while keeping the grid settings up.