### PR TITLE
Add support for CocoaPods on iOS

### DIFF
--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -44,6 +44,9 @@
 		<member name="application/generate_simulator_library_if_missing" type="bool" setter="" getter="">
 			If [code]true[/code], and ARM64 simulator library is missing from the export template, it is automatically generated from ARM64 device library.
 		</member>
+		<member name="application/enable_cocoapods" type="bool" setter="" getter="">
+			If [code]true[/code], the project will be exported with CocoaPods enabled.
+		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.
 		</member>

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -32,6 +32,9 @@
 		<member name="application/delete_old_export_files_unconditionally" type="bool" setter="" getter="">
 			If [code]true[/code], existing "project name" and "project name.xcodeproj" in the export destination directory will be unconditionally deleted during export.
 		</member>
+		<member name="application/enable_cocoapods" type="bool" setter="" getter="">
+			If [code]true[/code], the project will be exported with CocoaPods enabled.
+		</member>
 		<member name="application/export_method_debug" type="int" setter="" getter="">
 			Application distribution target (debug export).
 		</member>
@@ -43,9 +46,6 @@
 		</member>
 		<member name="application/generate_simulator_library_if_missing" type="bool" setter="" getter="">
 			If [code]true[/code], and ARM64 simulator library is missing from the export template, it is automatically generated from ARM64 device library.
-		</member>
-		<member name="application/enable_cocoapods" type="bool" setter="" getter="">
-			If [code]true[/code], the project will be exported with CocoaPods enabled.
 		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1769,19 +1769,19 @@ Error EditorExportPlatformIOS::_export_cocoapods(const Ref<EditorExportPreset> &
 	if (p_dependencies.size() <= 0) {
 		return OK;
 	}
-	
+
 	if (!p_preset->get("application/enable_cocoapods").operator bool()) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Cocoapods must be enabled in the export settings")));
 		return FAILED;
 	}
-	
+
 	for (int i = 0; i < p_dependencies.size(); i++) {
 		const String &dependency = p_dependencies[i];
-		
+
 		IOSExportAsset export_asset = { dependency, false, false, true };
 		r_exported_assets.push_back(export_asset);
 	}
-	
+
 	return OK;
 }
 
@@ -1874,17 +1874,17 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			added_linked_dependenciy_names.push_back(name);
 			plugin_linked_dependencies.push_back(dependency);
 		}
-		
+
 		for (int j = 0; j < plugin.pods_dependencies.size(); j++) {
 			String dependency = plugin.pods_dependencies[j];
-			
+
 			if (plugin_pods_dependencies.has(dependency)) {
 				continue;
 			}
 
 			plugin_pods_dependencies.push_back(dependency);
 		}
-		
+
 		for (int j = 0; j < plugin.system_dependencies.size(); j++) {
 			String dependency = plugin.system_dependencies[j];
 			String name = dependency.get_file();
@@ -2003,7 +2003,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 		// Export plugin files
 		err = _export_additional_assets(p_preset, dest_dir, plugin_files, false, false, r_exported_assets);
 		ERR_FAIL_COND_V(err != OK, err);
-		
+
 		// Export CocoaPods dependency
 		err = _export_cocoapods(p_preset, plugin_pods_dependencies, r_exported_assets);
 		ERR_FAIL_COND_V(err != OK, err);
@@ -2566,7 +2566,7 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 	if (ep.step("Making .xcarchive", 3)) {
 		return ERR_SKIP;
 	}
-	
+
 	if (p_preset->get("application/enable_cocoapods").operator bool()) {
 		// Gather CocoaPods dependencies
 		Dictionary dependencies;
@@ -2574,32 +2574,32 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 			const IOSExportAsset &asset = assets[i];
 			if (!asset.is_pod)
 				continue;
-			
+
 			Vector<String> parts = asset.exported_path.split(":");
 			String name = parts[0];
 			String version = parts[1];
-			
+
 			if (dependencies.has(name) && dependencies[name] != version) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("CocoaPods Setup"), vformat(TTR("Ambiguous CocoaPod dependency, %s wants version %s and %s"), name, version, dependencies[name]));
 				return err;
 			}
-			
+
 			dependencies[name] = version;
 			print_line("Added " + name + " : " + version + " to cocoapods dependencies");
 		}
-		
+
 		// Generate the podfile
 		err = _generate_podfile("ios", p_preset->get("application/min_ios_version").operator String(), binary_name, dependencies, dest_dir);
 		if (err != OK) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("CocoaPods Setup"), vformat(TTR("Failed to generate Podfile with code %d"), err));
 			return err;
 		}
-		
+
 		// Install the pods
 		List<String> pod_args;
 		pod_args.push_back("install");
 		pod_args.push_back("--project-directory=" + dest_dir);
