### PR TITLE
Core: Fix `operator[]` for typed dictionaries

### DIFF
--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -59,6 +59,7 @@ public:
 	Variant get_valid(const Variant &p_key) const;
 	Variant get(const Variant &p_key, const Variant &p_default) const;
 	Variant get_or_add(const Variant &p_key, const Variant &p_default);
+	bool set(const Variant &p_key, const Variant &p_value);
 
 	int size() const;
 	bool is_empty() const;

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_key.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_key.gd
@@ -1,0 +1,7 @@
+func get_key() -> Variant:
+	return "key"
+
+func test():
+	var typed: Dictionary[int, int]
+	typed[get_key()] = 0
+	print('not ok')

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_key.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_key.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/typed_dictionary_assign_differently_typed_key.gd
+>> 6
+>> Invalid assignment of property or key 'key' with value of type 'int' on a base object of type 'Dictionary[int, int]'.

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_value.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_value.gd
@@ -1,0 +1,7 @@
+func get_value() -> Variant:
+	return "value"
+
+func test():
+	var typed: Dictionary[int, int]
+	typed[0] = get_value()
+	print("not ok")

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_value.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_differently_typed_value.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/typed_dictionary_assign_differently_typed_value.gd
+>> 6
+>> Invalid assignment of property or key '0' with value of type 'String' on a base object of type 'Dictionary[int, int]'.


### PR DESCRIPTION
- Fixes #96772

Caused by an erroneous regression when rebasing the typed dictionary PR. Reimplements type checking and passing `_p->typed_fallback` to erroneous keys when using `operator[]` on dictionaries.

This is technically a partial fix, because it seems the untyped value assignment via `operator[]` is something that can happen regardless. However, fixing that will probably be a much more involved change, as the passed value isn't linked to the typed dictionary in isolation.