### PR TITLE
Don't show project settings starting with underscore

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -267,7 +267,7 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 
 String ProjectSettingsEditor::_get_setting_name() const {
 	String name = property_box->get_text().strip_edges();
-	if (!name.contains("/")) {
+	if (!name.begins_with("_") && !name.contains("/")) {
 		name = "global/" + name;
 	}
 	return name;


### PR DESCRIPTION
If you add a project setting that begins with underscore (e.g. _some_setting, without slashes), it will display under Global category. It's inconsistent with editor settings, which don't show underscored settings. This PR fixes the inconsistency.