### PR TITLE
[Windows] Only use long executable path when necessary, fix broken apksigner detection.

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2276,6 +2276,11 @@ String EditorExportPlatformAndroid::get_apksigner_path(int p_target_sdk, bool p_
 	bool failed = false;
 	String version_to_use;
 
+	String java_sdk_path = EDITOR_GET("export/android/java_sdk_path");
+	if (!java_sdk_path.is_empty()) {
+		OS::get_singleton()->set_environment("JAVA_HOME", java_sdk_path);
+	}
+
 	List<String> args;
 	args.push_back("--version");
 	String output;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -101,7 +101,7 @@ static String fix_path(const String &p_path) {
 	}
 	path = path.simplify_path();
 	path = path.replace("/", "\\");
-	if (!path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
+	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
 		path = R"(\\?\)" + path;
 	}
 	return path;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96762

Seems like Windows does not support `\\?\` prefixed long paths when running batch files (works fine with executables), so use for OS execute methods only if path is longer than 260 characters.

Fixes https://github.com/godotengine/godot/issues/95070

`apksigner` can't run without valid `JAVA_HOME` set, and it was updated only after it is called.