### PR TITLE
Add units and docs for Joint3D/2D stiffness and damping

### DIFF
--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -31,10 +31,12 @@
 			The higher, the faster.
 		</member>
 		<member name="relaxation" type="float" setter="set_param" getter="get_param" default="1.0">
-			Defines, how fast the swing- and twist-speed-difference on both sides gets synced.
+			The amount of relaxation, or inverse damping, applied to angular velocity when rotated beyond the swing span and/or twist span. It is measured in rad/N/m/s, or rad·s/kg/m² in SI base units. Unlike most joints in Godot which use damping, [ConeTwistJoint3D] uses inverse damping (relaxation), so higher values result in less damping and lower values result in more damping.
+			Higher relaxation values make the joint more elastic or bouncy. Lower values result in a smoother, more gradual reduction in swing and twist speed difference velocity, preventing oscillations or rapid rotation as the joint returns to its span limits.
 		</member>
 		<member name="softness" type="float" setter="set_param" getter="get_param" default="0.8">
-			The ease with which the joint starts to twist. If it's too low, it takes more force to start twisting the joint.
+			The stiffness factor applied to rotation beyond the swing span and twist span limits. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a harder limit, which more strongly resists rotation beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="swing_span" type="float" setter="set_param" getter="get_param" default="0.7853982">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.

--- a/doc/classes/DampedSpringJoint2D.xml
+++ b/doc/classes/DampedSpringJoint2D.xml
@@ -10,16 +10,18 @@
 	</tutorials>
 	<members>
 		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="1.0">
-			The spring joint's damping ratio. A value between [code]0[/code] and [code]1[/code]. When the two bodies move into different directions the system tries to align them to the spring axis again. A high [member damping] value forces the attached bodies to align faster.
+			The amount of damping applied to by the spring joint. It is measured in kg/s.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the spring returns to its equilibrium rest length, preventing oscillations or rapid movement. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="50.0">
 			The spring joint's maximum length. The two attached bodies cannot stretch it past this value.
 		</member>
 		<member name="rest_length" type="float" setter="set_rest_length" getter="get_rest_length" default="0.0">
-			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards this length.
+			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards this length, known as the equilibrium length or rest length.
 		</member>
 		<member name="stiffness" type="float" setter="set_stiffness" getter="get_stiffness" default="20.0">
-			The higher the value, the less the bodies attached to the joint will deform it. The joint applies an opposing force to the bodies, the product of the stiffness multiplied by the size difference from its resting length.
+			The stiffness of the spring joint. It is measured in kg/s². The joint applies an opposing force to the bodies, the product of the stiffness multiplied by the size difference from its resting length.
+			Higher linear stiffness results in a more rigid spring, which more strongly resists being compressed or stretched away from its equilibrium rest length. Lower values make the spring more elastic or bouncy.
 		</member>
 	</members>
 </class>

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -91,32 +91,34 @@
 	</methods>
 	<members>
 		<member name="angular_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
-			The amount of rotational damping across the X axis.
-			The lower, the longer an impulse from one side takes to travel to the other side.
+			The amount of damping applied to X angular velocity when a joint is rotated beyond the angular limit around the X axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
+			Higher angular damping results in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the joint returns to its angular limit. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="angular_limit_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
-			If [code]true[/code], rotation across the X axis is limited.
+			If [code]true[/code], rotation around the X axis is limited.
 		</member>
 		<member name="angular_limit_x/erp" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
-			When rotating across the X axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
+			When rotating around the X axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
 		<member name="angular_limit_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The maximum amount of force that can occur, when rotating around the X axis.
+			The maximum amount of torque (angular force) that the limit can apply to angular velocity around the X axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_limit_x/lower_angle" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The minimum rotation in negative direction to break loose and rotate around the X axis.
+			The maximum rotation in radians in the negative direction around the X axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular X limits are set to zero, the joint is fixed around the angular X axis.
 		</member>
 		<member name="angular_limit_x/restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The amount of rotational restitution across the X axis. The lower, the more restitution occurs.
+			The amount of rotational restitution across the X axis. The lower, the more restitution occurs. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_limit_x/softness" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
-			The speed of all rotations across the X axis.
+			The stiffness factor applied to rotation beyond the angular limit around the X axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a harder limit, which more strongly resists rotation beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="angular_limit_x/upper_angle" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The minimum rotation in positive direction to break loose and rotate around the X axis.
+			The maximum rotation in radians in the positive direction around the X axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular X limits are set to zero, the joint is fixed around the angular X axis.
 		</member>
 		<member name="angular_limit_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
-			The amount of rotational damping across the Y axis. The lower, the more damping occurs.
+			The amount of damping applied to Y angular velocity when a joint is rotated beyond the angular limit around the Y axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
+			Higher angular damping results in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the joint returns to its angular limit. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="angular_limit_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
 			If [code]true[/code], rotation across the Y axis is limited.
@@ -125,22 +127,24 @@
 			When rotating across the Y axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
 		<member name="angular_limit_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The maximum amount of force that can occur, when rotating around the Y axis.
+			The maximum amount of torque (angular force) that the limit can apply to angular velocity around the Y axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_limit_y/lower_angle" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The minimum rotation in negative direction to break loose and rotate around the Y axis.
+			The maximum rotation in radians in the negative direction around the Y axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular Y limits are set to zero, the joint is fixed around the angular Y axis.
 		</member>
 		<member name="angular_limit_y/restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The amount of rotational restitution across the Y axis. The lower, the more restitution occurs.
