### PR TITLE
Implement partial mipmap chains for images

### DIFF
--- a/core/io/image.h
+++ b/core/io/image.h
@@ -187,13 +187,13 @@ private:
 	Vector<uint8_t> data;
 	int width = 0;
 	int height = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0; // The main image isn't considered a mipmap.
 
 	void _copy_internals_from(const Image &p_image) {
 		format = p_image.format;
 		width = p_image.width;
 		height = p_image.height;
-		mipmaps = p_image.mipmaps;
+		mipmap_count = p_image.mipmap_count;
 		data = p_image.data;
 	}
 
@@ -257,7 +257,7 @@ public:
 		VALIDATE_3D_ERR_IMAGE_HAS_MIPMAPS,
 	};
 
-	static Image3DValidateError validate_3d_image(Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_images);
+	static Image3DValidateError validate_3d_image(Format p_format, int p_width, int p_height, int p_depth, int p_mipmap_count, const Vector<Ref<Image>> &p_images);
 	static String get_3d_image_validation_error_text(Image3DValidateError p_error);
 
 	/**
@@ -282,7 +282,7 @@ public:
 	/**
 	 * Generate a mipmap to an image (creates an image 1/4 the size, with averaging of 4->1)
 	 */
-	Error generate_mipmaps(bool p_renormalize = false);
+	Error generate_mipmaps(bool p_renormalize = false, int p_limit = -1);
 
 	enum RoughnessChannel {
 		ROUGHNESS_CHANNEL_R,
@@ -300,8 +300,8 @@ public:
 	/**
 	 * Creates new internal image data of a given size and format. Current image will be lost.
 	 */
-	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
-	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	void initialize_data(int p_width, int p_height, int p_mipmap_count, Format p_format);
+	void initialize_data(int p_width, int p_height, int p_mipmap_count, Format p_format, const Vector<uint8_t> &p_data);
 	void initialize_data(const char **p_xpm);
 
 	/**
@@ -322,9 +322,9 @@ public:
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 
-	static Ref<Image> create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
-	static Ref<Image> create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
-	void set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	static Ref<Image> create_empty(int p_width, int p_height, int p_mipmap_count, Format p_format);
+	static Ref<Image> create_from_data(int p_width, int p_height, int p_mipmap_count, Format p_format, const Vector<uint8_t> &p_data);
+	void set_data(int p_width, int p_height, int p_mipmap_count, Format p_format, const Vector<uint8_t> &p_data);
 
 	/**
 	 * create an empty image
@@ -333,11 +333,11 @@ public:
 	/**
 	 * create an empty image of a specific size and format
 	 */
-	Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
+	Image(int p_width, int p_height, int p_mipmap_count, Format p_format);
 	/**
 	 * import an image of a specific size and format from a pointer
 	 */
-	Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	Image(int p_width, int p_height, int p_mipmap_count, Format p_format, const Vector<uint8_t> &p_data);
 
 	~Image() {}
 
@@ -355,7 +355,7 @@ public:
 	static int get_format_block_size(Format p_format);
 	static void get_format_min_pixel_size(Format p_format, int &r_w, int &r_h);
 
-	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false);
+	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, int p_mipmap_count = 0);
 	static int get_image_required_mipmaps(int p_width, int p_height, Format p_format);
 	static Size2i get_image_mipmap_size(int p_width, int p_height, Format p_format, int p_mipmap);
 	static int64_t get_image_mipmap_offset(int p_width, int p_height, Format p_format, int p_mipmap);
@@ -447,7 +447,7 @@ public:
 		format = p_image->format;
 		width = p_image->width;
 		height = p_image->height;
-		mipmaps = p_image->mipmaps;
+		mipmap_count = p_image->mipmap_count;
 		data = p_image->data;
 	}
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -122,31 +122,31 @@
 			<return type="Image" />
 			<param index="0" name="width" type="int" />
 			<param index="1" name="height" type="int" />
