### PR TITLE
Fix eslint .pre-commit-config.yaml by removing commas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,11 +97,11 @@ repos:
         entry: eslint
         files: ^(platform/web/js/|modules/|misc/dist/html/).*\.(js|html)$
         args:
-          - --fix,
-          - --no-warn-ignored,
-          - --no-config-lookup,
-          - --config,
-          - platform/web/eslint.config.cjs,
+          - --fix
+          - --no-warn-ignored
+          - --no-config-lookup
+          - --config
+          - platform/web/eslint.config.cjs
         additional_dependencies:
           - '@eslint/js@^9.3.0'
           - '@html-eslint/eslint-plugin@^0.24.1'


### PR DESCRIPTION
eslint complains that it cannot find `platform/web/eslint.config.cjs,`. Notice the comma at the end.

This PR removes the commas in the list, certainly a typo. (yes, it converted a single line list (with commas to separate elements) to a multiline list that doesn't need the commas. See the regression PR: #94091