### PR TITLE
Pre-commit: Update clang-format to 18.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v17.0.6
+    rev: v18.1.8
     hooks:
       - id: clang-format
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java|glsl)$
@@ -39,7 +39,7 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.6.5
     hooks:
       - id: ruff
         args: [--fix]

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -212,9 +212,7 @@ void main() {
 #endif
 
 	{
-
 #CODE : SKY
-
 	}
 
 	color *= sky_energy_multiplier;

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -103,9 +103,9 @@ public:
 	virtual void configure(const RenderSceneBuffersConfiguration *p_config) override;
 	void configure_for_probe(Size2i p_size);
 
-	virtual void set_fsr_sharpness(float p_fsr_sharpness) override{};
-	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override{};
-	virtual void set_use_debanding(bool p_use_debanding) override{};
+	virtual void set_fsr_sharpness(float p_fsr_sharpness) override {}
+	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override {}
+	virtual void set_use_debanding(bool p_use_debanding) override {}
 	void set_apply_color_adjustments_in_post(bool p_apply_in_post);
 
 	void free_render_buffer_data();

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -582,7 +582,7 @@ public:
 
 	virtual RID decal_allocate() override;
 	virtual void decal_initialize(RID p_rid) override;
-	virtual void decal_free(RID p_rid) override{};
+	virtual void decal_free(RID p_rid) override {}
 
 	virtual void decal_set_size(RID p_decal, const Vector3 &p_size) override;
 	virtual void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture) override;

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -65,7 +65,7 @@ public:
 	virtual bool handles(const String &p_type) const;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const;
-	virtual void abort(){};
+	virtual void abort() {}
 
 	virtual bool generate_small_preview_automatically() const;
 	virtual bool can_generate_small_preview() const;

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -308,7 +308,7 @@ public:
 	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) const = 0;
-	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features){};
+	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
 
 	EditorExportPlatform();

--- a/editor/gui/editor_title_bar.h
+++ b/editor/gui/editor_title_bar.h
@@ -43,7 +43,7 @@ class EditorTitleBar : public HBoxContainer {
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 public:
 	void set_can_move_window(bool p_enabled);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -322,7 +322,7 @@ protected:
 public:
 	void add_transition(const StringName &p_from, const StringName &p_to, Ref<AnimationNodeStateMachineTransition> p_transition);
 
-	EditorAnimationMultiTransitionEdit(){};
+	EditorAnimationMultiTransitionEdit() {}
 };
 
 #endif // ANIMATION_STATE_MACHINE_EDITOR_H

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -51,7 +51,7 @@ public:
 	void set_dict(const Dictionary &p_dict);
 	Dictionary get_dict();
 
-	EditorPropertyFontMetaObject(){};
+	EditorPropertyFontMetaObject() {}
 };
 
 /*************************************************************************/
@@ -75,7 +75,7 @@ public:
 	void set_defaults(const Dictionary &p_dict);
 	Dictionary get_defaults();
 
-	EditorPropertyFontOTObject(){};
+	EditorPropertyFontOTObject() {}
 };
 
 /*************************************************************************/
@@ -103,7 +103,7 @@ class EditorPropertyFontMetaOverride : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
@@ -138,7 +138,7 @@ class EditorPropertyOTVariation : public EditorProperty {
 	EditorPaginator *paginator = nullptr;
 
 protected:
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
@@ -187,7 +187,7 @@ class EditorPropertyOTFeatures : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
@@ -256,7 +256,7 @@ protected:
 	virtual void _add_element() override;
 
 	void _add_font(int p_option);
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 public:
 	EditorPropertyFontNamesArray();

--- a/editor/plugins/gpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.h
@@ -59,7 +59,7 @@ protected:
 	Vector<Face3> geometry;
 
 	bool _generate(Vector<Vector3> &points, Vector<Vector3> &normals);
-	virtual void _generate_emission_points(){};
+	virtual void _generate_emission_points() {}
 	void _node_selected(const NodePath &p_path);
 
 public:

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -127,8 +127,8 @@ public:
 	virtual Variant get_navigation_state() override;
 	virtual Vector<String> get_functions() override;
 	virtual PackedInt32Array get_breakpoints() override;
-	virtual void set_breakpoint(int p_line, bool p_enabled) override{};
-	virtual void clear_breakpoints() override{};
+	virtual void set_breakpoint(int p_line, bool p_enabled) override {}
+	virtual void clear_breakpoints() override {}
 	virtual void goto_line(int p_line, int p_column = 0) override;
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	virtual void set_executing_line(int p_line) override;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1097,7 +1097,7 @@ void TileDataDefaultEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas_
 	}
 };
 
