### PR TITLE
Add method to get current stream(s) from interactive audio classes

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1023,7 +1023,30 @@ bool AudioStreamPlaybackInteractive::is_playing() const {
 	return active;
 }
 
+Vector<Ref<AudioStream>> AudioStreamPlaybackInteractive::get_playing_streams() const {
+	Vector<Ref<AudioStream>> playing_streams = Vector<Ref<AudioStream>>();
+	if (active) {
+		for (int i = 0; i < AudioStreamInteractive::MAX_CLIPS; i++) {
+			if (states[i].playback.is_valid() && states[i].playback->is_playing()) {
+				playing_streams.push_back(states[i].stream);
+			}
+		}
+	}
+	return playing_streams;
+}
+
+TypedArray<AudioStream> AudioStreamPlaybackInteractive::_get_playing_streams() const {
+	TypedArray<AudioStream> ret;
+	Vector<Ref<AudioStream>> streams = get_playing_streams();
+	int streams_amount = streams.size();
+	for (int i = 0; i < streams_amount; i++) {
+		ret.push_back(streams[i]);
+	}
+	return ret;
+}
+
 void AudioStreamPlaybackInteractive::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("switch_to_clip_by_name", "clip_name"), &AudioStreamPlaybackInteractive::switch_to_clip_by_name);
 	ClassDB::bind_method(D_METHOD("switch_to_clip", "clip_index"), &AudioStreamPlaybackInteractive::switch_to_clip);
+	ClassDB::bind_method(D_METHOD("get_playing_streams"), &AudioStreamPlaybackInteractive::_get_playing_streams);
 }

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -241,6 +241,8 @@ private:
 
 	void _queue(int p_to_clip_index, bool p_is_auto_advance);
 
+	TypedArray<AudioStream> _get_playing_streams() const;
+
 	int switch_request = -1;
 
 protected:
@@ -252,6 +254,7 @@ public:
 	virtual bool is_playing() const override;
 	virtual int get_loop_count() const override; // times it looped
 	virtual double get_playback_position() const override;
+	Vector<Ref<AudioStream>> get_playing_streams() const;
 	virtual void seek(double p_time) override;
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -390,6 +390,14 @@ bool AudioStreamPlaybackPlaylist::is_playing() const {
 	return active;
 }
 
+Ref<AudioStream> AudioStreamPlaybackPlaylist::get_playing_stream() const {
+	if (active) {
+		return playlist->audio_streams[play_order[play_index]];
+	}
+
+	return nullptr;
+}
+
 void AudioStreamPlaybackPlaylist::_update_playback_instances() {
 	stop();
 
@@ -400,4 +408,8 @@ void AudioStreamPlaybackPlaylist::_update_playback_instances() {
 			playback[i].unref();
 		}
 	}
+}
+
+void AudioStreamPlaybackPlaylist::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_playing_stream"), &AudioStreamPlaybackPlaylist::get_playing_stream);
 }

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -108,12 +108,16 @@ private:
 
 	void _update_playback_instances();
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 	virtual int get_loop_count() const override; // times it looped
 	virtual double get_playback_position() const override;
+	Ref<AudioStream> get_playing_stream() const;
 	virtual void seek(double p_time) override;
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -296,6 +296,29 @@ bool AudioStreamPlaybackSynchronized::is_playing() const {
 	return active;
 }
 
+Vector<Ref<AudioStream>> AudioStreamPlaybackSynchronized::get_playing_streams() const {
+	Vector<Ref<AudioStream>> playing_streams = Vector<Ref<AudioStream>>();
+
+	if (active) {
+		for (int i = 0; i < stream->stream_count; i++) {
+			if (playback[i].is_valid() && playback[i]->is_playing()) {
+				playing_streams.push_back(stream->audio_streams[i]);
+			}
+		}
+	}
+	return playing_streams;
+}
+
+TypedArray<AudioStream> AudioStreamPlaybackSynchronized::_get_playing_streams() const {
+	TypedArray<AudioStream> ret;
+	Vector<Ref<AudioStream>> streams = get_playing_streams();
+	int streams_amount = streams.size();
+	for (int i = 0; i < streams_amount; i++) {
+		ret.push_back(streams[i]);
+	}
+	return ret;
+}
+
 void AudioStreamPlaybackSynchronized::_update_playback_instances() {
 	stop();
 
@@ -306,4 +329,8 @@ void AudioStreamPlaybackSynchronized::_update_playback_instances() {
 			playback[i].unref();
 		}
 	}
+}
+
+void AudioStreamPlaybackSynchronized::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_playing_streams"), &AudioStreamPlaybackSynchronized::_get_playing_streams);
 }

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -101,12 +101,18 @@ private:
 
 	void _update_playback_instances();
 
+	TypedArray<AudioStream> _get_playing_streams() const;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 	virtual int get_loop_count() const override; // times it looped
 	virtual double get_playback_position() const override;
+	Vector<Ref<AudioStream>> get_playing_streams() const;
 	virtual void seek(double p_time) override;
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_playing_streams" qualifiers="const">
+			<return type="AudioStream[]" />
+			<description>
+				Returns all streams currently playing.
+			</description>
+		</method>
 		<method name="switch_to_clip">
 			<return type="void" />
 			<param index="0" name="clip_index" type="int" />

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
@@ -7,4 +7,12 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_playing_stream" qualifiers="const">
+			<return type="AudioStream" />
+			<description>
+				Returns the currently playing stream from the playlist.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackSynchronized" inherits="AudioStreamPlayback" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Playback component of [AudioStreamSynchronized].
 	</brief_description>
 	<description>
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_playing_streams" qualifiers="const">
+			<return type="AudioStream[]" />
+			<description>
+				Returns all streams currently playing.
+			</description>
+		</method>
+	</methods>
 </class>


### PR DESCRIPTION
Related to godotengine/godot-proposals#3307 and #88437 

Adds simple methods that return all relevant audio streams that are playing on a playback. This is useful for metadata, e.g. displaying a "now playing" from a playlist
