### PR TITLE
Avoid bubbling up changed notification when on new item/key of dictionaries to avoid inspector wipeout.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -869,7 +869,11 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 	}
 
 	object->set(p_property, p_value);
-	emit_changed(get_edited_property(), object->get_dict(), p_name, p_changing);
+	bool new_item_or_key = !p_property.begins_with("indices");
+	emit_changed(get_edited_property(), object->get_dict(), p_name, p_changing || new_item_or_key);
+	if (new_item_or_key) {
+		update_property();
+	}
 }
 
 void EditorPropertyDictionary::_change_type(Object *p_button, int p_slot_index) {


### PR DESCRIPTION
fix #95647
This fix the issue at hand but first of all I'm not sure this is the right fix second I'm not even sure this property should be exposed in the inspector as it doesn't seem to be the right way to edit it (dedicated interface in the animation bottom panel). In any case this fix is safe so it can be included anyway.
