### PR TITLE
Print shader compiler error when betsy shader fails to compile

### DIFF
--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -116,6 +116,7 @@ Error _compress_betsy(BetsyFormat p_format, Image *r_img) {
 	}
 
 	if (err != OK) {
+		compute_shader->print_errors("Betsy compress shader");
 		memdelete(rd);
 		if (rcd != nullptr) {
 			memdelete(rcd);


### PR DESCRIPTION
Currently if you have a compile error, nothing is printed. 

CC @BlueCube3310 This should help as you continue to work on the Betsy integration