### PR TITLE
Style: Change hardcoded template `crlf` to `lf`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@ thirdparty/* linguist-vendored
 *.bat eol=crlf
 *.sln eol=crlf
 *.csproj eol=crlf
-misc/msvs/*.template eol=crlf
 # And some test files where the EOL matters
 *.test.txt -text
 

--- a/misc/scripts/file_format.py
+++ b/misc/scripts/file_format.py
@@ -23,7 +23,7 @@ for file in sys.argv[1:]:
     if original == "":
         continue
 
-    EOL = "\r\n" if file.endswith((".csproj", ".sln", ".bat")) or file.startswith("misc/msvs") else "\n"
+    EOL = "\r\n" if file.endswith((".csproj", ".sln", ".bat")) else "\n"
     WANTS_BOM = file.endswith((".csproj", ".sln"))
 
     revamp = EOL.join([line.rstrip("\n\r\t ") for line in original.splitlines(True)]).rstrip(EOL) + EOL


### PR DESCRIPTION
Looked more into the `crlf` exception for msvs templates, as it turned out to be superficial. Those files are parsed and written with `\r\n` newlines explicitly, so the eol of the original file is ultimately irrelevant. As such, this removes the workaround conditionals in `file_format.py` & the eol setting in `.gitattributes`. As far as git is concerned, the files are already using `lf` eol internally, so they didn't need to be converted from `crlf` in this PR.