### PR TITLE
Open UV editor in point editing mode if no points

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -142,6 +142,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 
 	void _cancel_editing();
 	void _update_polygon_editing_state();
+	void _update_available_modes();
 
 	void _center_view();
 	void _update_zoom_and_pan(bool p_zoom_at_center);
@@ -157,6 +158,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	void _set_snap_step_y(real_t p_val);
 
 	void _uv_edit_mode_select(int p_mode);
+	void _uv_edit_popup_show();
 	void _uv_edit_popup_hide();
 	void _bone_paint_selected(int p_index);
 


### PR DESCRIPTION
Open polygon editor in point editing mode (with create tool) if there's no polygon yet. Disable other modes until points are added.
![uvnopoints](https://github.com/user-attachments/assets/85b6b2fc-d456-452c-b643-cca11b4e7840)
This UX issue was pointed out in #96731. Now users are directed to make some polygon first, disabling modes which cannot be used in this state.