### PR TITLE
Fix AnimationLibrary loading

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -81,9 +81,8 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 		List<Variant> keys;
 		d.get_key_list(&keys);
 		for (const Variant &K : keys) {
-			StringName lib_name = K;
-			Ref<AnimationLibrary> lib = d[lib_name];
-			add_animation_library(lib_name, lib);
+			Ref<AnimationLibrary> lib = d[K];
+			add_animation_library(K, lib);
 		}
 		emit_signal(SNAME("animation_libraries_updated"));
 


### PR DESCRIPTION
Fixes #96553
Seems like the String/StringName key unification only applies to GDScript, raw Dictionaries still differentiate between the two.

Dictionary access uses Variant anyway, so using converted key was pointless. The Variant passed to `add_animation_library()` is converted implicitly. It doesn't matter if it's stored in a variable or not.
