### PR TITLE
Fix `LineEdit` selects all text when it's just focused with arrow keys.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -58,9 +58,17 @@ void LineEdit::_edit() {
 		return;
 	}
 
+	if (select_all_on_focus) {
+		if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
+			// Select all when the mouse button is up.
+			pending_select_all_on_focus = true;
+		} else {
+			select_all();
+		}
+	}
+
 	editing = true;
 	_validate_caret_can_draw();
-
 	show_virtual_keyboard();
 	queue_redraw();
 	emit_signal(SNAME("editing_toggled"), true);
@@ -1331,15 +1339,6 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
-			if (select_all_on_focus) {
-				if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-					// Select all when the mouse button is up.
-					pending_select_all_on_focus = true;
-				} else {
-					select_all();
-				}
-			}
-
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
 				_edit();


### PR DESCRIPTION
Fix: `select_all_on_focus` is applied when we are just focusing the `LineEdit` with arrow keys and not editing it.