### PR TITLE
Make script list default wider, minimum narrower

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4107,9 +4107,9 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_list = memnew(ItemList);
 	script_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	scripts_vbox->add_child(script_list);
-	script_list->set_custom_minimum_size(Size2(150, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	script_list->set_custom_minimum_size(Size2(100, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	script_split->set_split_offset(70 * EDSCALE);
+	script_split->set_split_offset(200 * EDSCALE);
 	_sort_list_on_update = true;
 	script_list->connect("item_clicked", callable_mp(this, &ScriptEditor::_script_list_clicked), CONNECT_DEFERRED);
 	script_list->set_allow_rmb_select(true);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -773,6 +773,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	window_wrapper->set_margins_enabled(true);
 
 	main_split = memnew(HSplitContainer);
+	main_split->set_split_offset(200 * EDSCALE);
 	Ref<Shortcut> make_floating_shortcut = ED_SHORTCUT_AND_COMMAND("shader_editor/make_floating", TTR("Make Floating"));
 	window_wrapper->set_wrapped_control(main_split, make_floating_shortcut);
 
@@ -818,7 +819,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	SET_DRAG_FORWARDING_GCD(shader_list, ShaderEditorPlugin);
 
 	main_split->add_child(left_panel);
-	left_panel->set_custom_minimum_size(Size2(200, 300) * EDSCALE);
+	left_panel->set_custom_minimum_size(Size2(100, 300) * EDSCALE);
 
 	shader_tabs = memnew(TabContainer);
 	shader_tabs->set_tabs_visible(false);


### PR DESCRIPTION
Give more space to the script lists by default, but makes minimum smaller than it was. Unifies script editor and shader editor to use same values.

## Before
Here's how default&minimum value is in current master on 1080 resolution 100% editor scale:
![kuva](https://github.com/user-attachments/assets/db003e2f-763d-41f1-928c-0e117cdbd41e)
Script editor: 150 px
Shader editor: 200 px
Note how script editor's list is so narrow that even `new_script.gd(*)` doesn't fit.

## After
Here's the new default:
![kuva](https://github.com/user-attachments/assets/3666b4b5-58ba-4462-8146-823fbb344177)
Script editor: 200 px
Shader editor: 200 px
Note how code editor is still 115 chars wide, enough for usual code (exceeding 100 chars hampers readability anyway, no matter how big of a monitor).

Here's the new minimum:
![kuva](https://github.com/user-attachments/assets/9af928dc-eff7-4ff9-86e7-eeb77ded5ad7)
Script editor: 100 px
Shader editor: 100 px
As GUI doesn't break (altough it gets cramped), we shouldn't limit the user from customizing layout for small/portrait monitors.

Related: #96865 would benefit from this.