### PR TITLE
SCons: Set appropriate prefix when using clang-cl

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -390,6 +390,11 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
         env.AppendUnique(CPPDEFINES=["R128_STDC_ONLY"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 
+        # Ensure intellisense tools like `compile_commands.json` play nice with MSVC syntax.
+        env["CPPDEFPREFIX"] = "-D"
+        env["INCPREFIX"] = "-I"
+        env.AppendUnique(CPPDEFINES=[("alloca", "_alloca")])
+
     if env["silence_msvc"] and not env.GetOption("clean"):
         from tempfile import mkstemp
 


### PR DESCRIPTION
A minor change for the sake of `compile_commands.json`. The old prefixes worked perfectly fine in compilation, but some tools currently struggle to parse the MSVC-esque syntax; this helps intellisense properly recognize defines/includes by using clang's "expected" prefixes.