### PR TITLE
Add COMPACT display setting for Vectors in Inspector

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -915,18 +915,6 @@
 		<member name="interface/inspector/float_drag_speed" type="float" setter="" getter="">
 			Base speed for increasing/decreasing float values by dragging them in the inspector.
 		</member>
-		<member name="interface/inspector/vector2_display_style" type="int" setter="" getter="">
-			Controls how [Vector2] and [Vector2i] properties are displayed.
-			- [b]Vertical:[/b] Properties are shown on two lines.
-			- [b]Horizontal:[/b] Properties are shown on one line below the label.
-			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
-		</member>
-		<member name="interface/inspector/vector_types_display_style" type="int" setter="" getter="">
-			Controls how [Vector3], [Vector3i], [Vector4], [Vector4i], [Rect2], [Rect2i], [Plane], and [Quaternion] properties are displayed.
-			- [b]Vertical:[/b] Properties are shown on their own lines.
-			- [b]Horizontal:[/b] Properties are shown on one line below the label.
-			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
-		</member>
 		<member name="interface/inspector/max_array_dictionary_items_per_page" type="int" setter="" getter="">
 			The number of [Array] or [Dictionary] items to display on each "page" in the inspector. Higher values allow viewing more values per page, but take more time to load. This increased load time is noticeable when selecting nodes that have array or dictionary properties in the editor.
 		</member>
@@ -944,6 +932,18 @@
 		</member>
 		<member name="interface/inspector/show_low_level_opentype_features" type="bool" setter="" getter="">
 			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
+		</member>
+		<member name="interface/inspector/vector2_display_style" type="int" setter="" getter="">
+			Controls how [Vector2] and [Vector2i] properties are displayed.
+			- [b]Vertical:[/b] Properties are shown on two lines.
+			- [b]Horizontal:[/b] Properties are shown on one line below the label.
+			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
+		</member>
+		<member name="interface/inspector/vector_types_display_style" type="int" setter="" getter="">
+			Controls how [Vector3], [Vector3i], [Vector4], [Vector4i], [Rect2], [Rect2i], [Plane], and [Quaternion] properties are displayed.
+			- [b]Vertical:[/b] Properties are shown on their own lines.
+			- [b]Horizontal:[/b] Properties are shown on one line below the label.
+			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
 		</member>
 		<member name="interface/multi_window/enable" type="bool" setter="" getter="">
 			If [code]true[/code], multiple window support in editor is enabled. The following panels can become dedicated windows (i.e. made floating): Docks, Script editor, and Shader editor.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -915,11 +915,17 @@
 		<member name="interface/inspector/float_drag_speed" type="float" setter="" getter="">
 			Base speed for increasing/decreasing float values by dragging them in the inspector.
 		</member>
-		<member name="interface/inspector/horizontal_vector2_editing" type="bool" setter="" getter="">
-			If [code]true[/code], [Vector2] and [Vector2i] properties are shown on a single line in the inspector instead of two lines. This is overall more compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
+		<member name="interface/inspector/vector2_display_style" type="int" setter="" getter="">
+			Controls how [Vector2] and [Vector2i] properties are displayed.
+			- [b]Vertical:[/b] Properties are shown on two lines.
+			- [b]Horizontal:[/b] Properties are shown on one line below the label.
+			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
 		</member>
