### PR TITLE
LSP: Use snippet insert mode to add closing braces

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -191,6 +191,12 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 			item.data = request_data;
 			item.insertText = option.insert_text;
 
+			// LSP clients won't autoclose brackets. We can make it work using the snippet insert format.
+			if (item.insertText.ends_with("(")) {
+				item.insertText += "$1)";
+				item.insertTextFormat = lsp::InsertTextFormat::Snippet;
+			}
+
 			switch (option.kind) {
 				case ScriptLanguage::CODE_COMPLETION_KIND_ENUM:
 					item.kind = lsp::CompletionItemKind::Enum;

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1035,6 +1035,9 @@ struct CompletionItem {
 		dict["kind"] = kind;
 		dict["data"] = data;
 		dict["insertText"] = insertText;
+		if (insertTextFormat) {
+			dict["insertTextFormat"] = insertTextFormat;
+		}
 		if (resolved) {
 			dict["detail"] = detail;
 			dict["documentation"] = documentation.to_json();
@@ -1085,6 +1088,9 @@ struct CompletionItem {
 		}
 		if (p_dict.has("insertText")) {
 			insertText = p_dict["insertText"];
+		}
+		if (p_dict.has("insertTextFormat")) {
+			insertTextFormat = p_dict["insertTextFormat"];
 		}
 		if (p_dict.has("data")) {
 			data = p_dict["data"];


### PR DESCRIPTION
Fixes #84549

LSP clients don't seem to auto-close braces from insert texts (seems like unspecified territory). We can instead close them in the server and use the snippet insert mode to place the caret between the braces:


[Screencast from 2024-09-08 22-00-12.webm](https://github.com/user-attachments/assets/b2182824-b5c4-4bbb-bfe9-0e8143639cac)

> [!NOTE]  
> In theory this should be locked behind certain client capabilities, but from what I see we don't track them.