### PR TITLE
SCons: Make `lto=auto` prefer ThinLTO over full LTO for LLVM targets

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -184,8 +184,8 @@ def configure(env: "SConsEnvironment"):
 
     # LTO
 
-    if env["lto"] == "auto":  # Full LTO for production.
-        env["lto"] = "full"
+    if env["lto"] == "auto":  # Enable LTO for production.
+        env["lto"] = "thin" if env["use_llvm"] else "full"
 
     if env["lto"] != "none":
         if env["lto"] == "thin":

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -117,8 +117,8 @@ def configure(env: "SConsEnvironment"):
 
     # LTO
 
-    if env["lto"] == "auto":  # Full LTO for production.
-        env["lto"] = "full"
+    if env["lto"] == "auto":  # Enable LTO for production.
+        env["lto"] = "thin"
 
     if env["lto"] != "none":
         if env["lto"] == "thin":

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -762,8 +762,8 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## LTO
 
-    if env["lto"] == "auto":  # Full LTO for production with MinGW.
-        env["lto"] = "full"
+    if env["lto"] == "auto":  # Enable LTO for production with MinGW.
+        env["lto"] = "thin" if env["use_llvm"] else "full"
 
     if env["lto"] != "none":
         if env["lto"] == "thin":


### PR DESCRIPTION
*Edit:* Changed the scope of this PR to only impact targets for which we already used LLVM's full LTO, and change those to ThinLTO, to speed up builds significantly.

---

This speeds up build time considerably for these platforms compared to
using `lto=full`, which is sadly single-threaded with LLVM, unlike GCC.

Changes to default behavior of `lto=auto` (i.e. `production=yes`):
- Linux: Prefer ThinLTO for LLVM
- Web: Prefer ThinLTO
- Windows: Prefer ThinLTO for llvm-mingw

The following LLVM targets don't use LTO by default currently, which
needs to be assessed further (gains from LLVM LTO on performance need
to be weighed against the potential size increase from heavy inlining):
- Android 
- iOS  
- macOS
- Windows clang-cl 

---

Needs heavy testing and comparison of builds with and without LTO (`thin`/`full`) for the affected platforms.

We should benchmark and documents once and for all the impact of LTO on build time, build size, and performance for each platform, so we can default to the optimal configuration out of the box.