### PR TITLE
miniupnpc: Update to 2.2.8 (new major 18)

### DIFF
--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -131,7 +131,11 @@ void UPNP::parse_igd(Ref<UPNPDevice> dev, UPNPDev *devlist) {
 	GetUPNPUrls(&urls, &data, dev->get_description_url().utf8().get_data(), 0);
 
 	char addr[16];
+#if MINIUPNPC_API_VERSION >= 18
+	int i = UPNP_GetValidIGD(devlist, &urls, &data, (char *)&addr, 16, nullptr, 0);
+#else
 	int i = UPNP_GetValidIGD(devlist, &urls, &data, (char *)&addr, 16);
+#endif
 
 	if (i != 1) {
 		FreeUPNPUrls(&urls);

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -614,7 +614,7 @@ to solve some MSVC warnings. See the patches in the `patches` directory.
 ## miniupnpc
 
 - Upstream: https://github.com/miniupnp/miniupnp
-- Version: 2.2.7 (d4d5ec7d48c093b37b2ea5d7171ede21ce9d7ff2, 2024)
+- Version: 2.2.8 (b55145ec095652289a59c33603f3abafee898273, 2024)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/miniupnpc/include/miniupnpc.h
+++ b/thirdparty/miniupnpc/include/miniupnpc.h
@@ -1,9 +1,9 @@
-/* $Id: miniupnpc.h,v 1.63 2024/01/04 00:45:17 nanard Exp $ */
+/* $Id: miniupnpc.h,v 1.66 2024/06/08 22:13:14 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * Project: miniupnp
  * http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * Author: Thomas Bernard
- * Copyright (c) 2005-2022 Thomas Bernard
+ * Copyright (c) 2005-2024 Thomas Bernard
  * This software is subjects to the conditions detailed
  * in the LICENCE file provided within this distribution */
 #ifndef MINIUPNPC_H_INCLUDED
@@ -20,8 +20,8 @@
 #define UPNPDISCOVER_MEMORY_ERROR (-102)
 
 /* versions : */
-#define MINIUPNPC_VERSION	"2.2.6"
-#define MINIUPNPC_API_VERSION	17
+#define MINIUPNPC_VERSION	"2.2.8"
+#define MINIUPNPC_API_VERSION	18
 
 /* Source port:
    Using "1" as an alias for 1900 for backwards compatibility
@@ -108,9 +108,11 @@ struct UPNPUrls {
  * return values :
  *     0 = NO IGD found
  *     1 = A valid connected IGD has been found
- *     2 = A valid IGD has been found but it reported as
+ *     2 = A valid connected IGD has been found but its
+ *         IP address is reserved (non routable)
+ *     3 = A valid IGD has been found but it reported as
  *         not connected
- *     3 = an UPnP device has been found but was not recognized as an IGD
+ *     4 = an UPnP device has been found but was not recognized as an IGD
  *
  * In any non zero return case, the urls and data structures
  * passed as parameters are set. Donc forget to call FreeUPNPUrls(urls) to
@@ -119,8 +121,9 @@ struct UPNPUrls {
 MINIUPNP_LIBSPEC int
 UPNP_GetValidIGD(struct UPNPDev * devlist,
                  struct UPNPUrls * urls,
-				 struct IGDdatas * data,
-				 char * lanaddr, int lanaddrlen);
+                 struct IGDdatas * data,
+                 char * lanaddr, int lanaddrlen,
+                 char * wanaddr, int wanaddrlen);
 
 /* UPNP_GetIGDFromUrl()
  * Used when skipping the discovery process.

--- a/thirdparty/miniupnpc/src/addr_is_reserved.c
+++ b/thirdparty/miniupnpc/src/addr_is_reserved.c
@@ -3,7 +3,7 @@
  * Project : miniupnp
  * Web : http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * Author : Thomas BERNARD
- * copyright (c) 2005-2021 Thomas Bernard
+ * copyright (c) 2005-2024 Thomas Bernard
  * This software is subjet to the conditions detailed in the
  * provided LICENSE file. */
 #ifdef _WIN32
@@ -21,6 +21,9 @@ typedef unsigned long uint32_t;
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #endif /* _WIN32 */
+#ifdef DEBUG
+#include <stdio.h>
+#endif
 
 /* List of IP address blocks which are private / reserved and therefore not suitable for public external IP addresses */
 #define IP(a, b, c, d) (((a) << 24) + ((b) << 16) + ((c) << 8) + (d))
@@ -71,8 +74,12 @@ int addr_is_reserved(const char * addr_str)
 	address = ntohl(addr_n);
 
 	for (i = 0; i < sizeof(reserved)/sizeof(reserved[0]); ++i) {
-		if ((address >> reserved[i].rmask) == (reserved[i].address >> reserved[i].rmask))
+		if ((address >> reserved[i].rmask) == (reserved[i].address >> reserved[i].rmask)) {
+#ifdef DEBUG
+			printf("IP address %s is reserved\n", addr_str);
+#endif
 			return 1;
+		}
 	}
 
 	return 0;

--- a/thirdparty/miniupnpc/src/minisoap.c
+++ b/thirdparty/miniupnpc/src/minisoap.c
@@ -2,7 +2,7 @@
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * Project : miniupnp
  * Author : Thomas Bernard
- * Copyright (c) 2005-2023 Thomas Bernard
+ * Copyright (c) 2005-2024 Thomas Bernard
  * This software is subject to the conditions detailed in the
  * LICENCE file provided in this distribution.
  *
@@ -83,7 +83,7 @@ int soapPostSubmit(SOCKET fd,
 	 * Using HTTP/1.1 means we need to support chunked transfer-encoding :
 	 * When using HTTP/1.1, the router "BiPAC 7404VNOX" always use chunked
 	 * transfer encoding. */
-    /* Connection: Close is normally there only in HTTP/1.1 but who knows */
+    /* Connection: close is normally there only in HTTP/1.1 but who knows */
 	portstr[0] = '\0';
 	if(port != 80)
 		snprintf(portstr, sizeof(portstr), ":%hu", port);
@@ -98,9 +98,8 @@ int soapPostSubmit(SOCKET fd,
 					   "Content-Type: text/xml; charset=\"utf-8\"\r\n"
 #endif
 					   "SOAPAction: \"%s\"\r\n"
-					   "Connection: Close\r\n"
+					   "Connection: close\r\n"
 					   "Cache-Control: no-cache\r\n"	/* ??? */
-					   "Pragma: no-cache\r\n"
 					   "\r\n",
 					   url, httpversion, host, portstr, bodysize, action);
 	if ((unsigned int)headerssize >= sizeof(headerbuf))

--- a/thirdparty/miniupnpc/src/minissdpc.c
+++ b/thirdparty/miniupnpc/src/minissdpc.c
@@ -1,9 +1,9 @@
-/* $Id: minissdpc.c,v 1.49 2021/05/13 11:00:36 nanard Exp $ */
+/* $Id: minissdpc.c,v 1.51 2024/05/16 00:12:05 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * Project : miniupnp
  * Web : http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * Author : Thomas BERNARD
- * copyright (c) 2005-2021 Thomas Bernard
+ * copyright (c) 2005-2024 Thomas Bernard
  * This software is subjet to the conditions detailed in the
  * provided LICENCE file. */
 #include <stdio.h>
@@ -548,7 +548,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 #ifdef _WIN32
 	unsigned long _ttl = (unsigned long)ttl;
 #endif
-	int linklocal = 1;
+	int linklocal = 0;	/* try first with site-local multicast */
 	int sentok;
 
 	if(error)
@@ -1007,9 +1007,10 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			/* switch linklocal flag */
 			if(linklocal) {
 				linklocal = 0;
-				--deviceIndex;
 			} else {
+				/* try again with linklocal multicast */
 				linklocal = 1;
+				--deviceIndex;
 			}
 		}
 	}

--- a/thirdparty/miniupnpc/src/miniupnpc.c
+++ b/thirdparty/miniupnpc/src/miniupnpc.c
@@ -3,7 +3,7 @@
  * Project : miniupnp
  * Web : http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * Author : Thomas BERNARD
- * copyright (c) 2005-2021 Thomas Bernard
+ * copyright (c) 2005-2024 Thomas Bernard
  * This software is subjet to the conditions detailed in the
  * provided LICENSE file. */
 #include <stdlib.h>
@@ -92,15 +92,15 @@ MINIUPNP_LIBSPEC void parserootdesc(const char * buffer, int bufsize, struct IGD
 #endif
 }
 
-/* simpleUPnPcommand2 :
+/* simpleUPnPcommand :
  * not so simple !
  * return values :
  *   pointer - OK
  *   NULL - error */
-static char *
-simpleUPnPcommand2(SOCKET s, const char * url, const char * service,
-                   const char * action, struct UPNParg * args,
-                   int * bufsize, const char * httpversion)
+char *
+simpleUPnPcommand(int s, const char * url, const char * service,
+                  const char * action, struct UPNParg * args,
+                  int * bufsize)
 {
 	char hostname[MAXHOSTNAMELEN+1];
 	unsigned short port = 0;
@@ -197,15 +197,15 @@ simpleUPnPcommand2(SOCKET s, const char * url, const char * service,
 			return NULL;
 	}
 	if(!parseURL(url, hostname, &port, &path, NULL)) return NULL;
-	if(ISINVALID(s)) {
+	if(ISINVALID((SOCKET)s)) {
 		s = connecthostport(hostname, port, 0);
-		if(ISINVALID(s)) {
+		if(ISINVALID((SOCKET)s)) {
 			/* failed to connect */
 			return NULL;
 		}
 	}
 
-	n = soapPostSubmit(s, path, hostname, port, soapact, soapbody, httpversion);
+	n = soapPostSubmit(s, path, hostname, port, soapact, soapbody, "1.1");
 	if(n<=0) {
 #ifdef DEBUG
 		printf("Error sending SOAP request\n");
@@ -226,33 +226,6 @@ simpleUPnPcommand2(SOCKET s, const char * url, const char * service,
 	}
 #endif
 	closesocket(s);
-	return buf;
-}
-
-/* simpleUPnPcommand :
- * not so simple !
- * return values :
- *   pointer - OK
- *   NULL    - error */
-char *
-simpleUPnPcommand(int s, const char * url, const char * service,
-                  const char * action, struct UPNParg * args,
-                  int * bufsize)
-{
-	char * buf;
-
-#if 1
-	buf = simpleUPnPcommand2((SOCKET)s, url, service, action, args, bufsize, "1.1");
-#else
-	buf = simpleUPnPcommand2((SOCKET)s, url, service, action, args, bufsize, "1.0");
-	if (!buf || *bufsize == 0)
-	{
-#if DEBUG
-	    printf("Error or no result from SOAP request; retrying with HTTP/1.1\n");
-#endif
-		buf = simpleUPnPcommand2((SOCKET)s, url, service, action, args, bufsize, "1.1");
-	}
-#endif
 	return buf;
 }
 
@@ -534,9 +507,11 @@ UPNPIGD_IsConnected(struct UPNPUrls * urls, struct IGDdatas * data)
  *    -1 = Internal error
  *     0 = NO IGD found
  *     1 = A valid connected IGD has been found
- *     2 = A valid IGD has been found but it reported as
+ *     2 = A valid connected IGD has been found but its
+ *         IP address is reserved (non routable)
+ *     3 = A valid IGD has been found but it reported as
  *         not connected
- *     3 = an UPnP device has been found but was not recognized as an IGD
+ *     4 = an UPnP device has been found but was not recognized as an IGD
  *
  * In any positive non zero return case, the urls and data structures
  * passed as parameters are set. Don't forget to call FreeUPNPUrls(urls) to
@@ -545,11 +520,13 @@ UPNPIGD_IsConnected(struct UPNPUrls * urls, struct IGDdatas * data)
 MINIUPNP_LIBSPEC int
 UPNP_GetValidIGD(struct UPNPDev * devlist,
                  struct UPNPUrls * urls,
-				 struct IGDdatas * data,
-				 char * lanaddr, int lanaddrlen)
+                 struct IGDdatas * data,
+                 char * lanaddr, int lanaddrlen,
+                 char * wanaddr, int wanaddrlen)
 {
 	struct xml_desc {
 		char lanaddr[40];
+		char wanaddr[40];
 		char * xml;
 		int size;
 		int is_igd;
@@ -557,8 +534,8 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 	struct UPNPDev * dev;
 	int ndev = 0;
 	int i;
-	int state = -1; /* state 1 : IGD connected. State 2 : IGD. State 3 : anything */
-	char extIpAddr[16];
+	int state = -1; /* state 1 : IGD connected. State 2 : connected with reserved IP.
+	                 * State 3 : IGD. State 4 : anything */
 	int status_code = -1;
 
 	if(!devlist)
@@ -602,7 +579,7 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 		}
 	}
 	/* iterate the list to find a device depending on state */
-	for(state = 1; state <= 3; state++)
+	for(state = 1; state <= 4; state++)
 	{
 		for(dev = devlist, i = 0; dev; dev = dev->pNext, i++)
 		{
@@ -611,14 +588,14 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 				memset(data, 0, sizeof(struct IGDdatas));
 				memset(urls, 0, sizeof(struct UPNPUrls));
 				parserootdesc(desc[i].xml, desc[i].size, data);
-				if(desc[i].is_igd || state >= 3 )
+				if(desc[i].is_igd || state >= 4 )
 				{
 				  int is_connected;
 
 				  GetUPNPUrls(urls, data, dev->descURL, dev->scope_id);
 
-				  /* in state 2 and 3 we don't test if device is connected ! */
-				  if(state >= 2)
+				  /* in state 3 and 4 we don't test if device is connected ! */
+				  if(state >= 3)
 				    goto free_and_return;
 				  is_connected = UPNPIGD_IsConnected(urls, data);
 #ifdef DEBUG
@@ -626,9 +603,11 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 				     urls->controlURL, is_connected);
 #endif
 				  /* checks that status is connected AND there is a external IP address assigned */
-				  if(is_connected &&
-				     (UPNP_GetExternalIPAddress(urls->controlURL,  data->first.servicetype, extIpAddr) == 0)) {
-					if(!addr_is_reserved(extIpAddr))
+				  if(is_connected) {
+					if(state >= 2)
+					  goto free_and_return;
+				    if(UPNP_GetExternalIPAddress(urls->controlURL, data->first.servicetype, desc[i].wanaddr) == 0
+					   && !addr_is_reserved(desc[i].wanaddr))
 					  goto free_and_return;
 				  }
 				  FreeUPNPUrls(urls);
@@ -647,9 +626,11 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 				    printf("UPNPIGD_IsConnected(%s) = %d\n",
 				       urls->controlURL, is_connected);
 #endif
-				    if(is_connected &&
-				       (UPNP_GetExternalIPAddress(urls->controlURL,  data->first.servicetype, extIpAddr) == 0)) {
-					  if(!addr_is_reserved(extIpAddr))
+				    if(is_connected) {
+					  if(state >= 2)
+					    goto free_and_return;
+				      if(UPNP_GetExternalIPAddress(urls->controlURL, data->first.servicetype, desc[i].wanaddr) == 0
+					     && !addr_is_reserved(desc[i].wanaddr))
 					    goto free_and_return;
 				    }
 				    FreeUPNPUrls(urls);
@@ -661,8 +642,12 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 	}
 	state = 0;
 free_and_return:
-	if (lanaddr != NULL && state >= 1 && state <= 3 && i < ndev)
-		strncpy(lanaddr, desc[i].lanaddr, lanaddrlen);
+	if (state >= 1 && state <= 4 && i < ndev) {
+		if (lanaddr != NULL)
+			strncpy(lanaddr, desc[i].lanaddr, lanaddrlen);
+		if (wanaddr != NULL)
+			strncpy(wanaddr, desc[i].wanaddr, wanaddrlen);
+	}
 	for(i = 0; i < ndev; i++)
 		free(desc[i].xml);
 	free(desc);

--- a/thirdparty/miniupnpc/src/miniupnpcstrings.h
+++ b/thirdparty/miniupnpc/src/miniupnpcstrings.h
@@ -2,7 +2,7 @@
 #define MINIUPNPCSTRINGS_H_INCLUDED
 
 #define OS_STRING "Godot Engine/1.0"
-#define MINIUPNPC_VERSION_STRING "2.2.7"
+#define MINIUPNPC_VERSION_STRING "2.2.8"
 
 #if 0
 /* according to "UPnP Device Architecture 1.0" */

--- a/thirdparty/miniupnpc/src/miniwget.c
+++ b/thirdparty/miniupnpc/src/miniwget.c
@@ -2,7 +2,7 @@
 /* Project : miniupnp
  * Website : http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * Author : Thomas Bernard
- * Copyright (c) 2005-2023 Thomas Bernard
+ * Copyright (c) 2005-2024 Thomas Bernard
  * This software is subject to the conditions detailed in the
  * LICENCE file provided in this distribution. */
 
@@ -443,9 +443,8 @@ miniwget3(const char * host,
 	len = snprintf(buf, sizeof(buf),
                  "GET %s HTTP/%s\r\n"
 			     "Host: %s:%d\r\n"
-				 "Connection: Close\r\n"
+				 "Connection: close\r\n"
 				 "User-Agent: " OS_STRING " " UPNP_VERSION_STRING " MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
-
 				 "\r\n",
 			   path, httpversion, host, port);
 	if ((unsigned int)len >= sizeof(buf))
@@ -473,41 +472,6 @@ miniwget3(const char * host,
 	closesocket(s);
 	return content;
 }
-
-/* miniwget2() :
- * Call miniwget3(); retry with HTTP/1.1 if 1.0 fails. */
-static void *
-miniwget2(const char * host,
-          unsigned short port, const char * path,
-          int * size, char * addr_str, int addr_str_len,
-          unsigned int scope_id, int * status_code)
-{
-	char * respbuffer;
-
-#if 1
-	respbuffer = miniwget3(host, port, path, size,
-	                       addr_str, addr_str_len, "1.1",
-	                       scope_id, status_code);
-#else
-	respbuffer = miniwget3(host, port, path, size,
-	                       addr_str, addr_str_len, "1.0",
-	                       scope_id, status_code);
-	if (*size == 0)
-	{
-#ifdef DEBUG
-		printf("Retrying with HTTP/1.1\n");
-#endif
-		free(respbuffer);
-		respbuffer = miniwget3(host, port, path, size,
-		                       addr_str, addr_str_len, "1.1",
-		                       scope_id, status_code);
-	}
-#endif
-	return respbuffer;
-}
-
-
-
 
 /* parseURL()
  * arguments :
@@ -639,7 +603,7 @@ miniwget(const char * url, int * size,
 	printf("parsed url : hostname='%s' port=%hu path='%s' scope_id=%u\n",
 	       hostname, port, path, scope_id);
 #endif
-	return miniwget2(hostname, port, path, size, 0, 0, scope_id, status_code);
+	return miniwget3(hostname, port, path, size, 0, 0, "1.1", scope_id, status_code);
 }
 
 void *
@@ -660,5 +624,5 @@ miniwget_getaddr(const char * url, int * size,
 	printf("parsed url : hostname='%s' port=%hu path='%s' scope_id=%u\n",
 	       hostname, port, path, scope_id);
 #endif
-	return miniwget2(hostname, port, path, size, addr, addrlen, scope_id, status_code);
+	return miniwget3(hostname, port, path, size, addr, addrlen, "1.1", scope_id, status_code);
 }

--- a/thirdparty/miniupnpc/src/win32_snprintf.h
+++ b/thirdparty/miniupnpc/src/win32_snprintf.h
@@ -23,9 +23,9 @@
 	(defined(_MSC_VER) && _MSC_VER < 1900) /* Visual Studio older than 2015 */ || \
 	(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && defined(__NO_ISOCEXT)) /* mingw32 without iso c ext */ || \
 	(defined(__MINGW64_VERSION_MAJOR) && /* mingw-w64 not ... */ !( \
-		(defined (__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO != 0)) /* ... with ansi stdio */ || \
+		(defined (__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO != 0) /* ... with ansi stdio */ || \
 		(__MINGW64_VERSION_MAJOR >= 6 && defined(_UCRT)) /* ... at least 6.0.0 with ucrt */ || \
-		(__MINGW64_VERSION_MAJOR >= 8 && !defined(__NO_ISOCEXT)) /* ... at least 8.0.0 with iso c ext */ || \
+		(__MINGW64_VERSION_MAJOR >= 8 && !defined(__NO_ISOCEXT))) /* ... at least 8.0.0 with iso c ext */ || \
 	0) || \
 0)
 


### PR DESCRIPTION
Keep support for major 17 by using a version check for the changed API.

Fixes #93907.