### PR TITLE
[DRAFT] Add external texture support (Vulkan)

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1584,6 +1584,10 @@ RDD::TextureID RenderingDeviceDriverD3D12::_texture_create_shared_from_slice(Tex
 	return TextureID(tex_info);
 }
 
+RDD::TextureID RenderingDeviceDriverD3D12::texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type) {
+	ERR_FAIL_V_MSG(RDD::TextureID(), "Not implemented.");
+}
+
 void RenderingDeviceDriverD3D12::texture_free(TextureID p_texture) {
 	TextureInfo *tex_info = (TextureInfo *)p_texture.id;
 	VersatileResource::free(resources_allocator, tex_info);

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -352,6 +352,7 @@ public:
 	virtual TextureID texture_create_from_extension(uint64_t p_native_texture, TextureType p_type, DataFormat p_format, uint32_t p_array_layers, bool p_depth_stencil) override final;
 	virtual TextureID texture_create_shared(TextureID p_original_texture, const TextureView &p_view) override final;
 	virtual TextureID texture_create_shared_from_slice(TextureID p_original_texture, const TextureView &p_view, TextureSliceType p_slice_type, uint32_t p_layer, uint32_t p_layers, uint32_t p_mipmap, uint32_t p_mipmaps) override final;
+	virtual TextureID texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type = 0) override final;
 	virtual void texture_free(TextureID p_texture) override final;
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -119,6 +119,7 @@ public:
 	virtual TextureID texture_create_from_extension(uint64_t p_native_texture, TextureType p_type, DataFormat p_format, uint32_t p_array_layers, bool p_depth_stencil) override final;
 	virtual TextureID texture_create_shared(TextureID p_original_texture, const TextureView &p_view) override final;
 	virtual TextureID texture_create_shared_from_slice(TextureID p_original_texture, const TextureView &p_view, TextureSliceType p_slice_type, uint32_t p_layer, uint32_t p_layers, uint32_t p_mipmap, uint32_t p_mipmaps) override final;
+	virtual TextureID texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type = 0) override final;
 	virtual void texture_free(TextureID p_texture) override final;
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -461,6 +461,10 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create_shared_from_slice(Text
 	return rid::make(obj);
 }
 
+RDD::TextureID RenderingDeviceDriverMetal::texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type) {
+	ERR_FAIL_V_MSG(RDD::TextureID(), "not implemented");
+}
+
 void RenderingDeviceDriverMetal::texture_free(TextureID p_texture) {
 	rid::release(p_texture);
 }

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -14,7 +14,7 @@ if env["use_volk"]:
     env.Prepend(CPPPATH=[thirdparty_volk_dir])
 
 if env["platform"] == "android":
-    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])
+    env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR", "VK_ANDROID_external_memory_android_hardware_buffer"])
 elif env["platform"] == "ios":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_IOS_MVK", "VK_USE_PLATFORM_METAL_EXT"])
 elif env["platform"] == "linuxbsd":

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -216,6 +216,9 @@ public:
 #ifdef DEBUG_ENABLED
 		bool created_from_extension = false;
 #endif
+#if defined(ANDROID_ENABLED) && defined(__ANDROID_API__) && __ANDROID_API__ >= 26
+		VkSamplerYcbcrConversion ycbcr_conversion = VK_NULL_HANDLE;
+#endif
 	};
 
 	VkSampleCountFlagBits _ensure_supported_sample_count(TextureSamples p_requested_sample_count);
@@ -225,6 +228,7 @@ public:
 	virtual TextureID texture_create_from_extension(uint64_t p_native_texture, TextureType p_type, DataFormat p_format, uint32_t p_array_layers, bool p_depth_stencil) override final;
 	virtual TextureID texture_create_shared(TextureID p_original_texture, const TextureView &p_view) override final;
 	virtual TextureID texture_create_shared_from_slice(TextureID p_original_texture, const TextureView &p_view, TextureSliceType p_slice_type, uint32_t p_layer, uint32_t p_layers, uint32_t p_mipmap, uint32_t p_mipmaps) override final;
+	virtual TextureID texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type = 0) override final;
 	virtual void texture_free(TextureID p_texture) override final;
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1088,6 +1088,33 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 }
 
 void TextureStorage::texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) {
+	Texture texture;
+
+	texture.type = TextureStorage::TYPE_2D;
+
+	texture.width = p_width;
+	texture.height = p_height;
+	texture.layers = 1;
+	texture.mipmaps = 1;
+	texture.depth = 1;
+	texture.format = Image::FORMAT_RGB8;
+	texture.validated_format = Image::FORMAT_RGB8;
+
+	texture.rd_type = RD::TEXTURE_TYPE_2D;
+	texture.rd_format = RD::DATA_FORMAT_A8B8G8R8_UNORM_PACK32;
+	texture.rd_format_srgb = RD::DATA_FORMAT_A8B8G8R8_SRGB_PACK32;
+
+	texture.width_2d = texture.width;
+	texture.height_2d = texture.height;
+	texture.is_render_target = false;
+	texture.is_proxy = false;
+
+	if (p_external_buffer) {
+		texture.rd_texture = RD::get_singleton()->texture_create_external(p_width, p_height, p_external_buffer);
+		ERR_FAIL_COND(texture.rd_texture.is_null());
+	}
+
+	texture_owner.initialize_rid(p_texture, texture);
 }
 
 void TextureStorage::texture_proxy_initialize(RID p_texture, RID p_base) {
@@ -1365,6 +1392,18 @@ void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &
 }
 
 void TextureStorage::texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) {
+	Texture *tex = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL(tex);
+
+	tex->width = p_width;
+	tex->height = p_height;
+
+	if (p_external_buffer) {
+		if (tex->rd_texture.is_valid()) {
+			RD::get_singleton()->free(tex->rd_texture);
+		}
+		tex->rd_texture = RD::get_singleton()->texture_create_external(p_width, p_height, p_external_buffer);
+	}
 }
 
 void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1124,6 +1124,35 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 	return id;
 }
 
