### PR TITLE
NavMap::sync(): only acquire write lock when writes are needed

### DIFF
--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -128,6 +128,10 @@ Vector3 NavRegion::get_random_point(uint32_t p_navigation_layers, bool p_uniform
 	return NavMeshQueries3D::polygons_get_random_point(get_polygons(), p_navigation_layers, p_uniformly);
 }
 
+bool NavRegion::is_dirty() {
+	return polygons_dirty;
+}
+
 bool NavRegion::sync() {
 	RWLockWrite write_lock(region_rwlock);
 

--- a/modules/navigation/nav_region.h
+++ b/modules/navigation/nav_region.h
@@ -96,6 +96,7 @@ public:
 
 	real_t get_surface_area() const { return surface_area; };
 
+	bool is_dirty();
 	bool sync();
 
 private:


### PR DESCRIPTION
Fixes #96820

- Recommend viewing the diff with whitespace ignored (`git diff -b`). A large portion of the diff is indentation that didn't seem easily avoidable
- Not 100% sure it's the best strategy or that I found 100% of the possible `dirty` flags. It's my first time contributing to Godot.
- Works great in my local testing
- Style: I'm not sure if `is_dirty()` is the best name. I used this name because `check_dirty()` elsewhere has side effects, but `is_dirty()` does not have any side effects. Feel free to change it.