### PR TITLE
Expose 3D editor snap settings to EditorPlugin.

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -587,6 +587,24 @@
 				Returns the [PopupMenu] under [b]Scene &gt; Export As...[/b].
 			</description>
 		</method>
+		<method name="get_node_3d_rotate_snap">
+			<return type="float" />
+			<description>
+				Returns the amount of degrees the 3D editor's rotational snapping is set to.
+			</description>
+		</method>
+		<method name="get_node_3d_scale_snap">
+			<return type="float" />
+			<description>
+				Returns the amount of units the 3D editor's scale snapping is set to.
+			</description>
+		</method>
+		<method name="get_node_3d_translate_snap">
+			<return type="float" />
+			<description>
+				Returns the amount of units the 3D editor's translation snapping is set to.
+			</description>
+		</method>
 		<method name="get_plugin_version" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -611,6 +629,12 @@
 			<return type="void" />
 			<description>
 				Minimizes the bottom panel.
+			</description>
+		</method>
+		<method name="is_node_3d_snap_enabled">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the 3D editor currently has snapping mode enabled, and [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="make_bottom_panel_item_visible">

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -501,6 +501,22 @@ void EditorPlugin::remove_context_menu_plugin(ContextMenuSlot p_slot, const Ref<
 	EditorNode::get_editor_data().remove_context_menu_plugin(EditorData::ContextMenuSlot(p_slot), p_plugin);
 }
 
+bool EditorPlugin::is_node_3d_snap_enabled() {
+	return Node3DEditor::get_singleton()->is_snap_enabled();
+}
+
+real_t EditorPlugin::get_node_3d_translate_snap() {
+	return Node3DEditor::get_singleton()->get_translate_snap();
+}
+
+real_t EditorPlugin::get_node_3d_rotate_snap() {
+	return Node3DEditor::get_singleton()->get_rotate_snap();
+}
+
+real_t EditorPlugin::get_node_3d_scale_snap() {
+	return Node3DEditor::get_singleton()->get_scale_snap();
+}
+
 int find(const PackedStringArray &a, const String &v) {
 	const String *r = a.ptr();
 	for (int j = 0; j < a.size(); ++j) {
@@ -642,6 +658,11 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 	ClassDB::bind_method(D_METHOD("add_context_menu_plugin", "slot", "plugin"), &EditorPlugin::add_context_menu_plugin);
 	ClassDB::bind_method(D_METHOD("remove_context_menu_plugin", "slot", "plugin"), &EditorPlugin::remove_context_menu_plugin);
+
+	ClassDB::bind_method(D_METHOD("is_node_3d_snap_enabled"), &EditorPlugin::is_node_3d_snap_enabled);
+	ClassDB::bind_method(D_METHOD("get_node_3d_translate_snap"), &EditorPlugin::get_node_3d_translate_snap);
+	ClassDB::bind_method(D_METHOD("get_node_3d_rotate_snap"), &EditorPlugin::get_node_3d_rotate_snap);
+	ClassDB::bind_method(D_METHOD("get_node_3d_scale_snap"), &EditorPlugin::get_node_3d_scale_snap);
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -260,6 +260,11 @@ public:
 	void add_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin);
 	void remove_context_menu_plugin(ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin);
 
+	bool is_node_3d_snap_enabled();
+	real_t get_node_3d_translate_snap();
+	real_t get_node_3d_rotate_snap();
+	real_t get_node_3d_scale_snap();
+
 	void enable_plugin();
 	void disable_plugin();
 


### PR DESCRIPTION
Implements [#10704](https://github.com/godotengine/godot-proposals/issues/10704)

Adds methods to the EditorPlugin to get the snap settings from the 3D editor. I don't know whether or not this is the most preferred place to expose this API, but I'm pretty confident this needs to be exposed somewhere at least.