### PR TITLE
Canvas renderer: Remove redundant assignment

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1939,10 +1939,10 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 	}
 
 	{ //primitive
-		primitive_arrays.index_array[0] = shader.quad_index_array = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 1);
-		primitive_arrays.index_array[1] = shader.quad_index_array = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 2);
-		primitive_arrays.index_array[2] = shader.quad_index_array = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 3);
-		primitive_arrays.index_array[3] = shader.quad_index_array = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 6);
+		primitive_arrays.index_array[0] = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 1);
+		primitive_arrays.index_array[1] = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 2);
+		primitive_arrays.index_array[2] = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 3);
+		primitive_arrays.index_array[3] = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 6);
 	}
 
 	{


### PR DESCRIPTION
Removes a redundant assignment that could result in bugs if reordered.

The original assignment is here:

https://github.com/godotengine/godot/blob/5b5dc00c5275fa63fbbb098bebb7db8d0290b839/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L1938

and then overwritten by the following lines:

https://github.com/godotengine/godot/blob/99a7a9ccd60fbe4030e067b3c36d54b67737446d/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L1941-L1946