### PR TITLE
Use double comments in shader template light functions

### DIFF
--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -163,8 +163,8 @@ void fragment() {
 }
 
 //void light() {
-	// Called for every pixel for every light affecting the material.
-	// Uncomment to replace the default light processing function with this one.
+//	// Called for every pixel for every light affecting the material.
+//	// Uncomment to replace the default light processing function with this one.
 //}
 )";
 						break;
@@ -179,8 +179,8 @@ void fragment() {
 }
 
 //void light() {
-	// Called for every pixel for every light affecting the CanvasItem.
-	// Uncomment to replace the default light processing function with this one.
+//	// Called for every pixel for every light affecting the CanvasItem.
+//	// Uncomment to replace the default light processing function with this one.
 //}
 )";
 						break;


### PR DESCRIPTION
This PR adds a second layer of commenting to the `light()` function of CanvasItem and Spatial shader templates, so if you select and uncomment the `light()` function, you have a valid shader.

**Current behavior:**
If you create a new Spatial or CanvasItem shader, the template comes with a commented out `light()` function:
![Godot_v4 3-stable_win64_uZaOueifXP](https://github.com/user-attachments/assets/d4243edd-8e08-40fb-a2db-47bf61103fb3)

But if you select it and uncomment it with `ctrl+k`, you have a shader with a compile error, since the template only uses a single level of commenting:
![Godot_v4 3-stable_win64_2H9RUF2Nyc](https://github.com/user-attachments/assets/debc99e9-8794-45b7-a452-6c487092c7ef)

**This PR:**
Tested on the CI artifact:
Shader template:
![godot windows editor x86_64_KoKRfcQCK9](https://github.com/user-attachments/assets/65e60fcb-37d3-45f7-b5d6-9cd39b4452b3)

Select and uncomment the light function, and you have a valid shader:
![godot windows editor x86_64_qS4QuUrel0](https://github.com/user-attachments/assets/762fc48f-c25e-4acd-afee-e49373ea8693)



