### PR TITLE
Fix editor layout reset on startup

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5240,8 +5240,8 @@ void EditorNode::_copy_warning(const String &p_str) {
 }
 
 void EditorNode::_save_editor_layout() {
-	if (waiting_for_first_scan) {
-		return; // Scanning, do not touch docks.
+	if (!load_editor_layout_done) {
+		return;
 	}
 	Ref<ConfigFile> config;
 	config.instantiate();
@@ -5297,22 +5297,22 @@ void EditorNode::_load_editor_layout() {
 		if (overridden_default_layout >= 0) {
 			_layout_menu_option(overridden_default_layout);
 		}
-		return;
+	} else {
+		ep.step(TTR("Loading docks..."), 1, true);
+		editor_dock_manager->load_docks_from_config(config, "docks");
+
+		ep.step(TTR("Reopening scenes..."), 2, true);
+		_load_open_scenes_from_config(config);
+
+		ep.step(TTR("Loading central editor layout..."), 3, true);
+		_load_central_editor_layout_from_config(config);
+
+		ep.step(TTR("Loading plugin window layout..."), 4, true);
+		editor_data.set_plugin_window_layout(config);
+
+		ep.step(TTR("Editor layout ready."), 5, true);
 	}
-
-	ep.step(TTR("Loading docks..."), 1, true);
-	editor_dock_manager->load_docks_from_config(config, "docks");
-
-	ep.step(TTR("Reopening scenes..."), 2, true);
-	_load_open_scenes_from_config(config);
-
-	ep.step(TTR("Loading central editor layout..."), 3, true);
-	_load_central_editor_layout_from_config(config);
-
-	ep.step(TTR("Loading plugin window layout..."), 4, true);
-	editor_data.set_plugin_window_layout(config);
-
-	ep.step(TTR("Editor layout ready."), 5, true);
+	load_editor_layout_done = true;
 }
 
 void EditorNode::_save_central_editor_layout_to_config(Ref<ConfigFile> p_config_file) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -462,6 +462,7 @@ private:
 
 	bool requested_first_scan = false;
 	bool waiting_for_first_scan = true;
+	bool load_editor_layout_done = false;
 
 	int current_menu_option = 0;
 


### PR DESCRIPTION
- Fixes #96561

I'm pretty sure it's a regression from #93064. While loading the docks, `EditorDockManager::_update_layout` calls `EditorNode::get_singleton()->save_editor_layout_delayed()` before the editor finishes loading the last editor layout. This starts a timer to save the layout after 0.5 seconds. With the addition of a progress dialog in `EditorNode::_load_editor_layout`, the timer started in `save_editor_layout_delayed` can now be executed before the editor finishes loading, as the signal can be processed during `Main::Iteration`.

I added a new global boolean `load_editor_layout_done` to prevent the editor layout from being saved before it is fully loaded.
