### PR TITLE
[Editor] Prevent duplicate `Open in Editor` buttons in scene tree dock

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -491,10 +491,14 @@ void SceneTreeEditor::_update_node_tooltip(Node *p_node, TreeItem *p_item) {
 	String tooltip = p_node->get_name();
 
 	if (p_node == get_scene_node() && p_node->get_scene_inherited_state().is_valid()) {
-		p_item->add_button(0, get_editor_theme_icon(SNAME("InstanceOptions")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		if (p_item->get_button_by_id(0, BUTTON_SUBSCENE) == -1) {
+			p_item->add_button(0, get_editor_theme_icon(SNAME("InstanceOptions")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		}
 		tooltip += String("\n" + TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path());
 	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
-		p_item->add_button(0, get_editor_theme_icon(SNAME("InstanceOptions")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		if (p_item->get_button_by_id(0, BUTTON_SUBSCENE) == -1) {
+			p_item->add_button(0, get_editor_theme_icon(SNAME("InstanceOptions")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		}
 		tooltip += String("\n" + TTR("Instance:") + " " + p_node->get_scene_file_path());
 	}
 


### PR DESCRIPTION
Duplicate buttons were added when editor description changed

Also works with deleting the button before the check but I think this is a bit cleaner (it also has the benefit of ensuring the button stays in place)

Regression from:
* https://github.com/godotengine/godot/pull/82916

* Fixes: https://github.com/godotengine/godot/issues/96567

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
