### PR TITLE
Add Create Curve button to Path2D editor

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -42,7 +42,6 @@
 
 void Path2DEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			curve_edit->set_icon(get_editor_theme_icon(SNAME("CurveEdit")));
 			curve_edit_curve->set_icon(get_editor_theme_icon(SNAME("CurveCurve")));
@@ -50,6 +49,8 @@ void Path2DEditor::_notification(int p_what) {
 			curve_del->set_icon(get_editor_theme_icon(SNAME("CurveDelete")));
 			curve_close->set_icon(get_editor_theme_icon(SNAME("CurveClose")));
 			curve_clear_points->set_icon(get_editor_theme_icon(SNAME("Clear")));
+
+			create_curve_button->set_icon(get_editor_theme_icon(SNAME("Curve2D")));
 		} break;
 	}
 }
@@ -450,6 +451,16 @@ void Path2DEditor::_node_visibility_changed() {
 	}
 
 	canvas_item_editor->update_viewport();
+	_update_toolbar();
+}
+
+void Path2DEditor::_update_toolbar() {
+	if (!node) {
+		return;
+	}
+	bool has_curve = node->get_curve().is_valid();
+	toolbar->set_visible(has_curve);
+	create_curve_button->set_visible(!has_curve);
 }
 
 void Path2DEditor::edit(Node *p_path2d) {
@@ -463,6 +474,7 @@ void Path2DEditor::edit(Node *p_path2d) {
 
 	if (p_path2d) {
 		node = Object::cast_to<Path2D>(p_path2d);
+		_update_toolbar();
 
 		if (!node->is_connected(SceneStringName(visibility_changed), callable_mp(this, &Path2DEditor::_node_visibility_changed))) {
 			node->connect(SceneStringName(visibility_changed), callable_mp(this, &Path2DEditor::_node_visibility_changed));
@@ -477,7 +489,7 @@ void Path2DEditor::edit(Node *p_path2d) {
 }
 
 void Path2DEditor::_bind_methods() {
-	//ClassDB::bind_method(D_METHOD("_menu_option"),&Path2DEditor::_menu_option);
+	ClassDB::bind_method(D_METHOD("_update_toolbar"), &Path2DEditor::_update_toolbar);
 	ClassDB::bind_method(D_METHOD("_clear_curve_points"), &Path2DEditor::_clear_curve_points);
 	ClassDB::bind_method(D_METHOD("_restore_curve_points"), &Path2DEditor::_restore_curve_points);
 }
@@ -601,6 +613,21 @@ void Path2DEditor::_cancel_current_action() {
 	action = ACTION_NONE;
 }
 
+void Path2DEditor::_create_curve() {
+	ERR_FAIL_NULL(node);
+
+	Ref<Curve2D> new_curve;
+	new_curve.instantiate();
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Create Curve in Path2D"));
+	undo_redo->add_do_property(node, "curve", new_curve);
+	undo_redo->add_undo_property(node, "curve", Ref<Curve2D>());
+	undo_redo->add_do_method(this, "_update_toolbar");
+	undo_redo->add_undo_method(this, "_update_toolbar");
+	undo_redo->commit_action();
+}
+
 void Path2DEditor::_confirm_clear_points() {
 	if (!node || node->get_curve().is_null()) {
 		return;
@@ -648,6 +675,8 @@ void Path2DEditor::_restore_curve_points(Path2D *p_path2d, const PackedVector2Ar
 }
 
 Path2DEditor::Path2DEditor() {
+	toolbar = memnew(HBoxContainer);
+
 	curve_edit = memnew(Button);
 	curve_edit->set_theme_type_variation("FlatButton");
 	curve_edit->set_toggle_mode(true);
@@ -655,7 +684,7 @@ Path2DEditor::Path2DEditor() {
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip_text(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
 	curve_edit->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT));
-	add_child(curve_edit);
+	toolbar->add_child(curve_edit);
 
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_theme_type_variation("FlatButton");
@@ -663,7 +692,7 @@ Path2DEditor::Path2DEditor() {
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip_text(TTR("Select Control Points (Shift+Drag)"));
 	curve_edit_curve->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT_CURVE));
-	add_child(curve_edit_curve);
+	toolbar->add_child(curve_edit_curve);
 
 	curve_create = memnew(Button);
 	curve_create->set_theme_type_variation("FlatButton");
@@ -671,7 +700,7 @@ Path2DEditor::Path2DEditor() {
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip_text(TTR("Add Point (in empty space)") + "\n" + TTR("Right Click: Delete Point"));
 	curve_create->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CREATE));
-	add_child(curve_create);
+	toolbar->add_child(curve_create);
 
 	curve_del = memnew(Button);
 	curve_del->set_theme_type_variation("FlatButton");
@@ -679,42 +708,48 @@ Path2DEditor::Path2DEditor() {
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip_text(TTR("Delete Point"));
 	curve_del->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_DELETE));
-	add_child(curve_del);
+	toolbar->add_child(curve_del);
 
 	curve_close = memnew(Button);
 	curve_close->set_theme_type_variation("FlatButton");
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip_text(TTR("Close Curve"));
 	curve_close->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CLOSE));
-	add_child(curve_close);
+	toolbar->add_child(curve_close);
 
 	curve_clear_points = memnew(Button);
 	curve_clear_points->set_theme_type_variation("FlatButton");
 	curve_clear_points->set_focus_mode(Control::FOCUS_NONE);
 	curve_clear_points->set_tooltip_text(TTR("Clear Points"));
 	curve_clear_points->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_confirm_clear_points));
