### PR TITLE
Sort single clicked UI element by z-index

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2433,6 +2433,10 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			Vector<_SelectResult> selection = Vector<_SelectResult>();
 			// Retrieve the canvas items.
 			_get_canvas_items_at_pos(click, selection);
+
+			// Sort retrieved items by z-index.
+			selection.sort();
+
 			if (!selection.is_empty()) {
 				ci = selection[0].item;
 			}


### PR DESCRIPTION
Edit: this is just a bandaid solution and the change (although helpful) needs to be weighed against the risk of putting things in the codebase that don't fix the full issue.

Fixes #96576 
Small change, just need to sort the single-item selection possibilities by z-index before grabbing the 0th element.