### PR TITLE
Display project settings splash color on web export

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -38,7 +38,7 @@ body {
 }
 
 #status {
-	background-color: #242424;
+	background-color: $GODOT_SPLASH_COLOR;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -169,6 +169,7 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	replaces["$GODOT_PROJECT_NAME"] = GLOBAL_GET("application/config/name");
 	replaces["$GODOT_HEAD_INCLUDE"] = head_include + custom_head_include;
 	replaces["$GODOT_CONFIG"] = str_config;
+	replaces["$GODOT_SPLASH_COLOR"] = "#" + Color(GLOBAL_GET("application/boot_splash/bg_color")).to_html(false);
 	replaces["$GODOT_SPLASH"] = p_name + ".png";
 
 	if (p_preset->get("variant/thread_support")) {


### PR DESCRIPTION
This is a minor improvement to the new web export splash screen, which now displays the correct splash color specified in the project settings as the background, as was mentioned in #91852.

I've been a fan of Godot for quite some time now and have been using it for hobby projects, as well as convincing friends to try it. I don't have much experience with the inner workings of the engine, or C++ for that matter but I got very excited to find that I can help out with small additions too ;). My changes have been tested locally and work as expected but since this is my very first contribution to Godot, I'd appreciate a thorough check and I hope that everything is alright!

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/96874*