-void TileDataDefaultEditor::forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform){
+void TileDataDefaultEditor::forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {
 
 };
 

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -54,7 +54,7 @@ private:
 protected:
 	Ref<TileSet> tile_set;
 	TileData *_get_tile_data(TileMapCell p_cell);
-	virtual void _tile_set_changed(){};
+	virtual void _tile_set_changed() {}
 
 	static void _bind_methods();
 
@@ -63,13 +63,13 @@ public:
 
 	// Input to handle painting.
 	virtual Control *get_toolbar() { return nullptr; };
-	virtual void forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform){};
-	virtual void forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform){};
-	virtual void forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event){};
-	virtual void forward_painting_alternatives_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event){};
+	virtual void forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {}
+	virtual void forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {}
+	virtual void forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) {}
+	virtual void forward_painting_alternatives_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) {}
 
 	// Used to draw the tile data property value over a tile.
-	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false){};
+	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) {}
 };
 
 class DummyObject : public Object {

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -66,9 +66,9 @@ public:
 	};
 
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return false; };
-	virtual void forward_canvas_draw_over_viewport(Control *p_overlay){};
-	virtual void tile_set_changed(){};
-	virtual void edit(ObjectID p_tile_map_layer_id){};
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) {}
+	virtual void tile_set_changed() {}
+	virtual void edit(ObjectID p_tile_map_layer_id) {}
 };
 
 class TileMapLayerEditorTilesPlugin : public TileMapLayerSubEditorPlugin {

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -37,10 +37,10 @@
 #include "core/variant/variant.h"
 
 #ifndef LINE_NUMBER_TO_INDEX
-#define LINE_NUMBER_TO_INDEX(p_line) ((p_line)-1)
+#define LINE_NUMBER_TO_INDEX(p_line) ((p_line) - 1)
 #endif
 #ifndef COLUMN_NUMBER_TO_INDEX
-#define COLUMN_NUMBER_TO_INDEX(p_column) ((p_column)-1)
+#define COLUMN_NUMBER_TO_INDEX(p_column) ((p_column) - 1)
 #endif
 
 #ifndef SYMBOL_SEPERATOR

--- a/modules/navigation/nav_base.h
+++ b/modules/navigation/nav_base.h
@@ -64,7 +64,7 @@ public:
 	void set_owner_id(ObjectID p_owner_id) { owner_id = p_owner_id; }
 	ObjectID get_owner_id() const { return owner_id; }
 
-	virtual ~NavBase(){};
+	virtual ~NavBase() {}
 };
 
 #endif // NAV_BASE_H

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -705,7 +705,7 @@ class TextServerAdvanced : public TextServerExtension {
 	};
 
 protected:
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 	void full_copy(ShapedTextDataAdvanced *p_shaped);
 	void invalidate(ShapedTextDataAdvanced *p_shaped, bool p_text = false);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -574,7 +574,7 @@ class TextServerFallback : public TextServerExtension {
 	Mutex ft_mutex;
 
 protected:
-	static void _bind_methods(){};
+	static void _bind_methods() {}
 
 	void full_copy(ShapedTextDataFallback *p_shaped);
 	void invalidate(ShapedTextDataFallback *p_shaped);

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/SignalInfo.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/SignalInfo.java
@@ -50,7 +50,7 @@ public final class SignalInfo {
 		}
 
 		this.name = signalName;
-		this.paramTypes = paramTypes == null ? new Class<?>[ 0 ] : paramTypes;
+		this.paramTypes = paramTypes == null ? new Class<?>[0] : paramTypes;
 		this.paramTypesNames = new String[this.paramTypes.length];
 		for (int i = 0; i < this.paramTypes.length; i++) {
 			this.paramTypesNames[i] = this.paramTypes[i].getName();

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -48,7 +48,7 @@ class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
 		String cmd_args;
 		bool wait = false;
 
-		SSHCleanupCommand(){};
+		SSHCleanupCommand() {}
 		SSHCleanupCommand(const String &p_host, const String &p_port, const Vector<String> &p_ssh_arg, const String &p_cmd_args, bool p_wait = false) {
 			host = p_host;
 			port = p_port;

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -50,7 +50,7 @@
 
 #define LONG_BITS (sizeof(long) * 8)
 #define test_bit(nr, addr) (((1UL << ((nr) % LONG_BITS)) & ((addr)[(nr) / LONG_BITS])) != 0)
-#define NBITS(x) ((((x)-1) / LONG_BITS) + 1)
+#define NBITS(x) ((((x) - 1) / LONG_BITS) + 1)
 
 #ifdef UDEV_ENABLED
 static const char *ignore_str = "/dev/input/js";

--- a/platform/linuxbsd/wayland/key_mapping_xkb.h
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.h
@@ -51,7 +51,7 @@ class KeyMappingXKB {
 	static inline HashMap<Key, unsigned int, HashMapHasherKeys> scancode_map_inv;
 	static inline HashMap<unsigned int, KeyLocation, HashMapHasherKeys> location_map;
 
-	KeyMappingXKB(){};
+	KeyMappingXKB() {}
 
 public:
 	static void initialize();

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.h
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.h
@@ -52,8 +52,8 @@ private:
 public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
 
-	GLManagerEGL_X11(){};
-	~GLManagerEGL_X11(){};
+	GLManagerEGL_X11() {}
+	~GLManagerEGL_X11() {}
 };
 
 #endif // X11_ENABLED && GLES3_ENABLED

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -68,7 +68,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 		String cmd_args;
 		bool wait = false;
 
-		SSHCleanupCommand(){};
+		SSHCleanupCommand() {}
 		SSHCleanupCommand(const String &p_host, const String &p_port, const Vector<String> &p_ssh_arg, const String &p_cmd_args, bool p_wait = false) {
 			host = p_host;
 			port = p_port;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -381,7 +381,7 @@ public:
 		ctls[cid] = p_name;
 	}
 
-	virtual ~FileDialogEventHandler(){};
+	virtual ~FileDialogEventHandler() {}
 };
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -52,7 +52,7 @@ class EditorExportPlatformWindows : public EditorExportPlatformPC {
 		String cmd_args;
 		bool wait = false;
 
-		SSHCleanupCommand(){};
+		SSHCleanupCommand() {}
 		SSHCleanupCommand(const String &p_host, const String &p_port, const Vector<String> &p_ssh_arg, const String &p_cmd_args, bool p_wait = false) {
 			host = p_host;
 			port = p_port;

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -52,8 +52,8 @@ private:
 public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 
-	GLManagerANGLE_Windows(){};
-	~GLManagerANGLE_Windows(){};
+	GLManagerANGLE_Windows() {}
+	~GLManagerANGLE_Windows() {}
 };
 
 #endif // WINDOWS_ENABLED && GLES3_ENABLED

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -90,7 +90,7 @@ public:
 
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain); // For the center terrain bit
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain); // For peering bits
-	TerrainConstraint(){};
+	TerrainConstraint() {}
 };
 
 #ifdef DEBUG_ENABLED

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -50,14 +50,14 @@ public:
 
 	virtual Color get_color() const = 0;
 
