### PR TITLE
Fix load error popup showing on every progress dialog

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4065,7 +4065,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		}
 	}
 
-	if (p_clear_errors) {
+	if (p_clear_errors && !load_errors_queued_to_display) {
 		load_errors->clear();
 	}
 
@@ -4746,14 +4746,26 @@ void EditorNode::add_io_error(const String &p_error) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Error"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_error + "\n");
-	EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// the io errors to prevent the io popup to set it's parent to the progress dialog.
+	if (singleton->progress_dialog->is_visible()) {
+		singleton->load_errors_queued_to_display = true;
+	} else {
+		EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+	}
 }
 
 void EditorNode::add_io_warning(const String &p_warning) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Warning"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_warning + "\n");
-	EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// the io errors to prevent the io popup to set it's parent to the progress dialog.
+	if (singleton->progress_dialog->is_visible()) {
+		singleton->load_errors_queued_to_display = true;
+	} else {
+		EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+	}
 }
 
 bool EditorNode::_find_scene_in_use(Node *p_node, const String &p_path) const {
@@ -5022,6 +5034,14 @@ void EditorNode::progress_task_step_bg(const String &p_task, int p_step) {
 
 void EditorNode::progress_end_task_bg(const String &p_task) {
 	singleton->progress_hb->end_task(p_task);
+}
+
+void EditorNode::_progress_dialog_visibility_changed() {
+	// Open the io errors after the progress dialog is closed.
+	if (load_errors_queued_to_display && !progress_dialog->is_visible()) {
+		EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+		load_errors_queued_to_display = false;
+	}
 }
 
 String EditorNode::_get_system_info() const {
@@ -7033,6 +7053,7 @@ EditorNode::EditorNode() {
 	add_child(resource_preview);
 	progress_dialog = memnew(ProgressDialog);
 	progress_dialog->set_unparent_when_invisible(true);
+	progress_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &EditorNode::_progress_dialog_visibility_changed));
 
 	gui_base = memnew(Panel);
 	add_child(gui_base);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -369,6 +369,7 @@ private:
 
 	RichTextLabel *load_errors = nullptr;
 	AcceptDialog *load_error_dialog = nullptr;
+	bool load_errors_queued_to_display = false;
 
 	RichTextLabel *execute_outputs = nullptr;
 	AcceptDialog *execute_output_dialog = nullptr;
@@ -695,6 +696,8 @@ private:
 	void _notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes);
 
 	void _remove_all_not_owned_children(Node *p_node, Node *p_owner);
+
+	void _progress_dialog_visibility_changed();
 
 protected:
 	friend class FileSystemDock;


### PR DESCRIPTION
- Fixes partially #96798

That's a funny regression from #93064.

When starting up the editor, if a file is read-only, a "Load errors" dialog should open to display the I/O errors. However, with the addition of a progress bar during editor startup, the "Load errors" dialog was opened while the Progress dialog was active, making the Progress dialog the parent of the "Load errors" dialog.

This caused the issue where the "Load errors" dialog would flash every time the Progress dialog was shown, displaying the same error from the editor startup repeatedly.

The reason why the error for the `editor_doc_cache` file only occurred in the dev build is that the case is not reconstructed every time in the release build.

Also, I could not figure out why `adb.exe` was locking the file. I suspect there's an issue with Android Studio, but I'm not sure.

I was tempted to add a removal of the `.tmp` file if the save was not successful, but I guess that would defeat the purpose of the `backup_save_enabled` feature.

I modified `EditorNode` to prevent displayed the "Load errors" while a Progress dialog is opened and when the progress is closed, I open the "Load errors" dialog.