### PR TITLE
Wayland: Clear button mask on pointer leave

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1395,6 +1395,8 @@ void WaylandThread::_wl_pointer_on_leave(void *data, struct wl_pointer *wl_point
 
 	ss->pointed_surface = nullptr;
 
+	ss->pointer_data_buffer.pressed_button_mask.clear();
+
 	Ref<WindowEventMessage> msg;
 	msg.instantiate();
 	msg->event = DisplayServer::WINDOW_EVENT_MOUSE_EXIT;


### PR DESCRIPTION
While experimenting with the recent "extent to title" PR, I noticed that it's not guaranteed for a "button released" event to be emitted when the pointer leaves the main surface, leaving some buttons stuck.

Not doing this for tablets since the spec makes this behavior clear and explicit, so we (hopefully) shouldn't have this issue there.