### PR TITLE
Partially fix directory bug on Android

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -162,7 +162,7 @@ void ProjectDialog::_validate_path() {
 		}
 	}
 
-	if (target_path.is_empty() || target_path.is_relative_path()) {
+	if (target_path.is_relative_path()) {
 		_set_message(TTR("The path specified is invalid."), MESSAGE_ERROR, target_path_input_type);
 		return;
 	}
@@ -352,7 +352,7 @@ void ProjectDialog::_install_path_changed() {
 
 void ProjectDialog::_browse_project_path() {
 	String path = project_path->get_text();
-	if (path.is_empty()) {
+	if (path.is_relative_path()) {
 		path = EDITOR_GET("filesystem/directories/default_project_path");
 	}
 	if (mode == MODE_IMPORT && install_path->is_visible_in_tree()) {
@@ -382,12 +382,16 @@ void ProjectDialog::_browse_project_path() {
 void ProjectDialog::_browse_install_path() {
 	ERR_FAIL_COND_MSG(mode != MODE_IMPORT, "Install path is only used for MODE_IMPORT.");
 
+	String path = install_path->get_text();
+	if (path.is_relative_path() || !DirAccess::dir_exists_absolute(path)) {
+		path = EDITOR_GET("filesystem/directories/default_project_path");
+	}
 	if (create_dir->is_pressed()) {
 		// Select parent directory of install path.
-		fdialog_install->set_current_dir(install_path->get_text().get_base_dir());
+		fdialog_install->set_current_dir(path.get_base_dir());
 	} else {
 		// Select install path.
-		fdialog_install->set_current_dir(install_path->get_text());
+		fdialog_install->set_current_dir(path);
 	}
 
 	fdialog_install->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Similar fix like #95086 for `_browse_install_path()` also updated `_browse_project_path` to  account for local path.
### But I couldn't fix for a directory that doesn't exist.
For example something like `/storage/emulated/0/Documents/folderThatDoesntExist` will still cause ~~the same~~ similar issue as mentioned in #94570