### PR TITLE
Fix launching XR apps from the Android editor

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2947,9 +2947,6 @@
 		<member name="xr/openxr/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], Godot will setup and initialize OpenXR on startup.
 		</member>
-		<member name="xr/openxr/enabled.editor" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], Godot will setup and initialize OpenXR on editor startup.
-		</member>
 		<member name="xr/openxr/environment_blend_mode" type="int" setter="" getter="" default="&quot;0&quot;">
 			Specify how OpenXR should blend in the environment. This is specific to certain AR and passthrough devices where camera images are blended in by the XR compositor.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2550,7 +2550,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	// XR project settings.
 	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled", false);
-	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled.editor", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "xr/openxr/default_action_map", PROPERTY_HINT_FILE, "*.tres"), "res://openxr_action_map.tres");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/form_factor", PROPERTY_HINT_ENUM, "Head Mounted,Handheld"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo"), "1"); // "Mono,Stereo,Quad,Observer"

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -273,7 +273,9 @@ Vector<OpenXRExtensionWrapper *> OpenXRAPI::registered_extension_wrappers;
 bool OpenXRAPI::openxr_is_enabled(bool p_check_run_in_editor) {
 	if (XRServer::get_xr_mode() == XRServer::XRMODE_DEFAULT) {
 		if (Engine::get_singleton()->is_editor_hint() && p_check_run_in_editor) {
-			return GLOBAL_GET("xr/openxr/enabled.editor");
+			// For now, don't start OpenXR when the editor starts up. In the future, this may change
+			// if we want to integrate more XR features into the editor experience.
+			return false;
 		} else {
 			return GLOBAL_GET("xr/openxr/enabled");
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96831
Regression caused by https://github.com/godotengine/godot/pull/96780

We actually don't want to initialize OpenXR when the editor loads, so we were disabling it by checking `xr/openxr/enabled.editor`, which previously wasn't set and hence `false`. But when launching an XR app from the editor, we _do_ want to initialize OpenXR, which we can tell by checking the `xr/openxr/enabled` project setting.

This was broken when https://github.com/godotengine/godot/pull/96780 actually set `xr/openxr/enabled.editor` to `false`, because `GodotLib.getGlobal()` will get project settings with overrides, and "editor" is a valid feature tag, so all of sudden `xr/openxr/enabled` would return `false` (because of the override for `editor`), even though the "vanilla" project setting is set to `true`.

~~This PR adds `GodotLib.getProjectSetting()` which can get the "vanilla" project setting without overrides, and uses it to check if we are launching an XR app (and hence need to initialize OpenXR).~~

~~So, in a sort of way, this doesn't actually fix https://github.com/godotengine/godot/issues/96831 because the editor will still run at 1FPS if `xr/openxr/enabled.editor` is `true`, but it removes the need for users to enable that setting in the first place.~~

An alternate fix could be just removing the `xr/openxr/enabled.editor` setting and hard-coding OpenXR as disabled when the editor launches for now? One day, we may want to actually initialize it, but at the moment we're not using it, and it messes up rendering by OpenXR taking over the render loop.

**UPDATE:** After chatting with @m4gr3d, we decided to go for this "alternative fix", and this PR now removes the `xr/openxr/enabled.editor` project setting, and just hard-codes OpenXR as disabled when the editor launches.