### PR TITLE
Autocompletion: Don't use owner for inner classes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3164,7 +3164,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	HashMap<String, ScriptLanguage::CodeCompletionOption> options;
 
 	GDScriptParser::CompletionContext completion_context = parser.get_completion_context();
-	completion_context.base = p_owner;
+	if (completion_context.current_class != nullptr && completion_context.current_class->outer == nullptr) {
+		completion_context.base = p_owner;
+	}
 	bool is_function = false;
 
 	switch (completion_context.type) {


### PR DESCRIPTION
Fixes #95864

The object the script is attached to is not a valid owner of inner classes.
Edit: It might even not be a valid owner for the main class, but that would be a user error so I'll ignore it for now.

Not sure why the crash is so inconsistent, but I guess that happens when you call a method bind on an object of another type :shrug: