### PR TITLE
Fix `SkyRD::Sky::free()` freeing shared material

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -545,7 +545,6 @@ void SkyRD::Sky::free() {
 	}
 
 	if (material.is_valid()) {
-		RSG::material_storage->material_free(material);
 		material = RID();
 	}
 }


### PR DESCRIPTION
Fixes #95645 

When a scene that has a WorldEnvironment that contains a `Sky` resource gets closed, `SkyRD::Sky::free()` gets called, which currently frees the material used by that Sky. This is a problem when multiple Skies use the same material.
This PR aims to fix that by removing the instruction which frees the material, since it already gets freed when `Sky` gets unreferenced.