### PR TITLE
Fix Animated Path2D doesn't update PathFollow2D progress when scene is running.

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -167,16 +167,15 @@ void Path2D::_curve_changed() {
 		return;
 	}
 
-	if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_paths_hint()) {
-		return;
-	}
-
-	queue_redraw();
 	for (int i = 0; i < get_child_count(); i++) {
 		PathFollow2D *follow = Object::cast_to<PathFollow2D>(get_child(i));
 		if (follow) {
 			follow->path_changed();
 		}
+	}
+
+	if (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_paths_hint()) {
+		queue_redraw();
 	}
 }
 


### PR DESCRIPTION
PathFollow2D needs to update its transform whenever a curve changes (for instance a point change its position). 

I have tested with the project provided in https://github.com/godotengine/godot/issues/85813
_bugsquad edit:_ Fixes #85813.

I have noticed useless code in curve.cpp around call to _bake function:
```
	if (baked_cache_dirty) {
		_bake();
	}
```

and the _bake functions is like:

```
void Curve2D::_bake() const {
	if (!baked_cache_dirty) {
		return;
	}
```

My eyes bleed but I did not touch it for easy merge :)