### PR TITLE
Fix for GLES3 radiance cubemap update

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -933,7 +933,7 @@ void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_p
 	int max_processing_layer = sky->mipmap_count;
 
 	// Update radiance cubemap
-	if (sky->reflection_dirty && (sky->processing_layer > max_processing_layer || update_single_frame)) {
+	if (sky->reflection_dirty && (sky->processing_layer >= max_processing_layer || update_single_frame)) {
 		static const Vector3 view_normals[6] = {
 			Vector3(+1, 0, 0),
 			Vector3(-1, 0, 0),


### PR DESCRIPTION
# Info

With this fix, changing the WorldEnvironment's sky colours in Compatibility mode updates the radiance cubemap automatically, just as it happens in Vulcan. The same applies to the `Preview Environment` button in the editor.

The logical condition is now the same as in the Vulcan version. Could I ask for a review by the authors of the original pieces of code? @clayjohn @BastiaanOlij 

https://github.com/godotengine/godot/blob/6681f2563b99e14929a8acb27f4908fece398ef1/drivers/gles3/rasterizer_scene_gles3.cpp#L935-L936

https://github.com/godotengine/godot/blob/6681f2563b99e14929a8acb27f4908fece398ef1/servers/rendering/renderer_rd/environment/sky.cpp#L1273-L1274

# Bug

Previously, making changes to the sky colours in Compatibility mode only produced an effect in the background of the scene. 3D objects were still illuminated by the previous environment, as the cubemap was not regenerated. 

Lighting of objects was updated only after reloading the scene or creating a new `WorldEnvironment` or setting the `process_mode` in Sky to `SKY_MODE_REALTIME`.

1. scene
![scr 2024-09-16 09-39-40](https://github.com/user-attachments/assets/2470990a-0249-40cf-a127-203cc2625a38)

2. after changing sky colors in preview
![scr 2024-09-16 09-40-38](https://github.com/user-attachments/assets/d917e38a-c9ef-4ae2-a708-ccbfd08cd319)

3. after saving changes into worldenvironment
![scr 2024-09-16 09-40-49](https://github.com/user-attachments/assets/68852a28-b5a9-435e-ad72-f3041cd69fb5)

# Notes

I don't know to what extent this is normal behaviour, but for both GLES and Vulcan, in the default `process_mode` (SKY_MODE_AUTOMATIC), the radiance cubemap regenerates after a some delay (in Vulcan even after a few seconds). When SKY_MODE_REALTIME mode is enabled, the map regenerates immediately (maybe this mode should be selected by default when working in the editor?).