### PR TITLE
`Array` performance improvements to reduce copying/copy_on_write calls

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -287,9 +287,15 @@ void Array::push_back(const Variant &p_value) {
 void Array::append_array(const Array &p_array) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 
+	if (!is_typed() || _p->typed.can_reference(p_array._p->typed)) {
+		_p->array.append_array(p_array._p->array);
+		return;
+	}
+
 	Vector<Variant> validated_array = p_array._p->array;
+	Variant *write = validated_array.ptrw();
 	for (int i = 0; i < validated_array.size(); ++i) {
-		ERR_FAIL_COND(!_p->typed.validate(validated_array.write[i], "append_array"));
+		ERR_FAIL_COND(!_p->typed.validate(write[i], "append_array"));
 	}
 
 	_p->array.append_array(validated_array);
@@ -529,8 +535,9 @@ Array Array::recursive_duplicate(bool p_deep, int recursion_count) const {
 		recursion_count++;
 		int element_count = size();
 		new_arr.resize(element_count);
+		Variant *write = new_arr._p->array.ptrw();
 		for (int i = 0; i < element_count; i++) {
-			new_arr[i] = get(i).recursive_duplicate(true, recursion_count);
+			write[i] = get(i).recursive_duplicate(true, recursion_count);
 		}
 	} else {
 		new_arr._p->array = _p->array;
@@ -566,8 +573,9 @@ Array Array::slice(int p_begin, int p_end, int p_step, bool p_deep) const {
 	int result_size = (end - begin) / p_step + (((end - begin) % p_step != 0) ? 1 : 0);
 	result.resize(result_size);
 
+	Variant *write = result._p->array.ptrw();
 	for (int src_idx = begin, dest_idx = 0; dest_idx < result_size; ++dest_idx) {
-		result[dest_idx] = p_deep ? get(src_idx).duplicate(true) : get(src_idx);
+		write[dest_idx] = p_deep ? get(src_idx).duplicate(true) : get(src_idx);
 		src_idx += p_step;
 	}
 
@@ -581,6 +589,7 @@ Array Array::filter(const Callable &p_callable) const {
 	int accepted_count = 0;
 
 	const Variant *argptrs[1];
+	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
 		argptrs[0] = &get(i);
 
@@ -592,7 +601,7 @@ Array Array::filter(const Callable &p_callable) const {
 		}
 
 		if (result.operator bool()) {
-			new_arr[accepted_count] = get(i);
+			write[accepted_count] = get(i);
 			accepted_count++;
 		}
 	}
@@ -607,17 +616,15 @@ Array Array::map(const Callable &p_callable) const {
 	new_arr.resize(size());
 
 	const Variant *argptrs[1];
+	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
 		argptrs[0] = &get(i);
 
-		Variant result;
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
+		p_callable.callp(argptrs, 1, write[i], ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
 			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'map': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
 		}
-
-		new_arr[i] = result;
 	}
 
 	return new_arr;


### PR DESCRIPTION
- Avoid temporary copy of `p_array` in `Array::append_array` when types match
- Call `ptrw()` once before looping in methods that return new `Arrays`, to avoid `copy_on_write` call for each item (`recursive_duplicate`, `slice`, `filter`, `map`)

Compared with gdscript below.  Most methods changed are usually around 10-25% faster, will vary depending on types and sizes of arrays.

```gdscript
func _ready() -> void:
	time("test_append_array_untyped")
	time("test_append_array_int_float")
	time("test_duplicate_deep")
	time("test_slice_int")
	time("test_slice_str")
	time("test_filter")
	time("test_map")
	time("test_map_lambda")

func test_append_array_untyped():
	var a := []
	var r := range(100)
	for i in 100000:
		a.append_array(r)

func test_append_array_int_float():
	var a : Array[float] = []
	var r := range(100)
	for i in 100000:
		a.append_array(r)

func test_duplicate_deep():
	var a := range(100).map(func(i): return range(i))
	for i in 10000:
		a.duplicate(true)
	
func test_slice_int():
	var a := range(100)
	for i in 1000000:
		a.slice(0, 20)
		
func test_slice_str():
	var a := range(100).map(str)
	for i in 1000000:
		a.slice(0, 20)

func test_filter():
	var a := range(1000)
	for i in 1000:
		a.filter(func(n): return n % 3 == 0)

func test_map():
	var a := range(1000)
	for i in 10000:
		a.map(sqrt)

func test_map_lambda():
	var a := range(1000)
	for i in 10000:
		a.map(func(n): return n * n)

func time(test_name : String):
	var start := Time.get_ticks_msec()
	call(test_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [test_name, end - start])
```

old
```
test_append_array_untyped: 251ms
test_append_array_int_float: 307ms
test_duplicate_deep: 1002ms
test_slice_int: 572ms
test_slice_str: 1150ms
test_filter: 150ms
test_map: 421ms
test_map_lambda: 1092ms
```

new
```
test_append_array_untyped: 186ms
test_append_array_int_float: 300ms
test_duplicate_deep: 793ms
test_slice_int: 455ms
test_slice_str: 1096ms
test_filter: 137ms
test_map: 333ms
test_map_lambda: 979ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
