### PR TITLE
Add `post_process_frame` signal to SceneTree

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -307,6 +307,11 @@
 				Emitted immediately before [method Node._physics_process] is called on every node in this tree.
 			</description>
 		</signal>
+		<signal name="post_process_frame">
+			<description>
+				Emitted immediately before rendering happens, after [method Node._process] is called on every node in this tree, and after all timers, tweens, and more are updated for the frame.
+			</description>
+		</signal>
 		<signal name="process_frame">
 			<description>
 				Emitted immediately before [method Node._process] is called on every node in this tree.

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -624,6 +624,8 @@ bool SceneTree::process(double p_time) {
 #endif // _3D_DISABLED
 #endif // TOOLS_ENABLED
 
+	emit_signal(SNAME("post_process_frame"));
+
 	if (_physics_interpolation_enabled) {
 		RenderingServer::get_singleton()->pre_draw(true);
 	}
@@ -1735,6 +1737,7 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("node_configuration_warning_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 
 	ADD_SIGNAL(MethodInfo("process_frame"));
+	ADD_SIGNAL(MethodInfo("post_process_frame"));
 	ADD_SIGNAL(MethodInfo("physics_frame"));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);


### PR DESCRIPTION
This PR adds a new signal to SceneTree that runs after `_process` but before rendering: `post_process_frame`

Without this PR, it is impossible to run code after everything is done for the frame, but before rendering. I need to do this, I have a use case that requires running code after `_process`, timers, tweens, etc, but before any rendering. Without this PR, I would have to use `process_frame` (always 1 frame late), or put the code in some node (race condition with other nodes in the tree, either 0 or 1 frames late, and always 1 frame late with timers/tweens), or jerry-rig a tween (usually 0 frames late but really janky). Godot's own internal code has an "idle callbacks" system for this same purpose, but this is not exposed, so this PR allows user code to do something that Godot's internal code can already do.

So the order is `process_frame` -> `_process` -> timers/tweens/etc -> `post_process_frame` -> rendering.

EDIT: Actually, RenderingServer::frame_pre_draw should work for my use case.