+			The amount of rotational restitution across the Y axis. The lower, the more restitution occurs. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_limit_y/softness" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
-			The speed of all rotations across the Y axis.
+			The stiffness factor applied to rotation beyond the angular limit around the Y axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a harder limit, which more strongly resists rotation beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="angular_limit_y/upper_angle" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The minimum rotation in positive direction to break loose and rotate around the Y axis.
+			The maximum rotation in radians in the positive direction around the Y axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular Y limits are set to zero, the joint is fixed around the angular Y axis.
 		</member>
 		<member name="angular_limit_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
-			The amount of rotational damping across the Z axis. The lower, the more damping occurs.
+			The amount of damping applied to Z angular velocity when a joint is rotated beyond the angular limit around the Z axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
+			Higher angular damping results in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the joint returns to its angular limit. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="angular_limit_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
 			If [code]true[/code], rotation across the Z axis is limited.
@@ -149,127 +153,149 @@
 			When rotating across the Z axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
 		<member name="angular_limit_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The maximum amount of force that can occur, when rotating around the Z axis.
+			The maximum amount of torque (angular force) that the limit can apply to angular velocity around the Z axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_limit_z/lower_angle" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The minimum rotation in negative direction to break loose and rotate around the Z axis.
+			The maximum rotation in radians in the negative direction around the Z axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular Z limits are set to zero, the joint is fixed around the angular Z axis.
 		</member>
 		<member name="angular_limit_z/restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The amount of rotational restitution across the Z axis. The lower, the more restitution occurs.
+			The amount of rotational restitution across the Z axis. The lower, the more restitution occurs. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_limit_z/softness" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
-			The speed of all rotations across the Z axis.
+			The stiffness factor applied to rotation beyond the angular limit around the Z axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a harder limit, which more strongly resists rotation beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="angular_limit_z/upper_angle" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The minimum rotation in positive direction to break loose and rotate around the Z axis.
+			The maximum rotation in radians in the positive direction around the Z axis that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper angular Z limits are set to zero, the joint is fixed around the angular Z axis.
 		</member>
 		<member name="angular_motor_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
-			If [code]true[/code], a rotating motor at the X axis is enabled.
+			If [code]true[/code], then there is an angular motor on the X axis. More generally, the joint's rotation around the X axis will have a joint drive that targets the given angular velocity and tries to reach it while staying within the force limits.
 		</member>
 		<member name="angular_motor_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="300.0">
-			Maximum acceleration for the motor at the X axis.
+			The maximum amount of torque (angular force) that the motor can apply to angular velocity around the X axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_motor_x/target_velocity" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			Target speed for the motor at the X axis.
+			Target speed for the angular motor around the X axis, in radians per second.
 		</member>
 		<member name="angular_motor_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
-			If [code]true[/code], a rotating motor at the Y axis is enabled.
+			If [code]true[/code], then there is an angular motor on the Y axis. More generally, the joint's rotation around the Y axis will have a joint drive that targets the given angular velocity and tries to reach it while staying within the force limits.
 		</member>
 		<member name="angular_motor_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="300.0">
-			Maximum acceleration for the motor at the Y axis.
+			The maximum amount of torque (angular force) that the motor can apply to angular velocity around the X axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_motor_y/target_velocity" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			Target speed for the motor at the Y axis.
+			Target speed for the angular motor around the Y axis, in radians per second.
 		</member>
 		<member name="angular_motor_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
-			If [code]true[/code], a rotating motor at the Z axis is enabled.
+			If [code]true[/code], then there is an angular motor on the Z axis. More generally, the joint's rotation around the Z axis will have a joint drive that targets the given angular velocity and tries to reach it while staying within the force limits.
 		</member>
 		<member name="angular_motor_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="300.0">
-			Maximum acceleration for the motor at the Z axis.
+			The maximum amount of torque (angular force) that the motor can apply to angular velocity around the X axis. It is measured in Nm, or kg·m²/s² in SI base units.
 		</member>
 		<member name="angular_motor_z/target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			Target speed for the motor at the Z axis.
+			Target speed for the angular motor around the Z axis, in radians per second.
 		</member>
 		<member name="angular_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The amount of damping applied to X angular velocity when a joint drive acts as a spring around the X axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+			If [code]true[/code], then there is an angular spring on the X axis. More generally, the joint's rotation around the X axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="angular_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The equilibrium point of the spring around the X axis, in radians.
 		</member>
 		<member name="angular_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The stiffness of the spring around the X axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a more rigid spring, which more strongly resists being bent away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="angular_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The amount of damping applied to Y angular velocity when a joint drive acts as a spring around the Y axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+			If [code]true[/code], then there is an angular spring on the Y axis. More generally, the joint's rotation around the Y axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="angular_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The equilibrium point of the spring around the Y axis, in radians.
 		</member>
 		<member name="angular_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The stiffness of the spring around the Y axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a more rigid spring, which more strongly resists being bent away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="angular_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The amount of damping applied to Z angular velocity when a joint drive acts as a spring around the Z axis. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+			If [code]true[/code], then there is an angular spring on the Z axis. More generally, the joint's rotation around the Z axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="angular_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The equilibrium point of the spring around the Z axis, in radians.
 		</member>
 		<member name="angular_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The stiffness of the spring around the Z axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a more rigid spring, which more strongly resists being bent away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
-			The amount of damping that happens at the X motion.
+			The amount of damping applied to X linear velocity when a joint is moved beyond the linear limit along the X axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="linear_limit_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
 			If [code]true[/code], the linear motion across the X axis is limited.
 		</member>
 		<member name="linear_limit_x/lower_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The minimum difference between the pivot points' X axis.
+			The maximum distance in meters in the negative direction on the X axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear X limits are set to zero, the joint is fixed along the linear X axis.
 		</member>
 		<member name="linear_limit_x/restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
