### PR TITLE
Implement autostart for all profilers

### DIFF
--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -138,6 +138,7 @@ private:
 
 	void _activate_pressed();
 	void _clear_pressed();
+	void _autostart_toggled(bool p_toggled_on);
 
 	void _internal_profiles_pressed();
 
@@ -168,7 +169,7 @@ protected:
 public:
 	void add_frame_metric(const Metric &p_metric, bool p_final = false);
 	void set_enabled(bool p_enable, bool p_clear = true);
-	void set_pressed(bool p_pressed);
+	void set_profiling(bool p_pressed);
 	bool is_profiling();
 	bool is_seeking() { return seeking; }
 	void disable_seeking();

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -148,8 +148,8 @@ void EditorVisualProfiler::_item_selected() {
 }
 
 void EditorVisualProfiler::_update_plot() {
-	const int w = graph->get_size().width;
-	const int h = graph->get_size().height;
+	const int w = graph->get_size().width + 1; // `+1` is to prevent from crashing when visual profiler is auto started.
+	const int h = graph->get_size().height + 1;
 
 	bool reset_texture = false;
 
@@ -427,6 +427,10 @@ void EditorVisualProfiler::_clear_pressed() {
 	_update_plot();
 }
 
+void EditorVisualProfiler::_autostart_toggled(bool p_toggled_on) {
+	EditorSettings::get_singleton()->set_project_metadata("debug_options", "autostart_visual_profiler", p_toggled_on);
+}
+
 void EditorVisualProfiler::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
@@ -668,9 +672,10 @@ void EditorVisualProfiler::set_enabled(bool p_enable) {
 	activate->set_disabled(!p_enable);
 }
 
-void EditorVisualProfiler::set_pressed(bool p_pressed) {
-	activate->set_pressed(p_pressed);
+void EditorVisualProfiler::set_profiling(bool p_profiling) {
+	activate->set_pressed(p_profiling);
 	_update_button_text();
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 bool EditorVisualProfiler::is_profiling() {
@@ -746,6 +751,12 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_clear_pressed));
 	hb->add_child(clear_button);
+
+	CheckBox *autostart_checkbox = memnew(CheckBox);
+	autostart_checkbox->set_text(TTR("Autostart"));
+	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false));
+	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorVisualProfiler::_autostart_toggled));
+	hb->add_child(autostart_checkbox);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
 

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -109,6 +109,7 @@ private:
 
 	void _activate_pressed();
 	void _clear_pressed();
+	void _autostart_toggled(bool p_toggled_on);
 
 	String _get_time_as_text(float p_time);
 
@@ -137,7 +138,7 @@ protected:
 public:
 	void add_frame_metric(const Metric &p_metric);
 	void set_enabled(bool p_enable);
-	void set_pressed(bool p_pressed);
+	void set_profiling(bool p_profiling);
 	bool is_profiling();
 	bool is_seeking() { return seeking; }
 	void disable_seeking();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1012,6 +1012,14 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
 	emit_signal(SNAME("started"));
+
+	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
+		profiler->set_profiling(true);
+	}
+
+	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false)) {
+		visual_profiler->set_profiling(true);
+	}
 }
 
 void ScriptEditorDebugger::_update_buttons_state() {
@@ -1076,10 +1084,10 @@ void ScriptEditorDebugger::stop() {
 	profiler_signature.clear();
 
 	profiler->set_enabled(false, false);
-	profiler->set_pressed(false);
+	profiler->set_profiling(false);
 
 	visual_profiler->set_enabled(false);
-	visual_profiler->set_pressed(false);
+	visual_profiler->set_profiling(false);
 
 	inspector->edit(nullptr);
 	_update_buttons_state();

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -92,7 +92,9 @@ private:
 
 	void _activate_pressed();
 	void _clear_pressed();
+	void _autostart_toggled(bool p_toggled_on);
 	void _refresh();
+	void _update_button_text();
 	void _replication_button_clicked(TreeItem *p_item, int p_column, int p_idx, MouseButton p_button);
 
 protected:
@@ -111,6 +113,10 @@ public:
 	void add_sync_frame_data(const SyncInfo &p_frame);
 	void set_bandwidth(int p_incoming, int p_outgoing);
 	bool is_profiling();
+
+	void set_profiling(bool p_pressed);
+	void started();
+	void stopped();
 
 	EditorNetworkProfiler();
 };

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -106,6 +106,8 @@ void MultiplayerEditorDebugger::setup_session(int p_session_id) {
 	profiler->connect("enable_profiling", callable_mp(this, &MultiplayerEditorDebugger::_profiler_activate).bind(p_session_id));
 	profiler->connect("open_request", callable_mp(this, &MultiplayerEditorDebugger::_open_request));
 	profiler->set_name(TTR("Network Profiler"));
+	session->connect("started", callable_mp(profiler, &EditorNetworkProfiler::started));
+	session->connect("stopped", callable_mp(profiler, &EditorNetworkProfiler::stopped));
 	session->add_session_tab(profiler);
 	profilers[p_session_id] = profiler;
 }


### PR DESCRIPTION
Salvages #70766. Co-authored by @stmSi
Closes https://github.com/godotengine/godot-proposals/issues/6017

Additional changes on top of the original PR:
- Changed `Button` to `CheckBox` for improved readability and consistency (also removed the "Autoplay" icon)
- Minor refactoring: Rename `set_pressed(...)` to `set_profiling(...)` since the original name is very odd (not perfect, but something like `start_profiling()` and `stop_profiling()` would require further refactoring which is needed, but not part of this PR)

<img width="252" alt="{A1188438-0365-4AD7-9EBD-5758AB82293D}" src="https://github.com/user-attachments/assets/2a337441-ceee-4b1f-849c-c8327e2938da">
