### PR TITLE
Use `thread_local` for `bones_backup`

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -270,8 +270,6 @@ void Skeleton3D::_update_process_order() const {
 		}
 	}
 
-	bones_backup.resize(bones.size());
-
 	concatenated_bone_names = StringName();
 
 	_update_bones_nested_set();
@@ -339,11 +337,14 @@ void Skeleton3D::_notification(int p_what) {
 			thread_local LocalVector<bool> bone_global_pose_dirty_backup;
 
 			// Process modifiers.
+
+			thread_local LocalVector<BonePoseBackup> bones_backup;
 			_find_modifiers();
 			if (!modifiers.is_empty()) {
+				bones_backup.resize(bones.size());
 				// Store unmodified bone poses.
 				for (uint32_t i = 0; i < bones.size(); i++) {
-					bones_backup[i].save(bones[i]);
+					bones_backup[i].save(bonesptr[i]);
 				}
 				// Store dirty flags for global bone poses.
 				bone_global_pose_dirty_backup = bone_global_pose_dirty;

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -183,7 +183,6 @@ private:
 	void _process_modifiers();
 	void _process_changed();
 	void _make_modifiers_dirty();
-	mutable LocalVector<BonePoseBackup> bones_backup;
 
 	// Global bone pose calculation.
 	mutable LocalVector<int> nested_set_offset_to_bone_index; // Map from Bone::nested_set_offset to bone index.


### PR DESCRIPTION
Reduces memory usage and improves the performance of MRP #93568 by about 5%.