-			The amount of restitution on the X axis movement. The lower, the more momentum gets lost.
+			The amount of restitution on the X axis movement. The lower, the more momentum gets lost. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_limit_x/softness" type="float" setter="set_param_x" getter="get_param_x" default="0.7">
-			A factor applied to the movement across the X axis. The lower, the slower the movement.
+			The stiffness factor applied to movement beyond the linear limit along the X axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a harder limit, which more strongly resists movement beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="linear_limit_x/upper_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
-			The maximum difference between the pivot points' X axis.
+			The maximum distance in meters in the positive direction on the X axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear X limits are set to zero, the joint is fixed along the linear X axis.
 		</member>
 		<member name="linear_limit_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
-			The amount of damping that happens at the Y motion.
+			The amount of damping applied to Y linear velocity when a joint is moved beyond the linear limit along the Y axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="linear_limit_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
 			If [code]true[/code], the linear motion across the Y axis is limited.
 		</member>
 		<member name="linear_limit_y/lower_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The minimum difference between the pivot points' Y axis.
+			The maximum distance in meters in the negative direction on the Y axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear Y limits are set to zero, the joint is fixed along the linear Y axis.
 		</member>
 		<member name="linear_limit_y/restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
-			The amount of restitution on the Y axis movement. The lower, the more momentum gets lost.
+			The amount of restitution on the Y axis movement. The lower, the more momentum gets lost. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_limit_y/softness" type="float" setter="set_param_y" getter="get_param_y" default="0.7">
-			A factor applied to the movement across the Y axis. The lower, the slower the movement.
+			The stiffness factor applied to movement beyond the linear limit along the Y axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a harder limit, which more strongly resists movement beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="linear_limit_y/upper_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
-			The maximum difference between the pivot points' Y axis.
+			The maximum distance in meters in the positive direction on the Y axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear Y limits are set to zero, the joint is fixed along the linear Y axis.
 		</member>
 		<member name="linear_limit_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
-			The amount of damping that happens at the Z motion.
+			The amount of damping applied to Z linear velocity when a joint is moved beyond the linear limit along the Z axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="linear_limit_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
 			If [code]true[/code], the linear motion across the Z axis is limited.
 		</member>
 		<member name="linear_limit_z/lower_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The minimum difference between the pivot points' Z axis.
+			The maximum distance in meters in the negative direction on the Z axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear Z limits are set to zero, the joint is fixed along the linear Z axis.
 		</member>
 		<member name="linear_limit_z/restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
-			The amount of restitution on the Z axis movement. The lower, the more momentum gets lost.
+			The amount of restitution on the Z axis movement. The lower, the more momentum gets lost. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_limit_z/softness" type="float" setter="set_param_z" getter="get_param_z" default="0.7">
-			A factor applied to the movement across the Z axis. The lower, the slower the movement.
+			The stiffness factor applied to movement beyond the linear limit along the Z axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a harder limit, which more strongly resists movement beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="linear_limit_z/upper_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
-			The maximum difference between the pivot points' Z axis.
+			The maximum distance in meters in the positive direction on the Z axis that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper linear Z limits are set to zero, the joint is fixed along the linear Z axis.
 		</member>
 		<member name="linear_motor_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
-			If [code]true[/code], then there is a linear motor on the X axis. It will attempt to reach the target velocity while staying within the force limits.
+			If [code]true[/code], then there is a linear motor on the X axis. More generally, the joint's X axis will have a joint drive that targets the given linear velocity and attempts to reach it while staying within the force limits.
 		</member>
 		<member name="linear_motor_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The maximum force the linear motor can apply on the X axis while trying to reach the target velocity.
@@ -278,7 +304,7 @@
 			The speed that the linear motor will attempt to reach on the X axis.
 		</member>
 		<member name="linear_motor_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
-			If [code]true[/code], then there is a linear motor on the Y axis. It will attempt to reach the target velocity while staying within the force limits.
+			If [code]true[/code], then there is a linear motor on the Y axis. More generally, the joint's Y axis will have a joint drive that targets the given linear velocity and attempts to reach it while staying within the force limits.
 		</member>
 		<member name="linear_motor_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The maximum force the linear motor can apply on the Y axis while trying to reach the target velocity.
@@ -287,7 +313,7 @@
 			The speed that the linear motor will attempt to reach on the Y axis.
 		</member>
 		<member name="linear_motor_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
-			If [code]true[/code], then there is a linear motor on the Z axis. It will attempt to reach the target velocity while staying within the force limits.
+			If [code]true[/code], then there is a linear motor on the Z axis. More generally, the joint's Z axis will have a joint drive that targets the given linear velocity and attempts to reach it while staying within the force limits.
 		</member>
 		<member name="linear_motor_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The maximum force the linear motor can apply on the Z axis while trying to reach the target velocity.
@@ -296,109 +322,142 @@
 			The speed that the linear motor will attempt to reach on the Z axis.
 		</member>
 		<member name="linear_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+			The amount of damping applied to X linear velocity when a joint drive acts as a spring along the X axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the spring returns to its equilibrium point, preventing oscillations or rapid movement. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+			If [code]true[/code], then there is a linear spring on the X axis. More generally, the joint's X axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="linear_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The equilibrium point of the spring in meters along the X axis.
 		</member>
 		<member name="linear_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+			The stiffness of the spring along the X axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a more rigid spring, which more strongly resists being compressed or stretched away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+			The amount of damping applied to Y linear velocity when a joint drive acts as a spring along the Y axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the spring returns to its equilibrium point, preventing oscillations or rapid movement. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+			If [code]true[/code], then there is a linear spring on the Y axis. More generally, the joint's Y axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="linear_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The equilibrium point of the spring in meters along the Y axis.
 		</member>
 		<member name="linear_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+			The stiffness of the spring along the Y axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a more rigid spring, which more strongly resists being compressed or stretched away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+			The amount of damping applied to Z linear velocity when a joint drive acts as a spring along the Z axis. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the spring returns to its equilibrium point, preventing oscillations or rapid movement. Lower values make the spring more elastic or bouncy.
 		</member>
 		<member name="linear_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+			If [code]true[/code], then there is a linear spring on the Z axis. More generally, the joint's Z axis will have a joint drive that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</member>
 		<member name="linear_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The equilibrium point of the spring in meters along the Z axis.
 		</member>
 		<member name="linear_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+			The stiffness of the spring along the Z axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a more rigid spring, which more strongly resists being compressed or stretched away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_LINEAR_LOWER_LIMIT" value="0" enum="Param">
