### PR TITLE
Fix single-thread builds by putting the checks on threaded builds only

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -323,7 +323,9 @@ WorkerThreadPool::TaskID WorkerThreadPool::add_native_task(void (*p_func)(void *
 }
 
 WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description) {
+#ifdef THREADS_ENABLED
 	ERR_FAIL_COND_V_MSG(threads.is_empty(), INVALID_TASK_ID, "Can't add a task because the WorkerThreadPool is either not initialized yet or already terminated.");
+#endif
 
 	task_mutex.lock();
 	// Get a free task
@@ -543,7 +545,9 @@ void WorkerThreadPool::notify_yield_over(TaskID p_task_id) {
 }
 
 WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description) {
+#ifdef THREADS_ENABLED
 	ERR_FAIL_COND_V_MSG(threads.is_empty(), INVALID_TASK_ID, "Can't add a group task because the WorkerThreadPool is either not initialized yet or already terminated.");
+#endif
 	ERR_FAIL_COND_V(p_elements < 0, INVALID_TASK_ID);
 	if (p_tasks < 0) {
 		p_tasks = MAX(1u, threads.size());


### PR DESCRIPTION
> [!WARNING]
> This is a really ~~dumb~~ naive PR, but it could actually be the way to go.

Fix for single-threaded builds. It puts the added checks by https://github.com/godotengine/godot/commit/2d1dd41ef5dcb51ddb607ba572e63b605b9191be behind a check for thread-supported builds only.

Fixes #97073