### PR TITLE
Autocompletion: Improve test-runner location checks

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -638,6 +638,19 @@ static int _get_method_location(const StringName &p_class, const StringName &p_m
 	return depth | ScriptLanguage::LOCATION_PARENT_MASK;
 }
 
+static int _get_method_location(Ref<Script> p_script, const StringName &p_method) {
+	int depth = 0;
+	Ref<Script> scr = p_script;
+	while (scr.is_valid()) {
+		if (scr->get_member_line(p_method) != -1) {
+			return depth | ScriptLanguage::LOCATION_PARENT_MASK;
+		}
+		depth++;
+		scr = scr->get_base_script();
+	}
+	return depth + _get_method_location(p_script->get_instance_base_type(), p_method);
+}
+
 static int _get_enum_constant_location(const StringName &p_class, const StringName &p_enum_constant) {
 	if (!ClassDB::get_integer_constant_enum(p_class, p_enum_constant)) {
 		return ScriptLanguage::LOCATION_OTHER;
@@ -1214,7 +1227,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							if (E.name.begins_with("@")) {
 								continue;
 							}
-							int location = p_recursion_depth + _get_method_location(scr->get_class_name(), E.name);
+							int location = p_recursion_depth + _get_method_location(scr, E.name);
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 							if (E.arguments.size()) {
 								option.insert_text += "(";
@@ -1387,6 +1400,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				return;
 			} break;
 		}
+		// Not recursion strictly speaking, but we need to keep track of how deep a type is in the inheritance chain,
+		// to sort options correctly.
+		p_recursion_depth++;
 	}
 }
 

--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -32,27 +32,11 @@ The config file contains two section:
 
 `[output]` specifies the expected results for the test. The following key are supported:
 
-- `include: Array`: An unordered list of suggestions that should be in the result. Each entry is one dictionary with the following keys: `display`, `insert_text`, `kind`, `location`, which correspond to the suggestion struct which is used in the code. The runner only tests against specified keys, so in most cases `display` will suffice.
+- `include: Array`: A list of suggestions that should be in the result. Each entry is one dictionary with the following keys: `display`, `insert_text`, `kind`, which correspond to the suggestion struct which is used in the code. The runner only tests against specified keys, so in most cases `display` will suffice.
+  The list is split into buckets. items marked with `after: true` start a new bucket. Items inside the same bucket can occur in any order, but they have to occur behind all items of previous buckets.
+
 - `exclude: Array`: An array of suggestions which should not be in the result. The entries take the same form as for `include`.
 - `call_hint: String`: The expected call hint returned by autocompletion.
 - `forced: boolean`: Whether autocompletion is expected to force opening a completion window.
 
 Tests will only test against entries in `[output]` that were specified.
