### PR TITLE
WAV: Fix one frame overflow at the end

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -429,10 +429,10 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		loop_end = p_options["edit/loop_end"];
 		// Wrap around to max frames, so `-1` can be used to select the end, etc.
 		if (loop_begin < 0) {
-			loop_begin = CLAMP(loop_begin + frames + 1, 0, frames);
+			loop_begin = CLAMP(loop_begin + frames, 0, frames - 1);
 		}
 		if (loop_end < 0) {
-			loop_end = CLAMP(loop_end + frames + 1, 0, frames);
+			loop_end = CLAMP(loop_end + frames, 0, frames - 1);
 		}
 	}
 

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -297,7 +297,7 @@ int AudioStreamPlaybackWAV::mix(AudioFrame *p_buffer, float p_rate_scale, int p_
 	int64_t loop_end_fp = ((int64_t)base->loop_end << MIX_FRAC_BITS);
 	int64_t length_fp = ((int64_t)len << MIX_FRAC_BITS);
 	int64_t begin_limit = (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) ? loop_begin_fp : 0;
-	int64_t end_limit = (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) ? loop_end_fp : length_fp;
+	int64_t end_limit = (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) ? loop_end_fp : length_fp - MIX_FRAC_LEN;
 	bool is_stereo = base->stereo;
 
 	int32_t todo = p_frames;


### PR DESCRIPTION
**This fixes AudioStreamWAV decoding one additional frame after the last**
___

### Problem

Let's assume a PCM data with exactly 3000 frames as an example. This means the range should be 0-2999.

When you `mix` in AudioStreamPlaybackWAV, it considers you have to decode `p_frames` frames into `p_buffer`. There is a calculation right before the decoder is called (`limit`, `aux` and `target`) that is supposed to prevent the decoder (`do_resample()`) to get an index beyond the PCM data range and repeat the `while` loop in respect to the audio loop mode.

Assuming the audio has no loop points and goes from the very first frame to the last, here's the problem: when playing forward, the last frame (`end_limit` in the mix function) is assumed to be the length of the audio data (3000), not the last index (2999). Because of that, `target` ends up being calculated considering that additional frame, out of the range, and ends up making `do_resample()` get one more frame than it should.

The reason no errors happen when playing PCM audio data is because of the `DATA_PAD` (which reads a `0` value frame at that position, leading to a barely audible pop), and doesn't crash with QOA data because the resampling workaround doesn't allow the offset to be above the last frame index.

### Solution

Do what should be done: subtract 1 from the length whenever you point to the last frame.

Even if the `while` loop forces the audio to stop when the `offset` is beyond the last frame, it doesn't prevent that one extra end frame request from being passed to the decoder function.

If merged, any audio imported with any enabled Loop Mode and Loop End set to -1 will need to be reimported to remove the extra frame from the count. Not sure if this count as compatibility breaking, but existing projects should not be affected.

### Considerations

I found this by experimenting with #83483 (makes AudioStreamWAV use PlaybackResampled, removing the need for workarounds and data pad) with a QOA audio with 4160 frames (the number becomes the decode buffer size when instantiating playback) and it would crash for not being able to get index 4160.