### PR TITLE
GLTF: Don't give up loading a texture if importing it fails

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2581,7 +2581,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		EditorFileSystemDirectory *fs = nullptr;
 		int cpos = -1;
 		bool found = _find_file(file, &fs, cpos);
-		ERR_FAIL_COND_V_MSG(!found, ERR_UNCONFIGURED, "Can't find file '" + file + "'.");
+		ERR_FAIL_COND_V_MSG(!found, ERR_UNCONFIGURED, vformat("Can't find file '%s' during group reimport.", file));
 
 		//update modified times, to avoid reimport
 		fs->files[cpos]->modified_time = FileAccess::get_modified_time(file);
@@ -2631,7 +2631,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 	int cpos = -1;
 	if (p_update_file_system) {
 		bool found = _find_file(p_file, &fs, cpos);
-		ERR_FAIL_COND_V_MSG(!found, ERR_FILE_NOT_FOUND, "Can't find file '" + p_file + "'.");
+		ERR_FAIL_COND_V_MSG(!found, ERR_FILE_NOT_FOUND, vformat("Can't find file '%s' during file reimport.", p_file));
 	}
 
 	//try to obtain existing params

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -319,6 +319,8 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		state->set_import_as_skeleton_bones(true);
 	}
 	state->set_scene_name(blend_basename);
+	state->set_extract_path(p_path.get_base_dir());
+	state->set_extract_prefix(blend_basename);
 	err = gltf->append_from_file(sink.get_basename() + ".gltf", state, p_flags, base_dir);
 	if (err != OK) {
 		if (r_err) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3501,8 +3501,10 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 	}
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() && handling == GLTFState::GLTFHandleBinary::HANDLE_BINARY_EXTRACT_TEXTURES) {
-		if (p_state->base_path.is_empty()) {
-			WARN_PRINT("glTF: Couldn't extract image because the base path is empty. It will be loaded directly instead, uncompressed.");
+		if (p_state->extract_path.is_empty()) {
+			WARN_PRINT("glTF: Couldn't extract image because the base and extract paths are empty. It will be loaded directly instead, uncompressed.");
+		} else if (p_state->extract_path.begins_with("res://.godot/imported")) {
+			WARN_PRINT(vformat("glTF: Extract path is in the imported directory. Image index '%d' will be loaded directly, uncompressed.", p_index));
 		} else {
 			if (p_image->get_name().is_empty()) {
 				WARN_PRINT(vformat("glTF: Image index '%d' did not have a name. It will be automatically given a name based on its index.", p_index));
@@ -3511,7 +3513,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 			bool must_import = true;
 			Vector<uint8_t> img_data = p_image->get_data();
 			Dictionary generator_parameters;
-			String file_path = p_state->get_base_path().path_join(p_state->filename.get_basename() + "_" + p_image->get_name());
+			String file_path = p_state->get_extract_path().path_join(p_state->get_extract_prefix() + "_" + p_image->get_name());
 			file_path += p_file_extension.is_empty() ? ".png" : p_file_extension;
 			if (FileAccess::exists(file_path + ".import")) {
 				Ref<ConfigFile> config;
@@ -7349,7 +7351,7 @@ PackedByteArray GLTFDocument::generate_buffer(Ref<GLTFState> p_state) {
 Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_path) {
 	Ref<GLTFState> state = p_state;
 	ERR_FAIL_COND_V(state.is_null(), ERR_INVALID_PARAMETER);
-	state->base_path = p_path.get_base_dir();
+	state->set_base_path(p_path.get_base_dir());
 	state->filename = p_path.get_file();
 	Error err = _serialize(state);
 	if (err != OK) {
@@ -7462,7 +7464,7 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 	Ref<FileAccessMemory> file_access;
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
-	state->base_path = p_base_path.get_base_dir();
+	state->set_base_path(p_base_path.get_base_dir());
 	err = _parse(p_state, state->base_path, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
@@ -7479,7 +7481,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint
 	if (state == Ref<GLTFState>()) {
 		state.instantiate();
 	}
-	state->filename = p_path.get_file().get_basename();
+	state->set_filename(p_path.get_file().get_basename());
 	state->use_named_skin_binds = p_flags & GLTF_IMPORT_USE_NAMED_SKIN_BINDS;
 	state->discard_meshes_and_materials = p_flags & GLTF_IMPORT_DISCARD_MESHES_AND_MATERIALS;
 	state->force_generate_tangents = p_flags & GLTF_IMPORT_GENERATE_TANGENT_ARRAYS;
@@ -7493,7 +7495,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint
 	if (base_path.is_empty()) {
 		base_path = p_path.get_base_dir();
 	}
-	state->base_path = base_path;
+	state->set_base_path(base_path);
 	err = _parse(p_state, base_path, file);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -397,8 +397,27 @@ String GLTFState::get_base_path() {
 	return base_path;
 }
 
-void GLTFState::set_base_path(String p_base_path) {
+void GLTFState::set_base_path(const String &p_base_path) {
 	base_path = p_base_path;
+	if (extract_path.is_empty()) {
+		extract_path = p_base_path;
+	}
+}
+
+String GLTFState::get_extract_path() {
+	return extract_path;
+}
+
+void GLTFState::set_extract_path(const String &p_extract_path) {
+	extract_path = p_extract_path;
+}
+
+String GLTFState::get_extract_prefix() {
+	return extract_prefix;
+}
+
+void GLTFState::set_extract_prefix(const String &p_extract_prefix) {
+	extract_prefix = p_extract_prefix;
 }
 
 String GLTFState::get_filename() const {
@@ -407,6 +426,9 @@ String GLTFState::get_filename() const {
 
 void GLTFState::set_filename(const String &p_filename) {
 	filename = p_filename;
+	if (extract_prefix.is_empty()) {
+		extract_prefix = p_filename.get_basename();
+	}
 }
 
 Variant GLTFState::get_additional_data(const StringName &p_extension_name) {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -51,6 +51,8 @@ class GLTFState : public Resource {
 
 protected:
 	String base_path;
+	String extract_path;
+	String extract_prefix;
 	String filename;
 	Dictionary json;
 	int major_version = 0;
@@ -186,7 +188,13 @@ public:
 	void set_scene_name(String p_scene_name);
 
 	String get_base_path();
-	void set_base_path(String p_base_path);
+	void set_base_path(const String &p_base_path);
+
+	String get_extract_path();
+	void set_extract_path(const String &p_extract_path);
+
+	String get_extract_prefix();
+	void set_extract_prefix(const String &p_extract_prefix);
 
 	String get_filename() const;
 	void set_filename(const String &p_filename);


### PR DESCRIPTION
This fix is needed for #82455, but this PR does not completely solve that issue.

In the current master, if in the editor and the import settings are set to extract textures (default), the code in GLTFDocument will fail if it cannot extract and import a texture, resulting in that texture being missing from the model.

This PR is a fairly straightforward change: If we can't import, just load it uncompressed from the Image resource already loaded in memory, instead of giving up and inserting a blank texture.

More details: For each case where the image cannot be imported from `res://`, instead of setting a blank texture, use the loaded image. The return in this function now only happens after successful cases, so as a fallback, it will drop down to the bottom of the function, the uncompressed code. This is the same as if performing a runtime import. When writing this code I was curious if it would work if the project is exported, and actually yes, it does work.

As a bonus, I also added some text to two err_fail_conds in EditorFileSystem to make them distinct from each other.