### PR TITLE
Fix polygon node losing its UV toolbar

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -748,7 +748,9 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
 }
 
 void AbstractPolygon2DEditorPlugin::edit(Object *p_object) {
-	polygon_editor->edit(Object::cast_to<Node>(p_object));
+	Node *polygon_node = Object::cast_to<Node>(p_object);
+	polygon_editor->edit(polygon_node);
+	make_visible(polygon_node != nullptr);
 }
 
 bool AbstractPolygon2DEditorPlugin::handles(Object *p_object) const {


### PR DESCRIPTION
Fixes #96238

Found out that the toolbar remains hidden since it is being hidden on the node_removed event.