### PR TITLE
[Editor] Don't show popup when clicking empty in Favorites

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3418,6 +3418,11 @@ void FileSystemDock::_file_list_empty_clicked(const Vector2 &p_pos, MouseButton 
 
 	current_path = current_path_line_edit->get_text();
 
+	// Favorites isn't a directory so don't show menu.
+	if (current_path == "Favorites") {
+		return;
+	}
+
 	file_list_popup->clear();
 	file_list_popup->reset_size();
 


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/96562
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
