### PR TITLE
[Editor] Use toast (notification) instead of dialog when saving with no open scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2768,9 +2768,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				const int saved = _save_external_resources(true);
 				if (saved > 0) {
-					show_accept(
-							vformat(TTR("The current scene has no root node, but %d modified external resource(s) and/or plugin data were saved anyway."), saved),
-							TTR("OK"));
+					EditorToaster::get_singleton()->popup_str(vformat(TTR("The current scene has no root node, but %d modified external resource(s) and/or plugin data were saved anyway."), saved), EditorToaster::SEVERITY_INFO);
 				} else if (p_option == FILE_SAVE_AS_SCENE) {
 					// Don't show this dialog when pressing Ctrl + S to avoid interfering with script saving.
 					show_accept(


### PR DESCRIPTION
When saving (`ctrl+s`) with no open scene, such as when editing shaders, an dialog popup appears. This does not need to be a popup that requires a click to close. Instead, we can use the editor toaster. The information is still displayed, but no longer interrupts the flow of work.

Before:
![Godot_v4 3-stable_win64_XwZ7TVfRVi](https://github.com/user-attachments/assets/dfa41cc8-0036-452f-aee2-6ed347d8e3f2)

After:
![godot windows editor dev x86_64_1fENl6cLB5](https://github.com/user-attachments/assets/b0918b35-00ee-42cc-92a8-4fe866b9544e)

I might argue that it's not even correct for *any* message to appear when saving in this case. Files saving when you save is expected behavior. Saving scripts or scenes (even multiple at once) does not send any message to the console, the undo log, dialog popup, or toast. If a scene is open, then saving the same resources saved in this case is done silently. All signs point to this message being unnecessary.

But that change may require some discussion, since it's trying to match the current save behavior in other contexts.