### PR TITLE
Allow exporting extension package without including C# runtime

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -15,6 +15,7 @@ namespace GodotTools.Build
         public string Configuration { get; private set; }
         public string? RuntimeIdentifier { get; private set; }
         public string? PublishOutputDir { get; private set; }
+        public bool SelfPublished { get; private set; }
         public bool Restore { get; private set; }
         public bool Rebuild { get; private set; }
         public bool OnlyClean { get; private set; }
@@ -30,7 +31,7 @@ namespace GodotTools.Build
                 other.Solution == Solution &&
                 other.Project == Project &&
                 other.Configuration == Configuration && other.RuntimeIdentifier == RuntimeIdentifier &&
-                other.PublishOutputDir == PublishOutputDir && other.Restore == Restore &&
+                other.PublishOutputDir == PublishOutputDir && other.SelfPublished == SelfPublished && other.Restore == Restore &&
                 other.Rebuild == Rebuild && other.OnlyClean == OnlyClean &&
                 other.CustomProperties == CustomProperties &&
                 other.LogsDirPath == LogsDirPath;
@@ -44,6 +45,7 @@ namespace GodotTools.Build
             hash.Add(Configuration);
             hash.Add(RuntimeIdentifier);
             hash.Add(PublishOutputDir);
+            hash.Add(SelfPublished);
             hash.Add(Restore);
             hash.Add(Rebuild);
             hash.Add(OnlyClean);
@@ -71,13 +73,14 @@ namespace GodotTools.Build
         }
 
         public BuildInfo(string solution, string project, string configuration, string runtimeIdentifier,
-            string publishOutputDir, bool restore, bool rebuild, bool onlyClean)
+            string publishOutputDir, bool selfPublished, bool restore, bool rebuild, bool onlyClean)
         {
             Solution = solution;
             Project = project;
             Configuration = configuration;
             RuntimeIdentifier = runtimeIdentifier;
             PublishOutputDir = publishOutputDir;
+            SelfPublished = selfPublished;
             Restore = restore;
             Rebuild = rebuild;
             OnlyClean = onlyClean;

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -293,11 +293,12 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
+            bool selfPublished,
             bool includeDebugSymbols = true
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
-                runtimeIdentifier, publishOutputDir, restore: true, rebuild: false, onlyClean: false);
+                runtimeIdentifier, publishOutputDir, selfPublished, restore: true, rebuild: false, onlyClean: false);
 
             if (!includeDebugSymbols)
             {
@@ -329,9 +330,10 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
+            bool selfPublished,
             bool includeDebugSymbols = true
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+            platform, runtimeIdentifier, publishOutputDir, selfPublished, includeDebugSymbols));
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -216,8 +216,11 @@ namespace GodotTools.Build
             arguments.Add(buildInfo.RuntimeIdentifier!);
 
             // Self-published
-            arguments.Add("--self-contained");
-            arguments.Add("true");
+            if (buildInfo.SelfPublished)
+            {
+                arguments.Add("--self-contained");
+                arguments.Add("true");
+            }
 
             // Verbosity
             AddVerbosityArguments(buildInfo, arguments, editorSettings);

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -148,6 +148,7 @@ namespace GodotTools.Export
                 return;
 
             string osName = GetExportPlatform().GetOsName();
+            bool selfPublished = !(Path.GetExtension(path) == ".zip" || Path.GetExtension(path) == ".pck");
 
             if (!TryDeterminePlatformFromOSName(osName, out string? platform))
                 throw new NotSupportedException("Target platform not supported.");
@@ -255,7 +256,7 @@ namespace GodotTools.Export
 
                     // Execute dotnet publish.
                     if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
-                            runtimeIdentifier, publishOutputDir, includeDebugSymbols))
+                            runtimeIdentifier, publishOutputDir, selfPublished, includeDebugSymbols))
                     {
                         throw new InvalidOperationException("Failed to build project.");
                     }


### PR DESCRIPTION
Fix #95312
