### PR TITLE
Metal: Fix out of bounds crash when using debug draw modes

### DIFF
--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -560,10 +560,10 @@ void MDCommandBuffer::_render_clear_render_area() {
 		}
 	}
 	uint32_t ds_index = subpass.depth_stencil_reference.attachment;
-	MDAttachment const &attachment = pass.attachments[ds_index];
-	bool shouldClearDepth = (ds_index != RDD::AttachmentReference::UNUSED && attachment.shouldClear(subpass, false));
-	bool shouldClearStencil = (ds_index != RDD::AttachmentReference::UNUSED && attachment.shouldClear(subpass, true));
+	bool shouldClearDepth = (ds_index != RDD::AttachmentReference::UNUSED && pass.attachments[ds_index].shouldClear(subpass, false));
+	bool shouldClearStencil = (ds_index != RDD::AttachmentReference::UNUSED && pass.attachments[ds_index].shouldClear(subpass, true));
 	if (shouldClearDepth || shouldClearStencil) {
+		MDAttachment const &attachment = pass.attachments[ds_index];
 		BitField<RDD::TextureAspectBits> bits;
 		if (shouldClearDepth && attachment.type & MDAttachmentType::Depth) {
 			bits.set_flag(RDD::TEXTURE_ASPECT_DEPTH_BIT);


### PR DESCRIPTION
Closes #96821 by first checking the index is not `UNUSED` (0xffffffff), before accessing the vector.