### PR TITLE
Compatibility: Enable MSAA support for all non-web platforms

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -121,7 +121,7 @@ Config::Config() {
 #ifdef WEB_ENABLED
 	msaa_supported = (msaa_max_samples > 0);
 #else
-	msaa_supported = extensions.has("GL_EXT_framebuffer_multisample");
+	msaa_supported = true;
 #endif
 #ifndef IOS_ENABLED
 #ifdef WEB_ENABLED


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96275

MSAA support is built into GLES3 core, eliminating the need to check for `GL_EXT_framebuffer_multisample`, which was necessary only in GLES2 due to the lack of inherent multisample framebuffer support. This commit corrects an oversight from GLES2-based code, ensuring compatibility with GLES3 where multisampling is natively supported without extensions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