-	virtual void _value_changed(){};
+	virtual void _value_changed() {}
 
 	virtual void slider_draw(int p_which) = 0;
 	virtual bool apply_theme() const { return false; }
 	virtual ColorPicker::PickerShapeType get_shape_override() const { return ColorPicker::SHAPE_MAX; }
 
 	ColorMode(ColorPicker *p_color_picker);
-	virtual ~ColorMode(){};
+	virtual ~ColorMode() {}
 };
 
 class ColorModeHSV : public ColorMode {
@@ -81,7 +81,7 @@ public:
 	virtual void slider_draw(int p_which) override;
 
 	ColorModeHSV(ColorPicker *p_color_picker) :
-			ColorMode(p_color_picker){};
+			ColorMode(p_color_picker) {}
 };
 
 class ColorModeRGB : public ColorMode {
@@ -100,7 +100,7 @@ public:
 	virtual void slider_draw(int p_which) override;
 
 	ColorModeRGB(ColorPicker *p_color_picker) :
-			ColorMode(p_color_picker){};
+			ColorMode(p_color_picker) {}
 };
 
 class ColorModeRAW : public ColorMode {
@@ -122,7 +122,7 @@ public:
 	virtual bool apply_theme() const override;
 
 	ColorModeRAW(ColorPicker *p_color_picker) :
-			ColorMode(p_color_picker){};
+			ColorMode(p_color_picker) {}
 };
 
 class ColorModeOKHSL : public ColorMode {
@@ -147,9 +147,9 @@ public:
 	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }
 
 	ColorModeOKHSL(ColorPicker *p_color_picker) :
