### PR TITLE
Fix iOS Simulator compiler error

### DIFF
--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -1200,7 +1200,7 @@ void PixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> p_device) {
 
 // Disable for iOS simulator last.
 #if TARGET_OS_SIMULATOR
-	if (![mtlDevice supportsFamily:MTLGPUFamilyApple5]) {
+	if (![p_device supportsFamily:MTLGPUFamilyApple5]) {
 		disableAllMTLPixFmtCaps(R8Unorm_sRGB);
 		disableAllMTLPixFmtCaps(RG8Unorm_sRGB);
 		disableAllMTLPixFmtCaps(B5G6R5Unorm);


### PR DESCRIPTION
Small issue that got introduced in #88199, would cause a compiler error when compiled with `scons p=ios target=template_debug ios_simulator=yes arch=arm64`


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
