### PR TITLE
Add `BoneAttachment3D.get_external_skeleton_path`, deprecate `get_external_skeleton`

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -9,7 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_external_skeleton" qualifiers="const">
+		<method name="get_external_skeleton" qualifiers="const" deprecated="Use [method get_external_skeleton_path] instead.">
+			<return type="NodePath" />
+			<description>
+				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
+			</description>
+		</method>
+		<method name="get_external_skeleton_path" qualifiers="const">
 			<return type="NodePath" />
 			<description>
 				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
@@ -33,9 +39,16 @@
 				A function that is called automatically when the [Skeleton3D] is updated. This function is where the [BoneAttachment3D] node updates its position so it is correctly bound when it is [i]not[/i] set to override the bone pose.
 			</description>
 		</method>
-		<method name="set_external_skeleton">
+		<method name="set_external_skeleton" deprecated="Use [method set_external_skeleton_path] instead.">
 			<return type="void" />
 			<param index="0" name="external_skeleton" type="NodePath" />
+			<description>
+				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. See [method set_use_external_skeleton] to enable the external [Skeleton3D] node.
+			</description>
+		</method>
+		<method name="set_external_skeleton_path">
+			<return type="void" />
+			<param index="0" name="external_skeleton_path" type="NodePath" />
 			<description>
 				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. See [method set_use_external_skeleton] to enable the external [Skeleton3D] node.
 			</description>
@@ -44,7 +57,7 @@
 			<return type="void" />
 			<param index="0" name="use_external_skeleton" type="bool" />
 			<description>
-				Sets whether the BoneAttachment3D node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [method set_external_skeleton].
+				Sets whether the BoneAttachment3D node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [method set_external_skeleton_path].
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6126,7 +6126,7 @@ void GLTFDocument::_convert_bone_attachment_to_gltf(BoneAttachment3D *p_bone_att
 	Skeleton3D *skeleton;
 	// Note that relative transforms to external skeletons and pose overrides are not supported.
 	if (p_bone_attachment->get_use_external_skeleton()) {
-		skeleton = Object::cast_to<Skeleton3D>(p_bone_attachment->get_node_or_null(p_bone_attachment->get_external_skeleton()));
+		skeleton = Object::cast_to<Skeleton3D>(p_bone_attachment->get_node_or_null(p_bone_attachment->get_external_skeleton_path()));
 	} else {
 		skeleton = Object::cast_to<Skeleton3D>(p_bone_attachment->get_parent());
 	}

--- a/scene/3d/bone_attachment_3d.compat.inc
+++ b/scene/3d/bone_attachment_3d.compat.inc
@@ -38,6 +38,9 @@ void BoneAttachment3D::_on_bone_pose_update_bind_compat_90575(int p_bone_index) 
 
 void BoneAttachment3D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("on_bone_pose_update", "bone_index"), &BoneAttachment3D::_on_bone_pose_update_bind_compat_90575);
+
+	ClassDB::bind_method(D_METHOD("set_external_skeleton", "external_skeleton"), &BoneAttachment3D::set_external_skeleton_path);
+	ClassDB::bind_method(D_METHOD("get_external_skeleton"), &BoneAttachment3D::get_external_skeleton_path);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -56,8 +56,12 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 	if (p_path == SNAME("use_external_skeleton")) {
 		set_use_external_skeleton(p_value);
+#ifndef DISABLE_DEPRECATED
 	} else if (p_path == SNAME("external_skeleton")) {
-		set_external_skeleton(p_value);
+		set_external_skeleton_path(p_value);
+#endif // DISABLE_DEPRECATED
+	} else if (p_path == SNAME("external_skeleton_path")) {
+		set_external_skeleton_path(p_value);
 	}
 
 	return true;
@@ -66,8 +70,12 @@ bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
 	if (p_path == SNAME("use_external_skeleton")) {
 		r_ret = get_use_external_skeleton();
+#ifndef DISABLE_DEPRECATED
 	} else if (p_path == SNAME("external_skeleton")) {
-		r_ret = get_external_skeleton();
+		r_ret = get_external_skeleton_path();
+#endif // DISABLE_DEPRECATED
+	} else if (p_path == SNAME("external_skeleton_path")) {
+		r_ret = get_external_skeleton_path();
 	}
 
 	return true;
@@ -76,7 +84,10 @@ bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
 void BoneAttachment3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::BOOL, "use_external_skeleton", PROPERTY_HINT_NONE, ""));
 	if (use_external_skeleton) {
+#ifndef DISABLE_DEPRECATED
 		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "external_skeleton", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D"));
+#endif
+		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "external_skeleton_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D"));
 	}
 }
 
@@ -277,13 +288,13 @@ bool BoneAttachment3D::get_use_external_skeleton() const {
 	return use_external_skeleton;
 }
 
-void BoneAttachment3D::set_external_skeleton(NodePath p_path) {
+void BoneAttachment3D::set_external_skeleton_path(NodePath p_path) {
 	external_skeleton_node = p_path;
 	_update_external_skeleton_cache();
 	notify_property_list_changed();
 }
 
-NodePath BoneAttachment3D::get_external_skeleton() const {
+NodePath BoneAttachment3D::get_external_skeleton_path() const {
 	return external_skeleton_node;
 }
 
@@ -384,8 +395,9 @@ void BoneAttachment3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_use_external_skeleton", "use_external_skeleton"), &BoneAttachment3D::set_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_use_external_skeleton"), &BoneAttachment3D::get_use_external_skeleton);
-	ClassDB::bind_method(D_METHOD("set_external_skeleton", "external_skeleton"), &BoneAttachment3D::set_external_skeleton);
-	ClassDB::bind_method(D_METHOD("get_external_skeleton"), &BoneAttachment3D::get_external_skeleton);
+
+	ClassDB::bind_method(D_METHOD("set_external_skeleton_path", "external_skeleton_path"), &BoneAttachment3D::set_external_skeleton_path);
+	ClassDB::bind_method(D_METHOD("get_external_skeleton_path"), &BoneAttachment3D::get_external_skeleton_path);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -91,8 +91,8 @@ public:
 
 	void set_use_external_skeleton(bool p_external_skeleton);
 	bool get_use_external_skeleton() const;
-	void set_external_skeleton(NodePath p_skeleton);
-	NodePath get_external_skeleton() const;
+	void set_external_skeleton_path(NodePath p_skeleton);
+	NodePath get_external_skeleton_path() const;
 
 	virtual void on_skeleton_update();
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/10670