### PR TITLE
Avoid expensive sqrt operation in hot loop of `BitMap.grow_mask`

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -559,6 +559,7 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 
 	bool bit_value = p_pixels > 0;
 	p_pixels = Math::abs(p_pixels);
+	const int pixels2 = p_pixels * p_pixels;
 
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 
@@ -588,8 +589,8 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 						}
 					}
 
-					float d = Point2(j, i).distance_to(Point2(x, y)) - CMP_EPSILON;
-					if (d > p_pixels) {
+					float d = Point2(j, i).distance_squared_to(Point2(x, y)) - CMP_EPSILON2;
+					if (d > pixels2) {
 						continue;
 					}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

I've noticed that `BitMap.grow_mask` could be quite slow for large radii on large images, and while looking for ways to optimize the process I noticed that the operation performs a `distance_to` that could be converted into a `distance_squared_to`, avoiding a `sqrt` from being performed on every pixel, multiple times.

Guidance is requested on perhaps how to ensure this doesn't lead to an unwanted regression on pixels on the edge of expanded bitmaps.