### PR TITLE
Prevent calling `get_material` for invalid gizmo

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -771,6 +771,10 @@ bool EditorNode3DGizmo::is_subgizmo_selected(int p_id) const {
 	return ed->is_current_selected_gizmo(this) && ed->is_subgizmo_selected(p_id);
 }
 
+bool EditorNode3DGizmo::is_gizmo_valid() const {
+	return valid;
+}
+
 Vector<int> EditorNode3DGizmo::get_subgizmo_selection() const {
 	Vector<int> ret;
 
@@ -1012,6 +1016,8 @@ Ref<StandardMaterial3D> EditorNode3DGizmoPlugin::get_material(const String &p_na
 	if (p_gizmo.is_null() || materials[p_name].size() == 1) {
 		return materials[p_name][0];
 	}
+
+	ERR_FAIL_COND_V(!p_gizmo->is_gizmo_valid(), Ref<StandardMaterial3D>());
 
 	int index = (p_gizmo->is_selected() ? 1 : 0) + (p_gizmo->is_editable() ? 2 : 0);
 

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -130,6 +130,7 @@ public:
 	void handles_intersect_ray(Camera3D *p_camera, const Vector2 &p_point, bool p_shift_pressed, int &r_id, bool &r_secondary);
 	bool intersect_ray(Camera3D *p_camera, const Point2 &p_point, Vector3 &r_pos, Vector3 &r_normal);
 	bool is_subgizmo_selected(int p_id) const;
+	bool is_gizmo_valid() const;
 	Vector<int> get_subgizmo_selection() const;
 
 	virtual void clear() override;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96481

I suppose we can go even further and expose the function to gdscript?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
