### PR TITLE
Generate thumbnails on imported scenes.

### DIFF
--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -79,6 +79,7 @@ class EditorInterface : public Object {
 	// Editor tools.
 
 	TypedArray<Texture2D> _make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size);
+	AABB _calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb);
 
 protected:
 	static void _bind_methods();
@@ -107,6 +108,7 @@ public:
 	EditorUndoRedoManager *get_editor_undo_redo() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
+	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
 
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -147,6 +147,10 @@ void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, con
 
 		if (!p_path.begins_with("ID:")) {
 			modified_time = FileAccess::get_modified_time(p_path);
+			String import_path = p_path + ".import";
+			if (FileAccess::exists(import_path)) {
+				modified_time = MAX(modified_time, FileAccess::get_modified_time(import_path));
+			}
 		}
 
 		Item item;
@@ -237,7 +241,14 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			}
 			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE);
 			ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + cache_base + ".txt'. Check user write permissions.");
-			_write_preview_cache(f, thumbnail_size, has_small_texture, FileAccess::get_modified_time(p_item.path), FileAccess::get_md5(p_item.path), p_metadata);
+
+			uint64_t modtime = FileAccess::get_modified_time(p_item.path);
+			String import_path = p_item.path + ".import";
+			if (FileAccess::exists(import_path)) {
+				modtime = MAX(modtime, FileAccess::get_modified_time(import_path));
+			}
+
+			_write_preview_cache(f, thumbnail_size, has_small_texture, modtime, FileAccess::get_md5(p_item.path), p_metadata);
 		}
 	}
 
@@ -298,6 +309,11 @@ void EditorResourcePreview::_iterate() {
 		_generate_preview(texture, small_texture, item, cache_base, preview_metadata);
 	} else {
 		uint64_t modtime = FileAccess::get_modified_time(item.path);
+		String import_path = item.path + ".import";
+		if (FileAccess::exists(import_path)) {
+			modtime = MAX(modtime, FileAccess::get_modified_time(import_path));
+		}
+
 		int tsize;
 		bool has_small_texture;
 		uint64_t last_modtime;
@@ -513,6 +529,11 @@ void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 
 		if (cache.has(p_path)) {
 			uint64_t modified_time = FileAccess::get_modified_time(p_path);
+			String import_path = p_path + ".import";
+			if (FileAccess::exists(import_path)) {
+				modified_time = MAX(modified_time, FileAccess::get_modified_time(import_path));
+			}
+
 			if (modified_time != cache[p_path].modified_time) {
 				cache.erase(p_path);
 				call_invalidated = true;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/resource_saver.h"
 #include "core/object/script_language.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/import/3d/scene_import_settings.h"
@@ -2814,6 +2815,15 @@ void ResourceImporterScene::_optimize_track_usage(AnimationPlayer *p_player, Ani
 	}
 }
 
+void ResourceImporterScene::_generate_editor_preview_for_scene(const String &p_path, Node *p_scene) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	ERR_FAIL_COND_MSG(p_path.is_empty(), "Path is empty, cannot generate preview.");
+	ERR_FAIL_NULL_MSG(p_scene, "Scene is null, cannot generate preview.");
+	EditorInterface::get_singleton()->make_scene_preview(p_path, p_scene, 1024);
+}
+
 Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashMap<StringName, Variant> &p_options) {
 	Ref<EditorSceneFormatImporter> importer;
 	String ext = p_source_file.get_extension().to_lower();
@@ -3164,6 +3174,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
 		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
+		_generate_editor_preview_for_scene(p_source_file, scene);
 	} else {
 		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown scene import type: " + _scene_import_type);
 	}

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -236,6 +236,7 @@ class ResourceImporterScene : public ResourceImporter {
 	};
 
 	void _optimize_track_usage(AnimationPlayer *p_player, AnimationImportTracks *p_track_actions);
+	void _generate_editor_preview_for_scene(const String &p_path, Node *p_scene);
 
 	String _scene_import_type = "PackedScene";
 


### PR DESCRIPTION
![godot windows editor dev x86_64_OmkGxF9AY3](https://github.com/user-attachments/assets/3495e83a-22c5-4a92-82a4-42d0fc5e627e)

Ends a somewhat long-standing discontinuity of the imported scenes (FBX, GLTF, Collada, ect.) not having any thumbnail previews like regular Godot scenes. It does this by providing a hook step where they can be generated and cached upon reimport.

Keeping this in draft for now since it could probably benefit from further refactoring, improving bounds calculations for skinned meshes, and adding displayable gizmos for the cases where no mesh instances could be found (animation or collision-only imports, for example).

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8760.*