-			The minimum difference between the pivot points' axes.
+			The maximum distance in meters in the negative direction that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper limits are set to zero, the joint is fixed along that axis.
 		</constant>
 		<constant name="PARAM_LINEAR_UPPER_LIMIT" value="1" enum="Param">
-			The maximum difference between the pivot points' axes.
+			The maximum distance in meters in the positive direction that connected bodies may freely move without the limit applying stiffness force to bring them back within the lower and upper limits. If both the lower and upper limits are set to zero, the joint is fixed along that axis.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_SOFTNESS" value="2" enum="Param">
-			A factor applied to the movement across the axes. The lower, the slower the movement.
+			The stiffness factor applied to movement beyond the linear limit along the Y axis. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a harder limit, which more strongly resists movement beyond the limit. Lower values make the limit softer and more flexible.
 		</constant>
 		<constant name="PARAM_LINEAR_RESTITUTION" value="3" enum="Param">
-			The amount of restitution on the axes' movement. The lower, the more momentum gets lost.
+			The amount of restitution on the axes' movement. The lower, the more momentum gets lost. Restitution is a dimensionless value.
 		</constant>
 		<constant name="PARAM_LINEAR_DAMPING" value="4" enum="Param">
-			The amount of damping that happens at the linear motion across the axes.
+			The amount of damping applied to linear velocity when a joint is moved beyond the linear limit. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_LINEAR_MOTOR_TARGET_VELOCITY" value="5" enum="Param">
-			The velocity the linear motor will try to reach.
+			The speed that the linear motor will attempt to reach on the axes.
 		</constant>
 		<constant name="PARAM_LINEAR_MOTOR_FORCE_LIMIT" value="6" enum="Param">
-			The maximum force the linear motor will apply while trying to reach the velocity target.
+			The maximum force the linear motor can apply on the axes while trying to reach the target velocity.
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_STIFFNESS" value="7" enum="Param">
+			The stiffness of the spring in linear directions. It is measured in N/m, or kg/s² in SI base units.
+			Higher linear stiffness results in a more rigid spring, which more strongly resists being compressed or stretched away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_DAMPING" value="8" enum="Param">
+			The amount of damping applied to linear velocity when a joint drive acts as a spring. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the spring returns to its equilibrium point, preventing oscillations or rapid movement. Lower values make the spring more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT" value="9" enum="Param">
+			The equilibrium point of the spring in linear directions. It is measured in meters.
 		</constant>
 		<constant name="PARAM_ANGULAR_LOWER_LIMIT" value="10" enum="Param">
-			The minimum rotation in negative direction to break loose and rotate around the axes.
+			The maximum rotation in radians in the negative direction that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper limits are set to zero, the joint is fixed around that axis.
 		</constant>
 		<constant name="PARAM_ANGULAR_UPPER_LIMIT" value="11" enum="Param">
-			The minimum rotation in positive direction to break loose and rotate around the axes.
+			The maximum rotation in radians in the positive direction that connected bodies may freely rotate without the limit applying stiffness torque to bring them back within the lower and upper limits. If both the lower and upper limits are set to zero, the joint is fixed around that axis.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_SOFTNESS" value="12" enum="Param">
-			The speed of all rotations across the axes.
+			The stiffness factor applied to rotation beyond the angular limit. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
 		</constant>
 		<constant name="PARAM_ANGULAR_DAMPING" value="13" enum="Param">
-			The amount of rotational damping across the axes. The lower, the more damping occurs.
+			The amount of damping applied to angular velocity when a joint is rotated beyond the angular limit. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
+			Higher angular damping results in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the joint returns to its angular limit. Lower values make the joint more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_ANGULAR_RESTITUTION" value="14" enum="Param">
-			The amount of rotational restitution across the axes. The lower, the more restitution occurs.
+			The amount of rotational restitution. The lower, the more restitution occurs. Restitution is a dimensionless value.
 		</constant>
 		<constant name="PARAM_ANGULAR_FORCE_LIMIT" value="15" enum="Param">
-			The maximum amount of force that can occur, when rotating around the axes.
+			The maximum amount of torque (angular force) that the limit can apply to angular velocity. It is measured in Nm, or kg·m²/s² in SI base units.
 		</constant>
 		<constant name="PARAM_ANGULAR_ERP" value="16" enum="Param">
 			When rotating across the axes, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</constant>
 		<constant name="PARAM_ANGULAR_MOTOR_TARGET_VELOCITY" value="17" enum="Param">
-			Target speed for the motor at the axes.
+			Target speed for the angular motor in radians per second.
 		</constant>
 		<constant name="PARAM_ANGULAR_MOTOR_FORCE_LIMIT" value="18" enum="Param">
