### PR TITLE
Fix generic conversion icon

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -297,7 +297,7 @@ void EditorResourcePicker::_update_menu_items() {
 			if (has_theme_icon(what, EditorStringName(EditorIcons))) {
 				icon = get_editor_theme_icon(what);
 			} else {
-				icon = get_theme_icon(what, SNAME("Resource"));
+				icon = get_editor_theme_icon(SNAME("Object"));
 			}
 
 			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + relative_id);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3414,7 +3414,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 					if (has_theme_icon(E, SNAME("EditorIcons"))) {
 						icon = get_editor_theme_icon(E);
 					} else {
-						icon = get_editor_theme_icon(SNAME("Resource"));
+						icon = get_editor_theme_icon(SNAME("Object"));
 					}
 
 					container_menu->add_icon_item(icon, vformat(TTR(conversion_string_template), E), CONVERT_BASE_ID + relative_id);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/65585#discussion_r1739751764
Turns out Resource has no icon, so I replaced it with Object and also fixed similar bug in EditorResourcePicker.