### PR TITLE
Fix crash when re-importing GLTF scene while Animation window is open

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1393,7 +1393,7 @@ void AnimationPlayerEditor::_list_changed() {
 }
 
 void AnimationPlayerEditor::_current_animation_changed(const String &p_name) {
-	if (is_visible_in_tree()) {
+	if (is_visible_in_tree() && player) {
 		if (p_name.is_empty()) {
 			// Means [stop].
 			frame->set_value(0);


### PR DESCRIPTION
In `AnimationPlayerEditor::_node_removed`, it will set `player` to nullptr, but there's still some messages `_current_animation_changed` in call queue, so it crashed with `player` being nullptr.

Fixes https://github.com/godotengine/godot/issues/96631

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
