### PR TITLE
[MP] Fix division by zero in network profiler

### DIFF
--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -227,10 +227,10 @@ void EditorNetworkProfiler::add_sync_frame_data(const SyncInfo &p_frame) {
 		sync_data[p_frame.synchronizer].outgoing_syncs += p_frame.outgoing_syncs;
 	}
 	SyncInfo &info = sync_data[p_frame.synchronizer];
-	if (info.incoming_syncs) {
+	if (p_frame.incoming_syncs) {
 		info.incoming_size = p_frame.incoming_size / p_frame.incoming_syncs;
 	}
-	if (info.outgoing_syncs) {
+	if (p_frame.outgoing_syncs) {
 		info.outgoing_size = p_frame.outgoing_size / p_frame.outgoing_syncs;
 	}
 }


### PR DESCRIPTION
The debugger reports synchronizers with empty state to the editor even if no data is being sent to other peers.

The editor conditional to avoid division by zero was checking the wrong variable.

Fixes #96354 .

~Draft status~:
- ~As reported in #96450 we might want to show `0` for outgoing sync too, to clarify that no data is being set (although the synchronizer is still being processed).~:
  I'll create a proposal for a network profiler revamp to make the information clearer and include "On Change" states, but I think we should merge this as a crash fix in the meantime.