### PR TITLE
CI: Improve `godot-cpp` actions

### DIFF
--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -21,49 +21,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          sparse-checkout: .github
+
+      - name: Checkout godot-cpp
+        uses: actions/checkout@v4
+        with:
           submodules: recursive
+          repository: godotengine/godot-cpp
+          ref: ${{ env.GODOT_CPP_BRANCH }}
+          path: godot-cpp
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
-      # Checkout godot-cpp
-      - name: Checkout godot-cpp
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot-cpp
-          ref: ${{ env.GODOT_CPP_BRANCH }}
-          submodules: recursive
-          path: godot-cpp
+      - name: Setup GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
 
-      # Download generated API dump
       - name: Download GDExtension interface and API dump
         uses: ./.github/actions/download-artifact
         with:
           name: godot-api-dump
-          path: ./godot-api
+          path: ./godot-cpp/gdextension
 
-      # Extract and override existing files with generated files
-      - name: Extract GDExtension interface and API dump
-        run: |
-          cp -f godot-api/gdextension_interface.h godot-cpp/gdextension/
-          cp -f godot-api/extension_api.json godot-cpp/gdextension/
+      # TODO: Enable caching when godot-cpp has proper cache limiting.
 
-      # TODO: Add caching to the SCons build and store it for CI via the godot-cache
-      # action.
+      # - name: Restore Godot build cache
+      #   uses: ./.github/actions/godot-cache-restore
+      #   with:
+      #     cache-name: godot-cpp
+      #   continue-on-error: true
 
-      # Build godot-cpp test extension
       - name: Build godot-cpp test extension
-        run: |
-          cd godot-cpp/test
-          scons target=template_debug dev_build=yes
-          cd ../..
+        env: # Keep synced with godot-build.
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+          SCONS_CACHE_LIMIT: 7168
+        run: scons --directory=./godot-cpp/test target=template_debug dev_build=yes verbose=yes
 
-  gdextension-c-compile:
-    runs-on: 'ubuntu-20.04'
-    name: 'Check GDExtension header with a C compiler'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: 'Run C compiler on gdextension_interface.h'
-        run: |
-          gcc -c core/extension/gdextension_interface.h
+      # - name: Save Godot build cache
+      #   uses: ./.github/actions/godot-cache-save
+      #   with:
+      #     cache-name: godot-cpp
+      #   continue-on-error: true

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -57,3 +57,7 @@ jobs:
       - name: Class reference schema checks
         run: |
           xmllint --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml
+
+      - name: Run C compiler on `gdextension_interface.h`
+        run: |
+          gcc -c core/extension/gdextension_interface.h


### PR DESCRIPTION
Improves the GitHub Actions for `godot-cpp` in two primary ways:
- Relocated running C compiler on `gdextension_interface.h` to `static_checks`. This check was pushed waaaaay further back than it should've been, especially when the check itself takes less than a second. It's structurally and logistically much closer to the other static checks, which is where the action now resides.
- `godot-cpp` is now cached. There's no real reason for this SCons build to *not* have dedicated caching like the other workflows, so this adds exactly that. While this file would likely have to be retired entirely if other artifacts want to use `godot-cpp`, the current implementation means that the cache name can be safely hardcoded.