### PR TITLE
Remove debug print from Android `DisplayServer.screen_get_scale` implementation

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -258,7 +258,6 @@ float DisplayServerAndroid::screen_get_scale(int p_screen) const {
 		screen_scale = MIN(screen_scale, MIN(width_scale, height_scale));
 	}
 
-	print_line("Selected screen scale: ", screen_scale);
 	return screen_scale;
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97062

Verified with generated android template and simple test script that called DisplayServer.screen_get_scale().  Line no longer present in logcat.

script to test with:
<img width="373" alt="fix-code" src="https://github.com/user-attachments/assets/414556c4-97b3-44bc-a365-a77d0b8fa7bb">

logcat with master branch
<img width="601" alt="before_fix" src="https://github.com/user-attachments/assets/48be943e-405a-4330-b267-35b137fa6b32">

logcat with fix
<img width="561" alt="after-fix" src="https://github.com/user-attachments/assets/c4ccb89f-6bd9-4348-8a5d-cca7e6e9623b">




