### PR TITLE
Add option to show region names in the minimap.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1164,11 +1164,20 @@
 		<member name="text_editor/appearance/lines/word_wrap" type="int" setter="" getter="">
 			If [code]true[/code], wraps long lines over multiple lines to avoid horizontal scrolling. This is a display-only feature; it does not actually insert line breaks in your scripts.
 		</member>
+		<member name="text_editor/appearance/minimap/marker_font_size" type="int" setter="" getter="">
+			Minimap region name marker font size.
+		</member>
+		<member name="text_editor/appearance/minimap/minimap_draw_markers" type="bool" setter="" getter="">
+			If [code]true[/code], region name markers are shown on the minimap.
+		</member>
 		<member name="text_editor/appearance/minimap/minimap_width" type="int" setter="" getter="">
 			The width of the minimap in the script editor (in pixels).
 		</member>
 		<member name="text_editor/appearance/minimap/show_minimap" type="bool" setter="" getter="">
 			If [code]true[/code], draws an overview of the script near the scroll bar. The minimap can be left-clicked to scroll directly to a location in an "absolute" manner.
+		</member>
+		<member name="text_editor/appearance/minimap_marker_outline_size" type="int" setter="" getter="">
+			Minimap region name marker font outline size.
 		</member>
 		<member name="text_editor/appearance/whitespace/draw_spaces" type="bool" setter="" getter="">
 			If [code]true[/code], draws space characters as centered points.
@@ -1418,6 +1427,15 @@
 		</member>
 		<member name="text_editor/theme/highlighting/mark_color" type="Color" setter="" getter="">
 			The script editor's background color for lines with errors. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/current_line_color].
+		</member>
+		<member name="text_editor/theme/highlighting/marker_background_color" type="Color" setter="" getter="">
+			Minimap region name marker background color.
+		</member>
+		<member name="text_editor/theme/highlighting/marker_color" type="Color" setter="" getter="">
+			Minimap region name marker text color.
+		</member>
+		<member name="text_editor/theme/highlighting/marker_outline_color" type="Color" setter="" getter="">
+			Minimap region name marker text outline color.
 		</member>
 		<member name="text_editor/theme/highlighting/member_variable_color" type="Color" setter="" getter="">
 			The script editor's color for member variables on objects (e.g. [code]self.some_property[/code]).

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1322,6 +1322,9 @@
 		<member name="minimap_draw" type="bool" setter="set_draw_minimap" getter="is_drawing_minimap" default="false">
 			If [code]true[/code], a minimap is shown, providing an outline of your source code. The minimap uses a fixed-width text size.
 		</member>
+		<member name="minimap_draw_markers" type="bool" setter="set_draw_minimap_markers" getter="is_drawing_minimap_markers" default="false">
+			If [code]true[/code], region name markers are shown on the minimap.
+		</member>
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">
 			The width, in pixels, of the minimap.
 		</member>
@@ -1608,6 +1611,12 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the [Color] of the selected text. If equal to [code]Color(0, 0, 0, 0)[/code], it will be ignored.
 		</theme_item>
+		<theme_item name="marker_background_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+		</theme_item>
+		<theme_item name="marker_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
+		</theme_item>
+		<theme_item name="marker_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+		</theme_item>
 		<theme_item name="search_result_border_color" data_type="color" type="Color" default="Color(0.3, 0.3, 0.3, 0.4)">
 			[Color] of the border around text that matches the search query.
 		</theme_item>
@@ -1626,6 +1635,8 @@
 		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
 			Sets the spacing between the lines.
 		</theme_item>
+		<theme_item name="marker_outline_size" data_type="constant" type="int" default="1">
+		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
@@ -1635,6 +1646,8 @@
 		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Sets default font size.
+		</theme_item>
+		<theme_item name="marker_font_size" data_type="font_size" type="int">
 		</theme_item>
 		<theme_item name="space" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for space text characters.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1083,7 +1083,10 @@ void CodeTextEditor::update_editor_settings() {
 
 	// Appearance: Minimap
 	text_editor->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
+	text_editor->set_draw_minimap_markers(EDITOR_GET("text_editor/appearance/minimap/minimap_draw_markers"));
 	text_editor->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);
+	text_editor->add_theme_font_size_override("marker_font_size", EDITOR_GET("text_editor/appearance/minimap/marker_font_size"));
+	text_editor->add_theme_constant_override("marker_outline_size", EDITOR_GET("text_editor/appearance/minimap_marker_outline_size"));
 
 	// Appearance: Lines
 	text_editor->set_line_folding_enabled(EDITOR_GET("text_editor/appearance/lines/code_folding"));

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -113,7 +113,10 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 
 			// Appearance: Minimap
 			code_edit->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
