### PR TITLE
Prevent text file being trimmed by TextEditor

### DIFF
--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -286,11 +286,9 @@ Variant TextEditor::get_navigation_state() {
 }
 
 void TextEditor::trim_trailing_whitespace() {
-	code_editor->trim_trailing_whitespace();
 }
 
 void TextEditor::trim_final_newlines() {
-	code_editor->trim_final_newlines();
 }
 
 void TextEditor::insert_final_newline() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96440 
Trim trailing whitespace should only apply for a script, not `.md` files, , maybe we should have a White list for these file extensions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
