### PR TITLE
[RTL] Fix indent in tables and tables in indent.

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -153,6 +153,7 @@ private:
 		Color dc_ol_color;
 
 		Vector2 offset;
+		float indent = 0.0;
 		int char_offset = 0;
 		int char_count = 0;
 
@@ -205,6 +206,7 @@ private:
 		Size2 min_size_over = Size2(-1, -1);
 		Size2 max_size_over = Size2(-1, -1);
 		Rect2 padding;
+		int indent_level = 0;
 
 		ItemFrame() {
 			type = ITEM_FRAME;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96720

```bbcode
A[table=1][cell bg=red]a[/cell][cell]3[/cell][cell bg=blue][indent]3[/indent][/cell][cell bg=green][indent][indent]4[/indent][/indent][/cell][/table]:
[indent]A[table=1][cell bg=red]a[/cell][cell]3[/cell][cell bg=blue][indent]3[/indent][/cell][cell bg=green][indent][indent]4[/indent][/indent][/cell][/table]:[/indent]
[indent][indent]A[table=1][cell bg=red]a[/cell][cell]3[/cell][cell bg=blue][indent]3[/indent][/cell][cell bg=green][indent][indent]4[/indent][/indent][/cell][/table]:[/indent][/indent]
[indent]A[/indent]
[indent]B[img=20]res://icon.svg[/img]:[/indent]
B[img=20]res://icon.svg[/img]:
```
| Before | After |
|---|---|
| <img width="314" alt="Screenshot 2024-09-09 at 00 07 02" src="https://github.com/user-attachments/assets/3989faea-71c9-47e1-8a7a-68b9517b8ad1"> | <img width="314" alt="Screenshot 2024-09-09 at 00 03 25" src="https://github.com/user-attachments/assets/30660ca4-aa66-4a4e-9853-6a1949c7f9d3"> |

