### PR TITLE
Disable rounded window corners on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3982,6 +3982,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				::DwmSetWindowAttribute(windows[window_id].hWnd, use_legacy_dark_mode_before_20H1 ? DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 : DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 				SendMessageW(windows[window_id].hWnd, WM_PAINT, 0, 0);
 			}
+			Engine *engine = Engine::get_singleton();
+			if (!engine->is_project_manager_hint() && !engine->is_editor_hint()) {
+				DWM_WINDOW_CORNER_PREFERENCE corner_preference = DWMWCP_DONOTROUND;
+				::DwmSetWindowAttribute(windows[window_id].hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
+			}
 		} break;
 		case WM_NCPAINT: {
 			if (RenderingServer::get_singleton() && (windows[window_id].borderless || (windows[window_id].fullscreen && windows[window_id].multiwindow_fs))) {


### PR DESCRIPTION
I noticed when reading the latest [Dolphin progress report](https://dolphin-emu.org/blog/2024/09/04/dolphin-progress-report-release-2407-2409/) that it's actually possible to [disable the rounded corners](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/ui/apply-rounded-corners#example-3---rounding-an-apps-main-window-in-c) in Windows 11.

I feel like this is a desirable change for games in general, as it actually shows everything you render instead of hiding the bottom corners, which is particularly annoying when taking screenshots.

I suppose the argument against would be that it's inconsistent with the Windows 11 default, so non-game applications might look slightly odd to a user.