### PR TITLE
Fix `MeshInstance3D` gizmo redraw performance for `PlaneMesh` with larger subdiv value

### DIFF
--- a/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
@@ -33,6 +33,7 @@
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/soft_body_3d.h"
+#include "scene/resources/3d/primitive_meshes.h"
 
 MeshInstance3DGizmoPlugin::MeshInstance3DGizmoPlugin() {
 }
@@ -64,7 +65,22 @@ void MeshInstance3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		return; //none
 	}
 
-	Ref<TriangleMesh> tm = m->generate_triangle_mesh();
+	Ref<TriangleMesh> tm;
+
+	Ref<PlaneMesh> plane_mesh = mesh->get_mesh();
+	if (plane_mesh.is_valid() && (plane_mesh->get_subdivide_depth() > 0 || plane_mesh->get_subdivide_width() > 0)) {
+		// PlaneMesh subdiv makes gizmo redraw very slow due to TriangleMesh BVH calculation for every face.
+		// For gizmo collision this is very much unnecessary since a PlaneMesh is always flat, 2 faces is enough.
+		Ref<PlaneMesh> simple_plane_mesh;
+		simple_plane_mesh.instantiate();
+		simple_plane_mesh->set_orientation(plane_mesh->get_orientation());
+		simple_plane_mesh->set_size(plane_mesh->get_size());
+		simple_plane_mesh->set_center_offset(plane_mesh->get_center_offset());
+		tm = simple_plane_mesh->generate_triangle_mesh();
+	} else {
+		tm = m->generate_triangle_mesh();
+	}
+
 	if (tm.is_valid()) {
 		p_gizmo->add_collision_triangles(tm);
 	}


### PR DESCRIPTION
The `MeshInstance3D` editor gizmo had really low performance when the node had a `PlaneMesh` with larger subdiv value.

This caused noticeable editor frame stutters everytime the node was selected or unselected, the mesh was changed, or just an input happened close to the plane AABB.

E.g. a 100+ subdiv PlaneMesh for terrain / water would cause noticeable performance issues with each update. A 1000+ subdiv would freeze the entire editor for multiple seconds. With this change the update is almost instant again.

It was so slow due to every call to gizmo redraw creating a new `TriangleMesh` for the PlaneMesh gizmo collision.

The TriangleMesh did exessive BVH tree building and AABB calculations for every single mesh face and an average subdiv plane mesh had easily a few thousands of them. For a specialized Mesh type that can only be a flat plane no matter the subdiv this is totally unnecessary and 2 faces is enough for the input collision that the editor needs.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
