### PR TITLE
Globally remember advanced toggle in project settings

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -104,7 +104,8 @@ void ProjectSettingsEditor::_update_advanced(bool p_is_advanced) {
 }
 
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
-	EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", p_button_pressed);
+	EditorSettings::get_singleton()->set("_project_settings_advanced_mode", p_button_pressed);
+	EditorSettings::get_singleton()->save();
 	_update_advanced(p_button_pressed);
 	general_settings_inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
@@ -768,8 +769,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	set_ok_button_text(TTR("Close"));
 	set_hide_on_ok(true);
 
-	bool use_advanced = EditorSettings::get_singleton()->get_project_metadata("project_settings", "advanced_mode", false);
-
+	bool use_advanced = EDITOR_DEF("_project_settings_advanced_mode", false);
 	if (use_advanced) {
 		advanced->set_pressed(true);
 	}


### PR DESCRIPTION
Currently the Advanced button in Project Settings dialog is remembered per project.
It's safe to assume that when you enable it, you are an advanced user and want to see more settings. And if you enable it in one project, it's safe to assume that you are advanced user in any project.

This PR makes the option remembered globally for all projects.
Originally discussed here: https://github.com/godotengine/godot/pull/96467#discussion_r1741121165