### PR TITLE
Fix typo in `string_get_character_breaks()` sample code

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1732,7 +1732,7 @@
 				Returns array of the composite character boundaries.
 				[codeblock]
 				var ts = TextServerManager.get_primary_interface()
-				print(ts.string_get_word_breaks("Test ❤️‍🔥 Test")) # Prints [1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14]
+				print(ts.string_get_character_breaks("Test ❤️‍🔥 Test")) # Prints [1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14]
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
This codeblock was probably copied from the `string_get_word_breaks()` sample code below :P