-			ColorMode(p_color_picker){};
+			ColorMode(p_color_picker) {}
 
-	~ColorModeOKHSL(){};
+	~ColorModeOKHSL() {}
 };
 
 #endif // COLOR_MODE_H

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -571,25 +571,25 @@ public:
 	// Not exposed.
 	virtual void set_tile_set(const TileSet *p_tile_set);
 	TileSet *get_tile_set() const;
-	virtual void notify_tile_data_properties_should_change(){};
-	virtual void add_occlusion_layer(int p_index){};
-	virtual void move_occlusion_layer(int p_from_index, int p_to_pos){};
-	virtual void remove_occlusion_layer(int p_index){};
-	virtual void add_physics_layer(int p_index){};
-	virtual void move_physics_layer(int p_from_index, int p_to_pos){};
-	virtual void remove_physics_layer(int p_index){};
-	virtual void add_terrain_set(int p_index){};
-	virtual void move_terrain_set(int p_from_index, int p_to_pos){};
-	virtual void remove_terrain_set(int p_index){};
-	virtual void add_terrain(int p_terrain_set, int p_index){};
-	virtual void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos){};
-	virtual void remove_terrain(int p_terrain_set, int p_index){};
-	virtual void add_navigation_layer(int p_index){};
-	virtual void move_navigation_layer(int p_from_index, int p_to_pos){};
-	virtual void remove_navigation_layer(int p_index){};
-	virtual void add_custom_data_layer(int p_index){};
-	virtual void move_custom_data_layer(int p_from_index, int p_to_pos){};
-	virtual void remove_custom_data_layer(int p_index){};
+	virtual void notify_tile_data_properties_should_change() {}
+	virtual void add_occlusion_layer(int p_index) {}
+	virtual void move_occlusion_layer(int p_from_index, int p_to_pos) {}
+	virtual void remove_occlusion_layer(int p_index) {}
+	virtual void add_physics_layer(int p_index) {}
+	virtual void move_physics_layer(int p_from_index, int p_to_pos) {}
+	virtual void remove_physics_layer(int p_index) {}
+	virtual void add_terrain_set(int p_index) {}
+	virtual void move_terrain_set(int p_from_index, int p_to_pos) {}
+	virtual void remove_terrain_set(int p_index) {}
+	virtual void add_terrain(int p_terrain_set, int p_index) {}
+	virtual void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos) {}
+	virtual void remove_terrain(int p_terrain_set, int p_index) {}
+	virtual void add_navigation_layer(int p_index) {}
+	virtual void move_navigation_layer(int p_from_index, int p_to_pos) {}
+	virtual void remove_navigation_layer(int p_index) {}
+	virtual void add_custom_data_layer(int p_index) {}
+	virtual void move_custom_data_layer(int p_from_index, int p_to_pos) {}
+	virtual void remove_custom_data_layer(int p_index) {}
 	virtual void reset_state() override;
 
 	// Tiles.

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -77,7 +77,7 @@ protected:
 
 	Vector2 get_uv2_scale(Vector2 p_margin_scale = Vector2(1.0, 1.0)) const;
 	float get_lightmap_texel_size() const;
