### PR TITLE
Stop EditorNode from refreshing the current scene tab when not needed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1111,7 +1111,14 @@ void EditorNode::_resources_reimported(const Vector<String> &p_resources) {
 		ap->stop(true);
 	}
 
+	// Only refresh the current scene tab if it's been reimported.
+	// Otherwise the scene tab will try to grab focus unnecessarily.
+	bool should_refresh_current_scene_tab = false;
+	const String current_scene_tab = editor_data.get_scene_path(current_tab);
 	for (const String &E : scenes_reimported) {
+		if (!should_refresh_current_scene_tab && E == current_scene_tab) {
+			should_refresh_current_scene_tab = true;
+		}
 		reload_scene(E);
 	}
 
@@ -1121,7 +1128,9 @@ void EditorNode::_resources_reimported(const Vector<String> &p_resources) {
 	scenes_reimported.clear();
 	resources_reimported.clear();
 
-	_set_current_scene_nocheck(current_tab);
+	if (should_refresh_current_scene_tab) {
+		_set_current_scene_nocheck(current_tab);
+	}
 }
 
 void EditorNode::_sources_changed(bool p_exist) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/97021

This PR refocuses the currently-focused asset in the inspector after pressing the reimport button.

https://github.com/user-attachments/assets/b9613783-f7a0-4781-84fc-a51936aa6df5

