### PR TITLE
Warn if XRHandModifier3D used with OpenXR and hand-tracking disabled

### DIFF
--- a/scene/3d/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr_hand_modifier_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "xr_hand_modifier_3d.h"
 
+#include "core/config/project_settings.h"
 #include "servers/xr/xr_pose.h"
 #include "servers/xr_server.h"
 
@@ -281,6 +282,17 @@ void XRHandModifier3D::_tracker_changed(StringName p_tracker_name, XRServer::Tra
 
 void XRHandModifier3D::_skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new) {
 	_get_joint_data();
+}
+
+PackedStringArray XRHandModifier3D::get_configuration_warnings() const {
+	PackedStringArray warnings = SkeletonModifier3D::get_configuration_warnings();
+
+	// Detect OpenXR without the Hand Tracking extension.
+	if (GLOBAL_GET("xr/openxr/enabled") && !GLOBAL_GET("xr/openxr/extensions/hand_tracking")) {
+		warnings.push_back("XRHandModifier3D requires the OpenXR Hand Tracking extension to be enabled.");
+	}
+
+	return warnings;
 }
 
 void XRHandModifier3D::_notification(int p_what) {

--- a/scene/3d/xr_hand_modifier_3d.h
+++ b/scene/3d/xr_hand_modifier_3d.h
@@ -55,6 +55,8 @@ public:
 	void set_bone_update(BoneUpdate p_bone_update);
 	BoneUpdate get_bone_update() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	void _notification(int p_what);
 
 protected:


### PR DESCRIPTION
With hand-tracking switching from default-enabled to default-disabled in Godot 4.4+ it's common for older projects to have broken hand-tracking. To help with this issue, this PR adds a warning to XRHandModifier3D nodes if OpenXR is enabled, but the OpenXR hand-tracking extension is disabled.

![image](https://github.com/user-attachments/assets/e93db112-20eb-400b-a406-8837f5e2df66)