-			<param index="2" name="use_mipmaps" type="bool" />
+			<param index="2" name="mipmap_count" type="int" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
-				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates an empty image of given size and format. See [enum Format] constants. If [param mipmap_count] is greater than [code]0[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="create_empty" qualifiers="static">
 			<return type="Image" />
 			<param index="0" name="width" type="int" />
 			<param index="1" name="height" type="int" />
-			<param index="2" name="use_mipmaps" type="bool" />
+			<param index="2" name="mipmap_count" type="int" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
-				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates an empty image of given size and format. See [enum Format] constants. If [param mipmap_count] is greater than [code]0[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="create_from_data" qualifiers="static">
 			<return type="Image" />
 			<param index="0" name="width" type="int" />
 			<param index="1" name="height" type="int" />
-			<param index="2" name="use_mipmaps" type="bool" />
+			<param index="2" name="mipmap_count" type="int" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<param index="4" name="data" type="PackedByteArray" />
 			<description>
-				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code] then loads mipmaps for this image from [param data]. See [method generate_mipmaps].
+				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [param mipmap_count] is greater than [code]0[/code] then loads mipmaps for this image from [param data]. See [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="crop">
@@ -213,9 +213,11 @@
 		<method name="generate_mipmaps">
 			<return type="int" enum="Error" />
 			<param index="0" name="renormalize" type="bool" default="false" />
+			<param index="1" name="limit" type="int" default="-1" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code]. Enabling [param renormalize] when generating mipmaps for normal map textures will make sure all resulting vector values are normalized.
 				It is possible to check if the image has mipmaps by calling [method has_mipmaps] or [method get_mipmap_count]. Calling [method generate_mipmaps] on an image that already has mipmaps will replace existing mipmaps in the image.
+				[param limit] decides how many mipmaps will be generated. If set to -1, the full chain will be generated.
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -48,7 +48,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximal amount of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overbluring of distant images, especially ones with a low resolution.
+			If set to [code]-1[/code], the full mipmap chain will be generated. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting is ignored if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
 			Controls how the cubemap's texture is internally laid out. When using high-resolution cubemaps, [b]2×3[/b] and [b]3×2[/b] are less prone to exceeding hardware texture size limits compared to [b]1×6[/b] and [b]6×1[/b].

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -63,7 +63,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximal amount of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overbluring of distant images, especially ones with a low resolution.
+			If set to [code]-1[/code], the full mipmap chain will be generated. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting is ignored if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="process/fix_alpha_border" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], puts pixels of the same surrounding color in transition from transparent to opaque areas. For textures displayed with bilinear filtering, this helps to reduce the outline effect when exporting images from an image editor.

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -51,7 +51,7 @@ public:
 	int compress_mode = 0;
 	float lossy = 1.0;
 	int hdr_compression = 0;
-	bool mipmaps = true;
+	int mipmap_limit = 0;
 	bool high_quality = false;
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 	virtual ~LayeredTextureImport() {}
@@ -110,7 +110,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, int p_mipmap_limit, bool p_force_po2);
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -74,7 +74,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, int p_mipmap_limit, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -364,7 +364,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 		}
 	}
 
-	Ref<Image> image = memnew(Image(w, h, false, Image::FORMAT_RGBF, point_img));
+	Ref<Image> image = memnew(Image(w, h, 0, Image::FORMAT_RGBF, point_img));
 	Ref<ImageTexture> tex = ImageTexture::create_from_image(image);
 
 	Ref<ParticleProcessMaterial> mat = node->get_process_material();
@@ -390,7 +390,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 			}
 		}
 
-		Ref<Image> image2 = memnew(Image(w, h, false, Image::FORMAT_RGBF, point_img2));
+		Ref<Image> image2 = memnew(Image(w, h, 0, Image::FORMAT_RGBF, point_img2));
 		mat->set_emission_normal_texture(ImageTexture::create_from_image(image2));
 	} else {
 		mat->set_emission_shape(ParticleProcessMaterial::EMISSION_SHAPE_POINTS);

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -81,20 +81,7 @@ void TexturePreview::_update_metadata_label_text() {
 	const Ref<Image> image = texture->get_image();
 	if (image.is_valid()) {
 		const int mipmaps = image->get_mipmap_count();
-		// Avoid signed integer overflow that could occur with huge texture sizes by casting everything to uint64_t.
-		uint64_t memory = uint64_t(image->get_width()) * uint64_t(image->get_height()) * uint64_t(Image::get_format_pixel_size(image->get_format()));
-		// Handle VRAM-compressed formats that are stored with 4 bpp.
-		memory >>= Image::get_format_pixel_rshift(image->get_format());
-
-		float mipmaps_multiplier = 1.0;
-		float mipmap_increase = 0.25;
-		for (int i = 0; i < mipmaps; i++) {
-			// Each mip adds 25% memory usage of the previous one.
-			// With a complete mipmap chain, memory usage increases by ~33%.
-			mipmaps_multiplier += mipmap_increase;
-			mipmap_increase *= 0.25;
-		}
-		memory *= mipmaps_multiplier;
+		uint64_t memory = Image::get_image_data_size(image->get_width(), image->get_height(), image->get_format(), mipmaps);
 
 		if (mipmaps >= 1) {
 			metadata_label->set_text(

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -141,8 +141,8 @@ void TextureLayeredEditor::_update_gui() {
 	}
 
 	if (texture->has_mipmaps()) {
-		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), texture->get_format());
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), texture->get_format(), true) * texture->get_layers();
+		const int mip_count = texture->get_mipmap_count();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), texture->get_format(), mip_count) * texture->get_layers();
 
 		texture_info += vformat(TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
 				mip_count,

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -297,7 +297,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 
 	// Create the buffer for transcoded/decompressed data.
 	Vector<uint8_t> out_data;
-	out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels > 1));
+	out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels - 1));
 
 	uint8_t *dst = out_data.ptrw();
 	memset(dst, 0, out_data.size());