-		
+
 		String pod_str;
 		OS::get_singleton()->set_environment("LANG", "en_US.UTF-8"); // Required for Cocoapods to function
 		err = OS::get_singleton()->execute("/usr/local/bin/pod", pod_args, &pod_str, nullptr, true);
@@ -2652,7 +2652,7 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 	} else {
 		print_line("xcodebuild (.xcodeproj):\n" + archive_str);
 	}
-	
+
 	if (!archive_str.contains("** ARCHIVE SUCCEEDED **")) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), TTR("Xcode project build failed, see editor log for details."));
 		return FAILED;
@@ -2702,10 +2702,10 @@ Error EditorExportPlatformIOS::_generate_podfile(const String &platform, const S
 	}
 
 	file->store_string("platform :" + platform + ", '" + platform_version + "'\n\n");
-	
+
 	file->store_string("target '" + target_name + "' do\n");
 	file->store_string("\tuse_frameworks!\n\n");
-	
+
 	for (int i = 0; i < dependencies.size(); i++) {
 		String dependency = dependencies.get_key_at_index(i);
 		String version = dependencies.get_value_at_index(i);

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -290,6 +290,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/icon_interpolation", PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"), 4));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/export_project_only"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/enable_cocoapods"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/delete_old_export_files_unconditionally"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/generate_simulator_library_if_missing"), true));
 
@@ -1519,6 +1520,8 @@ void EditorExportPlatformIOS::_add_assets_to_project(const String &p_out_dir, co
 		String framework_id = "";
 
 		const IOSExportAsset &asset = p_additional_assets[i];
+		if (asset.is_pod)
+			continue;
 
 		String type;
 		if (asset.exported_path.ends_with(".framework")) {
@@ -1762,6 +1765,26 @@ Error EditorExportPlatformIOS::_export_additional_assets(const Ref<EditorExportP
 	return OK;
 }
 
+Error EditorExportPlatformIOS::_export_cocoapods(const Ref<EditorExportPreset> &p_preset, const Vector<String> &p_dependencies, Vector<IOSExportAsset> &r_exported_assets) {
+	if (p_dependencies.size() <= 0) {
+		return OK;
+	}
+	
+	if (!p_preset->get("application/enable_cocoapods").operator bool()) {
+		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Cocoapods must be enabled in the export settings")));
+		return FAILED;
+	}
+	
+	for (int i = 0; i < p_dependencies.size(); i++) {
+		const String &dependency = p_dependencies[i];
+		
+		IOSExportAsset export_asset = { dependency, false, false, true };
+		r_exported_assets.push_back(export_asset);
+	}
+	
+	return OK;
+}
+
 Error EditorExportPlatformIOS::_export_additional_assets(const Ref<EditorExportPreset> &p_preset, const String &p_out_dir, const Vector<SharedObject> &p_libraries, Vector<IOSExportAsset> &r_exported_assets) {
 	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
@@ -1813,6 +1836,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 	String plugin_deinitialization_cpp_code;
 
 	Vector<String> plugin_linked_dependencies;
+	Vector<String> plugin_pods_dependencies;
 	Vector<String> plugin_embedded_dependencies;
 	Vector<String> plugin_files;
 
@@ -1850,7 +1874,17 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			added_linked_dependenciy_names.push_back(name);
 			plugin_linked_dependencies.push_back(dependency);
 		}
+		
+		for (int j = 0; j < plugin.pods_dependencies.size(); j++) {
+			String dependency = plugin.pods_dependencies[j];
+			
+			if (plugin_pods_dependencies.has(dependency)) {
+				continue;
+			}
 
+			plugin_pods_dependencies.push_back(dependency);
+		}
+		
 		for (int j = 0; j < plugin.system_dependencies.size(); j++) {
 			String dependency = plugin.system_dependencies[j];
 			String name = dependency.get_file();
@@ -1968,6 +2002,10 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 
 		// Export plugin files
 		err = _export_additional_assets(p_preset, dest_dir, plugin_files, false, false, r_exported_assets);
+		ERR_FAIL_COND_V(err != OK, err);
+		
+		// Export CocoaPods dependency
+		err = _export_cocoapods(p_preset, plugin_pods_dependencies, r_exported_assets);
 		ERR_FAIL_COND_V(err != OK, err);
 	}
 
@@ -2528,11 +2566,59 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 	if (ep.step("Making .xcarchive", 3)) {
 		return ERR_SKIP;
 	}
+	
+	if (p_preset->get("application/enable_cocoapods").operator bool()) {
+		// Gather CocoaPods dependencies
+		Dictionary dependencies;
+		for (int i = 0; i < assets.size(); ++i) {
+			const IOSExportAsset &asset = assets[i];
+			if (!asset.is_pod)
+				continue;
+			
+			Vector<String> parts = asset.exported_path.split(":");
+			String name = parts[0];
+			String version = parts[1];
+			
+			if (dependencies.has(name) && dependencies[name] != version) {
+				add_message(EXPORT_MESSAGE_ERROR, TTR("CocoaPods Setup"), vformat(TTR("Ambiguous CocoaPod dependency, %s wants version %s and %s"), name, version, dependencies[name]));
+				return err;
+			}
+			
+			dependencies[name] = version;
+			print_line("Added " + name + " : " + version + " to cocoapods dependencies");
+		}
+		
+		// Generate the podfile
+		err = _generate_podfile("ios", p_preset->get("application/min_ios_version").operator String(), binary_name, dependencies, dest_dir);
+		if (err != OK) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("CocoaPods Setup"), vformat(TTR("Failed to generate Podfile with code %d"), err));
+			return err;
+		}
+		
+		// Install the pods
+		List<String> pod_args;
+		pod_args.push_back("install");
+		pod_args.push_back("--project-directory=" + dest_dir);
+		
+		String pod_str;
+		OS::get_singleton()->set_environment("LANG", "en_US.UTF-8"); // Required for Cocoapods to function
+		err = OS::get_singleton()->execute("/usr/local/bin/pod", pod_args, &pod_str, nullptr, true);
+		OS::get_singleton()->unset_environment("LANG");
+		if (err != OK) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("CocoaPods Setup"), vformat(TTR("Failed to run pod with code %d"), err));
+			return err;
+		}
+	}
 
 	String archive_path = p_path.get_basename() + ".xcarchive";
 	List<String> archive_args;
