### PR TITLE
[TextEdit] Add support for using SyntaxHighlighter for BiDi override and font override.

### DIFF
--- a/doc/classes/CodeHighlighter.xml
+++ b/doc/classes/CodeHighlighter.xml
@@ -4,12 +4,12 @@
 		A syntax highlighter intended for code.
 	</brief_description>
 	<description>
-		By adjusting various properties of this resource, you can change the colors of strings, comments, numbers, and other text patterns inside a [TextEdit] control.
+		By adjusting various properties of this resource, you can change the colors and font style of strings, comments, numbers, and other text patterns inside a [TextEdit] control.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_color_region">
+		<method name="add_color_region" deprecated="Use [method add_region] instead.">
 			<return type="void" />
 			<param index="0" name="start_key" type="String" />
 			<param index="1" name="end_key" type="String" />
@@ -20,41 +20,97 @@
 				If [param line_only] is [code]true[/code] or [param end_key] is an empty [String], the region does not carry over to the next line.
 			</description>
 		</method>
-		<method name="add_keyword_color">
+		<method name="add_keyword">
+			<return type="void" />
+			<param index="0" name="keyword" type="String" />
+			<param index="1" name="color" type="Color" />
+			<param index="2" name="style" type="int" enum="SyntaxHighlighter.SyntaxFontStyle" default="0" />
+			<description>
+				Sets the color and font style applied to the given keyword.
+				[param keyword] cannot contain any symbols except [code]_[/code].
+			</description>
+		</method>
+		<method name="add_keyword_color" deprecated="Use [method add_keyword] instead.">
 			<return type="void" />
 			<param index="0" name="keyword" type="String" />
 			<param index="1" name="color" type="Color" />
 			<description>
 				Sets the color for a keyword.
-				The keyword cannot contain any symbols except '_'.
+				[param keyword] cannot contain any symbols except [code]_[/code].
 			</description>
 		</method>
-		<method name="add_member_keyword_color">
+		<method name="add_member_keyword">
+			<return type="void" />
+			<param index="0" name="member_keyword" type="String" />
+			<param index="1" name="color" type="Color" />
+			<param index="2" name="style" type="int" enum="SyntaxHighlighter.SyntaxFontStyle" default="0" />
+			<description>
+				Sets the color and font style applied to the given member keyword. Unlike, [method add_keyword], it will not be highlighted if preceded by [code].[/code].
+				[param member_keyword] cannot contain any symbols except [code]_[/code].
+			</description>
+		</method>
+		<method name="add_member_keyword_color" deprecated="Use [method add_member_keyword] instead.">
 			<return type="void" />
 			<param index="0" name="member_keyword" type="String" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Sets the color for a member keyword.
-				The member keyword cannot contain any symbols except '_'.
-				It will not be highlighted if preceded by a '.'.
+				Sets the color applied to the given member keyword. Unlike, [method add_keyword], it will not be highlighted if preceded by [code].[/code].
+				[param member_keyword] cannot contain any symbols except [code]_[/code].
 			</description>
 		</method>
-		<method name="clear_color_regions">
+		<method name="add_region">
+			<return type="void" />
+			<param index="0" name="start_key" type="String" />
+			<param index="1" name="end_key" type="String" />
+			<param index="2" name="color" type="Color" />
+			<param index="3" name="style" type="int" enum="SyntaxHighlighter.SyntaxFontStyle" default="0" />
+			<param index="4" name="line_only" type="bool" default="false" />
+			<param index="5" name="text_segment" type="bool" default="false" />
+			<description>
+				Adds a color and font style region (such as for comments or strings) from [param start_key] to [param end_key]. Both keys should be symbols, and [param start_key] must not be shared with other delimiters.
+				If [param line_only] is [code]true[/code] or [param end_key] is an empty [String], the region does not carry over to the next line.
+			</description>
+		</method>
+		<method name="clear_color_regions" deprecated="Use [method clear_regions] instead.">
 			<return type="void" />
 			<description>
 				Removes all color regions.
 			</description>
 		</method>
-		<method name="clear_keyword_colors">
+		<method name="clear_keyword_colors" deprecated="Use [method clear_keywords] instead.">
 			<return type="void" />
 			<description>
 				Removes all keywords.
 			</description>
 		</method>
-		<method name="clear_member_keyword_colors">
+		<method name="clear_keywords">
+			<return type="void" />
+			<description>
+				Removes all keywords.
+			</description>
+		</method>
+		<method name="clear_member_keyword_colors" deprecated="Use [method clear_member_keywords] instead.">
 			<return type="void" />
 			<description>
 				Removes all member keywords.
+			</description>
+		</method>
+		<method name="clear_member_keywords">
+			<return type="void" />
+			<description>
+				Removes all member keywords.
+			</description>
+		</method>
+		<method name="clear_regions">
+			<return type="void" />
+			<description>
+				Removes all color and font style regions.
+			</description>
+		</method>
+		<method name="get_color_regions" qualifiers="const" deprecated="Use [member regions] instead.">
+			<return type="Dictionary" />
+			<description>
+				Returns all color regions, as a dictionary.
 			</description>
 		</method>
 		<method name="get_keyword_color" qualifiers="const">
@@ -64,6 +120,19 @@
 				Returns the color for a keyword.
 			</description>
 		</method>
+		<method name="get_keyword_colors" qualifiers="const" deprecated="Use [member keywords] instead.">
+			<return type="Dictionary" />
+			<description>
+				Returns the colors applied to all keywords, as a dictionary.
+			</description>
+		</method>
+		<method name="get_keyword_style" qualifiers="const">
+			<return type="int" enum="SyntaxHighlighter.SyntaxFontStyle" />
+			<param index="0" name="keyword" type="String" />
+			<description>
+				Returns the font style used for a keyword.
+			</description>
+		</method>
 		<method name="get_member_keyword_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="member_keyword" type="String" />
@@ -71,70 +140,158 @@
 				Returns the color for a member keyword.
 			</description>
 		</method>
-		<method name="has_color_region" qualifiers="const">
+		<method name="get_member_keyword_colors" qualifiers="const" deprecated="Use [member member_keywords] instead.">
+			<return type="Dictionary" />
+			<description>
+				Returns the colors applied to all member keywords, as a dictionary.
+			</description>
+		</method>
+		<method name="get_member_keyword_style" qualifiers="const">
+			<return type="int" enum="SyntaxHighlighter.SyntaxFontStyle" />
+			<param index="0" name="member_keyword" type="String" />
+			<description>
+				Returns the font style used for the given member keyword.
+			</description>
+		</method>
+		<method name="has_color_region" qualifiers="const" deprecated="Use [method has_region] instead.">
 			<return type="bool" />
 			<param index="0" name="start_key" type="String" />
 			<description>
 				Returns [code]true[/code] if the start key exists, else [code]false[/code].
 			</description>
 		</method>
-		<method name="has_keyword_color" qualifiers="const">
+		<method name="has_keyword" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="keyword" type="String" />
 			<description>
 				Returns [code]true[/code] if the keyword exists, else [code]false[/code].
 			</description>
 		</method>
-		<method name="has_member_keyword_color" qualifiers="const">
+		<method name="has_keyword_color" qualifiers="const" deprecated="Use [method has_keyword] instead.">
+			<return type="bool" />
+			<param index="0" name="keyword" type="String" />
+			<description>
+				Returns [code]true[/code] if the keyword exists, else [code]false[/code].
+			</description>
+		</method>
+		<method name="has_member_keyword" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="member_keyword" type="String" />
 			<description>
 				Returns [code]true[/code] if the member keyword exists, else [code]false[/code].
 			</description>
 		</method>
-		<method name="remove_color_region">
+		<method name="has_member_keyword_color" qualifiers="const" deprecated="Use [method has_member_keyword] instead.">
+			<return type="bool" />
+			<param index="0" name="member_keyword" type="String" />
+			<description>
+				Returns [code]true[/code] if the member keyword exists, else [code]false[/code].
+			</description>
+		</method>
+		<method name="has_region" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="start_key" type="String" />
+			<description>
+				Returns [code]true[/code] if the start key exists, else [code]false[/code].
+			</description>
+		</method>
+		<method name="remove_color_region" deprecated="Use [method remove_region] instead.">
 			<return type="void" />
 			<param index="0" name="start_key" type="String" />
 			<description>
 				Removes the color region that uses that start key.
 			</description>
 		</method>
-		<method name="remove_keyword_color">
+		<method name="remove_keyword">
 			<return type="void" />
 			<param index="0" name="keyword" type="String" />
 			<description>
 				Removes the keyword.
 			</description>
 		</method>
-		<method name="remove_member_keyword_color">
+		<method name="remove_keyword_color" deprecated="Use [method remove_keyword] instead.">
+			<return type="void" />
+			<param index="0" name="keyword" type="String" />
+			<description>
+				Removes the keyword.
+			</description>
+		</method>
+		<method name="remove_member_keyword">
 			<return type="void" />
 			<param index="0" name="member_keyword" type="String" />
 			<description>
 				Removes the member keyword.
 			</description>
 		</method>
+		<method name="remove_member_keyword_color" deprecated="Use [method remove_member_keyword] instead.">
+			<return type="void" />
+			<param index="0" name="member_keyword" type="String" />
+			<description>
+				Removes the member keyword.
+			</description>
+		</method>
+		<method name="remove_region">
+			<return type="void" />
+			<param index="0" name="start_key" type="String" />
+			<description>
+				Removes the color or font style region that uses the given start key.
+			</description>
+		</method>
+		<method name="set_color_regions" deprecated="Use [member regions] instead.">
+			<return type="void" />
+			<param index="0" name="color_regions" type="Dictionary" />
+			<description>
+				Sets color regions.
+			</description>
+		</method>
+		<method name="set_keyword_colors" deprecated="Use [member keywords] instead.">
+			<return type="void" />
+			<param index="0" name="keywords" type="Dictionary" />
+			<description>
+				Sets colors for keywords.
+			</description>
+		</method>
+		<method name="set_member_keyword_colors" deprecated="Use [member member_keywords] instead.">
+			<return type="void" />
+			<param index="0" name="member_keyword" type="Dictionary" />
+			<description>
+				Sets colors for member keywords.
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="color_regions" type="Dictionary" setter="set_color_regions" getter="get_color_regions" default="{}">
-			Sets the color regions. All existing regions will be removed. The [Dictionary] key is the region start and end key, separated by a space. The value is the region color.
-		</member>
 		<member name="function_color" type="Color" setter="set_function_color" getter="get_function_color" default="Color(0, 0, 0, 1)">
