### PR TITLE
Clarify the coordinate space for the bounding rectangle returned by `Label.get_character_bounds`

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -14,7 +14,7 @@
 			<return type="Rect2" />
 			<param index="0" name="pos" type="int" />
 			<description>
-				Returns the bounding rectangle of the character at position [param pos]. If the character is a non-visual character or [param pos] is outside the valid range, an empty [Rect2] is returned. If the character is a part of a composite grapheme, the bounding rectangle of the whole grapheme is returned.
+				Returns the bounding rectangle of the character at position [param pos] in the label's local coordinate system. If the character is a non-visual character or [param pos] is outside the valid range, an empty [Rect2] is returned. If the character is a part of a composite grapheme, the bounding rectangle of the whole grapheme is returned.
 			</description>
 		</method>
 		<method name="get_line_count" qualifiers="const">


### PR DESCRIPTION
This PR intends to clarify the documentation for `Label.get_character_bounds': that the coordinate space for the result bounding rectangle of the method is local.

Closes #95088