@@ -317,7 +317,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 		}
 	}
 
-	image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels > 1, image_format, out_data);
+	image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels - 1, image_format, out_data);
 
 	if (needs_ra_rg_swap) {
 		// Swap uncompressed RA-as-RG texture's color channels.

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -230,7 +230,7 @@ Error _compress_betsy(BetsyFormat p_format, Image *r_img) {
 
 	// Container for the compressed data.
 	Vector<uint8_t> dst_data;
-	dst_data.resize(Image::get_image_data_size(r_img->get_width(), r_img->get_height(), dest_format, r_img->has_mipmaps()));
+	dst_data.resize(Image::get_image_data_size(r_img->get_width(), r_img->get_height(), dest_format, r_img->get_mipmap_count()));
 	uint8_t *dst_data_ptr = dst_data.ptrw();
 
 	Vector<Vector<uint8_t>> src_images;
@@ -312,7 +312,7 @@ Error _compress_betsy(BetsyFormat p_format, Image *r_img) {
 	src_images.clear();
 
 	// Set the compressed data to the image.
-	r_img->set_data(r_img->get_width(), r_img->get_height(), r_img->has_mipmaps(), dest_format, dst_data);
+	r_img->set_data(r_img->get_width(), r_img->get_height(), r_img->get_mipmap_count(), dest_format, dst_data);
 
 	// Free the shader (dependencies will be cleared automatically).
 	rd->free(src_sampler);

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -160,7 +160,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Compress image data and (if required) mipmaps.
-	const bool has_mipmaps = r_img->has_mipmaps();
+	const int mip_count = r_img->get_mipmap_count();
 	int width = r_img->get_width();
 	int height = r_img->get_height();
 
@@ -194,12 +194,11 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 
 	// Create the buffer for compressed image data.
 	Vector<uint8_t> dest_data;
-	dest_data.resize(Image::get_image_data_size(width, height, target_format, has_mipmaps));
+	dest_data.resize(Image::get_image_data_size(width, height, target_format, mip_count));
 	uint8_t *dest_write = dest_data.ptrw();
 
 	const uint8_t *src_read = r_img->get_data().ptr();
 
-	const int mip_count = has_mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	Vector<uint32_t> padded_src;
 
 	for (int i = 0; i < mip_count + 1; i++) {
@@ -299,7 +298,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Replace original image with compressed one.
-	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
+	r_img->set_data(width, height, mip_count, target_format, dest_data);
 
 	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/noise/noise.cpp
+++ b/modules/noise/noise.cpp
@@ -133,7 +133,7 @@ Vector<Ref<Image>> Noise::_get_image(int p_width, int p_height, int p_depth, boo
 					idx++;
 				}
 			}
-			Ref<Image> img = memnew(Image(p_width, p_height, false, Image::FORMAT_L8, data));
+			Ref<Image> img = memnew(Image(p_width, p_height, 0, Image::FORMAT_L8, data));
 			images.write[d] = img;
 		}
 	} else {
@@ -156,7 +156,7 @@ Vector<Ref<Image>> Noise::_get_image(int p_width, int p_height, int p_depth, boo
 				}
 			}
 
-			Ref<Image> img = memnew(Image(p_width, p_height, false, Image::FORMAT_L8, data));
+			Ref<Image> img = memnew(Image(p_width, p_height, 0, Image::FORMAT_L8, data));
 			images.write[d] = img;
 		}
 	}

