### PR TITLE
Expose the optimize method of the Animation class to gdscript.

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -293,6 +293,15 @@
 				Returns the arguments values to be called on a method track for a given key in a given track.
 			</description>
 		</method>
+		<method name="optimize">
+			<return type="void" />
+			<param index="0" name="allowed_velocity_err" type="float" default="0.01" />
+			<param index="1" name="allowed_angular_err" type="float" default="0.01" />
+			<param index="2" name="precision" type="int" default="3" />
+			<description>
+				Optimize the animation and all its tracks in-place. This will preserve only as many keys as are necessary to keep the animation within the specified bounds.
+			</description>
+		</method>
 		<method name="position_track_insert_key">
 			<return type="int" />
 			<param index="0" name="track_idx" type="int" />

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3902,6 +3902,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &Animation::clear);
 	ClassDB::bind_method(D_METHOD("copy_track", "track_idx", "to_animation"), &Animation::copy_track);
 
+	ClassDB::bind_method(D_METHOD("optimize", "allowed_velocity_err", "allowed_angular_err", "precision"), &Animation::optimize, DEFVAL(0.01), DEFVAL(0.01), DEFVAL(3));
 	ClassDB::bind_method(D_METHOD("compress", "page_size", "fps", "split_tolerance"), &Animation::compress, DEFVAL(8192), DEFVAL(120), DEFVAL(4.0));
 
 	ClassDB::bind_method(D_METHOD("is_capture_included"), &Animation::is_capture_included);


### PR DESCRIPTION
This PR exposes the Animation optimize method so it can be accessed from scripts.

This is to support optimization of dynamically-generated animations such as when developing Mocap recording extensions.