### PR TITLE
Add Control+Shift+U (rebindable) action for Unicode input, show hex as it is entered.

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -400,6 +400,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_filedialog_refresh",                         TTRC("Refresh") },
     { "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
     { "ui_swap_input_direction ",                      TTRC("Swap Input Direction") },
+    { "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
     { "",                                              ""}
 	/* clang-format on */
 };
@@ -753,6 +754,10 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::ENTER));
 	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER));
 	default_builtin_cache.insert("ui_text_submit", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::U | KeyModifierMask::CTRL | KeyModifierMask::SHIFT));
+	default_builtin_cache.insert("ui_unicode_start", inputs);
 
 	// ///// UI Graph Shortcuts /////
 

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -37,6 +37,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="apply_ime">
+			<return type="void" />
+			<description>
+				Applies text from the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] (IME) and closes the IME if it is open.
+			</description>
+		</method>
+		<method name="cancel_ime">
+			<return type="void" />
+			<description>
+				Closes the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] (IME) if it is open. Any text in the IME will be lost.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -131,6 +143,12 @@
 			<return type="int" />
 			<description>
 				Returns the selection end column.
+			</description>
+		</method>
+		<method name="has_ime_text" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the user has text in the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] (IME).
 			</description>
 		</method>
 		<method name="has_selection" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1386,6 +1386,10 @@
 			Default [InputEventAction] to undo the most recent action.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_unicode_start" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to start Unicode character hexadecimal code input in a text field.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_up" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move up in the UI.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -92,6 +92,7 @@ private:
 	bool text_changed_dirty = false;
 
 	bool alt_start = false;
+	bool alt_start_no_hold = false;
 	uint32_t alt_code = 0;
 
 	String undo_text;
@@ -209,6 +210,9 @@ private:
 	void _edit();
 	void _unedit();
 
+	void _close_ime_window();
+	void _update_ime_window_position();
+
 	void _clear_undo_stack();
 	void _clear_redo();
 	void _create_undo_state();
@@ -262,6 +266,10 @@ protected:
 
 public:
 	bool is_editing() const;
+
+	bool has_ime_text() const;
+	void cancel_ime();
+	void apply_ime();
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1557,7 +1557,7 @@ void TextEdit::_notification(int p_what) {
 										carets.write[c].draw_pos.x = rect.position.x;
 									}
 								}
-								{
+								if (ime_selection.y > 0) {
 									// IME caret.
 									const Vector<Vector2> sel = TS->shaped_text_get_selection(rid, get_caret_column(c) + ime_selection.x, get_caret_column(c) + ime_selection.x + ime_selection.y);
 									for (int j = 0; j < sel.size(); j++) {
@@ -1688,39 +1688,93 @@ void TextEdit::unhandled_key_input(const Ref<InputEvent> &p_event) {
 bool TextEdit::alt_input(const Ref<InputEvent> &p_gui_input) {
 	Ref<InputEventKey> k = p_gui_input;
 	if (k.is_valid()) {
-		if (!k->is_pressed()) {
-			if (alt_start && k->get_keycode() == Key::ALT) {
-				alt_start = false;
-				if ((alt_code > 0x31 && alt_code < 0xd800) || (alt_code > 0xdfff && alt_code <= 0x10ffff)) {
-					handle_unicode_input(alt_code);
-				}
-				return true;
+		// Start Unicode input (hold).
+		if (k->is_alt_pressed() && k->get_keycode() == Key::KP_ADD && !alt_start && !alt_start_no_hold) {
+			if (has_selection()) {
+				delete_selection();
 			}
-			return false;
+			alt_start = true;
+			alt_code = 0;
+			ime_text = "u";
+			ime_selection = Vector2i(0, -1);
+			_update_ime_text();
+			return true;
 		}
 
-		if (k->is_alt_pressed()) {
-			if (!alt_start) {
-				if (k->get_keycode() == Key::KP_ADD) {
-					alt_start = true;
-					alt_code = 0;
-					return true;
-				}
-			} else {
-				if (k->get_keycode() >= Key::KEY_0 && k->get_keycode() <= Key::KEY_9) {
-					alt_code = alt_code << 4;
-					alt_code += (uint32_t)(k->get_keycode() - Key::KEY_0);
-				}
-				if (k->get_keycode() >= Key::KP_0 && k->get_keycode() <= Key::KP_9) {
-					alt_code = alt_code << 4;
-					alt_code += (uint32_t)(k->get_keycode() - Key::KP_0);
-				}
-				if (k->get_keycode() >= Key::A && k->get_keycode() <= Key::F) {
-					alt_code = alt_code << 4;
-					alt_code += (uint32_t)(k->get_keycode() - Key::A) + 10;
-				}
-				return true;
+		// Start Unicode input (press).
+		if (k->is_action("ui_unicode_start", true) && !alt_start && !alt_start_no_hold) {
+			if (has_selection()) {
+				delete_selection();
 			}
+			alt_start_no_hold = true;
+			alt_code = 0;
+			ime_text = "u";
+			ime_selection = Vector2i(0, -1);
+			_update_ime_text();
+			return true;
+		}
+
+		// Update Unicode input.
+		if (k->is_pressed() && ((k->is_alt_pressed() && alt_start) || alt_start_no_hold)) {
+			if (k->get_keycode() >= Key::KEY_0 && k->get_keycode() <= Key::KEY_9) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)(k->get_keycode() - Key::KEY_0);
+			} else if (k->get_keycode() >= Key::KP_0 && k->get_keycode() <= Key::KP_9) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)(k->get_keycode() - Key::KP_0);
+			} else if (k->get_keycode() >= Key::A && k->get_keycode() <= Key::F) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)(k->get_keycode() - Key::A) + 10;
+			} else if ((Key)k->get_unicode() >= Key::KEY_0 && (Key)k->get_unicode() <= Key::KEY_9) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)((Key)k->get_unicode() - Key::KEY_0);
+			} else if ((Key)k->get_unicode() >= Key::A && (Key)k->get_unicode() <= Key::F) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)((Key)k->get_unicode() - Key::A) + 10;
+			} else if (k->get_physical_keycode() >= Key::KEY_0 && k->get_physical_keycode() <= Key::KEY_9) {
+				alt_code = alt_code << 4;
+				alt_code += (uint32_t)(k->get_physical_keycode() - Key::KEY_0);
+			}
+			if (k->get_keycode() == Key::BACKSPACE) {
+				alt_code = alt_code >> 4;
+			}
+			if (alt_code > 0x10ffff) {
+				alt_code = 0x10ffff;
+			}
+			if (alt_code > 0) {
+				ime_text = vformat("u%s", String::num_int64(alt_code, 16, true));
+			} else {
+				ime_text = "u";
+			}
+			ime_selection = Vector2i(0, -1);
+			_update_ime_text();
+			return true;
+		}
+
+		// Submit Unicode input.
+		if ((!k->is_pressed() && alt_start && k->get_keycode() == Key::ALT) || (alt_start_no_hold && (k->is_action("ui_text_submit", true) || k->is_action("ui_accept", true)))) {
+			alt_start = false;
+			alt_start_no_hold = false;
+			if ((alt_code > 0x31 && alt_code < 0xd800) || (alt_code > 0xdfff && alt_code <= 0x10ffff)) {
+				ime_text = String();
+				ime_selection = Vector2i();
+				handle_unicode_input(alt_code);
+			} else {
+				ime_text = String();
+				ime_selection = Vector2i();
+			}
+			_update_ime_text();
+			return true;
+		}
+
+		// Cancel Unicode input.
+		if (alt_start_no_hold && k->is_action("ui_cancel", true)) {
+			alt_start = false;
+			alt_start_no_hold = false;
+			ime_text = String();
+			ime_selection = Vector2i();
+			_update_ime_text();
+			return true;
 		}
 	}
 	return false;
