### PR TITLE
[3.x] Improve error message when `OS.execute()` fails on Windows

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2978,7 +2978,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 		CloseHandle(pipe[0]); // Cleanup pipe handles.
 		CloseHandle(pipe[1]);
 	}
-	ERR_FAIL_COND_V(ret == 0, ERR_CANT_FORK);
+	ERR_FAIL_COND_V_MSG(ret == 0, ERR_CANT_FORK, "Could not create child process: " + String(modstr.ptr()));
 
 	if (p_blocking) {
 		if (r_pipe) {


### PR DESCRIPTION
This takes the error message from 4.x and backports it to 3.x.

PS: I noticed we don't have any such message when `OS.execute()` fails on Linux (and possibly macOS). This also applies to 4.x.

**Testing project:** [test_os_execute_3.x.zip](https://github.com/user-attachments/files/17051602/test_os_execute_3.x.zip)

- See https://github.com/godotengine/godot/issues/42719#issuecomment-2292617583.

## Preview

### Before

```
ERROR: Condition "ret == 0" is true. Returned: ERR_CANT_FORK
   at: execute (platform/windows/os_windows.cpp:2981)
ERROR: Condition "ret == 0" is true. Returned: ERR_CANT_FORK
   at: execute (platform/windows/os_windows.cpp:2981)
```

### After

```
ERROR: Could not create child process: non-existent-command
   at: (platform/windows/os_windows.cpp:2981)
ERROR: Could not create child process: non-existent-command with arguments
   at: (platform/windows/os_windows.cpp:2981)
```