### PR TITLE
Fix FileDialog default size

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -151,6 +151,7 @@
 			If [code]true[/code], the dialog will show hidden files.
 			[b]Note:[/b] This property is ignored by native file dialogs on Linux.
 		</member>
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" overrides="Window" default="Vector2i(640, 360)" />
 		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Save a File&quot;" />
 		<member name="use_native_dialog" type="bool" setter="set_use_native_dialog" getter="get_use_native_dialog" default="false">
 			If [code]true[/code], [member access] is set to [constant ACCESS_FILESYSTEM], and it is supported by the current [DisplayServer], OS native dialog will be used instead of custom one.

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1526,6 +1526,7 @@ FileDialog::FileDialog() {
 	update_dir();
 
 	set_hide_on_ok(false);
+	set_size(Size2(640, 360));
 
 	if (register_func) {
 		register_func(this);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/58780

Before: 
![Screenshot_20240914_132037](https://github.com/user-attachments/assets/5e0e0aec-a2f4-439c-9a02-e0d8ca6b5b70)


After:
![Screenshot_20240914_161601](https://github.com/user-attachments/assets/bed227a2-b6bf-4cb8-85d9-ab41767aea38)


