### PR TITLE
`HTTPRequest` make working with headers easier

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -118,7 +118,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 		if (sp == -1) {
 			continue;
 		}
-		String key = s.substr(0, sp).strip_edges();
+		String key = s.substr(0, sp).strip_edges().to_lower();
 		String value = s.substr(sp + 1).strip_edges();
 		ret[key] = value;
 	}

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -59,7 +59,7 @@
 		<method name="get_response_headers_as_dictionary">
 			<return type="Dictionary" />
 			<description>
-				Returns all response headers as a [Dictionary]. Each entry is composed by the header name, and a [String] containing the values separated by [code]"; "[/code]. The casing is kept the same as the headers were received.
+				Returns all response headers as a [Dictionary]. Each key is a header name in lower-case and each value is a [String] of values separated by [code]; [/code].
 				[codeblock]
 				{
 					"content-length": 12,

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -170,16 +170,45 @@
 				[b]Note:[/b] Some Web servers may not send a body length. In this case, the value returned will be [code]-1[/code]. If using chunked transfer encoding, the body length will also be [code]-1[/code].
 			</description>
 		</method>
+		<method name="get_dictionary_from_headers" qualifiers="static">
+			<return type="Dictionary" />
+			<param index="0" name="headers" type="PackedStringArray" />
+			<description>
+				Converts the [param headers] array into a [Dictionary]. Each key is a header name in lower-case and each value is a [String] of values separated by [code]; [/code].
+				[codeblock]
+				{
+				    "content-length": "12",
+				    "content-type": "application/json; charset=UTF-8",
+				}
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_downloaded_bytes" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the number of bytes this HTTPRequest downloaded.
 			</description>
 		</method>
+		<method name="get_header_value" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="headers" type="PackedStringArray" />
+			<param index="1" name="header_name" type="String" />
+			<description>
+				Returns the value of the case-insensitive header named [param header_name] in [param headers], as a [String]. If not found, returns an empty [String].
+			</description>
+		</method>
 		<method name="get_http_client_status" qualifiers="const">
 			<return type="int" enum="HTTPClient.Status" />
 			<description>
 				Returns the current status of the underlying [HTTPClient].
+			</description>
+		</method>
+		<method name="has_header" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="headers" type="PackedStringArray" />
+			<param index="1" name="header_name" type="String" />
+			<description>
+				Returns [code]true[/code] if given [param header_name] is found in [param headers] (case-insensitive).
 			</description>
 		</method>
 		<method name="request">

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -92,18 +92,17 @@ bool HTTPRequest::has_header(const PackedStringArray &p_headers, const String &p
 String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const String &p_header_name) {
 	String value = "";
 
-	String lowwer_case_header_name = p_header_name.to_lower();
+	String lower_case_header_name = p_header_name.to_lower();
 	for (int i = 0; i < p_headers.size(); i++) {
 		if (p_headers[i].find_char(':') > 0) {
 			Vector<String> parts = p_headers[i].split(":", false, 1);
-			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
-				value = parts[1].strip_edges();
-				break;
+			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lower_case_header_name) {
+				value = value + parts[1].strip_edges() + "; ";
 			}
 		}
 	}
 
-	return value;
+	return value.trim_suffix("; ");
 }
 
 Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_headers, HTTPClient::Method p_method, const String &p_request_data) {
@@ -661,6 +660,24 @@ void HTTPRequest::set_tls_options(const Ref<TLSOptions> &p_options) {
 	tls_options = p_options;
 }
 
+Dictionary HTTPRequest::get_dictionary_from_headers(const PackedStringArray &p_headers) {
+	Dictionary ret;
+	for (const String &s : p_headers) {
+		int sp = s.find(":");
+		if (sp == -1) {
+			continue;
+		}
+		String key = s.substr(0, sp).strip_edges().to_lower();
+		String value = s.substr(sp + 1, s.length()).strip_edges();
+		if (ret.has(key)) {
+			value = (String)ret[key] + "; " + value;
+		}
+		ret[key] = value;
+	}
+
+	return ret;
+}
+
 void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("request", "url", "custom_headers", "method", "request_data"), &HTTPRequest::request, DEFVAL(PackedStringArray()), DEFVAL(HTTPClient::METHOD_GET), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("request_raw", "url", "custom_headers", "method", "request_data_raw"), &HTTPRequest::request_raw, DEFVAL(PackedStringArray()), DEFVAL(HTTPClient::METHOD_GET), DEFVAL(PackedByteArray()));
@@ -695,6 +712,11 @@ void HTTPRequest::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::set_http_proxy);
 	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::set_https_proxy);
+
+	ClassDB::bind_static_method("HTTPRequest", D_METHOD("has_header", "headers", "header_name"), &HTTPRequest::has_header);
+	ClassDB::bind_static_method("HTTPRequest", D_METHOD("get_header_value", "headers", "header_name"), &HTTPRequest::get_header_value);
+
+	ClassDB::bind_static_method("HTTPRequest", D_METHOD("get_dictionary_from_headers", "headers"), &HTTPRequest::get_dictionary_from_headers);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE_PATH), "set_download_file", "get_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216,suffix:B"), "set_download_chunk_size", "get_download_chunk_size");

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -113,9 +113,6 @@ private:
 	Error _parse_url(const String &p_url);
 	Error _request();
 
-	bool has_header(const PackedStringArray &p_headers, const String &p_header_name);
-	String get_header_value(const PackedStringArray &p_headers, const String &header_name);
-
 	SafeFlag thread_done;
 	SafeFlag thread_request_quit;
 
@@ -167,6 +164,11 @@ public:
 	void set_https_proxy(const String &p_host, int p_port);
 
 	void set_tls_options(const Ref<TLSOptions> &p_options);
+
+	static bool has_header(const PackedStringArray &p_headers, const String &p_header_name);
+	static String get_header_value(const PackedStringArray &p_headers, const String &p_header_name);
+
+	static Dictionary get_dictionary_from_headers(const PackedStringArray &p_headers);
 
 	HTTPRequest();
 };


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/4734
- Supersedes #63713

Adding `HTTPRequest::get_dictionary_from_headers` to get a Dictionary from `headers` parameter on `request_completed`.
Making `HTTPRequest::has_header` and `HTTPRequest::get_header_value` public.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