-	add_child(curve_clear_points);
+	toolbar->add_child(curve_clear_points);
 
 	clear_points_dialog = memnew(ConfirmationDialog);
 	clear_points_dialog->set_title(TTR("Please Confirm..."));
 	clear_points_dialog->set_text(TTR("Remove all curve points?"));
 	clear_points_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CLEAR_POINTS));
-	add_child(clear_points_dialog);
-
-	PopupMenu *menu;
+	toolbar->add_child(clear_points_dialog);
 
 	handle_menu = memnew(MenuButton);
 	handle_menu->set_flat(false);
 	handle_menu->set_theme_type_variation("FlatMenuButton");
 	handle_menu->set_text(TTR("Options"));
-	add_child(handle_menu);
+	toolbar->add_child(handle_menu);
 
-	menu = handle_menu->get_popup();
+	PopupMenu *menu = handle_menu->get_popup();
 	menu->add_check_item(TTR("Mirror Handle Angles"));
 	menu->set_item_checked(HANDLE_OPTION_ANGLE, mirror_handle_angle);
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &Path2DEditor::_handle_option_pressed));
+
+	add_child(toolbar);
+
+	create_curve_button = memnew(Button);
+	create_curve_button->set_text(TTR("Create Curve"));
+	create_curve_button->hide();
+	add_child(create_curve_button);
+	create_curve_button->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_create_curve));
 }
 
 void Path2DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -58,6 +58,7 @@ class Path2DEditor : public HBoxContainer {
 	};
 
 	Mode mode = MODE_EDIT;
+	HBoxContainer *toolbar = nullptr;
 	Button *curve_clear_points = nullptr;
 	Button *curve_close = nullptr;
 	Button *curve_create = nullptr;
@@ -66,6 +67,7 @@ class Path2DEditor : public HBoxContainer {
 	Button *curve_edit_curve = nullptr;
 	MenuButton *handle_menu = nullptr;
 
+	Button *create_curve_button = nullptr;
 	ConfirmationDialog *clear_points_dialog = nullptr;
 
 	bool mirror_handle_angle = true;
@@ -100,7 +102,9 @@ class Path2DEditor : public HBoxContainer {
 	void _cancel_current_action();
 
 	void _node_visibility_changed();
+	void _update_toolbar();
 
+	void _create_curve();
 	void _confirm_clear_points();
 	void _clear_curve_points(Path2D *p_path2d);
 	void _restore_curve_points(Path2D *p_path2d, const PackedVector2Array &p_points);

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -113,6 +113,8 @@ class Path3DEditorPlugin : public EditorPlugin {
 	Ref<Path3DGizmoPlugin> path_3d_gizmo_plugin;
 
 	HBoxContainer *topmenu_bar = nullptr;
+
+	HBoxContainer *toolbar = nullptr;
 	Button *curve_create = nullptr;
 	Button *curve_edit = nullptr;
 	Button *curve_edit_curve = nullptr;
@@ -122,6 +124,7 @@ class Path3DEditorPlugin : public EditorPlugin {
 	Button *curve_clear_points = nullptr;
 	MenuButton *handle_menu = nullptr;
 
+	Button *create_curve_button = nullptr;
 	ConfirmationDialog *clear_points_dialog = nullptr;
 
 	float disk_size = 0.8;
@@ -138,14 +141,16 @@ class Path3DEditorPlugin : public EditorPlugin {
 	Path3D *path = nullptr;
 
 	void _update_theme();
+	void _update_toolbar();
 
 	void _mode_changed(int p_mode);
 	void _close_curve();
 	void _handle_option_pressed(int p_option);
 	bool handle_clicked = false;
-	bool mirror_handle_angle;
-	bool mirror_handle_length;
+	bool mirror_handle_angle = true;
+	bool mirror_handle_length = true;
 
+	void _create_curve();
 	void _confirm_clear_points();
 	void _clear_points();
 	void _clear_curve_points();


### PR DESCRIPTION
When Path2D has no Curve2D assigned, the toolbar buttons have no effect. Trying to do some operation will just unselect the node. This is a niche problem, because curve is auto-created in Path2D, but it's confusing once you run into it.

This PR adds a "Create Curve" button when no curve is assigned. It replaces the standard toolbar.

https://github.com/user-attachments/assets/113ec6e1-59ca-4ab7-b0e4-b5c6a7b95c35

Unfortunately there doesn't seem to be a way to detect when curve is removed while editing, so you need to re-select the node to update the toolbar. Not sure how to best solve that. I thought about adding some PropertyObserver, but not sure if there is use for it elsewhere (not counting in the future).