### PR TITLE
Style: Consolidate & migrate GDScript `.editorconfig`

### DIFF
--- a/modules/gdscript/.editorconfig
+++ b/modules/gdscript/.editorconfig
@@ -1,8 +1,3 @@
 [*.gd]
-indent_style = tab
 indent_size = 4
-insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.out]
-insert_final_newline = true

--- a/modules/gdscript/tests/scripts/.editorconfig
+++ b/modules/gdscript/tests/scripts/.editorconfig
@@ -1,0 +1,12 @@
+# This file is required to workaround `.editorconfig` autogeneration (see #96845).
+
+# Some tests handle invalid syntax deliberately; exclude relevant attributes.
+
+[parser/features/mixed_indentation_on_blank_lines.gd]
+trim_trailing_whitespace = false
+
+[parser/warnings/empty_file_newline.notest.gd]
+insert_final_newline = false
+
+[parser/warnings/empty_file_newline_comment.notest.gd]
+insert_final_newline = false

--- a/modules/gdscript/tests/scripts/parser/.editorconfig
+++ b/modules/gdscript/tests/scripts/parser/.editorconfig
@@ -1,2 +1,0 @@
-[*.{gd,out}]
-trim_trailing_whitespace = false


### PR DESCRIPTION
- Related: #96845

The above PR introduced [an issue](https://github.com/godotengine/godot/pull/96845#issuecomment-2344006884) where running GDScript tests will create a `.editorconfig` file in `modules/gdscript/tests/scripts/`. While it could be added as an ignored item in the local `.gitignore`, the generated file defines `root = true`, so all other config options would be erroneously discarded.

This fixes the issue by making use of the new intended behavior: a pre-existing `.editorconfig`. While a blank file would work, it felt much more appropriate to coincide this a minor style cleanup of the `.editorconfig` files already in the GDScript module. So now, rather than going from 2→3 files, we're going from 2→1, as all the relevant attributes can be safely handled in a single file (only `.gd`/`.out` were given attributes, and they're exclusively found in the test project itself).
