### PR TITLE
Add class icons to script list, separate doc list

### DIFF
--- a/editor/icons/ToolScript.svg
+++ b/editor/icons/ToolScript.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="20"><path fill="#5FB2FF" d="M18 12V20H10z"/></svg>

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -288,8 +288,13 @@ class ScriptEditor : public PanelContainer {
 	bool is_floating = false;
 	EditorHelpSearch *help_search_dialog = nullptr;
 
+	PanelContainer *script_list_container = nullptr;
 	ItemList *script_list = nullptr;
 	HSplitContainer *script_split = nullptr;
+	PanelContainer *help_header_container = nullptr;
+	TextureRect *help_icon = nullptr;
+	Label *help_header_label = nullptr;
+	ItemList *help_list = nullptr;
 	ItemList *members_overview = nullptr;
 	LineEdit *filter_scripts = nullptr;
 	LineEdit *filter_methods = nullptr;
@@ -447,7 +452,7 @@ class ScriptEditor : public PanelContainer {
 	bool _sort_list_on_update;
 
 	void _members_overview_selected(int p_idx);
-	void _script_selected(int p_idx);
+	void _script_selected(int p_idx, ItemList *p_list);
 
 	void _update_help_overview_visibility();
 	void _update_help_overview();
@@ -468,7 +473,7 @@ class ScriptEditor : public PanelContainer {
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
-	void _script_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
+	void _script_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index, ItemList *p_list);
 	void _make_script_list_context_menu();
 
 	void _help_search(const String &p_text);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -502,7 +502,11 @@ String ScriptTextEditor::get_name() {
 }
 
 Ref<Texture2D> ScriptTextEditor::get_theme_icon() {
-	if (get_parent_control()) {
+	Ref<Texture2D> icon = EditorNode::get_editor_data().get_script_icon(script);
+	if (icon.is_null()) {
+		icon = EditorNode::get_singleton()->get_class_icon(script->get_instance_base_type());
+	}
+	if (icon.is_null() && get_parent_control()) {
 		String icon_name = script->get_class();
 		if (script->is_built_in()) {
 			icon_name += "Internal";
@@ -514,8 +518,7 @@ Ref<Texture2D> ScriptTextEditor::get_theme_icon() {
 			return get_parent_control()->get_editor_theme_icon(script->get_class());
 		}
 	}
-
-	return Ref<Texture2D>();
+	return icon;
 }
 
 void ScriptTextEditor::_validate_script() {


### PR DESCRIPTION
Implements godotengine/godot-proposals#3557 (as per further suggestions in the thread [comment](https://github.com/godotengine/godot-proposals/issues/3557#issuecomment-2345515010))
Alternate to #96865 

![kuva](https://github.com/user-attachments/assets/62270c66-263d-4745-9c50-05965ce43631)

It's not perfect, but can be used to get feel how this suggestion works.