### PR TITLE
Remove duplicated read only checks in `EditorSpinSlider`

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -185,10 +185,6 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 
-	if (is_read_only()) {
-		return;
-	}
-
 	if (grabbing_grabber) {
 		if (mb.is_valid()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
@@ -241,7 +237,7 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 
 void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
-	if (k.is_valid() && k->is_pressed() && !is_read_only()) {
+	if (k.is_valid() && k->is_pressed() && !read_only) {
 		Key code = k->get_keycode();
 
 		switch (code) {
@@ -315,7 +311,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 	bool rtl = is_layout_rtl();
 	Vector2 size = get_size();
 
-	Ref<StyleBox> sb = get_theme_stylebox(is_read_only() ? SNAME("read_only") : CoreStringName(normal), SNAME("LineEdit"));
+	Ref<StyleBox> sb = get_theme_stylebox(read_only ? SNAME("read_only") : CoreStringName(normal), SNAME("LineEdit"));
 	if (!flat) {
 		draw_style_box(sb, Rect2(Vector2(), size));
 	}
@@ -327,14 +323,14 @@ void EditorSpinSlider::_draw_spin_slider() {
 	int label_width = font->get_string_size(label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width;
 	int number_width = size.width - sb->get_minimum_size().width - label_width - sep;
 
-	Ref<Texture2D> updown = get_theme_icon(is_read_only() ? SNAME("updown_disabled") : SNAME("updown"), SNAME("SpinBox"));
+	Ref<Texture2D> updown = get_theme_icon(read_only ? SNAME("updown_disabled") : SNAME("updown"), SNAME("SpinBox"));
 
 	String numstr = get_text_value();
 
 	int vofs = (size.height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 
-	Color fc = get_theme_color(is_read_only() ? SNAME("font_uneditable_color") : SceneStringName(font_color), SNAME("LineEdit"));
-	Color lc = get_theme_color(is_read_only() ? SNAME("read_only_label_color") : SNAME("label_color"));
+	Color fc = get_theme_color(read_only ? SNAME("font_uneditable_color") : SceneStringName(font_color), SNAME("LineEdit"));
+	Color lc = get_theme_color(read_only ? SNAME("read_only_label_color") : SNAME("label_color"));
 
 	if (flat && !label.is_empty()) {
 		Ref<StyleBox> label_bg = get_theme_stylebox(SNAME("label_bg"), SNAME("EditorSpinSlider"));
@@ -384,7 +380,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 
 	if (!hide_slider) {
 		if (get_step() == 1) {
-			Ref<Texture2D> updown2 = is_read_only() ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
+			Ref<Texture2D> updown2 = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
 			int updown_vofs = (size.height - updown2->get_height()) / 2;
 			if (rtl) {
 				updown_offset = sb->get_margin(SIDE_LEFT);
@@ -604,7 +600,7 @@ void EditorSpinSlider::_value_focus_exited() {
 		return;
 	}
 
-	if (is_read_only()) {
+	if (read_only) {
 		// Spin slider has become read only while it was being edited.
 		return;
 	}
@@ -665,7 +661,7 @@ bool EditorSpinSlider::is_grabbing() const {
 }
 
 void EditorSpinSlider::_focus_entered() {
-	if (is_read_only()) {
+	if (read_only) {
 		return;
 	}
 


### PR DESCRIPTION
There are checks for both `read_only` and `is_read_only()` at the beginning of `EditorSpinSlider::_grabber_gui_input()`. They were added by [two](https://github.com/godotengine/godot/pull/63249) [separate](https://github.com/godotengine/godot/pull/63751) PRs, and it is probably due to one of them rebasing after the other is merged :)

`editor_spin_slider.cpp` has overall mixed use of `read_only` and `is_read_only()`. The numbers are almost the same (7 vs 9).

Since `is_read_only()` is not virtual and is a plain getter, I also made read only checks in `EditorSpinSlider`'s implementation to use `read_only` directly for consistency in this PR.
