### PR TITLE
Fix PopupPanel and PopupMenu menu styles

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -534,7 +534,6 @@ ControlEditorPopupButton::ControlEditorPopupButton() {
 	set_focus_mode(FOCUS_NONE);
 
 	popup_panel = memnew(PopupPanel);
-	popup_panel->set_theme_type_variation("ControlEditorPopupPanel");
 	add_child(popup_panel);
 	popup_panel->connect("about_to_popup", callable_mp(this, &ControlEditorPopupButton::_popup_visibility_changed).bind(true));
 	popup_panel->connect("popup_hide", callable_mp(this, &ControlEditorPopupButton::_popup_visibility_changed).bind(false));

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -633,6 +633,16 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 			// in 4.0, and even if it was, it may not always work in practice (e.g. running with compositing disabled).
 			p_config.popup_style->set_corner_radius_all(0);
 
+			p_config.popup_border_style = p_config.popup_style->duplicate();
+			p_config.popup_border_style->set_content_margin_all(MAX(Math::round(EDSCALE), p_config.border_width) + 2 + (p_config.base_margin * 1.5) * EDSCALE);
+			// Always display a border for popups like PopupMenus so they can be distinguished from their background.
+			p_config.popup_border_style->set_border_width_all(MAX(Math::round(EDSCALE), p_config.border_width));
+			if (p_config.draw_extra_borders) {
+				p_config.popup_border_style->set_border_color(p_config.extra_border_color_2);
+			} else {
+				p_config.popup_border_style->set_border_color(p_config.dark_color_2);
+			}
+
 			p_config.window_style = p_config.popup_style->duplicate();
 			p_config.window_style->set_border_color(p_config.base_color);
 			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
@@ -707,7 +717,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		}
 
 		// PopupPanel
-		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_style);
+		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_border_style);
 	}
 
 	// Buttons.
