### PR TITLE
Expose `PathFollow3D::_update_transform()` as `update_transform()`

### DIFF
--- a/doc/classes/PathFollow3D.xml
+++ b/doc/classes/PathFollow3D.xml
@@ -18,6 +18,13 @@
 				Correct the [param transform]. [param rotation_mode] implicitly specifies how posture (forward, up and sideway direction) is calculated.
 			</description>
 		</method>
+		<method name="update_transform">
+			<return type="void" />
+			<description>
+				Updates the [member Node3D.transform] of the node based on the [member progress]. Use this if you updated the progress and you need to access the new properties right after when doing physics operations.
+				[b]Note:[/b] Despite it's name, this method is not related to [method Node3D.force_update_transform], as the later forces the update of the actual [member Node3D.transform] property. Calling [method Node3D.force_update_transform] doesn't actually call this method.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="cubic_interp" type="bool" setter="set_cubic_interpolation" getter="get_cubic_interpolation" default="true">
@@ -33,6 +40,7 @@
 		</member>
 		<member name="progress" type="float" setter="set_progress" getter="get_progress" default="0.0">
 			The distance from the first vertex, measured in 3D units along the path. Changing this value sets this node's position to a point within the path.
+			[b]Note:[/b] Any change to this value will trigger a deferred update. In order to update immediately, call [method update_transform].
 		</member>
 		<member name="progress_ratio" type="float" setter="set_progress_ratio" getter="get_progress_ratio" default="0.0">
 			The distance from the first vertex, considering 0.0 as the first vertex and 1.0 as the last. This is just another way of expressing the progress within the path, as the progress supplied is multiplied internally by the path's length.

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -393,6 +393,8 @@ void PathFollow3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tilt_enabled", "enabled"), &PathFollow3D::set_tilt_enabled);
 	ClassDB::bind_method(D_METHOD("is_tilt_enabled"), &PathFollow3D::is_tilt_enabled);
 
+	ClassDB::bind_method(D_METHOD("update_transform"), &PathFollow3D::_update_transform);
+
 	ClassDB::bind_static_method("PathFollow3D", D_METHOD("correct_posture", "transform", "rotation_mode"), &PathFollow3D::correct_posture);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress", PROPERTY_HINT_RANGE, "0,10000,0.01,or_less,or_greater,suffix:m"), "set_progress", "get_progress");


### PR DESCRIPTION
> [!WARNING]
> I'm particularly bad at doing doc, IMHO. Please verify if it makes sense before approving the PR.

> [!NOTE]
> **tl;dr** If you change `PathFollow3D.progress` during a physics frame, it doesn't update. The update is deferred. This exposed method updates the node immediately.

Currently, in user land, there's no way to manually trigger `PathFollow3D::_update_transform()` nor `PathFollow3D::update_transform()`. That's a problem, because it is useful to update the path follow, then gather information about the position and the basis and such.

I thought that [`Node3D::force_update_transform()`](https://docs.godotengine.org/en/stable/classes/class_node3d.html#class-node3d-method-force-update-transform) would suffice, but they aren't actually linked (surprisingly).

`Node3D::force_update_transform()` is used to apply/update the actual `transform` value to the children and such.
> Forces the transform to update. Transform changes in physics are not instant for performance reasons. Transforms are accumulated and then set. Use this if you need an up-to-date transform when doing physics operations.

`PathFollow3D::_update_transform()` (which `PathFollow3D::update_transform()` is only a wrapper) updates the `PathFollow3D` instance based on the curve and progress. See the logic here: https://github.com/godotengine/godot/blob/97ef3c837263099faf02d8ebafd6c77c94d2aaba/scene/3d/path_3d.cpp#L231-L281

For the wrapper, `PathFollow3D::update_transform()`, the method is unfortunately public for some reason. It seems to be only used internally in fact. See the code here: https://github.com/godotengine/godot/blob/97ef3c837263099faf02d8ebafd6c77c94d2aaba/scene/3d/path_3d.cpp#L219-L228

This PR exposes `PathFollow3D::_update_transform()` as `PathFollow3D.update_transform()`.

Honestly, `update_transform` is such an unfortunate name, as it does what it says, but it's so easy to confound with the actual `Node3D::force_update_transform()` that does a different thing.