### PR TITLE
Fix project manager stealing focus on i3

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2998,7 +2998,11 @@ bool DisplayServerX11::window_is_focused(WindowID p_window) const {
 
 	const WindowData &wd = windows[p_window];
 
-	return wd.focused;
+	Window focused_window;
+	int focus_ret_state;
+	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
+
+	return wd.x11_window == focused_window;
 }
 
 bool DisplayServerX11::window_can_draw(WindowID p_window) const {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -103,7 +103,7 @@ void LineEdit::_close_ime_window() {
 
 void LineEdit::_update_ime_window_position() {
 	DisplayServer::WindowID wid = get_window() ? get_window()->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
-	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
+	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME) || !DisplayServer::get_singleton()->window_is_focused(wid)) {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2958,7 +2958,7 @@ void TextEdit::_close_ime_window() {
 
 void TextEdit::_update_ime_window_position() {
 	DisplayServer::WindowID wid = get_window() ? get_window()->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
-	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
+	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME) || !DisplayServer::get_singleton()->window_is_focused(wid)) {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95824

**TL;DR:** This fix isn't ideal, but I think it's probably OK.

Here's what's going on in detail:

 - In `LineEdit`, on `NOTIFICATION_DRAW` (which happens every time the cursor blinks), if the `LineEdit` is focused, it will call `DisplayServer::window_set_ime_active()` which will grab focus for the window the `LineEdit` is in
 - Since `Control::has_focus()` only checks if the control is focused according to Godot and doesn't check if the window is focused, this can steal focus back to Godot as soon as the cursor blinks again
 - So, this PR adds a check to `DisplayServer::window_is_focused()`
 - Unfortunately, this on its own doesn't fix the issue, because we're using the X11 `FocusOut` event to mark a window as not focused, and these events come in asynchronously, creating a race condition. What happens is focus switches away from the project manager window, but before the `FocusOut` event is received, `LineEdit`'s cursor blinks and it still thinks it's window is focused
 - So, this PR also changes `DisplayServer::window_is_focused()` to do a synchronous check to see if the window is _really_ focused right now

This isn't ideal for a couple reasons:

1. It's ignoring the `WindowData::focused` flag (which we update in response to the X11 `FocusIn` and `FocusOut` events) which is used in a whole bunch of other places. However, I think this is OK, because those other places don't seem to be sensitive to similar race conditions, and it sort of makes sense that if we call `DisplayServer::window_is_focused()` then we probably want the most up-to-date data.
2. The fix isn't contained to `display_server_x11.cpp`, it has ventured into the `LineEdit` and `TextEdit` nodes. But the only possible fix that I could come up with entirely within `display_server_x11.cpp` would be to revert PR https://github.com/godotengine/godot/pull/93682, but that would cause problems with Gnome and KDE. However, I think this fix is OK, because the whole idea of grabbing focus in `NOTIFICATION_DRAW` seems a little problematic in the first place - adding some extra protections around that makes sense to me.

Please let me know what you think!