### PR TITLE
Use UTF-8 BOM when saving script files.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1064,6 +1064,9 @@
 		<member name="text_editor/behavior/files/restore_scripts_on_load" type="bool" setter="" getter="">
 			If [code]true[/code], reopens scripts that were opened in the last session when the editor is reopened on a given project.
 		</member>
+		<member name="text_editor/behavior/files/save_with_bom" type="bool" setter="" getter="">
+			If [code]true[/code], saves scripts and shaders with UTF-8 byte order mark.
+		</member>
 		<member name="text_editor/behavior/files/trim_final_newlines_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], trims all empty newlines after the final newline when saving a script. Final newlines refer to the empty newlines found at the end of files. Since these serve no practical purpose, they can and should be removed to make version control diffs less noisy.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -669,6 +669,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/restore_scripts_on_load", true);
 	_initial_set("text_editor/behavior/files/convert_indent_on_save", true);
 	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", false);
+	_initial_set("text_editor/behavior/files/save_with_bom", true);
 
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2401,6 +2401,11 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save text file '" + p_path + "'.");
 
+		if (EDITOR_GET("text_editor/behavior/files/save_with_bom").operator bool()) {
+			file->store_8(0xef); // Store UTF-8 BOM.
+			file->store_8(0xbb);
+			file->store_8(0xbf);
+		}
 		file->store_string(source);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -59,6 +59,7 @@
 #ifdef TOOLS_ENABLED
 #include "core/extension/gdextension_manager.h"
 #include "editor/editor_paths.h"
+#include "editor/editor_settings.h"
 #endif
 
 #include <stdint.h>
@@ -3056,6 +3057,13 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
 
+#ifdef TOOLS_ENABLED
+		if (Engine::get_singleton()->is_editor_hint() && EDITOR_GET("text_editor/behavior/files/save_with_bom").operator bool()) {
+			file->store_8(0xef); // Store UTF-8 BOM.
+			file->store_8(0xbb);
+			file->store_8(0xbf);
+		}
+#endif
 		file->store_string(source);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2870,6 +2870,13 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save C# script file '" + p_path + "'.");
 
+#ifdef TOOLS_ENABLED
+		if (Engine::get_singleton()->is_editor_hint() && EDITOR_GET("text_editor/behavior/files/save_with_bom").operator bool()) {
+			file->store_8(0xef); // Store UTF-8 BOM.
+			file->store_8(0xbb);
+			file->store_8(0xbf);
+		}
+#endif
 		file->store_string(source);
 
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -39,6 +39,7 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_help.h"
+#include "editor/editor_settings.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
@@ -323,6 +324,13 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint() && EDITOR_GET("text_editor/behavior/files/save_with_bom").operator bool()) {
+		file->store_8(0xef); // Store UTF-8 BOM.
+		file->store_8(0xbb);
+		file->store_8(0xbf);
+	}
+#endif
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 		return ERR_CANT_CREATE;

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -32,6 +32,10 @@
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/shader_preprocessor.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+
 void ShaderInclude::_dependency_changed() {
 	emit_changed();
 }
@@ -140,6 +144,13 @@ Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, co
 
 	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint() && EDITOR_GET("text_editor/behavior/files/save_with_bom").operator bool()) {
+		file->store_8(0xef); // Store UTF-8 BOM.
+		file->store_8(0xbb);
+		file->store_8(0xbf);
+	}
+#endif
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 		return ERR_CANT_CREATE;


### PR DESCRIPTION
Add editor setting (enabled by default) to save script (and shader) files with BOM, should improve encoding detection by other text editors/IDEs.

Fixes https://github.com/godotengine/godot/issues/27083