### PR TITLE
GraphEdit: Improve dotted pattern grid performance

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1646,24 +1646,34 @@ void GraphEdit::_draw_grid() {
 			Color transparent_grid_minor = theme_cache.grid_minor;
 			transparent_grid_minor.a *= CLAMP(1.0 * (zoom - 0.4), 0, 1);
 
-			for (int i = from_pos.x; i < from_pos.x + len.x; i++) {
-				for (int j = from_pos.y; j < from_pos.y + len.y; j++) {
-					Color color = transparent_grid_minor;
+			// Minor dots.
+			if (transparent_grid_minor.a != 0) {
+				for (int i = from_pos.x; i < from_pos.x + len.x; i++) {
+					for (int j = from_pos.y; j < from_pos.y + len.y; j++) {
+						if (ABS(i) % GRID_MINOR_STEPS_PER_MAJOR_DOT == 0 && ABS(j) % GRID_MINOR_STEPS_PER_MAJOR_DOT == 0) {
+							continue;
+						}
 
-					if (ABS(i) % GRID_MINOR_STEPS_PER_MAJOR_DOT == 0 && ABS(j) % GRID_MINOR_STEPS_PER_MAJOR_DOT == 0) {
-						color = theme_cache.grid_major;
+						float base_offset_x = i * snapping_distance * zoom - offset.x * zoom;
+						float base_offset_y = j * snapping_distance * zoom - offset.y * zoom;
+
+						draw_rect(Rect2(base_offset_x - 1, base_offset_y - 1, 3, 3), transparent_grid_minor);
 					}
-
-					if (color.a == 0) {
-						continue;
-					}
-
-					float base_offset_x = i * snapping_distance * zoom - offset.x * zoom;
-					float base_offset_y = j * snapping_distance * zoom - offset.y * zoom;
-
-					draw_rect(Rect2(base_offset_x - 1, base_offset_y - 1, 3, 3), color);
 				}
 			}
+
+			// Major dots.
+			if (theme_cache.grid_major.a != 0) {
+				for (int i = from_pos.x - from_pos.x % GRID_MINOR_STEPS_PER_MAJOR_DOT; i < from_pos.x + len.x; i += GRID_MINOR_STEPS_PER_MAJOR_DOT) {
+					for (int j = from_pos.y - from_pos.y % GRID_MINOR_STEPS_PER_MAJOR_DOT; j < from_pos.y + len.y; j += GRID_MINOR_STEPS_PER_MAJOR_DOT) {
+						float base_offset_x = i * snapping_distance * zoom - offset.x * zoom;
+						float base_offset_y = j * snapping_distance * zoom - offset.y * zoom;
+
+						draw_rect(Rect2(base_offset_x - 1, base_offset_y - 1, 3, 3), theme_cache.grid_major);
+					}
+				}
+			}
+
 		} break;
 	}
 }


### PR DESCRIPTION
Separate the drawing of major and minor dots so that they can be batched on rendering.

Size = ~2560*1400, Zoom = 42%:

| Before                               | After                                |
| ------------------------------------ | ------------------------------------ |
|  ![Pasted image 20240912200233](https://github.com/user-attachments/assets/9941e120-0cb2-45a4-8cf4-790b6ff8ec41)  |  ![Pasted image 20240912195126](https://github.com/user-attachments/assets/7ebe0f04-e64a-47c0-b2e3-b9da2161d098)  |

