### PR TITLE
Prevent editor spin slider from holding focus when not being edited

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -38,7 +38,7 @@
 #include "scene/theme/theme_db.h"
 
 bool EditorSpinSlider::is_text_field() const {
-	return true;
+	return value_input_popup && value_input_popup->is_visible();
 }
 
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95607 regression

Allow the main editor viewport to grab focus automatically when editor spin slider is not in text edit mode.

https://github.com/user-attachments/assets/c7db5d61-c29a-468d-a9c4-dcb283ab9b08

Reminder that all other inspector inputs except for text inputs allow the main viewport to regain focus on mouse hover.

