### PR TITLE
Fix ambiguity in `angle_difference` function documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -90,7 +90,7 @@
 			<param index="0" name="from" type="float" />
 			<param index="1" name="to" type="float" />
 			<description>
-				Returns the difference between the two angles, in the range of [code][-PI, +PI][/code]. When [param from] and [param to] are opposite, returns [code]-PI[/code] if [param from] is smaller than [param to], or [code]PI[/code] otherwise.
+				Returns the difference between the two angles (in radians), in the range of [code][-PI, +PI][/code]. When [param from] and [param to] are opposite, returns [code]-PI[/code] if [param from] is smaller than [param to], or [code]PI[/code] otherwise.
 			</description>
 		</method>
 		<method name="asin">


### PR DESCRIPTION
The current wording does not make it clear that the unit received by the function is in radians (or -PI to PI).
To make it more clear to the end user that the function should get a signed radian instead of angles, this has been explicitly added.

(Re-implemented from me doing it wrongly here https://github.com/godotengine/godot-docs/pull/9885)