-	virtual void _update_lightmap_size(){};
+	virtual void _update_lightmap_size() {}
 
 	void _on_settings_changed();
 
@@ -541,7 +541,7 @@ private:
 		Vector2 point;
 		bool sharp = false;
 
-		ContourPoint(){};
+		ContourPoint() {}
 		ContourPoint(const Vector2 &p_pt, bool p_sharp) {
 			point = p_pt;
 			sharp = p_sharp;
@@ -551,7 +551,7 @@ private:
 	struct ContourInfo {
 		real_t length = 0.0;
 		bool ccw = true;
-		ContourInfo(){};
+		ContourInfo() {}
 		ContourInfo(real_t p_len, bool p_ccw) {
 			length = p_len;
 			ccw = p_ccw;

--- a/scene/resources/camera_attributes.h
+++ b/scene/resources/camera_attributes.h
@@ -53,7 +53,7 @@ protected:
 	float auto_exposure_max = 64.0;
 	float auto_exposure_speed = 0.5;
 	float auto_exposure_scale = 0.4;
-	virtual void _update_auto_exposure(){};
+	virtual void _update_auto_exposure() {}
 
 public:
 	virtual RID get_rid() const override;

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -97,7 +97,7 @@ public:
 	/* MATERIAL API */
 	virtual RID material_allocate() override { return RID(); }
 	virtual void material_initialize(RID p_rid) override {}
-	virtual void material_free(RID p_rid) override{};
+	virtual void material_free(RID p_rid) override {}
 
 	virtual void material_set_render_priority(RID p_material, int priority) override {}
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) override {}

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -56,14 +56,14 @@ public:
 	/* Canvas Texture API */
 
 	virtual RID canvas_texture_allocate() override { return RID(); };
-	virtual void canvas_texture_initialize(RID p_rid) override{};
-	virtual void canvas_texture_free(RID p_rid) override{};
+	virtual void canvas_texture_initialize(RID p_rid) override {}
+	virtual void canvas_texture_free(RID p_rid) override {}
 
-	virtual void canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) override{};
-	virtual void canvas_texture_set_shading_parameters(RID p_canvas_texture, const Color &p_base_color, float p_shininess) override{};
+	virtual void canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) override {}
+	virtual void canvas_texture_set_shading_parameters(RID p_canvas_texture, const Color &p_base_color, float p_shininess) override {}
 
-	virtual void canvas_texture_set_texture_filter(RID p_item, RS::CanvasItemTextureFilter p_filter) override{};
-	virtual void canvas_texture_set_texture_repeat(RID p_item, RS::CanvasItemTextureRepeat p_repeat) override{};
+	virtual void canvas_texture_set_texture_filter(RID p_item, RS::CanvasItemTextureFilter p_filter) override {}
+	virtual void canvas_texture_set_texture_repeat(RID p_item, RS::CanvasItemTextureRepeat p_repeat) override {}
 
 	/* Texture API */
 
@@ -88,20 +88,20 @@ public:
 		ERR_FAIL_NULL(t);
 		t->image = p_image->duplicate();
 	};
-	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override{};
-	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override{};
-	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override{}; //all slices, then all the mipmaps, must be coherent
+	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override {}
+	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override {}
+	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override {} //all slices, then all the mipmaps, must be coherent
 
 	virtual RID texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY) override { return RID(); }
 
