### PR TITLE
Fix weird MSVC compilation error

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -866,12 +866,10 @@ static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_
 
 template <int CC, typename T>
 static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
-	enum {
-		FRAC_BITS = 8,
-		FRAC_LEN = (1 << FRAC_BITS),
-		FRAC_HALF = (FRAC_LEN >> 1),
-		FRAC_MASK = FRAC_LEN - 1
-	};
+	constexpr uint32_t FRAC_BITS = 8;
+	constexpr uint32_t FRAC_LEN = (1 << FRAC_BITS);
+	constexpr uint32_t FRAC_HALF = (FRAC_LEN >> 1);
+	constexpr uint32_t FRAC_MASK = FRAC_LEN - 1;
 
 	for (uint32_t i = 0; i < p_dst_height; i++) {
 		// Add 0.5 in order to interpolate based on pixel center


### PR DESCRIPTION
For some reason, MSVC doesn't appreciate uint8 math with enum constants.
I have no idea why I didn't have this error until a few weeks ago. The incriminating code was has not been changed recently which is super weird.
I still had the error even after updating VS2019.

The error is caused by the use of `<< FRAC_BITS` inside the `if constexpr (sizeof(T) == 1) {` condition in `_scale_bilinear`.
I tried a few different things, but declaring FRAC_BITS as uint32 seems to be the only thing that works.
It doesn't hurt to clean the code though, using an enum to store constants is error prone, since the type is inferred by the compiler.

Error log:
```
1>core\io\image.cpp(4325): fatal error C1001: Internal compiler error.
1>(compiler file 'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\PackExpander.cpp', line 2441)
1> To work around this problem, try simplifying or changing the program near the locations listed above.
1>If possible please provide a repro here: https://developercommunity.visualstudio.com
1>Please choose the Technical Support command on the Visual C++
1> Help menu, or open the Technical Support help file for more information
1>core\io\image.cpp(1272): note: see reference to function template instantiation 'void _scale_bilinear<1,uint8_t>(const uint8_t *__restrict ,uint8_t *__restrict ,uint32_t,uint32_t,uint32_t,uint32_t)' being compiled
```