### PR TITLE
Fix Viewport Texture must be set to use it

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -111,6 +111,9 @@ void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
 	if (get_local_scene() && !path.is_empty()) {
 		setup_local_to_scene();
 	} else {
+		if (path.is_empty()) {
+			vp_changed = false;
+		}
 		emit_changed();
 	}
 }
@@ -121,9 +124,7 @@ NodePath ViewportTexture::get_viewport_path_in_scene() const {
 
 int ViewportTexture::get_width() const {
 	if (!vp) {
-		if (!vp_pending) {
-			ERR_PRINT("Viewport Texture must be set to use it.");
-		}
+		_err_print_viewport_not_set();
 		return 0;
 	}
 	return vp->size.width;
@@ -131,9 +132,7 @@ int ViewportTexture::get_width() const {
 
 int ViewportTexture::get_height() const {
 	if (!vp) {
-		if (!vp_pending) {
-			ERR_PRINT("Viewport Texture must be set to use it.");
-		}
+		_err_print_viewport_not_set();
 		return 0;
 	}
 	return vp->size.height;
@@ -141,9 +140,7 @@ int ViewportTexture::get_height() const {
 
 Size2 ViewportTexture::get_size() const {
 	if (!vp) {
-		if (!vp_pending) {
-			ERR_PRINT("Viewport Texture must be set to use it.");
-		}
+		_err_print_viewport_not_set();
 		return Size2();
 	}
 	return vp->size;
@@ -163,12 +160,16 @@ bool ViewportTexture::has_alpha() const {
 
 Ref<Image> ViewportTexture::get_image() const {
 	if (!vp) {
-		if (!vp_pending) {
-			ERR_PRINT("Viewport Texture must be set to use it.");
-		}
+		_err_print_viewport_not_set();
 		return Ref<Image>();
 	}
 	return RS::get_singleton()->texture_2d_get(vp->texture_rid);
+}
+
+void ViewportTexture::_err_print_viewport_not_set() const {
+	if (!vp_pending && !vp_changed) {
+		ERR_PRINT("Viewport Texture must be set to use it.");
+	}
 }
 
 void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -63,6 +63,7 @@ class ViewportTexture : public Texture2D {
 	bool vp_changed = false;
 
 	void _setup_local_to_scene(const Node *p_loc_scene);
+	void _err_print_viewport_not_set() const;
 
 	mutable RID proxy_ph;
 	mutable RID proxy;


### PR DESCRIPTION
- Fixes #66247

This should fix the error "Viewport Texture must be set to use it," which is displayed when loading a scene with a `Viewport` as a texture.

The issue was that the scene had not been loaded when attempting to set the `ViewportTexture` to the mesh the first time during scene loading. Checking for `vp_changed` ensures that the errors occurs only when the `ViewPort` is not found.

Tested with MRPs from the issue and Godot demo projects:
[Procedural Materials](https://github.com/godotengine/godot-demo-projects/tree/master/3d/procedural_materials)  
[GUI in 3D](https://github.com/godotengine/godot-demo-projects/tree/master/viewport/gui_in_3d)
