### PR TITLE
Add method to swap array elements

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -743,6 +743,27 @@ void Array::shuffle() {
 	}
 }
 
+void Array::swap(int p_first, int p_second) {
+	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	const int s = _p->array.size();
+	if (s < 2) {
+		ERR_FAIL_MSG("Not enough elements in array to be swapped.");
+		return;
+	}
+	if (p_first < 0) {
+		p_first += s;
+	}
+	ERR_FAIL_INDEX(p_first, s);
+	if (p_second < 0) {
+		p_second += s;
+	}
+	ERR_FAIL_INDEX(p_second, s);
+	if (p_first == p_second) {
+		return;
+	}
+	SWAP(operator[](p_first), operator[](p_second));
+}
+
 int Array::bsearch(const Variant &p_value, bool p_before) const {
 	Variant value = p_value;
 	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search"), -1);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -146,6 +146,7 @@ public:
 	void sort();
 	void sort_custom(const Callable &p_callable);
 	void shuffle();
+	void swap(int p_first, int p_second);
 	int bsearch(const Variant &p_value, bool p_before = true) const;
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true) const;
 	void reverse();

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2522,6 +2522,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, sort, sarray(), varray());
 	bind_method(Array, sort_custom, sarray("func"), varray());
 	bind_method(Array, shuffle, sarray(), varray());
+	bind_method(Array, swap, sarray("first", "second"), varray());
 	bind_method(Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(Array, bsearch_custom, sarray("value", "func", "before"), varray(true));
 	bind_method(Array, reverse, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -805,6 +805,14 @@
 				[b]Note:[/b] You should not randomize the return value of [param func], as the heapsort algorithm expects a consistent result. Randomizing the return value will result in unexpected behavior.
 			</description>
 		</method>
+		<method name="swap">
+			<return type="void" />
+			<param index="0" name="first" type="int" />
+			<param index="1" name="second" type="int" />
+			<description>
+				Swaps the elements at indices [param first] and [param second]. If either parameter is negative, the corresponding index is relative to the end of the array. If either parameter is out of bounds, this method fails.
+			</description>
+		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -644,4 +644,55 @@ TEST_CASE("[Array] Test rfind_custom") {
 	CHECK_EQ(index, 4);
 }
 
+TEST_CASE("[Array] swap()") {
+	Array a1 = { 0, 1, 2, 3 };
+
+	Array a2 = a1.duplicate();
+	a2.swap(1, 2);
+	CHECK_EQ(a2[1], Variant(2));
+	CHECK_EQ(a2[2], Variant(1));
+
+	a2 = a1.duplicate();
+	a2.swap(0, -2);
+	CHECK_EQ(a2[0], Variant(2));
+	CHECK_EQ(a2[2], Variant(0));
+
+	a2 = a1.duplicate();
+	a2.swap(-1, 1);
+	CHECK_EQ(a2[3], Variant(1));
+	CHECK_EQ(a2[1], Variant(3));
+
+	a2 = a1.duplicate();
+	a2.swap(-3, -1);
+	CHECK_EQ(a2[1], Variant(3));
+	CHECK_EQ(a2[3], Variant(1));
+
+	a2 = a1.duplicate();
+	a2.swap(2, 2);
+	CHECK_EQ(a1, a2);
+
+	a2 = a1.duplicate();
+	// Out-of-bound index should fail.
+	ERR_PRINT_OFF;
+	a2.swap(1, 9);
+	CHECK_EQ(a1, a2);
+	ERR_PRINT_ON;
+
+	Array a3 = { 0 };
+	Array a4 = a3.duplicate();
+	// Array with less than 2 elements cannot swap.
+	ERR_PRINT_OFF;
+	a4.swap(0, 0);
+	CHECK_EQ(a3, a4);
+	ERR_PRINT_ON;
+
+	a3.clear();
+	a4.clear();
+	// Array with less than 2 elements cannot swap.
+	ERR_PRINT_OFF;
+	a4.swap(0, 0);
+	CHECK_EQ(a3, a4);
+	ERR_PRINT_ON;
+}
+
 } // namespace TestArray


### PR DESCRIPTION
Closes godotengine/godot-proposals#10771.

Adds a `swap` method to `Array`, allowing for more concise swapping of elements without using a buffer variable.