### PR TITLE
Add `EditorResourcePreviewGenerator::request_draw_and_wait`

### DIFF
--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -54,5 +54,12 @@
 				Returns [code]true[/code] if your generator supports the resource of type [param type].
 			</description>
 		</method>
+		<method name="request_draw_and_wait" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Call from within [method _generate] to request the rendering server draw to the [param viewport].
+			</description>
+		</method>
 	</methods>
 </class>

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -87,6 +87,8 @@ void EditorResourcePreviewGenerator::_bind_methods() {
 	GDVIRTUAL_BIND(_generate_from_path, "path", "size", "metadata");
 	GDVIRTUAL_BIND(_generate_small_preview_automatically);
 	GDVIRTUAL_BIND(_can_generate_small_preview);
+
+	ClassDB::bind_method(D_METHOD("request_draw_and_wait", "viewport"), &EditorResourcePreviewGenerator::request_draw_and_wait);
 }
 
 void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) {
@@ -116,6 +118,11 @@ void EditorResourcePreviewGenerator::DrawRequester::abort() {
 	if (EditorResourcePreview::get_singleton()->is_threaded()) {
 		semaphore.post();
 	}
+}
+
+void EditorResourcePreviewGenerator::request_draw_and_wait(RID viewport) const {
+	DrawRequester draw_requester;
+	draw_requester.request_and_wait(viewport);
 }
 
 Variant EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() {

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -68,6 +68,7 @@ public:
 
 	virtual bool generate_small_preview_automatically() const;
 	virtual bool can_generate_small_preview() const;
+	void request_draw_and_wait(RID viewport) const;
 };
 
 class EditorResourcePreview : public Node {


### PR DESCRIPTION
Adds EditorResourcePreviewGenerator::request_draw_and_wait to allow resource previewers implemented in GDScript to use the rendering server.  Preview renderers can, depending on configuration, be threaded or not threaded.  Because if the previewer is threaded isn't exposed its not possible to correctly implement a resource preview plugin that uses the RenderingServer in gdscript.

To make this possible, we expose the logic that MeshPreviewer and MaterialPreviewer use to render a preview on the RenderingServer to GDScript.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
