### PR TITLE
Allow Timer nodes to ignore engine time scale

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -45,6 +45,9 @@
 			[b]Note:[/b] After the timer enters the tree, this property is automatically set to [code]false[/code].
 			[b]Note:[/b] This property does nothing when the timer is running in the editor.
 		</member>
+		<member name="ignore_time_scale" type="bool" setter="set_ignore_time_scale" getter="get_ignore_time_scale" default="false">
+			If [code]true[/code], the timer will ignore [member Engine.time_scale] and update with the real, elapsed time.
+		</member>
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="is_one_shot" default="false">
 			If [code]true[/code], the timer will stop after reaching the end. Otherwise, as by default, the timer will automatically restart.
 		</member>

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -48,7 +48,11 @@ void Timer::_notification(int p_what) {
 			if (!processing || timer_process_callback == TIMER_PROCESS_PHYSICS || !is_processing_internal()) {
 				return;
 			}
-			time_left -= get_process_delta_time();
+			if (ignore_time_scale) {
+				time_left -= Engine::get_singleton()->get_process_step();
+			} else {
+				time_left -= get_process_delta_time();
+			}
 
 			if (time_left < 0) {
 				if (!one_shot) {
@@ -65,7 +69,11 @@ void Timer::_notification(int p_what) {
 			if (!processing || timer_process_callback == TIMER_PROCESS_IDLE || !is_physics_processing_internal()) {
 				return;
 			}
-			time_left -= get_physics_process_delta_time();
+			if (ignore_time_scale) {
+				time_left -= Engine::get_singleton()->get_process_step();
+			} else {
+				time_left -= get_physics_process_delta_time();
+			}
 
 			if (time_left < 0) {
 				if (!one_shot) {
@@ -132,6 +140,14 @@ void Timer::set_paused(bool p_paused) {
 
 bool Timer::is_paused() const {
 	return paused;
+}
+
+void Timer::set_ignore_time_scale(bool p_ignore) {
+	ignore_time_scale = p_ignore;
+}
+
+bool Timer::get_ignore_time_scale() {
+	return ignore_time_scale;
 }
 
 bool Timer::is_stopped() const {
@@ -206,6 +222,9 @@ void Timer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_paused", "paused"), &Timer::set_paused);
 	ClassDB::bind_method(D_METHOD("is_paused"), &Timer::is_paused);
 
+	ClassDB::bind_method(D_METHOD("set_ignore_time_scale", "ignore"), &Timer::set_ignore_time_scale);
+	ClassDB::bind_method(D_METHOD("get_ignore_time_scale"), &Timer::get_ignore_time_scale);
+
 	ClassDB::bind_method(D_METHOD("is_stopped"), &Timer::is_stopped);
 
 	ClassDB::bind_method(D_METHOD("get_time_left"), &Timer::get_time_left);
@@ -220,6 +239,7 @@ void Timer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "is_one_shot");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paused", "is_paused");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_time_scale"), "set_ignore_time_scale", "get_ignore_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "suffix:s", PROPERTY_USAGE_NONE), "", "get_time_left");
 
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_PHYSICS);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -41,6 +41,7 @@ class Timer : public Node {
 	bool autostart = false;
 	bool processing = false;
 	bool paused = false;
+	bool ignore_time_scale = false;
 
 	double time_left = -1.0;
 
@@ -68,6 +69,9 @@ public:
 
 	void set_paused(bool p_paused);
 	bool is_paused() const;
+
+	void set_ignore_time_scale(bool p_ignore);
+	bool get_ignore_time_scale();
 
 	bool is_stopped() const;
 


### PR DESCRIPTION
Sometimes, you don't want the `Timer` nodes to be impacted by the `Engine.time_scale` setting. This would be the case for example when you want to make HTTP calls to a server at regular intervals, without being affected by the time scale.

This PR adds the possibility to ignore `Engine.time_scale` in `Timer` nodes.

![Screenshot_20240905_225805](https://github.com/user-attachments/assets/05211c88-ebd9-4e29-9949-0a36d356face)


Note that this feature is already present when using `SceneTreeTimer create_timer(time_sec: float, process_always: bool = true, process_in_physics: bool = false, ignore_time_scale: bool = false)` 

But `SceneTreeTimer` is only one_shot, and thus cannot be an alternative solution when you need to run a function at regular intervals.

Testing this PR should be pretty straight forward.

1 - Add a `Node2D`, with a `Label` and `Timer` nodes as children
2 - Give the `Timer` something like 100 seconds wait time
3 - Add the script below 
4 - Run the game, then check & uncheck the `Ignore Time Scale` from the editor to see the difference

```gdscript
extends Node2D

@onready var label : Label = $Label
@onready var timer : Timer = $Timer

func _physics_process(delta: float) -> void:
	
	Engine.time_scale = 10
	label.text = "Timeout left : " + str(timer.time_left)
```

- *Production edit: See
https://github.com/godotengine/godot-proposals/issues/7775
and https://github.com/godotengine/godot-proposals/issues/10373.*