### PR TITLE
Code Editor: Add button to toggle between search and search+replace

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -70,6 +70,7 @@ class FindReplaceBar : public HBoxContainer {
 		SEARCH_PREV,
 	};
 
+	Button *toggle_replace_button = nullptr;
 	LineEdit *search_text = nullptr;
 	Label *matches_label = nullptr;
 	Button *find_prev = nullptr;
@@ -106,12 +107,14 @@ class FindReplaceBar : public HBoxContainer {
 
 	void _show_search(bool p_with_replace, bool p_show_only);
 	void _hide_bar(bool p_force_focus = false);
+	void _update_toggle_replace_button(bool p_replace_visible);
 
 	void _editor_text_changed();
 	void _search_options_changed(bool p_pressed);
 	void _search_text_changed(const String &p_text);
 	void _search_text_submitted(const String &p_text);
 	void _replace_text_submitted(const String &p_text);
+	void _toggle_replace_pressed();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10675
## Screenshots
<img width="793" alt="Capture d’écran 2024-09-07 à 15 20 16" src="https://github.com/user-attachments/assets/af83aa5e-6d38-4dad-a914-74eb4db1531c">
<img width="795" alt="Capture d’écran 2024-09-07 à 15 21 33" src="https://github.com/user-attachments/assets/70d81f03-da7a-4958-8a22-b99efb42f391">


It has a dynamic tooltip ("Show Replace" / "Hide Replace"), which also gives the shortcut to Replace (or Search if Replace is visible).
<img width="386" alt="Capture d’écran 2024-09-07 à 15 21 59" src="https://github.com/user-attachments/assets/fe880a60-dcb0-44ea-a18b-a3e623eddfc0">

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

## Behavior
Tested on the script editor and the shader editor.