### PR TITLE
AudioEffectPitchShift: Fix distortion when pitch is 1.0

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -286,6 +286,11 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 /* clang-format on */
 
 void AudioEffectPitchShiftInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+	// Avoid distortion by skipping processing if pitch_scale is 1.0.
+	if (Math::is_equal_approx(base->pitch_scale, 1.0f)) {
+		return;
+	}
+
 	float sample_rate = AudioServer::get_singleton()->get_mix_rate();
 
 	float *in_l = (float *)p_src_frames;


### PR DESCRIPTION
Fixes #96510

I believe the issue was some kind of `double` to `float` precision error.
It only occurred when changing the `pitch_scale` to a value different from `1.0` and then back to `1.0` (from GDScript or the inspector), but not by default or when hard-coding it to `1.0` in C++.

The project I used for testing:
[pitch-shift-bug.zip](https://github.com/user-attachments/files/17027217/pitch-shift-bug.zip)
Toggling the effect on and off should no longer yield any audible difference.