+RID RenderingDevice::texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type) {
+	_THREAD_SAFE_METHOD_
+
+	Texture texture;
+	texture.type = TEXTURE_TYPE_2D;
+	texture.format = DATA_FORMAT_A8B8G8R8_UNORM_PACK32;
+	texture.samples = TEXTURE_SAMPLES_1;
+	texture.width = p_width;
+	texture.height = p_height;
+	texture.depth = 1;
+	texture.layers = 1;
+	texture.mipmaps = 1;
+	texture.usage_flags = TEXTURE_USAGE_SAMPLING_BIT | TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+	texture.base_mipmap = 0;
+	texture.base_layer = 0;
+	texture.read_aspect_flags.set_flag(RDD::TEXTURE_ASPECT_COLOR_BIT);
+	texture.barrier_aspect_flags.set_flag(RDD::TEXTURE_ASPECT_COLOR_BIT);
+
+	texture.driver_id = driver->texture_create_external(p_width, p_height, p_external_buffer, p_external_buffer_type);
+	ERR_FAIL_COND_V(!texture.driver_id, RID());
+
+	RID id = texture_owner.make_rid(texture);
+#ifdef DEV_ENABLED
+	set_resource_name(id, "RID:" + itos(id.get_id()));
+#endif
+
+	return id;
+}
+
 Error RenderingDevice::texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data) {
 	return _texture_update(p_texture, p_layer, p_data, false, true);
 }
@@ -5940,6 +5969,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_create_shared", "view", "with_texture"), &RenderingDevice::_texture_create_shared);
 	ClassDB::bind_method(D_METHOD("texture_create_shared_from_slice", "view", "with_texture", "layer", "mipmap", "mipmaps", "slice_type"), &RenderingDevice::_texture_create_shared_from_slice, DEFVAL(1), DEFVAL(TEXTURE_SLICE_2D));
 	ClassDB::bind_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "usage_flags", "image", "width", "height", "depth", "layers"), &RenderingDevice::texture_create_from_extension);
+	ClassDB::bind_method(D_METHOD("texture_create_external", "width", "height", "external_buffer", "external_buffer_type"), &RenderingDevice::texture_create_external, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("texture_update", "texture", "layer", "data"), &RenderingDevice::texture_update);
 	ClassDB::bind_method(D_METHOD("texture_get_data", "texture", "layer"), &RenderingDevice::texture_get_data);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -322,6 +322,7 @@ public:
 	RID texture_create_shared(const TextureView &p_view, RID p_with_texture);
 	RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers);
 	RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps = 1, TextureSliceType p_slice_type = TEXTURE_SLICE_2D, uint32_t p_layers = 0);
+	RID texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type = 0);
 	Error texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data);
 	Vector<uint8_t> texture_get_data(RID p_texture, uint32_t p_layer); // CPU textures will return immediately, while GPU textures will most likely force a flush
 

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -280,6 +280,7 @@ public:
 	// texture_create_shared_*() can only use original, non-view textures as original. RenderingDevice is responsible for ensuring that.
 	virtual TextureID texture_create_shared(TextureID p_original_texture, const TextureView &p_view) = 0;
 	virtual TextureID texture_create_shared_from_slice(TextureID p_original_texture, const TextureView &p_view, TextureSliceType p_slice_type, uint32_t p_layer, uint32_t p_layers, uint32_t p_mipmap, uint32_t p_mipmaps) = 0;
+	virtual TextureID texture_create_external(int p_width, int p_height, uint64_t p_external_buffer, uint64_t p_external_buffer_type = 0) = 0;
 	virtual void texture_free(TextureID p_texture) = 0;
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) = 0;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) = 0;


### PR DESCRIPTION
This builds on top of PR https://github.com/godotengine/godot/pull/96982 to add external texture support for Vulkan.

**This is an unfinished work-in-progress.**

I ended up splitting this off into its own PR to finish later after I discovered that this will only work with Android API level 26 or higher. Presently, we have an API minimum of 21, which prevents this code from compiling.

So, I'll save this until after we increase the API minimum to 21 or higher. (Another option is including the code, but then requiring users to build with `scons ndk_platform=android-26` in order to support this feature, but it wouldn't be included in official builds.)