### PR TITLE
SCons: Fix `clang-cl` link/ar flags

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -620,18 +620,16 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
                 print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
                 sys.exit(255)
 
-            env.Append(CCFLAGS=["-flto=thin"])
-            env.Append(LINKFLAGS=["-flto=thin"])
+            env.AppendUnique(CCFLAGS=["-flto=thin"])
         elif env["use_llvm"]:
-            env.Append(CCFLAGS=["-flto"])
-            env.Append(LINKFLAGS=["-flto"])
+            env.AppendUnique(CCFLAGS=["-flto"])
         else:
             env.AppendUnique(CCFLAGS=["/GL"])
-            env.AppendUnique(ARFLAGS=["/LTCG"])
-            if env["progress"]:
-                env.AppendUnique(LINKFLAGS=["/LTCG:STATUS"])
-            else:
-                env.AppendUnique(LINKFLAGS=["/LTCG"])
+        if env["progress"]:
+            env.AppendUnique(LINKFLAGS=["/LTCG:STATUS"])
+        else:
+            env.AppendUnique(LINKFLAGS=["/LTCG"])
+        env.AppendUnique(ARFLAGS=["/LTCG"])
 
     if vcvars_msvc_config:
         env.Prepend(CPPPATH=[p for p in str(os.getenv("INCLUDE")).split(";")])


### PR DESCRIPTION
- Related #96785

While testing LTO in a `clang-cl` environment for the above PR, I realized that the link flags were incorrectly setup:
#### `lto=thin`
```
[100%] Linking Program bin\godot.windows.editor.dev.x86_64.llvm.exe ...
lld-link: warning: ignoring unknown argument '-flto=thin'
```
#### `lto=full`
```
[100%] Linking Program bin\godot.windows.editor.dev.x86_64.llvm.exe ...
lld-link: warning: ignoring unknown argument '-flto'
```
This was fixed by changing the arguments to MSVC syntax, as both the linker & AR tools accept the MSVC values.