### PR TITLE
Expose `LineEdit` `edit` and `unedit` methods.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -8,7 +8,7 @@
 		- When the [LineEdit] control is focused using the keyboard arrow keys, it will only gain focus and not enter edit mode.
 		- To enter edit mode, click on the control with the mouse or press the [code]ui_text_submit[/code] action (by default [kbd]Enter[/kbd] or [kbd]Kp Enter[/kbd]).
 		- To exit edit mode, press [code]ui_text_submit[/code] or [code]ui_cancel[/code] (by default [kbd]Escape[/kbd]) actions.
-		- Check [method is_editing] and [signal editing_toggled] for more information.
+		- Check [method edit], [method unedit], [method is_editing], and [signal editing_toggled] for more information.
 		[b]Important:[/b]
 		- Focusing the [LineEdit] with [code]ui_focus_next[/code] (by default [kbd]Tab[/kbd]) or [code]ui_focus_prev[/code] (by default [kbd]Shift + Tab[/kbd]) or [method Control.grab_focus] still enters edit mode (for compatibility).
 		[LineEdit] features many built-in shortcuts that are always available ([kbd]Ctrl[/kbd] here maps to [kbd]Cmd[/kbd] on macOS):
@@ -73,6 +73,13 @@
 			<return type="void" />
 			<description>
 				Clears the current selection.
+			</description>
+		</method>
+		<method name="edit">
+			<return type="void" />
+			<description>
+				Allows entering edit mode whether the [LineEdit] is focused or not.
+				Use [method Callable.call_deferred] if you want to enter edit mode on [signal text_submitted].
 			</description>
 		</method>
 		<method name="get_menu" qualifiers="const">
@@ -221,6 +228,12 @@
 			<return type="void" />
 			<description>
 				Selects the whole [String].
+			</description>
+		</method>
+		<method name="unedit">
+			<return type="void" />
+			<description>
+				Allows exiting edit mode while preserving focus.
 			</description>
 		</method>
 	</methods>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -644,6 +644,8 @@ void FindReplaceBar::_search_text_submitted(const String &p_text) {
 	} else {
 		search_next();
 	}
+
+	callable_mp(search_text, &LineEdit::edit).call_deferred();
 }
 
 void FindReplaceBar::_replace_text_submitted(const String &p_text) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -245,7 +245,21 @@ void ColorPicker::finish_shaders() {
 }
 
 void ColorPicker::set_focus_on_line_edit() {
-	callable_mp((Control *)c_text, &Control::grab_focus).call_deferred();
+	bool has_hardware_keyboard = true;
+#if defined(ANDROID_ENABLED) || defined(IOS_ENABLED)
+	has_hardware_keyboard = DisplayServer::get_singleton()->has_hardware_keyboard();
+#endif // ANDROID_ENABLED || IOS_ENABLED
+	if (has_hardware_keyboard) {
+		callable_mp((Control *)c_text, &Control::grab_focus).call_deferred();
+	} else {
+		// A hack to avoid showing the virtual keyboard when the ColorPicker window popups and
+		// no hardware keyboard is detected on Android and IOS.
+		// This will only focus the LineEdit without editing, the virtual keyboard will only be visible when
+		// we touch the LineEdit to enter edit mode.
+		callable_mp(c_text, &LineEdit::set_editable).call_deferred(false);
+		callable_mp((Control *)c_text, &Control::grab_focus).call_deferred();
+		callable_mp(c_text, &LineEdit::set_editable).call_deferred(true);
+	}
 }
 
 void ColorPicker::_update_controls() {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -207,9 +207,6 @@ private:
 		float base_scale = 1.0;
 	} theme_cache;
 
-	void _edit();
-	void _unedit();
-
 	void _close_ime_window();
 	void _update_ime_window_position();
 
@@ -265,6 +262,8 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	void edit();
+	void unedit();
 	bool is_editing() const;
 
 	bool has_ime_text() const;


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/97088
* Fixes: https://github.com/godotengine/godot/issues/97096
* Fixes: https://github.com/godotengine/godot/issues/97737
* Fixes: https://github.com/godotengine/godot/issues/88235