### PR TITLE
Use antialiased line drawing in animation Bezier editor

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -174,7 +174,7 @@ void AnimationBezierTrackEdit::_draw_track(int p_track, const Color &p_color) {
 		}
 
 		if (lines.size() >= 2) {
-			draw_multiline(lines, p_color, Math::round(EDSCALE));
+			draw_multiline(lines, p_color, Math::round(EDSCALE), true);
 		}
 	}
 }
@@ -208,7 +208,7 @@ void AnimationBezierTrackEdit::_draw_line_clipped(const Vector2 &p_from, const V
 		from = from.lerp(to, c);
 	}
 
-	draw_line(from, to, p_color, Math::round(EDSCALE));
+	draw_line(from, to, p_color, Math::round(EDSCALE), true);
 }
 
 void AnimationBezierTrackEdit::_notification(int p_what) {


### PR DESCRIPTION
This applies both to tangents and general line drawing, making the animation Bezier editor match the Curve editor inspector. Note that lines may look thicker as a result of how Godot draws antialiased lines, especially at lower editor scales.

I noticed this wasn't being done while testing https://github.com/godotengine/godot/pull/95564 :slightly_smiling_face:

## Preview

### Before

![Before](https://github.com/user-attachments/assets/59442a8b-e40f-46b7-a110-30570a382ea7)

### After

![After](https://github.com/user-attachments/assets/cbc4ac59-cb27-405f-a4a5-7a0d13893dba)