-			Sets color for functions. A function is a non-keyword string followed by a '('.
+			Sets color for functions. A function is a non-keyword string followed by a [code]([/code].
 		</member>
-		<member name="keyword_colors" type="Dictionary" setter="set_keyword_colors" getter="get_keyword_colors" default="{}">
-			Sets the keyword colors. All existing keywords will be removed. The [Dictionary] key is the keyword. The value is the keyword color.
+		<member name="function_style" type="int" setter="set_function_style" getter="get_function_style" enum="SyntaxHighlighter.SyntaxFontStyle" default="0">
+			Sets the font style for functions. A function is a non-keyword string followed by [code]([/code].
 		</member>
-		<member name="member_keyword_colors" type="Dictionary" setter="set_member_keyword_colors" getter="get_member_keyword_colors" default="{}">
-			Sets the member keyword colors. All existing member keyword will be removed. The [Dictionary] key is the member keyword. The value is the member keyword color.
+		<member name="keywords" type="Dictionary" setter="set_keywords" getter="get_keywords" default="{}">
+			Color and font style for keywords, as a [Dictionary] where each key is a keyword [String] and each value is a nested [Dictionary] with the following keys: [code]"color"[/code], [code]"style"[/code].
+		</member>
+		<member name="member_keywords" type="Dictionary" setter="set_member_keywords" getter="get_member_keywords" default="{}">
+			Color and font style for member keywords, as a [Dictionary] where each key is a keyword [String] and each value is a nested [Dictionary] with the following keys: [code]"color"[/code], [code]"style"[/code].
 		</member>
 		<member name="member_variable_color" type="Color" setter="set_member_variable_color" getter="get_member_variable_color" default="Color(0, 0, 0, 1)">
-			Sets color for member variables. A member variable is non-keyword, non-function string proceeded with a '.'.
+			Sets color for member variables. A member variable is non-keyword, non-function string proceeded with a [code].[/code].
+		</member>
+		<member name="member_variable_style" type="int" setter="set_member_variable_style" getter="get_member_variable_style" enum="SyntaxHighlighter.SyntaxFontStyle" default="0">
+			Sets the font style for member variables. A member variable is non-keyword, non-function string proceeded with a [code].[/code].
 		</member>
 		<member name="number_color" type="Color" setter="set_number_color" getter="get_number_color" default="Color(0, 0, 0, 1)">
 			Sets the color for numbers.
 		</member>
+		<member name="number_style" type="int" setter="set_number_style" getter="get_number_style" enum="SyntaxHighlighter.SyntaxFontStyle" default="0">
+			Sets the font style for numbers.
+		</member>
+		<member name="regions" type="Dictionary" setter="set_regions" getter="get_regions" default="{}">
+			Color and font style regions, [Dictionary] keys are [code]"start_key end_key"[/code] string, values are [Dictionary] with the following keys: [code]"color"[/code], [code]"style"[/code], and [code]text_segment[/code].
+		</member>
 		<member name="symbol_color" type="Color" setter="set_symbol_color" getter="get_symbol_color" default="Color(0, 0, 0, 1)">
 			Sets the color for symbols.
+		</member>
+		<member name="symbol_style" type="int" setter="set_symbol_style" getter="get_symbol_style" enum="SyntaxHighlighter.SyntaxFontStyle" default="0">
+			Sets the font style for symbols.
 		</member>
 	</members>
 </class>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1392,6 +1392,12 @@
 		<member name="text_editor/script_list/sort_scripts_by" type="int" setter="" getter="">
 			Specifies sorting used for Script Editor's open script list.
 		</member>
+		<member name="text_editor/syntax_highlighter_can_change_font" type="bool" setter="" getter="">
+			If [code]true[/code], if the syntax highlighter can change the text's font style.
+		</member>
+		<member name="text_editor/syntax_highlighter_for_bidi_override" type="bool" setter="" getter="">
+			If [code]true[/code], the syntax highlighter is used to tokenize the text for BiDi override.
+		</member>
 		<member name="text_editor/theme/color_theme" type="String" setter="" getter="">
 			The syntax theme to use in the script editor.
 			You can save your own syntax theme from your current settings by using [b]File &gt; Theme &gt; Save As...[/b] at the top of the script editor. The syntax theme will then be available locally in the list of color themes.
@@ -1402,6 +1408,9 @@
 		</member>
 		<member name="text_editor/theme/highlighting/base_type_color" type="Color" setter="" getter="">
 			The script editor's base type color (used for types like [Vector2], [Vector3], [Color], ...).
+		</member>
+		<member name="text_editor/theme/highlighting/base_type_style" type="int" setter="" getter="">
+			The script editor's base type font style (used for types like [Vector2], [Vector3], [Color], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/bookmark_color" type="Color" setter="" getter="">
 			The script editor's bookmark icon color (displayed in the gutter).
@@ -1426,6 +1435,9 @@
 			The script editor's comment color.
 			[b]Note:[/b] In GDScript, unlike Python, multiline strings are not considered to be comments, and will use the string highlighting color instead.
 		</member>
+		<member name="text_editor/theme/highlighting/comment_style" type="int" setter="" getter="">
+			The script editor's comment font style.
+		</member>
 		<member name="text_editor/theme/highlighting/completion_background_color" type="Color" setter="" getter="">
 			The script editor's autocompletion box background color.
 		</member>
@@ -1447,14 +1459,23 @@
 		<member name="text_editor/theme/highlighting/control_flow_keyword_color" type="Color" setter="" getter="">
 			The script editor's control flow keyword color (used for keywords like [code]if[/code], [code]for[/code], [code]return[/code], ...).
 		</member>
+		<member name="text_editor/theme/highlighting/control_flow_keyword_style" type="int" setter="" getter="">
+			The script editor's control flow keyword font style (used for keywords like [code]if[/code], [code]for[/code], [code]return[/code], ...).
+		</member>
 		<member name="text_editor/theme/highlighting/current_line_color" type="Color" setter="" getter="">
 			The script editor's background color for the line the caret is currently on. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/mark_color].
 		</member>
 		<member name="text_editor/theme/highlighting/doc_comment_color" type="Color" setter="" getter="">
 			The script editor's documentation comment color. In GDScript, this is used for comments starting with [code]##[/code]. In C#, this is used for comments starting with [code]///[/code] or [code]/**[/code].
 		</member>
+		<member name="text_editor/theme/highlighting/doc_comment_style" type="int" setter="" getter="">
+			The script editor's documentation comment font style. In GDScript, this is used for comments starting with [code]##[/code]. In C#, this is used for comments starting with [code]///[/code] or [code]/**[/code].
+		</member>
 		<member name="text_editor/theme/highlighting/engine_type_color" type="Color" setter="" getter="">
 			The script editor's engine type color ([Object], [Mesh], [Node], ...).
+		</member>
+		<member name="text_editor/theme/highlighting/engine_type_style" type="int" setter="" getter="">
+			The script editor's engine type font style ([Vector2], [Vector3], [Color], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/executing_line_color" type="Color" setter="" getter="">
 			The script editor's color for the debugger's executing line icon (displayed in the gutter).
@@ -1462,12 +1483,21 @@
 		<member name="text_editor/theme/highlighting/folded_code_region_color" type="Color" setter="" getter="">
 			The script editor's background line highlighting color for folded code region.
 		</member>
+		<member name="text_editor/theme/highlighting/folded_code_region_style" type="int" setter="" getter="">
+			The script editor's background line highlighting font style for folded code region.
+		</member>
 		<member name="text_editor/theme/highlighting/function_color" type="Color" setter="" getter="">
 			The script editor's function call color.
 			[b]Note:[/b] When using the GDScript syntax highlighter, this is replaced by the function definition color configured in the syntax theme for function definitions (e.g. [code]func _ready():[/code]).
 		</member>
+		<member name="text_editor/theme/highlighting/function_style" type="int" setter="" getter="">
+			The script editor's function call font style.
+		</member>
 		<member name="text_editor/theme/highlighting/keyword_color" type="Color" setter="" getter="">
 			The script editor's non-control flow keyword color (used for keywords like [code]var[/code], [code]func[/code], [code]extends[/code], ...).
+		</member>
+		<member name="text_editor/theme/highlighting/keyword_style" type="int" setter="" getter="">
+			The script editor's non-control flow keyword font style (used for keywords like [code]var[/code], [code]func[/code], [code]extends[/code], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/line_length_guideline_color" type="Color" setter="" getter="">
 			The script editor's color for the line length guideline. The "hard" line length guideline will be drawn with this color, whereas the "soft" line length guideline will be drawn with half of its opacity.
@@ -1482,8 +1512,14 @@
 			The script editor's color for member variables on objects (e.g. [code]self.some_property[/code]).
 			[b]Note:[/b] This color is not used for local variable declaration and access.
 		</member>
+		<member name="text_editor/theme/highlighting/member_variable_style" type="int" setter="" getter="">
+			The script editor's font style for member variables on objects (e.g. [code]self.some_property[/code]).
+		</member>
 		<member name="text_editor/theme/highlighting/number_color" type="Color" setter="" getter="">
 			The script editor's color for numbers (integer and floating-point).
+		</member>
+		<member name="text_editor/theme/highlighting/number_style" type="int" setter="" getter="">
+			The script editor's font style for numbers (integer and floating-point).
 		</member>
 		<member name="text_editor/theme/highlighting/safe_line_number_color" type="Color" setter="" getter="">
 			The script editor's color for type-safe line numbers. See also [member text_editor/theme/highlighting/line_number_color].
@@ -1501,8 +1537,14 @@
 		<member name="text_editor/theme/highlighting/string_color" type="Color" setter="" getter="">
 			The script editor's color for strings (single-line and multi-line).
 		</member>
+		<member name="text_editor/theme/highlighting/string_style" type="int" setter="" getter="">
+			The script editor's font style for strings (single-line and multi-line).
+		</member>
 		<member name="text_editor/theme/highlighting/symbol_color" type="Color" setter="" getter="">
 			The script editor's color for operators ([code]( ) [ ] { } + - * /[/code], ...).
+		</member>
+		<member name="text_editor/theme/highlighting/symbol_style" type="int" setter="" getter="">
+			The script editor's font style for operators ([code]( ) [ ] { } + - * /[/code], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/text_color" type="Color" setter="" getter="">
 			The script editor's color for text not highlighted by any syntax highlighting rule.
@@ -1512,6 +1554,9 @@
 		</member>
 		<member name="text_editor/theme/highlighting/user_type_color" type="Color" setter="" getter="">
 			The script editor's color for user-defined types (using [code]class_name[/code]).
+		</member>
+		<member name="text_editor/theme/highlighting/user_type_style" type="int" setter="" getter="">
+			The script editor's font style for user-defined types (using [code]class_name[/code]).
 		</member>
 		<member name="text_editor/theme/highlighting/word_highlighted_color" type="Color" setter="" getter="">
 			The script editor's color for words highlighted by selecting them. Only visible if [member text_editor/appearance/caret/highlight_all_occurrences] is [code]true[/code].

--- a/doc/classes/SyntaxHighlighter.xml
+++ b/doc/classes/SyntaxHighlighter.xml
@@ -70,4 +70,14 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="SYNTAX_STYLE_REGULAR" value="0" enum="SyntaxFontStyle">
+		</constant>
+		<constant name="SYNTAX_STYLE_BOLD" value="1" enum="SyntaxFontStyle">
+		</constant>
+		<constant name="SYNTAX_STYLE_ITALIC" value="2" enum="SyntaxFontStyle">
+		</constant>
+		<constant name="SYNTAX_STYLE_BOLD_ITALIC" value="3" enum="SyntaxFontStyle">
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -668,6 +668,18 @@
 				Returns the total number of lines in the text. This includes wrapped lines and excludes folded lines. If [member wrap_mode] is set to [constant LINE_WRAPPING_NONE] and no lines are folded (see [method CodeEdit.is_line_folded]) then this is equivalent to [method get_line_count]. See [method get_visible_line_count_in_range] for a limited range of lines.
 			</description>
 		</method>
+		<method name="get_use_syntax_highlighter_font_change" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the syntax highlighter can change the text's font style.
+			</description>
+		</method>
+		<method name="get_use_syntax_highlighter_for_bidi_override" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the syntax highlighter is used to tokenize the text for BiDi override.
+			</description>
+		</method>
 		<method name="get_v_scroll_bar" qualifiers="const">
 			<return type="VScrollBar" />
 			<description>
@@ -1222,6 +1234,20 @@
 				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code].
 			</description>
 		</method>
+		<method name="set_use_syntax_highlighter_font_change">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				If set to [code]true[/code], syntax highlighter can change text font style.
+			</description>
+		</method>
+		<method name="set_use_syntax_highlighter_for_bidi_override">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				If set to [code]true[/code], syntax highlighter is used to tokenize text for BiDi override.
+			</description>
+		</method>
 		<method name="skip_selection_for_next_occurrence">
 			<return type="void" />
 			<description>
@@ -1646,8 +1672,17 @@
 			The size of the text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 		</theme_item>
+		<theme_item name="bold_font" data_type="font" type="Font">
+			Sets the default bold [Font]. Used by syntax highlighter.
+		</theme_item>
+		<theme_item name="bold_italics_font" data_type="font" type="Font">
+			Sets the default bold italic [Font]. Used by syntax highlighter.
+		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			Sets the default [Font].
+		</theme_item>
+		<theme_item name="italics_font" data_type="font" type="Font">
+			Sets the default italic [Font]. Used by syntax highlighter.
 		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Sets default font size.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1092,6 +1092,8 @@ void CodeTextEditor::update_editor_settings() {
 	completion_node_path_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_path_color");
 	completion_comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
 	completion_doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+	text_editor->set_use_syntax_highlighter_for_bidi_override(EDITOR_GET("text_editor/syntax_highlighter_for_bidi_override"));
+	text_editor->set_use_syntax_highlighter_font_change(EDITOR_GET("text_editor/syntax_highlighter_can_change_font"));
 
 	// Appearance: Caret
 	text_editor->set_caret_type((TextEdit::CaretType)EDITOR_GET("text_editor/appearance/caret/type").operator int());
@@ -1833,6 +1835,8 @@ CodeTextEditor::CodeTextEditor() {
 	add_child(text_editor);
 	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 	text_editor->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_GDSCRIPT);
+	text_editor->set_use_syntax_highlighter_for_bidi_override(EDITOR_GET("text_editor/syntax_highlighter_for_bidi_override"));
+	text_editor->set_use_syntax_highlighter_font_change(EDITOR_GET("text_editor/syntax_highlighter_can_change_font"));
 	text_editor->set_draw_bookmarks_gutter(true);
 
 	text_editor->set_draw_line_numbers(true);

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -39,34 +39,42 @@
 
 void EditorNativeShaderSourceVisualizer::_load_theme_settings() {
 	syntax_highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+	syntax_highlighter->set_number_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style"));
 	syntax_highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	syntax_highlighter->set_symbol_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style"));
 	syntax_highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/function_color"));
+	syntax_highlighter->set_function_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style"));
 	syntax_highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/member_variable_color"));
+	syntax_highlighter->set_member_variable_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style"));
 
-	syntax_highlighter->clear_keyword_colors();
+	syntax_highlighter->clear_keywords();
 
 	List<String> keywords;
 	ShaderLanguage::get_keyword_list(&keywords);
-	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
+	Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 
 	for (const String &keyword : keywords) {
 		if (ShaderLanguage::is_control_flow_keyword(keyword)) {
-			syntax_highlighter->add_keyword_color(keyword, control_flow_keyword_color);
+			syntax_highlighter->add_keyword(keyword, control_flow_keyword_color, control_flow_keyword_style);
 		} else {
-			syntax_highlighter->add_keyword_color(keyword, keyword_color);
+			syntax_highlighter->add_keyword(keyword, keyword_color, keyword_style);
 		}
 	}
 
 	// Colorize comments.
-	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
-	syntax_highlighter->clear_color_regions();
-	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-	syntax_highlighter->add_color_region("//", "", comment_color, true);
+	Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
+	syntax_highlighter->clear_regions();
+	syntax_highlighter->add_region("/*", "*/", comment_color, comment_style, false, true);
+	syntax_highlighter->add_region("//", "", comment_color, comment_style, true, true);
 
 	// Colorize preprocessor statements.
-	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
-	syntax_highlighter->add_color_region("#", "", user_type_color, true);
+	Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	SyntaxHighlighter::SyntaxFontStyle user_type_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/user_type_style");
+	syntax_highlighter->add_region("#", "", user_type_color, user_type_style, true);
 
 	syntax_highlighter->set_uint_suffix_enabled(true);
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -54,6 +54,7 @@
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
+#include "scene/resources/syntax_highlighter.h"
 
 // PRIVATE METHODS
 
@@ -747,6 +748,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/completion/add_node_path_literals", false, true);
 	_initial_set("text_editor/completion/use_single_quotes", false, true);
 	_initial_set("text_editor/completion/colorize_suggestions", true);
+	_initial_set("text_editor/syntax_highlighter_for_bidi_override", true);
+	_initial_set("text_editor/syntax_highlighter_can_change_font", true);
 
 	// External editor (ScriptEditorPlugin)
 	_initial_set("text_editor/external/use_external_editor", false, true);
@@ -1050,15 +1053,28 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 void EditorSettings::_load_godot2_text_editor_theme() {
 	// Godot 2 is only a dark theme; it doesn't have a light theme counterpart.
+#define EDITOR_SETTING(m_type, m_property_hint, m_name, m_default_value, m_hint_string) \
+	_initial_set(m_name, m_default_value);                                              \
+	hints[m_name] = PropertyInfo(m_type, m_name, m_property_hint, m_hint_string);
+
 	_initial_set("text_editor/theme/highlighting/symbol_color", Color(0.73, 0.87, 1.0), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/symbol_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/keyword_color", Color(1.0, 1.0, 0.7), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/keyword_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/control_flow_keyword_color", Color(1.0, 0.85, 0.7), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/control_flow_keyword_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/base_type_color", Color(0.64, 1.0, 0.83), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/base_type_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/engine_type_color", Color(0.51, 0.83, 1.0), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/engine_type_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/user_type_color", Color(0.42, 0.67, 0.93), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/user_type_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/comment_color", Color(0.4, 0.4, 0.4), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/comment_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/doc_comment_color", Color(0.5, 0.6, 0.7), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/doc_comment_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/string_color", Color(0.94, 0.43, 0.75), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/string_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/background_color", Color(0.13, 0.12, 0.15), true);
 	_initial_set("text_editor/theme/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
 	_initial_set("text_editor/theme/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
@@ -1078,16 +1094,21 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/line_length_guideline_color", Color(0.3, 0.5, 0.8, 0.1), true);
 	_initial_set("text_editor/theme/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15), true);
 	_initial_set("text_editor/theme/highlighting/number_color", Color(0.92, 0.58, 0.2), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/number_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/function_color", Color(0.4, 0.64, 0.81), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/function_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/member_variable_color", Color(0.9, 0.31, 0.35), true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/member_variable_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4), true);
 	_initial_set("text_editor/theme/highlighting/bookmark_color", Color(0.08, 0.49, 0.98));
 	_initial_set("text_editor/theme/highlighting/breakpoint_color", Color(0.9, 0.29, 0.3));
 	_initial_set("text_editor/theme/highlighting/executing_line_color", Color(0.98, 0.89, 0.27));
 	_initial_set("text_editor/theme/highlighting/code_folding_color", Color(0.8, 0.8, 0.8, 0.8));
 	_initial_set("text_editor/theme/highlighting/folded_code_region_color", Color(0.68, 0.46, 0.77, 0.2));
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/theme/highlighting/folded_code_region_style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR, "Regular,Bold,Italic,Bold Italic");
 	_initial_set("text_editor/theme/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
 	_initial_set("text_editor/theme/highlighting/search_result_border_color", Color(0.41, 0.61, 0.91, 0.38));
+#undef EDITOR_SETTING
 }
 
 void EditorSettings::_load_default_visual_shader_editor_theme() {
@@ -1129,6 +1150,8 @@ bool EditorSettings::_save_text_editor_theme(const String &p_file) {
 	for (const String &key : keys) {
 		if (key.begins_with("text_editor/theme/highlighting/") && key.contains("color")) {
 			cf->set_value(theme_section, key.replace("text_editor/theme/highlighting/", ""), ((Color)props[key].variant).to_html());
+		} else if (key.begins_with("text_editor/theme/highlighting/") && key.contains("style")) {
+			cf->set_value(theme_section, key.replace("text_editor/theme/highlighting/", ""), ((int)props[key].variant));
 		}
 	}
 
@@ -1669,6 +1692,8 @@ void EditorSettings::load_text_editor_theme() {
 			// make sure it is actually a color
 			if (val.is_valid_html_color() && key.contains("color")) {
 				props["text_editor/theme/highlighting/" + key].variant = Color::html(val); // change manually to prevent "Settings changed" console spam
+			} else if (val.is_valid_html_color() && key.contains("style")) {
+				props["text_editor/theme/highlighting/" + key].variant = val;
 			}
 		}
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -107,29 +107,35 @@ void EditorSyntaxHighlighter::_bind_methods() {
 
 void EditorStandardSyntaxHighlighter::_update_cache() {
 	highlighter->set_text_edit(text_edit);
-	highlighter->clear_keyword_colors();
-	highlighter->clear_member_keyword_colors();
-	highlighter->clear_color_regions();
+	highlighter->clear_keywords();
+	highlighter->clear_member_keywords();
+	highlighter->clear_regions();
 
 	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	highlighter->set_symbol_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style"));
 	highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/function_color"));
+	highlighter->set_function_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style"));
 	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+	highlighter->set_number_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style"));
 	highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/member_variable_color"));
+	highlighter->set_member_variable_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style"));
 
 	/* Engine types. */
-	const Color type_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
+	Color type_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
+	SyntaxHighlighter::SyntaxFontStyle type_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/engine_type_style");
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
 	for (const StringName &E : types) {
-		highlighter->add_keyword_color(E, type_color);
+		highlighter->add_keyword(E, type_color, type_style);
 	}
 
 	/* User types. */
-	const Color usertype_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	Color usertype_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	SyntaxHighlighter::SyntaxFontStyle usertype_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/user_type_style");
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
 	for (const StringName &E : global_classes) {
-		highlighter->add_keyword_color(E, usertype_color);
+		highlighter->add_keyword(E, usertype_color, usertype_style);
 	}
 
 	/* Autoloads. */
@@ -137,7 +143,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {
-			highlighter->add_keyword_color(info.name, usertype_color);
+			highlighter->add_keyword(info.name, usertype_color, usertype_style);
 		}
 	}
 
@@ -154,28 +160,32 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 
 	if (scr_lang != nullptr) {
 		/* Core types. */
-		const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+		Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+		SyntaxHighlighter::SyntaxFontStyle basetype_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/base_type_style");
 		List<String> core_types;
 		scr_lang->get_core_type_words(&core_types);
 		for (const String &E : core_types) {
-			highlighter->add_keyword_color(E, basetype_color);
+			highlighter->add_keyword(E, basetype_color, basetype_style);
 		}
 
 		/* Reserved words. */
-		const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-		const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+		Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+		SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
+		Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+		SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 		List<String> keywords;
 		scr_lang->get_reserved_words(&keywords);
 		for (const String &E : keywords) {
 			if (scr_lang->is_control_flow_keyword(E)) {
-				highlighter->add_keyword_color(E, control_flow_keyword_color);
+				highlighter->add_keyword(E, control_flow_keyword_color, control_flow_keyword_style);
 			} else {
-				highlighter->add_keyword_color(E, keyword_color);
+				highlighter->add_keyword(E, keyword_color, keyword_style);
 			}
 		}
 
 		/* Member types. */
-		const Color member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+		Color member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+		SyntaxHighlighter::SyntaxFontStyle member_variable_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style");
 		if (instance_base != StringName()) {
 			List<PropertyInfo> plist;
 			ClassDB::get_property_list(instance_base, &plist);
@@ -187,44 +197,47 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 				if (prop_name.contains_char('/')) {
 					continue;
 				}
-				highlighter->add_member_keyword_color(prop_name, member_variable_color);
+				highlighter->add_member_keyword(prop_name, member_variable_color, member_variable_style);
 			}
 
 			List<String> clist;
 			ClassDB::get_integer_constant_list(instance_base, &clist);
 			for (const String &E : clist) {
-				highlighter->add_member_keyword_color(E, member_variable_color);
+				highlighter->add_member_keyword(E, member_variable_color, member_variable_style);
 			}
 		}
 
 		/* Comments */
-		const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+		Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+		SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
 		List<String> comments;
 		scr_lang->get_comment_delimiters(&comments);
 		for (const String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, comment_color, end.is_empty());
+			highlighter->add_region(beg, end, comment_color, comment_style, end.is_empty(), true);
 		}
 
 		/* Doc comments */
-		const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+		Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+		SyntaxHighlighter::SyntaxFontStyle doc_comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/doc_comment_style");
 		List<String> doc_comments;
 		scr_lang->get_doc_comment_delimiters(&doc_comments);
 		for (const String &doc_comment : doc_comments) {
 			String beg = doc_comment.get_slice(" ", 0);
 			String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, doc_comment_color, end.is_empty());
+			highlighter->add_region(beg, end, doc_comment_color, doc_comment_style, end.is_empty(), true);
 		}
 
 		/* Strings */
-		const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+		Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+		SyntaxHighlighter::SyntaxFontStyle string_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/string_style");
 		List<String> strings;
 		scr_lang->get_string_delimiters(&strings);
 		for (const String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, string_color, end.is_empty());
+			highlighter->add_region(beg, end, string_color, string_style, end.is_empty(), true);
 		}
 	}
 }
@@ -247,15 +260,16 @@ Ref<EditorSyntaxHighlighter> EditorPlainTextSyntaxHighlighter::_create() const {
 
 void EditorJSONSyntaxHighlighter::_update_cache() {
 	highlighter->set_text_edit(text_edit);
-	highlighter->clear_keyword_colors();
-	highlighter->clear_member_keyword_colors();
-	highlighter->clear_color_regions();
+	highlighter->clear_keywords();
+	highlighter->clear_member_keywords();
+	highlighter->clear_regions();
 
 	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
 	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
 
-	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
-	highlighter->add_color_region("\"", "\"", string_color);
+	Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+	SyntaxHighlighter::SyntaxFontStyle string_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/string_style");
+	highlighter->add_region("\"", "\"", string_color, string_style, true);
 }
 
 Ref<EditorSyntaxHighlighter> EditorJSONSyntaxHighlighter::_create() const {
@@ -268,9 +282,9 @@ Ref<EditorSyntaxHighlighter> EditorJSONSyntaxHighlighter::_create() const {
 
 void EditorMarkdownSyntaxHighlighter::_update_cache() {
 	highlighter->set_text_edit(text_edit);
-	highlighter->clear_keyword_colors();
-	highlighter->clear_member_keyword_colors();
-	highlighter->clear_color_regions();
+	highlighter->clear_keywords();
+	highlighter->clear_member_keywords();
+	highlighter->clear_regions();
 
 	// Disable automatic symbolic highlights, as these don't make sense for prose.
 	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
@@ -280,28 +294,33 @@ void EditorMarkdownSyntaxHighlighter::_update_cache() {
 
 	// Headings (any level).
 	const Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
-	highlighter->add_color_region("#", "", function_color);
+	SyntaxHighlighter::SyntaxFontStyle function_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style");
+	highlighter->add_region("#", "", function_color, function_style);
 
 	// Bold.
-	highlighter->add_color_region("**", "**", function_color);
+	highlighter->add_region("**", "**", function_color, function_style);
 	// `__bold__` syntax is not supported as color regions must begin with a symbol,
 	// not a character that is valid in an identifier.
 
 	// Code (both inline code and triple-backticks code blocks).
 	const Color code_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
-	highlighter->add_color_region("`", "`", code_color);
+	SyntaxHighlighter::SyntaxFontStyle type_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/engine_type_style");
+	highlighter->add_region("`", "`", code_color, type_style);
 
 	// Link (both references and inline links with URLs). The URL is not highlighted.
 	const Color link_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-	highlighter->add_color_region("[", "]", link_color);
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
+	highlighter->add_region("[", "]", link_color, keyword_style);
 
 	// Quote.
 	const Color quote_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
-	highlighter->add_color_region(">", "", quote_color, true);
+	SyntaxHighlighter::SyntaxFontStyle string_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/string_style");
+	highlighter->add_region(">", "", quote_color, string_style, true);
 
 	// HTML comment, which is also supported in Markdown.
 	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
-	highlighter->add_color_region("<!--", "-->", comment_color);
+	SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
+	highlighter->add_region("<!--", "-->", comment_color, comment_style);
 }
 
 Ref<EditorSyntaxHighlighter> EditorMarkdownSyntaxHighlighter::_create() const {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -228,23 +228,29 @@ void ShaderTextEditor::_load_theme_settings() {
 	}
 
 	syntax_highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+	syntax_highlighter->set_number_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style"));
 	syntax_highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	syntax_highlighter->set_symbol_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style"));
 	syntax_highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/function_color"));
+	syntax_highlighter->set_function_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style"));
 	syntax_highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/member_variable_color"));
+	syntax_highlighter->set_member_variable_style((SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style"));
 
-	syntax_highlighter->clear_keyword_colors();
+	syntax_highlighter->clear_keywords();
 
-	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
+	Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 
 	List<String> keywords;
 	ShaderLanguage::get_keyword_list(&keywords);
 
 	for (const String &E : keywords) {
 		if (ShaderLanguage::is_control_flow_keyword(E)) {
-			syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
+			syntax_highlighter->add_keyword(E, control_flow_keyword_color, control_flow_keyword_style);
 		} else {
-			syntax_highlighter->add_keyword_color(E, keyword_color);
+			syntax_highlighter->add_keyword(E, keyword_color, keyword_style);
 		}
 	}
 
@@ -252,7 +258,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	ShaderPreprocessor::get_keyword_list(&pp_keywords, false);
 
 	for (const String &E : pp_keywords) {
-		syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
+		syntax_highlighter->add_keyword(E, control_flow_keyword_color, control_flow_keyword_style);
 	}
 
 	// Colorize built-ins like `COLOR` differently to make them easier
@@ -304,22 +310,25 @@ void ShaderTextEditor::_load_theme_settings() {
 		}
 	}
 
-	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	SyntaxHighlighter::SyntaxFontStyle user_type_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/user_type_style");
 
 	for (const String &E : built_ins) {
-		syntax_highlighter->add_keyword_color(E, user_type_color);
+		syntax_highlighter->add_keyword(E, user_type_color, user_type_style);
 	}
 
 	// Colorize comments.
-	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
-	syntax_highlighter->clear_color_regions();
-	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-	syntax_highlighter->add_color_region("//", "", comment_color, true);
+	Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
+	syntax_highlighter->clear_regions();
+	syntax_highlighter->add_region("/*", "*/", comment_color, comment_style, false, true);
+	syntax_highlighter->add_region("//", "", comment_color, comment_style, true, true);
 
-	const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
-	syntax_highlighter->add_color_region("/**", "*/", doc_comment_color, false);
+	Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+	SyntaxHighlighter::SyntaxFontStyle doc_comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/doc_comment_style");
+	syntax_highlighter->add_region("/**", "*/", doc_comment_color, doc_comment_style, false, true);
 	// "/**/" will be treated as the start of the "/**" region, this line is guaranteed to end the color_region.
-	syntax_highlighter->add_color_region("/**/", "", comment_color, true);
+	syntax_highlighter->add_region("/**/", "", comment_color, comment_style, true, true);
 
 	// Disabled preprocessor branches use translucent text color to be easier to distinguish from comments.
 	syntax_highlighter->set_disabled_branch_color(Color(EDITOR_GET("text_editor/theme/highlighting/text_color")) * Color(1, 1, 1, 0.5));
@@ -333,8 +342,9 @@ void ShaderTextEditor::_load_theme_settings() {
 	}
 
 	// Colorize preprocessor include strings.
-	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
-	syntax_highlighter->add_color_region("\"", "\"", string_color, false);
+	Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+	SyntaxHighlighter::SyntaxFontStyle string_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/string_style");
+	syntax_highlighter->add_region("\"", "\"", string_color, string_style, false);
 
 	if (warnings_panel) {
 		// Warnings panel.

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1383,22 +1383,30 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 
 		Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
 		Color text_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
+
 		Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+		SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
 		Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+		SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 		Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+		SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
 		Color symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
+		SyntaxHighlighter::SyntaxFontStyle symbol_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style");
 		Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
+		SyntaxHighlighter::SyntaxFontStyle function_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style");
 		Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
+		SyntaxHighlighter::SyntaxFontStyle number_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style");
 		Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+		SyntaxHighlighter::SyntaxFontStyle members_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style");
 
 		expression_box->set_syntax_highlighter(expression_syntax_highlighter);
 		expression_box->add_theme_color_override("background_color", background_color);
 
 		for (const String &E : editor->keyword_list) {
 			if (ShaderLanguage::is_control_flow_keyword(E)) {
-				expression_syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
+				expression_syntax_highlighter->add_keyword(E, control_flow_keyword_color, control_flow_keyword_style);
 			} else {
-				expression_syntax_highlighter->add_keyword_color(E, keyword_color);
+				expression_syntax_highlighter->add_keyword(E, keyword_color, keyword_style);
 			}
 		}
 
@@ -1409,11 +1417,15 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 		expression_box->end_bulk_theme_override();
 
 		expression_syntax_highlighter->set_number_color(number_color);
+		expression_syntax_highlighter->set_number_style(number_style);
 		expression_syntax_highlighter->set_symbol_color(symbol_color);
+		expression_syntax_highlighter->set_symbol_style(symbol_style);
 		expression_syntax_highlighter->set_function_color(function_color);
+		expression_syntax_highlighter->set_function_style(function_style);
 		expression_syntax_highlighter->set_member_variable_color(members_color);
-		expression_syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-		expression_syntax_highlighter->add_color_region("//", "", comment_color, true);
+		expression_syntax_highlighter->set_member_variable_style(members_style);
+		expression_syntax_highlighter->add_region("/*", "*/", comment_color, comment_style, false, true);
+		expression_syntax_highlighter->add_region("//", "", comment_color, comment_style, true, true);
 
 		expression_box->clear_comment_delimiters();
 		expression_box->add_comment_delimiter("/*", "*/", false);
@@ -5202,13 +5214,22 @@ void VisualShaderEditor::_notification(int p_what) {
 			{
 				Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
 				Color text_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
+
 				Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+				SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
 				Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+				SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 				Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+				SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
 				Color symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
+				SyntaxHighlighter::SyntaxFontStyle symbol_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style");
 				Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
+				SyntaxHighlighter::SyntaxFontStyle function_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style");
 				Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
+				SyntaxHighlighter::SyntaxFontStyle number_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style");
 				Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+				SyntaxHighlighter::SyntaxFontStyle members_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style");
+
 				Color error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
 
 				preview_text->add_theme_color_override("background_color", background_color);
@@ -5216,9 +5237,9 @@ void VisualShaderEditor::_notification(int p_what) {
 
 				for (const String &E : keyword_list) {
 					if (ShaderLanguage::is_control_flow_keyword(E)) {
-						syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
+						syntax_highlighter->add_keyword(E, control_flow_keyword_color, control_flow_keyword_style);
 					} else {
-						syntax_highlighter->add_keyword_color(E, keyword_color);
+						syntax_highlighter->add_keyword(E, keyword_color, keyword_style);
 					}
 				}
 
@@ -5229,12 +5250,16 @@ void VisualShaderEditor::_notification(int p_what) {
 				preview_text->end_bulk_theme_override();
 
 				syntax_highlighter->set_number_color(number_color);
+				syntax_highlighter->set_number_style(number_style);
 				syntax_highlighter->set_symbol_color(symbol_color);
+				syntax_highlighter->set_symbol_style(symbol_style);
 				syntax_highlighter->set_function_color(function_color);
+				syntax_highlighter->set_function_style(function_style);
 				syntax_highlighter->set_member_variable_color(members_color);
-				syntax_highlighter->clear_color_regions();
-				syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-				syntax_highlighter->add_color_region("//", "", comment_color, true);
+				syntax_highlighter->set_member_variable_style(members_style);
+				syntax_highlighter->clear_regions();
+				syntax_highlighter->add_region("/*", "*/", comment_color, comment_style, false, true);
+				syntax_highlighter->add_region("//", "", comment_color, comment_style, true, true);
 
 				preview_text->clear_comment_delimiters();
 				preview_text->add_comment_delimiter("/*", "*/", false);

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -366,6 +366,16 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 		} break;
 	}
 
+	Ref<FontVariation> mono_fc_bold = mono_fc->duplicate();
+	mono_fc_bold->set_variation_embolden(0.8);
+
+	Ref<FontVariation> mono_fc_italic = mono_fc->duplicate();
+	mono_fc_italic->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+
+	Ref<FontVariation> mono_fc_bold_italic = mono_fc->duplicate();
+	mono_fc_bold_italic->set_variation_embolden(0.8);
+	mono_fc_bold_italic->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+
 	{
 		// Disable contextual alternates (coding ligatures).
 		Dictionary ftrs;
@@ -468,6 +478,9 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	// Code font
 	p_theme->set_font_size("source_size", EditorStringName(EditorFonts), int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
 	p_theme->set_font("source", EditorStringName(EditorFonts), mono_fc);
+	p_theme->set_font("source_bold", EditorStringName(EditorFonts), mono_fc_bold);
+	p_theme->set_font("source_italics", EditorStringName(EditorFonts), mono_fc_italic);
+	p_theme->set_font("source_bold_italics", EditorStringName(EditorFonts), mono_fc_bold_italic);
 
 	p_theme->set_font_size("expression_size", EditorStringName(EditorFonts), (int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
 	p_theme->set_font("expression", EditorStringName(EditorFonts), mono_other_fc);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -44,6 +44,7 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
+#include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/texture.h"
 
 // Theme configuration.
@@ -2622,14 +2623,23 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 
 	/* clang-format off */
 	setting->set_initial_value("text_editor/theme/highlighting/symbol_color",                    symbol_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/symbol_style",                    SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/keyword_color",                   keyword_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/keyword_style",                   SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/control_flow_keyword_color",      control_flow_keyword_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/control_flow_keyword_style",      SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/base_type_color",                 base_type_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/base_type_style",                 SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/engine_type_color",               engine_type_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/engine_type_style",               SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/user_type_color",                 user_type_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/user_type_style",                 SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/comment_color",                   comment_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/comment_style",                   SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/doc_comment_color",               doc_comment_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/doc_comment_style",               SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/string_color",                    string_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/string_style",                    SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/background_color",                te_background_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/completion_background_color",     completion_background_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/completion_selected_color",       completion_selected_color, true);
@@ -2649,14 +2659,18 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 	setting->set_initial_value("text_editor/theme/highlighting/line_length_guideline_color",     line_length_guideline_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/word_highlighted_color",          word_highlighted_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/number_color",                    number_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/number_style",                    SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/function_color",                  function_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/function_style",                  SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/member_variable_color",           member_variable_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/member_variable_style",           SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/mark_color",                      mark_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/bookmark_color",                  bookmark_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/breakpoint_color",                breakpoint_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/executing_line_color",            executing_line_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/code_folding_color",              code_folding_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/folded_code_region_color",        folded_code_region_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/folded_code_region_style",        SyntaxHighlighter::SYNTAX_STYLE_REGULAR, true);
 	setting->set_initial_value("text_editor/theme/highlighting/search_result_color",             search_result_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/search_result_border_color",      search_result_border_color, true);
 	/* clang-format on */
@@ -2673,6 +2687,10 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 	// Now theme is loaded, apply it to CodeEdit.
 	p_theme->set_font(SceneStringName(font), "CodeEdit", p_theme->get_font(SNAME("source"), EditorStringName(EditorFonts)));
 	p_theme->set_font_size(SceneStringName(font_size), "CodeEdit", p_theme->get_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
+
+	p_theme->set_font("bold_font", "CodeEdit", p_theme->get_font(SNAME("source_bold"), EditorStringName(EditorFonts)));
+	p_theme->set_font("italics_font", "CodeEdit", p_theme->get_font(SNAME("source_italics"), EditorStringName(EditorFonts)));
+	p_theme->set_font("bold_italics_font", "CodeEdit", p_theme->get_font(SNAME("source_bold_italics"), EditorStringName(EditorFonts)));
 
 	/* clang-format off */
 	p_theme->set_icon("tab",                  "CodeEdit", p_theme->get_icon(SNAME("GuiTab"), EditorStringName(EditorIcons)));

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -319,3 +319,12 @@ GH-100913
 Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_line_column_at_pos/arguments': size changed value in new API, from 2 to 3.
 
 Added optional argument to disallow positions that are outside the column range of the line. Compatibility method registered.
+
+
+GH-96588
+--------
+Validate extension JSON: API was removed: classes/CodeHighlighter/properties/color_regions
+Validate extension JSON: API was removed: classes/CodeHighlighter/properties/keyword_colors
+Validate extension JSON: API was removed: classes/CodeHighlighter/properties/member_keyword_colors
+
+Properties replaced with new 'regions', 'keywords', and 'member_keywords'. Compatibility getters/setters for old properties preserved.

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -77,6 +77,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 	Color keyword_color;
 	Color color;
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	bool text_segment = false;
 
 	color_region_cache[p_line] = -1;
 	int in_region = -1;
@@ -97,6 +100,8 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	const String &str = text_edit->get_line_with_ime(p_line);
 	const int line_length = str.length();
 	Color prev_color;
+	SyntaxHighlighter::SyntaxFontStyle prev_style = font_style;
+	bool prev_text_segment = false;
 
 	if (in_region != -1 && line_length == 0) {
 		color_region_cache[p_line] = in_region;
@@ -104,7 +109,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	for (int j = 0; j < line_length; j++) {
 		Dictionary highlighter_info;
 
+		text_segment = false;
 		color = font_color;
+		style = font_style;
 		bool is_char = !is_symbol(str[j]);
 		bool is_a_symbol = is_symbol(str[j]);
 		bool is_a_digit = is_digit(str[j]);
@@ -169,7 +176,11 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 								}
 							}
 							prev_color = color_regions[in_region].color;
+							prev_style = color_regions[in_region].style;
+							prev_text_segment = color_regions[in_region].is_string || color_regions[in_region].is_comment;
 							highlighter_info["color"] = color_regions[c].color;
+							highlighter_info["style"] = color_regions[c].style;
+							highlighter_info["text_segment"] = color_regions[c].is_string || color_regions[c].is_comment;
 							color_map[j] = highlighter_info;
 
 							j = line_length;
@@ -189,18 +200,30 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				// If we are in one, find the end key.
 				if (in_region != -1) {
 					Color region_color = color_regions[in_region].color;
+					SyntaxHighlighter::SyntaxFontStyle region_style = color_regions[in_region].style;
+					bool region_text_segment = color_regions[in_region].is_string || color_regions[in_region].is_comment;
 					if (in_node_path && color_regions[in_region].type == ColorRegion::TYPE_STRING) {
 						region_color = node_path_color;
+						region_style = node_path_style;
+						region_text_segment = false;
 					}
 					if (in_node_ref && color_regions[in_region].type == ColorRegion::TYPE_STRING) {
 						region_color = node_ref_color;
+						region_style = node_ref_style;
+						region_text_segment = false;
 					}
 					if (in_string_name && color_regions[in_region].type == ColorRegion::TYPE_STRING) {
 						region_color = string_name_color;
+						region_style = string_name_style;
+						region_text_segment = false;
 					}
 
 					prev_color = region_color;
+					prev_style = region_style;
+					prev_text_segment = region_text_segment;
 					highlighter_info["color"] = region_color;
+					highlighter_info["style"] = region_style;
+					highlighter_info["text_segment"] = region_text_segment;
 					color_map[j] = highlighter_info;
 
 					if (color_regions[in_region].is_comment) {
@@ -214,11 +237,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 									HashMap<String, CommentMarkerLevel>::ConstIterator E = comment_markers.find(str.substr(marker_start_pos, marker_len));
 									if (E) {
 										Dictionary marker_highlighter_info;
-										marker_highlighter_info["color"] = comment_marker_colors[E->value];
+										marker_highlighter_info["color"] = comment_marker_colors[E->value].color;
+										marker_highlighter_info["style"] = comment_marker_colors[E->value].style;
+										marker_highlighter_info["text_segment"] = true;
 										color_map[marker_start_pos] = marker_highlighter_info;
 
 										Dictionary marker_continue_highlighter_info;
 										marker_continue_highlighter_info["color"] = region_color;
+										marker_continue_highlighter_info["style"] = region_style;
+										marker_continue_highlighter_info["text_segment"] = region_text_segment;
 										color_map[from] = marker_continue_highlighter_info;
 									}
 								}
@@ -250,6 +277,8 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 								if (!color_regions[in_region].r_prefix) {
 									Dictionary escape_char_highlighter_info;
 									escape_char_highlighter_info["color"] = symbol_color;
+									escape_char_highlighter_info["style"] = symbol_style;
+									escape_char_highlighter_info["text_segment"] = true;
 									color_map[from] = escape_char_highlighter_info;
 								}
 
@@ -271,6 +300,8 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 									Dictionary region_continue_highlighter_info;
 									region_continue_highlighter_info["color"] = region_color;
+									region_continue_highlighter_info["style"] = region_style;
+									region_continue_highlighter_info["text_segment"] = region_text_segment;
 									color_map[from + 1] = region_continue_highlighter_info;
 								}
 
@@ -398,10 +429,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 			String word = str.substr(j, to - j);
 			Color col;
+			SyntaxHighlighter::SyntaxFontStyle sty = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 			if (global_functions.has(word)) {
 				// "assert" and "preload" are reserved, so highlight even if not followed by a bracket.
 				if (word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::ASSERT) || word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::PRELOAD)) {
 					col = global_function_color;
+					sty = global_function_style;
 				} else {
 					// For other global functions, check if followed by bracket.
 					int k = to;
@@ -411,16 +444,20 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 					if (str[k] == '(') {
 						col = global_function_color;
+						sty = global_function_style;
 					}
 				}
 			} else if (class_names.has(word)) {
-				col = class_names[word];
+				col = class_names[word].color;
+				sty = class_names[word].style;
 			} else if (reserved_keywords.has(word)) {
-				col = reserved_keywords[word];
+				col = reserved_keywords[word].color;
+				sty = reserved_keywords[word].style;
 				// Don't highlight `list` as a type in `for elem: Type in list`.
 				expect_type = false;
 			} else if (member_keywords.has(word)) {
-				col = member_keywords[word];
+				col = member_keywords[word].color;
+				sty = member_keywords[word].style;
 			}
 
 			if (col != Color()) {
@@ -436,6 +473,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				if (col != Color()) {
 					in_keyword = true;
 					keyword_color = col;
+					keyword_style = sty;
 				}
 			}
 		}
@@ -601,43 +639,68 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 		if (in_raw_string_prefix) {
 			color = string_color;
+			style = string_style;
+			text_segment = true;
 		} else if (in_node_ref) {
 			next_type = NODE_REF;
 			color = node_ref_color;
+			style = node_ref_style;
+			text_segment = false;
 		} else if (in_annotation) {
 			next_type = ANNOTATION;
 			color = annotation_color;
+			style = annotation_style;
+			text_segment = false;
 		} else if (in_string_name) {
 			next_type = STRING_NAME;
 			color = string_name_color;
+			style = string_name_style;
+			text_segment = false;
 		} else if (in_node_path) {
 			next_type = NODE_PATH;
 			color = node_path_color;
+			style = node_path_style;
+			text_segment = false;
 		} else if (in_keyword) {
 			next_type = KEYWORD;
 			color = keyword_color;
+			style = keyword_style;
+			text_segment = false;
 		} else if (in_signal_declaration) {
 			next_type = SIGNAL;
 			color = member_color;
+			style = member_style;
+			text_segment = false;
 		} else if (in_function_name) {
 			next_type = FUNCTION;
 			if (!in_lambda && in_function_declaration) {
 				color = function_definition_color;
+				style = function_definition_style;
 			} else {
 				color = function_color;
+				style = function_style;
 			}
+			text_segment = false;
 		} else if (in_number) {
 			next_type = NUMBER;
 			color = number_color;
+			style = number_style;
+			text_segment = false;
 		} else if (is_a_symbol) {
 			next_type = SYMBOL;
 			color = symbol_color;
+			style = symbol_style;
+			text_segment = false;
 		} else if (expect_type) {
 			next_type = TYPE;
 			color = type_color;
+			style = type_style;
+			text_segment = false;
 		} else if (in_member_variable) {
 			next_type = MEMBER;
 			color = member_color;
+			style = member_style;
+			text_segment = false;
 		} else {
 			next_type = IDENTIFIER;
 		}
@@ -669,9 +732,13 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 		prev_is_digit = is_a_digit;
 		prev_is_binary_op = is_binary_op;
 
-		if (color != prev_color) {
+		if (color != prev_color || style != prev_style || text_segment != prev_text_segment) {
 			prev_color = color;
+			prev_style = style;
+			prev_text_segment = text_segment;
 			highlighter_info["color"] = color;
+			highlighter_info["style"] = style;
+			highlighter_info["text_segment"] = text_segment;
 			color_map[j] = highlighter_info;
 		}
 	}
@@ -698,68 +765,96 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	font_color = text_edit->get_theme_color(SceneStringName(font_color));
 	symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
+	symbol_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/symbol_style");
 	function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
+	function_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/function_style");
+
 	number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
+	number_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/number_style");
 	member_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+	member_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/member_variable_style");
 
 	/* Engine types. */
-	const Color types_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
+	Color types_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
+	SyntaxHighlighter::SyntaxFontStyle types_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/engine_type_style");
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
 	for (const StringName &E : types) {
 		if (ClassDB::is_class_exposed(E)) {
-			class_names[E] = types_color;
+			class_names[E].color = types_color;
+			class_names[E].style = types_style;
 		}
 	}
 
 	/* User types. */
-	const Color usertype_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	Color usertype_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	SyntaxHighlighter::SyntaxFontStyle usertype_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/user_type_style");
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
 	for (const StringName &E : global_classes) {
-		class_names[E] = usertype_color;
+		class_names[E].color = usertype_color;
+		class_names[E].style = usertype_style;
 	}
 
 	/* Autoloads. */
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {
-			class_names[info.name] = usertype_color;
+			class_names[info.name].color = usertype_color;
+			class_names[info.name].style = usertype_style;
 		}
 	}
 
 	const GDScriptLanguage *gdscript = GDScriptLanguage::get_singleton();
 
 	/* Core types. */
-	const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+	Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+	SyntaxHighlighter::SyntaxFontStyle basetype_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/base_type_style");
 	List<String> core_types;
 	gdscript->get_core_type_words(&core_types);
 	for (const String &E : core_types) {
-		class_names[StringName(E)] = basetype_color;
+		class_names[StringName(E)].color = basetype_color;
+		class_names[StringName(E)].style = basetype_style;
 	}
-	class_names[SNAME("Variant")] = basetype_color;
-	class_names[SNAME("void")] = basetype_color;
+	class_names[SNAME("Variant")].color = basetype_color;
+	class_names[SNAME("Variant")].style = basetype_style;
+
+	class_names[SNAME("void")].color = basetype_color;
+	class_names[SNAME("void")].style = basetype_style;
+
 	// `get_core_type_words()` doesn't return primitive types.
-	class_names[SNAME("bool")] = basetype_color;
-	class_names[SNAME("int")] = basetype_color;
-	class_names[SNAME("float")] = basetype_color;
+	class_names[SNAME("bool")].color = basetype_color;
+	class_names[SNAME("bool")].style = basetype_style;
+
+	class_names[SNAME("int")].color = basetype_color;
+	class_names[SNAME("int")].style = basetype_style;
+
+	class_names[SNAME("float")].color = basetype_color;
+	class_names[SNAME("float")].style = basetype_style;
 
 	/* Reserved words. */
-	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/keyword_style");
+	Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+	SyntaxHighlighter::SyntaxFontStyle control_flow_keyword_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_style");
 	List<String> keyword_list;
 	gdscript->get_reserved_words(&keyword_list);
 	for (const String &E : keyword_list) {
 		if (gdscript->is_control_flow_keyword(E)) {
-			reserved_keywords[StringName(E)] = control_flow_keyword_color;
+			reserved_keywords[StringName(E)].color = control_flow_keyword_color;
+			reserved_keywords[StringName(E)].style = control_flow_keyword_style;
 		} else {
-			reserved_keywords[StringName(E)] = keyword_color;
+			reserved_keywords[StringName(E)].color = keyword_color;
+			reserved_keywords[StringName(E)].style = keyword_style;
 		}
 	}
 
 	// Highlight `set` and `get` as "keywords" with the function color to avoid conflicts with method calls.
-	reserved_keywords[SNAME("set")] = function_color;
-	reserved_keywords[SNAME("get")] = function_color;
+	reserved_keywords[SNAME("set")].color = function_color;
+	reserved_keywords[SNAME("set")].style = function_style;
+
+	reserved_keywords[SNAME("get")].color = function_color;
+	reserved_keywords[SNAME("get")].style = function_style;
 
 	/* Global functions. */
 	List<StringName> global_function_list;
@@ -773,45 +868,48 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	}
 
 	/* Comments */
-	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	SyntaxHighlighter::SyntaxFontStyle comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_style");
 	List<String> comments;
 	gdscript->get_comment_delimiters(&comments);
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, comment_color, end.is_empty());
+		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, comment_color, comment_style, end.is_empty());
 	}
 
 	/* Doc comments */
-	const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+	Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
+	SyntaxHighlighter::SyntaxFontStyle doc_comment_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/doc_comment_style");
 	List<String> doc_comments;
 	gdscript->get_doc_comment_delimiters(&doc_comments);
 	for (const String &doc_comment : doc_comments) {
 		String beg = doc_comment.get_slice(" ", 0);
 		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
-		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, doc_comment_color, end.is_empty());
+		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, doc_comment_color, doc_comment_style, end.is_empty());
 	}
 
 	/* Code regions */
-	const Color code_region_color = Color(EDITOR_GET("text_editor/theme/highlighting/folded_code_region_color").operator Color(), 1.0);
-	add_color_region(ColorRegion::TYPE_CODE_REGION, "#region", "", code_region_color, true);
-	add_color_region(ColorRegion::TYPE_CODE_REGION, "#endregion", "", code_region_color, true);
+	Color code_region_color = Color(EDITOR_GET("text_editor/theme/highlighting/folded_code_region_color").operator Color(), 1.0);
+	SyntaxHighlighter::SyntaxFontStyle code_region_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/folded_code_region_style");
+	add_color_region(ColorRegion::TYPE_CODE_REGION, "#region", "", code_region_color, code_region_style, true);
+	add_color_region(ColorRegion::TYPE_CODE_REGION, "#endregion", "", code_region_color, code_region_style, true);
 
 	/* Strings */
 	string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
-	add_color_region(ColorRegion::TYPE_STRING, "\"", "\"", string_color);
-	add_color_region(ColorRegion::TYPE_STRING, "'", "'", string_color);
-	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "\"\"\"", "\"\"\"", string_color);
-	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "'''", "'''", string_color);
-	add_color_region(ColorRegion::TYPE_STRING, "\"", "\"", string_color, false, true);
-	add_color_region(ColorRegion::TYPE_STRING, "'", "'", string_color, false, true);
-	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "\"\"\"", "\"\"\"", string_color, false, true);
-	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "'''", "'''", string_color, false, true);
+	string_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/string_style");
+	add_color_region(ColorRegion::TYPE_STRING, "\"", "\"", string_color, string_style);
+	add_color_region(ColorRegion::TYPE_STRING, "'", "'", string_color, string_style);
+	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "\"\"\"", "\"\"\"", string_color, string_style);
+	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "'''", "'''", string_color, string_style);
+	add_color_region(ColorRegion::TYPE_STRING, "\"", "\"", string_color, string_style, false, true);
+	add_color_region(ColorRegion::TYPE_STRING, "'", "'", string_color, string_style, false, true);
+	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "\"\"\"", "\"\"\"", string_color, string_style, false, true);
+	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "'''", "'''", string_color, string_style, false, true);
 
 	const Ref<Script> scr = _get_edited_resource();
 	if (scr.is_valid()) {
 		/* Member types. */
-		const Color member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
 		StringName instance_base = scr->get_instance_base_type();
 		if (instance_base != StringName()) {
 			List<PropertyInfo> plist;
@@ -824,13 +922,15 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 				if (prop_name.contains_char('/')) {
 					continue;
 				}
-				member_keywords[prop_name] = member_variable_color;
+				member_keywords[prop_name].color = member_color;
+				member_keywords[prop_name].style = member_style;
 			}
 
 			List<String> clist;
 			ClassDB::get_integer_constant_list(instance_base, &clist);
 			for (const String &E : clist) {
-				member_keywords[E] = member_variable_color;
+				member_keywords[E].color = member_color;
+				member_keywords[E].style = member_style;
 			}
 		}
 	}