+			code_edit->set_draw_minimap_markers(EDITOR_GET("text_editor/appearance/minimap/minimap_draw_markers"));
 			code_edit->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);
+			code_edit->add_theme_font_size_override("marker_font_size", EDITOR_GET("text_editor/appearance/minimap/marker_font_size"));
+			code_edit->add_theme_constant_override("marker_outline_size", EDITOR_GET("text_editor/appearance/minimap_marker_outline_size"));
 
 			// Appearance: Lines
 			code_edit->set_line_folding_enabled(EDITOR_GET("text_editor/appearance/lines/code_folding"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -662,7 +662,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Appearance: Minimap
 	_initial_set("text_editor/appearance/minimap/show_minimap", true, true);
+	_initial_set("text_editor/appearance/minimap/minimap_draw_markers", true, true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap/minimap_width", 80, "50,250,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap/marker_font_size", 14, "0,64,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/minimap_marker_outline_size", 1, "0,20,1")
 
 	// Appearance: Lines
 	_initial_set("text_editor/appearance/lines/code_folding", true, true);
@@ -1062,6 +1065,9 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/folded_code_region_color", Color(0.68, 0.46, 0.77, 0.2));
 	_initial_set("text_editor/theme/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
 	_initial_set("text_editor/theme/highlighting/search_result_border_color", Color(0.41, 0.61, 0.91, 0.38));
+	_initial_set("text_editor/theme/highlighting/marker_color", Color(0.67, 0.67, 0.67));
+	_initial_set("text_editor/theme/highlighting/marker_outline_color", Color(0, 0, 0));
+	_initial_set("text_editor/theme/highlighting/marker_background_color", Color(0.13, 0.12, 0.15, 0.85));
 }
 
 void EditorSettings::_load_default_visual_shader_editor_theme() {

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1222,6 +1222,12 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
 		p_theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
 
+		p_theme->set_color("marker_color", "TextEdit", p_config.font_color);
+		p_theme->set_color("marker_outline_color", "TextEdit", Color(0, 0, 0));
+		p_theme->set_color("marker_background_color", "TextEdit", Color(0, 0, 0, 0));
+		p_theme->set_font_size("marker_font_size", "TextEdit", 14);
+		p_theme->set_constant("marker_outline_size", "TextEdit", 1);
+
 		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
 		p_theme->set_constant("outline_size", "TextEdit", 0);
 		p_theme->set_constant("caret_width", "TextEdit", 1);
@@ -2534,6 +2540,7 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 
 	// Use the brightest background color on a light theme (which generally uses a negative contrast rate).
 	const Color te_background_color =             p_config.dark_theme ? p_config.dark_color_2 : p_config.dark_color_3;
+	const Color m_background_color =              Color(te_background_color.r, te_background_color.g, te_background_color.b, 0.85);
 	const Color completion_background_color =     p_config.dark_theme ? p_config.base_color : p_config.dark_color_2;
 	const Color completion_selected_color =       alpha1;
 	const Color completion_existing_color =       alpha2;
@@ -2542,6 +2549,7 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 	const Color completion_scroll_hovered_color = Color(mono_value, mono_value, mono_value, 0.4);
 	const Color completion_font_color =           p_config.font_color;
 	const Color text_color =                      p_config.font_color;
+	const Color text_outline_color =              Color(0, 0, 0);
 	const Color line_number_color =               dim_color;
 	const Color safe_line_number_color =          p_config.dark_theme ? (dim_color * Color(1, 1.2, 1, 1.5)) : Color(0, 0.4, 0, 0.75);
 	const Color caret_color =                     p_config.mono_color;
@@ -2606,6 +2614,9 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 	setting->set_initial_value("text_editor/theme/highlighting/folded_code_region_color",        folded_code_region_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/search_result_color",             search_result_color, true);
 	setting->set_initial_value("text_editor/theme/highlighting/search_result_border_color",      search_result_border_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/marker_color",                    text_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/marker_outline_color",            text_outline_color, true);
+	setting->set_initial_value("text_editor/theme/highlighting/marker_background_color",         m_background_color, true);
 	/* clang-format on */
 }
 
@@ -2633,6 +2644,8 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 	/* clang-format on */
 
 	p_theme->set_constant("line_spacing", "CodeEdit", EDITOR_GET("text_editor/appearance/whitespace/line_spacing"));
+	p_theme->set_font_size("marker_font_size", "CodeEdit", EDITOR_GET("text_editor/appearance/minimap/marker_font_size"));
+	p_theme->set_constant("marker_outline_size", "CodeEdit", EDITOR_GET("text_editor/appearance/minimap_marker_outline_size"));
 
 	const Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
 	Ref<StyleBoxFlat> code_edit_stylebox = make_flat_stylebox(background_color, p_config.widget_margin.x, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y, p_config.corner_radius);
@@ -2664,6 +2677,9 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 	p_theme->set_color("folded_code_region_color",        "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/folded_code_region_color"));
 	p_theme->set_color("search_result_color",             "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_color"));
 	p_theme->set_color("search_result_border_color",      "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_border_color"));
+	p_theme->set_color("marker_color",                    "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/marker_color"));
+	p_theme->set_color("marker_outline_color",            "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/marker_outline_color"));
+	p_theme->set_color("marker_background_color",         "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/marker_background_color"));
 	/* clang-format on */
 }
 
