### PR TITLE
[Editor] Separate `editor_node.cpp` for SCU to prevent errors

### DIFF
--- a/scu_builders.py
+++ b/scu_builders.py
@@ -290,7 +290,7 @@ def generate_scu_files(max_includes_per_scu):
     process_folder(["drivers/unix"])
     process_folder(["drivers/png"])
 
-    process_folder(["editor"], ["file_system_dock", "editor_resource_preview"], 32)
+    process_folder(["editor"], ["file_system_dock", "editor_resource_preview", "editor_node"], 32)
     process_folder(["editor/debugger"])
     process_folder(["editor/debugger/debug_adapter"])
     process_folder(["editor/export"])


### PR DESCRIPTION
Due to defines introduced by `platform/windows/platform_gl.h` SCU builds break on MSVC, alternative solution would be to explicitly udefine like this, but felt this was the least hacky solution:
```diff
diff --git a/editor/editor_node.cpp b/editor/editor_node.cpp
index 32e6126225..54f3715bf7 100644
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -169,6 +169,13 @@

 #if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
+
+// Cleanup nasty defines.
+#undef CreateDialog
+#undef ERROR
+#undef MOD_ALT
+#undef MOD_SHIFT
+#undef MOD_META
 #endif

 EditorNode *EditorNode::singleton = nullptr;
diff --git a/scu_builders.py b/scu_builders.py
index 041056fd68..fc5461196f 100644
--- a/scu_builders.py
+++ b/scu_builders.py
@@ -290,7 +290,7 @@ def generate_scu_files(max_includes_per_scu):
     process_folder(["drivers/unix"])
     process_folder(["drivers/png"])

-    process_folder(["editor"], ["file_system_dock", "editor_resource_preview", "editor_node"], 32)
+    process_folder(["editor"], ["file_system_dock", "editor_resource_preview"], 32)
     process_folder(["editor/debugger"])
     process_folder(["editor/debugger/debug_adapter"])
     process_folder(["editor/export"])
```

Or there might be some way to prevent these weird defines being made, but this should be the most simple solution

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
