### PR TITLE
Disable some android editor settings by default on XR devices

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -527,14 +527,17 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Touchscreen
 	bool has_touchscreen_ui = DisplayServer::get_singleton()->is_touchscreen_available();
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/increase_scrollbar_touch_area", has_touchscreen_ui, "")
-	set_restart_if_changed("interface/touchscreen/increase_scrollbar_touch_area", true);
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_long_press_as_right_click", has_touchscreen_ui, "")
-	set_restart_if_changed("interface/touchscreen/enable_long_press_as_right_click", true);
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_pan_and_scale_gestures", has_touchscreen_ui, "")
 	set_restart_if_changed("interface/touchscreen/enable_pan_and_scale_gestures", true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/touchscreen/scale_gizmo_handles", has_touchscreen_ui ? 3 : 1, "1,5,1")
 	set_restart_if_changed("interface/touchscreen/scale_gizmo_handles", true);
+
+	// Disable some touchscreen settings by default for the XR Editor.
+	bool is_native_touchscreen = has_touchscreen_ui && !OS::get_singleton()->has_feature("xr_editor");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_long_press_as_right_click", is_native_touchscreen, "")
+	set_restart_if_changed("interface/touchscreen/enable_long_press_as_right_click", true);
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/increase_scrollbar_touch_area", is_native_touchscreen, "")
+	set_restart_if_changed("interface/touchscreen/increase_scrollbar_touch_area", true);
 
 	// Scene tabs
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/scene_tabs/display_close_button", 1, "Never,If Tab Active,Always"); // TabBar::CloseButtonDisplayPolicy

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -511,4 +511,12 @@ abstract class BaseGodotEditor : GodotActivity() {
 		val godot = godot ?: return Error.ERR_UNCONFIGURED
 		return verifyApk(godot.fileAccessHandler, apkPath)
 	}
+
+	override fun supportsFeature(featureTag: String): Boolean {
+		if (featureTag == "xr_editor") {
+			return isNativeXRDevice();
+		}
+
+        return false
+    }
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -992,6 +992,10 @@ class Godot(private val context: Context) {
 	 */
 	@Keep
 	private fun hasFeature(feature: String): Boolean {
+		if (primaryHost?.supportsFeature(feature) ?: false) {
+			return true;
+		}
+
 		for (plugin in pluginRegistry.allPlugins) {
 			if (plugin.supportsFeature(feature)) {
 				return true

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -501,4 +501,12 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 		}
 		return Error.ERR_UNAVAILABLE;
 	}
+
+	@Override
+	public boolean supportsFeature(String featureTag) {
+		if (parentHost != null) {
+			return parentHost.supportsFeature(featureTag);
+		}
+		return false;
+	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
@@ -136,4 +136,13 @@ public interface GodotHost {
 	default Error verifyApk(@NonNull String apkPath) {
 		return Error.ERR_UNAVAILABLE;
 	}
+
+	/**
+	 * Returns whether the given feature tag is supported.
+	 *
+	 * @see <a href="https://docs.godotengine.org/en/stable/tutorials/export/feature_tags.html">Feature tags</a>
+	 */
+	default boolean supportsFeature(String featureTag) {
+		return false;
+	}
 }


### PR DESCRIPTION
Some touchscreen related editor settings enabled by default in the android editor aren't needed on XR devices, namely `enable_long_press_as_right_click` and `increase_scrollbar_touch_area`. This PR has those settings default to false on XR devices for better UX.