### PR TITLE
WorkerThreadPool: Revamp interaction with ScriptServer

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -323,8 +323,6 @@ WorkerThreadPool::TaskID WorkerThreadPool::add_native_task(void (*p_func)(void *
 }
 
 WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description) {
-	ERR_FAIL_COND_V_MSG(threads.is_empty(), INVALID_TASK_ID, "Can't add a task because the WorkerThreadPool is either not initialized yet or already terminated.");
-
 	task_mutex.lock();
 	// Get a free task
 	Task *task = task_allocator.alloc();
@@ -543,7 +541,6 @@ void WorkerThreadPool::notify_yield_over(TaskID p_task_id) {
 }
 
 WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description) {
-	ERR_FAIL_COND_V_MSG(threads.is_empty(), INVALID_TASK_ID, "Can't add a group task because the WorkerThreadPool is either not initialized yet or already terminated.");
 	ERR_FAIL_COND_V(p_elements < 0, INVALID_TASK_ID);
 	if (p_tasks < 0) {
 		p_tasks = MAX(1u, threads.size());
@@ -755,5 +752,5 @@ WorkerThreadPool::WorkerThreadPool() {
 }
 
 WorkerThreadPool::~WorkerThreadPool() {
-	DEV_ASSERT(threads.size() == 0 && "finish() hasn't been called!");
+	finish();
 }

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -124,7 +124,10 @@ private:
 	};
 
 	TightLocalVector<ThreadData> threads;
-	bool exit_threads = false;
+	enum Runlevel {
+		RUNLEVEL_NORMAL,
+		RUNLEVEL_EXIT,
+	} runlevel = RUNLEVEL_NORMAL;
 
 	HashMap<Thread::ID, int> thread_ids;
 	HashMap<
@@ -192,6 +195,9 @@ private:
 	};
 
 	void _wait_collaboratively(ThreadData *p_caller_pool_thread, Task *p_task);
+
+	void _switch_runlevel(Runlevel p_runlevel);
+	bool _handle_runlevel();
 
 #ifdef THREADS_ENABLED
 	static uint32_t _thread_enter_unlock_allowance_zone(THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &p_ulock);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -107,6 +107,8 @@ static Time *_time = nullptr;
 static core_bind::Geometry2D *_geometry_2d = nullptr;
 static core_bind::Geometry3D *_geometry_3d = nullptr;
 
+static WorkerThreadPool *worker_thread_pool = nullptr;
+
 extern Mutex _global_mutex;
 
 static GDExtensionManager *gdextension_manager = nullptr;
@@ -295,6 +297,8 @@ void register_core_types() {
 	GDREGISTER_NATIVE_STRUCT(AudioFrame, "float left;float right");
 	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
 
+	worker_thread_pool = memnew(WorkerThreadPool);
+
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Types");
 }
 
@@ -345,7 +349,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", WorkerThreadPool::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));
 
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Singletons");
 }
