### PR TITLE
Clipboard file / file path handling for Windows and macOS

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -647,6 +647,20 @@
 				Returns the user's clipboard as a string if possible.
 			</description>
 		</method>
+		<method name="clipboard_get_files" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the file paths of files on the user's clipboard if possible.
+				[b]Note:[/b] This method is only implemented on macOS and Windows. On Linux (X11/Wayland), files on the clipboard are represented as a newline-separated ([code]\n[/code]) list of file URIs (prefixed with [code]file://[/code]). use [method clipboard_get] to retrieve them.
+			</description>
+		</method>
+		<method name="clipboard_get_file_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of files on the user's clipboard.
+				[b]Note:[/b] This method is only implemented on macOS and Windows. See [method clipboard_get_files] for details about Linux (X11/Wayland).
+			</description>
+		</method>
 		<method name="clipboard_get_image" qualifiers="const">
 			<return type="Image" />
 			<description>
@@ -665,6 +679,13 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if there is a text content on the user's clipboard.
+			</description>
+		</method>
+		<method name="clipboard_has_file" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if there is a file on the user's clipboard.
+				[b]Note:[/b] This method is only implemented on macOS and Windows. See [method clipboard_get_files] for details about Linux (X11/Wayland).
 			</description>
 		</method>
 		<method name="clipboard_has_image" qualifiers="const">

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -63,8 +63,11 @@ protected:
 public:
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;
+	virtual Vector<String> clipboard_get_files() const override;
+	virtual int clipboard_get_file_count() const override;
 	virtual Ref<Image> clipboard_get_image() const override;
 	virtual bool clipboard_has() const override;
+	virtual bool clipboard_has_file() const override;
 	virtual bool clipboard_has_image() const override;
 
 	virtual int keyboard_get_layout_count() const override;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -69,6 +69,47 @@ String DisplayServerMacOSBase::clipboard_get() const {
 	return ret;
 }
 
+int DisplayServerMacOSBase::clipboard_get_file_count() const {
+	// If there is a way to modify the commented code to not count directories, it would be preferable. Keeping just in case.
+	//NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+	//NSArray *classArray = [NSArray arrayWithObject:[NSURL class]];
+	//NSDictionary *options = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:NSPasteboardURLReadingFileURLsOnlyKey];
+	//NSArray *fileURLs = [pasteboard readObjectsForClasses:classArray options:options];
+	//if (!fileURLs) {
+	//	return 0;
+	//}
+	//
+	//return fileURLs.count;
+	return clipboard_get_files().size();
+}
+
+Vector<String> DisplayServerMacOSBase::clipboard_get_files() const {
+	_THREAD_SAFE_METHOD_
+
+	NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+	NSArray *classArray = [NSArray arrayWithObject:[NSURL class]];
+	NSDictionary *options = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:NSPasteboardURLReadingFileURLsOnlyKey];
+
+	Vector<String> files;
+	BOOL ok = [pasteboard canReadObjectForClasses:classArray options:options];
+
+	if (!ok) {
+		return files;
+	}
+
+	NSArray *fileURLs = [pasteboard readObjectsForClasses:classArray options:options];
+
+	for (NSURL *url in fileURLs) {
+		if (!url.hasDirectoryPath) {
+			String file = String::utf8([url.filePathURL.path UTF8String]);
+			files.push_back(file);
+			continue;
+		}
+	}
+
+	return files;
+}
+
 Ref<Image> DisplayServerMacOSBase::clipboard_get_image() const {
 	Ref<Image> image;
 	NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
@@ -92,6 +133,12 @@ bool DisplayServerMacOSBase::clipboard_has() const {
 	NSArray *classArray = [NSArray arrayWithObject:[NSString class]];
 	NSDictionary *options = [NSDictionary dictionary];
 	return [pasteboard canReadObjectForClasses:classArray options:options];
+}
+
+bool DisplayServerMacOSBase::clipboard_has_file() const {
+	NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+	NSString *result = [pasteboard availableTypeFromArray:[NSArray arrayWithObjects:NSPasteboardTypeFileURL, nil]];
+	return result;
 }
 
 bool DisplayServerMacOSBase::clipboard_has_image() const {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1030,6 +1030,70 @@ String DisplayServerWindows::clipboard_get() const {
 	return ret;
 }
 
+Vector<String> DisplayServerWindows::clipboard_get_files() const {
+	_THREAD_SAFE_METHOD_
+
+	if (!windows.has(MAIN_WINDOW_ID)) {
+		return Vector<String>();
+	}
+
+	Vector<String> files;
+	if (!OpenClipboard(windows[MAIN_WINDOW_ID].hWnd)) {
+		ERR_FAIL_V_MSG(Vector<String>(), "Unable to open clipboard.");
+	}
+
+	if (IsClipboardFormatAvailable(CF_HDROP)) {
+		HGLOBAL mem = GetClipboardData(CF_HDROP);
+		if (mem != nullptr) {
+			HDROP hDropInfo = (HDROP)GlobalLock(mem);
+			if (hDropInfo != nullptr) {
+				int fcount = DragQueryFileW(hDropInfo, 0xFFFFFFFF, nullptr, 0);
+
+				for (int i = 0; i < fcount; i++) {
+					LocalVector<wchar_t> buf;
+					int size;
+					size = DragQueryFileW(hDropInfo, i, nullptr, 0);
+					if (size == 0) {
+						continue;
+					}
+
+					// DragQueryFileW does not return long file paths, so we're gonna convert it to one.
+					// There's no point trying to detect a short path to skip this
+					// GetLongPathNameW will return the correct path anyway.
+					buf.resize(MAX_PATH);
+					DragQueryFileW(hDropInfo, i, buf.ptr(), MAX_PATH);
+
+					// This needs to be +1 because the returned path length doesn't count the terminator, but space is required for it.
+					size = GetLongPathNameW(buf.ptr(), nullptr, 0) + 1;
+					buf.resize(size);
+					GetLongPathNameW(buf.ptr(), buf.ptr(), size);
+					String file = String::utf16((const char16_t *)buf.ptr());
+					files.push_back(file);
+				}
+				GlobalUnlock(mem);
+			}
+		}
+	}
+
+	CloseClipboard();
+
+	return files;
+}
+
+int DisplayServerWindows::clipboard_get_file_count() const {
+	int fcount = 0;
+	if (IsClipboardFormatAvailable(CF_HDROP)) {
+		HGLOBAL mem = GetClipboardData(CF_HDROP);
+		if (mem != nullptr) {
+			HDROP hDropInfo = (HDROP)GlobalLock(mem);
+			if (hDropInfo != nullptr) {
+				fcount = DragQueryFileW(hDropInfo, 0xFFFFFFFF, nullptr, 0);
+			}
+		}
+	}
+	return fcount;
+}
+
 Ref<Image> DisplayServerWindows::clipboard_get_image() const {
 	Ref<Image> image;
 	if (!windows.has(last_focused_window)) {
@@ -1109,6 +1173,10 @@ bool DisplayServerWindows::clipboard_has() const {
 	return (IsClipboardFormatAvailable(CF_TEXT) ||
 			IsClipboardFormatAvailable(CF_UNICODETEXT) ||
 			IsClipboardFormatAvailable(CF_OEMTEXT));
+}
+
+bool DisplayServerWindows::clipboard_has_file() const {
+	return IsClipboardFormatAvailable(CF_HDROP);
 }
 
 bool DisplayServerWindows::clipboard_has_image() const {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -559,8 +559,11 @@ public:
 
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;
+	virtual Vector<String> clipboard_get_files() const override;
+	virtual int clipboard_get_file_count() const override;
 	virtual Ref<Image> clipboard_get_image() const override;
 	virtual bool clipboard_has() const override;
+	virtual bool clipboard_has_file() const override;
 	virtual bool clipboard_has_image() const override;
 
 	virtual int get_screen_count() const override;

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -539,6 +539,14 @@ String DisplayServer::clipboard_get() const {
 	ERR_FAIL_V_MSG(String(), "Clipboard is not supported by this display server.");
 }
 
+int DisplayServer::clipboard_get_file_count() const {
+	ERR_FAIL_V_MSG(0, "Clipboard is not supported by this display server.");
+}
+
+Vector<String> DisplayServer::clipboard_get_files() const {
+	ERR_FAIL_V_MSG(Vector<String>(), "Clipboard is not supported by this display server.");
+}
+
 Ref<Image> DisplayServer::clipboard_get_image() const {
 	ERR_FAIL_V_MSG(Ref<Image>(), "Clipboard is not supported by this display server.");
 }
@@ -549,6 +557,10 @@ bool DisplayServer::clipboard_has() const {
 
 bool DisplayServer::clipboard_has_image() const {
 	return clipboard_get_image().is_valid();
+}
+
+bool DisplayServer::clipboard_has_file() const {
+	return clipboard_get_file_count() > 0;
 }
 
 void DisplayServer::clipboard_set_primary(const String &p_text) {
@@ -1377,8 +1389,11 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("clipboard_set", "clipboard"), &DisplayServer::clipboard_set);
 	ClassDB::bind_method(D_METHOD("clipboard_get"), &DisplayServer::clipboard_get);
+	ClassDB::bind_method(D_METHOD("clipboard_get_files"), &DisplayServer::clipboard_get_files);
+	ClassDB::bind_method(D_METHOD("clipboard_get_file_count"), &DisplayServer::clipboard_get_file_count);
 	ClassDB::bind_method(D_METHOD("clipboard_get_image"), &DisplayServer::clipboard_get_image);
 	ClassDB::bind_method(D_METHOD("clipboard_has"), &DisplayServer::clipboard_has);
+	ClassDB::bind_method(D_METHOD("clipboard_has_file"), &DisplayServer::clipboard_has_file);
 	ClassDB::bind_method(D_METHOD("clipboard_has_image"), &DisplayServer::clipboard_has_image);
 	ClassDB::bind_method(D_METHOD("clipboard_set_primary", "clipboard_primary"), &DisplayServer::clipboard_set_primary);
 	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -307,8 +307,11 @@ public:
 
 	virtual void clipboard_set(const String &p_text);
 	virtual String clipboard_get() const;
+	virtual Vector<String> clipboard_get_files() const;
+	virtual int clipboard_get_file_count() const;
 	virtual Ref<Image> clipboard_get_image() const;
 	virtual bool clipboard_has() const;
+	virtual bool clipboard_has_file() const;
 	virtual bool clipboard_has_image() const;
 	virtual void clipboard_set_primary(const String &p_text);
 	virtual String clipboard_get_primary() const;


### PR DESCRIPTION
The clipboard functions had different results across platforms when dealing with files on the users filesystem.

Nothing was returned when there were files (CF_HDROP) on the clipboard in Windows. 
On macOS, Files were only represented as `NSString`s and would only return the filename, instead of the full path.
This is unlike linux, which is able to return clipboard file paths as a newline-seperated list.

This adds simple handling for them.

`clipboard_has` appears to make more sense as a "clipboard_has_text", so i made a `clipboard_has_file` check, and a `clipboard_file_count` that returns the number of files selected. I have not wrote these for linux, as linux is returning file paths as strings on its own, and I don't know how to grab the number of selected files there.