### PR TITLE
Add Advanced Settings switch to Editor Settings

### DIFF
--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -67,6 +67,7 @@ private:
 		int order = 0;
 		Variant variant;
 		Variant initial;
+		bool basic = false;
 		bool has_default_value = false;
 		bool hide_from_editor = false;
 		bool save = false;
@@ -103,7 +104,7 @@ private:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _set_only(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _initial_set(const StringName &p_name, const Variant &p_value);
+	void _initial_set(const StringName &p_name, const Variant &p_value, bool p_basic = false);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _add_property_info_bind(const Dictionary &p_info);
 	bool _property_can_revert(const StringName &p_name) const;
@@ -147,6 +148,7 @@ public:
 	void raise_order(const String &p_setting);
 	void set_initial_value(const StringName &p_setting, const Variant &p_value, bool p_update_current = false);
 	void set_restart_if_changed(const StringName &p_setting, bool p_restart);
+	void set_basic(const StringName &p_setting, bool p_basic);
 	void set_manually(const StringName &p_setting, const Variant &p_value, bool p_emit_signal = false) {
 		if (p_emit_signal) {
 			_set(p_setting, p_value);
@@ -204,7 +206,8 @@ public:
 
 #define EDITOR_DEF(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val))
 #define EDITOR_DEF_RST(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), true)
-Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false);
+#define EDITOR_DEF_BASIC(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), false, true)
+Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 #define EDITOR_GET(m_var) _EDITOR_GET(m_var)
 Variant _EDITOR_GET(const String &p_setting);

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -45,6 +45,7 @@
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
@@ -803,6 +804,11 @@ void EditorSettingsDialog::_focus_current_search_box() {
 	}
 }
 
+void EditorSettingsDialog::_advanced_toggled(bool p_button_pressed) {
+	EditorSettings::get_singleton()->set("_editor_settings_advanced_mode", p_button_pressed);
+	inspector->set_restrict_to_basic_settings(!p_button_pressed);
+}
+
 void EditorSettingsDialog::_editor_restart() {
 	EditorNode::get_singleton()->save_all_scenes();
 	EditorNode::get_singleton()->restart_editor();
@@ -845,8 +851,16 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(search_box);
 
+	advanced_switch = memnew(CheckButton(TTR("Advanced Settings")));
+	hbc->add_child(advanced_switch);
+
+	bool use_advanced = EDITOR_DEF("_editor_settings_advanced_mode", false);
+	advanced_switch->set_pressed(use_advanced);
+	advanced_switch->connect(SceneStringName(toggled), callable_mp(this, &EditorSettingsDialog::_advanced_toggled));
+
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_use_filter(true);
+	inspector->set_restrict_to_basic_settings(!use_advanced);
 	inspector->register_search_box(search_box);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(inspector);

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -34,6 +34,7 @@
 #include "editor/action_map_editor.h"
 #include "scene/gui/dialogs.h"
 
+class CheckButton;
 class PanelContainer;
 class SectionedInspector;
 class TabContainer;
@@ -51,6 +52,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	Control *tab_shortcuts = nullptr;
 
 	LineEdit *search_box = nullptr;
+	CheckButton *advanced_switch = nullptr;
 	LineEdit *shortcut_search_box = nullptr;
 	EventListenerLineEdit *shortcut_search_by_event = nullptr;
 	SectionedInspector *inspector = nullptr;
@@ -99,6 +101,8 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	void _tabs_tab_changed(int p_tab);
 	void _focus_current_search_box();
+
+	void _advanced_toggled(bool p_button_pressed);
 
 	void _update_dynamic_property_hints();
 	PropertyInfo _create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name);

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -43,16 +43,16 @@ void register_android_exporter_types() {
 
 void register_android_exporter() {
 	// TODO: Move to editor_settings.cpp
-	EDITOR_DEF("export/android/debug_keystore", EditorPaths::get_singleton()->get_debug_keystore_path());
+	EDITOR_DEF_BASIC("export/android/debug_keystore", EditorPaths::get_singleton()->get_debug_keystore_path());
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore,*.jks"));
-	EDITOR_DEF("export/android/debug_keystore_user", DEFAULT_ANDROID_KEYSTORE_DEBUG_USER);
-	EDITOR_DEF("export/android/debug_keystore_pass", DEFAULT_ANDROID_KEYSTORE_DEBUG_PASSWORD);
+	EDITOR_DEF_BASIC("export/android/debug_keystore_user", DEFAULT_ANDROID_KEYSTORE_DEBUG_USER);
+	EDITOR_DEF_BASIC("export/android/debug_keystore_pass", DEFAULT_ANDROID_KEYSTORE_DEBUG_PASSWORD);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore_pass", PROPERTY_HINT_PASSWORD));
 
 #ifndef ANDROID_ENABLED
-	EDITOR_DEF("export/android/java_sdk_path", OS::get_singleton()->get_environment("JAVA_HOME"));
+	EDITOR_DEF_BASIC("export/android/java_sdk_path", OS::get_singleton()->get_environment("JAVA_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/java_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
-	EDITOR_DEF("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_HOME"));
+	EDITOR_DEF_BASIC("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/force_system_user", false);
 

--- a/platform/macos/export/export.cpp
+++ b/platform/macos/export/export.cpp
@@ -39,7 +39,7 @@ void register_macos_exporter_types() {
 void register_macos_exporter() {
 	// TODO: Move to editor_settings.cpp
 #ifndef ANDROID_ENABLED
-	EDITOR_DEF("export/macos/rcodesign", "");
+	EDITOR_DEF_BASIC("export/macos/rcodesign", "");
 #ifdef WINDOWS_ENABLED
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/macos/rcodesign", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #else

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -41,16 +41,16 @@ void register_windows_exporter_types() {
 void register_windows_exporter() {
 	// TODO: Move to editor_settings.cpp
 #ifndef ANDROID_ENABLED
-	EDITOR_DEF("export/windows/rcedit", "");
+	EDITOR_DEF_BASIC("export/windows/rcedit", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/rcedit", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #ifdef WINDOWS_ENABLED
-	EDITOR_DEF("export/windows/signtool", "");
+	EDITOR_DEF_BASIC("export/windows/signtool", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/signtool", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #else
-	EDITOR_DEF("export/windows/osslsigncode", "");
+	EDITOR_DEF_BASIC("export/windows/osslsigncode", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/osslsigncode", PROPERTY_HINT_GLOBAL_FILE));
 	// On non-Windows we need WINE to run rcedit
-	EDITOR_DEF("export/windows/wine", "");
+	EDITOR_DEF_BASIC("export/windows/wine", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/wine", PROPERTY_HINT_GLOBAL_FILE));
 #endif
 #endif


### PR DESCRIPTION
Closes #30866

https://github.com/user-attachments/assets/66909d8d-1d27-41dd-8c0d-855959c49766

Feel free to suggest changes to this list.

Other than that:
- `restore_scenes_on_load` is no longer marked as requiring restart
- enabled code that makes default value settings not stored