### PR TITLE
Fix shift clicking on Add Sun/Environment to Scene buttons

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7847,6 +7847,9 @@ void Node3DEditor::_sun_environ_settings_pressed() {
 	sun_environ_popup->set_position(pos - Vector2(sun_environ_popup->get_contents_minimum_size().width / 2, 0));
 	sun_environ_popup->reset_size();
 	sun_environ_popup->popup();
+	// Grabbing the focus is required for Shift modifier checking to be functional
+	// (when the Add sun/environment buttons are pressed).
+	sun_environ_popup->grab_focus();
 }
 
 void Node3DEditor::_add_sun_to_scene(bool p_already_added_environment) {


### PR DESCRIPTION
Believe this fixes: https://github.com/godotengine/godot/issues/73467
Only tested on Linux

First is a single click, second is shift click.

[Screencast_20240905_013752.webm](https://github.com/user-attachments/assets/99ab73ec-778b-4150-9e96-143c9d92dbfa)
