### PR TITLE
[C#] Fix building with `deprecated=no`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -135,7 +135,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <!-- Compat Sources -->
-  <ItemGroup>
+  <ItemGroup Condition=" '$(GodotNoDeprecated)' == '' ">
     <Compile Include="Compat.cs" />
   </ItemGroup>
   <!--

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -36,7 +36,7 @@
     </ProjectReference>
   </ItemGroup>
   <!-- Compat Sources -->
-  <ItemGroup>
+  <ItemGroup Condition=" '$(GodotNoDeprecated)' == '' ">
     <Compile Include="Compat.cs" />
   </ItemGroup>
   <!--


### PR DESCRIPTION
This fixes [GH-84426](https://github.com/godotengine/godot/issues/84426).

I added the option `--no-deprecated` to `build_assemblies.py`, which needs to be used, if the editor was built with `deprecated=no module_mono_enabled=yes`.

This conditionally disables code in `Compat.cs` which references deprecated classes or functions.