-	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override{};
-	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override{};
-	virtual void texture_proxy_update(RID p_proxy, RID p_base) override{};
+	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
+	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override {}
+	virtual void texture_proxy_update(RID p_proxy, RID p_base) override {}
 
 	//these two APIs can be used together or in combination with the others.
-	virtual void texture_2d_placeholder_initialize(RID p_texture) override{};
-	virtual void texture_2d_layered_placeholder_initialize(RID p_texture, RenderingServer::TextureLayeredType p_layered_type) override{};
-	virtual void texture_3d_placeholder_initialize(RID p_texture) override{};
+	virtual void texture_2d_placeholder_initialize(RID p_texture) override {}
+	virtual void texture_2d_layered_placeholder_initialize(RID p_texture, RenderingServer::TextureLayeredType p_layered_type) override {}
+	virtual void texture_3d_placeholder_initialize(RID p_texture) override {}
 
 	virtual Ref<Image> texture_2d_get(RID p_texture) const override {
 		DummyTexture *t = texture_owner.get_or_null(p_texture);
@@ -112,31 +112,31 @@ public:
 	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); };
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override { texture_free(p_by_texture); };
-	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override{};
+	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override {}
 
-	virtual void texture_set_path(RID p_texture, const String &p_path) override{};
+	virtual void texture_set_path(RID p_texture, const String &p_path) override {}
 	virtual String texture_get_path(RID p_texture) const override { return String(); };
 
 	virtual Image::Format texture_get_format(RID p_texture) const override { return Image::FORMAT_MAX; }
 
-	virtual void texture_set_detect_3d_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override{};
-	virtual void texture_set_detect_normal_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override{};
-	virtual void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) override{};
+	virtual void texture_set_detect_3d_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override {}
+	virtual void texture_set_detect_normal_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override {}
+	virtual void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) override {}
 
-	virtual void texture_debug_usage(List<RS::TextureInfo> *r_info) override{};
+	virtual void texture_debug_usage(List<RS::TextureInfo> *r_info) override {}
 
-	virtual void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) override{};
+	virtual void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) override {}
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) override { return Size2(); };
 
-	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RS::TextureLayeredType p_layer_type = RS::TEXTURE_LAYERED_2D_ARRAY) override{};
+	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RS::TextureLayeredType p_layer_type = RS::TEXTURE_LAYERED_2D_ARRAY) override {}
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override { return RID(); };
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override { return 0; };
 
 	/* DECAL API */
 	virtual RID decal_allocate() override { return RID(); }
 	virtual void decal_initialize(RID p_rid) override {}
-	virtual void decal_free(RID p_rid) override{};
+	virtual void decal_free(RID p_rid) override {}
 
 	virtual void decal_set_size(RID p_decal, const Vector3 &p_size) override {}
 	virtual void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture) override {}

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -316,8 +316,8 @@ public:
 
 		int last_shadow_filter = -1;
 
-		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override{};
-		virtual void free_data() override{};
+		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override {}
+		virtual void free_data() override {}
 
 		bool sync_gi_dependent_sets_validity(bool p_ensure_freed = false);
 

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -461,7 +461,7 @@ public:
 
 		RID get_voxel_gi_buffer();
 
-		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override{};
+		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override {}
 		virtual void free_data() override;
 	};
 
@@ -675,7 +675,7 @@ public:
 		int32_t cascade_dynamic_light_count[SDFGI::MAX_CASCADES]; //used dynamically
 		RID integrate_sky_uniform_set;
 
-		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override{};
+		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override {}
 		virtual void free_data() override;
 		~SDFGI();
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -366,12 +366,12 @@ protected:
 	virtual RID _render_buffers_get_normal_texture(Ref<RenderSceneBuffersRD> p_render_buffers) override;
 	virtual RID _render_buffers_get_velocity_texture(Ref<RenderSceneBuffersRD> p_render_buffers) override;
 
-	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override{};
-	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override{};
-	virtual void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override{};
+	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override {}
+	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override {}
+	virtual void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override {}
 
