### PR TITLE
Add `SCROLL_MODE_RESERVE` to ScrollContainer

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -102,6 +102,9 @@
 		<constant name="SCROLL_MODE_SHOW_NEVER" value="3" enum="ScrollMode">
 			Scrolling enabled, scrollbar will be hidden.
 		</constant>
+		<constant name="SCROLL_MODE_RESERVE" value="4" enum="ScrollMode">
+			Combines [constant SCROLL_MODE_AUTO] and [constant SCROLL_MODE_SHOW_ALWAYS]. The scrollbar is only visible if necessary, but the content size is adjusted as if it was always visible. It's useful for ensuring that content size stays the same regardless if the scrollbar is visible.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="panel" data_type="style" type="StyleBox">

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -44,6 +44,7 @@ public:
 		SCROLL_MODE_AUTO,
 		SCROLL_MODE_SHOW_ALWAYS,
 		SCROLL_MODE_SHOW_NEVER,
+		SCROLL_MODE_RESERVE,
 	};
 
 private:
@@ -74,6 +75,9 @@ private:
 	} theme_cache;
 
 	void _cancel_drag();
+
+	bool _is_h_scroll_visible() const;
+	bool _is_v_scroll_visible() const;
 
 protected:
 	Size2 get_minimum_size() const override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2121

https://github.com/user-attachments/assets/55c3d275-6921-4fc4-bf50-a3570efc16e3

The new mode ensures that the content does not resize when scrollbar visibility is toggled.