### PR TITLE
Fix 2D debug navigation flickering with tile maps

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -452,6 +452,7 @@ void NavigationRegion2D::_update_debug_mesh() {
 	const Transform2D region_gt = get_global_transform();
 
 	rs->canvas_item_set_parent(debug_instance_rid, get_world_2d()->get_canvas());
+	rs->canvas_item_set_z_index(debug_instance_rid, RS::CANVAS_ITEM_Z_MAX - 2);
 	rs->canvas_item_set_transform(debug_instance_rid, region_gt);
 
 	if (!debug_mesh_dirty) {


### PR DESCRIPTION
Both the tile map layers and the debug navigation canvas items did fight for the same z order causing a lot of flickering in certain situations.

Before the debug rendering was changed to server use in https://github.com/godotengine/godot/pull/92372 this was kinda hidden due to node order. This change now sets the z index one less the navigation agent debug paths index so the paths can render on top of the navigation mesh debug.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
