### PR TITLE
Core: Convert `Pair`/`KeyValue` to `constexpr`

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -89,7 +89,7 @@ class AStar3D : public RefCounted {
 		unsigned char direction = NONE;
 
 		static uint32_t hash(const Segment &p_seg) {
-			return PairHash<int64_t, int64_t>().hash(p_seg.key);
+			return HashMapHasherDefault::hash(p_seg.key);
 		}
 		bool operator==(const Segment &p_s) const { return key == p_s.key; }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -77,8 +77,8 @@ class OS {
 	// For tracking benchmark data
 	bool use_benchmark = false;
 	String benchmark_file;
-	HashMap<Pair<String, String>, uint64_t, PairHash<String, String>> benchmark_marks_from;
-	HashMap<Pair<String, String>, double, PairHash<String, String>> benchmark_marks_final;
+	HashMap<Pair<String, String>, uint64_t> benchmark_marks_from;
+	HashMap<Pair<String, String>, double> benchmark_marks_final;
 
 protected:
 	void _set_logger(CompositeLogger *p_logger);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -40,7 +40,9 @@
 
 static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 
-GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wplacement-new") // Silence a false positive warning (see GH-52119).
+GODOT_GCC_WARNING_PUSH
+GODOT_GCC_WARNING_IGNORE("-Wplacement-new") // Silence a false positive warning (see GH-52119).
+GODOT_GCC_WARNING_IGNORE("-Wmaybe-uninitialized") // False positive raised when using constexpr.
 
 template <typename T>
 class CowData {

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -52,6 +52,7 @@
 #include "core/string/node_path.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
+#include "core/templates/pair.h"
 #include "core/templates/rid.h"
 #include "core/typedefs.h"
 
@@ -323,6 +324,13 @@ struct HashMapHasherDefault {
 
 	template <typename T>
 	static _FORCE_INLINE_ uint32_t hash(const Ref<T> &p_ref) { return hash_one_uint64((uint64_t)p_ref.operator->()); }
+
+	template <typename F, typename S>
+	static _FORCE_INLINE_ uint32_t hash(const Pair<F, S> &p_pair) {
+		uint64_t h1 = hash(p_pair.first);
+		uint64_t h2 = hash(p_pair.second);
+		return hash_one_uint64((h1 << 32) | h2);
+	}
 
 	static _FORCE_INLINE_ uint32_t hash(const String &p_string) { return p_string.hash(); }
 	static _FORCE_INLINE_ uint32_t hash(const char *p_cstr) { return hash_djb2(p_cstr); }

--- a/core/templates/pair.h
+++ b/core/templates/pair.h
@@ -30,50 +30,29 @@
 
 #pragma once
 
-#include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
+
 template <typename F, typename S>
 struct Pair {
-	F first;
-	S second;
+	F first{};
+	S second{};
 
-	Pair() :
-			first(),
-			second() {
-	}
+	constexpr Pair() = default;
+	constexpr Pair(const F &p_first, const S &p_second) :
+			first(p_first), second(p_second) {}
 
-	Pair(F p_first, const S &p_second) :
-			first(p_first),
-			second(p_second) {
-	}
+	constexpr bool operator==(const Pair &p_other) const { return first == p_other.first && second == p_other.second; }
+	constexpr bool operator!=(const Pair &p_other) const { return first != p_other.first || second != p_other.second; }
+	constexpr bool operator<(const Pair &p_other) const { return first == p_other.first ? (second < p_other.second) : (first < p_other.first); }
+	constexpr bool operator<=(const Pair &p_other) const { return first == p_other.first ? (second <= p_other.second) : (first < p_other.first); }
+	constexpr bool operator>(const Pair &p_other) const { return first == p_other.first ? (second > p_other.second) : (first > p_other.first); }
+	constexpr bool operator>=(const Pair &p_other) const { return first == p_other.first ? (second >= p_other.second) : (first > p_other.first); }
 };
-
-template <typename F, typename S>
-bool operator==(const Pair<F, S> &pair, const Pair<F, S> &other) {
-	return (pair.first == other.first) && (pair.second == other.second);
-}
-
-template <typename F, typename S>
-bool operator!=(const Pair<F, S> &pair, const Pair<F, S> &other) {
-	return (pair.first != other.first) || (pair.second != other.second);
-}
 
 template <typename F, typename S>
 struct PairSort {
-	bool operator()(const Pair<F, S> &A, const Pair<F, S> &B) const {
-		if (A.first != B.first) {
-			return A.first < B.first;
-		}
-		return A.second < B.second;
-	}
-};
-
-template <typename F, typename S>
-struct PairHash {
-	static uint32_t hash(const Pair<F, S> &P) {
-		uint64_t h1 = HashMapHasherDefault::hash(P.first);
-		uint64_t h2 = HashMapHasherDefault::hash(P.second);
-		return hash_one_uint64((h1 << 32) | h2);
+	constexpr bool operator()(const Pair<F, S> &p_lhs, const Pair<F, S> &p_rhs) const {
+		return p_lhs < p_rhs;
 	}
 };
 
@@ -83,34 +62,31 @@ struct is_zero_constructible<Pair<F, S>> : std::conjunction<is_zero_constructibl
 
 template <typename K, typename V>
 struct KeyValue {
-	const K key;
-	V value;
+	const K key{};
+	V value{};
 
-	void operator=(const KeyValue &p_kv) = delete;
-	_FORCE_INLINE_ KeyValue(const KeyValue &p_kv) :
-			key(p_kv.key),
-			value(p_kv.value) {
-	}
-	_FORCE_INLINE_ KeyValue(const K &p_key, const V &p_value) :
-			key(p_key),
-			value(p_value) {
-	}
+	KeyValue &operator=(const KeyValue &p_kv) = delete;
+	KeyValue &operator=(KeyValue &&p_kv) = delete;
+
+	constexpr KeyValue(const KeyValue &p_kv) = default;
+	constexpr KeyValue(KeyValue &&p_kv) = default;
+	constexpr KeyValue(const K &p_key, const V &p_value) :
+			key(p_key), value(p_value) {}
+	constexpr KeyValue(const Pair<K, V> &p_pair) :
+			key(p_pair.first), value(p_pair.second) {}
+
+	constexpr bool operator==(const KeyValue &p_other) const { return key == p_other.key && value == p_other.value; }
+	constexpr bool operator!=(const KeyValue &p_other) const { return key != p_other.key || value != p_other.value; }
+	constexpr bool operator<(const KeyValue &p_other) const { return key == p_other.key ? (value < p_other.value) : (key < p_other.key); }
+	constexpr bool operator<=(const KeyValue &p_other) const { return key == p_other.key ? (value <= p_other.value) : (key < p_other.key); }
+	constexpr bool operator>(const KeyValue &p_other) const { return key == p_other.key ? (value > p_other.value) : (key > p_other.key); }
+	constexpr bool operator>=(const KeyValue &p_other) const { return key == p_other.key ? (value >= p_other.value) : (key > p_other.key); }
 };
 
 template <typename K, typename V>
-bool operator==(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
-	return (pair.key == other.key) && (pair.value == other.value);
-}
-
-template <typename K, typename V>
-bool operator!=(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
-	return (pair.key != other.key) || (pair.value != other.value);
-}
-
-template <typename K, typename V>
 struct KeyValueSort {
-	bool operator()(const KeyValue<K, V> &A, const KeyValue<K, V> &B) const {
-		return A.key < B.key;
+	constexpr bool operator()(const KeyValue<K, V> &p_lhs, const KeyValue<K, V> &p_rhs) const {
+		return p_lhs.key < p_rhs.key;
 	}
 };
 

--- a/modules/fbx/fbx_state.h
+++ b/modules/fbx/fbx_state.h
@@ -49,7 +49,7 @@ class FBXState : public GLTFState {
 	bool allow_geometry_helper_nodes = false;
 
 	HashMap<uint64_t, Image::AlphaMode> alpha_mode_cache;
-	HashMap<Pair<uint64_t, uint64_t>, GLTFTextureIndex, PairHash<uint64_t, uint64_t>> albedo_transparency_textures;
+	HashMap<Pair<uint64_t, uint64_t>, GLTFTextureIndex> albedo_transparency_textures;
 
 	Vector<GLTFSkinIndex> skin_indices;
 	Vector<GLTFSkinIndex> original_skin_indices;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -896,7 +896,7 @@ void Viewport::_process_picking() {
 										send_event = false;
 									}
 								}
-								HashMap<Pair<ObjectID, int>, uint64_t, PairHash<ObjectID, int>>::Iterator SF = physics_2d_shape_mouseover.find(Pair(res[i].collider_id, res[i].shape));
+								HashMap<Pair<ObjectID, int>, uint64_t>::Iterator SF = physics_2d_shape_mouseover.find(Pair(res[i].collider_id, res[i].shape));
 								if (!SF) {
 									physics_2d_shape_mouseover.insert(Pair(res[i].collider_id, res[i].shape), frame);
 									co->_mouse_shape_enter(res[i].shape);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -751,7 +751,7 @@ private:
 	// Collider to frame
 	HashMap<ObjectID, uint64_t> physics_2d_mouseover;
 	// Collider & shape to frame
-	HashMap<Pair<ObjectID, int>, uint64_t, PairHash<ObjectID, int>> physics_2d_shape_mouseover;
+	HashMap<Pair<ObjectID, int>, uint64_t> physics_2d_shape_mouseover;
 	// Cleans up colliders corresponding to old frames or all of them.
 	void _cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference = 0);
 #endif // PHYSICS_2D_DISABLED


### PR DESCRIPTION
- A general cleanup to the structs in `pair.h`, making them capable of `constexpr` if their types support it. Also migrates the comparison functions to within the templates themselves, including new greater/less than functions.
- The `Pair` hash function was moved to `hashfuncs.h`, removing the need to specify a different hasher than `HashMapHasherDefault` in hashmaps containing pairs.
- Suppressed GCC warning `maybe-uninitialized` in cowdata, which caused a false positive with a constexpr pair.