### PR TITLE
 Fix Blendshapes so they are cleared from MeshInstance3D when mesh is changed. 

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -115,6 +115,7 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 	}
 
 	mesh = p_mesh;
+	blend_shape_tracks.clear();
 
 	if (mesh.is_valid()) {
 		// If mesh is a PrimitiveMesh, calling get_rid on it can trigger a changed callback
@@ -123,7 +124,6 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 		mesh->connect_changed(callable_mp(this, &MeshInstance3D::_mesh_changed));
 		_mesh_changed();
 	} else {
-		blend_shape_tracks.clear();
 		blend_shape_properties.clear();
 		set_base(RID());
 		update_gizmos();
@@ -390,6 +390,7 @@ void MeshInstance3D::_mesh_changed() {
 
 	uint32_t initialize_bs_from = blend_shape_tracks.size();
 	blend_shape_tracks.resize(mesh->get_blend_shape_count());
+	blend_shape_properties.clear();
 
 	for (uint32_t i = 0; i < blend_shape_tracks.size(); i++) {
 		blend_shape_properties["blend_shapes/" + String(mesh->get_blend_shape_name(i))] = i;


### PR DESCRIPTION
Address the issue #96873 where blendshapes aren't properly removed when you swap out the mesh in a MeshInstance3D node. Seems like the blend_shape_tracks and blend_shape_properties needed to be cleared even if the mesh that changed was valid. 

This is my first PR for godot, so let me know if there is anything else I can do on my end. 

After making the changes, I then tested with the Minimal reproduction project (MRP) provided in the issue, and when the mesh is changed, the Blendshapes property is properly updated (and removed if no blendshapes are present in the new mesh)

current master commit (2c136e6170a40f58f2dfb89d32eadfca7156ef37) still has this issue when tested.

*Bugsquad edit:*
- Fixes #96873
