### PR TITLE
Core: Tidyup Array/Dictionary

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -36,9 +36,6 @@
 #include "core/templates/list.h"
 #include "core/templates/vector.h"
 
-template <typename T>
-class TypedArray;
-
 class Engine {
 public:
 	struct Singleton {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -33,9 +33,6 @@
 
 #include "core/object/class_db.h"
 
-template <typename T>
-class TypedArray;
-
 class ProjectSettings : public Object {
 	GDCLASS(ProjectSettings, Object);
 	_THREAD_SAFE_CLASS_

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -42,8 +42,6 @@
 #include "core/templates/safe_refcount.h"
 
 class MainLoop;
-template <typename T>
-class TypedArray;
 
 namespace core_bind {
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -36,9 +36,6 @@
 #include "core/object/object.h"
 #include "core/templates/hash_map.h"
 
-template <typename T>
-class TypedArray;
-
 class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -34,9 +34,6 @@
 #include "core/io/ip_address.h"
 #include "core/os/os.h"
 
-template <typename T>
-class TypedArray;
-
 struct _IP_ResolverPrivate;
 
 class IP : public Object {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -44,9 +44,6 @@
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant.h"
 
-template <typename T>
-class TypedArray;
-
 enum PropertyHint {
 	PROPERTY_HINT_NONE, ///< no hint provided.
 	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians_as_degrees][,degrees][,exp][,suffix:<keyword>] range.

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -40,8 +40,6 @@
 #include "core/variant/typed_array.h"
 
 class ScriptLanguage;
-template <typename T>
-class TypedArray;
 
 typedef void (*ScriptEditRequestFunction)(const String &p_path);
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -41,8 +41,7 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-class ArrayPrivate {
-public:
+struct Array::ArrayPrivate {
 	SafeRefCount refcount;
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -36,12 +36,15 @@
 #include <climits>
 
 class Variant;
-class ArrayPrivate;
 class Object;
 class StringName;
 class Callable;
 
+template <typename T>
+class TypedArray;
+
 class Array {
+	struct ArrayPrivate;
 	mutable ArrayPrivate *_p;
 	void _unref() const;
 

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -40,7 +40,7 @@
 #include "core/variant/type_info.h"
 #include "core/variant/variant_internal.h"
 
-struct DictionaryPrivate {
+struct Dictionary::DictionaryPrivate {
 	SafeRefCount refcount;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator> variant_map;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -31,15 +31,14 @@
 #ifndef DICTIONARY_H
 #define DICTIONARY_H
 
-#include "core/string/ustring.h"
 #include "core/templates/list.h"
 #include "core/variant/array.h"
 
-class Variant;
-
-struct DictionaryPrivate;
+template <typename K, typename V>
+class TypedDictionary;
 
 class Dictionary {
+	struct DictionaryPrivate;
 	mutable DictionaryPrivate *_p;
 
 	void _ref(const Dictionary &p_from) const;

--- a/main/performance.h
+++ b/main/performance.h
@@ -37,9 +37,6 @@
 #define PERF_WARN_OFFLINE_FUNCTION
 #define PERF_WARN_PROCESS_SYNC
 
-template <typename T>
-class TypedArray;
-
 class Performance : public Object {
 	GDCLASS(Performance, Object);
 

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -38,9 +38,6 @@
 
 #include <enet/enet.h>
 
-template <typename T>
-class TypedArray;
-
 class ENetConnection : public RefCounted {
 	GDCLASS(ENetConnection, RefCounted);
 

--- a/modules/gdscript/gdscript_utility_functions.h
+++ b/modules/gdscript/gdscript_utility_functions.h
@@ -34,9 +34,6 @@
 #include "core/string/string_name.h"
 #include "core/variant/variant.h"
 
-template <typename T>
-class TypedArray;
-
 class GDScriptUtilityFunctions {
 public:
 	typedef void (*FunctionPtr)(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error);

--- a/modules/gltf/structures/gltf_skin.h
+++ b/modules/gltf/structures/gltf_skin.h
@@ -36,9 +36,6 @@
 #include "core/io/resource.h"
 #include "scene/resources/3d/skin.h"
 
-template <typename T>
-class TypedArray;
-
 class GLTFSkin : public Resource {
 	GDCLASS(GLTFSkin, Resource);
 	friend class GLTFDocument;

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -35,9 +35,6 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 
-template <typename T>
-class TypedArray;
-
 class BitMap : public Resource {
 	GDCLASS(BitMap, Resource);
 	OBJ_SAVE_TYPE(BitMap);

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -43,8 +43,6 @@
 **/
 
 class CameraFeed;
-template <typename T>
-class TypedArray;
 
 class CameraServer : public Object {
 	GDCLASS(CameraServer, Object);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -36,8 +36,6 @@
 #include "core/object/ref_counted.h"
 
 class PhysicsDirectSpaceState2D;
-template <typename T>
-class TypedArray;
 
 class PhysicsDirectBodyState2D : public Object {
 	GDCLASS(PhysicsDirectBodyState2D, Object);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -39,8 +39,6 @@
 #include "core/variant/native_ptr.h"
 
 class PhysicsDirectSpaceState3D;
-template <typename T>
-class TypedArray;
 
 class PhysicsDirectBodyState3D : public Object {
 	GDCLASS(PhysicsDirectBodyState3D, Object);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -57,9 +57,6 @@
 #define ERR_NOT_ON_RENDER_THREAD_V(m_ret)
 #endif
 
-template <typename T>
-class TypedArray;
-
 class RenderingServer : public Object {
 	GDCLASS(RenderingServer, Object);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -37,9 +37,6 @@
 #include "core/variant/native_ptr.h"
 #include "core/variant/variant.h"
 
-template <typename T>
-class TypedArray;
-
 struct Glyph;
 struct CaretInfo;
 


### PR DESCRIPTION
A small assortment of adjustments pertaining to arrays and dictionaries. Originally conceived as part of a larger draft PR, but their scope was more incidental/distracting, so they're better suited to this more isolated and harmless scope.
- `TypedArray`/`TypedDictionary` now forward declared in base headers; removed extraneous forward declarations in other files
- `ArrayPrivate`/`DictionaryPrivate` now nested in base classes to avoid polluting global namespace
- `ArrayPrivate` converted from class to struct