### PR TITLE
[Buildsystem] Improve cache configuration usability

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -271,6 +271,8 @@ opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))
 opts.Add("scu_limit", "Max includes per SCU file when using scu_build (determines RAM use)", "0")
 opts.Add(BoolVariable("engine_update_check", "Enable engine update checks in the Project Manager", True))
 opts.Add(BoolVariable("steamapi", "Enable minimal SteamAPI integration for usage time tracking (editor only)", False))
+opts.Add("cache_path", "Path to the directory to use for the SCons cache, if left empty cache is not used", "")
+opts.Add("cache_limit", "Limit, in MB, for the SCons cache (default 1 GB)", 1024)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_brotli", "Use the built-in Brotli library", True))
@@ -617,6 +619,10 @@ if env["production"]:
 
 if env["strict_checks"]:
     env.Append(CPPDEFINES=["STRICT_CHECKS"])
+
+# Fetch cache configuration from the environment if present and unconfigured.
+env["cache_path"] = ARGUMENTS.get("cache_path", os.environ.get("SCONS_CACHE", ""))
+env["cache_limit"] = ARGUMENTS.get("cache_limit", os.environ.get("SCONS_CACHE_LIMIT", 1024))
 
 # Run SCU file generation script if in a SCU build.
 if env["scu_build"]:
@@ -1049,10 +1055,9 @@ GLSL_BUILDERS = {
 }
 env.Append(BUILDERS=GLSL_BUILDERS)
 
-scons_cache_path = os.environ.get("SCONS_CACHE")
-if scons_cache_path is not None:
-    CacheDir(scons_cache_path)
-    print("Scons cache enabled... (path: '" + scons_cache_path + "')")
+if env["cache_path"] != "":
+    CacheDir(env["cache_path"])
+    print("Scons cache enabled... (path: '" + env["cache_path"] + "')")
 
 if env["vsproj"]:
     env.vs_incs = []

--- a/methods.py
+++ b/methods.py
@@ -851,10 +851,10 @@ def show_progress(env):
 
     class cache_progress:
         # The default is 1 GB cache
-        def __init__(self, path=None, limit=pow(1024, 3)):
+        def __init__(self, path="", limit=pow(1024, 3)):
             self.path = path
             self.limit = limit
-            if env["verbose"] and path is not None:
+            if env["verbose"] and path != "":
                 screen.write(
                     "Current cache limit is {} (used: {})\n".format(
                         self.convert_size(limit), self.convert_size(self.get_size(path))
@@ -907,10 +907,10 @@ def show_progress(env):
     except Exception:
         pass
 
-    cache_directory = os.environ.get("SCONS_CACHE")
+    cache_directory = env["cache_path"]
     # Simple cache pruning, attached to SCons' progress callback. Trim the
     # cache directory to a size not larger than cache_limit.
-    cache_limit = float(os.getenv("SCONS_CACHE_LIMIT", 1024)) * 1024 * 1024
+    cache_limit = float(env["cache_limit"]) * 1024 * 1024
     progressor = cache_progress(cache_directory, cache_limit)
     Progress(progressor, interval=node_count_interval)
 
@@ -923,7 +923,7 @@ def clean_cache(env):
     import time
 
     class cache_clean:
-        def __init__(self, path=None, limit=pow(1024, 3)):
+        def __init__(self, path="", limit=pow(1024, 3)):
             self.path = path
             self.limit = limit
 
@@ -939,7 +939,7 @@ def clean_cache(env):
             [os.remove(f) for f in files]
 
         def file_list(self):
-            if self.path is None:
+            if self.path == "":
                 # Nothing to do
                 return []
             # Gather a list of (filename, (size, atime)) within the
@@ -976,10 +976,10 @@ def clean_cache(env):
         except Exception:
             pass
 
-    cache_directory = os.environ.get("SCONS_CACHE")
+    cache_directory = env["cache_path"]
     # Simple cache pruning, attached to SCons' progress callback. Trim the
     # cache directory to a size not larger than cache_limit.
-    cache_limit = float(os.getenv("SCONS_CACHE_LIMIT", 1024)) * 1024 * 1024
+    cache_limit = float(env["cache_limit"]) * 1024 * 1024
     cleaner = cache_clean(cache_directory, cache_limit)
 
     atexit.register(cache_finally)


### PR DESCRIPTION
While environment variables are useful for more general configuration and work well for CI they are a mess to work with if you want to use custom profiles or build different configurations from the command line

This adds two command line options to configure the cache path and limit, which take precedence over the environment variables

My own use case is that I build several different configurations and prefer to have a separate cache directory for each to avoid any mess, and doing so in powershell is a mess and forces you to export and reset environment variables constantly

Keeps everything else the same, and makes the fetching and initializing uniform, but uses the empty string for disabling the cache instead of `None` to allow clearing it when desired

As an example of the improvement in use, my "main" build template I use as a powershell script:
```powershell
$Env:SCONS_CACHE = ".cache/editor_debug_main"
$Env:SCONS_CACHE_LIMIT = 4096
scons platform=windows target=editor dev_build=Yes dev_mode=Yes scu_build=Yes debug_paths_relative=Yes extra_suffix="main" $args
```
I could ensure I don't pollute the environment by saving and restoring it which would make it even more annoying, with this PR it becomes as simple as:
```powershell
scons platform=windows target=editor dev_build=Yes dev_mode=Yes scu_build=Yes debug_paths_relative=Yes extra_suffix="main" cache_path=".cache/editor_debug_main" cache_limit=4096 $args
```
And can now be used from custom profiles as well as it now is a command line argument
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
