### PR TITLE
Mention user should remove compute shader hint when use `set_stage_source`

### DIFF
--- a/doc/classes/RDShaderSource.xml
+++ b/doc/classes/RDShaderSource.xml
@@ -23,6 +23,7 @@
 			<param index="1" name="source" type="String" />
 			<description>
 				Sets [param source] code for the specified shader [param stage]. Equivalent to setting one of [member source_compute], [member source_fragment], [member source_tesselation_control], [member source_tesselation_evaluation] or [member source_vertex].
+				[b]Note:[/b] If you set the compute shader source code using this method directly, remember to remove the Godot-specific hint [code]#[compute][/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96304 in doc.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