-	archive_args.push_back("-project");
-	archive_args.push_back(binary_dir + ".xcodeproj");
+	if (p_preset->get("application/enable_cocoapods").operator bool()) {
+		archive_args.push_back("-workspace");
+		archive_args.push_back(binary_dir + ".xcworkspace");
+	} else {
+		archive_args.push_back("-project");
+		archive_args.push_back(binary_dir + ".xcodeproj");
+	}
 	archive_args.push_back("-scheme");
 	archive_args.push_back(binary_name);
 	archive_args.push_back("-sdk");
@@ -2561,7 +2647,12 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 		return err;
 	}
 
-	print_line("xcodebuild (.xcarchive):\n" + archive_str);
+	if (p_preset->get("application/enable_cocoapods").operator bool()) {
+		print_line("xcodebuild (.xcworkspace):\n" + archive_str);
+	} else {
+		print_line("xcodebuild (.xcodeproj):\n" + archive_str);
+	}
+	
 	if (!archive_str.contains("** ARCHIVE SUCCEEDED **")) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), TTR("Xcode project build failed, see editor log for details."));
 		return FAILED;
@@ -2599,6 +2690,32 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 	add_message(EXPORT_MESSAGE_WARNING, TTR("Xcode Build"), TTR(".ipa can only be built on macOS. Leaving Xcode project without building the package."));
 #endif
 
+	return OK;
+}
+
+Error EditorExportPlatformIOS::_generate_podfile(const String &platform, const String &platform_version, const String &target_name, const Dictionary &dependencies, const String dest_dir) {
+	Ref<FileAccess> file = FileAccess::open(dest_dir + "Podfile", FileAccess::WRITE);
+
+	if (file.is_null()) {
+		print_error("Failed to open Podfile for writing.");
+		return FAILED;
+	}
+
+	file->store_string("platform :" + platform + ", '" + platform_version + "'\n\n");
+	
+	file->store_string("target '" + target_name + "' do\n");
+	file->store_string("\tuse_frameworks!\n\n");
+	
+	for (int i = 0; i < dependencies.size(); i++) {
+		String dependency = dependencies.get_key_at_index(i);
+		String version = dependencies.get_value_at_index(i);
+		file->store_string("\tpod '" + dependency + "','" + version + "'\n");
+	}
+
+	file->store_string("end\n");
+	file->close();
+
+	print_line("Podfile generated successfully!");
 	return OK;
 }
 

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -123,6 +123,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 		String exported_path;
 		bool is_framework = false; // framework is anything linked to the binary, otherwise it's a resource
 		bool should_embed = false;
+		bool is_pod = false; // Cocoa Pods
 	};
 
 	String _get_additional_plist_content();
@@ -142,9 +143,12 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 
 	void _add_assets_to_project(const String &p_out_dir, const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_project_data, const Vector<IOSExportAsset> &p_additional_assets);
 	Error _export_additional_assets(const Ref<EditorExportPreset> &p_preset, const String &p_out_dir, const Vector<String> &p_assets, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets);
