### PR TITLE
Fix OpenGL shadow textures not honoring texture type when reusing textures

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1521,6 +1521,11 @@ bool LightStorage::_shadow_atlas_find_shadow(ShadowAtlas *shadow_atlas, int *p_i
 		uint64_t min_pass = 0; // Pass of the existing one, try to use the least recently used one (LRU fashion).
 
 		for (int j = 0; j < sc; j++) {
+			if (sarr[j].owner_is_omni != is_omni) {
+				// Existing light instance type doesn't match new light instance type skip.
+				continue;
+			}
+
 			LightInstance *sli = light_instance_owner.get_or_null(sarr[j].owner);
 			if (!sli) {
 				// Found a released light instance.


### PR DESCRIPTION
Resolves #92091

When attempting to reuse old shadow textures in the compatibility renderer, it did not check whether the texture being reused matched the type of texture it was supposed to create (Cubemap texture for omnilights and 2D texture for spotlights). This led to the unexpected behavior described in #92091.

The solution I implemented now verifies that the new light instance is of the same type as the previous one.

I used this [MRP](https://github.com/user-attachments/files/16843822/TT-92091.zip) for testing.