@@ -845,9 +945,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 		node_ref_color = Color(0.39, 0.76, 0.35);
 		annotation_color = Color(1.0, 0.7, 0.45);
 		string_name_color = Color(1.0, 0.76, 0.65);
-		comment_marker_colors[COMMENT_MARKER_CRITICAL] = Color(0.77, 0.35, 0.35);
-		comment_marker_colors[COMMENT_MARKER_WARNING] = Color(0.72, 0.61, 0.48);
-		comment_marker_colors[COMMENT_MARKER_NOTICE] = Color(0.56, 0.67, 0.51);
+		comment_marker_colors[COMMENT_MARKER_CRITICAL].color = Color(0.77, 0.35, 0.35);
+		comment_marker_colors[COMMENT_MARKER_WARNING].color = Color(0.72, 0.61, 0.48);
+		comment_marker_colors[COMMENT_MARKER_NOTICE].color = Color(0.56, 0.67, 0.51);
 	} else {
 		function_definition_color = Color(0, 0.6, 0.6);
 		global_function_color = Color(0.36, 0.18, 0.72);
@@ -855,75 +955,85 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 		node_ref_color = Color(0.0, 0.5, 0);
 		annotation_color = Color(0.8, 0.37, 0);
 		string_name_color = Color(0.8, 0.56, 0.45);
-		comment_marker_colors[COMMENT_MARKER_CRITICAL] = Color(0.8, 0.14, 0.14);
-		comment_marker_colors[COMMENT_MARKER_WARNING] = Color(0.75, 0.39, 0.03);
-		comment_marker_colors[COMMENT_MARKER_NOTICE] = Color(0.24, 0.54, 0.09);
+		comment_marker_colors[COMMENT_MARKER_CRITICAL].color = Color(0.8, 0.14, 0.14);
+		comment_marker_colors[COMMENT_MARKER_WARNING].color = Color(0.75, 0.39, 0.03);
+		comment_marker_colors[COMMENT_MARKER_NOTICE].color = Color(0.24, 0.54, 0.09);
 	}
 
 	// TODO: Move to editor_settings.cpp
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/function_definition_color", function_definition_color);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/function_definition_style", function_definition_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/function_definition_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/global_function_color", global_function_color);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/global_function_style", global_function_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/global_function_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/node_path_color", node_path_color);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/node_path_style", node_path_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/node_path_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/node_reference_color", node_ref_color);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/node_reference_style", node_ref_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/node_reference_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/annotation_color", annotation_color);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/annotation_style", annotation_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/annotation_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/string_name_color", string_name_color);
-	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/critical_color", comment_marker_colors[COMMENT_MARKER_CRITICAL]);
-	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/warning_color", comment_marker_colors[COMMENT_MARKER_WARNING]);
-	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/notice_color", comment_marker_colors[COMMENT_MARKER_NOTICE]);
+	EDITOR_DEF("text_editor/theme/highlighting/gdscript/string_name_style", string_name_style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/gdscript/string_name_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/critical_color", comment_marker_colors[COMMENT_MARKER_CRITICAL].color);
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/critical_style", comment_marker_colors[COMMENT_MARKER_CRITICAL].style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/comment_markers/critical_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/warning_color", comment_marker_colors[COMMENT_MARKER_WARNING].color);
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/warning_style", comment_marker_colors[COMMENT_MARKER_WARNING].style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/comment_markers/warning_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/notice_color", comment_marker_colors[COMMENT_MARKER_NOTICE].color);
+	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/notice_style", comment_marker_colors[COMMENT_MARKER_NOTICE].style);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/theme/highlighting/comment_markers/notice_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"));
 	// The list is based on <https://github.com/KDE/syntax-highlighting/blob/master/data/syntax/alert.xml>.
 	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/critical_list", "ALERT,ATTENTION,CAUTION,CRITICAL,DANGER,SECURITY");
 	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/warning_list", "BUG,DEPRECATED,FIXME,HACK,TASK,TBD,TODO,WARNING");
 	EDITOR_DEF("text_editor/theme/highlighting/comment_markers/notice_list", "INFO,NOTE,NOTICE,TEST,TESTING");
 
 	if (text_edit_color_theme == "Default" || godot_2_theme) {
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/function_definition_color",
-				function_definition_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/global_function_color",
-				global_function_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/node_path_color",
-				node_path_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/node_reference_color",
-				node_ref_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/annotation_color",
-				annotation_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/gdscript/string_name_color",
-				string_name_color,
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/comment_markers/critical_color",
-				comment_marker_colors[COMMENT_MARKER_CRITICAL],
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/comment_markers/warning_color",
-				comment_marker_colors[COMMENT_MARKER_WARNING],
-				true);
-		EditorSettings::get_singleton()->set_initial_value(
-				"text_editor/theme/highlighting/comment_markers/notice_color",
-				comment_marker_colors[COMMENT_MARKER_NOTICE],
-				true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/function_definition_color", function_definition_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/function_definition_style", function_definition_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/global_function_color", global_function_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/global_function_style", global_function_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/node_path_color", node_path_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/node_path_style", node_path_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/node_reference_color", node_ref_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/node_reference_style", node_ref_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/annotation_color", annotation_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/annotation_style", annotation_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/string_name_color", string_name_color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/gdscript/string_name_style", string_name_style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/critical_color", comment_marker_colors[COMMENT_MARKER_CRITICAL].color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/critical_style", comment_marker_colors[COMMENT_MARKER_CRITICAL].style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/warning_color", comment_marker_colors[COMMENT_MARKER_WARNING].color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/warning_style", comment_marker_colors[COMMENT_MARKER_WARNING].style, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/notice_color", comment_marker_colors[COMMENT_MARKER_NOTICE].color, true);
+		EditorSettings::get_singleton()->set_initial_value("text_editor/theme/highlighting/comment_markers/notice_style", comment_marker_colors[COMMENT_MARKER_NOTICE].style, true);
 	}
 
 	function_definition_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/function_definition_color");
