### PR TITLE
Fix using Binutils `AR` with `TEMPFILE` on Windows

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -704,6 +704,17 @@ def get_is_ar_thin_supported(env):
     return False
 
 
+WINPATHSEP_RE = re.compile(r"\\([^\"'\\]|$)")
+
+
+def tempfile_arg_esc_func(arg):
+    from SCons.Subst import quote_spaces
+
+    arg = quote_spaces(arg)
+    # GCC requires double Windows slashes, let's use UNIX separator
+    return WINPATHSEP_RE.sub(r"/\1", arg)
+
+
 def configure_mingw(env: "SConsEnvironment"):
     # Workaround for MinGW. See:
     # https://www.scons.org/wiki/LongCmdLinesOnWin32
@@ -713,6 +724,8 @@ def configure_mingw(env: "SConsEnvironment"):
     env["ARCOM_ORIG"] = env["ARCOM"]
     env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
     env["TEMPFILESUFFIX"] = ".rsp"
+    if os.name == "nt":
+        env["TEMPFILEARGESCFUNC"] = tempfile_arg_esc_func
 
     ## Build type
 


### PR DESCRIPTION
Set `TEMPFILEARGESCFUNC`[1] to replace backslashes with forward slashes in paths.

[1]: https://scons.org/doc/production/HTML/scons-user/apa.html#cv-TEMPFILEARGESCFUNC

This should fix a regression from https://github.com/godotengine/godot/pull/96407#issuecomment-2360794970