### PR TITLE
[Tree] Improve Tree Performance by replacing computed height with TreeItem's cached minimum size

### DIFF
--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -1012,6 +1012,10 @@ int TextParagraph::hit_test(const Point2 &p_coords) const {
 	return TS->shaped_text_get_range(rid).y;
 }
 
+bool TextParagraph::is_dirty() {
+	return lines_dirty;
+}
+
 void TextParagraph::draw_dropcap(RID p_canvas, const Vector2 &p_pos, const Color &p_color) const {
 	_THREAD_SAFE_METHOD_
 

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -152,6 +152,8 @@ public:
 
 	int hit_test(const Point2 &p_coords) const;
 
+	bool is_dirty();
+
 	Mutex &get_mutex() const { return _thread_safe_; }
 
 	TextParagraph(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", float p_width = -1.f, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL);


### PR DESCRIPTION
Originally, `TreeItem`'s content height was computed in every draw while traversing the tree, even if the item content never changes. And there's already `minimum_size` cached in each item, which is computed in a similar way.

Tested on a massive plain-tree with 15K and 150K items(project file attached below), and got significant performance improvement (About 5~10x).
Here're results on my desktop when scrolling to near the bottom of tree.
Amount | This PR | Master
---------| ---------| --------
15K Items | 1543FPS | 152FPS
150K Items | 36FPS | 3FPS, and with a lot much longer start time

I also checked the behaviors of more complex `Tree`s in the editor, and didn't notice any obvious artifacts, but I'm not very sure if there were any side-effect after changing these.

Might partially fix these issues?
* *Closes: https://github.com/godotengine/godot/issues/70869*

EDIT:
After some "extreme" test with huge amount of auto-wrapping text `TreeItems` and scrolling fast will cause some item's height cache being outdated. 
~~I'm still looking for some other way to make this work. So convert this to draft now and will try reopen when I figured out.~~
I believe that's not related to this PR's modification, as I can reproduce the above issue in both 4.3 and master branch.  I'll open another issue about that.


[treetest.zip](https://github.com/user-attachments/files/16959026/treetest.zip)
