### PR TITLE
Implement StaticBlockAllocator for HashMap, List, RBMap, RBSet.

### DIFF
--- a/core/os/block_allocator.cpp
+++ b/core/os/block_allocator.cpp
@@ -1,0 +1,115 @@
+/**************************************************************************/
+/*  block_allocator.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "block_allocator.h"
+
+#include "core/os/memory.h"
+
+uint32_t BlockAllocator::get_total_blocks() {
+	return blocks_count;
+}
+
+void BlockAllocator::init(uint32_t p_structure_size, uint32_t p_start_size) {
+	ERR_FAIL_COND_MSG(is_initialized(), "Allocator is in use!!!");
+	if (p_structure_size < sizeof(FreeListElement)) {
+		structure_size = sizeof(FreeListElement);
+	} else {
+		structure_size = p_structure_size;
+	}
+	cur_block_size = p_start_size;
+	allocate_new_block(p_start_size);
+}
+
+void *BlockAllocator::alloc() {
+	void *pointer = 0;
+	uint8_t *block = blocks[blocks_count - 1];
+	size_t left = current_pointer - block;
+	total_elements++;
+	if (free_list != nullptr) {
+		pointer = free_list;
+		free_list = free_list->next;
+		return pointer;
+	}
+
+	if (unlikely(left >= cur_block_size * (size_t)structure_size)) {
+		cur_block_size = cur_block_size > 1 ? cur_block_size * 1.5f : 2;
+		allocate_new_block(cur_block_size);
+	}
+	pointer = current_pointer;
+	current_pointer += structure_size;
+
+	return pointer;
+}
+
+uint32_t BlockAllocator::get_blocks_capacity(uint32_t p_blocks_size) {
+	return next_power_of_2(p_blocks_size);
+}
+
+void BlockAllocator::allocate_new_block(size_t p_block_size) {
+	uint32_t blocks_capacity = get_blocks_capacity(blocks_count);
+	blocks_count++;
+	if (blocks_count > blocks_capacity) {
+		blocks = reinterpret_cast<uint8_t **>(memrealloc(blocks, get_blocks_capacity(blocks_count) * sizeof(uint8_t *)));
+	}
+	blocks[blocks_count - 1] = reinterpret_cast<uint8_t *>(memalloc(cur_block_size * (size_t)structure_size));
+	current_pointer = blocks[blocks_count - 1];
+}
+
+size_t BlockAllocator::get_total_elements() {
+	return total_elements;
+}
+
+uint32_t BlockAllocator::get_structure_size() {
+	return structure_size;
+}
+
+void BlockAllocator::free(void *p_ptr) {
+	FreeListElement *new_head = (FreeListElement *)p_ptr;
+	new_head->next = free_list;
+	free_list = new_head;
+	total_elements--;
+}
+
+void BlockAllocator::reset() {
+	if (blocks == nullptr) {
+		return;
+	}
+	for (uint32_t i = 0; i < blocks_count; i++) {
+		memfree(blocks[i]);
+	}
+	memfree(blocks);
+	blocks_count = 0;
+	blocks = nullptr;
+	free_list = nullptr;
+}
+
+BlockAllocator::~BlockAllocator() {
+	reset();
+}

--- a/core/os/static_block_allocator.cpp
+++ b/core/os/static_block_allocator.cpp
@@ -1,0 +1,175 @@
+/**************************************************************************/
+/*  static_block_allocator.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "static_block_allocator.h"
+
+#include "core/os/block_allocator.h"
+#include "core/os/os.h"
+#include "core/os/thread.h"
+#include "core/templates/a_hash_map.h"
+
+typedef AHashMap<int64_t, int64_t> SizeToIdMap;
+
+struct alignas(Thread::CACHE_LINE_BYTES) ThreadData {
+	LocalVector<BlockAllocator> allocs;
+	SpinLock mtx;
+	SizeToIdMap size_to_id = SizeToIdMap(32);
+};
+
+uint32_t total_num_allocators;
+int physics_threads_count;
+ThreadData *threads_data = nullptr;
+bool is_set_num_threads_by_OS = false;
+
+int32_t StaticBlockAllocator::_get_thread_id() {
+	return (Thread::get_caller_id() - Thread::MAIN_ID) % physics_threads_count;
+}
+
+int64_t StaticBlockAllocator::_create_id(int32_t p_size_pos, int32_t p_thread_id) {
+	union {
+		int64_t id;
+		struct {
+			int32_t pos;
+			int32_t thread_id;
+		};
+	} id_data;
+	id_data.pos = p_size_pos;
+	id_data.thread_id = p_thread_id;
+	return id_data.id;
+}
+
+void StaticBlockAllocator::_get_from_id(int64_t p_id, int32_t &r_size_pos, int32_t &r_thread_id) {
+	union {
+		int64_t id;
+		struct {
+			int32_t pos;
+			int32_t thread_id;
+		};
+	} id_data;
+	id_data.id = p_id;
+	r_size_pos = id_data.pos;
+	r_thread_id = id_data.thread_id;
+}
+
+void StaticBlockAllocator::_init() {
+	physics_threads_count = 1;
+	threads_data = (ThreadData *)Memory::alloc_aligned_static(sizeof(ThreadData), Thread::CACHE_LINE_BYTES);
+	memnew_placement(threads_data, ThreadData);
+}
+
+int64_t StaticBlockAllocator::_get_allocator_id_for_size(size_t p_size) {
+	if (unlikely(!is_set_num_threads_by_OS)) {
+		if (threads_data == nullptr) {
+			_init();
+		}
+		if (OS::get_singleton() != nullptr) {
+			physics_threads_count = OS::get_singleton()->get_processor_count();
+			if (physics_threads_count > 1) {
+				threads_data = (ThreadData *)Memory::realloc_aligned_static(threads_data, physics_threads_count * sizeof(ThreadData), sizeof(ThreadData), Thread::CACHE_LINE_BYTES);
+				for (int i = 1; i < physics_threads_count; i++) {
+					memnew_placement(&threads_data[i], ThreadData);
+				}
+			}
+			is_set_num_threads_by_OS = true;
+		}
+	}
+	int32_t thread_id = _get_thread_id();
+	ThreadData &t = threads_data[thread_id];
+	t.mtx.lock();
+	BlockAllocator *ptr = t.allocs.ptr();
+
+	int index = t.size_to_id.get_index(p_size);
+	int64_t pos = -1;
+
+	if (index != -1) {
+		pos = t.size_to_id.get_by_index(index).value;
+	}
+
+	if (unlikely(index == -1)) {
+		((SafeNumeric<uint32_t> *)(&total_num_allocators))->increment();
+		pos = t.allocs.size();
+		t.allocs.push_back(BlockAllocator());
+		t.allocs[pos].init(p_size, 8);
+		t.size_to_id.insert_new(p_size, pos);
+	} else if (!ptr[pos].is_initialized()) {
+		((SafeNumeric<uint32_t> *)(&total_num_allocators))->increment();
+		ptr[pos].init(p_size, 1);
+	}
+	int64_t id = _create_id(pos, thread_id);
+	t.mtx.unlock();
+	return id;
+}
+
+int64_t StaticBlockAllocator::get_allocator_id_for_size(size_t p_size) {
+	uint64_t pos = _get_allocator_id_for_size(p_size);
+	return pos;
+}
+
+void *StaticBlockAllocator::allocate_by_id(int64_t p_id) {
+	int32_t pos, thread_id;
+	_get_from_id(p_id, pos, thread_id);
+	ThreadData &t = threads_data[thread_id];
+	BlockAllocator &b_allocator = t.allocs.ptr()[pos];
+	t.mtx.lock();
+	if (unlikely(!b_allocator.is_initialized())) {
+		((SafeNumeric<uint32_t> *)(&total_num_allocators))->increment();
+		b_allocator.init(b_allocator.get_structure_size(), 1);
+	}
+	void *ret = b_allocator.alloc();
+	t.mtx.unlock();
+	return ret;
+}
+
+void StaticBlockAllocator::free_by_id(int64_t p_id, void *p_ptr) {
+	int32_t pos, thread_id;
+	_get_from_id(p_id, pos, thread_id);
+	ThreadData &t = threads_data[thread_id];
+	t.mtx.lock();
+	DEV_ASSERT(!(pos >= (int32_t)t.allocs.size() || !t.allocs.ptr()[pos].is_initialized()));
+	BlockAllocator &b_allocator = t.allocs.ptr()[pos];
+	b_allocator.free(p_ptr);
+
+	if (likely(b_allocator.get_total_elements() != 0)) {
+		t.mtx.unlock();
+		return;
+	}
+	b_allocator.reset();
+	if (unlikely(((SafeNumeric<uint32_t> *)(&total_num_allocators))->decrement() == 0)) {
+		t.mtx.unlock();
+		for (int i = 0; i < physics_threads_count; i++) {
+			threads_data[i].~ThreadData();
+		}
+		Memory::free_aligned_static(threads_data);
+		threads_data = nullptr;
+		is_set_num_threads_by_OS = false;
+		return;
+	}
+	t.mtx.unlock();
+}

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
-#include "core/os/memory.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_list.h"
+#include "core/templates/typed_static_block_allocator.h"
 
 #include <initializer_list>
 
@@ -64,7 +64,7 @@ struct HashMapElement {
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>,
-		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
+		typename Allocator = TypedStaticBlockAllocator<HashMapElement<TKey, TValue>>>
 class HashMap : private Allocator {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -33,6 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/os/memory.h"
 #include "core/templates/sort_list.h"
+#include "core/templates/typed_static_block_allocator.h"
 
 #include <initializer_list>
 
@@ -221,6 +222,7 @@ public:
 #endif
 private:
 	struct _Data {
+		TypedStaticBlockAllocator<Element> a;
 		Element *first = nullptr;
 		Element *last = nullptr;
 		int size_cache = 0;
@@ -245,7 +247,7 @@ private:
 				p_I->next_ptr->prev_ptr = p_I->prev_ptr;
 			}
 
-			memdelete_allocator<Element, A>(p_I);
+			a.delete_allocation(p_I);
 			size_cache--;
 
 			return true;
@@ -294,7 +296,7 @@ public:
 			_data->size_cache = 0;
 		}
 
-		Element *n = memnew_allocator(Element, A);
+		Element *n = _data->a.new_allocation();
 		n->value = (T &)value;
 
 		n->prev_ptr = _data->last;
@@ -333,7 +335,7 @@ public:
 			_data->size_cache = 0;
 		}
 
-		Element *n = memnew_allocator(Element, A);
+		Element *n = _data->a.new_allocation();
 		n->value = (T &)value;
 		n->prev_ptr = nullptr;
 		n->next_ptr = _data->first;
@@ -367,7 +369,7 @@ public:
 			return push_back(p_value);
 		}
 
-		Element *n = memnew_allocator(Element, A);
+		Element *n = _data->a.new_allocation();
 		n->value = (T &)p_value;
 		n->prev_ptr = p_element;
 		n->next_ptr = p_element->next_ptr;
@@ -393,7 +395,7 @@ public:
 			return push_back(p_value);
 		}
 
-		Element *n = memnew_allocator(Element, A);
+		Element *n = _data->a.new_allocation();
 		n->value = (T &)p_value;
 		n->prev_ptr = p_element->prev_ptr;
 		n->next_ptr = p_element;

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #include "core/error/error_macros.h"
-#include "core/os/memory.h"
 #include "core/templates/pair.h"
+#include "core/templates/typed_static_block_allocator.h"
 
 #include <initializer_list>
 
@@ -196,6 +196,7 @@ private:
 	struct _Data {
 		Element *_root = nullptr;
 		Element *_nil = nullptr;
+		TypedStaticBlockAllocator<Element> element_alloc;
 		int size_cache = 0;
 
 		_FORCE_INLINE_ _Data() {
@@ -209,14 +210,14 @@ private:
 		}
 
 		void _create_root() {
-			_root = memnew_allocator(Element(KeyValue<K, V>(K(), V())), A);
+			_root = element_alloc.new_allocation(Element(KeyValue<K, V>(K(), V())));
 			_root->parent = _root->left = _root->right = _nil;
 			_root->color = BLACK;
 		}
 
 		void _free_root() {
 			if (_root) {
-				memdelete_allocator<Element, A>(_root);
+				element_alloc.delete_allocation(_root);
 				_root = nullptr;
 			}
 		}
@@ -425,7 +426,7 @@ private:
 		}
 
 		typedef KeyValue<K, V> KV;
-		Element *new_node = memnew_allocator(Element(KV(p_key, p_value)), A);
+		Element *new_node = _data.element_alloc.new_allocation(Element(KV(p_key, p_value)));
 		new_node->parent = new_parent;
 		new_node->right = _data._nil;
 		new_node->left = _data._nil;
@@ -561,7 +562,7 @@ private:
 			p_node->_prev->_next = p_node->_next;
 		}
 
-		memdelete_allocator<Element, A>(p_node);
+		_data.element_alloc.delete_allocation(p_node);
 		_data.size_cache--;
 		ERR_FAIL_COND(_data._nil->color == RED);
 	}
@@ -586,7 +587,7 @@ private:
 
 		_cleanup_tree(p_element->left);
 		_cleanup_tree(p_element->right);
-		memdelete_allocator<Element, A>(p_element);
+		_data.element_alloc.delete_allocation(p_element);
 	}
 
 	void _copy_from(const RBMap &p_map) {


### PR DESCRIPTION
# About this PR
This PR improves performance and reduces RAM usage of the entire engine where `HashMap`, `List`, `RBMap`, `RBSet` are used. I implemented new `StaticBlockAllocator` for such structures as `HashMap`, `List`, `RBMap`, `RBSet`. I have also implemented a `BlockAllocator` which is used by `StaticBlockAllocator`.
 
# How elements in structures allocated?
Structures like `HashMap`, `List`, `RBMap`, `RBSet` currently use `malloc` which is wraped into `Memory` class for allocate and free memory for a new element. As many know this allocator is a general purpose allocator. For these data structures, for each element, `malloc` allocates a lot of metadata and also allocates a little more space than we asked for in case we want to use realloc. That is, if we want to allocate 16 bytes of data, malloc will allocate 32 of which 8 bytes will go to store the size we allocated and 8 bytes for the `realloc`. It is obvious that we are not going to allocate more than what is allocated to the List element.

<img src="https://github.com/user-attachments/assets/7ae8958a-644f-4ea3-aa93-7fcc2dfd3509" width="640" height="360">

Memory means class `Memory` from core.

# Custom allocators
The solution to this is to use custom allocators. Currently, godot uses PagedAllocator for RID allocation and for some HashMap. But this allocator is bad as the default allocator in that it needs to be initialized for each new instance, and the allocator itself weighs a lot, so it will not be suitable for scene use, since the nodes will weigh twice as much, and adding the first element to the Node will last a long.

So for default it turned out to be best to implement a static allocator that would have its own PagedAllocator for each element size. It turns out that PagedAllocator is not suitable for these purposes. So I used my BlockAllocator.

# What is BlockAllocator?
BlockAllocator is a hybrid of PagedAllocator and StackAllocator. I created it about half a year ago as my first allocator. If an element is deleted, it is written to the free_list. This list is stored in place of deleted items, which saves a lot of memory. Until the size of deleted list is not equal to 0, then the pointer of our allocator will not move further. With each new page, the page size is doubled. It turned out to be even better than PagedAllocator.

<img src="https://github.com/user-attachments/assets/2972dfc9-7f7e-4be8-8251-cefb238065b0" width="640" height="360">

**How free and alloc works.**

<img src="https://github.com/user-attachments/assets/b42b8936-8f68-4077-9672-79564d5ec619" width="640" height="360">

**How blocks of blocks are interconnected.**

<img src="https://github.com/user-attachments/assets/4349c50d-6c22-40c0-9021-01f7eb09f1f0" width="640" height="250">

# What is StaticBlockAllocator?
`StaticBlockAllocator` is a static allocator. It allocates to our size an id that we use to allocate and free data. When requesting an ID, the allocator checks whether it has an allocator of the required size. If there is none, then he creates it. This allocator for each thread has its own array of `BlockAllocator`, with unique sizes. If two threads use size 32 in two different threads, two allocators with that size will be created separately.

<img src="https://github.com/user-attachments/assets/6468bc1a-e8bd-408a-82dc-5847d56a2c09" width="640" height="360">

# What is TypedStaticBlockAllocator?
This is the final templated allocator for our structures. It weighs 8 bytes and stores the id provided by `StaticBlockAllocator`. According to this id, it allocates and frees data. Also calls the constructor and destructor for our classes.

# Performance Tests

Let's start by testing List\<int>.

Master branch:malloc implementation List\<int> 10 000 000 elements.
- Time insert: 236674 usec
- Time iteration: 39287 usec
- Time clear: 141672 usec 
- Time total: 417736 usec 

TypedStaticBlockAllocator:
- Time insert:     141104 usec
- Time iteration: 25416 usec
- Time clear:      76181 usec
- Time total:       242765 usec

Direct Usage BlockAllocator:
- Time insert:     96636 usec
- Time iteration: 26894 usec
- Time clear:      39474 usec
- Time total:       163112 usec

Direct Usage PagedAllocator:
- Time insert: 106321 usec
- Time iteration: 31373 usec
- Time clear: 59099 usec
- Time total: 196889 usec

Memory Usage List\<int> for 100 000 000 elements:
- BlockAllocator: 2,95 GB
- PagedAllocator: 3,62 GB
- Malloc: 4,63 GB

So, as you can see, my allocator works even better than PagedAllocator(although I thought it would be slower). It is worth paying attention to the improvement in iteration time, which means much faster work with allocated data, since it is more cache friendly.

Code used:
```c++
int var = 0;

template <typename T>
void test_list() {
	T list_standart;
	auto start = chrono::system_clock::now();
	{
		auto clock_start = chrono::system_clock::now();
		for (int i = 0; i < 10000000; i++) {
			list_standart.push_back(i);
		}
		auto clock_now = chrono::system_clock::now();
		auto currentTime = float(chrono::duration_cast<chrono::nanoseconds>(clock_now - clock_start).count());
		print_line("Time insert:", currentTime);
	}

	{
		auto clock_start = chrono::system_clock::now();
		for (const int num : list_standart) {
			var = num;
		}
		auto clock_now = chrono::system_clock::now();
		auto currentTime = float(chrono::duration_cast<chrono::nanoseconds>(clock_now - clock_start).count());
		print_line("Time iteration:", currentTime);
	}

	{
		auto clock_start = chrono::system_clock::now();
		list_standart.clear();
		auto clock_now = chrono::system_clock::now();
		auto currentTime = float(chrono::duration_cast<chrono::nanoseconds>(clock_now - clock_start).count());
		print_line("Time clear:", currentTime);
	}
	auto end = chrono::system_clock::now();
	auto currentTime = float(chrono::duration_cast<chrono::nanoseconds>(end - start).count());
	print_line("Time total:", currentTime);
}

void main_benchmark() {
	test_list<List<int>>();
}

```

**Dictionary test.**

Dictionary[int, String]

Master branch:
- Time insert:2655 msec
- Time iteration:325 msec
- Time clear:801 msec
- Time total:5116 msec

Current PR:
- Time insert:2472 msec
- Time iteration:288 msec
- Time clear:500 msec
- Time total:3260 msec

Code Used:
```gdscript
func _ready() -> void:
	var start_test :int = Time.get_ticks_msec()
	var dict : Dictionary[int, String]
	if true:
		var start :int = Time.get_ticks_msec()
		for i in 10000000:
			dict[i] = " "
		var end :int = Time.get_ticks_msec()
		print("Time insert:", end - start)
	
	if true:
		var start :int = Time.get_ticks_msec()
		for n in dict.keys():
			pass
		var end :int = Time.get_ticks_msec()
		print("Time iteration:", end - start)
		
	if true:
		var start :int = Time.get_ticks_msec()
		var num : int
		dict.clear()
		var end :int = Time.get_ticks_msec()
		print("Time clear:", end - start)
	var end_test :int = Time.get_ticks_msec()
	print("Time total:", end_test - start_test)
```
Memory Usage Dictionary[int, String] for 100 000 000 elements:
- Master: 11.37 GB
- Current PR: 8.4 GB

Code used:
```gdscript
for i in 100000000:
	dict[i] = " "
while true:
    pass
```

**The speed of adding children to the node.**

Add 1000000 Nodes as child: 
- Master: 3225423 usec
- Current PR: 2825762 usec

```gdscript
func _ready() -> void:
	var start :int = Time.get_ticks_usec()
	for i in 1000000:
		add_child(Node.new())
	
	var end :int = Time.get_ticks_usec()
	print(end - start)
```

# Some improved performance in MRPs
MRP from #85871.
Improves performance and reduces memory usage in the editor.
- Master 3,73 GB
- Current PR: 2,97 GB

Memory usage can be checked via htop or task manager.

Until this #92554 isn`t merged. This PR improves animation performance by 5%.

Also, this MRP #93568 loads 5% faster. And in general, projects are loaded 5-10% faster.


# Improving mesh generation
I used this demo. https://github.com/godotengine/godot-demo-projects/tree/master/3d/voxel.
Here, the chart shows the before and after average mesh generation time for a chunk.

![image-1](https://github.com/user-attachments/assets/7c16a7c2-43a7-4b39-92d1-a5680586306e)

# Better multithreading performance
This comment https://github.com/godotengine/godot/pull/97016#issuecomment-2356447368

# Godot Benchmarks
- Master:  [master.json](https://github.com/user-attachments/files/17074481/master.json)
- Current PR: [multithread_allocator.json](https://github.com/user-attachments/files/17074486/multithread_allocator.json)