### PR TITLE
Prevent trimming trailing whitespaces on lines with carets

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1126,9 +1126,15 @@ void CodeTextEditor::remove_find_replace_bar() {
 
 void CodeTextEditor::trim_trailing_whitespace() {
 	bool trimmed_whitespace = false;
+	Vector<int> lines_with_carets;
+
+	for (int j = 0; j < text_editor->get_caret_count(); j++) {
+		lines_with_carets.push_back(text_editor->get_caret_line(j));
+	}
+
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
 		String line = text_editor->get_line(i);
-		if (line.ends_with(" ") || line.ends_with("\t")) {
+		if ((line.ends_with(" ") || line.ends_with("\t")) && !lines_with_carets.has(i)) {
 			if (!trimmed_whitespace) {
 				text_editor->begin_complex_operation();
 				trimmed_whitespace = true;


### PR DESCRIPTION
This PR prevents trimming trailing whitespaces on lines with carets. It works with a single or multiple carets.

Many thanks for the feedback / recommendations!

Edit: I found a proposal related to it: https://github.com/godotengine/godot-proposals/issues/3229

https://github.com/user-attachments/assets/8859b355-8036-4b0b-8446-ed1aebb8020d