### PR TITLE
Make use of NavigationObstacle3D's transform

### DIFF
--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -115,9 +115,14 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditor::forward_3d_gui_input(Cam
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
 	}
 
-	Transform3D gt = obstacle_node->get_global_transform();
+	// Use special transformation rules for NavigationObstacle3D: Only take global y-rotation into account and limit scaling to positive values.
+	Transform3D gt;
+	gt.origin = obstacle_node->get_global_position();
+	gt.scale_basis(obstacle_node->get_global_basis().get_scale().abs().maxf(0.001));
+	gt.rotate_basis(Vector3(0.0, 1.0, 0.0), obstacle_node->get_global_rotation().y);
 	Transform3D gi = gt.affine_inverse();
 	Plane p(Vector3(0.0, 1.0, 0.0), gt.origin);
+	point_lines_meshinstance->set_transform(gt.translated(Vector3(0.0, 0.0, 0.00001)));
 
 	Ref<InputEventMouseButton> mb = p_event;
 
@@ -374,9 +379,12 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 	point_handle_mesh->clear_surfaces();
 	point_lines_mesh->clear_surfaces();
 	point_lines_meshinstance->set_material_override(line_material);
-	point_lines_mesh->surface_begin(Mesh::PRIMITIVE_LINES);
 
-	Rect2 rect;
+	if (poly.is_empty()) {
+		return;
+	}
+
+	point_lines_mesh->surface_begin(Mesh::PRIMITIVE_LINES);
 
 	for (int i = 0; i < poly.size(); i++) {
 		Vector2 p, p2;
@@ -392,12 +400,6 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 			p2 = poly[(i + 1) % poly.size()];
 		}
 
-		if (i == 0) {
-			rect.position = p;
-		} else {
-			rect.expand_to(p);
-		}
-
 		Vector3 point = Vector3(p.x, 0.0, p.y);
 		Vector3 next_point = Vector3(p2.x, 0.0, p2.y);
 
@@ -411,57 +413,7 @@ void NavigationObstacle3DEditor::_polygon_draw() {
 		//vpc->draw_texture(handle,point-handle->get_size()*0.5);
 	}
 
-	rect = rect.grow(1);
-
-	AABB r;
-	r.position.x = rect.position.x;
-	r.position.y = 0.0;
-	r.position.z = rect.position.y;
-	r.size.x = rect.size.x;
-	r.size.y = 0;
-	r.size.z = rect.size.y;
-
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position);
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0.3, 0, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position);
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0.0, 0.3, 0));
-
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(r.size.x, 0, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(r.size.x, 0, 0) - Vector3(0.3, 0, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(r.size.x, 0, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(r.size.x, 0, 0) + Vector3(0, 0.3, 0));
-
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0, r.size.y, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0, r.size.y, 0) - Vector3(0, 0.3, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0, r.size.y, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + Vector3(0, r.size.y, 0) + Vector3(0.3, 0, 0));
-
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + r.size);
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + r.size - Vector3(0.3, 0, 0));
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + r.size);
-	point_lines_mesh->surface_set_color(Color(0.8, 0.8, 0.8, 0.2));
-	point_lines_mesh->surface_add_vertex(r.position + r.size - Vector3(0.0, 0.3, 0));
-
 	point_lines_mesh->surface_end();
-
-	if (poly.size() == 0) {
-		return;
-	}
 
 	Array point_handle_mesh_array;
 	point_handle_mesh_array.resize(Mesh::ARRAY_MAX);
