### PR TITLE
Hide FastNoiseLite Domain Warp Fractal Lacunarity in inspector if not relevant

### DIFF
--- a/modules/noise/doc_classes/FastNoiseLite.xml
+++ b/modules/noise/doc_classes/FastNoiseLite.xml
@@ -30,10 +30,10 @@
 			A low value places more emphasis on the lower frequency base layers, while a high value puts more emphasis on the higher frequency layers.
 		</member>
 		<member name="domain_warp_fractal_lacunarity" type="float" setter="set_domain_warp_fractal_lacunarity" getter="get_domain_warp_fractal_lacunarity" default="6.0">
-			Octave lacunarity of the fractal noise which warps the space. Increasing this value results in higher octaves producing noise with finer details and a rougher appearance.
+			Octave lacunarity of the fractal noise which warps the space. Increasing this value results in higher octaves producing noise with finer details and a rougher appearance. Only effective if [member domain_warp_fractal_type] is [constant DOMAIN_WARP_FRACTAL_PROGRESSIVE] or [constant DOMAIN_WARP_FRACTAL_INDEPENDENT].
 		</member>
 		<member name="domain_warp_fractal_octaves" type="int" setter="set_domain_warp_fractal_octaves" getter="get_domain_warp_fractal_octaves" default="5">
-			The number of noise layers that are sampled to get the final value for the fractal noise which warps the space.
+			The number of noise layers that are sampled to get the final value for the fractal noise which warps the space. Higher values result in more detailed noise at the cost of slower generation times.
 		</member>
 		<member name="domain_warp_fractal_type" type="int" setter="set_domain_warp_fractal_type" getter="get_domain_warp_fractal_type" enum="FastNoiseLite.DomainWarpFractalType" default="1">
 			The method for combining octaves into a fractal which is used to warp the space. See [enum DomainWarpFractalType].
@@ -52,7 +52,7 @@
 			Frequency multiplier between subsequent octaves. Increasing this value results in higher octaves producing noise with finer details and a rougher appearance.
 		</member>
 		<member name="fractal_octaves" type="int" setter="set_fractal_octaves" getter="get_fractal_octaves" default="5">
-			The number of noise layers that are sampled to get the final value for fractal noise types.
+			The number of noise layers that are sampled to get the final value for fractal noise types. Higher values result in more detailed noise at the cost of slower generation times.
 		</member>
 		<member name="fractal_ping_pong_strength" type="float" setter="set_fractal_ping_pong_strength" getter="get_fractal_ping_pong_strength" default="2.0">
 			Sets the strength of the fractal ping pong type.

--- a/modules/noise/fastnoise_lite.cpp
+++ b/modules/noise/fastnoise_lite.cpp
@@ -261,6 +261,7 @@ void FastNoiseLite::set_domain_warp_fractal_type(DomainWarpFractalType p_domain_
 
 	_domain_warp_noise.SetFractalType(_convert_domain_warp_fractal_type_enum(p_domain_warp_fractal_type));
 	emit_changed();
+	notify_property_list_changed();
 }
 
 FastNoiseLite::DomainWarpFractalType FastNoiseLite::get_domain_warp_fractal_type() const {
@@ -493,6 +494,11 @@ void FastNoiseLite::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if (p_property.name != "domain_warp_enabled" && p_property.name.begins_with("domain_warp") && !domain_warp_enabled) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (p_property.name == "domain_warp_fractal_lacunarity" && domain_warp_fractal_type == DOMAIN_WARP_FRACTAL_NONE) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		return;
 	}


### PR DESCRIPTION
This property is only relevant if Domain Warp Fractal Type is set to a value other than None. Otherwise, it has no effect.

**Note:** Fractal Octaves and Fractal Gain are still effective even if Domain Warp Fractal Type is None.

## Preview

![image](https://github.com/user-attachments/assets/cbaae159-6ecf-4ad5-9046-50c96e6f41d3)
