### PR TITLE
Add forgotten `get_space()` check in `GodotArea3D::remove_soft_body_from_query()`

### DIFF
--- a/servers/physics_3d/godot_area_3d.h
+++ b/servers/physics_3d/godot_area_3d.h
@@ -188,7 +188,7 @@ void GodotArea3D::add_soft_body_to_query(GodotSoftBody3D *p_soft_body, uint32_t 
 void GodotArea3D::remove_soft_body_from_query(GodotSoftBody3D *p_soft_body, uint32_t p_soft_body_shape, uint32_t p_area_shape) {
 	BodyKey bk(p_soft_body, p_soft_body_shape, p_area_shape);
 	monitored_soft_bodies[bk].dec();
-	if (!monitor_query_list.in_list()) {
+	if (get_space() && !monitor_query_list.in_list()) {
 		_queue_monitor_update();
 	}
 }


### PR DESCRIPTION
My fault, I added a `get_space()` check for the other `GodotArea3D::remove_*_from_query()` but forgot about `soft_body`.


Fix #97116.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