--- a/modules/noise/noise.h
+++ b/modules/noise/noise.h
@@ -195,7 +195,7 @@ class Noise : public Resource {
 					wr(x, y) = _alpha_blend<T>(bottom_blend, top_blend, ypos);
 				}
 			}
-			Ref<Image> image = memnew(Image(p_width, p_height, false, format, dest));
+			Ref<Image> image = memnew(Image(p_width, p_height, 0, format, dest));
 			p_src.write[d].unref();
 			images.write[d] = image;
 		}
@@ -240,7 +240,7 @@ class Noise : public Resource {
 					dest.write[i] = out;
 				}
 
-				Ref<Image> new_image = memnew(Image(images[0]->get_width(), images[0]->get_height(), false, images[0]->get_format(), dest));
+				Ref<Image> new_image = memnew(Image(images[0]->get_width(), images[0]->get_height(), 0, images[0]->get_format(), dest));
 				new_images.write[z % p_depth] = new_image;
 			}
 			return new_images;

--- a/modules/squish/image_decompress_squish.cpp
+++ b/modules/squish/image_decompress_squish.cpp
@@ -88,7 +88,7 @@ void image_decompress_squish(Image *p_image) {
 		h >>= 1;
 	}
 
-	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
+	p_image->set_data(p_image->get_width(), p_image->get_height(), mm_count, target_format, data);
 
 	if (source_format == Image::FORMAT_DXT5_RA_AS_RG) {
 		p_image->convert_ra_rgba8_to_rg();

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -147,7 +147,7 @@ private:
 	int w = 0;
 	int h = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	LayeredType layered_type = LayeredType::LAYERED_TYPE_2D_ARRAY;
 
 	virtual void reload_from_file() override;
@@ -166,6 +166,7 @@ public:
 	int get_height() const override;
 	int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;

--- a/scene/resources/curve_texture.cpp
+++ b/scene/resources/curve_texture.cpp
@@ -122,7 +122,7 @@ void CurveTexture::_update() {
 		}
 	}
 
