### PR TITLE
CTRL-click or middle-click Inspector fields to jump to nodes & resources in Scene & FileSystem windows

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2874,7 +2874,12 @@ void EditorPropertyNodePath::_node_selected(const NodePath &p_path, bool p_absol
 	update_property();
 }
 
-void EditorPropertyNodePath::_node_assign() {
+void EditorPropertyNodePath::_on_click() {
+	if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+		_select_node_in_scene_tree();
+		return;
+	}
+
 	if (!scene_tree) {
 		scene_tree = memnew(SceneTreeDialog);
 		scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
@@ -2892,6 +2897,34 @@ void EditorPropertyNodePath::_node_assign() {
 		n = Object::cast_to<Node>(val);
 	}
 	scene_tree->popup_scenetree_dialog(n, get_base_node());
+}
+
+void EditorPropertyNodePath::_select_node_in_scene_tree() {
+	Node *target_node = _get_node_in_scene_tree();
+	if (!target_node) {
+		return;
+	}
+
+	bool isEditableFromRoot = true;
+	Node *owner = target_node->get_owner();
+	if (owner != nullptr && owner != target_node->get_tree()->get_edited_scene_root()) {
+		// Node is within a scene instance, so we check that it's editable
+		Node *pt = owner;
+		owner = owner->get_owner();
+		while (owner) {
+			if (!owner->is_editable_instance(pt)) {
+				isEditableFromRoot = false;
+				break;
+			}
+			pt = owner;
+			owner = pt->get_owner();
+		}
+	}
+
+	if (isEditableFromRoot) {
+		SceneTreeDock::get_singleton()->set_selected(target_node);
+		SceneTreeDock::get_singleton()->set_selection({ target_node });
+	}
 }
 
 void EditorPropertyNodePath::_assign_draw() {
@@ -2937,14 +2970,7 @@ void EditorPropertyNodePath::_menu_option(int p_idx) {
 		} break;
 
 		case ACTION_SELECT: {
-			const Node *edited_node = get_base_node();
-			ERR_FAIL_NULL(edited_node);
-
-			const NodePath &np = _get_node_path();
-			Node *target_node = edited_node->get_node_or_null(np);
-			ERR_FAIL_NULL(target_node);
-
-			SceneTreeDock::get_singleton()->set_selected(target_node);
+			_select_node_in_scene_tree();
 		} break;
 	}
 }
@@ -2978,6 +3004,21 @@ const NodePath EditorPropertyNodePath::_get_node_path() const {
 	} else {
 		return val;
 	}
+}
+
+Node *EditorPropertyNodePath::_get_node_in_scene_tree() {
+	const Node *edited_node = get_base_node();
+	if (!edited_node) {
+		return nullptr;
+	}
+
+	const NodePath &np = _get_node_path();
+	Node *target_node = edited_node->get_node_or_null(np);
+	if (!target_node) {
+		return nullptr;
+	}
+
+	return target_node;
 }
 
 bool EditorPropertyNodePath::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
@@ -3028,6 +3069,16 @@ bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const 
 	}
 
 	return false;
+}
+
+void EditorPropertyNodePath::gui_input(const Ref<InputEvent> &p_ev) {
+	Ref<InputEventMouseButton> mb = p_ev;
+
+	if (!mb.is_valid() || !mb->is_pressed() || mb->get_button_index() != MouseButton::MIDDLE) {
+		return;
+	}
+
+	_select_node_in_scene_tree();
 }
 
 void EditorPropertyNodePath::update_property() {
@@ -3136,8 +3187,9 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_clip_text(true);
 	assign->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	assign->set_expand_icon(true);
-	assign->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	assign->connect(SceneStringName(draw), callable_mp(this, &EditorPropertyNodePath::_assign_draw));
+	assign->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyNodePath::_on_click));
+	assign->connect(SceneStringName(gui_input), callable_mp(this, &EditorPropertyNodePath::gui_input));
 	SET_DRAG_FORWARDING_CD(assign, EditorPropertyNodePath);
 	hbc->add_child(assign);
 

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -663,8 +663,8 @@ class EditorPropertyNodePath : public EditorProperty {
 	bool dropping = false;
 
 	Vector<StringName> valid_types;
+	void _on_click();
 	void _node_selected(const NodePath &p_path, bool p_absolute = true);
-	void _node_assign();
 	void _assign_draw();
 	Node *get_base_node();
 	void _update_menu();
@@ -672,6 +672,8 @@ class EditorPropertyNodePath : public EditorProperty {
 	void _accept_text();
 	void _text_submitted(const String &p_text);
 	const NodePath _get_node_path() const;
+	Node *_get_node_in_scene_tree();
+	void _select_node_in_scene_tree();
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
@@ -684,6 +686,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	void gui_input(const Ref<InputEvent> &p_ev) override;
 	virtual void update_property() override;
 	void setup(const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
 	EditorPropertyNodePath();

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -142,6 +142,13 @@ void EditorResourcePicker::_resource_selected() {
 		return;
 	}
 
+	if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+		if (edited_resource.is_valid() && edited_resource->get_path().is_resource_file()) {
+			FileSystemDock::get_singleton()->navigate_to_path(edited_resource->get_path());
+		}
+		return;
+	}
+
 	emit_signal(SNAME("resource_selected"), edited_resource, false);
 }
 
@@ -587,23 +594,23 @@ void EditorResourcePicker::_button_draw() {
 void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+	if (mb.is_valid() && mb->is_pressed()) {
 		// Only attempt to update and show the menu if we have
 		// a valid resource or the Picker is editable, as
 		// there will otherwise be nothing to display.
-		if (edited_resource.is_valid() || is_editable()) {
-			if (edit_menu && edit_menu->is_visible()) {
-				edit_button->set_pressed(false);
-				edit_menu->hide();
-				return;
+		if (mb->get_button_index() == MouseButton::RIGHT) {
+			if (edited_resource.is_valid() || is_editable()) {
+				_update_menu_items();
+
+				Vector2 pos = get_screen_position() + mb->get_position();
+				edit_menu->reset_size();
+				edit_menu->set_position(pos);
+				edit_menu->popup();
 			}
-
-			_update_menu_items();
-
-			Vector2 pos = get_screen_position() + mb->get_position();
-			edit_menu->reset_size();
-			edit_menu->set_position(pos);
-			edit_menu->popup();
+		} else if (mb->get_button_index() == MouseButton::MIDDLE) {
+			if (edited_resource.is_valid() && edited_resource->get_path().is_resource_file()) {
+				FileSystemDock::get_singleton()->navigate_to_path(edited_resource->get_path());
+			}
 		}
 	}
 }


### PR DESCRIPTION
Resolves [#10642](https://github.com/godotengine/godot-proposals/issues/10642).

- CTRL-click or middle-click a `Resource` to select it in the FileSystem window
- CTRL-click or middle-click a `Node` to select it in the Scene window, if able; no-op otherwise
  - Fix bug: previous behavior of right-click "Show Node in Tree" set `selected` to the node, even though it didn't show it

These aren't currently bound to anything, so the change should be non-destructive.