### PR TITLE
Fix `is_inside_tree` error when inspecting an Environment resource

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -636,7 +636,7 @@ void EditorSpinSlider::_grabber_mouse_exited() {
 
 void EditorSpinSlider::set_read_only(bool p_enable) {
 	read_only = p_enable;
-	if (read_only && value_input) {
+	if (read_only && value_input && value_input->is_inside_tree()) {
 		value_input->release_focus();
 	}
 


### PR DESCRIPTION
Fix #96644