-	Ref<Image> image = memnew(Image(_width, 1, false, texture_mode == TEXTURE_MODE_RGB ? Image::FORMAT_RGBF : Image::FORMAT_RF, data));
+	Ref<Image> image = memnew(Image(_width, 1, 0, texture_mode == TEXTURE_MODE_RGB ? Image::FORMAT_RGBF : Image::FORMAT_RF, data));
 
 	if (_texture.is_valid()) {
 		if (_current_texture_mode != texture_mode || _current_width != _width) {
@@ -324,7 +324,7 @@ void CurveXYZTexture::_update() {
 		}
 	}
 
-	Ref<Image> image = memnew(Image(_width, 1, false, Image::FORMAT_RGBF, data));
+	Ref<Image> image = memnew(Image(_width, 1, 0, Image::FORMAT_RGBF, data));
 
 	if (_texture.is_valid()) {
 		if (_current_width != _width) {

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -94,7 +94,7 @@ void GradientTexture1D::_update() {
 
 	if (use_hdr) {
 		// High dynamic range.
-		Ref<Image> image = memnew(Image(width, 1, false, Image::FORMAT_RGBAF));
+		Ref<Image> image = memnew(Image(width, 1, 0, Image::FORMAT_RGBAF));
 		Gradient &g = **gradient;
 		// `create()` isn't available for non-uint8_t data, so fill in the data manually.
 		for (int i = 0; i < width; i++) {
@@ -127,7 +127,7 @@ void GradientTexture1D::_update() {
 			}
 		}
 
-		Ref<Image> image = memnew(Image(width, 1, false, Image::FORMAT_RGBA8, data));
+		Ref<Image> image = memnew(Image(width, 1, 0, Image::FORMAT_RGBA8, data));
 
 		if (texture.is_valid()) {
 			RID new_texture = RS::get_singleton()->texture_2d_create(image);

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -41,7 +41,7 @@ class ImageTexture : public Texture2D {
 
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_L8;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	int w = 0;
 	int h = 0;
 	Size2 size_override;
@@ -97,7 +97,7 @@ class ImageTextureLayered : public TextureLayered {
 	int width = 0;
 	int height = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	Error _create_from_images(const TypedArray<Image> &p_images);
 
@@ -113,6 +113,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual LayeredType get_layered_type() const override;
 
 	Error create_from_images(Vector<Ref<Image>> p_images);
@@ -135,7 +136,7 @@ class ImageTexture3D : public Texture3D {
 	int width = 1;
 	int height = 1;
 	int depth = 1;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	TypedArray<Image> _get_images() const;
 	void _set_images(const TypedArray<Image> &p_images);
@@ -143,7 +144,7 @@ class ImageTexture3D : public Texture3D {
 protected:
 	static void _bind_methods();
 
-	Error _create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data);
+	Error _create(Image::Format p_format, int p_width, int p_height, int p_depth, int p_mipmap_count, const TypedArray<Image> &p_data);
 	void _update(const TypedArray<Image> &p_data);
 
 public:
@@ -152,8 +153,9 @@ public:
 	virtual int get_height() const override;
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 
-	Error create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data);
+	Error create(Image::Format p_format, int p_width, int p_height, int p_depth, int p_mipmap_count, const Vector<Ref<Image>> &p_data);
 	void update(const Vector<Ref<Image>> &p_data);
 	virtual Vector<Ref<Image>> get_data() const override;
 

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -89,7 +89,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 				data_size -= mipsize;
 			}
 
-			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps, format, image_data)));
+			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps ? -1 : 0, format, image_data)));
 
 		} break;
 		case COMPRESSION_MODE_BASIS_UNIVERSAL: {
@@ -100,7 +100,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 		case COMPRESSION_MODE_S3TC:
 		case COMPRESSION_MODE_ETC2:
 		case COMPRESSION_MODE_BPTC: {
-			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps, format, p_data.slice(20))));
+			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps ? -1 : 0, format, p_data.slice(20))));
 		} break;
 	}
 	ERR_FAIL_COND(image.is_null());

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -161,6 +161,12 @@ bool Texture3D::has_mipmaps() const {
 	return ret;
 }
 
+int Texture3D::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_REQUIRED_CALL(_get_mipmap_count, ret);
+	return ret;
+}
+
 Vector<Ref<Image>> Texture3D::get_data() const {
 	TypedArray<Image> ret;
 	GDVIRTUAL_REQUIRED_CALL(_get_data, ret);
@@ -229,6 +235,12 @@ int TextureLayered::get_layers() const {
 bool TextureLayered::has_mipmaps() const {
 	bool ret = false;
 	GDVIRTUAL_REQUIRED_CALL(_has_mipmaps, ret);
+	return ret;
+}
+
+int TextureLayered::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_REQUIRED_CALL(_get_mipmap_count, ret);
 	return ret;
 }
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -99,6 +99,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_height)
 	GDVIRTUAL0RC(int, _get_layers)
 	GDVIRTUAL0RC(bool, _has_mipmaps)
+	GDVIRTUAL0RC(int, _get_mipmap_count)
 	GDVIRTUAL1RC(Ref<Image>, _get_layer_data, int)
 public:
 	enum LayeredType {
@@ -113,6 +114,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_layers() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Ref<Image> get_layer_data(int p_layer) const;
 
 	TextureLayered() {}
@@ -133,6 +135,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_height)
 	GDVIRTUAL0RC(int, _get_depth)
 	GDVIRTUAL0RC(bool, _has_mipmaps)
+	GDVIRTUAL0RC(int, _get_mipmap_count)
 	GDVIRTUAL0RC(TypedArray<Image>, _get_data)
 public:
 	virtual Image::Format get_format() const;
