### PR TITLE
Use collision detection ray to reposition an object already in the scene

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -245,6 +245,7 @@ private:
 	bool auto_orthogonal;
 	bool lock_rotation;
 	bool transform_gizmo_visible = true;
+	bool collision_reposition = false;
 	real_t gizmo_scale;
 
 	bool freelook_active;
@@ -338,7 +339,6 @@ private:
 		TRANSFORM_ROTATE,
 		TRANSFORM_TRANSLATE,
 		TRANSFORM_SCALE
-
 	};
 	enum TransformPlane {
 		TRANSFORM_VIEW,
@@ -471,7 +471,7 @@ private:
 	void _list_select(Ref<InputEventMouseButton> b);
 	Point2 _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
-	Vector3 _get_instance_position(const Point2 &p_pos) const;
+	Vector3 _get_instance_position(const Point2 &p_pos, Node3D *p_node) const;
 	static AABB _calculate_spatial_bounds(const Node3D *p_parent, bool p_omit_top_level = false, const Transform3D *p_bounds_orientation = nullptr);
 
 	Node *_sanitize_preview_node(Node *p_node) const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes: https://github.com/godotengine/godot-proposals/issues/755

Related: https://github.com/godotengine/godot/pull/88511

Currently only works with one object at a time. Multiple objects would probably be a future PR if desired. 

Currently does not have a key binding by default: 

Works similar to "instant transformations" in that pressing the key initiates the function, and left click commits it.  

![image](https://github.com/user-attachments/assets/69e23427-7e66-415c-ad1f-37839d4247c8)

https://github.com/user-attachments/assets/d22159dd-d932-4f22-807c-49f7eea721cd




