### PR TITLE
ResourceLoader: Fix deadlocks caused by the resource changed feature

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -860,7 +860,7 @@ Ref<Resource> ResourceLoader::_load_complete_inner(LoadToken &p_load_token, Erro
 						}
 					}
 					core_bind::Semaphore done;
-					MessageQueue::get_main_singleton()->push_callable(callable_mp(&done, &core_bind::Semaphore::post));
+					MessageQueue::get_main_singleton()->push_callable(callable_mp(&done, &core_bind::Semaphore::post).bind(1));
 					done.wait();
 				}
 			}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -533,8 +533,10 @@ void EditorResourcePreview::stop() {
 			}
 
 			while (!exited.is_set()) {
+				// Sync pending work.
 				OS::get_singleton()->delay_usec(10000);
-				RenderingServer::get_singleton()->sync(); //sync pending stuff, as thread may be blocked on rendering server
+				RenderingServer::get_singleton()->sync();
+				MessageQueue::get_singleton()->flush();
 			}
 
 			thread.wait_to_finish();


### PR DESCRIPTION
- One commit is another fixup to #96593. (Despite the `DEFVAL(1)`, the callable would fail due to not enough arguments unless I explicitly bind an argument!)
- The other commit applies to the resource previewer. The main thread shouldn't be blocked when there are loads in progress, or otherwise the resource changed connections can't be flushed to it. You shouldn't block the main thread regardless this, even if we support busy polling the status of threaded resource loads, but that's a bonus. And the resource previewer was busy looping upon waiting for its thread to exit. It was letting the rendering server sync, but that's only part of the whole picture. In situations like that you'd rather run a full iteration, guaranteeing the engine "breathes" and can make progress in anything async.

Fixes #96790.