### PR TITLE
Expose `ResourceImporter::get_format_version` via `EditorImportPlugin::_get_format_version()`

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -127,6 +127,12 @@
 				If this method is not overridden, it will return [code]true[/code] by default (i.e., safe for parallel importing).
 			</description>
 		</method>
+		<method name="_get_format_version" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Gets the format version of this importer. Increment this version when making incompatible changes to the format of the imported resources.
+			</description>
+		</method>
 		<method name="_get_import_options" qualifiers="virtual const">
 			<return type="Dictionary[]" />
 			<param index="0" name="path" type="String" />

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -112,6 +112,14 @@ int EditorImportPlugin::get_import_order() const {
 	ERR_FAIL_V_MSG(-1, "Unimplemented _get_import_order in add-on.");
 }
 
+int EditorImportPlugin::get_format_version() const {
+	int ret = 0;
+	if (GDVIRTUAL_CALL(_get_format_version, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
 void EditorImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, int p_preset) const {
 	Array needed;
 	needed.push_back("name");
@@ -220,6 +228,7 @@ void EditorImportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_resource_type)
 	GDVIRTUAL_BIND(_get_priority)
 	GDVIRTUAL_BIND(_get_import_order)
+	GDVIRTUAL_BIND(_get_format_version)
 	GDVIRTUAL_BIND(_get_option_visibility, "path", "option_name", "options")
 	GDVIRTUAL_BIND(_import, "source_file", "save_path", "options", "platform_variants", "gen_files");
 	GDVIRTUAL_BIND(_can_import_threaded);

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -50,6 +50,7 @@ protected:
 	GDVIRTUAL0RC(String, _get_resource_type)
 	GDVIRTUAL0RC(float, _get_priority)
 	GDVIRTUAL0RC(int, _get_import_order)
+	GDVIRTUAL0RC(int, _get_format_version)
 	GDVIRTUAL3RC(bool, _get_option_visibility, String, StringName, Dictionary)
 	GDVIRTUAL5RC(Error, _import, String, String, Dictionary, TypedArray<String>, TypedArray<String>)
 	GDVIRTUAL0RC(bool, _can_import_threaded)
@@ -67,6 +68,7 @@ public:
 	virtual String get_resource_type() const override;
 	virtual float get_priority() const override;
 	virtual int get_import_order() const override;
+	virtual int get_format_version() const override;
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/10658

I threw this together since it was easy enough to do, however, I haven't tested it since this isn't my area.

@HiddenJesse Could you give this a try with your project? If you're using it with GDExtension, you'll need to use `godot --dump-extension-api` to get a new `extension_api.json` for your bindings (ex godot-cpp) to know about the new virtual method.