### PR TITLE
[Editor] Add `.editorconfig` to the projects.

### DIFF
--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -245,7 +245,7 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
-		// Check that the project data directory '.gdignore' file exists
+		// Check that the project data directory `.gdignore` file exists.
 		String project_data_gdignore_file_path = project_data_dir.path_join(".gdignore");
 		if (!FileAccess::exists(project_data_gdignore_file_path)) {
 			// Add an empty .gdignore file to avoid scan.
@@ -253,8 +253,24 @@ EditorPaths::EditorPaths() {
 			if (f.is_valid()) {
 				f->store_line("");
 			} else {
-				ERR_PRINT("Failed to create file " + project_data_gdignore_file_path);
+				ERR_PRINT("Failed to create file " + project_data_gdignore_file_path.quote() + ".");
 			}
+		}
+
+		// Check that `.editorconfig` file exists.
+		String project_editorconfig_path = "res://.editorconfig";
+		if (!FileAccess::exists(project_editorconfig_path)) {
+			Ref<FileAccess> f = FileAccess::open(project_editorconfig_path, FileAccess::WRITE);
+			if (f.is_valid()) {
+				f->store_line("root = true");
+				f->store_line("");
+				f->store_line("[*]");
+				f->store_line("charset = utf-8");
+				f->close();
+			} else {
+				ERR_PRINT("Failed to create file " + project_editorconfig_path.quote() + ".");
+			}
+			FileAccess::set_hidden_attribute(project_editorconfig_path, true);
 		}
 
 		Engine::get_singleton()->set_shader_cache_path(project_data_dir);


### PR DESCRIPTION
Adds `.editorconfig` to ensure external editors/IDEs use UTF-8 encoding.

Fixes https://github.com/godotengine/godot/issues/27083
Supersede https://github.com/godotengine/godot/pull/96837