### PR TITLE
Enable Auto Reload Scripts on External Change by default in the editor settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1180,7 +1180,9 @@
 			If [code]true[/code], tool scripts will be automatically soft-reloaded after they are saved.
 		</member>
 		<member name="text_editor/behavior/files/auto_reload_scripts_on_external_change" type="bool" setter="" getter="">
-			If [code]true[/code], automatically reloads scripts in the editor when they have been modified and saved by external editors.
+			If [code]true[/code], automatically reloads scripts and text-based shaders in the editor when they have been modified and saved by external editors or tools and the editor regains focus. External changes can be discarded by using the Undo function after they've been loaded in the editor.
+			If [code]false[/code], a file conflict dialog will always be displayed when the editor regains focus. This dialog allows you to choose whether to keep local changes or discard them.
+			[b]Note:[/b] Even when this setting is [code]true[/code], a file conflict dialog is still displayed in certain situations. For instance, it will display when the script editor has unsaved changes that the external editor did not account for.
 		</member>
 		<member name="text_editor/behavior/files/autosave_interval_secs" type="int" setter="" getter="">
 			If set to a value greater than [code]0[/code], automatically saves the current script following the specified interval (in seconds). This can be used to prevent data loss if the editor crashes.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -692,7 +692,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/autosave_interval_secs", 0);
 	_initial_set("text_editor/behavior/files/restore_scripts_on_load", true);
 	_initial_set("text_editor/behavior/files/convert_indent_on_save", true);
-	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", false);
+	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", true);
 	_initial_set("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true);
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);
 


### PR DESCRIPTION
This follows the behavior of most code editors such as VS Code nowadays.

While this behavior can also be obtained when the setting is disabled (by choosing Discard local changes and reload), it's tedious to have to go through this dialog every time:

![image](https://github.com/user-attachments/assets/d49c4b51-53a3-46ec-9439-874eb1c6e589)

This is particularly the case when using external formatters.

When the setting is enabled, external changes can still be discarded by using the Undo function after they've been loaded.

Note that a file conflict dialog is still displayed in certain situations. For instance, it will display when the script editor has unsaved changes that the external editor did not account for.

- This closes https://github.com/godotengine/godot-proposals/issues/10632.
- See also https://github.com/godotengine/godot/issues/98876.