### PR TITLE
[Tests] `create_test` script: Improve argument description and snake_case name conversion

### DIFF
--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -13,12 +13,16 @@ def main():
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
     parser = argparse.ArgumentParser(description="Creates a new unit test file.")
-    parser.add_argument("name", type=str, help="The unit test name in PascalCase notation")
+    parser.add_argument(
+        "name",
+        type=str,
+        help="Specifies the class or component name to be tested, in PascalCase (e.g., MeshInstance3D). The name will be prefixed with 'test_' for the header file and 'Test' for the namespace.",
+    )
     parser.add_argument(
         "path",
         type=str,
         nargs="?",
-        help="The path to the unit test file relative to the tests folder (default: .)",
+        help="The path to the unit test file relative to the tests folder (e.g. core). This should correspond to the relative path of the class or component being tested. (default: .)",
         default=".",
     )
     parser.add_argument(
@@ -29,9 +33,10 @@ def main():
     )
     args = parser.parse_args()
 
-    snake_case_regex = re.compile(r"(?<!^)(?=[A-Z])")
-    name_snake_case = snake_case_regex.sub("_", args.name).lower()
-
+    snake_case_regex = re.compile(r"(?<!^)(?=[A-Z, 0-9])")
+    # Replace 2D, 3D, and 4D with 2d, 3d, and 4d, respectively. This avoids undesired splits like node_3_d.
+    prefiltered_name = re.sub(r"([234])D", lambda match: match.group(1).lower() + "d", args.name)
+    name_snake_case = snake_case_regex.sub("_", prefiltered_name).lower()
     file_path = os.path.normpath(os.path.join(args.path, f"test_{name_snake_case}.h"))
 
     print(file_path)


### PR DESCRIPTION
Certain argument descriptions were a bit misleading/unclear. This PR aims to fix that and makes the script a bit more pleasant to use in general.