+	function_definition_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/function_definition_style");
 	global_function_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/global_function_color");
+	global_function_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/global_function_style");
 	node_path_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_path_color");
+	node_path_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/node_path_style");
 	node_ref_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_reference_color");
+	node_ref_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/node_reference_style");
 	annotation_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/annotation_color");
+	annotation_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/annotation_style");
 	string_name_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/string_name_color");
+	string_name_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/gdscript/string_name_style");
 	type_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
-	comment_marker_colors[COMMENT_MARKER_CRITICAL] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_color");
-	comment_marker_colors[COMMENT_MARKER_WARNING] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/warning_color");
-	comment_marker_colors[COMMENT_MARKER_NOTICE] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/notice_color");
+	type_style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/base_type_style");
+	comment_marker_colors[COMMENT_MARKER_CRITICAL].color = EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_color");
+	comment_marker_colors[COMMENT_MARKER_CRITICAL].style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_style");
+	comment_marker_colors[COMMENT_MARKER_WARNING].color = EDITOR_GET("text_editor/theme/highlighting/comment_markers/warning_color");
+	comment_marker_colors[COMMENT_MARKER_WARNING].style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_markers/warning_style");
+	comment_marker_colors[COMMENT_MARKER_NOTICE].color = EDITOR_GET("text_editor/theme/highlighting/comment_markers/notice_color");
+	comment_marker_colors[COMMENT_MARKER_NOTICE].style = (SyntaxHighlighter::SyntaxFontStyle)(int)EDITOR_GET("text_editor/theme/highlighting/comment_markers/notice_style");
 
 	comment_markers.clear();
 	Vector<String> critical_list = EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_list").operator String().split(",", false);
