### PR TITLE
Fix error reopening non existing scene on startup

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5249,14 +5249,18 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 
 	PackedStringArray scenes = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
 	for (int i = 0; i < scenes.size(); i++) {
-		load_scene(scenes[i]);
+		if (FileAccess::exists(scenes[i])) {
+			load_scene(scenes[i]);
+		}
 	}
 
 	if (p_layout->has_section_key(EDITOR_NODE_CONFIG_SECTION, "current_scene")) {
 		String current_scene = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene");
-		int current_scene_idx = scenes.find(current_scene);
-		if (current_scene_idx >= 0) {
-			_set_current_scene(current_scene_idx);
+		for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+			if (editor_data.get_scene_path(i) == current_scene) {
+				_set_current_scene(i);
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fixes #95326

Added a check for the scene's existence on disk before loading it and changed the method for finding the scene to reopen, ensuring it works correctly if the scene in the `editor_layout.cfg` no longer exists.