### PR TITLE
[Resource Loader] Do not check property type for non registered properties.

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -845,27 +845,29 @@ Error ResourceLoaderBinary::load() {
 				}
 			}
 
-			if (value.get_type() == Variant::ARRAY) {
-				Array set_array = value;
-				bool is_get_valid = false;
-				Variant get_value = res->get(name, &is_get_valid);
-				if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
-					Array get_array = get_value;
-					if (!set_array.is_same_typed(get_array)) {
-						value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+			if (ClassDB::has_property(res->get_class_name(), name)) {
+				if (value.get_type() == Variant::ARRAY) {
+					Array set_array = value;
+					bool is_get_valid = false;
+					Variant get_value = res->get(name, &is_get_valid);
+					if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
+						Array get_array = get_value;
+						if (!set_array.is_same_typed(get_array)) {
+							value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+						}
 					}
 				}
-			}
 
-			if (value.get_type() == Variant::DICTIONARY) {
-				Dictionary set_dict = value;
-				bool is_get_valid = false;
-				Variant get_value = res->get(name, &is_get_valid);
-				if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
-					Dictionary get_dict = get_value;
-					if (!set_dict.is_same_typed(get_dict)) {
-						value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-								get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+				if (value.get_type() == Variant::DICTIONARY) {
+					Dictionary set_dict = value;
+					bool is_get_valid = false;
+					Variant get_value = res->get(name, &is_get_valid);
+					if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
+						Dictionary get_dict = get_value;
+						if (!set_dict.is_same_typed(get_dict)) {
+							value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
+									get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+						}
 					}
 				}
 			}

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2947,6 +2947,9 @@
 		<member name="xr/openxr/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], Godot will setup and initialize OpenXR on startup.
 		</member>
+		<member name="xr/openxr/enabled.editor" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], Godot will setup and initialize OpenXR on editor startup.
+		</member>
 		<member name="xr/openxr/environment_blend_mode" type="int" setter="" getter="" default="&quot;0&quot;">
 			Specify how OpenXR should blend in the environment. This is specific to certain AR and passthrough devices where camera images are blended in by the XR compositor.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2541,6 +2541,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	// XR project settings.
 	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled", false);
+	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled.editor", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "xr/openxr/default_action_map", PROPERTY_HINT_FILE, "*.tres"), "res://openxr_action_map.tres");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/form_factor", PROPERTY_HINT_ENUM, "Head Mounted,Handheld"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo"), "1"); // "Mono,Stereo,Quad,Observer"

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -612,27 +612,29 @@ Error ResourceLoaderText::load() {
 						}
 					}
 
-					if (value.get_type() == Variant::ARRAY) {
-						Array set_array = value;
-						bool is_get_valid = false;
-						Variant get_value = res->get(assign, &is_get_valid);
-						if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
-							Array get_array = get_value;
-							if (!set_array.is_same_typed(get_array)) {
-								value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+					if (ClassDB::has_property(res->get_class_name(), assign)) {
+						if (value.get_type() == Variant::ARRAY) {
+							Array set_array = value;
+							bool is_get_valid = false;
+							Variant get_value = res->get(assign, &is_get_valid);
+							if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
+								Array get_array = get_value;
+								if (!set_array.is_same_typed(get_array)) {
+									value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+								}
 							}
 						}
-					}
 
-					if (value.get_type() == Variant::DICTIONARY) {
-						Dictionary set_dict = value;
-						bool is_get_valid = false;
-						Variant get_value = res->get(assign, &is_get_valid);
-						if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
-							Dictionary get_dict = get_value;
-							if (!set_dict.is_same_typed(get_dict)) {
-								value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-										get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+						if (value.get_type() == Variant::DICTIONARY) {
+							Dictionary set_dict = value;
+							bool is_get_valid = false;
+							Variant get_value = res->get(assign, &is_get_valid);
+							if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
+								Dictionary get_dict = get_value;
+								if (!set_dict.is_same_typed(get_dict)) {
+									value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
+											get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+								}
 							}
 						}
 					}
@@ -752,27 +754,29 @@ Error ResourceLoaderText::load() {
 					}
 				}
 
-				if (value.get_type() == Variant::ARRAY) {
-					Array set_array = value;
-					bool is_get_valid = false;
-					Variant get_value = resource->get(assign, &is_get_valid);
-					if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
-						Array get_array = get_value;
-						if (!set_array.is_same_typed(get_array)) {
-							value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+				if (ClassDB::has_property(resource->get_class_name(), assign)) {
+					if (value.get_type() == Variant::ARRAY) {
+						Array set_array = value;
+						bool is_get_valid = false;
+						Variant get_value = resource->get(assign, &is_get_valid);
+						if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
+							Array get_array = get_value;
+							if (!set_array.is_same_typed(get_array)) {
+								value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+							}
 						}
 					}
-				}
 
-				if (value.get_type() == Variant::DICTIONARY) {
-					Dictionary set_dict = value;
-					bool is_get_valid = false;
-					Variant get_value = resource->get(assign, &is_get_valid);
-					if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
-						Dictionary get_dict = get_value;
-						if (!set_dict.is_same_typed(get_dict)) {
-							value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-									get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+					if (value.get_type() == Variant::DICTIONARY) {
+						Dictionary set_dict = value;
+						bool is_get_valid = false;
+						Variant get_value = resource->get(assign, &is_get_valid);
+						if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
+							Dictionary get_dict = get_value;
+							if (!set_dict.is_same_typed(get_dict)) {
+								value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
+										get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96769

Properties can be added dynamically and not necessarily exist in the new empty instance of the Resource. So skip type check for these (there's no way to know the type in advance, and if needed check can be implemented in `_set` method of the specific `Resource`).

Also adds missing definition for `xr/openxr/enabled.editor`.