### PR TITLE
Fix AudioStreamPlayer3D still processing when out of range

### DIFF
--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -105,6 +105,7 @@ private:
 	float linear_attenuation = 0;
 
 	float max_distance = 0.0;
+	bool was_further_than_max_distance_last_frame = false;
 
 	Ref<VelocityTracker3D> velocity_tracker;
 


### PR DESCRIPTION
Fixes #96670

Although said in [documentation](https://docs.godotengine.org/en/stable/classes/class_audiostreamplayer3d.html#class-audiostreamplayer3d-property-max-distance), AudioStreamPlayer3D doesn't do the claimed optimization: avoiding audio mixing when further than `max_distance` from the AudioListener3D. So I did a seemingly simple change to the if statement for an early exit of its processing loop:
```cpp
if (total_max > max_distance) {
	continue; //can't hear this sound in this listener
}
```
Into this,
```cpp
if (dist > total_max || total_max > max_distance) {
	HashMap<StringName, Vector<AudioFrame>> bus_volumes;
	for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
		// So the player gets muted and stops mixing when out of range.
		AudioServer::get_singleton()->set_playback_bus_volumes_linear(playback, bus_volumes);
	}
	continue; //can't hear this sound in this listener
}
```
Without `set_playback_bus_volumes_linear()`, the sound keeps playing if you exit the `max_distance` radius, and the audio server doesn't get the speed boost.
**Note**: the playhead position will continue to be updated even if this is called.

This oversight looks like it is also the case in 3.x, so it should probably be updated too.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