+	Error _export_cocoapods(const Ref<EditorExportPreset> &p_preset, const Vector<String> &p_dependencies, Vector<IOSExportAsset> &r_exported_assets);
 	Error _copy_asset(const Ref<EditorExportPreset> &p_preset, const String &p_out_dir, const String &p_asset, const String *p_custom_file_name, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets);
 	Error _export_additional_assets(const Ref<EditorExportPreset> &p_preset, const String &p_out_dir, const Vector<SharedObject> &p_libraries, Vector<IOSExportAsset> &r_exported_assets);
 	Error _export_ios_plugins(const Ref<EditorExportPreset> &p_preset, IOSConfigData &p_config_data, const String &dest_dir, Vector<IOSExportAsset> &r_exported_assets, bool p_debug);
+
+	Error _generate_podfile(const String &platform, const String &platform_version, const String &target_name, const Dictionary &dependencies, const String dest_dir);
 
 	Error _export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_simulator, bool p_oneclick);
 

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -193,11 +193,13 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 
 	if (config_file->has_section(PluginConfigIOS::DEPENDENCIES_SECTION)) {
 		Vector<String> linked_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_LINKED_KEY, Vector<String>());
+		Vector<String> pods_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_PODS_KEY, Vector<String>());
 		Vector<String> embedded_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_EMBEDDED_KEY, Vector<String>());
 		Vector<String> system_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_SYSTEM_KEY, Vector<String>());
 		Vector<String> files = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_FILES_KEY, Vector<String>());
 
 		plugin_config.linked_dependencies = resolve_local_dependencies(config_base_dir, linked_dependencies);
+		plugin_config.pods_dependencies = pods_dependencies;
 		plugin_config.embedded_dependencies = resolve_local_dependencies(config_base_dir, embedded_dependencies);
 		plugin_config.system_dependencies = resolve_system_dependencies(system_dependencies);
 

--- a/platform/ios/export/godot_plugin_config.h
+++ b/platform/ios/export/godot_plugin_config.h
@@ -66,6 +66,7 @@ struct PluginConfigIOS {
 	inline static const char *DEPENDENCIES_LINKED_KEY = "linked";
 	inline static const char *DEPENDENCIES_EMBEDDED_KEY = "embedded";
 	inline static const char *DEPENDENCIES_SYSTEM_KEY = "system";
+	inline static const char *DEPENDENCIES_PODS_KEY = "pods";
 	inline static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
 	inline static const char *DEPENDENCIES_FILES_KEY = "files";
 	inline static const char *DEPENDENCIES_LINKER_FLAGS = "linker_flags";
@@ -103,6 +104,7 @@ struct PluginConfigIOS {
 	Vector<String> linked_dependencies;
 	Vector<String> embedded_dependencies;
 	Vector<String> system_dependencies;
+	Vector<String> pods_dependencies;
 
 	Vector<String> files_to_copy;
 	Vector<String> capabilities;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR adds support for [CocoaPods](https://cocoapods.org/) on iOS. Implements [this proposal](https://github.com/godotengine/godot-proposals/issues/4758)

# Description
CocoaPods is a dependency manager for iOS which is widely used to provide native libraries similar to Gradle for Android. Currently there's no support for these pods and thus users are unable to use the one click deploy when implementing their own native plugins which rely on a CocoaPod dependency. Instead people are forced to export the project and setup CocoaPods for each build manually which does not scale well.

This PR makes use of the `.gdip` file that is required for iOS Native Plugins and simply adds a `pods` variable where you can specify the pod name and version with the following format: `pods=["POD_NAME:POD_VERSION"]`. In the export settings you simple enable CocoaPods (disabled by default to avoid changing the standard workflow for iOS exporting) and are then able to build your project as normal with the CocoaPods dependencies automatically added to your project.

## Status

I've marked the PR as a draft as there are some parts I'm not fully happy with and would like some suggestions on how to improve those, namely how to transfer the dependencies from the `.gdip` file to the actual build process. I also don't fully know where I need to go in order to update the documentation nor if I need to do anything related to the translations of the new error messages and option inside the Export window.

## How to test

The system is already functional and you can use this sample project in order to try it out: [ioscocoapodstest.zip](https://github.com/user-attachments/files/16887386/ioscocoapodstest.zip). This project uses the IronSourceSDK as a dependency and simply calls `[ISIntegrationHelper validateIntegration]` in order to verify that everything was setup correctly. When you run the project on an iOS device it should say `Found Plugin 1234` and inside the Console you should be able to see a list of `IntegrationHelper` messages with the IronSource adapter being verified with version 8.3.0.

The source code for this plugin (extremely rough code) is available here: [GodotSamplePlugin.zip](https://github.com/user-attachments/files/16887353/GodotSamplePlugin.zip). In order to use it you must add the godot source to the root folder of this project and run `pod install` inside the root folder. You can then open the `GodotSamplePlugin.xcworkspace` and build the project via the `ExternalBuildTest` target. The final binary will be placed in the `bin/` folder. The GDIP can be found in the sample project above under the `ios/plugsin/GodotSamplePlugin` folder.