-
-## Writing autocompletion tests
-
-To avoid failing edge cases a certain behavior needs to be tested multiple times. Some things that tests should account for:
-
-- All possible types: Test with all possible types that apply to the tested behavior. (For the last points testing against `SCRIPT` and `CLASS` should suffice. `CLASS` can be obtained through C#, `SCRIPT` through GDScript. Relying on autoloads to be of type `SCRIPT` is not good, since this might change in the future.)
-
-  - `BUILTIN`
-  - `NATIVE`
-  - GDScripts (with `class_name` as well as `preload`ed)
-  - C# (as standin for all other language bindings) (with `class_name` as well as `preload`ed)
-  - Autoloads
-
-- Possible contexts: the completion might be placed in different places of the program. e.g:
-  - initializers of class members
-  - directly inside a suite
-  - assignments inside a suite
-  - as parameter to a call

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/add_node_path_tween.cfg
@@ -3,7 +3,7 @@ add_node_path_literals=true
 [output]
 include=[
     {"insert_text": "^\"property_of_a\""},
-    {"insert_text": "^\"name\""},
+    {"insert_text": "^\"name\"", "after": true},
 ]
 exclude=[
     {"insert_text": "\"property_of_a\""},

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/argument_options_inside_string_literal.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/argument_options_inside_string_literal.cfg
@@ -1,5 +1,5 @@
 [output]
 include=[
     {"insert_text": "\"property_of_a\""},
-    {"insert_text": "\"name\""},
+    {"insert_text": "\"name\"", "after": true},
 ]

--- a/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/string_literals/dont_add_node_path_tween.cfg
@@ -3,7 +3,7 @@ add_node_path_literals=false
 [output]
 include=[
     {"insert_text": "\"property_of_a\""},
-    {"insert_text": "\"name\""},
+    {"insert_text": "\"name\"", "after": true},
 ]
 exclude=[
     {"insert_text": "^\"property_of_a\""},

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.cfg
@@ -1,9 +1,6 @@
 [output]
 include=[
-    {"display": "DrawMode",
-     "location": 256},
-    {"display": "Anchor",
-     "location": 257},
-    {"display": "TextureRepeat",
-     "location": 258},
+    {"display": "DrawMode"},
+    {"display": "Anchor", "after": true},
+    {"display": "TextureRepeat", "after": true},
 ]

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.cfg
@@ -1,5 +1,5 @@
 [output]
 include=[
-    {"display": "HEURISTIC_MAX"},
     {"display": "HEURISTIC_OCTILE"},
+    {"display": "HEURISTIC_MAX"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
@@ -1,17 +1,6 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
-    ; GDScript: class_a.notest.gd
-    {"display": "property_of_a"},
-    {"display": "func_of_a"},
-    {"display": "signal_of_a"},
-
-    ; GDScript: identifiers.gd
+    ; GDScript: identifiers_in_call.gd
     {"display": "test_signal_1"},
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
@@ -22,4 +11,14 @@ include=[
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},
     {"display": "local_test_var_2"},
+
+    ; GDScript: class_a.notest.gd
+    {"display": "property_of_a", "after": true},
+    {"display": "func_of_a"},
+    {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
@@ -1,17 +1,6 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
-    ; GDScript: class_a.notest.gd
-    {"display": "property_of_a"},
-    {"display": "func_of_a"},
-    {"display": "signal_of_a"},
-
-    ; GDScript: identifiers.gd
+    ; GDScript: identifiers_in_function_body.gd
     {"display": "test_signal_1"},
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
@@ -22,4 +11,14 @@ include=[
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},
     {"display": "local_test_var_2"},
+
+    ; GDScript: class_a.notest.gd
+    {"display": "property_of_a", "after": true},
+    {"display": "func_of_a"},
+    {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
@@ -1,17 +1,6 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
-    ; GDScript: class_a.notest.gd
-    {"display": "property_of_a"},
-    {"display": "func_of_a"},
-    {"display": "signal_of_a"},
-
-    ; GDScript: identifiers.gd
+    ; GDScript: identifiers_in_unclosed_call.gd
     {"display": "test_signal_1"},
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
@@ -22,4 +11,14 @@ include=[
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},
     {"display": "local_test_var_2"},
+
+    ; GDScript: class_a.notest.gd
+    {"display": "property_of_a", "after": true},
+    {"display": "func_of_a"},
+    {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
@@ -1,17 +1,5 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 exclude=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-    {"display": "add_child"},
-
-    ; GDScript: class_a.notest.gd
-    {"display": "property_of_a"},
-    {"display": "func_of_a"},
-    {"display": "signal_of_a"},
-
     ; GDScript: no_completion_in_string.gd
     {"display": "test_signal_1"},
     {"display": "test_signal_2"},
@@ -23,4 +11,15 @@ exclude=[
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},
     {"display": "local_test_var_2"},
+
+    ; GDScript: class_a.notest.gd
+    {"display": "property_of_a", "after": true},
+    {"display": "func_of_a"},
+    {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
+    {"display": "add_child"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/self.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/self.cfg
@@ -1,16 +1,5 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
-    ; GDScript: class_a.notest.gd
-    {"display": "property_of_a"},
-    {"display": "func_of_a"},
-    {"display": "signal_of_a"},
-
     ; GDScript: self.gd
     {"display": "test_signal_1"},
     {"display": "test_signal_2"},
@@ -18,4 +7,14 @@ include=[
     {"display": "test_var_2"},
     {"display": "test_func_1"},
     {"display": "test_func_2"},
+
+    ; GDScript: class_a.notest.gd
+    {"display": "property_of_a", "after": true},
+    {"display": "func_of_a"},
+    {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
@@ -2,15 +2,15 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; Area2D
     {"display": "get_overlapping_areas"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
@@ -2,15 +2,15 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; Area2D
     {"display": "get_overlapping_areas"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]
 exclude=[
     ; AnimationPlayer

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
@@ -2,13 +2,13 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; AnimationPlayer
     {"display": "autoplay"},
     {"display": "play"},
     {"display": "animation_changed"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
@@ -2,15 +2,15 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; Area2D
     {"display": "get_overlapping_areas"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
@@ -2,15 +2,15 @@
 scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; Area2D
     {"display": "get_overlapping_areas"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]
 exclude=[
     ; AnimationPlayer

--- a/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
-    ; Node
-    {"display": "add_child"},
-    {"display": "owner"},
-    {"display": "child_entered_tree"},
-
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
     {"display": "func_of_a"},
     {"display": "signal_of_a"},
+
+    ; Node
+    {"display": "add_child", "after": true},
+    {"display": "owner"},
+    {"display": "child_entered_tree"},
 ]


### PR DESCRIPTION
This was an idea for the original implementation that I dropped since it wasn't a deal breaker, so I'm adding it now.

The location check in the option matching is removed since I consider the exact location values an implementation detail, also its impossible to write meaningful forward compatible tests using exact location values.

Instead options can set `after: true` which means that all previous options must have occurred before the test runner continues. (This effectively splits the list into ordered buckets, but matching inside of the buckets is unordered, does that make any sense :sweat_smile:)

I went through the existing tests and added location buckets were it made sense (mostly to split the different types in the inheritance chain), I also had to fix some small issues with the location generation that made the tests fail.

Includes the test runner changes from #94996 to reduce the risk of merge conflicts. (Support for `class_name` and muting error printing during parsing, since the test scripts may contain errors on purpose).