@@ -140,6 +143,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_depth() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Vector<Ref<Image>> get_data() const;
 	virtual Ref<Resource> create_placeholder() const;
 };

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1219,7 +1219,7 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 void TextureStorage::texture_2d_placeholder_initialize(RID p_texture) {
 	//this could be better optimized to reuse an existing image , done this way
 	//for now to get it working
-	Ref<Image> image = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	Ref<Image> image = Image::create_empty(4, 4, 0, Image::FORMAT_RGBA8);
 	image->fill(Color(1, 0, 1, 1));
 
 	texture_2d_initialize(p_texture, image);
@@ -1228,7 +1228,7 @@ void TextureStorage::texture_2d_placeholder_initialize(RID p_texture) {
 void TextureStorage::texture_2d_layered_placeholder_initialize(RID p_texture, RS::TextureLayeredType p_layered_type) {
 	//this could be better optimized to reuse an existing image , done this way
 	//for now to get it working
-	Ref<Image> image = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	Ref<Image> image = Image::create_empty(4, 4, 0, Image::FORMAT_RGBA8);
 	image->fill(Color(1, 0, 1, 1));
 
 	Vector<Ref<Image>> images;
@@ -1247,7 +1247,7 @@ void TextureStorage::texture_2d_layered_placeholder_initialize(RID p_texture, RS
 void TextureStorage::texture_3d_placeholder_initialize(RID p_texture) {
 	//this could be better optimized to reuse an existing image , done this way
 	//for now to get it working
-	Ref<Image> image = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	Ref<Image> image = Image::create_empty(4, 4, 0, Image::FORMAT_RGBA8);
 	image->fill(Color(1, 0, 1, 1));
 
 	Vector<Ref<Image>> images;
@@ -1294,9 +1294,9 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 			ndp[ofs * 4 + 2] = Math::make_half_float(float(b) / 1023.0);
 			ndp[ofs * 4 + 3] = Math::make_half_float(float(a) / 3.0);
 		}
-		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, new_data);
+		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps - 1, tex->validated_format, new_data);
 	} else {
-		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
+		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps - 1, tex->validated_format, data);
 	}
 
 	ERR_FAIL_COND_V(image->is_empty(), Ref<Image>());
@@ -1319,7 +1319,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 
 	Vector<uint8_t> data = RD::get_singleton()->texture_get_data(tex->rd_texture, p_layer);
 	ERR_FAIL_COND_V(data.is_empty(), Ref<Image>());
