### PR TITLE
[3.x] `Object::call()` prevent debug lock accessing dangling pointer

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -43,14 +43,17 @@
 #ifdef DEBUG_ENABLED
 
 struct _ObjectDebugLock {
-	Object *obj;
+	ObjectID obj_id;
 
 	_ObjectDebugLock(Object *p_obj) {
-		obj = p_obj;
-		obj->_lock_index.ref();
+		obj_id = p_obj->get_instance_id();
+		p_obj->_lock_index.ref();
 	}
 	~_ObjectDebugLock() {
-		obj->_lock_index.unref();
+		Object *obj_ptr = ObjectDB::get_instance(obj_id);
+		if (likely(obj_ptr)) {
+			obj_ptr->_lock_index.unref();
+		}
 	}
 };
 


### PR DESCRIPTION
Self deleting an object within a call was leading to crashes due to referencing freed memory, due to a raw pointer stored in the debug lock.

Fixes #75658

## Notes
* Myself and @RandomShaper independently came on the same solution, his in #96856 for 4.x.
* As he snatched the PR in 4.x, I so snatch the PR in 3.x. :grinning: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
