### PR TITLE
Fix Vulkan Instance initialized twice in ProjectDialog

### DIFF
--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1224,6 +1224,11 @@ void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_i
 
 bool DisplayServer::can_create_rendering_device() {
 #if defined(RD_ENABLED)
+	RenderingDevice *device = RenderingDevice::get_singleton();
+	if (device) {
+		return true;
+	}
+
 	Error err;
 	RenderingContextDriver *rcd = nullptr;
 


### PR DESCRIPTION
Fixes #96722

I refactored a bit to be able to share as much code as possible with other systems that create a local device,

I first wanted to replace the `create_local_rendering_device()`, but since it's apparently used in GDScript, I did not know if it was possible to pass pointer reference arguments.

Note: this does not fix the leak that still exists in `create_local_rendering_device()`: #71003