### PR TITLE
Fix missing material override after two glb reimports

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6144,7 +6144,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 						base_packed_scene = current_packed_scene;
 					}
 					if (!local_scene_cache.find(path)) {
-						current_packed_scene = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REPLACE_DEEP, &err);
+						current_packed_scene = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
 						local_scene_cache[path] = current_packed_scene;
 					} else {
 						current_packed_scene = local_scene_cache[path];


### PR DESCRIPTION
- Fixes #96443

The problem was because both objects in the scene inherited from the same resource. When the first inherited scene was loaded, the `MeshInstance3D` connected itself to the mesh's `changed` signal. Then, when the second inherited scene was loaded, the `EditorNode` called `ResourceLoader::load` with `ResourceFormatLoader::CACHE_MODE_REPLACE_DEEP`, forcing the mesh to reload a second time. However, since the first `MeshInstance3D` was already connected, when the loader updated the name of the mesh, it emitted the `changed` signal, triggering `MeshInstance3D::_mesh_changed`. The issue was that `set_name` was called before the mesh surfaces were loaded, causing the `surface_override_materials` to be resized to zero on the first `MeshInstance3D`.

I replaced `ResourceFormatLoader::CACHE_MODE_REPLACE_DEEP` with `ResourceFormatLoader::CACHE_MODE_REPLACE`. This should not cause any problems because `EditorNode::reload_instances_with_path_in_edited_scenes` already reloads every scene in the inherited chain. In fact, this should improve scene reloading since, with the deep parameter, the mesh was being reloaded for each inherited level!

I also retested this MRP that I used to test scene reimportation:
[test-godot-blender-reimport-missing-node-v6.zip](https://github.com/user-attachments/files/16830553/test-godot-blender-reimport-missing-node-v6.zip)