### PR TITLE
Fix SCU global namespace conflict in `resource_format_text.cpp`

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -35,16 +35,11 @@
 #include "core/io/missing_resource.h"
 #include "core/object/script_language.h"
 
-// Version 2: Changed names for Basis, AABB, Vectors, etc.
-// Version 3: New string ID for ext/subresources, breaks forward compat.
-// Version 4: PackedByteArray can be base64 encoded, and PackedVector4Array was added.
-#define FORMAT_VERSION 4
-// For compat, save as version 3 if not using PackedVector4Array or no big PackedByteArray.
-#define FORMAT_VERSION_COMPAT 3
-
-#define _printerr() ERR_PRINT(String(res_path + ":" + itos(lines) + " - Parse Error: " + error_text).utf8().get_data());
-
 ///
+
+void ResourceLoaderText::_printerr() {
+	ERR_PRINT(String(res_path + ":" + itos(lines) + " - Parse Error: " + error_text).utf8().get_data());
+}
 
 Ref<Resource> ResourceLoaderText::get_resource() {
 	return resource;
@@ -1734,7 +1729,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		if (load_steps > 1) {
 			title += "load_steps=" + itos(load_steps) + " ";
 		}
-		title += "format=" + itos(use_compat ? FORMAT_VERSION_COMPAT : FORMAT_VERSION) + "";
+		title += "format=" + itos(use_compat ? ResourceLoaderText::FORMAT_VERSION_COMPAT : ResourceLoaderText::FORMAT_VERSION) + "";
 
 		ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(local_path, true);
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -38,6 +38,17 @@
 #include "scene/resources/packed_scene.h"
 
 class ResourceLoaderText {
+public:
+	enum {
+		// Version 2: Changed names for Basis, AABB, Vectors, etc.
+		// Version 3: New string ID for ext/subresources, breaks forward compat.
+		// Version 4: PackedByteArray can be base64 encoded, and PackedVector4Array was added.
+		FORMAT_VERSION = 4,
+		// For compat, save as version 3 if not using PackedVector4Array or no big PackedByteArray.
+		FORMAT_VERSION_COMPAT = 3,
+	};
+
+private:
 	bool translation_remapped = false;
 	String local_path;
 	String res_path;
@@ -100,6 +111,7 @@ class ResourceLoaderText {
 
 	static Error _parse_sub_resource_dummy(DummyReadData *p_data, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
 	static Error _parse_ext_resource_dummy(DummyReadData *p_data, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
+	void _printerr();
 
 	VariantParser::ResourceParser rp;
 


### PR DESCRIPTION
`FORMAT_VERSION` is used in multiple places in the codebase, and #defining it was causing conflicts.

## Notes
* I hadn't built master in quite a few days, am surprised no one else was getting this conflict.
* This likely only occurs in SCU build, as other files attempt to add `FORMAT_VERSION` in enums _after_ `resource_format_text.cpp` has #defined it.
* Everywhere else seems to more sensibly use `FORMAT_VERSION` in local enums, which is safer for making sure the correct version is used.
* `FORMAT_VERSION_COMPAT` and `_printerr()` weren't causing build errors for me, but seemed worth fixing at the same time.

In general `#define` should be used with care due to the potential for conflicts with global namespace (and the use of contrived naming may be recommended for defines). This applies not just in SCU builds.

The alternative here would have been to exclude the problematic `.cpp` from the SCU build in `scene/resources/SCsub`, but in this case it looks more sensible to fix the unnecessary use of global namespace, which may fix more bugs in the long run.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