@@ -541,6 +493,7 @@ NavigationObstacle3DEditor::NavigationObstacle3DEditor() {
 	point_lines_mesh.instantiate();
 	point_lines_meshinstance->set_mesh(point_lines_mesh);
 	point_lines_meshinstance->set_transform(Transform3D(Basis(), Vector3(0, 0, 0.00001)));
+	point_lines_meshinstance->set_as_top_level(true);
 
 	line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
 	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -176,13 +176,19 @@ void NavigationObstacle3D::_notification(int p_what) {
 				}
 #ifdef DEBUG_ENABLED
 				if (fake_agent_radius_debug_instance.is_valid() && radius > 0.0) {
-					Transform3D debug_transform;
-					debug_transform.origin = get_global_position();
+					// Prevent non-positive scaling.
+					const Vector3 safe_scale = get_global_basis().get_scale().abs().maxf(0.001);
+					// Agent radius is a scalar value and does not support non-uniform scaling, choose the largest axis.
+					const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
+					const Vector3 uniform_max_scale = Vector3(scaling_max_value, scaling_max_value, scaling_max_value);
+					const Transform3D debug_transform = Transform3D(Basis().scaled(uniform_max_scale), get_global_position());
 					RS::get_singleton()->instance_set_transform(fake_agent_radius_debug_instance, debug_transform);
 				}
 				if (static_obstacle_debug_instance.is_valid() && get_vertices().size() > 0) {
-					Transform3D debug_transform;
-					debug_transform.origin = get_global_position();
+					// Prevent non-positive scaling.
+					const Vector3 safe_scale = get_global_basis().get_scale().abs().maxf(0.001);
+					// Obstacles are projected to the xz-plane, so only rotation around the y-axis can be taken into account.
+					const Transform3D debug_transform = Transform3D(Basis().scaled(safe_scale).rotated(Vector3(0.0, 1.0, 0.0), get_global_rotation().y), get_global_position());
 					RS::get_singleton()->instance_set_transform(static_obstacle_debug_instance, debug_transform);
 				}
 #endif // DEBUG_ENABLED
@@ -352,6 +358,25 @@ void NavigationObstacle3D::set_carve_navigation_mesh(bool p_enabled) {
 
 bool NavigationObstacle3D::get_carve_navigation_mesh() const {
 	return carve_navigation_mesh;
+}
+
+PackedStringArray NavigationObstacle3D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node3D::get_configuration_warnings();
+
+	if (get_global_rotation().x != 0.0 || get_global_rotation().z != 0.0) {
+		warnings.push_back(RTR("NavigationObstacle3D only takes global rotation around the y-axis into account. Rotations around the x-axis or z-axis might lead to unexpected results."));
+	}
+
+	const Vector3 global_scale = get_global_basis().get_scale();
+	if (global_scale.x < 0.001 || global_scale.y < 0.001 || global_scale.z < 0.001) {
+		warnings.push_back(RTR("NavigationObstacle3D does not support negative or zero scaling."));
+	}
+
+	if (radius > 0.0 && !get_global_basis().is_conformal()) {
+		warnings.push_back(RTR("The agent radius can only be scaled uniformly. The largest scale value along the three axes will be used."));
+	}
+
+	return warnings;
 }
 
 void NavigationObstacle3D::_update_map(RID p_map) {

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -117,6 +117,8 @@ public:
 	void set_carve_navigation_mesh(bool p_enabled);
 	bool get_carve_navigation_mesh() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 private:
 	void _update_map(RID p_map);
 	void _update_position(const Vector3 p_position);


### PR DESCRIPTION
Fixes #85722.

(Edit: This PR is basically done, if you'd like to see it merged please test it in your own projects and let me know if it works as expected!)

Currently, the vertices of a NavigationObstacle3D are not affected by the node's transform. This severely limits their usefulness in my opinion since level designers can not place instances of pre-made obstacles in a level.

For example, let's say a project has a "fallen tree" scene which contains a NavigationObstacle3D node that is set up with vertices that match the outline of the tree. A level designer would now like to place instances of this scene in the world to affect the navigation mesh. But rotating or scaling the tree does not apply to the vertices of the obstacle, leading to incorrect navigation. They would instead have to place individual obstacle nodes and set up the vertices again for each of them, making iteration of the level layout very labor intensive.

In #82593 it was mentioned that letting the transform affect the vertices would break compatibility, but given the problem described above I would argue it is worth it. From a user perspective the current behavior is very unexpected and seems like a bug.

One remaining problem I have with my PR is that I don't know how to deal with the obstacle's radius since the node's scaling can be non-uniform. It's not as big of an issue as the vertices since you only have to adjust a single parameter so for now I did not touch it.

Edit: There now is also a 2D version at #99030.