### PR TITLE
Expose `Viewport.gui_cancel_drag()` to GDScript as a counterpart to `Control.force_drag()`

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -117,6 +117,12 @@
 				Returns the visible rectangle in global screen coordinates.
 			</description>
 		</method>
+		<method name="gui_cancel_drag">
+			<return type="void" />
+			<description>
+				Cancels the drag operation that was previously started through [method Control._get_drag_data] or forced with [method Control.force_drag].
+			</description>
+		</method>
 		<method name="gui_get_drag_data" qualifiers="const">
 			<return type="Variant" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4695,6 +4695,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("warp_mouse", "position"), &Viewport::warp_mouse);
 	ClassDB::bind_method(D_METHOD("update_mouse_cursor_state"), &Viewport::update_mouse_cursor_state);
 
+	ClassDB::bind_method(D_METHOD("gui_cancel_drag"), &Viewport::gui_cancel_drag);
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data"), &Viewport::gui_get_drag_data);
 	ClassDB::bind_method(D_METHOD("gui_is_dragging"), &Viewport::gui_is_dragging);
 	ClassDB::bind_method(D_METHOD("gui_is_drag_successful"), &Viewport::gui_is_drag_successful);


### PR DESCRIPTION
Using [Control.force_drag()](https://docs.godotengine.org/en/stable/classes/class_control.html#class-control-method-force-drag) has no counterpart to abort a drag operation. The expectation is that a left mouse click completes the operation. This small changes exposes the Viewport.gui_cancel_drag() method to GDScript, per @KoBeWi's [suggestion](https://github.com/godotengine/godot-proposals/issues/10624#issuecomment-2323264847) in godotengine/godot-proposals/issues/10624.