### PR TITLE
[MP] Fix division by zero crash

### DIFF
--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -210,10 +210,10 @@ void EditorNetworkProfiler::add_rpc_frame_data(const RPCNodeInfo &p_frame) {
 		rpc_data[p_frame.node].incoming_rpc += p_frame.incoming_rpc;
 		rpc_data[p_frame.node].outgoing_rpc += p_frame.outgoing_rpc;
 	}
-	if (p_frame.incoming_rpc) {
+	if (p_frame.incoming_rpc && p_frame.incoming_rpc > 0) {
 		rpc_data[p_frame.node].incoming_size = p_frame.incoming_size / p_frame.incoming_rpc;
 	}
-	if (p_frame.outgoing_rpc) {
+	if (p_frame.outgoing_rpc && p_frame.outgoing_rpc > 0) {
 		rpc_data[p_frame.node].outgoing_size = p_frame.outgoing_size / p_frame.outgoing_rpc;
 	}
 }
@@ -227,10 +227,10 @@ void EditorNetworkProfiler::add_sync_frame_data(const SyncInfo &p_frame) {
 		sync_data[p_frame.synchronizer].outgoing_syncs += p_frame.outgoing_syncs;
 	}
 	SyncInfo &info = sync_data[p_frame.synchronizer];
-	if (info.incoming_syncs) {
+	if (info.incoming_syncs && p_frame.incoming_syncs > 0) {
 		info.incoming_size = p_frame.incoming_size / p_frame.incoming_syncs;
 	}
-	if (info.outgoing_syncs) {
+	if (info.outgoing_syncs && p_frame.outgoing_syncs > 0) {
 		info.outgoing_size = p_frame.outgoing_size / p_frame.outgoing_syncs;
 	}
 }


### PR DESCRIPTION
While this indeed fixes https://github.com/godotengine/godot/issues/96354, I still have no idea what was a root cause of this issue in a first place. 
There is this part in `SceneReplicationInterface::_send_sync`:
```cpp
const List<NodePath> props = sync->get_replication_config_ptr()->get_sync_properties(); // This always returns no props
```
Reason why in my project I was getting these divisions by zero was because this line always returned no props, and yet code underneath it kept executing. It gets a resulting size of 0, submits it to the profiler and this crash would occur.
Even with this fix it feels like there is an overarching issue, since now object is still somehow synced, but the reported size is always reported as zero, even if it is actually being replicated from time to time.