### PR TITLE
Clear imported track flag when duplicating animations.

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -210,6 +210,10 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 				Ref<Animation> animation = al->get_animation(animation_name);
 				if (EditorNode::get_singleton()->is_resource_read_only(animation)) {
 					animation = animation->duplicate();
+					// Remove the imported flag from all the tracks in the duplicate.
+					for (int track_idx = 0; track_idx < animation->get_track_count(); track_idx++) {
+						animation->track_set_imported(track_idx, false);
+					}
 				}
 				ald->add_animation(animation_name, animation);
 			}
@@ -282,6 +286,11 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 			StringName anim_name = file_dialog_animation;
 
 			Ref<Animation> animd = anim->duplicate();
+
+			// Remove the imported flag from all the tracks in the duplicate.
+			for (int track_idx = 0; track_idx < animd->get_track_count(); track_idx++) {
+				animd->track_set_imported(track_idx, false);
+			}
 
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(vformat(TTR("Make Animation Unique: %s"), anim_name));

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1270,6 +1270,11 @@ Ref<Animation> AnimationPlayerEditor::_animation_clone(Ref<Animation> p_anim) {
 	}
 	new_anim->set_path("");
 
+	// Clear the imported flag.
+	for (int track_idx = 0; track_idx < new_anim->get_track_count(); track_idx++) {
+		new_anim->track_set_imported(track_idx, false);
+	}
+
 	return new_anim;
 }
 


### PR DESCRIPTION
When creating local duplicate animations or whole animation libraries via the animation library editor, clear the 'imported' flag from them. This will remove the inaccurate `Imported Scene` warning.