### PR TITLE
ResourceLoader: Add thread-aware resource changed mechanism

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -40,12 +40,12 @@
 #include <stdio.h>
 
 void Resource::emit_changed() {
-	if (ResourceLoader::is_within_load() && MessageQueue::get_main_singleton() != MessageQueue::get_singleton() && !MessageQueue::get_singleton()->is_flushing()) {
-		// Let the connection happen on the call queue, later, since signals are not thread-safe.
-		call_deferred("emit_signal", CoreStringName(changed));
-	} else {
-		emit_signal(CoreStringName(changed));
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		ResourceLoader::resource_changed_emit(this);
+		return;
 	}
+
+	emit_signal(CoreStringName(changed));
 }
 
 void Resource::_resource_path_changed() {
@@ -166,22 +166,22 @@ bool Resource::editor_can_reload_from_file() {
 }
 
 void Resource::connect_changed(const Callable &p_callable, uint32_t p_flags) {
-	if (ResourceLoader::is_within_load() && MessageQueue::get_main_singleton() != MessageQueue::get_singleton() && !MessageQueue::get_singleton()->is_flushing()) {
-		// Let the check and connection happen on the call queue, later, since signals are not thread-safe.
-		callable_mp(this, &Resource::connect_changed).call_deferred(p_callable, p_flags);
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		ResourceLoader::resource_changed_connect(this, p_callable, p_flags);
 		return;
 	}
+
 	if (!is_connected(CoreStringName(changed), p_callable) || p_flags & CONNECT_REFERENCE_COUNTED) {
 		connect(CoreStringName(changed), p_callable, p_flags);
 	}
 }
 
 void Resource::disconnect_changed(const Callable &p_callable) {
-	if (ResourceLoader::is_within_load() && MessageQueue::get_main_singleton() != MessageQueue::get_singleton() && !MessageQueue::get_singleton()->is_flushing()) {
-		// Let the check and disconnection happen on the call queue, later, since signals are not thread-safe.
-		callable_mp(this, &Resource::disconnect_changed).call_deferred(p_callable);
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		ResourceLoader::resource_changed_disconnect(this, p_callable);
 		return;
 	}
+
 	if (is_connected(CoreStringName(changed), p_callable)) {
 		disconnect(CoreStringName(changed), p_callable);
 	}

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -106,6 +106,8 @@ class ResourceLoader {
 		MAX_LOADERS = 64
 	};
 
+	struct ThreadLoadTask;
+
 public:
 	enum ThreadLoadStatus {
 		THREAD_LOAD_INVALID_RESOURCE,
@@ -124,7 +126,7 @@ public:
 		String local_path;
 		String user_path;
 		uint32_t user_rc = 0; // Having user RC implies regular RC incremented in one, until the user RC reaches zero.
-		Ref<Resource> res_if_unregistered;
+		ThreadLoadTask *task_if_unregistered = nullptr;
 
 		void clear();
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -189,6 +189,13 @@ private:
 		Ref<Resource> resource;
 		bool use_sub_threads = false;
 		HashSet<String> sub_tasks;
+
+		struct ResourceChangedConnection {
+			Resource *source = nullptr;
+			Callable callable;
+			uint32_t flags = 0;
+		};
+		LocalVector<ResourceChangedConnection> resource_changed_connections;
 	};
 
 	static void _run_load_task(void *p_userdata);
@@ -196,6 +203,7 @@ private:
 	static thread_local int load_nesting;
 	static thread_local HashMap<int, HashMap<String, Ref<Resource>>> res_ref_overrides; // Outermost key is nesting level.
 	static thread_local Vector<String> load_paths_stack;
+	static thread_local ThreadLoadTask *curr_load_task;
 
 	static SafeBinaryMutex<BINARY_MUTEX_TAG> thread_load_mutex;
 	friend SafeBinaryMutex<BINARY_MUTEX_TAG> &_get_res_loader_mutex();
@@ -215,6 +223,10 @@ public:
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
 
 	static bool is_within_load() { return load_nesting > 0; };
+
+	static void resource_changed_connect(Resource *p_source, const Callable &p_callable, uint32_t p_flags);
+	static void resource_changed_disconnect(Resource *p_source, const Callable &p_callable);
+	static void resource_changed_emit(Resource *p_source);
 
 	static Ref<Resource> load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
 	static bool exists(const String &p_path, const String &p_type_hint = "");


### PR DESCRIPTION
- **ResourceLoader: Simplify handling of unregistered tasks** (Preliminary work for the other commit)

The unregistered task mechnaism is used to isolate a uncached load from a cached one with the same path. This commit simplifies how unregistered loads are handled.

That brings the benefit of more code shared between both, which removes the constraint of uncached loads having to complete synchronously.

- **ResourceLoader: Add thread-aware resource changed mechanism**

Signals are not thread-safe. Therefore, resource loaders shouldn't deal with them. However, there's a special signal in `Resource`, `changed`, which is a common need during resource loading. Fortunately, it has its own API.

This commit lets the `ResourceLoader` intervene that API during threaded loading so the handling of the `changed` signal can happen in a safe manner.

The general idea is that during loads, only the resources known to a loader thread participate in the signal. When a load is awaited by another, the awaited one propagates its record of connections to the awaiter, which can happen recursively. The awaited one keeps its records until it dies, so they are available to any other load chaining with it. Finally, when a leaf task is awaited, the connections are migrated to the standard signal mechanism on the main thread.

This replaces the current attempt at thread-safe `changed` signaling, which wasn't good enough because 1) it tried to achieve safety by deferring the calls within a load thread, which changed the expected flow too much; and 2) it couldn't avoid multiple load threads from dealing with the connection maps of the objects involved, therefore not being as robust as desirable. That said, the mechanism in this PR is much more resilient, but, at the end of the day, signals are not thread-safe in Godot, so it can only guarantee correctness within its realm (resource loading).

The implementation tries to be simple in these ways:
- Linear search (no hashing). Should be good enough for the relatively small amount of cases expected. In case it's found to be a problem, a hashmap can be used instead.
- No connection flags implemented. In cases where, e.g., `CONNECT_REFERENCE_COUNTED` is used, like `AnimationNodeBlendTree`, or other flags, this implementation will forward them to the standard signal mechanism, but won't honor them during loads.

---

Fixes #96115.