@@ -2762,6 +2778,7 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/code_font") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("editors/visual_editors") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
+				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/appearance") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/help") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("docks/property_editor/subresource_hue_tint") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("filesystem/file_dialog/thumbnail_size") ||

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -842,6 +842,21 @@ void CodeEdit::_cut_internal(int p_caret) {
 	}
 }
 
+String CodeEdit::_line_marker(int p_line) const {
+	ERR_FAIL_INDEX_V(p_line, get_line_count(), String());
+	if (code_region_start_string.is_empty()) {
+		return String();
+	}
+	if (is_in_string(p_line) != -1) {
+		return String();
+	}
+	String line_text = get_line(p_line).strip_edges();
+	if (!line_text.begins_with(code_region_start_string)) {
+		return String();
+	}
+	return line_text.lstrip(code_region_start_string).strip_edges();
+}
+
 /* Indent management */
 void CodeEdit::set_indent_size(const int p_size) {
 	ERR_FAIL_COND_MSG(p_size <= 0, "Indend size must be greater than 0.");

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -323,6 +323,8 @@ protected:
 	virtual void _backspace_internal(int p_caret) override;
 	virtual void _cut_internal(int p_caret) override;
 
+	virtual String _line_marker(int p_line) const override;
+
 	GDVIRTUAL1(_confirm_code_completion, bool)
 	GDVIRTUAL1(_request_code_completion, bool)
 	GDVIRTUAL1RC(TypedArray<Dictionary>, _filter_code_completion_candidates, TypedArray<Dictionary>)

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -538,6 +538,7 @@ private:
 
 	// Minimap.
 	bool draw_minimap = false;
+	bool draw_minimap_markers = false;
 
 	int minimap_width = 80;
 	Point2 minimap_char_size = Point2(1, 2);
@@ -610,6 +611,12 @@ private:
 		Color background_color = Color(1, 1, 1);
 		Color current_line_color = Color(1, 1, 1);
 		Color word_highlighted_color = Color(1, 1, 1);
+
+		Color marker_color = Color(1, 1, 1);
+		Color marker_outline_color = Color(0, 0, 0);
+		Color marker_background_color = Color(0.3, 0.3, 0.3, 0.8);
+		int marker_font_size = 8;
+		int marker_outline_size = 1;
 	} theme_cache;
 
 	bool window_has_focus = true;
@@ -707,6 +714,8 @@ protected:
 	virtual void _copy_internal(int p_caret);
 	virtual void _paste_internal(int p_caret);
 	virtual void _paste_primary_clipboard_internal(int p_caret);
+
+	virtual String _line_marker(int p_line) const { return String(); };
 
 	GDVIRTUAL2(_handle_unicode_input, int, int)
 	GDVIRTUAL1(_backspace, int)
@@ -1016,6 +1025,9 @@ public:
 	// Minimap
 	void set_draw_minimap(bool p_enabled);
 	bool is_drawing_minimap() const;
+
+	void set_draw_minimap_markers(bool p_enabled);
+	bool is_drawing_minimap_markers() const;
 
 	void set_minimap_width(int p_minimap_width);
 	int get_minimap_width() const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -483,6 +483,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("search_result_color", "TextEdit", Color(0.3, 0.3, 0.3));
 	theme->set_color("search_result_border_color", "TextEdit", Color(0.3, 0.3, 0.3, 0.4));
 
+	theme->set_color("marker_color", "TextEdit", control_font_color);
+	theme->set_color("marker_outline_color", "TextEdit", Color(0, 0, 0));
+	theme->set_color("marker_background_color", "TextEdit", Color(0, 0, 0));
+	theme->set_font_size("marker_font_size", "TextEdit", 8);
+	theme->set_constant("marker_outline_size", "TextEdit", 1);
+
 	theme->set_constant("line_spacing", "TextEdit", Math::round(4 * scale));
 	theme->set_constant("outline_size", "TextEdit", 0);
 	theme->set_constant("caret_width", "TextEdit", 1);


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/9742

<img width="826" alt="Screenshot 2024-09-16 at 11 45 13" src="https://github.com/user-attachments/assets/f7558fef-c19e-4be4-96b8-816409a639e6">