-			Maximum acceleration for the motor at the axes.
+			The maximum amount of torque (angular force) that the motor can apply to angular velocity. It is measured in Nm, or kg·m²/s² in SI base units.
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_STIFFNESS" value="19" enum="Param">
+			The stiffness of the spring around the axes. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a more rigid spring, which more strongly resists being bent away from its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_DAMPING" value="20" enum="Param">
+			The amount of damping applied to angular velocity when a joint drive acts as a spring. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
+			Higher angular damping results in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the spring returns to its equilibrium point. Lower values make the spring more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT" value="21" enum="Param">
+			The equilibrium point of the spring around the axes. It is measured in radians.
 		</constant>
 		<constant name="PARAM_MAX" value="22" enum="Param">
 			Represents the size of the [enum Param] enum.
 		</constant>
 		<constant name="FLAG_ENABLE_LINEAR_LIMIT" value="0" enum="Flag">
-			If enabled, linear motion is possible within the given limits.
+			If enabled for some or all axes, linear motion across these axes is limited.
 		</constant>
 		<constant name="FLAG_ENABLE_ANGULAR_LIMIT" value="1" enum="Flag">
-			If enabled, rotational motion is possible within the given limits.
+			If enabled for some or all axes, rotation across these axes is limited.
 		</constant>
 		<constant name="FLAG_ENABLE_LINEAR_SPRING" value="3" enum="Flag">
+			If enabled for some or all axes, there is a linear spring across these axes. More generally, the joint's linear motion along these axes will have a spring that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</constant>
 		<constant name="FLAG_ENABLE_ANGULAR_SPRING" value="2" enum="Flag">
+			If enabled for some or all axes, there is an angular spring across these axes. More generally, the joint's rotation around these axes will have a spring that targets the equilibrium point and attempts to move towards it with the given stiffness and damping values.
 		</constant>
 		<constant name="FLAG_ENABLE_MOTOR" value="4" enum="Flag">
-			If enabled, there is a rotational motor across these axes.
+			If enabled for some or all axes, there is a rotational or angular motor across these axes. More generally, the joint's rotation around these axes will have a joint drive that targets the given angular velocity and tries to reach it while staying within the force limits.
 		</constant>
 		<constant name="FLAG_ENABLE_LINEAR_MOTOR" value="5" enum="Flag">
-			If enabled, there is a linear motor across these axes.
+			If enabled for some or all axes, there is a linear motor across these axes. More generally, the joint's linear motion along these axes will have a joint drive that targets the given linear velocity and tries to reach it while staying within the force limits.
 		</constant>
 		<constant name="FLAG_MAX" value="6" enum="Flag">
 			Represents the size of the [enum Flag] enum.

--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -51,9 +51,12 @@
 			The minimum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
 		</member>
 		<member name="angular_limit/relaxation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The lower this value, the more the rotation gets slowed down.
+			The amount of relaxation, or inverse damping, applied to angular velocity when the hinge is rotated beyond the angular limit around the Z axis. It is measured in rad/N/m/s, or rad·s/kg/m² in SI base units. Unlike most joints in Godot which use damping, HingeJoint3D uses inverse damping (relaxation), so higher values result in less damping and lower values result in more damping.
+			Higher relaxation values make the joint more elastic or bouncy. Lower values result in a smoother, more gradual reduction in angular velocity, preventing oscillations or rapid rotation as the joint returns to its angular limit.
 		</member>
 		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="0.9" deprecated="This property is never set by the engine and is kept for compatibility purposes.">
+			The stiffness factor applied to rotation beyond the hinge's angular limit around the Z axis. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
+			Higher angular stiffness results in a harder limit, which more strongly resists rotation beyond the limit. Lower values make the limit softer and more flexible.
 		</member>
 		<member name="angular_limit/upper" type="float" setter="set_param" getter="get_param" default="1.5707964">
 			The maximum rotation. Only active if [member angular_limit/enable] is [code]true[/code].

--- a/doc/classes/PinJoint2D.xml
+++ b/doc/classes/PinJoint2D.xml
@@ -25,7 +25,7 @@
 			Target speed for the motor. In radians per second.
 		</member>
 		<member name="softness" type="float" setter="set_softness" getter="get_softness" default="0.0">
-			The higher this value, the more the bond to the pinned partner can flex.
+			The higher this value, the more the bond to the pinned partner can flex. Lower values are stiffer, while higher values are softer. It is measured in s²/kg.
 		</member>
 	</members>
 </class>

--- a/doc/classes/PinJoint3D.xml
+++ b/doc/classes/PinJoint3D.xml
@@ -30,10 +30,11 @@
 			The force with which the pinned objects stay in positional relation to each other. The higher, the stronger.
 		</member>
 		<member name="params/damping" type="float" setter="set_param" getter="get_param" default="1.0">
-			The force with which the pinned objects stay in velocity relation to each other. The higher, the stronger.
+			The amount of damping applied to linear velocity. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</member>
 		<member name="params/impulse_clamp" type="float" setter="set_param" getter="get_param" default="0.0">
-			If above 0, this value is the maximum value for an impulse that this Joint3D produces.
+			If above 0, this value is the maximum value for an impulse that this Joint3D produces. It is measured in N·s, or kg·m/s in SI base units.
 		</member>
 	</members>
 	<constants>
@@ -41,10 +42,11 @@
 			The force with which the pinned objects stay in positional relation to each other. The higher, the stronger.
 		</constant>
 		<constant name="PARAM_DAMPING" value="1" enum="Param">
-			The force with which the pinned objects stay in velocity relation to each other. The higher, the stronger.
+			The amount of damping applied to linear velocity. It is measured in N·s/m, or kg/s in SI base units.
+			Higher linear damping results in a more gradual reduction in linear velocity, creating smoother, gentler behavior as the joint returns to its limit, preventing oscillations or rapid movement. Lower values make the joint more elastic or bouncy.
 		</constant>
 		<constant name="PARAM_IMPULSE_CLAMP" value="2" enum="Param">
