### PR TITLE
TranslationServer: Add fast path for comparison of equal locales

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -284,6 +284,11 @@ String TranslationServer::_standardize_locale(const String &p_locale, bool p_add
 }
 
 int TranslationServer::compare_locales(const String &p_locale_a, const String &p_locale_b) const {
+	if (p_locale_a == p_locale_b) {
+		// Exact match.
+		return 10;
+	}
+
 	String locale_a = _standardize_locale(p_locale_a, true);
 	String locale_b = _standardize_locale(p_locale_b, true);
 


### PR DESCRIPTION
Hereby, if the strings are equal, all the string manipulation required for detailed comparison is avoided.