### PR TITLE
Expose `has_undo()` and `has_redo()` of LineEdit

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -151,10 +151,22 @@
 				Returns [code]true[/code] if the user has text in the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] (IME).
 			</description>
 		</method>
+		<method name="has_redo" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a "redo" action is available.
+			</description>
+		</method>
 		<method name="has_selection" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the user has selected text.
+			</description>
+		</method>
+		<method name="has_undo" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if an "undo" action is available.
 			</description>
 		</method>
 		<method name="insert_text_at_caret">

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2763,6 +2763,8 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("select", "from", "to"), &LineEdit::select, DEFVAL(0), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("select_all"), &LineEdit::select_all);
 	ClassDB::bind_method(D_METHOD("deselect"), &LineEdit::deselect);
+	ClassDB::bind_method(D_METHOD("has_undo"), &LineEdit::has_undo);
+	ClassDB::bind_method(D_METHOD("has_redo"), &LineEdit::has_redo);
 	ClassDB::bind_method(D_METHOD("has_selection"), &LineEdit::has_selection);
 	ClassDB::bind_method(D_METHOD("get_selected_text"), &LineEdit::get_selected_text);
 	ClassDB::bind_method(D_METHOD("get_selection_from_column"), &LineEdit::get_selection_from_column);


### PR DESCRIPTION
Some progress towards https://github.com/godotengine/godot-proposals/issues/9207.

When using LineEdit, you might want to make a custom context menu or other utility for Undo/Redo. One thing that makes this harder than it needs to be is the inability to easily tell if LineEdits can undo/redo, which makes it impossible to disable their corresponding buttons:

![image](https://github.com/user-attachments/assets/138a4fc9-4120-4244-9b52-2ac91ecf41f2)

TextEdits already expose this.