### PR TITLE
[Android editor] Limit when OpenXR runtime permissions are requested

### DIFF
--- a/platform/android/java/editor/src/meta/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/meta/java/org/godotengine/editor/GodotEditor.kt
@@ -45,15 +45,13 @@ open class GodotEditor : BaseGodotEditor() {
 
 		internal val XR_RUN_GAME_INFO = EditorWindowInfo(GodotXRGame::class.java, 1667, ":GodotXRGame")
 
-		internal const val USE_ANCHOR_API_PERMISSION = "com.oculus.permission.USE_ANCHOR_API"
 		internal const val USE_SCENE_PERMISSION = "com.oculus.permission.USE_SCENE"
 	}
 
 	override fun getExcludedPermissions(): MutableSet<String> {
 		val excludedPermissions = super.getExcludedPermissions()
-		// The USE_ANCHOR_API and USE_SCENE permissions are requested when the "xr/openxr/enabled"
-		// project setting is enabled.
-		excludedPermissions.add(USE_ANCHOR_API_PERMISSION)
+		// The USE_SCENE permission is requested when the "xr/openxr/enabled" project setting
+		// is enabled.
 		excludedPermissions.add(USE_SCENE_PERMISSION)
 		return excludedPermissions
 	}

--- a/platform/android/java/editor/src/meta/java/org/godotengine/editor/GodotXRGame.kt
+++ b/platform/android/java/editor/src/meta/java/org/godotengine/editor/GodotXRGame.kt
@@ -31,7 +31,6 @@
 package org.godotengine.editor
 
 import org.godotengine.godot.GodotLib
-import org.godotengine.godot.utils.PermissionsUtil
 import org.godotengine.godot.xr.XRMode
 
 /**
@@ -62,8 +61,16 @@ open class GodotXRGame: GodotGame() {
 
 		val openxrEnabled = GodotLib.getGlobal("xr/openxr/enabled").toBoolean()
 		if (openxrEnabled) {
-			permissionsToEnable.add(USE_ANCHOR_API_PERMISSION)
-			permissionsToEnable.add(USE_SCENE_PERMISSION)
+			// We only request permissions when the `automatically_request_runtime_permissions`
+			// project setting is enabled.
+			// If the project setting is not defined, we fall-back to the default behavior which is
+			// to automatically request permissions.
+			val automaticallyRequestPermissionsSetting = GodotLib.getGlobal("xr/openxr/extensions/automatically_request_runtime_permissions")
+			val automaticPermissionsRequestEnabled = automaticallyRequestPermissionsSetting.isNullOrEmpty() ||
+				automaticallyRequestPermissionsSetting.toBoolean()
+			if (automaticPermissionsRequestEnabled) {
+				permissionsToEnable.add(USE_SCENE_PERMISSION)
+			}
 		}
 
 		return permissionsToEnable

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -472,19 +472,22 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusout(JNIEnv *env,
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getGlobal(JNIEnv *env, jclass clazz, jstring path) {
 	String js = jstring_to_string(path, env);
 
-	return env->NewStringUTF(GLOBAL_GET(js).operator String().utf8().get_data());
+	Variant setting_with_override = GLOBAL_GET(js);
+	String setting_value = (setting_with_override.get_type() == Variant::NIL) ? "" : setting_with_override;
+	return env->NewStringUTF(setting_value.utf8().get_data());
 }
 
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getEditorSetting(JNIEnv *env, jclass clazz, jstring p_setting_key) {
-	String editor_setting = "";
+	String editor_setting_value = "";
 #ifdef TOOLS_ENABLED
 	String godot_setting_key = jstring_to_string(p_setting_key, env);
-	editor_setting = EDITOR_GET(godot_setting_key).operator String();
+	Variant editor_setting = EDITOR_GET(godot_setting_key);
+	editor_setting_value = (editor_setting.get_type() == Variant::NIL) ? "" : editor_setting;
 #else
 	WARN_PRINT("Access to the Editor Settings in only available on Editor builds");
 #endif
 
-	return env->NewStringUTF(editor_setting.utf8().get_data());
+	return env->NewStringUTF(editor_setting_value.utf8().get_data());
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params) {


### PR DESCRIPTION
This PR updates the Android editor to request OpenXR permissions for a running XR game only when the `xr/openxr/extensions/automatically_request_runtime_permissions` project setting is enabled.

Note that the project setting is introduced in https://github.com/GodotVR/godot_openxr_vendors/pull/203, but this PR can be merged independently of it as the logic is set up to handle when the project setting is missing / not defined.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
