### PR TITLE
Add a more detailed error message when instantiating a scene with missing export properties

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -527,7 +527,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 			bool valid;
 			Array array = dnp.base->get(dnp.property, &valid);
-			ERR_CONTINUE(!valid);
+			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, dnp.base->get_name()));
 			array = array.duplicate();
 
 			array.resize(paths.size());
@@ -540,7 +540,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 			bool valid;
 			Dictionary dict = dnp.base->get(dnp.property, &valid);
-			ERR_CONTINUE(!valid);
+			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, dnp.base->get_name()));
 			dict = dict.duplicate();
 			bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
 					ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");


### PR DESCRIPTION
As mentioned in the macro of `ERR_CONTINUE`, it should [only be used when there is no sensible error message](https://github.com/godotengine/godot/blob/6daa6a8513c5debb1faa6f6ca48a218ceb741d87/core/error/error_macros.h#L475C4-L475C62).

In this case, I was searching for the cause of the ominous error in my project - which were impossible to find without further information.

With this new error message it is much easier as a game dev to understand the problem and fix it.