-			If above 0, this value is the maximum value for an impulse that this Joint3D produces.
+			If above 0, this value is the maximum value for an impulse that this Joint3D produces. It is measured in N·s, or kg·m/s in SI base units.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -27,40 +27,37 @@
 	</methods>
 	<members>
 		<member name="angular_limit/damping" type="float" setter="set_param" getter="get_param" default="0.0">
-			The amount of damping of the rotation when the limit is surpassed.
-			A lower damping value allows a rotation initiated by body A to travel to body B slower.
+			The amount of damping of the rotation when the limit is surpassed. A lower damping value allows a rotation initiated by body A to travel to body B slower. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_limit/lower_angle" type="float" setter="set_param" getter="get_param" default="0.0">
 			The lower limit of rotation in the slider.
 		</member>
 		<member name="angular_limit/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution of the rotation when the limit is surpassed.
-			Does not affect damping.
+			The amount of restitution of the rotation when the limit is surpassed. Does not affect damping. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the all rotation once the limit is surpassed.
-			Makes all rotation slower when between 0 and 1.
+			The stiffness factor applied to the all rotation once the limit is surpassed. Makes all rotation slower when between 0 and 1. Lower values are softer, while higher values are stiffer. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
 		</member>
 		<member name="angular_limit/upper_angle" type="float" setter="set_param" getter="get_param" default="0.0">
 			The upper limit of rotation in the slider.
 		</member>
 		<member name="angular_motion/damping" type="float" setter="set_param" getter="get_param" default="1.0">
-			The amount of damping of the rotation in the limits.
+			The amount of damping of the rotation in the limits. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_motion/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution of the rotation in the limits.
+			The amount of restitution of the rotation in the limits. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_motion/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the all rotation in the limits.
+			The stiffness factor applied to the all rotation in the limits. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
 		</member>
 		<member name="angular_ortho/damping" type="float" setter="set_param" getter="get_param" default="1.0">
-			The amount of damping of the rotation across axes orthogonal to the slider.
+			The amount of damping of the rotation across axes orthogonal to the slider. It is measured in N·m·s/rad, or kg·m²/s/rad in SI base units.
 		</member>
 		<member name="angular_ortho/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution of the rotation across axes orthogonal to the slider.
+			The amount of restitution of the rotation across axes orthogonal to the slider. Restitution is a dimensionless value.
 		</member>
 		<member name="angular_ortho/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the all rotation across axes orthogonal to the slider.
+			The stiffness factor applied to the all rotation across axes orthogonal to the slider. It is measured in N·m/rad, or kg·m²/s²/rad in SI base units.
 		</member>
 		<member name="linear_limit/damping" type="float" setter="set_param" getter="get_param" default="1.0">
 			The amount of damping that happens once the limit defined by [member linear_limit/lower_distance] and [member linear_limit/upper_distance] is surpassed.
@@ -69,31 +66,31 @@
 			The minimum difference between the pivot points on their X axis before damping happens.
 		</member>
 		<member name="linear_limit/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
+			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_limit/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
+			The stiffness factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement. It is measured in N/m, or kg/s² in SI base units.
 		</member>
 		<member name="linear_limit/upper_distance" type="float" setter="set_param" getter="get_param" default="1.0">
 			The maximum difference between the pivot points on their X axis before damping happens.
 		</member>
 		<member name="linear_motion/damping" type="float" setter="set_param" getter="get_param" default="0.0">
-			The amount of damping inside the slider limits.
+			The amount of damping inside the slider limits. It is measured in N·s/m, or kg/s in SI base units.
 		</member>
 		<member name="linear_motion/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution inside the slider limits.
+			The amount of restitution inside the slider limits. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_motion/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the movement across the slider axis as long as the slider is in the limits. The lower, the slower the movement.
+			The stiffness factor applied to the movement across the slider axis as long as the slider is in the limits. The lower, the slower the movement. It is measured in N/m, or kg/s² in SI base units.
 		</member>
 		<member name="linear_ortho/damping" type="float" setter="set_param" getter="get_param" default="1.0">
-			The amount of damping when movement is across axes orthogonal to the slider.
+			The amount of damping when movement is across axes orthogonal to the slider. It is measured in N·s/m, or kg/s in SI base units.
 		</member>
 		<member name="linear_ortho/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
-			The amount of restitution when movement is across axes orthogonal to the slider.
+			The amount of restitution when movement is across axes orthogonal to the slider. Restitution is a dimensionless value.
 		</member>
 		<member name="linear_ortho/softness" type="float" setter="set_param" getter="get_param" default="1.0">
