### PR TITLE
Fix resource loader not resolving shallow loaded scripts through dependencies (reverted)

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1057,6 +1057,26 @@ void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
 }
 
+void GDScript::set_path_cache(const String &p_path) {
+	if (ResourceCache::has(p_path)) {
+		set_path(p_path, true);
+		return;
+	}
+
+	if (is_root_script()) {
+		Script::set_path_cache(p_path);
+	}
+
+	String old_path = path;
+	path = p_path;
+	path_valid = true;
+	GDScriptCache::move_script(old_path, p_path);
+
+	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
+		kv.value->set_path_cache(p_path);
+	}
+}
+
 void GDScript::set_path(const String &p_path, bool p_take_over) {
 	if (is_root_script()) {
 		Script::set_path(p_path, p_take_over);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -300,6 +300,7 @@ public:
 
 	virtual Error reload(bool p_keep_state = false) override;
 
+	virtual void set_path_cache(const String &p_path) override;
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -311,7 +311,7 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 
 	Ref<GDScript> script;
 	script.instantiate();
-	script->set_path(p_path, true);
+	script->set_path_cache(p_path);
 	if (remapped_path.get_extension().to_lower() == "gdc") {
 		Vector<uint8_t> buffer = get_binary_tokens(remapped_path);
 		if (buffer.is_empty()) {
@@ -358,6 +358,7 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 			return script;
 		}
 	}
+	script->set_path(p_path, true);
 
 	if (p_update_from_disk) {
 		if (p_path.get_extension().to_lower() == "gdc") {


### PR DESCRIPTION
When a script first gets shallow loaded through a dependency and and then requested by the resource loader, that script is already registered in `ResourceCache` and will therefore not be properly reloaded, which is necessary in order to resolve any Script inheritance. This can lead to errors when assigning objects with that script to a reference of its parent.

`GDScript` now overwrites `set_path_cache` which does not register it in the `RessourceCache`. `set_path_cache` replaces a call to `set_path` in `get_shallow_script`. `get_full_script` now calls `set_path` to register the script.

- Fixes https://github.com/godotengine/godot/issues/95909