### PR TITLE
MRP for memory leak in test runner when using [Editor] test tag

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -37,6 +37,8 @@
 #include "editor/editor_settings.h"
 #endif // TOOLS_ENABLED
 
+#include "tests/test_mrp.h"
+
 #include "tests/core/config/test_project_settings.h"
 #include "tests/core/input/test_input_event.h"
 #include "tests/core/input/test_input_event_key.h"

--- a/tests/test_mrp.h
+++ b/tests/test_mrp.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  test_mrp.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_MRP_H
+#define TEST_MRP_H
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/editor_settings.h"
+#include "tests/test_macros.h"
+
+namespace MRPTests {
+
+TEST_CASE("[Editor] Test MRP") {
+	EditorSettings::get_singleton()->set_setting("interface/editor/editor_language", "es");
+	String language = EditorSettings::get_singleton()->get_setting("interface/editor/editor_language");
+	CHECK(language == "es");
+}
+
+} // namespace MRPTests
+
+#endif // TOOLS_ENABLED
+
+#endif // TEST_MRP_H


### PR DESCRIPTION
This is an MRP for https://github.com/godotengine/godot/issues/96671. This is not a fix, and should not be merged. The CI check `Linux / Editor with clang sanitizers` should fail with a memory leak.

Relevant log:
```
...
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:2327)

=================================================================
==2822==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 464 byte(s) in 1 object(s) allocated from:
    #0 0xc17b99d in malloc (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0xc17b99d)
    #1 0x2d442fce in Memory::alloc_static(unsigned long, bool) /home/runner/work/godot/godot/core/os/memory.cpp:108:14
    #2 0x2d442e24 in operator new(unsigned long, char const*) /home/runner/work/godot/godot/core/os/memory.cpp:41:9
    #3 0x189fa763 in EditorPaths::create() /home/runner/work/godot/godot/editor/editor_paths.cpp:102:2
    #4 0xe94a4e8 in GodotTestCaseListener::test_case_start(doctest::TestCaseData const&) /home/runner/work/godot/godot/tests/test_main.cpp:319:5
    #5 0xe981dc5 in doctest::Context::run() /home/runner/work/godot/godot/./thirdparty/doctest/doctest.h:6982:13
    #6 0xddab2e4 in test_main(int, char**) /home/runner/work/godot/godot/tests/test_main.cpp:245:22
    #7 0xc5eca79 in Main::test_entrypoint(int, char**, bool&) /home/runner/work/godot/godot/main/main.cpp:870:17
    #8 0xc1ae1cc in main /home/runner/work/godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:68:2
    #9 0x7fd89b2c6082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)

Indirect leak of 160 byte(s) in 1 object(s) allocated from:
    #0 0xc17b99d in malloc (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0xc17b99d)
    #1 0x2d442fce in Memory::alloc_static(unsigned long, bool) /home/runner/work/godot/godot/core/os/memory.cpp:108:14
    #2 0xe7b99bb in Error CowData<char32_t>::resize<false>(long) /home/runner/work/godot/godot/./core/templates/cowdata.h:342:35
    #3 0xe387397 in String::resize(int) /home/runner/work/godot/godot/./core/string/ustring.h:219:45
    #4 0x3019f1af in String::copy_from(char const*) /home/runner/work/godot/godot/core/string/ustring.cpp:303:2
    #5 0x301c9da8 in String::String(char const*) /home/runner/work/godot/godot/core/string/ustring.cpp:2493:2
    #6 0x189fbc3c in EditorPaths::EditorPaths() /home/runner/work/godot/godot/editor/editor_paths.h:51:35
    #7 0x189fa7ab in EditorPaths::create() /home/runner/work/godot/godot/editor/editor_paths.cpp:102:2
    #8 0xe94a4e8 in GodotTestCaseListener::test_case_start(doctest::TestCaseData const&) /home/runner/work/godot/godot/tests/test_main.cpp:319:5
    #9 0xe981dc5 in doctest::Context::run() /home/runner/work/godot/godot/./thirdparty/doctest/doctest.h:6982:13
    #10 0xddab2e4 in test_main(int, char**) /home/runner/work/godot/godot/tests/test_main.cpp:245:22
    #11 0xc5eca79 in Main::test_entrypoint(int, char**, bool&) /home/runner/work/godot/godot/main/main.cpp:870:17
    #12 0xc1ae1cc in main /home/runner/work/godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:68:2
    #13 0x7fd89b2c6082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
...    
```