### PR TITLE
Fix `AudioStreamMicrophone` crash on scene-reload

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -39,6 +39,9 @@
 
 #include <functiondiscoverykeys.h>
 
+#include <wrl/client.h>
+using Microsoft::WRL::ComPtr;
+
 // Define IAudioClient3 if not already defined by MinGW headers
 #if defined __MINGW32__ || defined __MINGW64__
 
@@ -106,6 +109,12 @@ const IID IID_IAudioClient = __uuidof(IAudioClient);
 const IID IID_IAudioClient3 = __uuidof(IAudioClient3);
 const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
 const IID IID_IAudioCaptureClient = __uuidof(IAudioCaptureClient);
+
+#define SAFE_RELEASE(memory)   \
+	if ((memory) != nullptr) { \
+		(memory)->Release();   \
+		(memory) = nullptr;    \
+	}
 
 #define REFTIMES_PER_SEC 10000000
 #define REFTIMES_PER_MILLISEC 10000
@@ -302,7 +311,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		audioProps.bIsOffload = FALSE;
 		audioProps.eCategory = AudioCategory_GameEffects;
 
-		hr = ((IAudioClient3 *)p_device->audio_client.Get())->SetClientProperties(&audioProps);
+		hr = ((IAudioClient3 *)p_device->audio_client)->SetClientProperties(&audioProps);
 		ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_CANT_OPEN, "WASAPI: SetClientProperties failed with error 0x" + String::num_uint64(hr, 16) + ".");
 	}
 
@@ -385,7 +394,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		}
 
 	} else {
-		IAudioClient3 *device_audio_client_3 = (IAudioClient3 *)p_device->audio_client.Get();
+		IAudioClient3 *device_audio_client_3 = (IAudioClient3 *)p_device->audio_client;
 
 		// AUDCLNT_STREAMFLAGS_RATEADJUST is an invalid flag with IAudioClient3, therefore we have to use
 		// the closest supported mix rate supported by the audio driver.
@@ -516,9 +525,9 @@ Error AudioDriverWASAPI::audio_device_finish(AudioDeviceWASAPI *p_device) {
 		p_device->active.clear();
 	}
 
-	p_device->audio_client.Reset();
-	p_device->render_client.Reset();
-	p_device->capture_client.Reset();
+	SAFE_RELEASE(p_device->audio_client)
+	SAFE_RELEASE(p_device->render_client)
+	SAFE_RELEASE(p_device->capture_client)
 
 	return OK;
 }

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -40,18 +40,15 @@
 
 #include <audioclient.h>
 #include <mmdeviceapi.h>
-#include <wrl/client.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
-using Microsoft::WRL::ComPtr;
 
 class AudioDriverWASAPI : public AudioDriver {
 	class AudioDeviceWASAPI {
 	public:
-		ComPtr<IAudioClient> audio_client = nullptr;
-		ComPtr<IAudioRenderClient> render_client = nullptr; // Output
-		ComPtr<IAudioCaptureClient> capture_client = nullptr; // Input
+		IAudioClient *audio_client = nullptr;
+		IAudioRenderClient *render_client = nullptr; // Output
+		IAudioCaptureClient *capture_client = nullptr; // Input
 		SafeFlag active;
 
 		WORD format_tag = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix #96995: AudioStreamPlayer crashing when stream set to Microphone and autoplay is set to on.