@@ -377,6 +381,8 @@ void unregister_core_types() {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Unregister Types");
 
 	// Destroy singletons in reverse order to ensure dependencies are not broken.
+
+	memdelete(worker_thread_pool);
 
 	memdelete(_engine_debugger);
 	memdelete(_marshalls);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4501,6 +4501,8 @@ void Main::cleanup(bool p_force) {
 	ResourceLoader::clear_translation_remaps();
 	ResourceLoader::clear_path_remaps();
 
+	WorkerThreadPool::get_singleton()->exit_languages_threads();
+
 	ScriptServer::finish_languages();
 
 	// Sync pending commands that may have been queued from a different thread during ScriptServer finalization

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -140,7 +140,6 @@ static Engine *engine = nullptr;
 static ProjectSettings *globals = nullptr;
 static Input *input = nullptr;
 static InputMap *input_map = nullptr;
-static WorkerThreadPool *worker_thread_pool = nullptr;
 static TranslationServer *translation_server = nullptr;
 static Performance *performance = nullptr;
 static PackedData *packed_data = nullptr;
@@ -691,8 +690,6 @@ Error Main::test_setup() {
 
 	register_core_settings(); // Here globals are present.
 
-	worker_thread_pool = memnew(WorkerThreadPool);
-
 	translation_server = memnew(TranslationServer);
 	tsman = memnew(TextServerManager);
 
@@ -803,8 +800,6 @@ void Main::test_cleanup() {
 	ResourceSaver::remove_custom_savers();
 	PropertyListHelper::clear_base_helpers();
 
-	WorkerThreadPool::get_singleton()->finish();
-
 #ifdef TOOLS_ENABLED
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_EDITOR);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_EDITOR);
@@ -845,9 +840,6 @@ void Main::test_cleanup() {
 #endif // _3D_DISABLED
 	if (physics_server_2d_manager) {
 		memdelete(physics_server_2d_manager);
-	}
-	if (worker_thread_pool) {
-		memdelete(worker_thread_pool);
 	}
 	if (globals) {
 		memdelete(globals);
@@ -939,7 +931,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	register_core_settings(); //here globals are present
 
-	worker_thread_pool = memnew(WorkerThreadPool);
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);
 	GDREGISTER_CLASS(Performance);
@@ -2628,10 +2619,6 @@ error:
 	}
 	if (translation_server) {
 		memdelete(translation_server);
-	}
-	if (worker_thread_pool) {
-		worker_thread_pool->finish();
-		memdelete(worker_thread_pool);
 	}
 	if (globals) {
 		memdelete(globals);
@@ -4514,8 +4501,6 @@ void Main::cleanup(bool p_force) {
 	ResourceLoader::clear_translation_remaps();
 	ResourceLoader::clear_path_remaps();
 
-	WorkerThreadPool::get_singleton()->finish();
-
 	ScriptServer::finish_languages();
 
 	// Sync pending commands that may have been queued from a different thread during ScriptServer finalization
@@ -4605,9 +4590,6 @@ void Main::cleanup(bool p_force) {
 #endif // _3D_DISABLED
 	if (physics_server_2d_manager) {
 		memdelete(physics_server_2d_manager);
-	}
-	if (worker_thread_pool) {
-		memdelete(worker_thread_pool);
 	}
 	if (globals) {
 		memdelete(globals);


### PR DESCRIPTION
First, this reverts 2d1dd41ef5dcb51ddb607ba572e63b605b9191be from #96760. The approach there is not enough, given that with separate thread rendering, there's a cyclic dependency chain on shutdown:
- `WorkerThreadPool` must finish before `ScriptServer`.
- `RenderingServer` must finish before `WorkerThreadPool`.
- `ScriptServer` must finish before `RenderingServer`.

A way of breaking the cycle, which this PR implements, is splitting `WorkerThreadPool` regular lifetime into ~two~ three🆕 "runlevels":
- One that works as usual.
- One that waits until all the threads are idle, with no more tasks queued, plus adding more tasks blocked (not rejected, just they have to wait). 🆕
- One that also works normally, but where languages have already been terminated.

I've put the pure refactor into its own commit, which would help a lot for bisect and also for easier reviewing.

It should still fix #95809 (CC @CedNaru).

Fixes #96931.
Fixes #96978. 🆕
Fixes #97073. 🆕🆕

---

**Cherry-picking note:** We don't have `MutexLock::temp_unlock()`/`temp_relock()` in 4.3. Therefore, the most recent commit in this PR needs to have the following patch applied:
```diff
diff --git a/core/object/worker_thread_pool.cpp b/core/object/worker_thread_pool.cpp
index 37a605cb10..2f0e3d4c2a 100644
+++ b/core/object/worker_thread_pool.cpp
@@ -233,11 +233,11 @@ void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high
        // in custom builds.
        bool process_on_calling_thread = threads.size() == 0;
        if (process_on_calling_thread) {
-               p_lock.temp_unlock();
+               task_mutex.unlock();
                for (uint32_t i = 0; i < p_count; i++) {
                        _process_task(p_tasks[i]);
                }
-               p_lock.temp_relock();
+               task_mutex.lock();
                return;
        }

@@ -576,9 +576,9 @@ bool WorkerThreadPool::_handle_runlevel(ThreadData *p_thread_data, MutexLock<Bin
                } break;
                case RUNLEVEL_EXIT_LANGUAGES: {
                        if (!p_thread_data->exited_languages) {
-                               p_lock.temp_unlock();
+                               task_mutex.unlock();
                                ScriptServer::thread_exit();
-                               p_lock.temp_relock();
+                               task_mutex.lock();
                                p_thread_data->exited_languages = true;
                                runlevel_data.exit_languages.num_exited_threads++;
                                control_cond_var.notify_all();
```