-	Ref<Image> image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
+	Ref<Image> image = Image::create_from_data(tex->width, tex->height, tex->mipmaps - 1, tex->validated_format, data);
 	ERR_FAIL_COND_V(image->is_empty(), Ref<Image>());
 	if (tex->format != tex->validated_format) {
 		image->convert(tex->format);
@@ -1345,7 +1345,7 @@ Vector<Ref<Image>> TextureStorage::texture_3d_get(RID p_texture) const {
 		ERR_FAIL_COND_V(bs.offset + bs.buffer_size > (uint32_t)all_data.size(), Vector<Ref<Image>>());
 		Vector<uint8_t> sub_region = all_data.slice(bs.offset, bs.offset + bs.buffer_size);
 
-		Ref<Image> img = Image::create_from_data(bs.size.width, bs.size.height, false, tex->validated_format, sub_region);
+		Ref<Image> img = Image::create_from_data(bs.size.width, bs.size.height, 0, tex->validated_format, sub_region);
 		ERR_FAIL_COND_V(img->is_empty(), Vector<Ref<Image>>());
 		if (tex->format != tex->validated_format) {
 			img->convert(tex->format);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -140,7 +140,7 @@ RID RenderingServer::get_test_texture() {
 		}
 	}
 
-	Ref<Image> data = memnew(Image(TEST_TEXTURE_SIZE, TEST_TEXTURE_SIZE, false, Image::FORMAT_RGB8, test_data));
+	Ref<Image> data = memnew(Image(TEST_TEXTURE_SIZE, TEST_TEXTURE_SIZE, 0, Image::FORMAT_RGB8, test_data));
 
 	test_texture = texture_2d_create(data);
 

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -42,7 +42,7 @@
 namespace TestImage {
 
 TEST_CASE("[Image] Instantiation") {
-	Ref<Image> image = memnew(Image(8, 4, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(8, 4, 0, Image::FORMAT_RGBA8));
 	CHECK_MESSAGE(
 			!image->is_empty(),
 			"An image created with specified size and format should not be empty at first.");
@@ -72,14 +72,14 @@ TEST_CASE("[Image] Instantiation") {
 			"Duplicated images should have the same data.");
 
 	image_data = image->get_data();
-	Ref<Image> image_from_data = memnew(Image(8, 4, false, Image::FORMAT_RGBA8, image_data));
+	Ref<Image> image_from_data = memnew(Image(8, 4, 0, Image::FORMAT_RGBA8, image_data));
 	CHECK_MESSAGE(
 			image->get_data() == image_from_data->get_data(),
 			"An image created from data of another image should have the same data of the original image.");
 }
 
 TEST_CASE("[Image] Saving and loading") {
-	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(4, 4, 0, Image::FORMAT_RGBA8));
 	const String save_path_png = TestUtils::get_temp_path("image.png");
 	const String save_path_exr = TestUtils::get_temp_path("image.exr");
 
@@ -174,7 +174,7 @@ TEST_CASE("[Image] Saving and loading") {
 }
 
 TEST_CASE("[Image] Basic getters") {
-	Ref<Image> image = memnew(Image(8, 4, false, Image::FORMAT_LA8));
+	Ref<Image> image = memnew(Image(8, 4, 0, Image::FORMAT_LA8));
 	CHECK(image->get_width() == 8);
 	CHECK(image->get_height() == 4);
 	CHECK(image->get_size() == Vector2(8, 4));
@@ -185,7 +185,7 @@ TEST_CASE("[Image] Basic getters") {
 }
 
 TEST_CASE("[Image] Resizing") {
-	Ref<Image> image = memnew(Image(8, 8, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(8, 8, 0, Image::FORMAT_RGBA8));
 	// Crop
 	image->crop(4, 4);
 	CHECK_MESSAGE(
@@ -214,7 +214,7 @@ TEST_CASE("[Image] Resizing") {
 			"get_size() should return the correct size after shrink_x2().");
 
 	// resize_to_po2()
-	Ref<Image> image_po_2 = memnew(Image(14, 28, false, Image::FORMAT_RGBA8));
+	Ref<Image> image_po_2 = memnew(Image(14, 28, 0, Image::FORMAT_RGBA8));
 	image_po_2->resize_to_po2();
 	CHECK_MESSAGE(
 			image_po_2->get_size() == Vector2(16, 32),
@@ -222,7 +222,7 @@ TEST_CASE("[Image] Resizing") {
 }
 
 TEST_CASE("[Image] Modifying pixels of an image") {
-	Ref<Image> image = memnew(Image(3, 3, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(3, 3, 0, Image::FORMAT_RGBA8));
 	image->set_pixel(0, 0, Color(1, 1, 1, 1));
 	CHECK_MESSAGE(
 			!image->is_invisible(),
@@ -235,7 +235,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 			"Image's get_used_rect should return the expected value, larger than Rect2i(0, 0, 0, 0) if it's visible.");
 
 	image->set_pixelv(Vector2(0, 0), Color(0.5, 0.5, 0.5, 0.5));
-	Ref<Image> image2 = memnew(Image(3, 3, false, Image::FORMAT_RGBA8));
+	Ref<Image> image2 = memnew(Image(3, 3, 0, Image::FORMAT_RGBA8));
 
 	// Fill image with color
 	image2->fill(Color(0.5, 0.5, 0.5, 0.5));
@@ -317,7 +317,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 
 	// Pre-multiply Alpha then Convert from RGBA to L8, checking alpha
 	{
-		Ref<Image> gray_image = memnew(Image(3, 3, false, Image::FORMAT_RGBA8));
+		Ref<Image> gray_image = memnew(Image(3, 3, 0, Image::FORMAT_RGBA8));
 		gray_image->fill_rect(Rect2i(0, 0, 3, 3), Color(1, 1, 1, 0));
 		gray_image->set_pixel(1, 1, Color(1, 1, 1, 1));
 		gray_image->set_pixel(1, 2, Color(0.5, 0.5, 0.5, 0.5));
@@ -338,7 +338,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 }
 
 TEST_CASE("[Image] Custom mipmaps") {
-	Ref<Image> image = memnew(Image(100, 100, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(100, 100, 0, Image::FORMAT_RGBA8));
 
 	REQUIRE(!image->has_mipmaps());
 	image->generate_mipmaps();
@@ -363,7 +363,7 @@ TEST_CASE("[Image] Custom mipmaps") {
 				data_ptr[mip_offset + i] = mip * 5;
 			}
 		}
-		image->set_data(image->get_width(), image->get_height(), image->has_mipmaps(), image->get_format(), data);
+		image->set_data(image->get_width(), image->get_height(), image->get_mipmap_count(), image->get_format(), data);
 	}
 
 	// Byte format conversion.
@@ -419,7 +419,7 @@ TEST_CASE("[Image] Custom mipmaps") {
 TEST_CASE("[Image] Convert image") {
 	for (int format = Image::FORMAT_RF; format < Image::FORMAT_RGBE9995; format++) {
 		for (int new_format = Image::FORMAT_RF; new_format < Image::FORMAT_RGBE9995; new_format++) {
-			Ref<Image> image = memnew(Image(4, 4, false, (Image::Format)format));
+			Ref<Image> image = memnew(Image(4, 4, 0, (Image::Format)format));
 			image->convert((Image::Format)new_format);
 			String format_string = Image::format_names[(Image::Format)format];
 			String new_format_string = Image::format_names[(Image::Format)new_format];
@@ -428,13 +428,13 @@ TEST_CASE("[Image] Convert image") {
 		}
 	}
 
-	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(4, 4, 0, Image::FORMAT_RGBA8));
 	PackedByteArray image_data = image->get_data();
 	ERR_PRINT_OFF;
 	image->convert((Image::Format)-1);
 	ERR_PRINT_ON;
 	CHECK_MESSAGE(image->get_data() == image_data, "Image conversion to invalid type (-1) should not alter image.");
-	Ref<Image> image2 = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
+	Ref<Image> image2 = memnew(Image(4, 4, 0, Image::FORMAT_RGBA8));
 	image_data = image2->get_data();
 	ERR_PRINT_OFF;
 	image2->convert((Image::Format)(Image::FORMAT_MAX + 1));

--- a/tests/scene/test_image_texture.h
+++ b/tests/scene/test_image_texture.h
@@ -51,7 +51,7 @@ TEST_CASE("[SceneTree][ImageTexture] constructor") {
 }
 
 TEST_CASE("[SceneTree][ImageTexture] create_from_image") {
-	Ref<Image> image = memnew(Image(16, 8, true, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(16, 8, -1, Image::FORMAT_RGBA8));
 	Ref<ImageTexture> image_texture = ImageTexture::create_from_image(image);
 	CHECK(image_texture->get_width() == 16);
 	CHECK(image_texture->get_height() == 8);
@@ -62,7 +62,7 @@ TEST_CASE("[SceneTree][ImageTexture] create_from_image") {
 
 TEST_CASE("[SceneTree][ImageTexture] set_image") {
 	Ref<ImageTexture> image_texture = memnew(ImageTexture);
-	Ref<Image> image = memnew(Image(8, 4, false, Image::FORMAT_RGB8));
+	Ref<Image> image = memnew(Image(8, 4, 0, Image::FORMAT_RGB8));
 	image_texture->set_image(image);
 	CHECK(image_texture->get_width() == 8);
 	CHECK(image_texture->get_height() == 4);
@@ -74,7 +74,7 @@ TEST_CASE("[SceneTree][ImageTexture] set_image") {
 }
 
 TEST_CASE("[SceneTree][ImageTexture] set_size_override") {
-	Ref<Image> image = memnew(Image(16, 8, false, Image::FORMAT_RGB8));
+	Ref<Image> image = memnew(Image(16, 8, 0, Image::FORMAT_RGB8));
 	Ref<ImageTexture> image_texture = ImageTexture::create_from_image(image);
 	CHECK(image_texture->get_width() == 16);
 	CHECK(image_texture->get_height() == 8);
@@ -84,7 +84,7 @@ TEST_CASE("[SceneTree][ImageTexture] set_size_override") {
 }
 
 TEST_CASE("[SceneTree][ImageTexture] is_pixel_opaque") {
-	Ref<Image> image = memnew(Image(8, 8, false, Image::FORMAT_RGBA8));
+	Ref<Image> image = memnew(Image(8, 8, 0, Image::FORMAT_RGBA8));
 	image->set_pixel(0, 0, Color(0.0, 0.0, 0.0, 0.0)); // not opaque
 	image->set_pixel(0, 1, Color(0.0, 0.0, 0.0, 0.1)); // not opaque
 	image->set_pixel(0, 2, Color(0.0, 0.0, 0.0, 0.5)); // opaque


### PR DESCRIPTION
Fixes #96635
Fixes #86330
Fixes #63934
Alternative to #86360

Adds support for partial mipmap chains for images. This allows loading DDS/KTX files without full mipmap chains and restores the "mipmap limit" property in the texture importers.

TODO:
- [ ] Ensure this works correctly for every texture type,
- [ ] Don't break compatibility with older textures / scripts / GDExtensions