@@ -940,7 +1050,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	}
 }
 
-void GDScriptSyntaxHighlighter::add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only, bool p_r_prefix) {
+void GDScriptSyntaxHighlighter::add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style, bool p_line_only, bool p_r_prefix) {
 	ERR_FAIL_COND_MSG(p_start_key.is_empty(), "Color region start key cannot be empty.");
 	ERR_FAIL_COND_MSG(!is_symbol(p_start_key[0]), "Color region start key must start with a symbol.");
 
@@ -961,6 +1071,7 @@ void GDScriptSyntaxHighlighter::add_color_region(ColorRegion::Type p_type, const
 	ColorRegion color_region;
 	color_region.type = p_type;
 	color_region.color = p_color;
+	color_region.style = p_style;
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
 	color_region.line_only = p_line_only;

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -48,6 +48,7 @@ private:
 
 		Type type = TYPE_NONE;
 		Color color;
+		SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 		String start_key;
 		String end_key;
 		bool line_only = false;
@@ -58,9 +59,13 @@ private:
 	Vector<ColorRegion> color_regions;
 	HashMap<int, int> color_region_cache;
 
-	HashMap<StringName, Color> class_names;
-	HashMap<StringName, Color> reserved_keywords;
-	HashMap<StringName, Color> member_keywords;
+	struct ColorRec {
+		Color color;
+		SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	};
+	HashMap<StringName, ColorRec> class_names;
+	HashMap<StringName, ColorRec> reserved_keywords;
+	HashMap<StringName, ColorRec> member_keywords;
 	HashSet<StringName> global_functions;
 
 	enum Type {
@@ -82,19 +87,33 @@ private:
 
 	// Colors.
 	Color font_color;
+	SyntaxHighlighter::SyntaxFontStyle font_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color symbol_color;
+	SyntaxHighlighter::SyntaxFontStyle symbol_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color function_color;
+	SyntaxHighlighter::SyntaxFontStyle function_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color global_function_color;
+	SyntaxHighlighter::SyntaxFontStyle global_function_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color function_definition_color;
+	SyntaxHighlighter::SyntaxFontStyle function_definition_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color built_in_type_color;
+	SyntaxHighlighter::SyntaxFontStyle built_in_type_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color number_color;
+	SyntaxHighlighter::SyntaxFontStyle number_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color member_color;
+	SyntaxHighlighter::SyntaxFontStyle member_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color string_color;
+	SyntaxHighlighter::SyntaxFontStyle string_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color node_path_color;
+	SyntaxHighlighter::SyntaxFontStyle node_path_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color node_ref_color;
+	SyntaxHighlighter::SyntaxFontStyle node_ref_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color annotation_color;
+	SyntaxHighlighter::SyntaxFontStyle annotation_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color string_name_color;
+	SyntaxHighlighter::SyntaxFontStyle string_name_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color type_color;
+	SyntaxHighlighter::SyntaxFontStyle type_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 
 	enum CommentMarkerLevel {
 		COMMENT_MARKER_CRITICAL,
@@ -102,10 +121,10 @@ private:
 		COMMENT_MARKER_NOTICE,
 		COMMENT_MARKER_MAX,
 	};
-	Color comment_marker_colors[COMMENT_MARKER_MAX];
+	ColorRec comment_marker_colors[COMMENT_MARKER_MAX];
 	HashMap<String, CommentMarkerLevel> comment_markers;
 
-	void add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false, bool p_r_prefix = false);
+	void add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR, bool p_line_only = false, bool p_r_prefix = false);
 
 public:
 	virtual void _update_cache() override;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -145,15 +145,22 @@ private:
 			Color color = Color(1, 1, 1);
 		};
 
