### PR TITLE
Document use of pre-calculated triangulation when drawing polygons

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -96,6 +96,7 @@
 			<param index="3" name="texture" type="Texture2D" default="null" />
 			<description>
 				Draws a colored polygon of any number of points, convex or concave. Unlike [method draw_polygon], a single color must be specified for the whole polygon.
+				[b]Note:[/b] If you frequently redraw the same polygon with a large number of vertices, consider pre-calculating the triangulation with [method Geometry2D.triangulate_polygon] and using [method draw_mesh], [method draw_multimesh], or [method RenderingServer.canvas_item_add_triangle_array].
 			</description>
 		</method>
 		<method name="draw_dashed_line">
@@ -251,6 +252,7 @@
 			<param index="3" name="texture" type="Texture2D" default="null" />
 			<description>
 				Draws a solid polygon of any number of points, convex or concave. Unlike [method draw_colored_polygon], each point's color can be changed individually. See also [method draw_polyline] and [method draw_polyline_colors]. If you need more flexibility (such as being able to use bones), use [method RenderingServer.canvas_item_add_triangle_array] instead.
+				[b]Note:[/b] If you frequently redraw the same polygon with a large number of vertices, consider pre-calculating the triangulation with [method Geometry2D.triangulate_polygon] and using [method draw_mesh], [method draw_multimesh], or [method RenderingServer.canvas_item_add_triangle_array].
 			</description>
 		</method>
 		<method name="draw_polyline">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -329,6 +329,7 @@
 			<param index="4" name="texture" type="RID" default="RID()" />
 			<description>
 				Draws a 2D polygon on the [CanvasItem] pointed to by the [param item] [RID]. If you need more flexibility (such as being able to use bones), use [method canvas_item_add_triangle_array] instead. See also [method CanvasItem.draw_polygon].
+				[b]Note:[/b] If you frequently redraw the same polygon with a large number of vertices, consider pre-calculating the triangulation with [method Geometry2D.triangulate_polygon] and using [method CanvasItem.draw_mesh], [method CanvasItem.draw_multimesh], or [method canvas_item_add_triangle_array].
 			</description>
 		</method>
 		<method name="canvas_item_add_polyline">


### PR DESCRIPTION
`canvas_item_add_polygon()` triangulates the polygon on each call, unlike `canvas_item_add_triangle_array()`.

https://github.com/godotengine/godot/blob/e2dd56bea7a1aa13fe74fd6eac049e4cbde0434c/servers/rendering/renderer_canvas_cull.cpp#L1623-L1663

Using the latter method or a mesh with pre-calculated triangulation significantly reduces rendering time.

```
draw_colored_polygon()           | 49.446 msec
canvas_item_add_triangle_array() |  2.148 msec
draw_mesh()                      |  0.009 msec
```