### PR TITLE
Fix EditorSpinSlider blocking viewport from getting focus

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -37,10 +37,6 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/theme/theme_db.h"
 
-bool EditorSpinSlider::is_text_field() const {
-	return true;
-}
-
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 	if (!read_only && grabber->is_visible()) {
 		Key key = (OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos") || OS::get_singleton()->has_feature("web_ios")) ? Key::META : Key::CTRL;

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -101,8 +101,6 @@ protected:
 	void _focus_entered();
 
 public:
-	virtual bool is_text_field() const override;
-
 	String get_tooltip(const Point2 &p_pos) const override;
 
 	String get_text_value() const;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -160,11 +160,12 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (ED_IS_SHORTCUT("scene_tree/rename", p_event)) {
-		// Prevent renaming if a button is focused
-		// to avoid conflict with Enter shortcut on macOS
-		if (!focus_owner || !Object::cast_to<BaseButton>(focus_owner)) {
-			_tool_selected(TOOL_RENAME);
+		// Prevent renaming if a button or a range is focused
+		// to avoid conflict with Enter shortcut on macOS.
+		if (focus_owner && (Object::cast_to<BaseButton>(focus_owner) || Object::cast_to<Range>(focus_owner))) {
+			return;
 		}
+		_tool_selected(TOOL_RENAME);
 #ifdef MODULE_REGEX_ENABLED
 	} else if (ED_IS_SHORTCUT("scene_tree/batch_rename", p_event)) {
 		_tool_selected(TOOL_BATCH_RENAME);


### PR DESCRIPTION
Reverts a part of https://github.com/godotengine/godot/pull/93165 to fix https://github.com/godotengine/godot/issues/95607 without reintroducing https://github.com/godotengine/godot/issues/88102. Supersedes https://github.com/godotengine/godot/pull/96660.

Making spin slider a text field was a mistake on our part because it technically isn't one, it has one that appears when it's being edited, which in turn does all focus blocking just fine on its own. This PR instead checks for range in the scene tree dock specifically for the rename shortcut to solve the <kbd>Enter</kbd> conflict on macOS