### PR TITLE
Rework creating new folders in editor

### DIFF
--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -31,6 +31,7 @@
 #include "directory_create_dialog.h"
 
 #include "core/io/dir_access.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
 #include "editor/gui/editor_validation_panel.h"
 #include "editor/themes/editor_scale.h"
@@ -100,15 +101,7 @@ void DirectoryCreateDialog::ok_pressed() {
 	const String error = _validate_path(path);
 	ERR_FAIL_COND_MSG(!error.is_empty(), error);
 
-	Error err;
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-
-	err = da->change_dir(base_dir);
-	ERR_FAIL_COND_MSG(err != OK, "Cannot open directory '" + base_dir + "'.");
-
-	print_verbose("Making folder " + path + " in " + base_dir);
-	err = da->make_dir_recursive(path);
-
+	Error err = EditorFileSystem::get_singleton()->make_dir_recursive(path, base_dir);
 	if (err == OK) {
 		emit_signal(SNAME("dir_created"), base_dir.path_join(path));
 	} else {

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
+#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
 #include "core/object/worker_thread_pool.h"
@@ -3067,33 +3068,51 @@ void EditorFileSystem::move_group_file(const String &p_path, const String &p_new
 	}
 }
 
-void EditorFileSystem::add_new_directory(const String &p_path) {
-	String path = p_path.get_base_dir();
-	EditorFileSystemDirectory *parent = filesystem;
-	int base = p_path.count("/");
-	int max_bit = base + 1;
-
-	while (path != "res://") {
-		EditorFileSystemDirectory *dir = get_filesystem_path(path);
-		if (dir) {
-			parent = dir;
-			break;
-		}
-		path = path.get_base_dir();
-		base--;
+Error EditorFileSystem::make_dir_recursive(const String &p_path, const String &p_base_path) {
+	Error err;
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	if (!p_base_path.is_empty()) {
+		err = da->change_dir(p_base_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot open base directory '" + p_base_path + "'.");
 	}
 
-	for (int i = base; i < max_bit; i++) {
+	if (da->dir_exists(p_path)) {
+		return ERR_ALREADY_EXISTS;
+	}
+
+	err = da->make_dir_recursive(p_path);
+	if (err != OK) {
+		return err;
+	}
+
+	const String path = da->get_current_dir();
+	EditorFileSystemDirectory *parent = get_filesystem_path(path);
+	ERR_FAIL_NULL_V(parent, ERR_FILE_NOT_FOUND);
+
+	const PackedStringArray folders = p_path.trim_prefix(path).trim_suffix("/").split("/");
+	bool first = true;
+
+	for (const String &folder : folders) {
+		const int current = parent->find_dir_index(folder);
+		if (current > -1) {
+			parent = parent->get_subdir(current);
+			continue;
+		}
+
 		EditorFileSystemDirectory *efd = memnew(EditorFileSystemDirectory);
 		efd->parent = parent;
-		efd->name = p_path.get_slice("/", i);
+		efd->name = folder;
 		parent->subdirs.push_back(efd);
 
-		if (i == base) {
+		if (first) {
 			parent->subdirs.sort_custom<DirectoryComparator>();
+			first = false;
 		}
 		parent = efd;
 	}
+
+	emit_signal(SNAME("filesystem_changed"));
+	return OK;
 }
 
 ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate) {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -370,7 +370,7 @@ public:
 	bool is_group_file(const String &p_path) const;
 	void move_group_file(const String &p_path, const String &p_new_path);
 
-	void add_new_directory(const String &p_path);
+	Error make_dir_recursive(const String &p_path, const String &p_base_path = String());
 
 	static bool _should_skip_directory(const String &p_path);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -647,8 +647,7 @@ void FileSystemDock::_notification(int p_what) {
 			}
 
 			if (do_redraw) {
-				_update_file_list(true);
-				_update_tree(get_uncollapsed_paths());
+				update_all();
 			}
 
 			if (EditorThemeManager::is_generated_theme_outdated()) {
@@ -1300,13 +1299,7 @@ void FileSystemDock::_fs_changed() {
 	scanning_vb->hide();
 	split_box->show();
 
-	if (tree->is_visible()) {
-		_update_tree(get_uncollapsed_paths());
-	}
-
-	if (file_list_vb->is_visible()) {
-		_update_file_list(true);
-	}
+	update_all();
 
 	if (!select_after_scan.is_empty()) {
 		_navigate_to_path(select_after_scan);
@@ -1316,15 +1309,6 @@ void FileSystemDock::_fs_changed() {
 	}
 
 	set_process(false);
-}
-
-void FileSystemDock::_directory_created(const String &p_path) {
-	if (!DirAccess::exists(p_path)) {
-		return;
-	}
-	EditorFileSystem::get_singleton()->add_new_directory(p_path);
-	_update_tree(get_uncollapsed_paths());
-	_update_file_list(true);
 }
 
 void FileSystemDock::_set_scanning_mode() {
@@ -2697,6 +2681,16 @@ void FileSystemDock::fix_dependencies(const String &p_for_file) {
 	deps_editor->edit(p_for_file);
 }
 
+void FileSystemDock::update_all() {
+	if (tree->is_visible()) {
+		_update_tree(get_uncollapsed_paths());
+	}
+
+	if (file_list_vb->is_visible()) {
+		_update_file_list(true);
+	}
+}
+
 void FileSystemDock::focus_on_path() {
 	current_path_line_edit->grab_focus();
 	current_path_line_edit->select_all();
@@ -3118,9 +3112,7 @@ void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu)
 	}
 
 	_update_folder_colors_setting();
-
-	_update_tree(get_uncollapsed_paths());
-	_update_file_list(true);
+	update_all();
 
 	emit_signal(SNAME("folder_color_changed"));
 }
@@ -3793,8 +3785,7 @@ void FileSystemDock::set_file_sort(FileSortOption p_file_sort) {
 	file_sort = p_file_sort;
 
 	// Update everything needed.
-	_update_tree(get_uncollapsed_paths());
-	_update_file_list(true);
+	update_all();
 }
 
 void FileSystemDock::_file_sort_popup(int p_id) {
@@ -4184,7 +4175,6 @@ FileSystemDock::FileSystemDock() {
 
 	make_dir_dialog = memnew(DirectoryCreateDialog);
 	add_child(make_dir_dialog);
-	make_dir_dialog->connect("dir_created", callable_mp(this, &FileSystemDock::_directory_created));
 
 	make_scene_dialog = memnew(SceneCreateDialog);
 	add_child(make_scene_dialog);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -260,7 +260,6 @@ private:
 	void _toggle_file_display();
 	void _set_file_display(bool p_active);
 	void _fs_changed();
-	void _directory_created(const String &p_path);
 
 	void _select_file(const String &p_path, bool p_select_in_favorites = false);
 	void _tree_activate_file();
@@ -405,6 +404,7 @@ public:
 	ScriptCreateDialog *get_script_create_dialog() const;
 
 	void fix_dependencies(const String &p_for_file);
+	void update_all();
 
 	int get_h_split_offset() const { return split_box_offset_h; }
 	void set_h_split_offset(int p_offset) { split_box_offset_h = p_offset; }

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -191,7 +191,6 @@ void EditorDirDialog::_make_dir_confirm(const String &p_path) {
 	}
 
 	new_dir_path = p_path + "/";
-	EditorFileSystem::get_singleton()->scan_changes(); // We created a dir, so rescan changes.
 }
 
 void EditorDirDialog::_bind_methods() {


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot/pull/93372#discussion_r1757855514, this makes EditorFileSystem responsible for creating new folders.

I also added `update_all()` method to FileSystemDock. I needed it for something, but it ended up as simple helper.