### PR TITLE
Speed up lambda capture handling

### DIFF
--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -97,25 +97,25 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 	}
 
 	if (captures_amount > 0) {
-		Vector<const Variant *> args;
-		args.resize(p_argcount + captures_amount);
+		const int total_argcount = p_argcount + captures_amount;
+		const Variant **args = (const Variant **)alloca(sizeof(Variant *) * total_argcount);
 		for (int i = 0; i < captures_amount; i++) {
-			args.write[i] = &captures[i];
+			args[i] = &captures[i];
 			if (captures[i].get_type() == Variant::OBJECT) {
 				bool was_freed = false;
 				captures[i].get_validated_object_with_check(was_freed);
 				if (was_freed) {
 					ERR_PRINT(vformat(R"(Lambda capture at index %d was freed. Passed "null" instead.)", i));
 					static Variant nil;
-					args.write[i] = &nil;
+					args[i] = &nil;
 				}
 			}
 		}
 		for (int i = 0; i < p_argcount; i++) {
-			args.write[i + captures_amount] = p_arguments[i];
+			args[i + captures_amount] = p_arguments[i];
 		}
 
-		r_return_value = function->call(nullptr, args.ptrw(), args.size(), r_call_error);
+		r_return_value = function->call(nullptr, args, total_argcount, r_call_error);
 		switch (r_call_error.error) {
 			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
 				r_call_error.argument -= captures_amount;
@@ -229,25 +229,25 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 	}
 
 	if (captures_amount > 0) {
-		Vector<const Variant *> args;
-		args.resize(p_argcount + captures_amount);
+		const int total_argcount = p_argcount + captures_amount;
+		const Variant **args = (const Variant **)alloca(sizeof(Variant *) * total_argcount);
 		for (int i = 0; i < captures_amount; i++) {
-			args.write[i] = &captures[i];
+			args[i] = &captures[i];
 			if (captures[i].get_type() == Variant::OBJECT) {
 				bool was_freed = false;
 				captures[i].get_validated_object_with_check(was_freed);
 				if (was_freed) {
 					ERR_PRINT(vformat(R"(Lambda capture at index %d was freed. Passed "null" instead.)", i));
 					static Variant nil;
-					args.write[i] = &nil;
+					args[i] = &nil;
 				}
 			}
 		}
 		for (int i = 0; i < p_argcount; i++) {
-			args.write[i + captures_amount] = p_arguments[i];
+			args[i + captures_amount] = p_arguments[i];
 		}
 
-		r_return_value = function->call(static_cast<GDScriptInstance *>(object->get_script_instance()), args.ptrw(), args.size(), r_call_error);
+		r_return_value = function->call(static_cast<GDScriptInstance *>(object->get_script_instance()), args, total_argcount, r_call_error);
 		switch (r_call_error.error) {
 			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
 				r_call_error.argument -= captures_amount;


### PR DESCRIPTION
Updated `GDScriptLambdaCallable::call` and `GDScriptLambdaSelfCallable::call` to use `alloca` instead of `Vector` when using captures, to avoid extra allocation/copy_on_write calls on each lambda function call.

This makes functions like `Array.map` and `Array.filter` around 60% faster when using simple lambda functions with captures, compared with gdscript below:

```gdscript
func _ready() -> void:
	time("test_no_capture")
	time("test_map_multiply")
	time("test_filter")
	time("test_self_lambda")

func test_no_capture():
	var a := range(1000)
	for i in 1000:
		a.map(func(n): return n * 2)

func test_map_multiply():
	var a := range(1000)
	var multiplier := 5
	for i in 1000:
		a.map(func(n): return n * multiplier)

func test_filter():
	var a := range(1000)
	var min := 500
	for i in 1000:
		a.filter(func(n): return n >= min)

var max := 750
func test_self_lambda():
	var a := range(1000)
	var min := 500
	for i in 1000:
		a.filter(func(n): return n >= min && n <= max)

func time(test_name : String):
	var start := Time.get_ticks_msec()
	call(test_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [test_name, end - start])
```

Old:
```
test_no_capture: 111ms
test_map_multiply: 212ms
test_filter: 215ms
test_self_lambda: 265ms
```

New:
```
test_no_capture: 111ms
test_map_multiply: 129ms
test_filter: 131ms
test_self_lambda: 180ms
```

Using `alloca` does require additional stack space, which has a small impact on how many recursive calls can be made when `p_argcount + captures_amount` is large.  The first example below (5 captures + 22 arguments) crashes for me at 567 recursive calls with the new code, and at 574 with old code.  The second example (1 capture + 4 arguments) crashes at 606 recursive calls in both versions.  I think the difference is small enough to be ok, but I can look into avoiding `alloca` for larger sizes if needed.

```gdscript
func test_recursive_call_large():
	var c1 := 1
	var c2 := 1
	var c3 := 1
	var c4 := 1
	var c5 := 1
	var recursive_func := func(x, f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20):
		if x > 0:
			print(c1 + c2 + c3 + c4 + c5)
			f.call(x-1, f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
	
	# 566 max new, 573 old
	recursive_func.call(573, recursive_func, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
	
func test_recursive_call_small():
	var c1 := 1
	var recursive_func := func(x, f, p1, p2):
		if x > 0:
			print(c1)
			f.call(x-1, f, p1, p2)
	
	recursive_func.call(605, recursive_func, 1, 2) # 605 max both
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
