### PR TITLE
Editor: Open online docs in the editor language

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -189,7 +189,7 @@ def version_info_builder(target, source, env):
 #define VERSION_MODULE_CONFIG "{module_config}"
 #define VERSION_WEBSITE "{website}"
 #define VERSION_DOCS_BRANCH "{docs_branch}"
-#define VERSION_DOCS_URL "https://docs.godotengine.org/en/" VERSION_DOCS_BRANCH
+#define VERSION_DOCS_URL "https://docs.godotengine.org/"
 """.format(**env.version_info)
         )
 

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -702,6 +702,9 @@
 		<member name="interface/editor/mouse_extra_buttons_navigate_history" type="bool" setter="" getter="">
 			If [code]true[/code], the mouse's additional side buttons will be usable to navigate in the script editor's file history. Set this to [code]false[/code] if you're using the side buttons for other purposes (such as a push-to-talk button in a VoIP program).
 		</member>
+		<member name="interface/editor/online_docs_language" type="String" setter="" getter="">
+			If [code]auto[/code], then the online docs will open in the default editor language specified in [member interface/editor/editor_language], or the English docs if no translation is found.
+		</member>
 		<member name="interface/editor/project_manager_screen" type="int" setter="" getter="">
 			The preferred monitor to display the project manager.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3185,7 +3185,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			command_palette->open_popup();
 		} break;
 		case HELP_DOCS: {
-			OS::get_singleton()->shell_open(VERSION_DOCS_URL "/");
+			String doc_url = EditorSettings::get_singleton()->get_online_docs_url();
+			OS::get_singleton()->shell_open(doc_url);
 		} break;
 		case HELP_FORUM: {
 			OS::get_singleton()->shell_open("https://forum.godotengine.org/");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -397,7 +397,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			best = "en";
 		}
 
+		// These are the languages with a translation for the online docs
+		String docs_lang_hint = "auto,en,cs,de,es,fr,it,ja,ko,pl,pt-br,ru,uk,zh-cn,zh-tw";
+
 		EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_ENUM, "interface/editor/editor_language", best, lang_hint, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+		EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/editor/online_docs_language", "auto", docs_lang_hint);
 	}
 
 	/* Interface */
@@ -1142,6 +1146,40 @@ void EditorSettings::setup_language() {
 
 	// Load extractable translation for projects.
 	load_extractable_translations(lang);
+}
+
+String EditorSettings::get_online_docs_url() {
+	String default_language = EditorSettings::get_singleton()->get_setting("interface/editor/editor_language");
+	String override_language = EditorSettings::get_singleton()->get_setting("interface/editor/online_docs_language");
+
+	Vector<String> doc_languages;
+	doc_languages.push_back("en");
+	doc_languages.push_back("cs");
+	doc_languages.push_back("de");
+	doc_languages.push_back("es");
+	doc_languages.push_back("fr");
+	doc_languages.push_back("it");
+	doc_languages.push_back("ja");
+	doc_languages.push_back("ko");
+	doc_languages.push_back("pl");
+	doc_languages.push_back("pt-br");
+	doc_languages.push_back("ru");
+	doc_languages.push_back("uk");
+	doc_languages.push_back("zh-cn");
+	doc_languages.push_back("zh-tw");
+
+	String language = "en";
+	if ((doc_languages.find(default_language) >= 0)) {
+		language = default_language;
+	}
+	if ((doc_languages.find(override_language) >= 0)) {
+		language = override_language;
+	}
+
+	// For versioning, the English online docs use "latest", "stable", "4.3", "4.4", etc, and the translated online docs use "3.x", "4.x", etc.
+	// While "stable" or "latest" will redirect to "4.x" on the translated docs, "4.3" will not redirect.
+	String version = (language == "en") ? VERSION_DOCS_BRANCH : vformat("%s.x", VERSION_MAJOR);
+	return vformat(VERSION_DOCS_URL "%s/%s/", language, version);
 }
 
 void EditorSettings::setup_network() {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -134,6 +134,7 @@ public:
 
 	static void create();
 	void setup_language();
+	String get_online_docs_url();
 	void setup_network();
 	static void save();
 	static void destroy();

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -553,7 +553,8 @@ void ProjectExportDialog::_enc_filters_changed(const String &p_filters) {
 }
 
 void ProjectExportDialog::_open_key_help_link() {
-	OS::get_singleton()->shell_open(vformat("%s/contributing/development/compiling/compiling_with_script_encryption_key.html", VERSION_DOCS_URL));
+	String doc_url = EditorSettings::get_singleton()->get_online_docs_url();
+	OS::get_singleton()->shell_open(vformat("%s/contributing/development/compiling/compiling_with_script_encryption_key.html", doc_url));
 }
 
 void ProjectExportDialog::_enc_pck_changed(bool p_pressed) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1367,12 +1367,14 @@ void ScriptEditor::_menu_option(int p_option) {
 				const HashMap<String, DocData::ClassDoc>::ConstIterator E = EditorHelp::get_doc_data()->class_list.find(eh->get_class());
 				native_class_doc = E && !E->value.is_script_doc;
 			}
+
+			String doc_url_base = EditorSettings::get_singleton()->get_online_docs_url();
 			if (native_class_doc) {
 				String name = eh->get_class().to_lower();
-				String doc_url = vformat(VERSION_DOCS_URL "/classes/class_%s.html", name);
+				String doc_url = vformat("%s/classes/class_%s.html", doc_url_base, name);
 				OS::get_singleton()->shell_open(doc_url);
 			} else {
-				OS::get_singleton()->shell_open(VERSION_DOCS_URL "/");
+				OS::get_singleton()->shell_open(doc_url_base);
 			}
 		} break;
 		case WINDOW_NEXT: {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -727,7 +727,8 @@ void TextShaderEditor::_menu_option(int p_option) {
 			code_editor->remove_all_bookmarks();
 		} break;
 		case HELP_DOCS: {
-			OS::get_singleton()->shell_open(vformat("%s/tutorials/shaders/shader_reference/index.html", VERSION_DOCS_URL));
+			String doc_url = EditorSettings::get_singleton()->get_online_docs_url();
+			OS::get_singleton()->shell_open(vformat("%s/tutorials/shaders/shader_reference/index.html", doc_url));
 		} break;
 	}
 	if (p_option != SEARCH_FIND && p_option != SEARCH_REPLACE && p_option != SEARCH_GOTO_LINE) {

--- a/tests/editor/test_editor_translation.h
+++ b/tests/editor/test_editor_translation.h
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  test_editor_translation.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_EDITOR_TRANSLATION_H
+#define TEST_EDITOR_TRANSLATION_H
+
+#ifdef TOOLS_ENABLED
+
+#include "tests/test_macros.h"
+
+#include "core/version.h"
+#include "editor/editor_settings.h"
+
+namespace EditorTranslationTests {
+
+static String build_url(String &p_language) {
+	String version = (p_language == "en") ? VERSION_DOCS_BRANCH : vformat("%s.x", VERSION_MAJOR);
+	return vformat(VERSION_DOCS_URL "%s/%s/", p_language, version);
+}
+
+TEST_CASE("[Editor][EditorSettings][Translation] Docs URL changes based on editor language settings") {
+	String english = "en";
+	String translated = "fr"; // French
+	String untranslated = "gl"; // Galician
+
+	SUBCASE("Editor language is English, online docs language is auto.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", english);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", "auto");
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(english));
+	}
+
+	SUBCASE("Editor language is English, online docs language is overridden.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", english);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", translated);
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(translated));
+	}
+
+	SUBCASE("Editor language has translated online docs, online docs language is auto.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", translated);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", "auto");
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(translated));
+	}
+
+	SUBCASE("Editor language has translated online docs, online docs language is overridden.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", translated);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", english);
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(english));
+	}
+
+	SUBCASE("Editor language has untranslated online docs, online docs language is auto.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", untranslated);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", "auto");
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(english));
+	}
+
+	SUBCASE("Editor language has untranslated online docs, online docs language is overridden.") {
+		EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", untranslated);
+		EditorSettings::get_singleton()->set_setting("interface/editor/online_docs_language", translated);
+		CHECK(EditorSettings::get_singleton()->get_online_docs_url() == build_url(translated));
+	}
+}
+
+} // namespace EditorTranslationTests
+
+#endif // TOOLS_ENABLED
+
+#endif // TEST_EDITOR_TRANSLATION_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -102,6 +102,7 @@
 #include "tests/core/variant/test_dictionary.h"
 #include "tests/core/variant/test_variant.h"
 #include "tests/core/variant/test_variant_utility.h"
+#include "tests/editor/test_editor_translation.h"
 #include "tests/scene/test_animation.h"
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/10538.

With this PR, by default opening the online docs from within the editor will try to use the editor's language. Two new editor settings are added: a string `online_docs_language` and a boolean `override_online_docs_language`. When trying to open the online docs, the editor will try in order:
- If an override language is set, open the online docs in the override language.
- If no override is set, open the docs in the main editor language if the online docs are translated into that language.
- Otherwise, open the online docs in English.

I chose a full language override, so any online docs language can be used. Alternately, we could have no setting, or we could have a simple boolean setting to "use editor language for online docs", and default to `en` if it is not set. A full override supports a user who, for example, has a first language `ar` (no online translation), second language `es` (online translation), and third language `en` (online translation, but less well understood by the user).


This still needs work:
- [ ] Find the correct place to construct the translated online docs URL. `editor_settings.h` seems like the wrong place for this function, but nothing else seemed exactly right. I looked at `translation_server.h`, `editor_help.h`, and `editor_translation.h`.
- [ ] Store the list of languages with online translations in one place, rather than a duplicate list in both the editor setting and the function that constructs the URL.
- [x] The setting `override_online_docs_language` could be removed if a `default` language is added to `online_docs_language`.
- [ ] Ideally, deal with cases such as `pt` / `pt-br` gracefully. You can choose both `pt` (Portuguese) or `pt-br` (Brazilian Portuguese) for the editor language, but the online docs only have `pt-br`. If the editor is set to `pt`, falling back to `en` rather than `pt-br` for the online docs seems wrong. Perhaps this should be a dictionary that maps editor languages to online docs languages, with most falling back to `en` if not supported by the online docs.
- [ ] Verify that changing the `VERSION_DOCS_URL` macro does not affect anything. I checked all the references in code, but there might be side effects elsewhere. Possibly rename it, as it no longer contains a version.
- [ ] Possibly rename editor settings.
- [ ] Update unit tests once other code is changed. Maybe move unit tests to another location.
- [ ] Revise editor setting descriptions once all other changes are made.
- [ ] Performance and code style.