@@ -1310,18 +1320,11 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 
 		// PopupMenu.
 		{
-			Ref<StyleBoxFlat> style_popup_menu = p_config.popup_style->duplicate();
+			Ref<StyleBoxFlat> style_popup_menu = p_config.popup_border_style->duplicate();
 			// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
 			// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
 			// and it looks weird. 1px solves this.
-			style_popup_menu->set_content_margin_individual(EDSCALE, 2 * EDSCALE, EDSCALE, 2 * EDSCALE);
-			// Always display a border for PopupMenus so they can be distinguished from their background.
-			style_popup_menu->set_border_width_all(EDSCALE);
-			if (p_config.draw_extra_borders) {
-				style_popup_menu->set_border_color(p_config.extra_border_color_2);
-			} else {
-				style_popup_menu->set_border_color(p_config.dark_color_2);
-			}
+			style_popup_menu->set_content_margin_individual(Math::round(EDSCALE), 2 * EDSCALE, Math::round(EDSCALE), 2 * EDSCALE);
 			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
 
 			Ref<StyleBoxFlat> style_menu_hover = p_config.button_style_hover->duplicate();
@@ -1331,17 +1334,17 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 
 			Ref<StyleBoxLine> style_popup_separator(memnew(StyleBoxLine));
 			style_popup_separator->set_color(p_config.separator_color);
-			style_popup_separator->set_grow_begin(p_config.popup_margin - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_separator->set_grow_end(p_config.popup_margin - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_separator->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_separator->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
 			style_popup_separator->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
 
 			Ref<StyleBoxLine> style_popup_labeled_separator_left(memnew(StyleBoxLine));
-			style_popup_labeled_separator_left->set_grow_begin(p_config.popup_margin - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_left->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
 			style_popup_labeled_separator_left->set_color(p_config.separator_color);
 			style_popup_labeled_separator_left->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
 
 			Ref<StyleBoxLine> style_popup_labeled_separator_right(memnew(StyleBoxLine));
-			style_popup_labeled_separator_right->set_grow_end(p_config.popup_margin - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_right->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
 			style_popup_labeled_separator_right->set_color(p_config.separator_color);
 			style_popup_labeled_separator_right->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
 
@@ -2114,21 +2117,6 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 
 		// EditorValidationPanel.
 		p_theme->set_stylebox(SceneStringName(panel), "EditorValidationPanel", p_config.tree_panel_style);
-
-		// ControlEditor.
-		{
-			p_theme->set_type_variation("ControlEditorPopupPanel", "PopupPanel");
-
-			Ref<StyleBoxFlat> control_editor_popup_style = p_config.popup_style->duplicate();
-			control_editor_popup_style->set_shadow_size(0);
-			control_editor_popup_style->set_content_margin(SIDE_LEFT, p_config.base_margin * EDSCALE);
-			control_editor_popup_style->set_content_margin(SIDE_TOP, p_config.base_margin * EDSCALE);
-			control_editor_popup_style->set_content_margin(SIDE_RIGHT, p_config.base_margin * EDSCALE);
-			control_editor_popup_style->set_content_margin(SIDE_BOTTOM, p_config.base_margin * EDSCALE);
-			control_editor_popup_style->set_border_width_all(0);
-
-			p_theme->set_stylebox(SceneStringName(panel), "ControlEditorPopupPanel", control_editor_popup_style);
-		}
 	}
 
 	// Editor inspector.

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -135,6 +135,7 @@ class EditorThemeManager {
 		Ref<StyleBoxFlat> button_style_hover;
 
 		Ref<StyleBoxFlat> popup_style;
+		Ref<StyleBoxFlat> popup_border_style;
 		Ref<StyleBoxFlat> window_style;
 		Ref<StyleBoxFlat> dialog_style;
 		Ref<StyleBoxFlat> panel_container_style;

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -391,7 +391,6 @@ void ScreenSelect::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			set_icon(get_editor_theme_icon("MakeFloating"));
-			popup_background->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("PanelForeground", EditorStringName(EditorStyles)));
 
 			const real_t popup_height = real_t(get_theme_font_size(SceneStringName(font_size))) * 2.0;
 			popup->set_min_size(Size2(0, popup_height * 3));
@@ -454,13 +453,9 @@ ScreenSelect::ScreenSelect() {
 	// Create the popup.
 	const Size2 borders = Size2(4, 4) * EDSCALE;
 
-	popup = memnew(Popup);
+	popup = memnew(PopupPanel);
 	popup->connect("popup_hide", callable_mp(static_cast<BaseButton *>(this), &ScreenSelect::set_pressed).bind(false));
 	add_child(popup);
-
-	popup_background = memnew(Panel);
-	popup_background->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
-	popup->add_child(popup_background);
 
 	MarginContainer *popup_root = memnew(MarginContainer);
 	popup_root->add_theme_constant_override("margin_right", borders.width);

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -88,7 +88,6 @@ class ScreenSelect : public Button {
 	GDCLASS(ScreenSelect, Button);
 
 	Popup *popup = nullptr;
-	Panel *popup_background = nullptr;
 	HBoxContainer *screen_list = nullptr;
 
 	void _build_advanced_menu();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/96517
Edit: Fixes: https://github.com/godotengine/godot/issues/67657 (border part)

This makes popup menus using PopupPanel and PopupMenus have same base look, as it is in Godot 3. 

## Panel border

Adding a default border to the PopupPanel to make it easier to differentiate from the background. 
I believe this was removed in PR https://github.com/godotengine/godot/pull/45607 and then added back for PopupMenus in PR https://github.com/godotengine/godot/pull/48655 (also removed support for Border Size on PopupMenus)

Before:
![ps_ss_before](https://github.com/user-attachments/assets/845c6774-ac72-437d-b72f-19ccaa6a4271)

After:
![Screenshot_20240902_224247](https://github.com/user-attachments/assets/bcb7b5a1-984e-42f2-8b4a-c9306326d715)


### Border color

In Godot 3 both styles of popup menus uses the same border color, light on dark theme and dark border on light themes. 

Godot 3 example:
| 1        |2         
| ------------- |:-------------:| 
| ![ps_3_2](https://github.com/user-attachments/assets/2670d77a-b559-4390-9b6b-449e493458b3)     |![ps_3_1](https://github.com/user-attachments/assets/a8ff8515-3020-4af9-931b-6d3907c647c9) |


Currently Godot 4 uses dark border for PopupMenus and with Border Size in Editor Settings set to 1 or 2 PopupPanel uses a light border in dark themes.

Before: _with border size set_
| 1        |2         
| ------------- |:-------------:| 
|    ![Screenshot_20240902_133942](https://github.com/user-attachments/assets/b7dc73e6-fa30-4c45-9b0a-5944e381536c) |![ps_border_size_color_before](https://github.com/user-attachments/assets/9f64c554-13ae-426e-a1ad-cc01de5c1846) |

After: _border size is set to deafult_
| 1        |2         
| ------------- |:-------------:| 
| ![Screenshot_20240903_000646](https://github.com/user-attachments/assets/a30a65ba-1aaf-4c0d-8d80-844126111031) |![Screenshot_20240902_224259](https://github.com/user-attachments/assets/cf959633-1aa7-4936-a93f-4f3a947401a5) |

Because the PopupMenu border is visible by default I went with that color for both in this PR. 

Maybe there could be a editor setting for changing outline color, but that would need to be a proposal in that case. 


## Border Size

In Godot 3 both PopupPanel and PopupMenus uses the Border Size.

PopupPanel uses this already.

This PR also changes PopupMenus to use the editor setting Border Size for the outer border.


### Separator width

Due to the change of using Border Size the separator line in PopupMenus was much more obvious that it overlaps the outer border. So this was also changed

Before:
![ps_sep_zoom_before](https://github.com/user-attachments/assets/97c7199a-acaf-4f82-a101-6abe15c07d40)

After:
![Screenshot_20240902_224601](https://github.com/user-attachments/assets/bd43c48f-1e2a-4063-a386-9ce06079501b)


## Compact

Before:
![ps_ap_compact_before](https://github.com/user-attachments/assets/d6b40461-cc46-4a29-8ad7-20dca2a65255)

After:
![Screenshot_20240903_003120](https://github.com/user-attachments/assets/76f889f2-95a4-4156-9448-f887ea600409)


