### PR TITLE
Fix Undo/Redo not working in Bezier Animation Editor when moving keys

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1443,6 +1443,11 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					i++;
 				}
 
+				AnimationPlayerEditor *ape = AnimationPlayerEditor::get_singleton();
+				if (ape) {
+					undo_redo->add_do_method(ape, "_animation_update_key_frame");
+					undo_redo->add_undo_method(ape, "_animation_update_key_frame");
+				}
 				undo_redo->commit_action();
 
 			} else if (select_single_attempt != IntPair(-1, -1)) {
@@ -1967,15 +1972,6 @@ void AnimationBezierTrackEdit::delete_selection() {
 void AnimationBezierTrackEdit::_bezier_track_insert_key_at_anim(const Ref<Animation> &p_anim, int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode) {
 	int idx = p_anim->bezier_track_insert_key(p_track, p_time, p_value, p_in_handle, p_out_handle);
 	p_anim->bezier_track_set_key_handle_mode(p_track, idx, p_handle_mode);
-
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Animation Bezier Curve Change Call"));
-	AnimationPlayerEditor *ape = AnimationPlayerEditor::get_singleton();
-	if (ape) {
-		undo_redo->add_do_method(ape, "_animation_update_key_frame");
-		undo_redo->add_undo_method(ape, "_animation_update_key_frame");
-	}
-	undo_redo->commit_action();
 }
 
 void AnimationBezierTrackEdit::_bind_methods() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97146, introduced by https://github.com/godotengine/godot/pull/96753

In the PR I was registering the animation refresh _do_ and _undo_ method call inside AnimationBezierTrackEdit::_bezier_track_insert_key_at_anim thinking it was the correct place to refresh once the track is moved.

This is incorrect since this method itself is called by the undo_redo.commit() registed back in gui_input. So I moved it to the _ape_ call to gui_input, after all other undo_redo callbacks caused by a move are registered.