### PR TITLE
Fix jumping to editor help does not scroll correctly sometimes

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2378,11 +2378,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	}
 
 	if (class_desc->is_finished()) {
-		// call_deferred() is not enough.
-		if (class_desc->is_connected(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph))) {
-			class_desc->disconnect(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph));
-		}
-		class_desc->connect(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).bind(line), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
+		class_desc->scroll_to_paragraph(line);
 	} else {
 		scroll_to = line;
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3607,14 +3607,13 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 
 	eh->set_name(cname);
 	tab_container->add_child(eh);
+	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
-
-	callable_mp(this, &ScriptEditor::_help_tab_goto).call_deferred(cname, p_desc);
 }
 
 bool ScriptEditor::_help_tab_goto(const String &p_name, const String &p_desc) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/96448
Fixes: https://github.com/godotengine/godot/issues/96515

The whole `go to help` code was executed twice for no reason, which led to the broken scrolling sometimes and to the somewhat hacky fix done in https://github.com/godotengine/godot/pull/90035 to fix that most of the time.

Turns out that the original PR, that fixed something else but led to the scrolling regression, done in https://github.com/godotengine/godot/pull/82498 was actually close to being correct. It removed the duplicate tab change, but actually the 'wrong' one.

In this PR, we remove the other duplicate that does excactly the same code again which was previously already done. This fixes the scrolling and allows us to revert the `draw connect` code to how it was done previously. Also made the sure that the issue https://github.com/godotengine/godot/issues/82292 which was fixed in https://github.com/godotengine/godot/pull/82498 still does not happen.
