### PR TITLE
Change "deconstructor" to "destructor" in `NOTIFICATION_PREDELETE` docs

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1121,7 +1121,7 @@
 			Notification received when the object is initialized, before its script is attached. Used internally.
 		</constant>
 		<constant name="NOTIFICATION_PREDELETE" value="1">
-			Notification received when the object is about to be deleted. Can act as the deconstructor of some programming languages.
+			Notification received when the object is about to be deleted. Can be used like destructors in object-oriented programming languages.
 		</constant>
 		<constant name="NOTIFICATION_EXTENSION_RELOADED" value="2">
 			Notification received when the object finishes hot reloading. This notification is only sent for extensions classes and derived.


### PR DESCRIPTION
This is probably a bit nitpicky and unnecessary, but as far as I can see, every seemingly reliable sources refer to this concept
as a "destructor" rather than a "deconstructor", including the [Wikipedia page title](https://en.wikipedia.org/wiki/Destructor_(computer_programming)). "Deconstructor" seems very rarely used and is considered incorrect by some.