### PR TITLE
Fix issue with GDScript binary tokens being non-deterministic

### DIFF
--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -296,6 +296,7 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code,
 	encode_uint32(identifier_map.size(), &contents.write[0]);
 	encode_uint32(constant_map.size(), &contents.write[4]);
 	encode_uint32(token_lines.size(), &contents.write[8]);
+	encode_uint32(0, &contents.write[12]); // Unused, kept for compatibility. Please remove at next `TOKENIZER_VERSION` increment.
 	encode_uint32(token_counter, &contents.write[16]);
 
 	int buf_pos = 20;


### PR DESCRIPTION
Fixes #96854.

This fixes the issue of GDScript files exported with "Binary tokens" or "Compressed binary tokens" having different contents (and thus hash) with most exports, despite the corresponding GDScript file being identical.

This PR addresses this by simply writing zeroes to the gap at bytes 13-16, and marking the gap as ~~reserved~~ unused, in order to preserve backwards compatibility.

~~If backwards compatibility isn't deemed important I can of course just shift everything after the 12th byte down 4 bytes instead.~~