### PR TITLE
C#: Clear existing data directory in export output

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -232,6 +232,13 @@ namespace GodotTools.Export
                         projectDataDirName = Path.Combine("Contents", "Resources", projectDataDirName);
                     }
 
+                    // Delete old publish output files to prevent problems with file mixing.
+                    string projectDataDir = Path.Join(ProjectSettings.GlobalizePath("res://"), Path.GetDirectoryName(path), projectDataDirName);
+                    if (!embedBuildResults && Directory.Exists(projectDataDir))
+                    {
+                        Directory.Delete(projectDataDir, true);
+                    }
+
                     // Create temporary publish output directory.
                     string publishOutputDir;
 


### PR DESCRIPTION
Partial fix for #96299 (embed_build_outputs=false)