-		<member name="interface/inspector/horizontal_vector_types_editing" type="bool" setter="" getter="">
-			If [code]true[/code], [Vector3], [Vector3i], [Vector4], [Vector4i], [Rect2], [Rect2i], [Plane], and [Quaternion] properties are shown on a single line in the inspector instead of multiple lines. This is overall more compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
+		<member name="interface/inspector/vector_types_display_style" type="int" setter="" getter="">
+			Controls how [Vector3], [Vector3i], [Vector4], [Vector4i], [Rect2], [Rect2i], [Plane], and [Quaternion] properties are displayed.
+			- [b]Vertical:[/b] Properties are shown on their own lines.
+			- [b]Horizontal:[/b] Properties are shown on one line below the label.
+			- [b]Compact:[/b] Properties are shown on one line next to the label. This option is the most compact, but it can be harder to view and edit large values without expanding the inspector horizontally.
 		</member>
 		<member name="interface/inspector/max_array_dictionary_items_per_page" type="int" setter="" getter="">
 			The number of [Array] or [Dictionary] items to display on each "page" in the inspector. Higher values allow viewing more values per page, but take more time to load. This increased load time is noticeable when selecting nodes that have array or dictionary properties in the editor.

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -206,7 +206,6 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 	} else if (horizontal) {
 		bc = memnew(HBoxContainer);
 		hb->add_child(bc);
-		set_bottom_editor(hb);
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -171,7 +171,7 @@ void EditorPropertyVectorN::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, bool p_horizontal) {
+EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, VectorDisplayStyle displayStyle) {
 	vector_type = p_type;
 	switch (vector_type) {
 		case Variant::VECTOR2:
@@ -193,14 +193,17 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 			ERR_PRINT("Not a Vector type.");
 			break;
 	}
-	bool horizontal = p_force_wide || p_horizontal;
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	BoxContainer *bc;
 
-	if (horizontal) {
+	if (displayStyle == HORIZONTAL || p_force_wide) {
+		bc = memnew(HBoxContainer);
+		hb->add_child(bc);
+		set_bottom_editor(hb);
+	} else if (displayStyle == COMPACT) {
 		bc = memnew(HBoxContainer);
 		hb->add_child(bc);
 	} else {
@@ -217,7 +220,7 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 		bc->add_child(spin[i]);
 		spin[i]->set_flat(true);
 		spin[i]->set_label(String(COMPONENT_LABELS[i]));
-		if (horizontal) {
+		if (displayStyle == HORIZONTAL || displayStyle == COMPACT) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
 		spin[i]->connect(SceneStringName(value_changed), callable_mp(this, &EditorPropertyVectorN::_value_changed).bind(String(COMPONENT_LABELS[i])));
@@ -238,25 +241,25 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 	hb->add_child(linked);
 
 	add_child(hb);
-	if (!horizontal) {
+	if (displayStyle == VERTICAL) {
 		set_label_reference(spin_sliders[0]); // Show text and buttons around this.
 	}
 }
 
 EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR2, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector2_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR2, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector2_display_style")) {}
 
 EditorPropertyVector2i::EditorPropertyVector2i(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR2I, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector2_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR2I, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector2_display_style")) {}
 
 EditorPropertyVector3::EditorPropertyVector3(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR3, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector_types_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR3, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector_types_display_style")) {}
 
 EditorPropertyVector3i::EditorPropertyVector3i(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR3I, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector_types_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR3I, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector_types_display_style")) {}
 
 EditorPropertyVector4::EditorPropertyVector4(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR4, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector_types_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR4, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector_types_display_style")) {}
 
 EditorPropertyVector4i::EditorPropertyVector4i(bool p_force_wide) :
-		EditorPropertyVectorN(Variant::VECTOR4I, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector_types_editing")) {}
+		EditorPropertyVectorN(Variant::VECTOR4I, p_force_wide, (VectorDisplayStyle)(int)EDITOR_GET("interface/inspector/vector_types_display_style")) {}

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -200,10 +200,7 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 
 	BoxContainer *bc;
 
-	if (p_force_wide) {
-		bc = memnew(HBoxContainer);
-		hb->add_child(bc);
-	} else if (horizontal) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
 		hb->add_child(bc);
 	} else {

--- a/editor/editor_properties_vector.h
+++ b/editor/editor_properties_vector.h
@@ -61,9 +61,14 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum VectorDisplayStyle {
+		VERTICAL,
+		HORIZONTAL,
+		COMPACT
+	};
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step = 1.0, bool p_hide_slider = true, bool p_link = false, const String &p_suffix = String(), bool p_radians_as_degrees = false);
-	EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, bool p_horizontal);
+	EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, VectorDisplayStyle displayStyle);
 };
 
 class EditorPropertyVector2 : public EditorPropertyVectorN {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -515,8 +515,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/default_float_step", 0.001, "0.0000001,1,0.0000001", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/disable_folding", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/auto_unfold_foreign_scenes", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/horizontal_vector2_editing", false, "")
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/horizontal_vector_types_editing", true, "")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/vector2_display_style", 0, "Vertical,Horizontal,Compact")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/vector_types_display_style", 0, "Vertical,Horizontal,Compact")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/open_resources_in_current_inspector", true, "")
 
 	PackedStringArray open_in_new_inspector_defaults;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -516,7 +516,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/disable_folding", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/auto_unfold_foreign_scenes", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/vector2_display_style", 0, "Vertical,Horizontal,Compact")
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/vector_types_display_style", 0, "Vertical,Horizontal,Compact")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/vector_types_display_style", 1, "Vertical,Horizontal,Compact")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/open_resources_in_current_inspector", true, "")
 
 	PackedStringArray open_in_new_inspector_defaults;


### PR DESCRIPTION
Make the horizontal `Vector` display (controlled by `interface/inspector/horizontal_vector2_editing`) take up 1 line instead of 2.

Current (vertical) Vector display:
![image](https://github.com/user-attachments/assets/1f3a35d0-477b-42ff-8915-e68eeba42042)

Current (horizontal) Vector display:
![image](https://github.com/user-attachments/assets/92ae82f2-8b04-4207-ba12-aa6fcb26ed41)

New ("compact") Vector display:
![image](https://github.com/user-attachments/assets/a35c0d9c-705b-423e-b227-bb7f696dce56)

I can't really see much benefit to the current behavior; it seems like the intent is presumably to use more horizontal space in exchange for less vertical space...