-	virtual void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) override{};
-	virtual void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override{};
+	virtual void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) override {}
+	virtual void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override {}
 
 	/* Geometry instance */
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -165,9 +165,9 @@ public:
 
 	/* LIGHTING */
 
-	virtual void setup_added_reflection_probe(const Transform3D &p_transform, const Vector3 &p_half_size){};
-	virtual void setup_added_light(const RS::LightType p_type, const Transform3D &p_transform, float p_radius, float p_spot_aperture){};
-	virtual void setup_added_decal(const Transform3D &p_transform, const Vector3 &p_half_size){};
+	virtual void setup_added_reflection_probe(const Transform3D &p_transform, const Vector3 &p_half_size) {}
+	virtual void setup_added_light(const RS::LightType p_type, const Transform3D &p_transform, float p_radius, float p_spot_aperture) {}
+	virtual void setup_added_decal(const Transform3D &p_transform, const Vector3 &p_half_size) {}
 
 	/* GI */
 

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -46,7 +46,7 @@ public:
 		int group = 0;
 		CharString text;
 		bool default_enabled = true;
-		VariantDefine(){};
+		VariantDefine() {}
 		VariantDefine(int p_group, const String &p_text, bool p_default_enabled) {
 			group = p_group;
 			default_enabled = p_default_enabled;

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -41,11 +41,10 @@ layout(location = 3) out vec2 pixel_size_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = 1, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 #GLOBALS
@@ -258,11 +257,10 @@ layout(location = 3) in vec2 pixel_size_interp;
 layout(location = 0) out vec4 frag_color;
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = 1, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 vec2 screen_uv_to_sdf(vec2 p_uv) {

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -106,9 +106,10 @@ layout(set = 0, binding = 3, std140) uniform DirectionalLights {
 directional_lights;
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = 1, binding = 0, std140) uniform MaterialUniforms{
+layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-} material;
+}
+material;
 #endif
 
 layout(set = 2, binding = 0) uniform textureCube radiance;
@@ -247,9 +248,7 @@ void main() {
 #endif //USE_CUBEMAP_PASS
 
 	{
-
 #CODE : SKY
-
 	}
 
 	frag_color.rgb = color;

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -77,9 +77,10 @@ layout(r32ui, set = 1, binding = 4) uniform volatile uimage3D light_only_map;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = 2, binding = 0, std140) uniform MaterialUniforms{
+layout(set = 2, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-} material;
+}
+material;
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -116,9 +116,10 @@ layout(location = 8) out vec4 prev_screen_position;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms{
+layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-} material;
+}
+material;
 #endif
 
 float global_time;
