### PR TITLE
Remove unneeded quotes from autocomplete % nodes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3482,10 +3482,10 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						opt = opt.substr(1);
 					}
 
-					// The path needs quotes if at least one of its components (excluding `/` separations)
+					// The path needs quotes if at least one of its components (excluding `%` prefix and `/` separations)
 					// is not a valid identifier.
 					bool path_needs_quote = false;
-					for (const String &part : opt.split("/")) {
+					for (const String &part : opt.trim_prefix("%").split("/")) {
 						if (!part.is_valid_ascii_identifier()) {
 							path_needs_quote = true;
 							break;

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_unique.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_unique.cfg
@@ -1,0 +1,9 @@
+[input]
+scene="res://completion/get_node/get_node.tscn"
+[output]
+include=[
+    {"display": "%UniqueA"},
+]
+exclude=[
+    {"display": "\"%UniqueA\""},
+]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_unique.gd
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_unique.gd
@@ -1,0 +1,5 @@
+extends Node
+
+func a():
+    $➡
+    pass


### PR DESCRIPTION
Removes unnecessary quotes for suggestions like $"%MyNode".