### PR TITLE
LSP: Don't use smart resolve for completion

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -229,19 +229,6 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 			arr[i] = item.to_json();
 			i++;
 		}
-	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
-		arr = native_member_completions.duplicate();
-
-		for (KeyValue<String, ExtendGDScriptParser *> &E : GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts) {
-			ExtendGDScriptParser *scr = E.value;
-			const Array &items = scr->get_member_completions();
-
-			const int start_size = arr.size();
-			arr.resize(start_size + items.size());
-			for (int i = start_size; i < arr.size(); i++) {
-				arr[i] = items[i - start_size];
-			}
-		}
 	}
 	return arr;
 }


### PR DESCRIPTION
Fixes #69912
Fixes #64666 (the specifc case does not get completion right now but that is a different issue, with this pr no empty insertText should happen)
Fixes #64658
Fixes #47930

This feature might yield better results for lookup or hover, but when the GDScriptLanguage gives an empty list of completion options this is what the user should get.