### PR TITLE
Fix non const animation node `_process` virtual function

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -63,7 +63,7 @@
 				When inheriting from [AnimationRootNode], implement this virtual method to return whether the [param parameter] is read-only. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
-		<method name="_process" qualifiers="virtual const" deprecated="Currently this is mostly useless as there is a lack of many APIs to extend AnimationNode by GDScript. It is planned that a more flexible API using structures will be provided in the future.">
+		<method name="_process" qualifiers="virtual" deprecated="Currently this is mostly useless as there is a lack of many APIs to extend AnimationNode by GDScript. It is planned that a more flexible API using structures will be provided in the future.">
 			<return type="float" />
 			<param index="0" name="time" type="float" />
 			<param index="1" name="seek" type="bool" />

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -95,3 +95,10 @@ Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/argum
 
 Default deadzone value was changed. No adjustments should be necessary.
 Compatibility method registered.
+
+
+GH-97020
+--------
+Validate extension JSON: Error: Field 'classes/AnimationNode/methods/_process': is_const changed value in new API, from true to false.
+
+`_process` virtual method fixed to be non const instead.

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -151,7 +151,7 @@ protected:
 	GDVIRTUAL1RC(Ref<AnimationNode>, _get_child_by_name, StringName)
 	GDVIRTUAL1RC(Variant, _get_parameter_default_value, StringName)
 	GDVIRTUAL1RC(bool, _is_parameter_read_only, StringName)
-	GDVIRTUAL4RC(double, _process, double, bool, bool, bool)
+	GDVIRTUAL4R(double, _process, double, bool, bool, bool)
 	GDVIRTUAL0RC(String, _get_caption)
 	GDVIRTUAL0RC(bool, _has_filter)
 


### PR DESCRIPTION
Quick fix for https://github.com/godotengine/godot/issues/74807

I'm working on a motion matching implementation, and am currently improving its API. I currently think the best way to do this by extending AnimationRootNode, but the docs mention the _process method is deprecated, and that many APIs are missing to be able to extend animation nodes. I guess my question is, is this the case? If so, is there anything planned to support this in coming releases?

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/74807*