-			A factor applied to the movement across axes orthogonal to the slider.
+			The stiffness factor applied to the movement across axes orthogonal to the slider. Lower values are softer, while higher values are stiffer. It is measured in N/m, or kg/s² in SI base units.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/physics/joints/damped_spring_joint_2d.cpp
+++ b/scene/2d/physics/joints/damped_spring_joint_2d.cpp
@@ -123,8 +123,8 @@ void DampedSpringJoint2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "1,65535,1,exp,suffix:px"), "set_length", "get_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rest_length", PROPERTY_HINT_RANGE, "0,65535,1,exp,suffix:px"), "set_rest_length", "get_rest_length");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stiffness", PROPERTY_HINT_RANGE, "0.1,64,0.1,exp"), "set_stiffness", "get_stiffness");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0.01,16,0.01,exp"), "set_damping", "get_damping");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stiffness", PROPERTY_HINT_RANGE, U"0.1,64,0.1,exp,suffix:kg/s\u00B2"), "set_stiffness", "get_stiffness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0.01,16,0.01,exp,suffix:kg/s"), "set_damping", "get_damping");
 }
 
 DampedSpringJoint2D::DampedSpringJoint2D() {

--- a/scene/2d/physics/joints/pin_joint_2d.cpp
+++ b/scene/2d/physics/joints/pin_joint_2d.cpp
@@ -166,7 +166,7 @@ void PinJoint2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_angular_limit_enabled", "enabled"), &PinJoint2D::set_angular_limit_enabled);
 	ClassDB::bind_method(D_METHOD("is_angular_limit_enabled"), &PinJoint2D::is_angular_limit_enabled);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "softness", PROPERTY_HINT_RANGE, "0.00,16,0.01,exp"), "set_softness", "get_softness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "softness", PROPERTY_HINT_RANGE, U"0.00,16,0.01,exp,suffix:s\u00B2/kg"), "set_softness", "get_softness");
 	ADD_GROUP("Angular Limit", "angular_limit_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "angular_limit_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_angular_limit_enabled", "is_angular_limit_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_angular_limit_lower", "get_angular_limit_lower");

--- a/scene/3d/physics/joints/cone_twist_joint_3d.cpp
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.cpp
@@ -40,8 +40,8 @@ void ConeTwistJoint3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_TWIST_SPAN);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_BIAS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "relaxation", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_RELAXATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N\u22C5m/rad"), "set_param", "get_param", PARAM_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "relaxation", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:rad\u22C5s/kg/m\u00B2 (rad/N/m/s) (inverse damping)"), "set_param", "get_param", PARAM_RELAXATION);
 
 	BIND_ENUM_CONSTANT(PARAM_SWING_SPAN);
 	BIND_ENUM_CONSTANT(PARAM_TWIST_SPAN);

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
@@ -56,23 +56,23 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/upper_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_x", "get_param_x", PARAM_LINEAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/lower_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_x", "get_param_x", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N/m (kg/s\u00B2)"), "set_param_x", "get_param_x", PARAM_LINEAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param_x", "get_param_x", PARAM_LINEAR_DAMPING);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/upper_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_y", "get_param_y", PARAM_LINEAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/lower_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_y", "get_param_y", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N/m (kg/s\u00B2)"), "set_param_y", "get_param_y", PARAM_LINEAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param_y", "get_param_y", PARAM_LINEAR_DAMPING);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/upper_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_z", "get_param_z", PARAM_LINEAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/lower_distance", PROPERTY_HINT_NONE, "suffix:m"), "set_param_z", "get_param_z", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N/m (kg/s\u00B2)"), "set_param_z", "get_param_z", PARAM_LINEAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param_z", "get_param_z", PARAM_LINEAR_DAMPING);
 
 	ADD_GROUP("Linear Motor", "linear_motor_");
 
@@ -91,18 +91,18 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ADD_GROUP("Linear Spring", "linear_spring_");
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/stiffness"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/damping"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/stiffness", PROPERTY_HINT_NONE, U"suffix:N/m (kg/s\u00B2)"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5s/m (kg/s)"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/equilibrium_point", PROPERTY_HINT_NONE, "suffix:m"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/stiffness"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/damping"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/stiffness", PROPERTY_HINT_NONE, U"suffix:N/m (kg/s\u00B2)"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5s/m (kg/s)"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/equilibrium_point", PROPERTY_HINT_NONE, "suffix:m"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/stiffness"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/damping"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/stiffness", PROPERTY_HINT_NONE, U"suffix:N/m (kg/s\u00B2)"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5s/m (kg/s)"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/equilibrium_point", PROPERTY_HINT_NONE, "suffix:m"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
 
 	ADD_GROUP("Angular Limit", "angular_limit_");
@@ -110,27 +110,27 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_x", "get_param_x", PARAM_ANGULAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_x", "get_param_x", PARAM_ANGULAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m/rad"), "set_param_x", "get_param_x", PARAM_ANGULAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_x", "get_param_x", PARAM_ANGULAR_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/force_limit", PROPERTY_HINT_NONE, U"suffix:kg\u22C5m\u00B2/s\u00B2 (Nm)"), "set_param_x", "get_param_x", PARAM_ANGULAR_FORCE_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/erp"), "set_param_x", "get_param_x", PARAM_ANGULAR_ERP);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_y", "get_param_y", PARAM_ANGULAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_y", "get_param_y", PARAM_ANGULAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m/rad"), "set_param_y", "get_param_y", PARAM_ANGULAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_y", "get_param_y", PARAM_ANGULAR_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/force_limit", PROPERTY_HINT_NONE, U"suffix:kg\u22C5m\u00B2/s\u00B2 (Nm)"), "set_param_y", "get_param_y", PARAM_ANGULAR_FORCE_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/erp"), "set_param_y", "get_param_y", PARAM_ANGULAR_ERP);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_z", "get_param_z", PARAM_ANGULAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_z", "get_param_z", PARAM_ANGULAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m/rad"), "set_param_z", "get_param_z", PARAM_ANGULAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/damping", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_z", "get_param_z", PARAM_ANGULAR_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/force_limit", PROPERTY_HINT_NONE, U"suffix:kg\u22C5m\u00B2/s\u00B2 (Nm)"), "set_param_z", "get_param_z", PARAM_ANGULAR_FORCE_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/erp"), "set_param_z", "get_param_z", PARAM_ANGULAR_ERP);
 
@@ -151,18 +151,18 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ADD_GROUP("Angular Spring", "angular_spring_");
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/stiffness"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/damping"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/stiffness", PROPERTY_HINT_NONE, U"suffix:N\u22C5m/rad"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/equilibrium_point", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/stiffness"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/damping"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/stiffness", PROPERTY_HINT_NONE, U"suffix:N\u22C5m/rad"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/equilibrium_point", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/stiffness"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/damping"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/stiffness", PROPERTY_HINT_NONE, U"suffix:N\u22C5m/rad"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/damping", PROPERTY_HINT_NONE, U"suffix:N\u22C5m\u22C5s/rad (kg\u22C5m\u00B2/s/rad)"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/equilibrium_point", PROPERTY_HINT_RANGE, "-180,180,0.01,radians_as_degrees"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LOWER_LIMIT);

