### PR TITLE
Use non-linear mapping for ReflectionProbe mip levels to match sky

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -933,7 +933,7 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 
 		vec4 reflection;
 
-		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), roughness * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier;
+		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier;
 		reflection.rgb *= reflections.data[ref_index].exposure_normalization;
 		if (reflections.data[ref_index].exterior) {
 			reflection.rgb = mix(specular_light, reflection.rgb, blend);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/85299

This is the same change from https://github.com/godotengine/godot/pull/69514 and it should have been applied to ReflectionProbes at that time. 

This change isn't needed for the compatibility renderer because it uses a linear mapping of perceptual roughness to mipmap levels


_Scene from the MRP (with roughness layers disabled for sky so the quality matches exactly)_
_Sky reflection_
<img width="724" alt="Screenshot 2024-09-01 at 12 35 18 AM" src="https://github.com/user-attachments/assets/d5c83cbf-4e7d-4215-b73f-0c8788d750c3">
_Probe reflection_
<img width="660" alt="Screenshot 2024-09-01 at 12 35 27 AM" src="https://github.com/user-attachments/assets/79f51774-5c15-4810-a447-dd7f6dc1cab5">