@@ -3117,7 +3171,9 @@ void TextEdit::cancel_ime() {
 		return;
 	}
 	ime_text = String();
-	ime_selection = Point2();
+	ime_selection = Vector2i();
+	alt_start = false;
+	alt_start_no_hold = false;
 	_close_ime_window();
 	_update_ime_text();
 }
@@ -3126,10 +3182,18 @@ void TextEdit::apply_ime() {
 	if (!has_ime_text()) {
 		return;
 	}
+
 	// Force apply the current IME text.
-	String insert_ime_text = ime_text;
-	cancel_ime();
-	insert_text_at_caret(insert_ime_text);
+	if (alt_start || alt_start_no_hold) {
+		cancel_ime();
+		if ((alt_code > 0x31 && alt_code < 0xd800) || (alt_code > 0xdfff && alt_code <= 0x10ffff)) {
+			handle_unicode_input(alt_code);
+		}
+	} else {
+		String insert_ime_text = ime_text;
+		cancel_ime();
+		insert_text_at_caret(insert_ime_text);
+	}
 }
 
 void TextEdit::set_editable(bool p_editable) {
@@ -5966,7 +6030,7 @@ void TextEdit::adjust_viewport_to_caret(int p_caret) {
 
 	// Get position of the end of caret.
 	if (has_ime_text()) {
-		if (ime_selection.y != 0) {
+		if (ime_selection.y > 0) {
 			caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x + ime_selection.y, get_caret_line(p_caret), get_caret_column(p_caret));
 		} else {
 			caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_text.size(), get_caret_line(p_caret), get_caret_column(p_caret));
@@ -6018,7 +6082,7 @@ void TextEdit::center_viewport_to_caret(int p_caret) {
 
 		// Get position of the end of caret.
 		if (has_ime_text()) {
-			if (ime_selection.y != 0) {
+			if (ime_selection.y > 0) {
 				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x + ime_selection.y, get_caret_line(p_caret), get_caret_column(p_caret));
 			} else {
 				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_text.size(), get_caret_line(p_caret), get_caret_column(p_caret));

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -276,6 +276,7 @@ private:
 	bool setting_text = false;
 
 	bool alt_start = false;
+	bool alt_start_no_hold = false;
 	uint32_t alt_code = 0;
 
 	// Text properties.


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/10654

- Adds `ui_unicode_start` action (set to Control+Shift+U by default) start Unicode hex input (code submitted/canceled by `ui_text_submit`/`ui_cancel` actions).
- Adds hex code display (for both Alt+ and new action).

https://github.com/user-attachments/assets/ceff8455-33dc-4a61-8e78-5920c9b0b680