--- a/scene/3d/physics/joints/hinge_joint_3d.cpp
+++ b/scene/3d/physics/joints/hinge_joint_3d.cpp
@@ -45,8 +45,8 @@ void HingeJoint3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/upper", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_LIMIT_UPPER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/lower", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_LIMIT_LOWER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_LIMIT_BIAS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/relaxation", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_RELAXATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:N\u22C5m/rad"), "set_param", "get_param", PARAM_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/relaxation", PROPERTY_HINT_RANGE, U"0.01,16,0.01,suffix:rad/N/m/s (rad\u22C5s/kg/m\u00B2) (inverse damping)"), "set_param", "get_param", PARAM_LIMIT_RELAXATION);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "motor/enable"), "set_flag", "get_flag", FLAG_ENABLE_MOTOR);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "motor/target_velocity", PROPERTY_HINT_RANGE, U"-200,200,0.01,or_greater,or_less,radians_as_degrees,suffix:\u00B0/s"), "set_param", "get_param", PARAM_MOTOR_TARGET_VELOCITY);

--- a/scene/3d/physics/joints/pin_joint_3d.cpp
+++ b/scene/3d/physics/joints/pin_joint_3d.cpp
@@ -37,8 +37,8 @@ void PinJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &PinJoint3D::get_param);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"), "set_param", "get_param", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"), "set_param", "get_param", PARAM_IMPULSE_CLAMP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/damping", PROPERTY_HINT_RANGE, U"0.01,8.0,0.01,suffix:N\u22C5s/m"), "set_param", "get_param", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/impulse_clamp", PROPERTY_HINT_RANGE, U"0.0,64.0,0.01,suffix:N\u22C5s"), "set_param", "get_param", PARAM_IMPULSE_CLAMP);
 
 	BIND_ENUM_CONSTANT(PARAM_BIAS);
 	BIND_ENUM_CONSTANT(PARAM_DAMPING);

--- a/scene/3d/physics/joints/slider_joint_3d.cpp
+++ b/scene/3d/physics/joints/slider_joint_3d.cpp
@@ -38,27 +38,27 @@ void SliderJoint3D::_bind_methods() {
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/upper_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01,suffix:m"), "set_param", "get_param", PARAM_LINEAR_LIMIT_UPPER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/lower_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01,suffix:m"), "set_param", "get_param", PARAM_LINEAR_LIMIT_LOWER);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N/m (kg/s\u00B2)"), "set_param", "get_param", PARAM_LINEAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param", "get_param", PARAM_LINEAR_LIMIT_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N/m (kg/s\u00B2)"), "set_param", "get_param", PARAM_LINEAR_MOTION_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param", "get_param", PARAM_LINEAR_MOTION_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N/m (kg/s\u00B2)"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5s/m (kg/s)"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_DAMPING);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_UPPER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_LOWER);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N\u22C5m/rad"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5m\u22C5s/rad"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N\u22C5m/rad"), "set_param", "get_param", PARAM_ANGULAR_MOTION_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5m\u22C5s/rad"), "set_param", "get_param", PARAM_ANGULAR_MOTION_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/softness", PROPERTY_HINT_RANGE, U"0.01,16.0,0.01,suffix:N\u22C5m/rad"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_SOFTNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/damping", PROPERTY_HINT_RANGE, U"0,16.0,0.01,suffix:N\u22C5m\u22C5s/rad"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_DAMPING);
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_UPPER);
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_LOWER);


### PR DESCRIPTION
Similar to what #94862 does for VehicleWheel3D, this PR adds units for the Joint2D/3D-derived nodes.

General info on stiffness and damping in metric:

- Stiffness is measured in different units depending on the type of stiffness. For linear stiffness, it is measured in Newtons per meter, or kg/s² in SI base units. For angular stiffness, it is measured in Newton-meters per radian, or kg⋅m²/s²/rad in SI base units. This difference is because linear stiffness involves force divided by distance (N / m), while angular stiffness involves torque divided by angle (N⋅m / rad).

- Damping is measured in different units depending on the type of damping. For linear damping, it is measured in Newton-seconds per meter, or kg/s in SI base units. For angular damping, it is measured in Newton-meter-seconds per radian, or kg⋅m²/s/rad in SI base units. This difference is because linear damping involves impulse divided by distance (N⋅s / m), while angular damping involves torque-impulse divided by angle (N⋅m⋅s / rad).

Godot-specific info:

- The "softness" property in 3D is incorrectly named, it's actually stiffness. We should rename this in the future.

- The "softness" property in PinJoint2D is actually softness, *inverse* stiffness, so it's s²/kg instead of kg/s². This may be worth replacing in the future for consistency with other joints using stiffness. The conversion is `1.0 / softness == stiffness` and `1.0 / stiffness == softness`.

- The "relaxation" property on HingeJoint3D and ConeTwistJoint3D is *inverse* damping, so it's rad⋅s/kg/m² or rad/N/m/s. This may be worth replacing in the future for consistency with other joints using damping. The conversion is `1.0 / relaxation == damping` and `1.0 / damping == relaxation`.

EDIT: This screenshot is outdated, it now prioritizes the Newton-based units as requested by @akien-mga.

<img width="300" alt="Screenshot 2024-09-03 at 4 48 29 AM" src="https://github.com/user-attachments/assets/1b9ab561-757a-4173-a666-84342b3b8b23">
