### PR TITLE
Disallow property keying on read-only animations.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3689,7 +3689,7 @@ void AnimationTrackEditor::update_keying() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if (is_visible_in_tree() && animation.is_valid() && editor_history->get_path_size() > 0) {
 		Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
-		keying_enabled = Object::cast_to<Node>(obj) != nullptr || Object::cast_to<MultiNodeEdit>(obj) != nullptr;
+		keying_enabled = (Object::cast_to<Node>(obj) != nullptr || Object::cast_to<MultiNodeEdit>(obj) != nullptr) && !read_only;
 	}
 
 	if (keying_enabled == keying) {
@@ -3880,7 +3880,13 @@ void AnimationTrackEditor::make_insert_queue() {
 void AnimationTrackEditor::commit_insert_queue() {
 	bool reset_allowed = true;
 	AnimationPlayer *player = AnimationPlayerEditor::get_singleton()->get_player();
-	if (player->has_animation(SceneStringName(RESET)) && player->get_animation(SceneStringName(RESET)) == animation) {
+
+	Ref<Animation> reset_animation;
+	if (player->has_animation(SceneStringName(RESET))) {
+		reset_animation = player->get_animation(SceneStringName(RESET));
+	}
+
+	if (reset_animation.is_valid() && reset_animation == animation) {
 		// Avoid messing with the reset animation itself.
 		reset_allowed = false;
 	} else {
@@ -3888,12 +3894,31 @@ void AnimationTrackEditor::commit_insert_queue() {
 		for (const AnimationTrackEditor::InsertData &E : insert_data) {
 			if (track_type_is_resettable(E.type)) {
 				some_resettable = true;
-				break;
+
+				// Check if we already have a matching reset track.
+				if (reset_animation.is_valid()) {
+					for (int idx = 0; idx < reset_animation->get_track_count(); idx++) {
+						if (reset_animation->track_get_path(idx) == E.path && reset_animation->track_get_type(idx) == E.type) {
+							some_resettable = false;
+							break;
+						}
+					}
+				}
+
+				if (some_resettable) {
+					break;
+				}
 			}
 		}
+
 		if (!some_resettable) {
 			reset_allowed = false;
 		}
+	}
+
+	// Check if we are permitted to edit the RESET animation.
+	if (reset_allowed && reset_animation.is_valid()) {
+		reset_allowed = !EditorNode::get_singleton()->is_resource_read_only(reset_animation);
 	}
 
 	// Organize insert data.
@@ -3955,6 +3980,8 @@ void AnimationTrackEditor::commit_insert_queue() {
 		insert_confirm->set_ok_button_text(TTR("Create"));
 		insert_confirm->popup_centered();
 	} else {
+		all_bezier = false;
+		reset_allowed = false;
 		_insert_track(reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), all_bezier && EDITOR_GET("editors/animation/default_create_bezier_tracks"));
 	}
 


### PR DESCRIPTION
Prevents property keying from being used on resources classified as read-only (ones embedded in other resources and/or imported scenes). It will likewise prevent RESET tracks from being added if the RESET animation is also read-only.

The current behaviour allows users to freely add new keys to an animation, whether its read-only or not. The resource will then become local when the scene is reloaded. It is debatable that user might want to be allowed to break an animation's reference to an externally embedded source, but right now, it done as more of an accidental consequence and no information is presented to user about the implications of breaking the reference to the original animation.

For now, outright disallowing this seems the most consistent design-consistent approach; users can easily still make animations local via the animation library editor if they want, but restricting it will prevent accidental unintentional destructive edits.