@@ -808,11 +809,10 @@ ivec2 multiview_uv(ivec2 uv) {
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -107,11 +107,10 @@ layout(location = 6) mediump out vec3 binormal_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 #ifdef MODE_DUAL_PARABOLOID
@@ -671,11 +670,10 @@ ivec2 multiview_uv(ivec2 uv) {
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -168,11 +168,10 @@ layout(set = 2, binding = 1) uniform texture2D height_field_texture;
 /* SET 3: MATERIAL */
 
 #ifdef MATERIAL_UNIFORMS_USED
-layout(set = 3, binding = 0, std140) uniform MaterialUniforms{
-
+layout(set = 3, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
-
-} material;
+}
+material;
 #endif
 
 layout(push_constant, std430) uniform Params {

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -192,7 +192,7 @@ public:
 		RID get_debug_texture();
 		const Size2i &get_occlusion_buffer_size() const { return occlusion_buffer_size; }
 
-		virtual ~HZBuffer(){};
+		virtual ~HZBuffer() {}
 	};
 
 	static RendererSceneOcclusionCull *get_singleton() { return singleton; }

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -34,7 +34,7 @@
 #include "core/object/object.h"
 #include "core/variant/type_info.h"
 
-#define STEPIFY(m_number, m_alignment) ((((m_number) + ((m_alignment)-1)) / (m_alignment)) * (m_alignment))
+#define STEPIFY(m_number, m_alignment) ((((m_number) + ((m_alignment) - 1)) / (m_alignment)) * (m_alignment))
 
 class RenderingDeviceCommons : public Object {
 	////////////////////////////////////////////

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -36,7 +36,7 @@
 
 class RendererMaterialStorage {
 public:
-	virtual ~RendererMaterialStorage(){};
+	virtual ~RendererMaterialStorage() {}
 
 	/* GLOBAL SHADER UNIFORM API */
 	virtual void global_shader_parameter_add(const StringName &p_name, RS::GlobalShaderParameterType p_type, const Variant &p_value) = 0;

--- a/servers/rendering/storage/render_scene_buffers.h
+++ b/servers/rendering/storage/render_scene_buffers.h
@@ -91,7 +91,7 @@ public:
 	void set_use_debanding(bool p_use_debanding) { use_debanding = p_use_debanding; }
 
 	RenderSceneBuffersConfiguration() {}
-	virtual ~RenderSceneBuffersConfiguration(){};
+	virtual ~RenderSceneBuffersConfiguration() {}
 };
 
 class RenderSceneBuffers : public RefCounted {
@@ -101,8 +101,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	RenderSceneBuffers(){};
-	virtual ~RenderSceneBuffers(){};
+	RenderSceneBuffers() {}
+	virtual ~RenderSceneBuffers() {}
 
 	virtual void configure(const RenderSceneBuffersConfiguration *p_config) = 0;
 
@@ -124,7 +124,7 @@ protected:
 	GDVIRTUAL1(_set_use_debanding, bool)
 
 public:
-	virtual ~RenderSceneBuffersExtension(){};
+	virtual ~RenderSceneBuffersExtension() {}
 
 	virtual void configure(const RenderSceneBuffersConfiguration *p_config) override;
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -61,7 +61,7 @@ public:
 	/* Texture API */
 	virtual bool can_create_resources_async() const = 0;
 
-	virtual ~RendererTextureStorage(){};
+	virtual ~RendererTextureStorage() {}
 
 	virtual RID texture_allocate() = 0;
 	virtual void texture_free(RID p_rid) = 0;

--- a/servers/xr/xr_controller_tracker.cpp
+++ b/servers/xr/xr_controller_tracker.cpp
@@ -32,7 +32,7 @@
 
 #include "core/input/input.h"
 
-void XRControllerTracker::_bind_methods(){};
+void XRControllerTracker::_bind_methods() {}
 
 XRControllerTracker::XRControllerTracker() {
 	type = XRServer::TRACKER_CONTROLLER;

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -137,10 +137,10 @@ public:
 	virtual RID get_color_texture(); /* obtain color output texture (if applicable) */
 	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
 	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */
-	virtual void pre_render(){};
+	virtual void pre_render() {}
 	virtual bool pre_draw_viewport(RID p_render_target) { return true; }; /* inform XR interface we are about to start our viewport draw process */
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
-	virtual void end_frame(){};
+	virtual void end_frame() {}
 
 	/** passthrough **/
 


### PR DESCRIPTION
This requires updating `pre-commit` and `identify` Python packages to their latest versions, to add support for the `metal` file type:

```
pip install --upgrade pre-commit identify
```
(Technically only updating `identify` might be enough but it's good to be up-to-date for good measure.)

Also update ruff pre-commit to 0.6.5, doesn't seem to cause changes.

---

The need to update `identify` might be a bit annoying as users will run into cryptic errors like this:
```
An error has occurred: InvalidManifestError: 
==> File /home/akien/.cache/pre-commit/repolyo4sjx6/.pre-commit-hooks.yaml
==> At Hook(id='clang-format')
==> At key: types_or
==> At index 9
=====> Type tag 'textproto' is not recognized.  Try upgrading identify and pre-commit?
Check the log at /home/akien/.cache/pre-commit/pre-commit.log
```

I wonder if we can have a pre-commit hook that runs first and makes sure `identify` is up to date?