+		struct FontOverride {
+			Vector2i range;
+			SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+		};
+
 		struct Line {
 			Vector<Gutter> gutters;
+			Vector<FontOverride> font_overrides;
 
 			String data;
 			Array bidi_override;
-			Ref<TextParagraph> data_buf;
 
 			String ime_data;
 			Array ime_bidi_override;
+
+			Ref<TextParagraph> data_buf;
 
 			Color background_color = Color(0, 0, 0, 0);
 			bool hidden = false;
@@ -170,8 +177,16 @@ private:
 		bool is_dirty = false;
 		bool tab_size_dirty = false;
 
+		Ref<SyntaxHighlighter> syntax_highlighter;
+		bool hl_stt = false;
+		bool hl_font_map = false;
+
 		mutable Vector<Line> text;
 		Ref<Font> font;
+		Ref<Font> bold_font;
+		Ref<Font> bold_italics_font;
+		Ref<Font> italics_font;
+
 		int font_size = -1;
 		int font_height = 0;
 
@@ -194,13 +209,22 @@ private:
 		int gutter_count = 0;
 		bool indent_wrapped_lines = false;
 
+		void _calculate_line_height() const;
+		void _calculate_max_line_width() const;
+
+		void _parse_highlighter_map(int p_line);
+
 	public:
+		void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
+		void set_use_syntax_highlighter_for_bidi_override(bool p_enabled);
+		void set_use_syntax_highlighter_font_change(bool p_enabled);
+
 		void set_tab_size(int p_tab_size);
 		int get_tab_size() const;
 		void set_indent_wrapped_lines(bool p_enabled);
 		bool is_indent_wrapped_lines() const;
 
-		void set_font(const Ref<Font> &p_font);
+		void set_font(const Ref<Font> &p_font, const Ref<Font> &p_bold_font, const Ref<Font> &p_bold_italics_font, const Ref<Font> &p_italics_font);
 		void set_font_size(int p_font_size);
 		void set_direction_and_language(TextServer::Direction p_direction, const String &p_language);
 		void set_draw_control_chars(bool p_enabled);
@@ -232,6 +256,7 @@ private:
 
 		void set(int p_line, const String &p_text, const Array &p_bidi_override);
 		void set_ime(int p_line, const String &p_text, const Array &p_bidi_override);
+
 		void set_hidden(int p_line, bool p_hidden);
 		bool is_hidden(int p_line) const;
 		void insert(int p_at, const Vector<String> &p_text, const Vector<Array> &p_bidi_override);
@@ -574,6 +599,9 @@ private:
 	Ref<SyntaxHighlighter> syntax_highlighter;
 	HashMap<int, Vector<Pair<int64_t, Color>>> syntax_highlighting_cache;
 
+	bool hl_stt = false;
+	bool hl_font_map = false;
+
 	Vector<Pair<int64_t, Color>> _get_line_syntax_highlighting(int p_line);
 	void _clear_syntax_highlighting_cache();
 
@@ -603,6 +631,10 @@ private:
 		Ref<Texture2D> space_icon;
 
 		Ref<Font> font;
+		Ref<Font> bold_font;
+		Ref<Font> bold_italics_font;
+		Ref<Font> italics_font;
+
 		int font_size = 16;
 		Color font_color = Color(1, 1, 1);
 		Color font_readonly_color = Color(1, 1, 1);
@@ -755,6 +787,12 @@ public:
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 	void set_structured_text_bidi_override_options(Array p_args);
 	Array get_structured_text_bidi_override_options() const;
+
+	void set_use_syntax_highlighter_for_bidi_override(bool p_enabled);
+	bool get_use_syntax_highlighter_for_bidi_override() const;
+
+	void set_use_syntax_highlighter_font_change(bool p_enabled);
+	bool get_use_syntax_highlighter_font_change() const;
 
 	void set_tab_size(const int p_size);
 	int get_tab_size() const;

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -63,6 +63,12 @@ void SyntaxHighlighter::_lines_edited_from(int p_from_line, int p_to_line) {
 	}
 }
 
