### PR TITLE
Fix description of invalid values for `Theme.default_font_size`

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -551,7 +551,7 @@
 		</member>
 		<member name="default_font_size" type="int" setter="set_default_font_size" getter="get_default_font_size" default="-1">
 			The default font size of this theme resource. Used as the default value when trying to fetch a font size value that doesn't exist in this theme or is in invalid state. If the default font size is also missing or invalid, the engine fallback value is used (see [member ThemeDB.fallback_font_size]).
-			Values below [code]0[/code] are invalid and can be used to unset the property. Use [method has_default_font_size] to check if this value is valid.
+			Values below [code]1[/code] are invalid and can be used to unset the property. Use [method has_default_font_size] to check if this value is valid.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Current documentation does not match documentation for method has_default_font_size mentioned in last paragraph, which has this information "The value must be greater than 0 to be considered valid".
