### PR TITLE
Clarify behavior of `InputEvent.is_match` and `Shortcut.matches_event`

### DIFF
--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -91,6 +91,7 @@
 			<description>
 				Returns [code]true[/code] if the specified [param event] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
 				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				[b]Note:[/b] Only considers the event configuration (such as the keyboard key or joypad axis), not state information like [method is_pressed], [method is_released], [method is_echo], or [method is_canceled].
 			</description>
 		</method>
 		<method name="is_pressed" qualifiers="const">

--- a/doc/classes/Shortcut.xml
+++ b/doc/classes/Shortcut.xml
@@ -26,7 +26,7 @@
 			<return type="bool" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Returns whether any [InputEvent] in [member events] equals [param event].
+				Returns whether any [InputEvent] in [member events] equals [param event]. This uses [method InputEvent.is_match] to compare events.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
- Shortcut: Clarifies how matches_event() method compares events
- InputEvent: Clarifies is_match() method does not consider event states

Fixes #97048
