### PR TITLE
Vulkan: Remove texture allocation check

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1778,9 +1778,6 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create_from_extension(uint64
 
 RDD::TextureID RenderingDeviceDriverVulkan::texture_create_shared(TextureID p_original_texture, const TextureView &p_view) {
 	const TextureInfo *owner_tex_info = (const TextureInfo *)p_original_texture.id;
-#ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_V(!owner_tex_info->allocation.handle, TextureID());
-#endif
 
 	VkImageViewCreateInfo image_view_create_info = owner_tex_info->vk_view_create_info;
 	image_view_create_info.format = RD_TO_VK_FORMAT[p_view.format];


### PR DESCRIPTION
During `DEBUG_ENABLED` (the default for Godot editor as distributed by Godot) a texture allocation check in `texture_create_shared()` causes foreign textures (those without `tex_info->allocation`) created by `texture_create_from_extension()` to fail, because such textures from external sources naturally lack the required allocation information.

https://github.com/godotengine/godot/blob/61be39aed28bd47b6e85664a7861f1f8b4c358b2/drivers/vulkan/rendering_device_driver_vulkan.cpp#L1781-L1783

For example, a `VkImage` may be passed to `texture_create_from_extension()`, which is a function to handle incoming textures from external sources:

https://github.com/godotengine/godot/blob/61be39aed28bd47b6e85664a7861f1f8b4c358b2/servers/rendering/rendering_device.cpp#L941-L943

But when the result is applied as albedo on a StandardMaterial3D, it will lead to the following error.

```text
ERROR: Condition "!owner_tex_info->allocation.handle" is true. Returning: TextureID()
   at: texture_create_shared (drivers/vulkan/rendering_device_driver_vulkan.cpp:1600)
ERROR: Condition "!texture.driver_id" is true. Returning: RID()
   at: texture_create_shared (servers/rendering/rendering_device.cpp:906)
ERROR: Condition "!owner_tex_info->allocation.handle" is true. Returning: TextureID()
   at: texture_create_shared (drivers/vulkan/rendering_device_driver_vulkan.cpp:1600)
ERROR: Condition "!texture.driver_id" is true. Returning: RID()
   at: texture_create_shared (servers/rendering/rendering_device.cpp:906)
```

This PR removes the check, because for foreign textures (like `VkImage`) you only need a view, which `texture_create_from_extension` creates, and then just display the view, regardless of allocation information. In simple terms, this PR is necessary for external renderers to supply Godot with external textures.