### PR TITLE
Fix trackpad code completion scrolling

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -277,15 +277,17 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				code_completion_force_item_center = -1;
 				queue_redraw();
 			}
-			code_completion_pan_offset += 1.0f;
+			code_completion_pan_offset = 0;
 		} else if (code_completion_pan_offset >= +1.0) {
 			if (code_completion_current_selected < code_completion_options.size() - 1) {
 				code_completion_current_selected++;
 				code_completion_force_item_center = -1;
 				queue_redraw();
 			}
-			code_completion_pan_offset -= 1.0f;
+			code_completion_pan_offset = 0;
 		}
+		accept_event();
+		return;
 	}
 
 	Ref<InputEventMouseButton> mb = p_gui_input;


### PR DESCRIPTION
This PR makes it so that the code stops interpreting past the fact the gestures done inside the code completion window.

This PR also sets `code_completion_pan_offset` to `0` as otherwise, you could do multiple gestures past the beginning of the list or the end, and it would take time to "return" to the list afterwards, as there is no upper/lower limit to the offset.


### Before
[before.webm](https://github.com/user-attachments/assets/18ef4b87-4a5c-45f6-8a0c-9d6e3fb259a6)


### After
[after.webm](https://github.com/user-attachments/assets/370fa11d-fd9e-41c5-be56-2bbe69f93c9b)

Fixes #94415