### PR TITLE
GDScript: Fix SceneTreeTimer leaked when awaiting it while quitting

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -287,5 +287,10 @@ GDScriptFunctionState::~GDScriptFunctionState() {
 		MutexLock lock(GDScriptLanguage::singleton->mutex);
 		scripts_list.remove_from_list();
 		instances_list.remove_from_list();
+
+		_clear_connections();
+		if (ObjectDB::get_instance(get_instance_id())) {
+			_clear_stack();
+		}
 	}
 }


### PR DESCRIPTION
Fixes #79669
Fixes #84860

### Reproduce

Create a Node with gdscript:

```gdscript
extends Node

func _ready() -> void:
	print("start")
	await get_tree().create_timer(30.0).timeout
	print("end")
```
Then launch Godot in shell and terminate the game window before timer timeout, a memory leak warning will appear:

![image](https://github.com/user-attachments/assets/66ca5e34-122c-4a07-8623-35ad4245760d)

But with a C# script, there's no leaking warning.

```csharp
public partial class TimerNode : Node
{
    public override async void _Ready()
    {
        GD.Print("c# start");
        await ToSignal(GetTree().CreateTimer(10), SceneTreeTimer.SignalName.Timeout);
        GD.Print("c# end");
    }
}
```

### My commit

Clear stacks and connections in GDScriptFunctionState's dtor as same as its _signal_callback does.