+void SyntaxHighlighter::clear_line_highlighting_cache(int p_line) {
+	if (highlighting_cache.has(p_line)) {
+		highlighting_cache.erase(p_line);
+	}
+}
+
 void SyntaxHighlighter::clear_highlighting_cache() {
 	highlighting_cache.clear();
 
@@ -108,6 +114,11 @@ void SyntaxHighlighter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_highlighting_cache"), &SyntaxHighlighter::clear_highlighting_cache);
 	ClassDB::bind_method(D_METHOD("get_text_edit"), &SyntaxHighlighter::get_text_edit);
 
+	BIND_ENUM_CONSTANT(SYNTAX_STYLE_REGULAR);
+	BIND_ENUM_CONSTANT(SYNTAX_STYLE_BOLD);
+	BIND_ENUM_CONSTANT(SYNTAX_STYLE_ITALIC);
+	BIND_ENUM_CONSTANT(SYNTAX_STYLE_BOLD_ITALIC);
+
 	GDVIRTUAL_BIND(_get_line_syntax_highlighting, "line")
 	GDVIRTUAL_BIND(_clear_highlighting_cache)
 	GDVIRTUAL_BIND(_update_cache)
@@ -127,6 +138,9 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 	bool is_hex_notation = false;
 	Color keyword_color;
 	Color color;
+	SyntaxHighlighter::SyntaxFontStyle keyword_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	bool text_segment = false;
 
 	color_region_cache[p_line] = -1;
 	int in_region = -1;
@@ -147,6 +161,8 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 	const String &str = text_edit->get_line_with_ime(p_line);
 	const int line_length = str.length();
 	Color prev_color;
+	SyntaxHighlighter::SyntaxFontStyle prev_style = font_style;
+	bool prev_text_segment = false;
 
 	if (in_region != -1 && str.length() == 0) {
 		color_region_cache[p_line] = in_region;
@@ -154,7 +170,9 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 	for (int j = 0; j < line_length; j++) {
 		Dictionary highlighter_info;
 
+		text_segment = false;
 		color = font_color;
+		style = font_style;
 		bool is_char = !is_symbol(str[j]);
 		bool is_a_symbol = is_symbol(str[j]);
 		bool is_number = is_digit(str[j]);
@@ -209,7 +227,11 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 								}
 							}
 							prev_color = color_regions[in_region].color;
+							prev_style = color_regions[in_region].style;
+							prev_text_segment = color_regions[in_region].text_segment;
 							highlighter_info["color"] = color_regions[c].color;
+							highlighter_info["style"] = color_regions[c].style;
+							highlighter_info["text_segment"] = color_regions[c].text_segment;
 							color_map[j] = highlighter_info;
 
 							j = line_length;
@@ -230,8 +252,14 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 					bool is_string = (color_regions[in_region].start_key == "\"" || color_regions[in_region].start_key == "\'");
 
 					Color region_color = color_regions[in_region].color;
+					SyntaxHighlighter::SyntaxFontStyle region_style = color_regions[in_region].style;
+					bool region_text_segment = color_regions[in_region].text_segment;
 					prev_color = region_color;
+					prev_style = region_style;
+					prev_text_segment = region_text_segment;
 					highlighter_info["color"] = region_color;
+					highlighter_info["style"] = region_style;
+					highlighter_info["text_segment"] = region_text_segment;
 					color_map[j] = highlighter_info;
 
 					/* search the line */
@@ -254,6 +282,8 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 							if (is_string) {
 								Dictionary escape_char_highlighter_info;
 								escape_char_highlighter_info["color"] = symbol_color;
+								escape_char_highlighter_info["style"] = symbol_style;
+								escape_char_highlighter_info["text_segment"] = true;
 								color_map[from] = escape_char_highlighter_info;
 							}
 
@@ -262,7 +292,11 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 							if (is_string) {
 								Dictionary region_continue_highlighter_info;
 								prev_color = region_color;
+								prev_style = region_style;
+								prev_text_segment = region_text_segment;
 								region_continue_highlighter_info["color"] = region_color;
+								region_continue_highlighter_info["style"] = region_style;
+								region_continue_highlighter_info["text_segment"] = region_text_segment;
 								color_map[from + 1] = region_continue_highlighter_info;
 							}
 							continue;
@@ -336,10 +370,13 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 
 			String word = str.substr(j, to - j);
 			Color col;
+			SyntaxHighlighter::SyntaxFontStyle sty = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 			if (keywords.has(word)) {
-				col = keywords[word];
+				col = keywords[word].color;
+				sty = keywords[word].style;
 			} else if (member_keywords.has(word)) {
-				col = member_keywords[word];
+				col = member_keywords[word].color;
+				sty = member_keywords[word].style;
 				for (int k = j - 1; k >= 0; k--) {
 					if (str[k] == '.') {
 						col = Color(); //member indexing not allowed
@@ -353,6 +390,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 			if (col != Color()) {
 				in_keyword = true;
 				keyword_color = col;
+				keyword_style = sty;
 			}
 		}
 
@@ -390,22 +428,36 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 
 		if (in_keyword) {
 			color = keyword_color;
+			style = keyword_style;
+			text_segment = false;
 		} else if (in_member_variable) {
 			color = member_color;
+			style = member_style;
+			text_segment = false;
 		} else if (in_function_name) {
 			color = function_color;
+			style = function_style;
+			text_segment = false;
 		} else if (is_a_symbol) {
 			color = symbol_color;
+			style = symbol_style;
+			text_segment = false;
 		} else if (is_number) {
 			color = number_color;
+			style = number_style;
+			text_segment = false;
 		}
 
 		prev_is_char = is_char;
 		prev_is_number = is_number;
 
-		if (color != prev_color) {
+		if (color != prev_color || style != prev_style || text_segment != prev_text_segment) {
 			prev_color = color;
+			prev_style = style;
+			prev_text_segment = text_segment;
 			highlighter_info["color"] = color;
+			highlighter_info["style"] = style;
+			highlighter_info["text_segment"] = text_segment;
 			color_map[j] = highlighter_info;
 		}
 	}
@@ -421,73 +473,187 @@ void CodeHighlighter::_update_cache() {
 	font_color = text_edit->get_font_color();
 }
 
+#ifndef DISABLE_DEPRECATED
 void CodeHighlighter::add_keyword_color(const String &p_keyword, const Color &p_color) {
-	keywords[p_keyword] = p_color;
+	add_keyword(p_keyword, p_color, SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+}
+#endif
+
+void CodeHighlighter::add_keyword(const String &p_keyword, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style) {
+	ColorRec rec;
+	rec.color = p_color;
+	rec.style = p_style;
+	keywords[p_keyword] = rec;
 	clear_highlighting_cache();
 }
 
-void CodeHighlighter::remove_keyword_color(const String &p_keyword) {
+void CodeHighlighter::remove_keyword(const String &p_keyword) {
 	keywords.erase(p_keyword);
 	clear_highlighting_cache();
 }
 
-bool CodeHighlighter::has_keyword_color(const String &p_keyword) const {
+bool CodeHighlighter::has_keyword(const String &p_keyword) const {
 	return keywords.has(p_keyword);
 }
 
 Color CodeHighlighter::get_keyword_color(const String &p_keyword) const {
 	ERR_FAIL_COND_V(!keywords.has(p_keyword), Color());
-	return keywords[p_keyword];
+	return keywords[p_keyword].color;
 }
 
-void CodeHighlighter::set_keyword_colors(const Dictionary p_keywords) {
-	keywords = p_keywords;
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_keyword_style(const String &p_keyword) const {
+	ERR_FAIL_COND_V(!keywords.has(p_keyword), SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	return keywords[p_keyword].style;
+}
+
+void CodeHighlighter::set_keywords(const Dictionary &p_keywords) {
+	keywords.clear();
+	List<Variant> keys;
+	p_keywords.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		const Dictionary &hl_data = p_keywords[key];
+
+		const Color &color = hl_data.get("color", Color());
+		SyntaxHighlighter::SyntaxFontStyle style = (SyntaxHighlighter::SyntaxFontStyle)(int)hl_data.get("style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+		add_keyword(key, color, style);
+	}
 	clear_highlighting_cache();
 }
 
-void CodeHighlighter::clear_keyword_colors() {
+#ifndef DISABLE_DEPRECATED
+void CodeHighlighter::set_keyword_colors(const Dictionary &p_keywords) {
+	keywords.clear();
+	List<Variant> keys;
+	p_keywords.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		const Color &color = p_keywords[key];
+
+		add_keyword(key, color, SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	}
+	clear_highlighting_cache();
+}
+#endif
+
+void CodeHighlighter::clear_keywords() {
 	keywords.clear();
 	clear_highlighting_cache();
 }
 
-Dictionary CodeHighlighter::get_keyword_colors() const {
-	return keywords;
+Dictionary CodeHighlighter::get_keywords() const {
+	Dictionary ret;
+	for (const KeyValue<String, ColorRec> &E : keywords) {
+		Dictionary rec;
+		rec["color"] = E.value.color;
+		rec["style"] = E.value.style;
+		ret[E.key] = rec;
+	}
+	return ret;
 }
 
+#ifndef DISABLE_DEPRECATED
+Dictionary CodeHighlighter::get_keyword_colors() const {
+	Dictionary ret;
+	for (const KeyValue<String, ColorRec> &E : keywords) {
+		ret[E.key] = E.value.color;
+	}
+	return ret;
+}
+#endif
+
+#ifndef DISABLE_DEPRECATED
 void CodeHighlighter::add_member_keyword_color(const String &p_member_keyword, const Color &p_color) {
-	member_keywords[p_member_keyword] = p_color;
+	add_member_keyword(p_member_keyword, p_color, SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+}
+#endif
+
+void CodeHighlighter::add_member_keyword(const String &p_member_keyword, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style) {
+	ColorRec rec;
+	rec.color = p_color;
+	rec.style = p_style;
+	member_keywords[p_member_keyword] = rec;
 	clear_highlighting_cache();
 }
 
-void CodeHighlighter::remove_member_keyword_color(const String &p_member_keyword) {
+void CodeHighlighter::remove_member_keyword(const String &p_member_keyword) {
 	member_keywords.erase(p_member_keyword);
 	clear_highlighting_cache();
 }
 
-bool CodeHighlighter::has_member_keyword_color(const String &p_member_keyword) const {
+bool CodeHighlighter::has_member_keyword(const String &p_member_keyword) const {
 	return member_keywords.has(p_member_keyword);
 }
 
 Color CodeHighlighter::get_member_keyword_color(const String &p_member_keyword) const {
 	ERR_FAIL_COND_V(!member_keywords.has(p_member_keyword), Color());
-	return member_keywords[p_member_keyword];
+	return member_keywords[p_member_keyword].color;
 }
 
-void CodeHighlighter::set_member_keyword_colors(const Dictionary &p_member_keywords) {
-	member_keywords = p_member_keywords;
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_member_keyword_style(const String &p_member_keyword) const {
+	ERR_FAIL_COND_V(!member_keywords.has(p_member_keyword), SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	return member_keywords[p_member_keyword].style;
+}
+
+void CodeHighlighter::set_member_keywords(const Dictionary &p_member_keywords) {
+	member_keywords.clear();
+	List<Variant> keys;
+	p_member_keywords.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		const Dictionary &hl_data = p_member_keywords[key];
+
+		const Color &color = hl_data.get("color", Color());
+		SyntaxHighlighter::SyntaxFontStyle style = (SyntaxHighlighter::SyntaxFontStyle)(int)hl_data.get("style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+		add_member_keyword(key, color, style);
+	}
 	clear_highlighting_cache();
 }
 
-void CodeHighlighter::clear_member_keyword_colors() {
+#ifndef DISABLE_DEPRECATED
+void CodeHighlighter::set_member_keyword_colors(const Dictionary &p_member_keywords) {
+	member_keywords.clear();
+	List<Variant> keys;
+	p_member_keywords.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		const Color &color = p_member_keywords[key];
+
+		add_member_keyword(key, color, SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	}
+	clear_highlighting_cache();
+}
+#endif
+
+void CodeHighlighter::clear_member_keywords() {
 	member_keywords.clear();
 	clear_highlighting_cache();
 }
 
-Dictionary CodeHighlighter::get_member_keyword_colors() const {
-	return member_keywords;
+Dictionary CodeHighlighter::get_member_keywords() const {
+	Dictionary ret;
+	for (const KeyValue<String, ColorRec> &E : member_keywords) {
+		Dictionary rec;
+		rec["color"] = E.value.color;
+		rec["style"] = E.value.style;
+		ret[E.key] = rec;
+	}
+	return ret;
 }
 
+#ifndef DISABLE_DEPRECATED
+Dictionary CodeHighlighter::get_member_keyword_colors() const {
+	Dictionary ret;
+	for (const KeyValue<String, ColorRec> &E : member_keywords) {
+		ret[E.key] = E.value.color;
+	}
+	return ret;
+}
+#endif
+
+#ifndef DISABLE_DEPRECATED
 void CodeHighlighter::add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only) {
+	add_region(p_start_key, p_end_key, p_color, SyntaxHighlighter::SYNTAX_STYLE_REGULAR, p_line_only, false);
+}
+#endif
+
+void CodeHighlighter::add_region(const String &p_start_key, const String &p_end_key, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style, bool p_line_only, bool p_is_text_segment) {
 	for (int i = 0; i < p_start_key.length(); i++) {
 		ERR_FAIL_COND_MSG(!is_symbol(p_start_key[i]), "color regions must start with a symbol");
 	}
@@ -511,11 +677,13 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
 	color_region.line_only = p_line_only || p_end_key.is_empty();
+	color_region.style = p_style;
+	color_region.text_segment = p_is_text_segment;
 	color_regions.insert(at, color_region);
 	clear_highlighting_cache();
 }
 
-void CodeHighlighter::remove_color_region(const String &p_start_key) {
+void CodeHighlighter::remove_region(const String &p_start_key) {
 	for (int i = 0; i < color_regions.size(); i++) {
 		if (color_regions[i].start_key == p_start_key) {
 			color_regions.remove_at(i);
@@ -525,7 +693,7 @@ void CodeHighlighter::remove_color_region(const String &p_start_key) {
 	clear_highlighting_cache();
 }
 
-bool CodeHighlighter::has_color_region(const String &p_start_key) const {
+bool CodeHighlighter::has_region(const String &p_start_key) const {
 	for (int i = 0; i < color_regions.size(); i++) {
 		if (color_regions[i].start_key == p_start_key) {
 			return true;
@@ -534,6 +702,30 @@ bool CodeHighlighter::has_color_region(const String &p_start_key) const {
 	return false;
 }
 
+void CodeHighlighter::set_regions(const Dictionary &p_regions) {
+	color_regions.clear();
+
+	List<Variant> keys;
+	p_regions.get_key_list(&keys);
+
+	for (const Variant &E : keys) {
+		String key = E;
+
+		String start_key = key.get_slice(" ", 0);
+		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
+
+		const Dictionary &hl_data = p_regions[key];
+
+		const Color &color = hl_data.get("color", Color());
+		SyntaxHighlighter::SyntaxFontStyle style = (SyntaxHighlighter::SyntaxFontStyle)(int)hl_data.get("style", SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+		bool is_text_segment = hl_data.get("text_segment", false);
+
+		add_region(start_key, end_key, color, style, end_key.is_empty(), is_text_segment);
+	}
+	clear_highlighting_cache();
+}
+
+#ifndef DISABLE_DEPRECATED
 void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 	color_regions.clear();
 
@@ -546,16 +738,31 @@ void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 		String start_key = key.get_slice(" ", 0);
 		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
 
-		add_color_region(start_key, end_key, p_color_regions[key], end_key.is_empty());
+		add_region(start_key, end_key, p_color_regions[key], SyntaxHighlighter::SYNTAX_STYLE_REGULAR, end_key.is_empty(), false);
 	}
 	clear_highlighting_cache();
 }
+#endif
 
-void CodeHighlighter::clear_color_regions() {
+void CodeHighlighter::clear_regions() {
 	color_regions.clear();
 	clear_highlighting_cache();
 }
 
+Dictionary CodeHighlighter::get_regions() const {
+	Dictionary r_regions;
+	for (int i = 0; i < color_regions.size(); i++) {
+		ColorRegion region = color_regions[i];
+		Dictionary rec;
+		rec["color"] = region.color;
+		rec["style"] = region.style;
+		rec["text_segment"] = region.text_segment;
+		r_regions[region.start_key + (region.end_key.is_empty() ? "" : " " + region.end_key)] = rec;
+	}
+	return r_regions;
+}
+
+#ifndef DISABLE_DEPRECATED
 Dictionary CodeHighlighter::get_color_regions() const {
 	Dictionary r_color_regions;
 	for (int i = 0; i < color_regions.size(); i++) {
@@ -564,54 +771,99 @@ Dictionary CodeHighlighter::get_color_regions() const {
 	}
 	return r_color_regions;
 }
+#endif
 
 void CodeHighlighter::_bind_methods() {
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("add_keyword_color", "keyword", "color"), &CodeHighlighter::add_keyword_color);
-	ClassDB::bind_method(D_METHOD("remove_keyword_color", "keyword"), &CodeHighlighter::remove_keyword_color);
-	ClassDB::bind_method(D_METHOD("has_keyword_color", "keyword"), &CodeHighlighter::has_keyword_color);
+	ClassDB::bind_method(D_METHOD("remove_keyword_color", "keyword"), &CodeHighlighter::remove_keyword);
+	ClassDB::bind_method(D_METHOD("has_keyword_color", "keyword"), &CodeHighlighter::has_keyword);
+#endif
+	ClassDB::bind_method(D_METHOD("add_keyword", "keyword", "color", "style"), &CodeHighlighter::add_keyword, DEFVAL(SyntaxHighlighter::SYNTAX_STYLE_REGULAR));
+	ClassDB::bind_method(D_METHOD("remove_keyword", "keyword"), &CodeHighlighter::remove_keyword);
+	ClassDB::bind_method(D_METHOD("has_keyword", "keyword"), &CodeHighlighter::has_keyword);
 	ClassDB::bind_method(D_METHOD("get_keyword_color", "keyword"), &CodeHighlighter::get_keyword_color);
+	ClassDB::bind_method(D_METHOD("get_keyword_style", "keyword"), &CodeHighlighter::get_keyword_style);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_keyword_colors", "keywords"), &CodeHighlighter::set_keyword_colors);
-	ClassDB::bind_method(D_METHOD("clear_keyword_colors"), &CodeHighlighter::clear_keyword_colors);
+	ClassDB::bind_method(D_METHOD("clear_keyword_colors"), &CodeHighlighter::clear_keywords);
 	ClassDB::bind_method(D_METHOD("get_keyword_colors"), &CodeHighlighter::get_keyword_colors);
+#endif
+	ClassDB::bind_method(D_METHOD("set_keywords", "keywords"), &CodeHighlighter::set_keywords);
+	ClassDB::bind_method(D_METHOD("clear_keywords"), &CodeHighlighter::clear_keywords);
+	ClassDB::bind_method(D_METHOD("get_keywords"), &CodeHighlighter::get_keywords);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("add_member_keyword_color", "member_keyword", "color"), &CodeHighlighter::add_member_keyword_color);
-	ClassDB::bind_method(D_METHOD("remove_member_keyword_color", "member_keyword"), &CodeHighlighter::remove_member_keyword_color);
-	ClassDB::bind_method(D_METHOD("has_member_keyword_color", "member_keyword"), &CodeHighlighter::has_member_keyword_color);
+	ClassDB::bind_method(D_METHOD("remove_member_keyword_color", "member_keyword"), &CodeHighlighter::remove_member_keyword);
+	ClassDB::bind_method(D_METHOD("has_member_keyword_color", "member_keyword"), &CodeHighlighter::has_member_keyword);
+#endif
+	ClassDB::bind_method(D_METHOD("add_member_keyword", "member_keyword", "color", "style"), &CodeHighlighter::add_member_keyword, DEFVAL(SyntaxHighlighter::SYNTAX_STYLE_REGULAR));
+	ClassDB::bind_method(D_METHOD("remove_member_keyword", "member_keyword"), &CodeHighlighter::remove_member_keyword);
+	ClassDB::bind_method(D_METHOD("has_member_keyword", "member_keyword"), &CodeHighlighter::has_member_keyword);
 	ClassDB::bind_method(D_METHOD("get_member_keyword_color", "member_keyword"), &CodeHighlighter::get_member_keyword_color);
+	ClassDB::bind_method(D_METHOD("get_member_keyword_style", "member_keyword"), &CodeHighlighter::get_member_keyword_style);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_member_keyword_colors", "member_keyword"), &CodeHighlighter::set_member_keyword_colors);
-	ClassDB::bind_method(D_METHOD("clear_member_keyword_colors"), &CodeHighlighter::clear_member_keyword_colors);
+	ClassDB::bind_method(D_METHOD("clear_member_keyword_colors"), &CodeHighlighter::clear_member_keywords);
 	ClassDB::bind_method(D_METHOD("get_member_keyword_colors"), &CodeHighlighter::get_member_keyword_colors);
+#endif
+	ClassDB::bind_method(D_METHOD("set_member_keywords", "member_keyword"), &CodeHighlighter::set_member_keywords);
+	ClassDB::bind_method(D_METHOD("clear_member_keywords"), &CodeHighlighter::clear_member_keywords);
+	ClassDB::bind_method(D_METHOD("get_member_keywords"), &CodeHighlighter::get_member_keywords);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("add_color_region", "start_key", "end_key", "color", "line_only"), &CodeHighlighter::add_color_region, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("remove_color_region", "start_key"), &CodeHighlighter::remove_color_region);
-	ClassDB::bind_method(D_METHOD("has_color_region", "start_key"), &CodeHighlighter::has_color_region);
+	ClassDB::bind_method(D_METHOD("remove_color_region", "start_key"), &CodeHighlighter::remove_region);
+	ClassDB::bind_method(D_METHOD("has_color_region", "start_key"), &CodeHighlighter::has_region);
 
 	ClassDB::bind_method(D_METHOD("set_color_regions", "color_regions"), &CodeHighlighter::set_color_regions);
-	ClassDB::bind_method(D_METHOD("clear_color_regions"), &CodeHighlighter::clear_color_regions);
+	ClassDB::bind_method(D_METHOD("clear_color_regions"), &CodeHighlighter::clear_regions);
 	ClassDB::bind_method(D_METHOD("get_color_regions"), &CodeHighlighter::get_color_regions);
+#endif
+	ClassDB::bind_method(D_METHOD("add_region", "start_key", "end_key", "color", "style", "line_only", "text_segment"), &CodeHighlighter::add_region, DEFVAL(SyntaxHighlighter::SYNTAX_STYLE_REGULAR), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_region", "start_key"), &CodeHighlighter::remove_region);
+	ClassDB::bind_method(D_METHOD("has_region", "start_key"), &CodeHighlighter::has_region);
+
+	ClassDB::bind_method(D_METHOD("set_regions", "color_regions"), &CodeHighlighter::set_regions);
+	ClassDB::bind_method(D_METHOD("clear_regions"), &CodeHighlighter::clear_regions);
+	ClassDB::bind_method(D_METHOD("get_regions"), &CodeHighlighter::get_regions);
 
 	ClassDB::bind_method(D_METHOD("set_function_color", "color"), &CodeHighlighter::set_function_color);
 	ClassDB::bind_method(D_METHOD("get_function_color"), &CodeHighlighter::get_function_color);
+	ClassDB::bind_method(D_METHOD("set_function_style", "style"), &CodeHighlighter::set_function_style);
+	ClassDB::bind_method(D_METHOD("get_function_style"), &CodeHighlighter::get_function_style);
 
 	ClassDB::bind_method(D_METHOD("set_number_color", "color"), &CodeHighlighter::set_number_color);
 	ClassDB::bind_method(D_METHOD("get_number_color"), &CodeHighlighter::get_number_color);
+	ClassDB::bind_method(D_METHOD("set_number_style", "style"), &CodeHighlighter::set_number_style);
+	ClassDB::bind_method(D_METHOD("get_number_style"), &CodeHighlighter::get_number_style);
 
 	ClassDB::bind_method(D_METHOD("set_symbol_color", "color"), &CodeHighlighter::set_symbol_color);
 	ClassDB::bind_method(D_METHOD("get_symbol_color"), &CodeHighlighter::get_symbol_color);
+	ClassDB::bind_method(D_METHOD("set_symbol_style", "style"), &CodeHighlighter::set_symbol_style);
+	ClassDB::bind_method(D_METHOD("get_symbol_style"), &CodeHighlighter::get_symbol_style);
 
 	ClassDB::bind_method(D_METHOD("set_member_variable_color", "color"), &CodeHighlighter::set_member_variable_color);
 	ClassDB::bind_method(D_METHOD("get_member_variable_color"), &CodeHighlighter::get_member_variable_color);
+	ClassDB::bind_method(D_METHOD("set_member_variable_style", "style"), &CodeHighlighter::set_member_variable_style);
+	ClassDB::bind_method(D_METHOD("get_member_variable_style"), &CodeHighlighter::get_member_variable_style);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "number_color"), "set_number_color", "get_number_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "symbol_color"), "set_symbol_color", "get_symbol_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "function_color"), "set_function_color", "get_function_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "member_variable_color"), "set_member_variable_color", "get_member_variable_color");
 
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "keyword_colors"), "set_keyword_colors", "get_keyword_colors");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "member_keyword_colors"), "set_member_keyword_colors", "get_member_keyword_colors");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_regions"), "set_color_regions", "get_color_regions");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "number_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"), "set_number_style", "get_number_style");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "symbol_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"), "set_symbol_style", "get_symbol_style");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "function_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"), "set_function_style", "get_function_style");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "member_variable_style", PROPERTY_HINT_ENUM, "Regular,Bold,Italic,Bold Italic"), "set_member_variable_style", "get_member_variable_style");
+
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "keywords"), "set_keywords", "get_keywords");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "member_keywords"), "set_member_keywords", "get_member_keywords");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "regions"), "set_regions", "get_regions");
 }
 
 void CodeHighlighter::set_uint_suffix_enabled(bool p_enabled) {
@@ -627,6 +879,15 @@ Color CodeHighlighter::get_number_color() const {
 	return number_color;
 }
 
+void CodeHighlighter::set_number_style(SyntaxHighlighter::SyntaxFontStyle p_style) {
+	number_style = p_style;
+	clear_highlighting_cache();
+}
+
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_number_style() const {
+	return number_style;
+}
+
 void CodeHighlighter::set_symbol_color(Color p_color) {
 	symbol_color = p_color;
 	clear_highlighting_cache();
@@ -634,6 +895,15 @@ void CodeHighlighter::set_symbol_color(Color p_color) {
 
 Color CodeHighlighter::get_symbol_color() const {
 	return symbol_color;
+}
+
+void CodeHighlighter::set_symbol_style(SyntaxHighlighter::SyntaxFontStyle p_style) {
+	symbol_style = p_style;
+	clear_highlighting_cache();
+}
+
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_symbol_style() const {
+	return symbol_style;
 }
 
 void CodeHighlighter::set_function_color(Color p_color) {
@@ -645,6 +915,15 @@ Color CodeHighlighter::get_function_color() const {
 	return function_color;
 }
 
+void CodeHighlighter::set_function_style(SyntaxHighlighter::SyntaxFontStyle p_style) {
+	function_style = p_style;
+	clear_highlighting_cache();
+}
+
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_function_style() const {
+	return function_style;
+}
+
 void CodeHighlighter::set_member_variable_color(Color p_color) {
 	member_color = p_color;
 	clear_highlighting_cache();
@@ -652,4 +931,13 @@ void CodeHighlighter::set_member_variable_color(Color p_color) {
 
 Color CodeHighlighter::get_member_variable_color() const {
 	return member_color;
+}
+
+void CodeHighlighter::set_member_variable_style(SyntaxHighlighter::SyntaxFontStyle p_style) {
+	member_style = p_style;
+	clear_highlighting_cache();
+}
+
+SyntaxHighlighter::SyntaxFontStyle CodeHighlighter::get_member_variable_style() const {
+	return member_style;
 }

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -38,6 +38,13 @@ class TextEdit;
 
 class SyntaxHighlighter : public Resource {
 	GDCLASS(SyntaxHighlighter, Resource)
+public:
+	enum SyntaxFontStyle {
+		SYNTAX_STYLE_REGULAR,
+		SYNTAX_STYLE_BOLD,
+		SYNTAX_STYLE_ITALIC,
+		SYNTAX_STYLE_BOLD_ITALIC,
+	};
 
 private:
 	RBMap<int, Dictionary> highlighting_cache;
@@ -56,6 +63,8 @@ public:
 	Dictionary get_line_syntax_highlighting(int p_line);
 	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) { return Dictionary(); }
 
+	void clear_line_highlighting_cache(int p_line);
+
 	void clear_highlighting_cache();
 	virtual void _clear_highlighting_cache() {}
 
@@ -69,6 +78,8 @@ public:
 	virtual ~SyntaxHighlighter() {}
 };
 
+VARIANT_ENUM_CAST(SyntaxHighlighter::SyntaxFontStyle);
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class CodeHighlighter : public SyntaxHighlighter {
@@ -77,6 +88,8 @@ class CodeHighlighter : public SyntaxHighlighter {
 private:
 	struct ColorRegion {
 		Color color;
+		SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+		bool text_segment = false;
 		String start_key;
 		String end_key;
 		bool line_only = false;
@@ -84,14 +97,23 @@ private:
 	Vector<ColorRegion> color_regions;
 	HashMap<int, int> color_region_cache;
 
-	Dictionary keywords;
-	Dictionary member_keywords;
+	struct ColorRec {
+		Color color;
+		SyntaxHighlighter::SyntaxFontStyle style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
+	};
+	HashMap<String, ColorRec> keywords;
+	HashMap<String, ColorRec> member_keywords;
 
 	Color font_color;
+	SyntaxHighlighter::SyntaxFontStyle font_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color member_color;
+	SyntaxHighlighter::SyntaxFontStyle member_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color function_color;
+	SyntaxHighlighter::SyntaxFontStyle function_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color symbol_color;
+	SyntaxHighlighter::SyntaxFontStyle symbol_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 	Color number_color;
+	SyntaxHighlighter::SyntaxFontStyle number_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR;
 
 	bool uint_suffix_enabled = false;
 
@@ -104,43 +126,75 @@ public:
 	virtual void _clear_highlighting_cache() override;
 	virtual void _update_cache() override;
 
+#ifndef DISABLE_DEPRECATED
 	void add_keyword_color(const String &p_keyword, const Color &p_color);
-	void remove_keyword_color(const String &p_keyword);
-	bool has_keyword_color(const String &p_keyword) const;
+#endif
+	void add_keyword(const String &p_keyword, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	void remove_keyword(const String &p_keyword);
+	bool has_keyword(const String &p_keyword) const;
+
 	Color get_keyword_color(const String &p_keyword) const;
+	SyntaxHighlighter::SyntaxFontStyle get_keyword_style(const String &p_member_keyword) const;
 
-	void set_keyword_colors(const Dictionary p_keywords);
-	void clear_keyword_colors();
+#ifndef DISABLE_DEPRECATED
+	void set_keyword_colors(const Dictionary &p_keywords);
 	Dictionary get_keyword_colors() const;
+#endif
+	void set_keywords(const Dictionary &p_keywords);
+	void clear_keywords();
+	Dictionary get_keywords() const;
 
+#ifndef DISABLE_DEPRECATED
 	void add_member_keyword_color(const String &p_member_keyword, const Color &p_color);
-	void remove_member_keyword_color(const String &p_member_keyword);
-	bool has_member_keyword_color(const String &p_member_keyword) const;
+#endif
+	void add_member_keyword(const String &p_keyword, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR);
+	void remove_member_keyword(const String &p_keyword);
+	bool has_member_keyword(const String &p_keyword) const;
+
 	Color get_member_keyword_color(const String &p_member_keyword) const;
+	SyntaxHighlighter::SyntaxFontStyle get_member_keyword_style(const String &p_member_keyword) const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_member_keyword_colors(const Dictionary &p_color_regions);
-	void clear_member_keyword_colors();
 	Dictionary get_member_keyword_colors() const;
+#endif
+	void set_member_keywords(const Dictionary &p_color_regions);
+	void clear_member_keywords();
+	Dictionary get_member_keywords() const;
 
+#ifndef DISABLE_DEPRECATED
 	void add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);
-	void remove_color_region(const String &p_start_key);
-	bool has_color_region(const String &p_start_key) const;
 
 	void set_color_regions(const Dictionary &p_member_keyword);
-	void clear_color_regions();
 	Dictionary get_color_regions() const;
+#endif
+	void add_region(const String &p_start_key, const String &p_end_key, const Color &p_color, SyntaxHighlighter::SyntaxFontStyle p_style = SyntaxHighlighter::SYNTAX_STYLE_REGULAR, bool p_line_only = false, bool p_is_text_segment = false);
+	void remove_region(const String &p_start_key);
+	bool has_region(const String &p_start_key) const;
+
+	void set_regions(const Dictionary &p_regions);
+	void clear_regions();
+	Dictionary get_regions() const;
 
 	void set_number_color(Color p_color);
 	Color get_number_color() const;
+	void set_number_style(SyntaxHighlighter::SyntaxFontStyle p_style);
+	SyntaxHighlighter::SyntaxFontStyle get_number_style() const;
 
 	void set_symbol_color(Color p_color);
 	Color get_symbol_color() const;
+	void set_symbol_style(SyntaxHighlighter::SyntaxFontStyle p_style);
+	SyntaxHighlighter::SyntaxFontStyle get_symbol_style() const;
 
 	void set_function_color(Color p_color);
 	Color get_function_color() const;
+	void set_function_style(SyntaxHighlighter::SyntaxFontStyle p_style);
+	SyntaxHighlighter::SyntaxFontStyle get_function_style() const;
 
 	void set_member_variable_color(Color p_color);
 	Color get_member_variable_color() const;
+	void set_member_variable_style(SyntaxHighlighter::SyntaxFontStyle p_style);
+	SyntaxHighlighter::SyntaxFontStyle get_member_variable_style() const;
 
 	void set_uint_suffix_enabled(bool p_enabled);
 };

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -488,6 +488,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("outline_size", "TextEdit", 0);
 	theme->set_constant("caret_width", "TextEdit", 1);
 
+	theme->set_font("bold_font", "TextEdit", bold_font);
+	theme->set_font("italics_font", "TextEdit", italics_font);
+	theme->set_font("bold_italics_font", "TextEdit", bold_italics_font);
+
 	// CodeEdit
 
 	theme->set_stylebox(CoreStringName(normal), "CodeEdit", style_line_edit);


### PR DESCRIPTION
- Adds support for using syntax highlighter for better handling of BiDi string and comments in the code.
Related proposal - https://github.com/godotengine/godot-proposals/issues/10629
- Adds support for using bold/italic font variants in the syntax highlighting, since highlighter is used in the text shaping process anyway, it's mostly free.
Related proposal - https://github.com/godotengine/godot-proposals/issues/1781

<img width="516" alt="Screenshot 2024-09-05 at 07 57 47" src="https://github.com/user-attachments/assets/461b3874-9433-497e-9c4a-59b451e2e188">
