### PR TITLE
Fix `editor_doc_cache` locked by `adb` process on editor startup

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -294,7 +294,9 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 
 		// Check for devices updates
 		String adb = get_adb_path();
-		if (ea->has_runnable_preset.is_set() && FileAccess::exists(adb)) {
+		// adb.exe was locking the editor_doc_cache file on startup. Adding a check for is_editor_ready provides just enough time
+		// to regenerate the doc cache.
+		if (ea->has_runnable_preset.is_set() && FileAccess::exists(adb) && EditorNode::get_singleton()->is_editor_ready()) {
 			String devices;
 			List<String> args;
 			args.push_back("devices");


### PR DESCRIPTION
- Fixes #96798

I was able to reproduce the problem consistently under the following conditions:
- The Godot Editor can be either self-contained or not.
- Android Export needs to be configured in the Editor Settings.
- The project must have an Android Export setup.
- There needs to be an older version of `editor_doc_cache-4.4.res` in the cache folder:
  - Not self-contained: `C:\Users\[user]\AppData\Local\Godot`
  - Self-contained: `[editorpath]\editor_data\cache`
- Start the project. While adb is running, the EditorHelp tries to rewrite the `editor_doc_cache-4.4.res` on disk and fails.

I tried reproducing the problem by starting adb in a loop in PowerShell and writing to `editor_doc_cache-4.4.res` in another PowerShell script but was never able to trigger the issue. I also changed the working directory when starting `adb.exe` in `OS_Windows::execute` without success. I still don't understand why adb locks this particular file only when started from Godot.

The fix was to postpone the first adb call until after the first scan is completed by adding a check for `EditorNode::get_singleton()->is_editor_ready()` in `EditorExportPlatformAndroid::_check_for_changes_poll_thread`. In any case, it wasn't particularly useful to call adb so early, even before the editor is ready.

Here is a small MRP project I used to reproduce the issue:
[test-godot-export-android.zip](https://github.com/user-attachments/files/17002646/test-godot-export-android.zip)
