### PR TITLE
Implement optimizations to `BitMap.grow_mask`

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -613,7 +613,6 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 				// Skip until we find the circle in the distance mask
 				while (x <= x1 && !distance_mask->get_bit(x - x0, y - y0)) {
 					x++;
-					continue;
 				}
 
 				for (; x <= x1; x++) {

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -557,6 +557,18 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 		return;
 	}
 
+	// Shortcuts
+	// Request enlarges any single pixel to the full bitmap's size
+	if (p_pixels >= width && p_pixels >= height && get_true_bit_count() > 0) {
+		set_bit_rect(Rect2i(0, 0, width, height), true);
+		return;
+	}
+	// Request shrinks past any bit that could be set
+	if (p_pixels <= -width && p_pixels <= -height) {
+		set_bit_rect(Rect2i(0, 0, width, height), false);
+		return;
+	}
+
 	bool bit_value = p_pixels > 0;
 	p_pixels = Math::abs(p_pixels);
 	const int pixels2 = p_pixels * p_pixels;
@@ -568,6 +580,19 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 	copy->create(get_size());
 	copy->bitmask = bitmask;
 
+	// Pre-compute distances to avoid re-computations on every pixel
+	Ref<BitMap> distance_mask;
+	distance_mask.instantiate();
+	distance_mask->create(Size2i(p_pixels * 2 + 1, p_pixels * 2 + 1));
+
+	for (int y = 0; y < distance_mask->get_size().y; y++) {
+		for (int x = 0; x < distance_mask->get_size().x; x++) {
+			float d = Point2(p_pixels, p_pixels).distance_squared_to(Point2(x, y)) - CMP_EPSILON2;
+
+			distance_mask->set_bit(x, y, d <= pixels2);
+		}
+	}
+
 	for (int i = r.position.y; i < r.position.y + r.size.height; i++) {
 		for (int j = r.position.x; j < r.position.x + r.size.width; j++) {
 			if (bit_value == get_bit(j, i)) {
@@ -576,8 +601,13 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 
 			bool found = false;
 
-			for (int y = i - p_pixels; y <= i + p_pixels; y++) {
-				for (int x = j - p_pixels; x <= j + p_pixels; x++) {
+			const int y0 = i - p_pixels;
+			const int y1 = i + p_pixels;
+			const int x0 = j - p_pixels;
+			const int x1 = j + p_pixels;
+
+			for (int y = y0; y <= y1; y++) {
+				for (int x = x0; x <= x1; x++) {
 					bool outside = false;
 
 					if ((x < p_rect.position.x) || (x >= p_rect.position.x + p_rect.size.x) || (y < p_rect.position.y) || (y >= p_rect.position.y + p_rect.size.y)) {
@@ -589,8 +619,9 @@ void BitMap::grow_mask(int p_pixels, const Rect2i &p_rect) {
 						}
 					}
 
-					float d = Point2(j, i).distance_squared_to(Point2(x, y)) - CMP_EPSILON2;
-					if (d > pixels2) {
+					const int mask_y = y - y0;
+					const int mask_x = x - x0;
+					if (!distance_mask->get_bit(mask_x, mask_y)) {
 						continue;
 					}
 

--- a/tests/scene/test_bit_map.h
+++ b/tests/scene/test_bit_map.h
@@ -351,8 +351,9 @@ TEST_CASE("[BitMap] Grow and shrink mask") {
 
 TEST_CASE("[BitMap] Grow and shrink very large mask") {
 	const Size2i dim{ 2040, 2040 };
-	BitMap bit_map{};
-	bit_map.create(dim);
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+	bit_map->create(dim);
 
 	// Create sparse bit map that is a repetition of the given 3x3 pattern:
 	// | | | |
@@ -360,36 +361,34 @@ TEST_CASE("[BitMap] Grow and shrink very large mask") {
 	// | | | |
 	for (int x = 1; x < dim.x; x += 3) {
 		for (int y = 1; y < dim.y; y += 3) {
-			bit_map.set_bit(x, y, true);
+			bit_map->set_bit(x, y, true);
 		}
 	}
 
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 462400, "Creating a spaced grid of 3x3 cells with the center cell set in a 2040x2040 bit map should be (2040 / 3)^2=462400 bits");
-	bit_map.grow_mask(20, Rect2i(0, 0, 2040, 2040));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4161600, "Growing with size of 20 should set all bits surrounding all patterns (2040x2040=4161600) to true");
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 462400, "Creating a spaced grid of 3x3 cells with the center cell set in a 2040x2040 bit map should be (2040 / 3)^2=462400 bits");
+	bit_map->grow_mask(20, Rect2i(Point2i(), dim));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 4161600, "Growing with size of 20 should set all bits surrounding all patterns (2040x2040=4161600) to true");
 
-	reset_bit_map(bit_map);
-
+	bit_map->set_bit_rect(Rect2i(Point2i(), dim), false);
 	for (int x = 1; x < dim.x; x += 3) {
 		for (int y = 1; y < dim.y; y += 3) {
-			bit_map.set_bit(x, y, true);
+			bit_map->set_bit(x, y, true);
 		}
 	}
 
-	bit_map.grow_mask(-1, Rect2i(0, 0, 2040, 2040));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Shrinking with size of 1 should set all bits to false");
+	bit_map->grow_mask(-1, Rect2i(Point2i(), dim));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "Shrinking with size of 1 should set all bits to false");
 
-	reset_bit_map(bit_map);
-	bit_map.set_bit(1020, 1020, true); // single bit on at the center of large bitmap
+	bit_map->set_bit_rect(Rect2i(Point2i(), dim), false);
+	bit_map->set_bit(1020, 1020, true); // single bit on at the center of large bitmap
 
-	bit_map.grow_mask(2040, Rect2i(0, 0, 2040, 2040));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4161600, "Growing single bit with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
+	bit_map->grow_mask(dim.x, Rect2i(Point2i(), dim));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 4161600, "Growing single bit with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
 
-	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 2040, 2040), true); // full bitmap
+	bit_map->set_bit_rect(Rect2i(Point2i(), dim), true); // full bitmap
 
-	bit_map.grow_mask(-2040, Rect2i(0, 0, 2040, 2040));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Shrinking full bitmap with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
+	bit_map->grow_mask(-dim.x, Rect2i(Point2i(), dim));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "Shrinking full bitmap with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
 }
 
 TEST_CASE("[BitMap] Blit") {

--- a/tests/scene/test_bit_map.h
+++ b/tests/scene/test_bit_map.h
@@ -349,6 +349,49 @@ TEST_CASE("[BitMap] Grow and shrink mask") {
 	CHECK_MESSAGE(bit_map.get_bitv(Point2i(131, 131)) == false, "Bits that are on the edge of the shape should be set to false");
 }
 
+TEST_CASE("[BitMap] Grow and shrink very large mask") {
+	const Size2i dim{ 2040, 2040 };
+	BitMap bit_map{};
+	bit_map.create(dim);
+
+	// Create sparse bit map that is a repetition of the given 3x3 pattern:
+	// | | | |
+	// | |X| |
+	// | | | |
+	for (int x = 1; x < dim.x; x += 3) {
+		for (int y = 1; y < dim.y; y += 3) {
+			bit_map.set_bit(x, y, true);
+		}
+	}
+
+	CHECK_MESSAGE(bit_map.get_true_bit_count() == 462400, "Creating a spaced grid of 3x3 cells with the center cell set in a 2040x2040 bit map should be (2040 / 3)^2=462400 bits");
+	bit_map.grow_mask(20, Rect2i(0, 0, 2040, 2040));
+	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4161600, "Growing with size of 20 should set all bits surrounding all patterns (2040x2040=4161600) to true");
+
+	reset_bit_map(bit_map);
+
+	for (int x = 1; x < dim.x; x += 3) {
+		for (int y = 1; y < dim.y; y += 3) {
+			bit_map.set_bit(x, y, true);
+		}
+	}
+
+	bit_map.grow_mask(-1, Rect2i(0, 0, 2040, 2040));
+	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Shrinking with size of 1 should set all bits to false");
+
+	reset_bit_map(bit_map);
+	bit_map.set_bit(1020, 1020, true); // single bit on at the center of large bitmap
+
+	bit_map.grow_mask(2040, Rect2i(0, 0, 2040, 2040));
+	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4161600, "Growing single bit with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
+
+	reset_bit_map(bit_map);
+	bit_map.set_bit_rect(Rect2i(0, 0, 2040, 2040), true); // full bitmap
+
+	bit_map.grow_mask(-2040, Rect2i(0, 0, 2040, 2040));
+	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Shrinking full bitmap with size of 2040 on a bitmap of 2040x2040 should set all bits to true");
+}
+
 TEST_CASE("[BitMap] Blit") {
 	Point2i blit_pos{ 128, 128 };
 	Point2i bit_map_size{ 256, 256 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This patch is a continuation of #96885, and includes two changes to `BitMap::grow_mask`:

1. Pre-computation of distances via an intermediary `BitMap` mask before the sweep process;
2. Two logical shortcuts that arise from growing/shrinking masks past the width/height of the `BitMap`, which avoids both computing very large distance masks and the process of sweeping pixels thereafter.

The logical shortcuts are so:

1. If the request is to grow by an amount greater than both the `width`/`height` of the `BitMap`, any set pixel would grow to fill the entire image, and can be replaced with an appropriate `set_bit_rect(full_area, true)`;
2. If the request is to shrink by an amount greater than both the `width`/`height` of the `BitMap`, all set pixels would be erased, and can be replaced with `set_bit_rect(full_area, false)`.

Both of these shortcut checks could be decreased to `width / 2`/`height / 2`, but I opted for a conservative number that is logically safe if width and height are either even or odd.

The changes also include a new unit test to test the behavior of inflating/shrinking the mask by the `BitMap`'s size, as well as the distance mask optimization behavior.

In my preliminary tests the optimization leads to about 30% performance gains in cases where the radii of expansion is 40 on a 2040x2040 image (20s down from 30s on my AMD 3600X), but since that involved timing things with an external stopwatch manually the actual performance gains might be different, but should still be measurable.