### PR TITLE
Fix "reparent to new node" when node has internal children

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2932,7 +2932,7 @@ void SceneTreeDock::_create() {
 		int original_position = -1;
 		if (only_one_top_node) {
 			parent = top_node->get_parent();
-			original_position = top_node->get_index();
+			original_position = top_node->get_index(false);
 		} else {
 			parent = top_node->get_parent()->get_parent();
 		}


### PR DESCRIPTION
Followup to #79209
Fixes https://github.com/godotengine/godot/pull/79209#discussion_r1746936928